### PR TITLE
fix(tui): align codex auth flow for tty sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,6 +2896,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,6 +4304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5302,6 +5326,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plist"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.13.1",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5433,6 +5470,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
+dependencies = [
+ "bitflags 2.11.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
+
+[[package]]
 name = "pulp"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5468,6 +5524,15 @@ name = "pulp-wasm-simd-flag"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -5679,19 +5744,25 @@ dependencies = [
  "lancedb",
  "open",
  "owo-colors",
+ "pulldown-cmark",
  "rand 0.8.5",
  "ratatui",
  "regex",
+ "regex-lite",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
  "sha2",
+ "syntect",
  "tempfile",
+ "textwrap",
  "thiserror 2.0.18",
  "tiktoken-rs",
  "tokenizers",
  "tokio",
+ "two-face",
+ "unicode-width",
  "url",
  "urlencoding",
  "uuid",
@@ -5917,6 +5988,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -6473,6 +6550,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6708,6 +6791,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -6988,6 +7092,17 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -7394,6 +7509,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "two-face"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285c51f8a6ade109ed4566d33ac4fb289fb5d6cf87ed70908a5eaf65e948e34"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "syntect",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7479,6 +7605,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -8358,6 +8490,15 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,16 @@ crossterm = { version = "0.29", features = ["event-stream"] }
 walkdir = "2.5"
 glob = "0.3"
 regex = "1.11"
+regex-lite = "0.1.8"
 uuid = { version = "1.11", features = ["v4"] }
 lancedb = "0.27"
 futures = "0.3"
 rusqlite = "0.32"
+pulldown-cmark = "0.10"
+textwrap = "0.16.2"
+unicode-width = "0.2"
+syntect = "5"
+two-face = { version = "0.5", default-features = false, features = ["syntect-default-onig"] }
 agent-client-protocol = { version = "0.10", features = ["unstable"] }
 hf-hub = "0.4"
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,6 @@
 use crate::tool::{ToolManager};
 use crate::tool_result::{default_tool_result_store_dir, repair_tool_result_history, ToolResultStore};
-use crate::llm::LlmBackend;
+use crate::llm::{ContextBudget, LlmBackend};
 use crate::vectordb::{VectorDB, MemoryMetadata};
 use crate::session::SessionManager;
 use crate::workspace::WorkspaceMemory;
@@ -58,6 +58,17 @@ pub struct PendingApproval {
 pub struct CompletedInteraction {
     pub title: String,
     pub summary: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CompactState {
+    pub estimated_history_tokens: usize,
+    pub context_window_tokens: Option<usize>,
+    pub compact_threshold_tokens: usize,
+    pub reserved_output_tokens: usize,
+    pub compaction_count: usize,
+    pub last_compaction_before_tokens: Option<usize>,
+    pub last_compaction_after_tokens: Option<usize>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -235,6 +246,7 @@ pub struct Agent {
     pub pending_approval: Option<PendingApproval>,
     pub completed_user_input: Option<CompletedInteraction>,
     pub completed_approval: Option<CompletedInteraction>,
+    pub compact_state: CompactState,
     inspection_progress: InspectionProgress,
 }
 
@@ -266,6 +278,7 @@ impl Agent {
             pending_approval: None,
             completed_user_input: None,
             completed_approval: None,
+            compact_state: CompactState::default(),
             inspection_progress: InspectionProgress::default(),
         }
     }
@@ -439,24 +452,63 @@ impl Agent {
     where
         F: FnMut(AgentEvent) + Send,
     {
-        let bpe = tiktoken_rs::cl100k_base().unwrap();
-        let current_tokens: usize = self.history.iter().map(|m| {
-            bpe.encode_with_special_tokens(&m.content.to_string()).len()
-        }).sum();
+        self.compact_history_with_reporter(false, &mut report).await
+    }
 
-        if current_tokens > 10000 {
-            report(AgentEvent::Status(
-                "Compacting long conversation history.".to_string(),
-            ));
-            let split_idx = (self.history.len() as f64 * 0.8) as usize;
-            let summary = self.llm_backend.summarize(&self.history[..split_idx]).await?;
-            let mut new_history = vec![Message {
-                role: "system".to_string(),
-                content: json!(format!("SUMMARY OF PREVIOUS CONVERSATION: {}", summary)),
-            }];
-            new_history.extend_from_slice(&self.history[split_idx..]);
-            self.history = new_history;
+    pub async fn compact_now_with_reporter<F>(&mut self, mut report: F) -> Result<bool>
+    where
+        F: FnMut(AgentEvent) + Send,
+    {
+        self.compact_history_with_reporter(true, &mut report).await?;
+        Ok(self.compact_state.last_compaction_before_tokens.is_some())
+    }
+
+    async fn compact_history_with_reporter<F>(&mut self, force: bool, report: &mut F) -> Result<()>
+    where
+        F: FnMut(AgentEvent) + Send,
+    {
+        let current_tokens = estimate_history_tokens(&self.history)?;
+        let compact_budget = self.current_compact_budget();
+        self.compact_state.estimated_history_tokens = current_tokens;
+        self.compact_state.context_window_tokens =
+            compact_budget.as_ref().map(|budget| budget.context_window_tokens);
+        self.compact_state.compact_threshold_tokens =
+            compact_budget.as_ref().map(|budget| budget.compact_threshold_tokens).unwrap_or(10_000);
+        self.compact_state.reserved_output_tokens =
+            compact_budget.as_ref().map(|budget| budget.reserved_output_tokens).unwrap_or(0);
+        self.compact_state.last_compaction_before_tokens = None;
+        self.compact_state.last_compaction_after_tokens = None;
+
+        let threshold = self.compact_state.compact_threshold_tokens;
+        if !force && current_tokens <= threshold {
+            return Ok(());
         }
+        if self.history.len() < 2 {
+            return Ok(());
+        }
+
+        report(AgentEvent::Status(if force {
+            "Compacting conversation history on demand.".to_string()
+        } else {
+            "Compacting long conversation history.".to_string()
+        }));
+
+        let split_idx = (self.history.len() as f64 * 0.8) as usize;
+        let split_idx = split_idx.clamp(1, self.history.len().saturating_sub(1));
+        let summary = self.llm_backend.summarize(&self.history[..split_idx]).await?;
+        let mut new_history = vec![Message {
+            role: "system".to_string(),
+            content: json!(format!("SUMMARY OF PREVIOUS CONVERSATION: {}", summary)),
+        }];
+        new_history.extend_from_slice(&self.history[split_idx..]);
+        self.history = new_history;
+        self.session_manager.save_session(&self.session_id, &self.history)?;
+
+        let compacted_tokens = estimate_history_tokens(&self.history)?;
+        self.compact_state.estimated_history_tokens = compacted_tokens;
+        self.compact_state.compaction_count += 1;
+        self.compact_state.last_compaction_before_tokens = Some(current_tokens);
+        self.compact_state.last_compaction_after_tokens = Some(compacted_tokens);
         Ok(())
     }
 
@@ -881,6 +933,11 @@ impl Agent {
             .get_schemas_filtered(|name| self.is_tool_allowed_in_current_mode(name))
     }
 
+    fn current_compact_budget(&self) -> Option<ContextBudget> {
+        let tools = self.visible_tool_schemas();
+        self.llm_backend.context_budget(&self.history, &tools)
+    }
+
     fn is_tool_allowed_in_current_mode(&self, name: &str) -> bool {
         match self.execution_mode {
             AgentExecutionMode::Execute => true,
@@ -1190,6 +1247,14 @@ fn tool_result_message(tool_use_id: &str, content: String, is_error: bool) -> Me
         role: "user".to_string(),
         content: json!([block]),
     }
+}
+
+fn estimate_history_tokens(history: &[Message]) -> Result<usize> {
+    let bpe = tiktoken_rs::cl100k_base()?;
+    Ok(history
+        .iter()
+        .map(|message| bpe.encode_with_special_tokens(&message.content.to_string()).len())
+        .sum())
 }
 
 #[cfg(test)]
@@ -1702,5 +1767,39 @@ mod tests {
             .current_plan
             .iter()
             .all(|step| step.status == PlanStepStatus::Completed));
+    }
+
+    #[tokio::test]
+    async fn manual_compact_replaces_older_history_with_summary() {
+        let backend = Arc::new(SequencedBackend::new(Vec::new()));
+        let mut agent = Agent::new(
+            ToolManager::new(),
+            backend,
+            Arc::new(VectorDB::new("data/lancedb")),
+            Arc::new(SessionManager::new().expect("session manager")),
+            Arc::new(WorkspaceMemory::new().expect("workspace memory")),
+        );
+        agent.history = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!("inspect the repo"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!("I checked Cargo.toml and src/main.rs"),
+            },
+        ];
+
+        let compacted = agent
+            .compact_now_with_reporter(|_| {})
+            .await
+            .expect("compact should succeed");
+
+        assert!(compacted);
+        assert_eq!(agent.compact_state.compaction_count, 1);
+        assert!(agent.history[0]
+            .content
+            .to_string()
+            .contains("SUMMARY OF PREVIOUS CONVERSATION"));
     }
 }

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -6,6 +6,13 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use url::Url;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextBudget {
+    pub context_window_tokens: usize,
+    pub reserved_output_tokens: usize,
+    pub compact_threshold_tokens: usize,
+}
+
 #[async_trait]
 pub trait LlmBackend: Send + Sync {
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<AnthropicResponse>;
@@ -19,6 +26,9 @@ pub trait LlmBackend: Send + Sync {
     }
     async fn embed(&self, text: &str) -> Result<Vec<f32>>;
     async fn summarize(&self, messages: &[Message]) -> Result<String>;
+    fn context_budget(&self, _messages: &[Message], _tools: &[Value]) -> Option<ContextBudget> {
+        None
+    }
 }
 
 pub struct MockLlm;
@@ -128,6 +138,10 @@ impl LlmBackend for OpenAiCompatibleBackend {
         let res = request.json(&body).send().await?;
         let resp_json: Value = res.json().await?;
         Ok(extract_message_text(resp_json["choices"][0]["message"].get("content")).unwrap_or_default())
+    }
+
+    fn context_budget(&self, _messages: &[Message], _tools: &[Value]) -> Option<ContextBudget> {
+        model_context_budget(self.model.as_str())
     }
 }
 
@@ -490,6 +504,14 @@ impl LlmBackend for OllamaBackend {
             .join("\n\n");
         Ok(text)
     }
+
+    fn context_budget(&self, messages: &[Message], tools: &[Value]) -> Option<ContextBudget> {
+        let context_window_tokens = self
+            .num_ctx
+            .map(|value| value as usize)
+            .or_else(|| suggest_ollama_num_ctx(messages, tools, self.thinking).map(|value| value as usize))?;
+        Some(context_budget_from_window(context_window_tokens))
+    }
 }
 
 fn http_client_for_target(base_url: &str) -> Result<reqwest::Client> {
@@ -606,6 +628,34 @@ fn build_ollama_options(
     Some(json!({
         "num_ctx": num_ctx,
     }))
+}
+
+fn context_budget_from_window(context_window_tokens: usize) -> ContextBudget {
+    let reserved_output_tokens = (context_window_tokens / 8).clamp(1024, 4096);
+    let compact_threshold_tokens = context_window_tokens
+        .saturating_sub(reserved_output_tokens)
+        .saturating_sub(2048);
+    ContextBudget {
+        context_window_tokens,
+        reserved_output_tokens,
+        compact_threshold_tokens,
+    }
+}
+
+fn model_context_budget(model: &str) -> Option<ContextBudget> {
+    let canonical = model.trim().to_ascii_lowercase();
+    let context_window_tokens = if canonical.contains("gpt-5")
+        || canonical.contains("codex")
+        || canonical.contains("gpt-4.1")
+        || canonical.contains("gpt-4o")
+    {
+        200_000
+    } else if canonical.contains("gpt-4") {
+        128_000
+    } else {
+        return None;
+    };
+    Some(context_budget_from_window(context_window_tokens))
 }
 
 fn suggest_ollama_num_ctx(messages: &[Message], tools: &[Value], thinking: bool) -> Option<u32> {
@@ -769,6 +819,14 @@ impl LlmBackend for CodexBackend {
     async fn summarize(&self, m: &[Message]) -> Result<String> { 
         OpenAiCompatibleBackend { api_key: self.api_key.clone(), base_url: self.base_url.clone(), model: self.model.clone() }.summarize(m).await 
     }
+    fn context_budget(&self, messages: &[Message], tools: &[Value]) -> Option<ContextBudget> {
+        OpenAiCompatibleBackend {
+            api_key: self.api_key.clone(),
+            base_url: self.base_url.clone(),
+            model: self.model.clone(),
+        }
+        .context_budget(messages, tools)
+    }
 }
 
 pub struct GeminiBackend { pub api_key: String, pub model: String }
@@ -777,14 +835,17 @@ impl LlmBackend for GeminiBackend {
     async fn ask(&self, _: &[Message], _: &[Value]) -> Result<AnthropicResponse> { Err(anyhow!("Gemini pending")) }
     async fn embed(&self, _: &str) -> Result<Vec<f32>> { Err(anyhow!("Gemini pending")) }
     async fn summarize(&self, _: &[Message]) -> Result<String> { Err(anyhow!("Gemini pending")) }
+    fn context_budget(&self, _messages: &[Message], _tools: &[Value]) -> Option<ContextBudget> {
+        model_context_budget(self.model.as_str())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         apply_ollama_stream_event, build_ollama_options, extract_message_text,
-        parse_tool_arguments, suggest_ollama_num_ctx, to_ollama_messages, to_openai_messages,
-        should_bypass_proxy, Message,
+        model_context_budget, parse_tool_arguments, should_bypass_proxy, suggest_ollama_num_ctx,
+        to_ollama_messages, to_openai_messages, Message,
     };
     use serde_json::json;
 
@@ -898,6 +959,13 @@ mod tests {
 
         let options = build_ollama_options(&messages, &[], true, Some(65536)).unwrap();
         assert_eq!(options["num_ctx"], json!(65536));
+    }
+
+    #[test]
+    fn derives_context_budget_for_codex_like_models() {
+        let budget = model_context_budget("gpt-5.1-codex").expect("budget");
+        assert_eq!(budget.context_window_tokens, 200_000);
+        assert!(budget.compact_threshold_tokens < budget.context_window_tokens);
     }
 
     #[test]

--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -19,6 +19,7 @@ pub enum AppEvent {
     SelectPendingOption(usize),
     CycleModelSelection,
     SaveBaseUrlInput,
+    SaveApiKeyInput,
     SelectHelpTab(HelpTab),
     StartOAuth,
     ApplyOverlaySelection,

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -7,7 +7,7 @@ use super::state::{
     PROVIDER_FAMILIES,
 };
 
-pub const COMMAND_SPECS: [CommandSpec; 12] = [
+pub const COMMAND_SPECS: [CommandSpec; 13] = [
     CommandSpec {
         category: "Session",
         name: "help",
@@ -56,6 +56,13 @@ pub const COMMAND_SPECS: [CommandSpec; 12] = [
         usage: "/search <pattern> [in <path>]",
         summary: "Search the workspace with grep and keep the result in the current turn.",
         detail: "Run a local regex search without going through the model. Results show up in the current turn as an exploration step, which makes follow-up reads and review prompts feel more like Codex/Claude exploration.",
+    },
+    CommandSpec {
+        category: "Session",
+        name: "compact",
+        usage: "/compact",
+        summary: "Compact the current conversation history immediately.",
+        detail: "Force one explicit history compaction pass using the current backend summarizer. This keeps the current turn/session but replaces older history with a summary, closer to Codex manual compaction than a silent trim.",
     },
     CommandSpec {
         category: "Setup",
@@ -113,6 +120,7 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
         "plan" => LocalCommandKind::Plan,
         "approval" => LocalCommandKind::Approval,
         "search" => LocalCommandKind::Search,
+        "compact" => LocalCommandKind::Compact,
         "setup" => LocalCommandKind::Setup,
         "model" => LocalCommandKind::Model,
         "base-url" => LocalCommandKind::BaseUrl,
@@ -149,7 +157,7 @@ pub fn recommended_commands(app: &TuiApp) -> Vec<&'static CommandSpec> {
     let names: &[&str] = if app.is_busy() {
         &["status", "help", "clear"]
     } else {
-        &["search", "resume", "plan", "approval", "model", "base-url", "status", "help", "clear", "setup"]
+        &["search", "compact", "resume", "plan", "approval", "model", "base-url", "status", "help", "clear", "setup"]
     };
     names
         .iter()
@@ -195,7 +203,7 @@ pub fn command_detail_text(spec: &CommandSpec) -> String {
 }
 
 pub fn general_help_text() -> &'static str {
-    "RARA uses a single composer as the control surface.\n\nNormal input goes to the current agent.\nSlash commands stay local and open overlays or update runtime state.\n\nExplore:\n  /search <pattern> [in <path>] runs local grep and keeps the result in the current turn\n\nModes:\n  /plan toggles read-only planning mode\n  /approval toggles bash approval between suggestion and always\n\nEditing:\n  apply_patch is the default tool for updating existing files\n  write_file is for new files or full rewrites\n  replace is only a simple fallback for unique string swaps\n\nKeyboard:\n  Enter submit current composer input\n  Esc close the current overlay only\n  Up/Down or j/k move inside lists\n  1/2/3 switch help tabs or choose guided model options\n\nExit:\n  /quit or /exit leave the TUI."
+    "RARA uses a single composer as the control surface.\n\nNormal input goes to the current agent.\nSlash commands stay local and open overlays or update runtime state.\n\nExplore:\n  /search <pattern> [in <path>] runs local grep and keeps the result in the current turn\n\nCompaction:\n  /compact forces one history compaction pass\n\nModes:\n  /plan toggles read-only planning mode\n  /approval toggles bash approval between suggestion and always\n\nEditing:\n  apply_patch is the default tool for updating existing files\n  write_file is for new files or full rewrites\n  replace is only a simple fallback for unique string swaps\n\nKeyboard:\n  Enter submit current composer input\n  Esc close the current overlay only\n  Up/Down or j/k move inside lists\n  1/2/3 switch help tabs or choose guided model options\n\nExit:\n  /quit or /exit leave the TUI."
 }
 
 fn command_score(spec: &CommandSpec, query: &str) -> Option<u8> {
@@ -241,7 +249,7 @@ pub fn help_text() -> String {
         .collect::<Vec<_>>()
         .join("\n");
     format!(
-        "Built-in commands:\n{}\n\nExplore:\n  /search    run local grep in the workspace or a subpath\n\nSessions:\n  /resume    reopen a recent local session\n\nModes:\n  /plan      toggle read-only planning mode\n  /approval  toggle bash approval mode\n\nEditing:\n  apply_patch  preferred for editing existing files\n  write_file   use for new files or full rewrites\n  replace      simple fallback for unique string replacement\n\nKeyboard:\n  Enter submit\n  Esc close current overlay\n  S open setup\n\nExit:\n  /quit\n  /exit\n\nModel switching:\n  /model\n\nProvider URL:\n  /base-url",
+        "Built-in commands:\n{}\n\nExplore:\n  /search    run local grep in the workspace or a subpath\n\nCompaction:\n  /compact   summarize older conversation history now\n\nSessions:\n  /resume    reopen a recent local session\n\nModes:\n  /plan      toggle read-only planning mode\n  /approval  toggle bash approval mode\n\nEditing:\n  apply_patch  preferred for editing existing files\n  write_file   use for new files or full rewrites\n  replace      simple fallback for unique string replacement\n\nKeyboard:\n  Enter submit\n  Esc close current overlay\n  S open setup\n\nExit:\n  /quit\n  /exit\n\nModel switching:\n  /model\n\nProvider URL:\n  /base-url",
         commands
     )
 }
@@ -308,10 +316,34 @@ pub fn status_resources_text(app: &TuiApp) -> String {
         "-".to_string()
     };
     let state_db = app.state_db_status.as_deref().unwrap_or("-");
+    let context = match app.snapshot.context_window_tokens {
+        Some(window) => format!(
+            "{} / {} (~auto @ {}, reserve {})",
+            app.snapshot.estimated_history_tokens,
+            window,
+            app.snapshot.compact_threshold_tokens,
+            app.snapshot.reserved_output_tokens
+        ),
+        None => format!(
+            "{} (~auto @ {})",
+            app.snapshot.estimated_history_tokens,
+            app.snapshot.compact_threshold_tokens
+        ),
+    };
+    let last_compact = match (
+        app.snapshot.last_compaction_before_tokens,
+        app.snapshot.last_compaction_after_tokens,
+    ) {
+        (Some(before), Some(after)) => format!("{before} -> {after}"),
+        _ => "-".to_string(),
+    };
     format!(
-        "tokens={} in / {} out\ncache={}\nstate_db={}",
+        "tokens={} in / {} out\ncontext_estimate={}\ncompactions={} (last: {})\ncache={}\nstate_db={}",
         app.snapshot.total_input_tokens,
         app.snapshot.total_output_tokens,
+        context,
+        app.snapshot.compaction_count,
+        last_compact,
         cache,
         state_db,
     )
@@ -664,6 +696,13 @@ mod tests {
         let command = parse_local_command("/search agent loop").expect("search should parse");
         assert!(matches!(command.kind, LocalCommandKind::Search));
         assert_eq!(command.arg.as_deref(), Some("agent loop"));
+    }
+
+    #[test]
+    fn parses_compact_command() {
+        let command = parse_local_command("/compact").expect("compact should parse");
+        assert!(matches!(command.kind, LocalCommandKind::Compact));
+        assert_eq!(command.arg.as_deref(), None);
     }
 
     #[test]

--- a/src/tui/highlight.rs
+++ b/src/tui/highlight.rs
@@ -1,0 +1,164 @@
+use ratatui::{
+    style::{Color as RtColor, Modifier, Style},
+    text::{Line, Span},
+};
+use std::sync::{OnceLock, RwLock};
+use syntect::{
+    easy::HighlightLines,
+    highlighting::{
+        Color as SyntectColor, FontStyle, Style as SyntectStyle, Theme,
+    },
+    parsing::SyntaxReference,
+    util::LinesWithEndings,
+};
+use two_face::theme::EmbeddedThemeName;
+
+static SYNTAX_SET: OnceLock<syntect::parsing::SyntaxSet> = OnceLock::new();
+static THEME: OnceLock<RwLock<Theme>> = OnceLock::new();
+
+const ANSI_ALPHA_INDEX: u8 = 0x00;
+const ANSI_ALPHA_DEFAULT: u8 = 0x01;
+const OPAQUE_ALPHA: u8 = 0xFF;
+const MAX_HIGHLIGHT_BYTES: usize = 512 * 1024;
+const MAX_HIGHLIGHT_LINES: usize = 10_000;
+
+fn syntax_set() -> &'static syntect::parsing::SyntaxSet {
+    SYNTAX_SET.get_or_init(two_face::syntax::extra_newlines)
+}
+
+fn theme_lock() -> &'static RwLock<Theme> {
+    THEME.get_or_init(|| {
+        RwLock::new(
+            two_face::theme::extra()
+                .get(EmbeddedThemeName::CatppuccinMocha)
+                .clone(),
+        )
+    })
+}
+
+fn current_syntax_theme() -> Theme {
+    match theme_lock().read() {
+        Ok(theme) => theme.clone(),
+        Err(poisoned) => poisoned.into_inner().clone(),
+    }
+}
+
+#[allow(clippy::disallowed_methods)]
+fn ansi_palette_color(index: u8) -> RtColor {
+    match index {
+        0x00 => RtColor::Black,
+        0x01 => RtColor::Red,
+        0x02 => RtColor::Green,
+        0x03 => RtColor::Yellow,
+        0x04 => RtColor::Blue,
+        0x05 => RtColor::Magenta,
+        0x06 => RtColor::Cyan,
+        0x07 => RtColor::Gray,
+        n => RtColor::Indexed(n),
+    }
+}
+
+#[allow(clippy::disallowed_methods)]
+fn convert_syntect_color(color: SyntectColor) -> Option<RtColor> {
+    match color.a {
+        ANSI_ALPHA_INDEX => Some(ansi_palette_color(color.r)),
+        ANSI_ALPHA_DEFAULT => None,
+        OPAQUE_ALPHA => Some(RtColor::Rgb(color.r, color.g, color.b)),
+        _ => Some(RtColor::Rgb(color.r, color.g, color.b)),
+    }
+}
+
+fn convert_style(syn_style: SyntectStyle) -> Style {
+    let mut rt_style = Style::default();
+
+    if let Some(fg) = convert_syntect_color(syn_style.foreground) {
+        rt_style = rt_style.fg(fg);
+    }
+
+    if syn_style.font_style.contains(FontStyle::BOLD) {
+        rt_style.add_modifier |= Modifier::BOLD;
+    }
+
+    rt_style
+}
+
+fn find_syntax(lang: &str) -> Option<&'static SyntaxReference> {
+    let ss = syntax_set();
+
+    let patched = match lang {
+        "csharp" | "c-sharp" => "c#",
+        "golang" => "go",
+        "python3" => "python",
+        "shell" => "bash",
+        _ => lang,
+    };
+
+    if let Some(syntax) = ss.find_syntax_by_token(patched) {
+        return Some(syntax);
+    }
+    if let Some(syntax) = ss.find_syntax_by_name(patched) {
+        return Some(syntax);
+    }
+    let lower = patched.to_ascii_lowercase();
+    if let Some(syntax) = ss
+        .syntaxes()
+        .iter()
+        .find(|syntax| syntax.name.to_ascii_lowercase() == lower)
+    {
+        return Some(syntax);
+    }
+    ss.find_syntax_by_extension(lang)
+}
+
+fn highlight_to_line_spans_with_theme(
+    code: &str,
+    lang: &str,
+    theme: &Theme,
+) -> Option<Vec<Vec<Span<'static>>>> {
+    if code.is_empty() {
+        return None;
+    }
+    if code.len() > MAX_HIGHLIGHT_BYTES || code.lines().count() > MAX_HIGHLIGHT_LINES {
+        return None;
+    }
+
+    let syntax = find_syntax(lang)?;
+    let mut highlighter = HighlightLines::new(syntax, theme);
+    let mut lines = Vec::new();
+
+    for line in LinesWithEndings::from(code) {
+        let ranges = highlighter.highlight_line(line, syntax_set()).ok()?;
+        let mut spans = Vec::new();
+        for (style, text) in ranges {
+            let text = text.trim_end_matches(['\n', '\r']);
+            if text.is_empty() {
+                continue;
+            }
+            spans.push(Span::styled(text.to_string(), convert_style(style)));
+        }
+        if spans.is_empty() {
+            spans.push(Span::raw(String::new()));
+        }
+        lines.push(spans);
+    }
+
+    Some(lines)
+}
+
+fn highlight_to_line_spans(code: &str, lang: &str) -> Option<Vec<Vec<Span<'static>>>> {
+    let theme = current_syntax_theme();
+    highlight_to_line_spans_with_theme(code, lang, &theme)
+}
+
+pub(crate) fn highlight_code_to_lines(code: &str, lang: &str) -> Vec<Line<'static>> {
+    if let Some(line_spans) = highlight_to_line_spans(code, lang) {
+        line_spans.into_iter().map(Line::from).collect()
+    } else {
+        let mut result: Vec<Line<'static>> =
+            code.lines().map(|line| Line::from(line.to_string())).collect();
+        if result.is_empty() {
+            result.push(Line::from(String::new()));
+        }
+        result
+    }
+}

--- a/src/tui/line_utils.rs
+++ b/src/tui/line_utils.rs
@@ -1,0 +1,52 @@
+use ratatui::text::{Line, Span};
+
+pub fn line_to_static(line: &Line<'_>) -> Line<'static> {
+    Line {
+        style: line.style,
+        alignment: line.alignment,
+        spans: line
+            .spans
+            .iter()
+            .map(|span| Span {
+                style: span.style,
+                content: std::borrow::Cow::Owned(span.content.to_string()),
+            })
+            .collect(),
+    }
+}
+
+pub fn push_owned_lines(src: &[Line<'_>], out: &mut Vec<Line<'static>>) {
+    for line in src {
+        out.push(line_to_static(line));
+    }
+}
+
+pub fn prefix_lines(
+    lines: Vec<Line<'static>>,
+    initial_prefix: Span<'static>,
+    subsequent_prefix: Span<'static>,
+) -> Vec<Line<'static>> {
+    lines
+        .into_iter()
+        .enumerate()
+        .map(|(idx, line)| {
+            let mut spans = Vec::with_capacity(line.spans.len() + 1);
+            spans.push(if idx == 0 {
+                initial_prefix.clone()
+            } else {
+                subsequent_prefix.clone()
+            });
+            spans.extend(line.spans);
+            Line::from(spans).style(line.style)
+        })
+        .collect()
+}
+
+pub fn is_blank_line_spaces_only(line: &Line<'_>) -> bool {
+    if line.spans.is_empty() {
+        return true;
+    }
+    line.spans
+        .iter()
+        .all(|span| span.content.is_empty() || span.content.chars().all(|ch| ch == ' '))
+}

--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+
+use ratatui::text::Line;
+
+pub(crate) fn append_markdown(
+    markdown_source: &str,
+    width: Option<usize>,
+    cwd: Option<&Path>,
+    lines: &mut Vec<Line<'static>>,
+) {
+    let rendered =
+        crate::tui::markdown_render::render_markdown_text_with_width_and_cwd(markdown_source, width, cwd);
+    crate::tui::line_utils::push_owned_lines(&rendered.lines, lines);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lines_to_strings(lines: &[Line<'static>]) -> Vec<String> {
+        lines.iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.clone())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn append_markdown_preserves_plain_text_line() {
+        let mut out = Vec::new();
+        append_markdown(
+            "Hi! How can I help with rara today?\n",
+            None,
+            None,
+            &mut out,
+        );
+        assert_eq!(
+            lines_to_strings(&out),
+            vec!["Hi! How can I help with rara today?".to_string()]
+        );
+    }
+
+    #[test]
+    fn append_markdown_renders_ordered_list_item_on_one_line() {
+        let mut out = Vec::new();
+        append_markdown("1. Tight item\n", None, None, &mut out);
+        assert_eq!(lines_to_strings(&out), vec!["1. Tight item".to_string()]);
+    }
+}

--- a/src/tui/markdown_render.rs
+++ b/src/tui/markdown_render.rs
@@ -1,0 +1,824 @@
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use dirs::home_dir;
+use pulldown_cmark::{
+    CodeBlockKind, CowStr, Event, HeadingLevel, Options, Parser, Tag, TagEnd,
+};
+use ratatui::{
+    style::Style,
+    text::{Line, Span, Text},
+};
+use regex_lite::Regex;
+use url::Url;
+
+use crate::tui::highlight::highlight_code_to_lines;
+
+#[derive(Default)]
+struct MarkdownStyles {
+    h1: Style,
+    h2: Style,
+    h3: Style,
+    h4: Style,
+    h5: Style,
+    h6: Style,
+    code: Style,
+    emphasis: Style,
+    strong: Style,
+    strikethrough: Style,
+    ordered_list_marker: Style,
+    unordered_list_marker: Style,
+    link: Style,
+    blockquote: Style,
+}
+
+impl MarkdownStyles {
+    fn new() -> Self {
+        Self {
+            h1: Style::new().bold().underlined(),
+            h2: Style::new().bold(),
+            h3: Style::new().bold().italic(),
+            h4: Style::new().italic(),
+            h5: Style::new().italic(),
+            h6: Style::new().italic(),
+            code: Style::new().cyan(),
+            emphasis: Style::new().italic(),
+            strong: Style::new().bold(),
+            strikethrough: Style::new().crossed_out(),
+            ordered_list_marker: Style::new().light_blue(),
+            unordered_list_marker: Style::new(),
+            link: Style::new().cyan().underlined(),
+            blockquote: Style::new().green(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct IndentContext {
+    prefix: Vec<Span<'static>>,
+    marker: Option<Vec<Span<'static>>>,
+    is_list: bool,
+}
+
+impl IndentContext {
+    fn new(prefix: Vec<Span<'static>>, marker: Option<Vec<Span<'static>>>, is_list: bool) -> Self {
+        Self {
+            prefix,
+            marker,
+            is_list,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LinkState {
+    destination: String,
+    show_destination: bool,
+    local_target_display: Option<String>,
+}
+
+static COLON_LOCATION_SUFFIX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r":\d+(?::\d+)?(?:[-–]\d+(?::\d+)?)?$").expect("valid regex"));
+
+static HASH_LOCATION_SUFFIX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^L\d+(?:C\d+)?(?:-L\d+(?:C\d+)?)?$").expect("valid regex"));
+
+pub(crate) fn render_markdown_text(input: &str) -> Text<'static> {
+    render_markdown_text_with_width(input, None)
+}
+
+pub(crate) fn render_markdown_text_with_width(input: &str, width: Option<usize>) -> Text<'static> {
+    let cwd = std::env::current_dir().ok();
+    render_markdown_text_with_width_and_cwd(input, width, cwd.as_deref())
+}
+
+pub(crate) fn render_markdown_text_with_width_and_cwd(
+    input: &str,
+    _width: Option<usize>,
+    cwd: Option<&Path>,
+) -> Text<'static> {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    let parser = Parser::new_ext(input, options);
+    let mut writer = Writer::new(parser, cwd);
+    writer.run();
+    writer.text
+}
+
+struct Writer<'a, I>
+where
+    I: Iterator<Item = Event<'a>>,
+{
+    iter: I,
+    text: Text<'static>,
+    styles: MarkdownStyles,
+    inline_styles: Vec<Style>,
+    indent_stack: Vec<IndentContext>,
+    list_indices: Vec<Option<u64>>,
+    link: Option<LinkState>,
+    needs_newline: bool,
+    pending_marker_line: bool,
+    in_paragraph: bool,
+    in_code_block: bool,
+    code_block_lang: Option<String>,
+    code_block_buffer: String,
+    cwd: Option<PathBuf>,
+    line_ends_with_local_link_target: bool,
+    pending_local_link_soft_break: bool,
+    current_line_content: Option<Line<'static>>,
+    current_line_style: Style,
+}
+
+impl<'a, I> Writer<'a, I>
+where
+    I: Iterator<Item = Event<'a>>,
+{
+    fn new(iter: I, cwd: Option<&Path>) -> Self {
+        Self {
+            iter,
+            text: Text::default(),
+            styles: MarkdownStyles::new(),
+            inline_styles: Vec::new(),
+            indent_stack: Vec::new(),
+            list_indices: Vec::new(),
+            link: None,
+            needs_newline: false,
+            pending_marker_line: false,
+            in_paragraph: false,
+            in_code_block: false,
+            code_block_lang: None,
+            code_block_buffer: String::new(),
+            cwd: cwd.map(Path::to_path_buf),
+            line_ends_with_local_link_target: false,
+            pending_local_link_soft_break: false,
+            current_line_content: None,
+            current_line_style: Style::default(),
+        }
+    }
+
+    fn run(&mut self) {
+        while let Some(event) = self.iter.next() {
+            self.prepare_for_event(&event);
+            self.handle_event(event);
+        }
+        self.flush_current_line();
+    }
+
+    fn prepare_for_event(&mut self, event: &Event<'a>) {
+        if !self.pending_local_link_soft_break {
+            return;
+        }
+
+        if matches!(event, Event::Text(text) if text.trim_start().starts_with(':')) {
+            self.pending_local_link_soft_break = false;
+            return;
+        }
+
+        self.pending_local_link_soft_break = false;
+        self.push_line(Line::default());
+    }
+
+    fn handle_event(&mut self, event: Event<'a>) {
+        match event {
+            Event::Start(tag) => self.start_tag(tag),
+            Event::End(tag) => self.end_tag(tag),
+            Event::Text(text) => self.text(text),
+            Event::Code(code) => self.code(code),
+            Event::SoftBreak => self.soft_break(),
+            Event::HardBreak => self.hard_break(),
+            Event::Rule => {
+                self.flush_current_line();
+                if !self.text.lines.is_empty() {
+                    self.push_blank_line();
+                }
+                self.push_line(Line::from("———"));
+                self.needs_newline = true;
+            }
+            Event::Html(html) => self.html(html, false),
+            Event::InlineHtml(html) => self.html(html, true),
+            Event::FootnoteReference(_) | Event::TaskListMarker(_) => {}
+        }
+    }
+
+    fn start_tag(&mut self, tag: Tag<'a>) {
+        match tag {
+            Tag::Paragraph => self.start_paragraph(),
+            Tag::Heading { level, .. } => self.start_heading(level),
+            Tag::BlockQuote => self.start_blockquote(),
+            Tag::CodeBlock(kind) => {
+                let indent = match kind {
+                    CodeBlockKind::Fenced(_) => None,
+                    CodeBlockKind::Indented => Some(Span::from(" ".repeat(4))),
+                };
+                let lang = match kind {
+                    CodeBlockKind::Fenced(lang) => Some(lang.to_string()),
+                    CodeBlockKind::Indented => None,
+                };
+                self.start_codeblock(lang, indent);
+            }
+            Tag::List(start) => self.start_list(start),
+            Tag::Item => self.start_item(),
+            Tag::Emphasis => self.push_inline_style(self.styles.emphasis),
+            Tag::Strong => self.push_inline_style(self.styles.strong),
+            Tag::Strikethrough => self.push_inline_style(self.styles.strikethrough),
+            Tag::Link { dest_url, .. } => self.push_link(dest_url.to_string()),
+            Tag::HtmlBlock
+            | Tag::FootnoteDefinition(_)
+            | Tag::Table(_)
+            | Tag::TableHead
+            | Tag::TableRow
+            | Tag::TableCell
+            | Tag::Image { .. }
+            | Tag::MetadataBlock(_) => {}
+        }
+    }
+
+    fn end_tag(&mut self, tag: TagEnd) {
+        match tag {
+            TagEnd::Paragraph => self.end_paragraph(),
+            TagEnd::Heading(_) => self.end_heading(),
+            TagEnd::BlockQuote => self.end_blockquote(),
+            TagEnd::CodeBlock => self.end_codeblock(),
+            TagEnd::List(_) => self.end_list(),
+            TagEnd::Item => {
+                self.indent_stack.pop();
+                self.pending_marker_line = false;
+            }
+            TagEnd::Emphasis | TagEnd::Strong | TagEnd::Strikethrough => self.pop_inline_style(),
+            TagEnd::Link => self.pop_link(),
+            TagEnd::HtmlBlock
+            | TagEnd::FootnoteDefinition
+            | TagEnd::Table
+            | TagEnd::TableHead
+            | TagEnd::TableRow
+            | TagEnd::TableCell
+            | TagEnd::Image
+            | TagEnd::MetadataBlock(_) => {}
+        }
+    }
+
+    fn start_paragraph(&mut self) {
+        if self.needs_newline {
+            self.push_blank_line();
+        }
+        self.push_line(Line::default());
+        self.needs_newline = false;
+        self.in_paragraph = true;
+    }
+
+    fn end_paragraph(&mut self) {
+        self.needs_newline = true;
+        self.in_paragraph = false;
+        self.pending_marker_line = false;
+    }
+
+    fn start_heading(&mut self, level: HeadingLevel) {
+        if self.needs_newline {
+            self.push_line(Line::default());
+            self.needs_newline = false;
+        }
+        let heading_style = match level {
+            HeadingLevel::H1 => self.styles.h1,
+            HeadingLevel::H2 => self.styles.h2,
+            HeadingLevel::H3 => self.styles.h3,
+            HeadingLevel::H4 => self.styles.h4,
+            HeadingLevel::H5 => self.styles.h5,
+            HeadingLevel::H6 => self.styles.h6,
+        };
+        let content = format!("{} ", "#".repeat(level as usize));
+        self.push_line(Line::from(vec![Span::styled(content, heading_style)]));
+        self.push_inline_style(heading_style);
+        self.needs_newline = false;
+    }
+
+    fn end_heading(&mut self) {
+        self.needs_newline = true;
+        self.pop_inline_style();
+    }
+
+    fn start_blockquote(&mut self) {
+        if self.needs_newline {
+            self.push_blank_line();
+            self.needs_newline = false;
+        }
+        self.indent_stack.push(IndentContext::new(
+            vec![Span::from("> ")],
+            None,
+            false,
+        ));
+    }
+
+    fn end_blockquote(&mut self) {
+        self.indent_stack.pop();
+        self.needs_newline = true;
+    }
+
+    fn text(&mut self, text: CowStr<'a>) {
+        if self.suppressing_local_link_label() {
+            return;
+        }
+        self.line_ends_with_local_link_target = false;
+        if self.pending_marker_line {
+            self.push_line(Line::default());
+        }
+        self.pending_marker_line = false;
+
+        if self.in_code_block && self.code_block_lang.is_some() {
+            self.code_block_buffer.push_str(&text);
+            return;
+        }
+
+        if self.in_code_block && !self.needs_newline {
+            let has_content = self
+                .current_line_content
+                .as_ref()
+                .map(|line| !line.spans.is_empty())
+                .unwrap_or(false);
+            if has_content {
+                self.push_line(Line::default());
+            }
+        }
+
+        for (idx, line) in text.lines().enumerate() {
+            if self.needs_newline {
+                self.push_line(Line::default());
+                self.needs_newline = false;
+            }
+            if idx > 0 {
+                self.push_line(Line::default());
+            }
+            let span = Span::styled(
+                line.to_string(),
+                self.inline_styles.last().copied().unwrap_or_default(),
+            );
+            self.push_span(span);
+        }
+        self.needs_newline = false;
+    }
+
+    fn code(&mut self, code: CowStr<'a>) {
+        if self.suppressing_local_link_label() {
+            return;
+        }
+        self.line_ends_with_local_link_target = false;
+        if self.pending_marker_line {
+            self.push_line(Line::default());
+            self.pending_marker_line = false;
+        }
+        let span = Span::styled(code.into_string(), self.styles.code);
+        self.push_span(span);
+    }
+
+    fn html(&mut self, html: CowStr<'a>, inline: bool) {
+        if self.suppressing_local_link_label() {
+            return;
+        }
+        self.line_ends_with_local_link_target = false;
+        self.pending_marker_line = false;
+        for (idx, line) in html.lines().enumerate() {
+            if self.needs_newline {
+                self.push_line(Line::default());
+                self.needs_newline = false;
+            }
+            if idx > 0 {
+                self.push_line(Line::default());
+            }
+            let style = self.inline_styles.last().copied().unwrap_or_default();
+            self.push_span(Span::styled(line.to_string(), style));
+        }
+        self.needs_newline = !inline;
+    }
+
+    fn hard_break(&mut self) {
+        if self.suppressing_local_link_label() {
+            return;
+        }
+        self.line_ends_with_local_link_target = false;
+        self.push_line(Line::default());
+    }
+
+    fn soft_break(&mut self) {
+        if self.suppressing_local_link_label() {
+            return;
+        }
+        if self.line_ends_with_local_link_target {
+            self.pending_local_link_soft_break = true;
+            self.line_ends_with_local_link_target = false;
+            return;
+        }
+        self.line_ends_with_local_link_target = false;
+        self.push_line(Line::default());
+    }
+
+    fn start_list(&mut self, index: Option<u64>) {
+        if self.list_indices.is_empty() && self.needs_newline {
+            self.push_line(Line::default());
+        }
+        self.list_indices.push(index);
+    }
+
+    fn end_list(&mut self) {
+        self.list_indices.pop();
+        self.needs_newline = true;
+    }
+
+    fn start_item(&mut self) {
+        self.pending_marker_line = true;
+        let depth = self.list_indices.len();
+        let is_ordered = self
+            .list_indices
+            .last()
+            .map(Option::is_some)
+            .unwrap_or(false);
+        let width = depth * 4 - 3;
+        let marker = if let Some(last_index) = self.list_indices.last_mut() {
+            match last_index {
+                None => Some(vec![Span::styled(
+                    " ".repeat(width - 1) + "- ",
+                    self.styles.unordered_list_marker,
+                )]),
+                Some(index) => {
+                    *index += 1;
+                    Some(vec![Span::styled(
+                        format!("{:width$}. ", *index - 1),
+                        self.styles.ordered_list_marker,
+                    )])
+                }
+            }
+        } else {
+            None
+        };
+        let indent_prefix = if depth == 0 {
+            Vec::new()
+        } else {
+            let indent_len = if is_ordered { width + 2 } else { width + 1 };
+            vec![Span::from(" ".repeat(indent_len))]
+        };
+        self.indent_stack
+            .push(IndentContext::new(indent_prefix, marker, true));
+        self.needs_newline = false;
+    }
+
+    fn start_codeblock(&mut self, lang: Option<String>, indent: Option<Span<'static>>) {
+        self.flush_current_line();
+        if !self.text.lines.is_empty() {
+            self.push_blank_line();
+        }
+        self.in_code_block = true;
+        self.code_block_lang = lang
+            .as_deref()
+            .and_then(|value| value.split([',', ' ', '\t']).next())
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string);
+        self.code_block_buffer.clear();
+        self.indent_stack.push(IndentContext::new(
+            vec![indent.unwrap_or_default()],
+            None,
+            false,
+        ));
+        self.needs_newline = true;
+    }
+
+    fn end_codeblock(&mut self) {
+        if let Some(lang) = self.code_block_lang.take() {
+            let code = std::mem::take(&mut self.code_block_buffer);
+            if !code.is_empty() {
+                let highlighted = highlight_code_to_lines(&code, &lang);
+                for line in highlighted {
+                    self.push_line(Line::default());
+                    for span in line.spans {
+                        self.push_span(span);
+                    }
+                }
+            }
+        }
+
+        self.needs_newline = true;
+        self.in_code_block = false;
+        self.indent_stack.pop();
+    }
+
+    fn push_inline_style(&mut self, style: Style) {
+        let current = self.inline_styles.last().copied().unwrap_or_default();
+        self.inline_styles.push(current.patch(style));
+    }
+
+    fn pop_inline_style(&mut self) {
+        self.inline_styles.pop();
+    }
+
+    fn push_link(&mut self, dest_url: String) {
+        let show_destination = should_render_link_destination(&dest_url);
+        self.link = Some(LinkState {
+            show_destination,
+            local_target_display: if is_local_path_like_link(&dest_url) {
+                render_local_link_target(&dest_url, self.cwd.as_deref())
+            } else {
+                None
+            },
+            destination: dest_url,
+        });
+    }
+
+    fn pop_link(&mut self) {
+        if let Some(link) = self.link.take() {
+            if link.show_destination {
+                self.push_span(" (".into());
+                self.push_span(Span::styled(link.destination, self.styles.link));
+                self.push_span(")".into());
+            } else if let Some(local_target_display) = link.local_target_display {
+                if self.pending_marker_line {
+                    self.push_line(Line::default());
+                }
+                let style = self
+                    .inline_styles
+                    .last()
+                    .copied()
+                    .unwrap_or_default()
+                    .patch(self.styles.code);
+                self.push_span(Span::styled(local_target_display, style));
+                self.line_ends_with_local_link_target = true;
+            }
+        }
+    }
+
+    fn suppressing_local_link_label(&self) -> bool {
+        self.link
+            .as_ref()
+            .and_then(|link| link.local_target_display.as_ref())
+            .is_some()
+    }
+
+    fn flush_current_line(&mut self) {
+        if let Some(line) = self.current_line_content.take() {
+            let style = self.current_line_style;
+            let mut spans = self.prefix_spans(false);
+            let mut line = line;
+            spans.append(&mut line.spans);
+            self.text.lines.push(Line::from_iter(spans).style(style));
+            self.line_ends_with_local_link_target = false;
+        }
+    }
+
+    fn push_line(&mut self, line: Line<'static>) {
+        self.flush_current_line();
+        let blockquote_active = self
+            .indent_stack
+            .iter()
+            .any(|ctx| ctx.prefix.iter().any(|span| span.content.contains('>')));
+        self.current_line_style = if blockquote_active {
+            self.styles.blockquote
+        } else {
+            line.style
+        };
+        self.current_line_content = Some(line);
+        self.pending_marker_line = false;
+        self.line_ends_with_local_link_target = false;
+    }
+
+    fn push_span(&mut self, span: Span<'static>) {
+        if let Some(line) = self.current_line_content.as_mut() {
+            line.push_span(span);
+        } else {
+            self.push_line(Line::from(vec![span]));
+        }
+    }
+
+    fn push_blank_line(&mut self) {
+        self.flush_current_line();
+        if self.indent_stack.iter().all(|ctx| ctx.is_list) {
+            self.text.lines.push(Line::default());
+        } else {
+            self.push_line(Line::default());
+            self.flush_current_line();
+        }
+    }
+
+    fn prefix_spans(&self, pending_marker_line: bool) -> Vec<Span<'static>> {
+        let mut prefix = Vec::new();
+        let last_marker_index = if pending_marker_line {
+            self.indent_stack
+                .iter()
+                .enumerate()
+                .rev()
+                .find_map(|(idx, ctx)| ctx.marker.as_ref().map(|_| idx))
+        } else {
+            None
+        };
+        let last_list_index = self.indent_stack.iter().rposition(|ctx| ctx.is_list);
+
+        for (idx, ctx) in self.indent_stack.iter().enumerate() {
+            if pending_marker_line {
+                if Some(idx) == last_marker_index {
+                    if let Some(marker) = &ctx.marker {
+                        prefix.extend(marker.iter().cloned());
+                    }
+                    continue;
+                }
+                if ctx.is_list && last_marker_index.is_some_and(|marker_idx| marker_idx > idx) {
+                    continue;
+                }
+            } else if ctx.is_list && Some(idx) != last_list_index {
+                continue;
+            }
+            prefix.extend(ctx.prefix.iter().cloned());
+        }
+
+        prefix
+    }
+}
+
+fn should_render_link_destination(dest_url: &str) -> bool {
+    !is_local_path_like_link(dest_url)
+}
+
+fn is_local_path_like_link(dest_url: &str) -> bool {
+    dest_url.starts_with("file://")
+        || dest_url.starts_with('/')
+        || dest_url.starts_with("~/")
+        || dest_url.starts_with("./")
+        || dest_url.starts_with("../")
+        || dest_url.starts_with("\\\\")
+        || matches!(
+            dest_url.as_bytes(),
+            [drive, b':', separator, ..]
+                if drive.is_ascii_alphabetic() && matches!(separator, b'/' | b'\\')
+        )
+}
+
+fn render_local_link_target(dest_url: &str, cwd: Option<&Path>) -> Option<String> {
+    let (path_text, location_suffix) = parse_local_link_target(dest_url)?;
+    let mut rendered = display_local_link_path(&path_text, cwd);
+    if let Some(location_suffix) = location_suffix {
+        rendered.push_str(&location_suffix);
+    }
+    Some(rendered)
+}
+
+fn parse_local_link_target(dest_url: &str) -> Option<(String, Option<String>)> {
+    if dest_url.starts_with("file://") {
+        let url = Url::parse(dest_url).ok()?;
+        let path_text = file_url_to_local_path_text(&url)?;
+        let location_suffix = url
+            .fragment()
+            .and_then(normalize_hash_location_suffix_fragment);
+        return Some((path_text, location_suffix));
+    }
+
+    let mut path_text = dest_url;
+    let mut location_suffix = None;
+    if let Some((candidate_path, fragment)) = dest_url.rsplit_once('#') {
+        if let Some(normalized) = normalize_hash_location_suffix_fragment(fragment) {
+            path_text = candidate_path;
+            location_suffix = Some(normalized);
+        }
+    }
+    if location_suffix.is_none() {
+        if let Some(suffix) = extract_colon_location_suffix(path_text) {
+            let path_len = path_text.len().saturating_sub(suffix.len());
+            path_text = &path_text[..path_len];
+            location_suffix = Some(suffix);
+        }
+    }
+
+    let decoded_path_text =
+        urlencoding::decode(path_text).unwrap_or(std::borrow::Cow::Borrowed(path_text));
+    Some((expand_local_link_path(&decoded_path_text), location_suffix))
+}
+
+fn normalize_hash_location_suffix_fragment(fragment: &str) -> Option<String> {
+    HASH_LOCATION_SUFFIX_RE
+        .is_match(fragment)
+        .then(|| format!("#{fragment}"))
+        .and_then(|suffix| normalize_markdown_hash_location_suffix(&suffix))
+}
+
+fn normalize_markdown_hash_location_suffix(suffix: &str) -> Option<String> {
+    let fragment = suffix.strip_prefix('#')?;
+    let (start, end) = match fragment.split_once('-') {
+        Some((start, end)) => (start, Some(end)),
+        None => (fragment, None),
+    };
+    let (start_line, start_column) = parse_markdown_hash_location_point(start)?;
+    let mut normalized = format!(":{start_line}");
+    if let Some(column) = start_column {
+        normalized.push(':');
+        normalized.push_str(column);
+    }
+    if let Some(end) = end {
+        let (end_line, end_column) = parse_markdown_hash_location_point(end)?;
+        normalized.push('-');
+        normalized.push_str(end_line);
+        if let Some(column) = end_column {
+            normalized.push(':');
+            normalized.push_str(column);
+        }
+    }
+    Some(normalized)
+}
+
+fn parse_markdown_hash_location_point(point: &str) -> Option<(&str, Option<&str>)> {
+    let point = point.strip_prefix('L')?;
+    match point.split_once('C') {
+        Some((line, column)) => Some((line, Some(column))),
+        None => Some((point, None)),
+    }
+}
+
+fn extract_colon_location_suffix(path_text: &str) -> Option<String> {
+    COLON_LOCATION_SUFFIX_RE
+        .find(path_text)
+        .filter(|matched| matched.end() == path_text.len())
+        .map(|matched| matched.as_str().to_string())
+}
+
+fn expand_local_link_path(path_text: &str) -> String {
+    if let Some(rest) = path_text.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return normalize_local_link_path_text(&home.join(rest).to_string_lossy());
+        }
+    }
+
+    normalize_local_link_path_text(path_text)
+}
+
+fn file_url_to_local_path_text(url: &Url) -> Option<String> {
+    if let Ok(path) = url.to_file_path() {
+        return Some(normalize_local_link_path_text(&path.to_string_lossy()));
+    }
+
+    let mut path_text = url.path().to_string();
+    if let Some(host) = url.host_str() {
+        if !host.is_empty() && host != "localhost" {
+            path_text = format!("//{host}{path_text}");
+        } else if matches!(
+            path_text.as_bytes(),
+            [b'/', drive, b':', b'/', ..] if drive.is_ascii_alphabetic()
+        ) {
+            path_text.remove(0);
+        }
+    } else if matches!(
+        path_text.as_bytes(),
+        [b'/', drive, b':', b'/', ..] if drive.is_ascii_alphabetic()
+    ) {
+        path_text.remove(0);
+    }
+
+    Some(normalize_local_link_path_text(&path_text))
+}
+
+fn normalize_local_link_path_text(path_text: &str) -> String {
+    if let Some(rest) = path_text.strip_prefix("\\\\") {
+        format!("//{}", rest.replace('\\', "/").trim_start_matches('/'))
+    } else {
+        path_text.replace('\\', "/")
+    }
+}
+
+fn is_absolute_local_link_path(path_text: &str) -> bool {
+    path_text.starts_with('/')
+        || path_text.starts_with("//")
+        || matches!(
+            path_text.as_bytes(),
+            [drive, b':', b'/', ..] if drive.is_ascii_alphabetic()
+        )
+}
+
+fn trim_trailing_local_path_separator(path_text: &str) -> &str {
+    if path_text == "/" || path_text == "//" {
+        return path_text;
+    }
+    if matches!(path_text.as_bytes(), [drive, b':', b'/'] if drive.is_ascii_alphabetic()) {
+        return path_text;
+    }
+    path_text.trim_end_matches('/')
+}
+
+fn strip_local_path_prefix<'a>(path_text: &'a str, cwd_text: &str) -> Option<&'a str> {
+    let path_text = trim_trailing_local_path_separator(path_text);
+    let cwd_text = trim_trailing_local_path_separator(cwd_text);
+    if path_text == cwd_text {
+        return None;
+    }
+    if cwd_text == "/" || cwd_text == "//" {
+        return path_text.strip_prefix('/');
+    }
+
+    path_text
+        .strip_prefix(cwd_text)
+        .and_then(|rest| rest.strip_prefix('/'))
+}
+
+fn display_local_link_path(path_text: &str, cwd: Option<&Path>) -> String {
+    let path_text = normalize_local_link_path_text(path_text);
+    if !is_absolute_local_link_path(&path_text) {
+        return path_text;
+    }
+    if let Some(cwd) = cwd {
+        let cwd_text = normalize_local_link_path_text(&cwd.to_string_lossy());
+        if let Some(stripped) = strip_local_path_prefix(&path_text, &cwd_text) {
+            return stripped.to_string();
+        }
+    }
+    path_text
+}

--- a/src/tui/markdown_render.rs
+++ b/src/tui/markdown_render.rs
@@ -126,7 +126,10 @@ where
     line_ends_with_local_link_target: bool,
     pending_local_link_soft_break: bool,
     current_line_content: Option<Line<'static>>,
+    current_initial_indent: Vec<Span<'static>>,
+    current_subsequent_indent: Vec<Span<'static>>,
     current_line_style: Style,
+    current_line_in_code_block: bool,
 }
 
 impl<'a, I> Writer<'a, I>
@@ -152,7 +155,10 @@ where
             line_ends_with_local_link_target: false,
             pending_local_link_soft_break: false,
             current_line_content: None,
+            current_initial_indent: Vec::new(),
+            current_subsequent_indent: Vec::new(),
             current_line_style: Style::default(),
+            current_line_in_code_block: false,
         }
     }
 
@@ -552,10 +558,13 @@ where
     fn flush_current_line(&mut self) {
         if let Some(line) = self.current_line_content.take() {
             let style = self.current_line_style;
-            let mut spans = self.prefix_spans(false);
+            let mut spans = self.current_initial_indent.clone();
             let mut line = line;
             spans.append(&mut line.spans);
             self.text.lines.push(Line::from_iter(spans).style(style));
+            self.current_initial_indent.clear();
+            self.current_subsequent_indent.clear();
+            self.current_line_in_code_block = false;
             self.line_ends_with_local_link_target = false;
         }
     }
@@ -571,7 +580,11 @@ where
         } else {
             line.style
         };
+        let was_pending = self.pending_marker_line;
+        self.current_initial_indent = self.prefix_spans(was_pending);
+        self.current_subsequent_indent = self.prefix_spans(false);
         self.current_line_content = Some(line);
+        self.current_line_in_code_block = self.in_code_block;
         self.pending_marker_line = false;
         self.line_ends_with_local_link_target = false;
     }

--- a/src/tui/markdown_stream.rs
+++ b/src/tui/markdown_stream.rs
@@ -1,0 +1,95 @@
+use std::path::{Path, PathBuf};
+
+use ratatui::text::Line;
+
+use crate::tui::{line_utils::is_blank_line_spaces_only, markdown};
+
+pub(crate) struct MarkdownStreamCollector {
+    buffer: String,
+    committed_line_count: usize,
+    width: Option<usize>,
+    cwd: PathBuf,
+}
+
+impl MarkdownStreamCollector {
+    pub fn new(width: Option<usize>, cwd: &Path) -> Self {
+        Self {
+            buffer: String::new(),
+            committed_line_count: 0,
+            width,
+            cwd: cwd.to_path_buf(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.buffer.clear();
+        self.committed_line_count = 0;
+    }
+
+    pub fn push_delta(&mut self, delta: &str) {
+        self.buffer.push_str(delta);
+    }
+
+    pub fn commit_complete_lines(&mut self) -> Vec<Line<'static>> {
+        let source = self.buffer.clone();
+        let Some(last_newline_idx) = source.rfind('\n') else {
+            return Vec::new();
+        };
+        let source = source[..=last_newline_idx].to_string();
+        let mut rendered = Vec::new();
+        markdown::append_markdown(&source, self.width, Some(self.cwd.as_path()), &mut rendered);
+        let mut complete_line_count = rendered.len();
+        if complete_line_count > 0 && is_blank_line_spaces_only(&rendered[complete_line_count - 1]) {
+            complete_line_count -= 1;
+        }
+
+        if self.committed_line_count >= complete_line_count {
+            return Vec::new();
+        }
+
+        let out = rendered[self.committed_line_count..complete_line_count].to_vec();
+        self.committed_line_count = complete_line_count;
+        out
+    }
+
+    pub fn finalize_and_drain(&mut self) -> Vec<Line<'static>> {
+        let mut source = self.buffer.clone();
+        if !source.ends_with('\n') {
+            source.push('\n');
+        }
+        let mut rendered = Vec::new();
+        markdown::append_markdown(&source, self.width, Some(self.cwd.as_path()), &mut rendered);
+        let out = if self.committed_line_count >= rendered.len() {
+            Vec::new()
+        } else {
+            rendered[self.committed_line_count..].to_vec()
+        };
+        self.clear();
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_cwd() -> PathBuf {
+        std::env::temp_dir()
+    }
+
+    #[test]
+    fn no_commit_until_newline() {
+        let mut collector = MarkdownStreamCollector::new(None, &test_cwd());
+        collector.push_delta("Hello");
+        assert!(collector.commit_complete_lines().is_empty());
+        collector.push_delta("\n");
+        assert_eq!(collector.commit_complete_lines().len(), 1);
+    }
+
+    #[test]
+    fn finalize_commits_partial_line() {
+        let mut collector = MarkdownStreamCollector::new(None, &test_cwd());
+        collector.push_delta("Partial");
+        assert_eq!(collector.finalize_and_drain().len(), 1);
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -577,7 +577,8 @@ fn flush_committed_history(
         let width = terminal_size()?.0;
         let lines = startup_card_lines(app, width);
         if !lines.is_empty() {
-            terminal.insert_before(lines.len() as u16, |buf| {
+            let line_count = wrapped_history_line_count(lines.as_slice(), width);
+            terminal.insert_before(line_count, |buf| {
                 Paragraph::new(lines)
                     .wrap(ratatui::widgets::Wrap { trim: false })
                     .render(buf.area, buf);
@@ -592,7 +593,8 @@ fn flush_committed_history(
             lines.insert(0, ratatui::text::Line::from(""));
         }
         if !lines.is_empty() {
-            let line_count = lines.len() as u16;
+            let width = terminal_size()?.0;
+            let line_count = wrapped_history_line_count(lines.as_slice(), width);
             terminal.insert_before(line_count, |buf| {
                 Paragraph::new(lines)
                     .wrap(ratatui::widgets::Wrap { trim: false })
@@ -602,6 +604,15 @@ fn flush_committed_history(
         app.inserted_turns += 1;
     }
     Ok(())
+}
+
+fn wrapped_history_line_count(lines: &[Line<'static>], width: u16) -> u16 {
+    let wrap_width = usize::from(width.max(1));
+    lines
+        .iter()
+        .map(|line| line.width().max(1).div_ceil(wrap_width))
+        .sum::<usize>()
+        .max(1) as u16
 }
 
 fn startup_card_lines(app: &TuiApp, width: u16) -> Vec<Line<'static>> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -75,8 +75,15 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
         let size = terminal_size()?;
         let desired_height = desired_viewport_height(&app, size.0, size.1);
         if desired_height != viewport_height {
-            viewport_height = desired_height;
-            terminal = build_terminal(viewport_height)?;
+            match build_terminal(desired_height) {
+                Ok(new_terminal) => {
+                    viewport_height = desired_height;
+                    terminal = new_terminal;
+                }
+                Err(err) => {
+                    app.push_notice(format!("Skipped viewport rebuild: {err}"));
+                }
+            }
         }
         flush_committed_history(&mut terminal, &mut app)?;
         terminal.draw(|f| render(f, &app))?;
@@ -93,8 +100,16 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
                         }
                         Some(UiEvent::Draw) => {
                             let size = terminal_size()?;
-                            viewport_height = desired_viewport_height(&app, size.0, size.1);
-                            terminal = build_terminal(viewport_height)?;
+                            let desired_height = desired_viewport_height(&app, size.0, size.1);
+                            match build_terminal(desired_height) {
+                                Ok(new_terminal) => {
+                                    viewport_height = desired_height;
+                                    terminal = new_terminal;
+                                }
+                                Err(err) => {
+                                    app.push_notice(format!("Skipped terminal redraw rebuild: {err}"));
+                                }
+                            }
                         }
                         Some(UiEvent::Paste(text)) => {
                             handle_paste(text, &mut app);
@@ -135,13 +150,21 @@ fn handle_paste(text: String, app: &mut TuiApp) {
 }
 
 fn build_terminal(viewport_height: u16) -> anyhow::Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
-    let terminal = Terminal::with_options(
+    match Terminal::with_options(
         CrosstermBackend::new(io::stdout()),
         TerminalOptions {
             viewport: Viewport::Inline(viewport_height.max(1)),
         },
-    )?;
-    Ok(terminal)
+    ) {
+        Ok(terminal) => Ok(terminal),
+        Err(inline_err) => {
+            let terminal = Terminal::new(CrosstermBackend::new(io::stdout()))
+                .map_err(|fallback_err| anyhow::anyhow!(
+                    "failed to build inline terminal: {inline_err}; fullscreen fallback also failed: {fallback_err}"
+                ))?;
+            Ok(terminal)
+        }
+    }
 }
 
 fn map_key_to_event(key: KeyCode, app: &TuiApp) -> AppEvent {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -18,6 +18,7 @@ use crossterm::{
 use futures::StreamExt;
 use ratatui::{
     backend::CrosstermBackend,
+    text::{Line, Span},
     widgets::{Paragraph, Widget},
     Terminal, TerminalOptions, Viewport,
 };
@@ -110,6 +111,11 @@ fn handle_paste(text: String, app: &mut TuiApp) {
         return;
     }
 
+    if matches!(app.overlay, Some(Overlay::ApiKeyEditor)) {
+        app.api_key_input.push_str(&text);
+        return;
+    }
+
     app.input.push_str(&text);
     if app.input.trim_start().starts_with('/') {
         app.open_overlay(Overlay::CommandPalette);
@@ -194,9 +200,23 @@ fn map_key_to_event(key: KeyCode, app: &TuiApp) -> AppEvent {
             KeyCode::Enter => AppEvent::ApplyOverlaySelection,
             _ => AppEvent::Noop,
         },
+        Some(Overlay::CodexAuthGuide) => match key {
+            KeyCode::Esc => AppEvent::CloseOverlay,
+            KeyCode::Char('1') | KeyCode::Char('o') => AppEvent::StartOAuth,
+            KeyCode::Char('2') | KeyCode::Char('a') => AppEvent::OpenOverlay(Overlay::ApiKeyEditor),
+            KeyCode::Enter => AppEvent::StartOAuth,
+            _ => AppEvent::Noop,
+        },
         Some(Overlay::BaseUrlEditor) => match key {
             KeyCode::Esc => AppEvent::CloseOverlay,
             KeyCode::Enter => AppEvent::SaveBaseUrlInput,
+            KeyCode::Backspace => AppEvent::Backspace,
+            KeyCode::Char(c) => AppEvent::InputChar(c),
+            _ => AppEvent::Noop,
+        },
+        Some(Overlay::ApiKeyEditor) => match key {
+            KeyCode::Esc => AppEvent::CloseOverlay,
+            KeyCode::Enter => AppEvent::SaveApiKeyInput,
             KeyCode::Backspace => AppEvent::Backspace,
             KeyCode::Char(c) => AppEvent::InputChar(c),
             _ => AppEvent::Noop,
@@ -243,6 +263,8 @@ async fn dispatch_event(
         AppEvent::InputChar(c) => {
             if matches!(app.overlay, Some(Overlay::BaseUrlEditor)) {
                 app.base_url_input.push(c);
+            } else if matches!(app.overlay, Some(Overlay::ApiKeyEditor)) {
+                app.api_key_input.push(c);
             } else {
                 app.input.push(c);
                 if app.input.trim_start().starts_with('/') {
@@ -255,6 +277,8 @@ async fn dispatch_event(
         AppEvent::Backspace => {
             if matches!(app.overlay, Some(Overlay::BaseUrlEditor)) {
                 app.base_url_input.pop();
+            } else if matches!(app.overlay, Some(Overlay::ApiKeyEditor)) {
+                app.api_key_input.pop();
             } else {
                 app.input.pop();
             }
@@ -301,8 +325,13 @@ async fn dispatch_event(
             if matches!(app.overlay, Some(Overlay::Setup)) {
                 app.select_local_model(app.model_picker_idx);
             } else if matches!(app.overlay, Some(Overlay::ModelPicker)) && !app.is_busy() {
-                app.select_local_model(app.model_picker_idx);
-                start_rebuild_task(app);
+                if should_open_codex_auth_guide(app) {
+                    app.select_local_model(app.model_picker_idx);
+                    app.open_overlay(Overlay::CodexAuthGuide);
+                } else {
+                    app.select_local_model(app.model_picker_idx);
+                    start_rebuild_task(app);
+                }
             }
         }
         AppEvent::SelectPendingOption(idx) => {
@@ -345,12 +374,32 @@ async fn dispatch_event(
             ));
             app.close_overlay();
         }
+        AppEvent::SaveApiKeyInput => {
+            let value = app.api_key_input.trim();
+            if value.is_empty() {
+                app.push_notice("Enter a Codex API key or press Esc to go back.");
+            } else if app.is_busy() {
+                app.push_notice("Wait for the current task before saving the API key.");
+            } else {
+                app.config.api_key = Some(value.to_string());
+                app.config.provider = "codex".into();
+                if app.config.model.is_none() {
+                    app.config.model = Some("codex".into());
+                }
+                app.config_manager.save(&app.config)?;
+                app.notice = Some("Saved Codex API key. Rebuilding backend.".into());
+                app.overlay = None;
+                start_rebuild_task(app);
+            }
+        }
         AppEvent::SelectHelpTab(tab) => {
             app.open_overlay(Overlay::Help(tab));
         }
         AppEvent::StartOAuth => {
             if app.is_busy() {
                 app.push_notice("Wait for the current task before starting login.");
+            } else if is_ssh_session() {
+                app.push_notice("OAuth browser login is unavailable in SSH/headless sessions. Use Codex API key instead.");
             } else {
                 start_oauth_task(app, Arc::clone(oauth_manager));
             }
@@ -404,7 +453,11 @@ async fn dispatch_event(
                     app.push_notice("A task is already running. Wait for it to finish.");
                 } else {
                     app.select_local_model(app.model_picker_idx);
-                    start_rebuild_task(app);
+                    if should_open_codex_auth_guide(app) {
+                        app.open_overlay(Overlay::CodexAuthGuide);
+                    } else {
+                        start_rebuild_task(app);
+                    }
                 }
             }
             Some(Overlay::Setup) => {
@@ -412,6 +465,15 @@ async fn dispatch_event(
                     app.push_notice("A task is already running. Wait for it to finish.");
                 } else {
                     start_rebuild_task(app);
+                }
+            }
+            Some(Overlay::CodexAuthGuide) => {
+                if app.is_busy() {
+                    app.push_notice("A task is already running. Wait for it to finish.");
+                } else if is_ssh_session() {
+                    app.push_notice("OAuth browser login is unavailable in SSH/headless sessions. Use Codex API key instead.");
+                } else {
+                    start_oauth_task(app, Arc::clone(oauth_manager));
                 }
             }
             _ => {}
@@ -481,10 +543,13 @@ fn flush_committed_history(
     app: &mut TuiApp,
 ) -> anyhow::Result<()> {
     if !app.startup_card_inserted {
-        let lines = startup_card_lines(app);
+        let width = terminal_size()?.0;
+        let lines = startup_card_lines(app, width);
         if !lines.is_empty() {
             terminal.insert_before(lines.len() as u16, |buf| {
-                Paragraph::new(lines).render(buf.area, buf);
+                Paragraph::new(lines)
+                    .wrap(ratatui::widgets::Wrap { trim: false })
+                    .render(buf.area, buf);
             })?;
         }
         app.startup_card_inserted = true;
@@ -498,7 +563,9 @@ fn flush_committed_history(
         if !lines.is_empty() {
             let line_count = lines.len() as u16;
             terminal.insert_before(line_count, |buf| {
-                Paragraph::new(lines).render(buf.area, buf);
+                Paragraph::new(lines)
+                    .wrap(ratatui::widgets::Wrap { trim: false })
+                    .render(buf.area, buf);
             })?;
         }
         app.inserted_turns += 1;
@@ -506,22 +573,51 @@ fn flush_committed_history(
     Ok(())
 }
 
-fn startup_card_lines(app: &TuiApp) -> Vec<ratatui::text::Line<'static>> {
-    vec![
-        ratatui::text::Line::from("╭──────────────────────────────────────────────╮"),
-        ratatui::text::Line::from("│ >_ RARA                                      │"),
-        ratatui::text::Line::from("│                                              │"),
-        ratatui::text::Line::from(format!(
-            "│ model:     {:<25} /model to change │",
-            truncate_for_startup_card(app.current_model_label(), 25)
-        )),
-        ratatui::text::Line::from(format!(
-            "│ directory: {:<32} │",
-            truncate_for_startup_card(&display_directory_for_startup(app), 32)
-        )),
-        ratatui::text::Line::from("╰──────────────────────────────────────────────╯"),
-        ratatui::text::Line::from(""),
-    ]
+fn startup_card_lines(app: &TuiApp, width: u16) -> Vec<Line<'static>> {
+    let Some(inner_width) = startup_card_inner_width(width) else {
+        return Vec::new();
+    };
+
+    let model_label = "model:";
+    let directory_label = "directory:";
+    let label_width = directory_label.len();
+    let model_prefix = format!("{model_label:<label_width$} ");
+    let hint = "/model to change";
+    let hint_width = display_width(hint);
+    let model_prefix_width = display_width(&model_prefix);
+    let model_available_width = inner_width
+        .saturating_sub(model_prefix_width)
+        .saturating_sub(1)
+        .saturating_sub(hint_width);
+    let model_value = truncate_for_startup_card(app.current_model_label(), model_available_width);
+    let model_value_width = display_width(&model_value);
+    let gap_width = inner_width
+        .saturating_sub(model_prefix_width)
+        .saturating_sub(model_value_width)
+        .saturating_sub(hint_width)
+        .max(1);
+    let directory_prefix = format!("{directory_label:<label_width$} ");
+    let directory_max_width = inner_width.saturating_sub(display_width(&directory_prefix));
+
+    let lines = vec![
+        Line::from(vec![Span::from(">_ "), Span::from("RARA")]),
+        Line::from(""),
+        Line::from(vec![
+            Span::from(model_prefix),
+            Span::from(model_value),
+            Span::from(" ".repeat(gap_width)),
+            Span::from(hint),
+        ]),
+        Line::from(vec![
+            Span::from(directory_prefix),
+            Span::from(truncate_path_middle(
+                &display_directory_for_startup(app),
+                directory_max_width,
+            )),
+        ]),
+    ];
+
+    with_border(lines, inner_width)
 }
 
 fn display_directory_for_startup(app: &TuiApp) -> String {
@@ -542,15 +638,75 @@ fn display_directory_for_startup(app: &TuiApp) -> String {
 }
 
 fn truncate_for_startup_card(value: &str, width: usize) -> String {
-    let chars = value.chars().collect::<Vec<_>>();
-    if chars.len() <= width {
+    if display_width(value) <= width {
         return value.to_string();
     }
     if width <= 1 {
         return "…".to_string();
     }
-    let kept = chars.into_iter().take(width - 1).collect::<String>();
+    let kept = value.chars().take(width - 1).collect::<String>();
     format!("{kept}…")
+}
+
+fn truncate_path_middle(value: &str, width: usize) -> String {
+    if display_width(value) <= width {
+        return value.to_string();
+    }
+    if width <= 1 {
+        return "…".to_string();
+    }
+    if width <= 5 {
+        return truncate_for_startup_card(value, width);
+    }
+
+    let keep_left = (width - 1) / 2;
+    let keep_right = width - 1 - keep_left;
+    let chars = value.chars().collect::<Vec<_>>();
+    let left = chars.iter().take(keep_left).collect::<String>();
+    let right = chars
+        .iter()
+        .rev()
+        .take(keep_right)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<String>();
+    format!("{left}…{right}")
+}
+
+fn startup_card_inner_width(width: u16) -> Option<usize> {
+    if width < 8 {
+        return None;
+    }
+    Some(std::cmp::min(width.saturating_sub(4) as usize, 56))
+}
+
+fn with_border(lines: Vec<Line<'static>>, inner_width: usize) -> Vec<Line<'static>> {
+    let mut out = Vec::with_capacity(lines.len() + 3);
+    let border_inner_width = inner_width + 2;
+    out.push(Line::from(format!("╭{}╮", "─".repeat(border_inner_width))));
+
+    for line in lines {
+        let used_width = line
+            .iter()
+            .map(|span| display_width(span.content.as_ref()))
+            .sum::<usize>();
+        let mut spans = Vec::with_capacity(line.spans.len() + 3);
+        spans.push(Span::from("│ "));
+        spans.extend(line.into_iter());
+        if used_width < inner_width {
+            spans.push(Span::from(" ".repeat(inner_width - used_width)));
+        }
+        spans.push(Span::from(" │"));
+        out.push(Line::from(spans));
+    }
+
+    out.push(Line::from(format!("╰{}╯", "─".repeat(border_inner_width))));
+    out
+}
+
+fn display_width(value: &str) -> usize {
+    value.chars().count()
 }
 
 fn restore_latest_session(
@@ -700,4 +856,16 @@ pub(crate) fn provider_requires_api_key(provider: &str) -> bool {
         provider,
         "mock" | "local" | "local-candle" | "gemma4" | "qwen3" | "qwn3" | "ollama"
     )
+}
+
+fn should_open_codex_auth_guide(app: &TuiApp) -> bool {
+    let presets = current_model_presets(app.provider_picker_idx);
+    let Some((_, provider, _)) = presets.get(app.model_picker_idx) else {
+        return false;
+    };
+    *provider == "codex" && app.config.api_key.as_deref().is_none_or(str::is_empty)
+}
+
+fn is_ssh_session() -> bool {
+    std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_TTY").is_some()
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -36,7 +36,7 @@ use crate::state_db::StateDb;
 use self::app_event::AppEvent;
 use self::command::{palette_command_by_index, palette_commands, parse_local_command};
 use self::event_stream::{translate_event, UiEvent};
-use self::render::{committed_turn_lines, render};
+use self::render::{committed_turn_lines, desired_viewport_height, render};
 use self::runtime::{
     execute_local_command, finish_running_task_if_ready, start_oauth_task, start_pending_approval_task, start_query_task,
     start_rebuild_task,
@@ -48,8 +48,10 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, Hide)?;
-    let mut terminal = build_terminal()?;
+    let initial_size = terminal_size()?;
     let mut app = TuiApp::new(crate::config::ConfigManager::new()?);
+    let mut viewport_height = desired_viewport_height(&app, initial_size.0, initial_size.1);
+    let mut terminal = build_terminal(viewport_height)?;
     let mut agent_slot = Some(agent);
     match StateDb::new() {
         Ok(state_db) => {
@@ -70,6 +72,12 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
     let result = loop {
         finish_running_task_if_ready(&mut app, &mut agent_slot).await?;
         clamp_command_palette_selection(&mut app);
+        let size = terminal_size()?;
+        let desired_height = desired_viewport_height(&app, size.0, size.1);
+        if desired_height != viewport_height {
+            viewport_height = desired_height;
+            terminal = build_terminal(viewport_height)?;
+        }
         flush_committed_history(&mut terminal, &mut app)?;
         terminal.draw(|f| render(f, &app))?;
 
@@ -84,7 +92,9 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
                             }
                         }
                         Some(UiEvent::Draw) => {
-                            terminal = build_terminal()?;
+                            let size = terminal_size()?;
+                            viewport_height = desired_viewport_height(&app, size.0, size.1);
+                            terminal = build_terminal(viewport_height)?;
                         }
                         Some(UiEvent::Paste(text)) => {
                             handle_paste(text, &mut app);
@@ -124,13 +134,11 @@ fn handle_paste(text: String, app: &mut TuiApp) {
     }
 }
 
-fn build_terminal() -> anyhow::Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
-    let (_, rows) = terminal_size()?;
-    let viewport_height = rows.max(1);
+fn build_terminal(viewport_height: u16) -> anyhow::Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     let terminal = Terminal::with_options(
         CrosstermBackend::new(io::stdout()),
         TerminalOptions {
-            viewport: Viewport::Inline(viewport_height),
+            viewport: Viewport::Inline(viewport_height.max(1)),
         },
     )?;
     Ok(terminal)

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,11 @@
 mod app_event;
 mod command;
 mod event_stream;
+mod highlight;
+mod line_utils;
+mod markdown;
+mod markdown_render;
+mod markdown_stream;
 mod render;
 mod runtime;
 mod state;
@@ -9,7 +14,7 @@ use std::io;
 use std::sync::Arc;
 
 use crossterm::{
-    cursor::{Hide, Show},
+    cursor::Show,
     event::{EventStream, KeyCode},
     execute,
     terminal::size as terminal_size,
@@ -46,8 +51,6 @@ use crate::agent::BashApprovalMode;
 
 pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Result<()> {
     enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, Hide)?;
     let initial_size = terminal_size()?;
     let mut app = TuiApp::new(crate::config::ConfigManager::new()?);
     let mut viewport_height = desired_viewport_height(&app, initial_size.0, initial_size.1);
@@ -588,7 +591,8 @@ fn flush_committed_history(
     }
     while app.inserted_turns < app.committed_turns.len() {
         let turn = &app.committed_turns[app.inserted_turns];
-        let mut lines = committed_turn_lines(turn.entries.as_slice());
+        let cwd = (!app.snapshot.cwd.is_empty()).then(|| std::path::Path::new(app.snapshot.cwd.as_str()));
+        let mut lines = committed_turn_lines(turn.entries.as_slice(), cwd);
         if app.inserted_turns > 0 && !lines.is_empty() {
             lines.insert(0, ratatui::text::Line::from(""));
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,6 +28,7 @@ use ratatui::{
     Terminal, TerminalOptions, Viewport,
 };
 use tokio::time::{interval, Duration};
+use unicode_width::UnicodeWidthStr;
 
 use crate::agent::Agent;
 use crate::agent::CompletedInteraction;
@@ -752,7 +753,7 @@ fn with_border(lines: Vec<Line<'static>>, inner_width: usize) -> Vec<Line<'stati
 }
 
 fn display_width(value: &str) -> usize {
-    value.chars().count()
+    UnicodeWidthStr::width(value)
 }
 
 fn restore_latest_session(
@@ -912,6 +913,6 @@ fn should_open_codex_auth_guide(app: &TuiApp) -> bool {
     *provider == "codex" && app.config.api_key.as_deref().is_none_or(str::is_empty)
 }
 
-fn is_ssh_session() -> bool {
+pub(crate) fn is_ssh_session() -> bool {
     std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_TTY").is_some()
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -519,6 +519,8 @@ fn render_overlay(f: &mut Frame, app: &TuiApp, overlay: Overlay) {
         Overlay::ResumePicker => render_resume_picker_modal(f, app, popup),
         Overlay::ModelPicker => render_model_picker_modal(f, app, popup),
         Overlay::BaseUrlEditor => render_base_url_editor_modal(f, app, popup),
+        Overlay::CodexAuthGuide => render_codex_auth_guide_modal(f, app, popup),
+        Overlay::ApiKeyEditor => render_api_key_editor_modal(f, app, popup),
     }
 }
 
@@ -897,7 +899,7 @@ fn render_provider_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
         chunks[1],
     );
     f.render_widget(
-        Paragraph::new("1/2 select  Up/Down move  Enter continue  Esc close")
+        Paragraph::new("1/2/3 select  Up/Down move  Enter continue  Esc close")
             .alignment(Alignment::Center),
         chunks[2],
     );
@@ -999,11 +1001,16 @@ fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(3), Constraint::Min(6), Constraint::Length(2)])
         .split(area);
-    f.render_widget(
-        Paragraph::new(format!(
+    let help = if provider_label == "Codex" && api_key_status(&app.config) == "missing" {
+        "Provider: Codex\nAuthentication is required before this preset can be used.\nEnter opens the Codex login guide."
+    } else {
+        &format!(
             "Provider: {provider_label}\nBase URL: {}\nSelect a concrete model preset. Enter applies immediately.",
             app.config.base_url.as_deref().unwrap_or("http://localhost:11434"),
-        ))
+        )
+    };
+    f.render_widget(
+        Paragraph::new(help)
             .block(Block::default().borders(Borders::ALL).title(" Model Picker ")),
         chunks[0],
     );
@@ -1012,7 +1019,11 @@ fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
         chunks[1],
     );
     f.render_widget(
-        Paragraph::new("1/2/3 apply directly  Up/Down move  B edit base URL  Enter apply  Esc close")
+        Paragraph::new(if provider_label == "Codex" {
+            "1/2 choose  Up/Down move  Enter continue  Esc close"
+        } else {
+            "1/2/3 apply directly  Up/Down move  B edit base URL  Enter apply  Esc close"
+        })
             .alignment(Alignment::Center),
         chunks[2],
     );
@@ -1030,6 +1041,65 @@ fn render_base_url_editor_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     let editor = Paragraph::new(app.base_url_input.as_str())
         .block(Block::default().borders(Borders::ALL).title(" Value "));
     let footer = Paragraph::new("Enter save  Esc back to model picker")
+        .alignment(Alignment::Center);
+    f.render_widget(intro, chunks[0]);
+    f.render_widget(editor, chunks[1]);
+    f.render_widget(footer, chunks[2]);
+}
+
+fn render_codex_auth_guide_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(8), Constraint::Min(6), Constraint::Length(2)])
+        .split(area);
+    let ssh_hint = if std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_TTY").is_some() {
+        "\n\nSSH session detected. Browser OAuth on a remote shell usually cannot complete the localhost callback. Use API key in SSH/headless sessions."
+    } else {
+        ""
+    };
+    let intro = format!(
+        "Codex needs authentication before this preset can be used.\n\n\
+         [1] OAuth login\n\
+         [2] API key\n\n\
+         OAuth matches the Codex desktop flow when this TUI is running locally.{ssh_hint}"
+    );
+    f.render_widget(
+        Paragraph::new(intro)
+            .block(Block::default().borders(Borders::ALL).title(" Codex Login "))
+            .wrap(Wrap { trim: false }),
+        chunks[0],
+    );
+
+    let body = Paragraph::new(format!(
+        "Current model: {}\nProvider: codex\nKey status: {}\n\n\
+         Pick OAuth for local desktop login, or API key for headless / SSH usage.",
+        app.current_model_label(),
+        api_key_status(&app.config),
+    ))
+    .block(Block::default().borders(Borders::LEFT | Borders::RIGHT).title(" Details "))
+    .wrap(Wrap { trim: false });
+    f.render_widget(body, chunks[1]);
+
+    f.render_widget(
+        Paragraph::new("1 OAuth  2 API key  Enter OAuth  Esc back")
+            .alignment(Alignment::Center),
+        chunks[2],
+    );
+}
+
+fn render_api_key_editor_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(4), Constraint::Length(3), Constraint::Length(2)])
+        .split(area);
+    let intro = Paragraph::new(
+        "Paste a Codex-compatible API key. This is the recommended path for SSH/headless sessions.",
+    )
+    .block(Block::default().borders(Borders::ALL).title(" Codex API Key "))
+    .wrap(Wrap { trim: false });
+    let editor = Paragraph::new(app.api_key_input.as_str())
+        .block(Block::default().borders(Borders::ALL).title(" Value "));
+    let footer = Paragraph::new("Enter save and rebuild  Esc back to login guide")
         .alignment(Alignment::Center);
     f.render_widget(intro, chunks[0]);
     f.render_widget(editor, chunks[1]);

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -19,7 +19,7 @@ use super::state::{
 pub fn render(f: &mut Frame, app: &TuiApp) {
     let layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(8), Constraint::Length(5)])
+        .constraints([Constraint::Fill(1), Constraint::Length(5)])
         .split(f.area());
 
     render_transcript(f, app, layout[0]);
@@ -38,15 +38,13 @@ pub fn desired_viewport_height(app: &TuiApp, width: u16, rows: u16) -> u16 {
     let bottom_pane_height = 5u16;
     let transcript_width = width.max(20) as usize;
     let transcript_lines = if app.active_turn.entries.is_empty() {
-        1
+        0
     } else {
         estimate_wrapped_line_count(&current_turn_lines(app), transcript_width).max(1) as u16
     };
 
-    let desired = bottom_pane_height
-        .saturating_add(transcript_lines)
-        .saturating_add(1);
-    desired.clamp(bottom_pane_height.saturating_add(1), rows.max(1))
+    let desired = bottom_pane_height.saturating_add(transcript_lines);
+    desired.clamp(bottom_pane_height, rows.max(1))
 }
 
 fn render_bottom_pane(f: &mut Frame, app: &TuiApp, area: Rect) {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -30,21 +30,17 @@ pub fn render(f: &mut Frame, app: &TuiApp) {
     }
 }
 
-pub fn desired_viewport_height(app: &TuiApp, width: u16, rows: u16) -> u16 {
+pub fn desired_viewport_height(app: &TuiApp, _width: u16, rows: u16) -> u16 {
     if app.overlay.is_some() {
         return rows.max(1);
     }
 
     let bottom_pane_height = 5u16;
-    let transcript_width = width.max(20) as usize;
-    let transcript_lines = if app.active_turn.entries.is_empty() {
-        0
-    } else {
-        estimate_wrapped_line_count(&current_turn_lines(app), transcript_width).max(1) as u16
-    };
-
-    let desired = bottom_pane_height.saturating_add(transcript_lines);
-    desired.clamp(bottom_pane_height, rows.max(1))
+    let has_active_content = !app.active_turn.entries.is_empty();
+    if !has_active_content {
+        return bottom_pane_height.clamp(1, rows.max(1));
+    }
+    rows.max(1)
 }
 
 fn render_bottom_pane(f: &mut Frame, app: &TuiApp, area: Rect) {
@@ -99,21 +95,6 @@ fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
             .scroll((app.transcript_scroll as u16, 0)),
         area,
     );
-}
-
-fn estimate_wrapped_line_count(lines: &[Line<'static>], width: usize) -> usize {
-    let width = width.max(1);
-    lines.iter()
-        .map(|line| {
-            let content_width = line
-                .spans
-                .iter()
-                .map(|span| span.content.chars().count())
-                .sum::<usize>()
-                .max(1);
-            content_width.div_ceil(width)
-        })
-        .sum()
 }
 
 pub fn committed_turn_lines(entries: &[TranscriptEntry]) -> Vec<Line<'static>> {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -5,6 +5,9 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Tabs, Wrap},
     Frame,
 };
+use std::path::Path;
+use textwrap::Options;
+use unicode_width::UnicodeWidthStr;
 
 use super::command::{
     api_key_status, command_detail_text, command_spec_by_index, general_help_text, help_text,
@@ -12,6 +15,7 @@ use super::command::{
     palette_commands, quick_actions_text, recent_transcript_preview, status_prompt_sources_text,
     status_plan_text, status_request_user_input_text, status_resources_text, status_runtime_text, status_workspace_text,
 };
+use super::line_utils::prefix_lines;
 use super::state::{
     current_model_presets, HelpTab, Overlay, PROVIDER_FAMILIES, TaskKind, TranscriptEntry, TuiApp,
 };
@@ -23,10 +27,14 @@ pub fn render(f: &mut Frame, app: &TuiApp) {
         .split(f.area());
 
     render_transcript(f, app, layout[0]);
-    render_bottom_pane(f, app, layout[1]);
+    let mut cursor = render_bottom_pane(f, app, layout[1]);
 
     if let Some(overlay) = app.overlay {
-        render_overlay(f, app, overlay);
+        cursor = render_overlay(f, app, overlay).or(cursor);
+    }
+
+    if let Some((x, y)) = cursor {
+        f.set_cursor_position((x, y));
     }
 }
 
@@ -43,14 +51,15 @@ pub fn desired_viewport_height(app: &TuiApp, _width: u16, rows: u16) -> u16 {
     rows.max(1)
 }
 
-fn render_bottom_pane(f: &mut Frame, app: &TuiApp, area: Rect) {
+fn render_bottom_pane(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)> {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(1), Constraint::Min(3), Constraint::Length(1)])
         .split(area);
     render_activity_bar(f, app, chunks[0]);
-    render_composer(f, app, chunks[1]);
+    let cursor = render_composer(f, app, chunks[1]);
     render_footer(f, app, chunks[2]);
+    cursor
 }
 
 fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
@@ -97,7 +106,7 @@ fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
     );
 }
 
-pub fn committed_turn_lines(entries: &[TranscriptEntry]) -> Vec<Line<'static>> {
+pub fn committed_turn_lines(entries: &[TranscriptEntry], cwd: Option<&Path>) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     if let Some(user) = entries.iter().find(|entry| entry.role == "You") {
         lines.extend(prefixed_message_lines("You", &user.message, 4));
@@ -142,7 +151,12 @@ pub fn committed_turn_lines(entries: &[TranscriptEntry]) -> Vec<Line<'static>> {
 
     for entry in tail_entries {
         let max_lines = if entry.role == "Agent" { 8 } else { 4 };
-        lines.extend(prefixed_message_lines(&entry.role, &entry.message, max_lines));
+        lines.extend(formatted_message_lines(
+            &entry.role,
+            &entry.message,
+            max_lines,
+            cwd,
+        ));
         lines.push(Line::from(""));
     }
 
@@ -174,6 +188,7 @@ fn current_turn_lines(app: &TuiApp) -> Vec<Line<'static>> {
         .rev()
         .find(|entry| entry.role == "Agent")
         .map(|entry| entry.message.as_str());
+    let streaming_agent_lines = app.agent_stream_lines();
     let latest_system = current_turn
         .iter()
         .rev()
@@ -185,6 +200,7 @@ fn current_turn_lines(app: &TuiApp) -> Vec<Line<'static>> {
         .find(|entry| entry.role == "Tool Result" || entry.role == "Tool Error")
         .map(|entry| (entry.role.as_str(), entry.message.as_str()));
     let mut lines = Vec::new();
+    let cwd = (!app.snapshot.cwd.is_empty()).then(|| Path::new(app.snapshot.cwd.as_str()));
 
     if !user_message.is_empty() {
         lines.extend(prefixed_message_lines("You", user_message, 4));
@@ -263,10 +279,12 @@ fn current_turn_lines(app: &TuiApp) -> Vec<Line<'static>> {
             super::state::RuntimePhase::RunningTool | super::state::RuntimePhase::SendingPrompt
         );
 
-    if let Some(agent_message) = latest_agent.filter(|_| !suppress_intermediate_agent) {
-        lines.extend(prefixed_message_lines("Agent", agent_message, usize::MAX));
+    if let Some(stream_lines) = streaming_agent_lines.filter(|_| !suppress_intermediate_agent) {
+        lines.extend(rendered_markdown_lines("Agent", stream_lines, usize::MAX));
+    } else if let Some(agent_message) = latest_agent.filter(|_| !suppress_intermediate_agent) {
+        lines.extend(formatted_message_lines("Agent", agent_message, usize::MAX, cwd));
     } else if let Some(system_message) = latest_system {
-        lines.extend(prefixed_message_lines("System", system_message, 14));
+        lines.extend(formatted_message_lines("System", system_message, 14, cwd));
     } else if let Some((role, tool_result)) = latest_tool_result {
         lines.extend(prefixed_message_lines(role, tool_result, 14));
     } else if app.is_busy() {
@@ -388,6 +406,86 @@ fn prefixed_message_lines(role: &str, message: &str, max_lines: usize) -> Vec<Li
     lines
 }
 
+fn formatted_message_lines(
+    role: &str,
+    message: &str,
+    max_lines: usize,
+    cwd: Option<&Path>,
+) -> Vec<Line<'static>> {
+    if matches!(role, "Agent" | "System") {
+        return markdown_message_lines(role, message, max_lines, cwd);
+    }
+    prefixed_message_lines(role, message, max_lines)
+}
+
+fn markdown_message_lines(
+    role: &str,
+    message: &str,
+    max_lines: usize,
+    cwd: Option<&Path>,
+) -> Vec<Line<'static>> {
+    let mut rendered = Vec::new();
+    super::markdown::append_markdown(message, None, cwd, &mut rendered);
+    let rendered_len = rendered.len();
+
+    if rendered.is_empty() {
+        return vec![Line::from(role.to_string())];
+    }
+
+    let capped = if max_lines == usize::MAX {
+        rendered.len()
+    } else {
+        max_lines.min(rendered.len())
+    };
+
+    let mut lines = vec![Line::from(role.to_string())];
+    let prefixed = prefix_lines(
+        rendered.into_iter().take(capped).collect(),
+        Span::raw("  "),
+        Span::raw("  "),
+    );
+    lines.extend(prefixed);
+    if capped < rendered_len {
+        lines.push(Line::from(Span::styled(
+            format!("  ... {} more line(s)", rendered_len - capped),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    lines
+}
+
+fn rendered_markdown_lines(
+    role: &str,
+    rendered: &[Line<'static>],
+    max_lines: usize,
+) -> Vec<Line<'static>> {
+    if rendered.is_empty() {
+        return vec![Line::from(role.to_string())];
+    }
+
+    let rendered_len = rendered.len();
+    let capped = if max_lines == usize::MAX {
+        rendered_len
+    } else {
+        max_lines.min(rendered_len)
+    };
+
+    let mut lines = vec![Line::from(role.to_string())];
+    let prefixed = prefix_lines(
+        rendered.iter().take(capped).cloned().collect(),
+        Span::raw("  "),
+        Span::raw("  "),
+    );
+    lines.extend(prefixed);
+    if capped < rendered_len {
+        lines.push(Line::from(Span::styled(
+            format!("  ... {} more line(s)", rendered_len - capped),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    lines
+}
+
 fn is_exploration_tool(name: &str) -> bool {
     matches!(name, "list_files" | "read_file" | "glob" | "grep" | "search_files")
 }
@@ -474,7 +572,7 @@ fn animated_activity_label(app: &TuiApp, label: &str) -> String {
     format!("{label}{dots}")
 }
 
-fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) {
+fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)> {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(2), Constraint::Length(1)])
@@ -529,6 +627,7 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) {
         Paragraph::new(Span::styled(hint, Style::default().fg(Color::Gray))).alignment(Alignment::Left),
         chunks[1],
     );
+    Some(composer_cursor_position(app.input.as_str(), chunks[0]))
 }
 
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
@@ -556,19 +655,43 @@ fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
     );
 }
 
-fn render_overlay(f: &mut Frame, app: &TuiApp, overlay: Overlay) {
+fn render_overlay(f: &mut Frame, app: &TuiApp, overlay: Overlay) -> Option<(u16, u16)> {
     let popup = centered_rect(78, 70, f.area());
     f.render_widget(Clear, popup);
     match overlay {
-        Overlay::Help(tab) => render_help_modal(f, app, popup, tab),
-        Overlay::CommandPalette => render_command_palette(f, app, popup),
-        Overlay::Status => render_status_modal(f, app, popup),
-        Overlay::Setup => render_setup_modal(f, app, popup),
-        Overlay::ProviderPicker => render_provider_picker_modal(f, app, popup),
-        Overlay::ResumePicker => render_resume_picker_modal(f, app, popup),
-        Overlay::ModelPicker => render_model_picker_modal(f, app, popup),
+        Overlay::Help(tab) => {
+            render_help_modal(f, app, popup, tab);
+            None
+        }
+        Overlay::CommandPalette => {
+            render_command_palette(f, app, popup);
+            None
+        }
+        Overlay::Status => {
+            render_status_modal(f, app, popup);
+            None
+        }
+        Overlay::Setup => {
+            render_setup_modal(f, app, popup);
+            None
+        }
+        Overlay::ProviderPicker => {
+            render_provider_picker_modal(f, app, popup);
+            None
+        }
+        Overlay::ResumePicker => {
+            render_resume_picker_modal(f, app, popup);
+            None
+        }
+        Overlay::ModelPicker => {
+            render_model_picker_modal(f, app, popup);
+            None
+        }
         Overlay::BaseUrlEditor => render_base_url_editor_modal(f, app, popup),
-        Overlay::CodexAuthGuide => render_codex_auth_guide_modal(f, app, popup),
+        Overlay::CodexAuthGuide => {
+            render_codex_auth_guide_modal(f, app, popup);
+            None
+        }
         Overlay::ApiKeyEditor => render_api_key_editor_modal(f, app, popup),
     }
 }
@@ -1078,7 +1201,7 @@ fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     );
 }
 
-fn render_base_url_editor_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
+fn render_base_url_editor_modal(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)> {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(4), Constraint::Length(3), Constraint::Length(2)])
@@ -1094,6 +1217,7 @@ fn render_base_url_editor_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_widget(intro, chunks[0]);
     f.render_widget(editor, chunks[1]);
     f.render_widget(footer, chunks[2]);
+    Some(editor_cursor_position(app.base_url_input.as_str(), chunks[1]))
 }
 
 fn render_codex_auth_guide_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
@@ -1136,7 +1260,7 @@ fn render_codex_auth_guide_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     );
 }
 
-fn render_api_key_editor_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
+fn render_api_key_editor_modal(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)> {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(4), Constraint::Length(3), Constraint::Length(2)])
@@ -1153,6 +1277,70 @@ fn render_api_key_editor_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_widget(intro, chunks[0]);
     f.render_widget(editor, chunks[1]);
     f.render_widget(footer, chunks[2]);
+    Some(editor_cursor_position(app.api_key_input.as_str(), chunks[1]))
+}
+
+fn composer_cursor_position(input: &str, area: Rect) -> (u16, u16) {
+    wrapped_text_cursor_position(input, area, Some("› "), None)
+}
+
+fn editor_cursor_position(input: &str, area: Rect) -> (u16, u16) {
+    wrapped_text_cursor_position(input, inner_rect(area), None, None)
+}
+
+fn inner_rect(area: Rect) -> Rect {
+    Rect {
+        x: area.x.saturating_add(1),
+        y: area.y.saturating_add(1),
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    }
+}
+
+fn wrapped_text_cursor_position(
+    input: &str,
+    area: Rect,
+    initial_indent: Option<&str>,
+    subsequent_indent: Option<&str>,
+) -> (u16, u16) {
+    if area.width == 0 || area.height == 0 {
+        return (area.x, area.y);
+    }
+
+    let initial_indent = initial_indent.unwrap_or("");
+    let subsequent_indent = subsequent_indent.unwrap_or("");
+    let mut wrapped_rows: Vec<String> = Vec::new();
+
+    if input.is_empty() {
+        wrapped_rows.push(initial_indent.to_string());
+    } else {
+        for logical_line in input.split('\n') {
+            let options = Options::new(area.width as usize)
+                .initial_indent(initial_indent)
+                .subsequent_indent(subsequent_indent)
+                .break_words(false);
+            let wraps = textwrap::wrap(logical_line, options);
+            if wraps.is_empty() {
+                wrapped_rows.push(initial_indent.to_string());
+            } else {
+                wrapped_rows.extend(wraps.into_iter().map(|line| line.into_owned()));
+            }
+        }
+    }
+
+    let last_row = wrapped_rows
+        .last()
+        .cloned()
+        .unwrap_or_else(|| initial_indent.to_string());
+    let row_index = wrapped_rows.len().saturating_sub(1);
+    let cursor_y = area
+        .y
+        .saturating_add(row_index.min(area.height.saturating_sub(1) as usize) as u16);
+    let display_width = UnicodeWidthStr::width(last_row.as_str()) as u16;
+    let max_x_offset = area.width.saturating_sub(1);
+    let cursor_x = area.x.saturating_add(display_width.min(max_x_offset));
+
+    (cursor_x, cursor_y)
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -100,8 +100,7 @@ fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
 pub fn committed_turn_lines(entries: &[TranscriptEntry]) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     if let Some(user) = entries.iter().find(|entry| entry.role == "You") {
-        lines.push(Line::from(role_badge_span("You")));
-        push_message_lines(&mut lines, &user.message, 4);
+        lines.extend(prefixed_message_lines("You", &user.message, 4));
         lines.push(Line::from(""));
     }
 
@@ -118,8 +117,8 @@ pub fn committed_turn_lines(entries: &[TranscriptEntry]) -> Vec<Line<'static>> {
         lines.push(Line::from(""));
     }
 
-    if let Some(summary) = current_turn_tool_summary(entry_refs.as_slice()) {
-        lines.push(Line::from(section_span("Actions", Color::LightYellow)));
+    if let Some(summary) = current_turn_tool_summary(entry_refs.as_slice(), false, None) {
+        lines.push(Line::from(section_span("Ran", Color::LightYellow)));
         lines.extend(summary.lines().map(|line| Line::from(format!("  {line}"))));
         lines.push(Line::from(""));
     }
@@ -142,9 +141,8 @@ pub fn committed_turn_lines(entries: &[TranscriptEntry]) -> Vec<Line<'static>> {
     };
 
     for entry in tail_entries {
-        lines.push(Line::from(role_badge_span(&entry.role)));
         let max_lines = if entry.role == "Agent" { 8 } else { 4 };
-        push_message_lines(&mut lines, &entry.message, max_lines);
+        lines.extend(prefixed_message_lines(&entry.role, &entry.message, max_lines));
         lines.push(Line::from(""));
     }
 
@@ -189,8 +187,7 @@ fn current_turn_lines(app: &TuiApp) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
     if !user_message.is_empty() {
-        lines.push(Line::from(role_badge_span("You")));
-        lines.push(Line::from(format!("  {}", user_message)));
+        lines.extend(prefixed_message_lines("You", user_message, 4));
         lines.push(Line::from(""));
     }
 
@@ -210,8 +207,17 @@ fn current_turn_lines(app: &TuiApp) -> Vec<Line<'static>> {
         lines.push(Line::from(""));
     }
 
-    if let Some(summary) = current_turn_tool_summary(current_turn.as_slice()) {
-        lines.push(Line::from(section_span("Actions", Color::LightYellow)));
+    if let Some(summary) = current_turn_tool_summary(
+        current_turn.as_slice(),
+        app.is_busy() && latest_agent.is_none(),
+        app.runtime_phase_detail.as_deref(),
+    ) {
+        let (title, color) = if app.is_busy() && latest_agent.is_none() {
+            ("Running", Color::Yellow)
+        } else {
+            ("Ran", Color::LightYellow)
+        };
+        lines.push(Line::from(section_span(title, color)));
         lines.extend(summary.lines().map(|line| Line::from(format!("  {line}"))));
         lines.push(Line::from(""));
     }
@@ -258,20 +264,11 @@ fn current_turn_lines(app: &TuiApp) -> Vec<Line<'static>> {
         );
 
     if let Some(agent_message) = latest_agent.filter(|_| !suppress_intermediate_agent) {
-        lines.push(Line::from(role_badge_span("Agent")));
-        for line in agent_message.lines() {
-            lines.push(Line::from(format!("  {line}")));
-        }
+        lines.extend(prefixed_message_lines("Agent", agent_message, usize::MAX));
     } else if let Some(system_message) = latest_system {
-        lines.push(Line::from(role_badge_span("System")));
-        for line in system_message.lines().take(14) {
-            lines.push(Line::from(format!("  {line}")));
-        }
+        lines.extend(prefixed_message_lines("System", system_message, 14));
     } else if let Some((role, tool_result)) = latest_tool_result {
-        lines.push(Line::from(role_badge_span(role)));
-        for line in tool_result.lines().take(14) {
-            lines.push(Line::from(format!("  {line}")));
-        }
+        lines.extend(prefixed_message_lines(role, tool_result, 14));
     } else if app.is_busy() {
         lines.push(Line::from(section_span("Working", Color::Yellow)));
         lines.push(Line::from(format!(
@@ -280,9 +277,6 @@ fn current_turn_lines(app: &TuiApp) -> Vec<Line<'static>> {
                 .as_deref()
                 .unwrap_or("waiting for the current turn to finish")
         )));
-    } else {
-        lines.push(Line::from(section_span("Ready", Color::Green)));
-        lines.push(Line::from("  No final answer yet."));
     }
 
     lines
@@ -333,50 +327,65 @@ fn current_turn_exploration_summary_from_entries(
     Some(lines.join("\n"))
 }
 
-fn current_turn_tool_summary(current_turn: &[&TranscriptEntry]) -> Option<String> {
-    let tools = current_turn
+fn current_turn_tool_summary(
+    current_turn: &[&TranscriptEntry],
+    show_live_detail: bool,
+    live_detail: Option<&str>,
+) -> Option<String> {
+    let actions = current_turn
         .iter()
         .filter_map(|entry| {
             if entry.role != "Tool" {
                 return None;
             }
-            let name = entry.message.split_whitespace().next()?;
-            if is_exploration_tool(name) {
-                return None;
-            }
-            Some(name.to_string())
+            tool_action_label(&entry.message)
         })
         .collect::<Vec<_>>();
-    if tools.is_empty() {
+    if actions.is_empty() {
         return None;
     }
 
-    let mut parts = vec![format!("Used {} tool call(s): {}", tools.len(), tools.join(", "))];
-    let results = current_turn
-        .iter()
-        .filter(|entry| entry.role == "Tool Result" || entry.role == "Tool Error")
-        .count();
-    if results > 0 {
-        parts.push(format!("Recorded {} tool result(s).", results));
+    let mut lines = actions
+        .into_iter()
+        .map(|action| format!("└ {action}"))
+        .collect::<Vec<_>>();
+
+    if show_live_detail {
+        lines.push(format!(
+            "└ {}",
+            live_detail.unwrap_or("waiting for tool output")
+        ));
     }
-    Some(parts.join("\n"))
+
+    Some(lines.join("\n"))
 }
 
-fn push_message_lines(lines: &mut Vec<Line<'static>>, message: &str, max_lines: usize) {
+fn prefixed_message_lines(role: &str, message: &str, max_lines: usize) -> Vec<Line<'static>> {
     let message_lines = message.lines().collect::<Vec<_>>();
     if message_lines.is_empty() {
-        lines.push(Line::from("  "));
-        return;
+        return vec![Line::from(format!("{role}:"))];
     }
-    for line in message_lines.iter().take(max_lines) {
+
+    let capped = if max_lines == usize::MAX {
+        message_lines.len()
+    } else {
+        max_lines
+    };
+
+    let mut lines = Vec::new();
+    if let Some(first) = message_lines.first() {
+        lines.push(Line::from(format!("{role}: {first}")));
+    }
+    for line in message_lines.iter().skip(1).take(capped.saturating_sub(1)) {
         lines.push(Line::from(format!("  {line}")));
     }
-    if message_lines.len() > max_lines {
+    if message_lines.len() > capped {
         lines.push(Line::from(Span::styled(
-            format!("  ... {} more line(s)", message_lines.len() - max_lines),
+            format!("  ... {} more line(s)", message_lines.len() - capped),
             Style::default().fg(Color::DarkGray),
         )));
     }
+    lines
 }
 
 fn is_exploration_tool(name: &str) -> bool {
@@ -394,6 +403,24 @@ fn exploration_action_label(message: &str) -> Option<String> {
         "grep" => Some(format!("Search {}", if rest.is_empty() { "workspace" } else { rest.as_str() })),
         "search_files" => Some(format!("Search files {}", if rest.is_empty() { "workspace" } else { rest.as_str() })),
         _ => None,
+    }
+}
+
+fn tool_action_label(message: &str) -> Option<String> {
+    let mut parts = message.split_whitespace();
+    let name = parts.next()?;
+    if is_exploration_tool(name) {
+        return None;
+    }
+
+    let rest = parts.collect::<Vec<_>>().join(" ");
+    match name {
+        "bash" => Some(format!("Run {}", if rest.is_empty() { "command" } else { rest.as_str() })),
+        "apply_patch" => Some("Apply patch".to_string()),
+        "write_file" => Some(format!("Write {}", if rest.is_empty() { "file" } else { rest.as_str() })),
+        "replace" => Some(format!("Edit {}", if rest.is_empty() { "file" } else { rest.as_str() })),
+        "web_fetch" => Some(format!("Fetch {}", if rest.is_empty() { "resource" } else { rest.as_str() })),
+        other => Some(format!("Run {}", if rest.is_empty() { other } else { message })),
     }
 }
 
@@ -496,7 +523,7 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) {
     } else if app.agent_execution_mode_label() == "plan" {
         "plan mode  /plan return to execute"
     } else {
-        "/search grep  terminal scrollback for history  /plan toggle  /quit exit"
+        "/search grep  /compact summarize history  /plan toggle  /quit exit"
     };
     f.render_widget(
         Paragraph::new(Span::styled(hint, Style::default().fg(Color::Gray))).alignment(Alignment::Left),
@@ -505,13 +532,22 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) {
 }
 
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
+    let context = match app.snapshot.context_window_tokens {
+        Some(window) => format!(
+            "ctx~={}/{}",
+            app.snapshot.estimated_history_tokens,
+            window
+        ),
+        None => format!("ctx~={}", app.snapshot.estimated_history_tokens),
+    };
     let summary = format!(
-        "key={}  history={}  local={}  tokens={} in / {} out",
+        "key={}  history={}  local={}  tokens={} in / {} out  {}",
         api_key_status(&app.config),
         app.snapshot.history_len,
         app.transcript_entry_count(),
         app.snapshot.total_input_tokens,
         app.snapshot.total_output_tokens,
+        context,
     );
     f.render_widget(
         Paragraph::new(Line::from(Span::styled(summary, Style::default().fg(Color::DarkGray))))
@@ -1142,25 +1178,6 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
 
 fn command_preview_text(spec: &super::state::CommandSpec) -> String {
     format!("{}\n\n{}", spec.usage, spec.summary)
-}
-
-fn role_badge_span(role: &str) -> Span<'static> {
-    let (fg, bg) = match role {
-        "You" => (Color::Black, Color::LightBlue),
-        "Agent" => (Color::Black, Color::White),
-        "Tool" => (Color::Black, Color::Rgb(231, 201, 92)),
-        "Tool Result" => (Color::Black, Color::LightGreen),
-        "Tool Error" => (Color::White, Color::Red),
-        "Download" => (Color::Black, Color::LightBlue),
-        "Runtime" => (Color::Black, Color::LightBlue),
-        "Status" => (Color::White, Color::DarkGray),
-        "System" => (Color::Black, Color::Magenta),
-        _ => (Color::White, Color::DarkGray),
-    };
-    Span::styled(
-        format!(" {} ", role),
-        Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD),
-    )
 }
 
 fn section_span<'a>(title: &'a str, color: Color) -> Span<'a> {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -30,6 +30,25 @@ pub fn render(f: &mut Frame, app: &TuiApp) {
     }
 }
 
+pub fn desired_viewport_height(app: &TuiApp, width: u16, rows: u16) -> u16 {
+    if app.overlay.is_some() {
+        return rows.max(1);
+    }
+
+    let bottom_pane_height = 5u16;
+    let transcript_width = width.max(20) as usize;
+    let transcript_lines = if app.active_turn.entries.is_empty() {
+        1
+    } else {
+        estimate_wrapped_line_count(&current_turn_lines(app), transcript_width).max(1) as u16
+    };
+
+    let desired = bottom_pane_height
+        .saturating_add(transcript_lines)
+        .saturating_add(1);
+    desired.clamp(bottom_pane_height.saturating_add(1), rows.max(1))
+}
+
 fn render_bottom_pane(f: &mut Frame, app: &TuiApp, area: Rect) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -82,6 +101,21 @@ fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
             .scroll((app.transcript_scroll as u16, 0)),
         area,
     );
+}
+
+fn estimate_wrapped_line_count(lines: &[Line<'static>], width: usize) -> usize {
+    let width = width.max(1);
+    lines.iter()
+        .map(|line| {
+            let content_width = line
+                .spans
+                .iter()
+                .map(|span| span.content.chars().count())
+                .sum::<usize>()
+                .max(1);
+            content_width.div_ceil(width)
+        })
+        .sum()
 }
 
 pub fn committed_turn_lines(entries: &[TranscriptEntry]) -> Vec<Line<'static>> {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1225,7 +1225,7 @@ fn render_codex_auth_guide_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(8), Constraint::Min(6), Constraint::Length(2)])
         .split(area);
-    let ssh_hint = if std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_TTY").is_some() {
+    let ssh_hint = if super::is_ssh_session() {
         "\n\nSSH session detected. Browser OAuth on a remote shell usually cannot complete the localhost callback. Use API key in SSH/headless sessions."
     } else {
         ""

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -47,6 +47,7 @@ pub async fn execute_local_command(
         LocalCommandKind::Plan => "plan",
         LocalCommandKind::Approval => "approval",
         LocalCommandKind::Search => "search",
+        LocalCommandKind::Compact => "compact",
         LocalCommandKind::Setup => "setup",
         LocalCommandKind::Model => "model",
         LocalCommandKind::BaseUrl => "base-url",
@@ -112,6 +113,13 @@ pub async fn execute_local_command(
             app.push_notice(notice);
         }
         LocalCommandKind::Search => handle_search_command(command.arg.as_deref(), app).await?,
+        LocalCommandKind::Compact => {
+            if let Some(agent) = agent_slot.take() {
+                start_compact_task(app, agent);
+            } else {
+                app.push_notice("No active agent available for compaction.");
+            }
+        }
         LocalCommandKind::Setup => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening setup".into()));
             app.open_overlay(Overlay::Setup);
@@ -229,7 +237,9 @@ pub fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agent) {
         let tx = sender.clone();
         let result = agent
             .query_with_mode_and_events(prompt, AgentOutputMode::Silent, move |event| {
-                let _ = tx.send(convert_agent_event(event));
+                if let Some(event) = convert_agent_event(event) {
+                    let _ = tx.send(event);
+                }
             })
             .await;
         TaskCompletion::Query { agent, result }
@@ -237,6 +247,35 @@ pub fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agent) {
 
     app.running_task = Some(RunningTask {
         kind: TaskKind::Query,
+        receiver,
+        handle,
+        started_at: Instant::now(),
+        next_heartbeat_after_secs: 2,
+    });
+}
+
+pub fn start_compact_task(app: &mut TuiApp, mut agent: Agent) {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    agent.set_execution_mode(app.agent_execution_mode);
+    agent.set_bash_approval_mode(app.bash_approval_mode);
+    app.notice = Some("Compacting conversation history.".into());
+    app.set_runtime_phase(RuntimePhase::ProcessingResponse, Some("compacting history".into()));
+    app.push_entry("You", "/compact");
+
+    let handle = tokio::spawn(async move {
+        let tx = sender.clone();
+        let result = agent
+            .compact_now_with_reporter(move |event| {
+                if let Some(event) = convert_agent_event(event) {
+                    let _ = tx.send(event);
+                }
+            })
+            .await;
+        TaskCompletion::Compact { agent, result }
+    });
+
+    app.running_task = Some(RunningTask {
+        kind: TaskKind::Compact,
         receiver,
         handle,
         started_at: Instant::now(),
@@ -262,7 +301,9 @@ pub fn start_pending_approval_task(
         let tx = sender.clone();
         let result = agent
             .answer_pending_approval_with_events(selection, AgentOutputMode::Silent, move |event| {
-                let _ = tx.send(convert_agent_event(event));
+                if let Some(event) = convert_agent_event(event) {
+                    let _ = tx.send(event);
+                }
             })
             .await;
         TaskCompletion::Query { agent, result }
@@ -385,6 +426,45 @@ pub async fn finish_running_task_if_ready(
                             .unwrap_or("http://localhost:11434");
                         message.push_str(&format!("\nbase_url={base_url}"));
                     }
+                    app.push_entry("System", message.clone());
+                    app.push_notice(message);
+                }
+            }
+        }
+        TaskCompletion::Compact { agent, result } => {
+            *agent_slot = Some(agent);
+            if let Some(agent) = agent_slot.as_ref() {
+                app.sync_snapshot(agent);
+            }
+            match result {
+                Ok(true) => {
+                    if let Some((before, after)) = app
+                        .snapshot
+                        .last_compaction_before_tokens
+                        .zip(app.snapshot.last_compaction_after_tokens)
+                    {
+                        let message = format!(
+                            "Conversation compacted.\nEstimated history tokens: {before} -> {after}"
+                        );
+                        app.push_entry("Agent", message.clone());
+                        app.push_notice(message);
+                    } else {
+                        app.push_entry("Agent", "Conversation compacted.");
+                        app.push_notice("Conversation compacted.");
+                    }
+                    app.finalize_active_turn();
+                    app.set_runtime_phase(RuntimePhase::Idle, Some("history compacted".into()));
+                }
+                Ok(false) => {
+                    let message = "Conversation history did not need compaction.";
+                    app.push_entry("Agent", message);
+                    app.push_notice(message);
+                    app.finalize_active_turn();
+                    app.set_runtime_phase(RuntimePhase::Idle, Some("compact skipped".into()));
+                }
+                Err(err) => {
+                    app.set_runtime_phase(RuntimePhase::Failed, Some("compact failed".into()));
+                    let message = format!("Compaction failed: {err}");
                     app.push_entry("System", message.clone());
                     app.push_notice(message);
                 }
@@ -543,33 +623,42 @@ fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
     }
 }
 
-fn convert_agent_event(event: AgentEvent) -> TuiEvent {
+fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
     match event {
-        AgentEvent::Status(message) => TuiEvent::Transcript {
+        AgentEvent::Status(message) => Some(TuiEvent::Transcript {
             role: "Status",
             message,
-        },
-        AgentEvent::AssistantText(text) => TuiEvent::Transcript {
+        }),
+        AgentEvent::AssistantText(text) => Some(TuiEvent::Transcript {
             role: "Agent",
             message: text,
-        },
-        AgentEvent::AssistantDelta(text) => TuiEvent::Transcript {
+        }),
+        AgentEvent::AssistantDelta(text) => Some(TuiEvent::Transcript {
             role: "Agent Delta",
             message: text,
-        },
-        AgentEvent::ToolUse { name, input } => TuiEvent::Transcript {
+        }),
+        AgentEvent::ToolUse { name, input } => Some(TuiEvent::Transcript {
             role: "Tool",
             message: format_tool_use(&name, &input),
-        },
+        }),
         AgentEvent::ToolResult {
             name,
             content,
             is_error,
-        } => TuiEvent::Transcript {
+        } => {
+            if is_exploration_tool_name(&name) {
+                return None;
+            }
+            Some(TuiEvent::Transcript {
             role: if is_error { "Tool Error" } else { "Tool Result" },
             message: format_tool_result(&name, &content),
-        },
+            })
+        }
     }
+}
+
+fn is_exploration_tool_name(name: &str) -> bool {
+    matches!(name, "list_files" | "read_file" | "glob" | "grep" | "search_files")
 }
 
 fn format_tool_use(name: &str, input: &serde_json::Value) -> String {

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -793,7 +793,7 @@ async fn run_oauth_login(
     let (verifier, challenge) = oauth_manager.generate_pkce();
     let (port, receiver) = oauth_manager.start_callback_server().await?;
     let auth_url = oauth_manager.get_authorize_url(&challenge, port);
-    let is_ssh = std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_TTY").is_some();
+    let is_ssh = super::is_ssh_session();
     let _ = sender.send(TuiEvent::Transcript {
         role: "Runtime",
         message: if is_ssh {

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -433,13 +433,15 @@ pub async fn finish_running_task_if_ready(
                 app.setup_status = Some("Saved OAuth token.".into());
                 app.notice = app.setup_status.clone();
                 app.set_runtime_phase(RuntimePhase::OAuthSaved, Some("oauth token saved".into()));
-                app.close_overlay();
+                app.overlay = None;
                 app.push_entry("Runtime", "Saved OAuth token.");
-                app.finalize_active_turn();
+                start_rebuild_task(app);
             }
             Err(err) => {
                 app.set_runtime_phase(RuntimePhase::Failed, Some("oauth failed".into()));
-                app.push_notice(format!("OAuth failed:\n{}", format_error_chain(&err)));
+                let message = format!("OAuth failed:\n{}", format_error_chain(&err));
+                app.push_entry("System", message.clone());
+                app.push_notice(message);
             }
         },
     }
@@ -697,11 +699,24 @@ async fn run_oauth_login(
 ) -> anyhow::Result<String> {
     let (verifier, challenge) = oauth_manager.generate_pkce();
     let (port, receiver) = oauth_manager.start_callback_server().await?;
+    let auth_url = oauth_manager.get_authorize_url(&challenge, port);
+    let is_ssh = std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_TTY").is_some();
     let _ = sender.send(TuiEvent::Transcript {
         role: "Runtime",
-        message: format!("Opened OAuth flow on localhost:{port}."),
+        message: if is_ssh {
+            format!(
+                "SSH session detected. OAuth browser login is not reliable from a remote shell because the callback listens on localhost:{port}.\nUse Codex API key instead, or open this URL from the same machine running the TUI:\n{auth_url}"
+            )
+        } else {
+            format!("Starting OAuth flow.\nOpen this URL if the browser does not launch automatically:\n{auth_url}")
+        },
     });
-    let _ = open::that(oauth_manager.get_authorize_url(&challenge, port));
+    if is_ssh {
+        return Err(anyhow!(
+            "OAuth browser login is unavailable in SSH/headless sessions; use Codex API key instead"
+        ));
+    }
+    let _ = open::that(&auth_url);
 
     let code = receiver.await?;
     let _ = sender.send(TuiEvent::Transcript {

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -411,11 +411,13 @@ pub async fn finish_running_task_if_ready(
             }
             match result {
                 Ok(_) => {
+                    app.finalize_agent_stream(None);
                     app.finalize_active_turn();
                     app.notice = Some("Prompt finished.".into());
                     app.set_runtime_phase(RuntimePhase::Idle, Some("prompt finished".into()));
                 }
                 Err(err) => {
+                    app.finalize_agent_stream(None);
                     app.set_runtime_phase(RuntimePhase::Failed, Some("query failed".into()));
                     let mut message = format!("Query failed: {err}");
                     if app.config.provider == "ollama" {
@@ -589,7 +591,7 @@ fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                     RuntimePhase::ProcessingResponse,
                     Some("streaming model output".into()),
                 );
-                app.append_to_latest_entry("Agent", &message);
+                app.append_agent_delta(&message);
                 return;
             } else if role == "Tool" || role == "Tool Result" || role == "Tool Error" {
                 app.set_runtime_phase(
@@ -601,6 +603,8 @@ fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                     RuntimePhase::ProcessingResponse,
                     Some("receiving model output".into()),
                 );
+                app.finalize_agent_stream(Some(message));
+                return;
             } else if role == "Download" {
                 let detail = message.lines().next().unwrap_or(role).trim().to_string();
                 if detail.starts_with("Ready ·") {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -45,6 +45,7 @@ pub enum LocalCommandKind {
     Plan,
     Approval,
     Search,
+    Compact,
     Setup,
     Model,
     BaseUrl,
@@ -95,6 +96,13 @@ pub struct RuntimeSnapshot {
     pub history_len: usize,
     pub total_input_tokens: u32,
     pub total_output_tokens: u32,
+    pub estimated_history_tokens: usize,
+    pub context_window_tokens: Option<usize>,
+    pub compact_threshold_tokens: usize,
+    pub reserved_output_tokens: usize,
+    pub compaction_count: usize,
+    pub last_compaction_before_tokens: Option<usize>,
+    pub last_compaction_after_tokens: Option<usize>,
     pub plan_steps: Vec<(String, String)>,
     pub plan_explanation: Option<String>,
     pub pending_question: Option<(String, Vec<(String, String)>, Option<String>)>,
@@ -112,6 +120,7 @@ pub struct PendingApprovalSnapshot {
 
 pub enum TaskKind {
     Query,
+    Compact,
     Rebuild,
     OAuth,
 }
@@ -120,6 +129,10 @@ pub enum TaskCompletion {
     Query {
         agent: Agent,
         result: anyhow::Result<()>,
+    },
+    Compact {
+        agent: Agent,
+        result: anyhow::Result<bool>,
     },
     Rebuild {
         result: anyhow::Result<Agent>,
@@ -333,6 +346,13 @@ impl TuiApp {
             history_len: agent.history.len(),
             total_input_tokens: agent.total_input_tokens,
             total_output_tokens: agent.total_output_tokens,
+            estimated_history_tokens: agent.compact_state.estimated_history_tokens,
+            context_window_tokens: agent.compact_state.context_window_tokens,
+            compact_threshold_tokens: agent.compact_state.compact_threshold_tokens,
+            reserved_output_tokens: agent.compact_state.reserved_output_tokens,
+            compaction_count: agent.compact_state.compaction_count,
+            last_compaction_before_tokens: agent.compact_state.last_compaction_before_tokens,
+            last_compaction_after_tokens: agent.compact_state.last_compaction_after_tokens,
             plan_steps: agent
                 .current_plan
                 .iter()

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -25,6 +25,8 @@ pub enum Overlay {
     ModelPicker,
     ResumePicker,
     BaseUrlEditor,
+    CodexAuthGuide,
+    ApiKeyEditor,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -208,6 +210,7 @@ pub struct TuiApp {
     pub model_picker_idx: usize,
     pub command_palette_idx: usize,
     pub base_url_input: String,
+    pub api_key_input: String,
     pub recent_commands: Vec<String>,
     pub recent_sessions: Vec<PersistedSessionSummary>,
     pub resume_picker_idx: usize,
@@ -222,7 +225,11 @@ impl TuiApp {
     pub fn new(cm: ConfigManager) -> Self {
         let cfg = cm.load();
         let overlay = if cfg.api_key.is_none() && super::provider_requires_api_key(&cfg.provider) {
-            Some(Overlay::Setup)
+            if cfg.provider == "codex" {
+                Some(Overlay::CodexAuthGuide)
+            } else {
+                Some(Overlay::Setup)
+            }
         } else {
             None
         };
@@ -248,6 +255,7 @@ impl TuiApp {
             model_picker_idx,
             command_palette_idx: 0,
             base_url_input: String::new(),
+            api_key_input: String::new(),
             recent_commands: Vec::new(),
             recent_sessions: Vec::new(),
             resume_picker_idx: 0,
@@ -460,6 +468,9 @@ impl TuiApp {
                 .clone()
                 .unwrap_or_else(|| "http://localhost:11434".to_string());
         }
+        if matches!(overlay, Overlay::ApiKeyEditor) {
+            self.api_key_input = self.config.api_key.clone().unwrap_or_default();
+        }
         self.overlay = Some(overlay);
     }
 
@@ -497,6 +508,8 @@ impl TuiApp {
     pub fn close_overlay(&mut self) {
         self.overlay = match self.overlay {
             Some(Overlay::BaseUrlEditor) => Some(Overlay::ModelPicker),
+            Some(Overlay::ApiKeyEditor) => Some(Overlay::CodexAuthGuide),
+            Some(Overlay::CodexAuthGuide) => Some(Overlay::ModelPicker),
             _ => None,
         };
     }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -2,11 +2,15 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::task::JoinHandle;
 use std::time::Instant;
 use std::sync::Arc;
+use std::path::PathBuf;
 use serde_json::json;
+use ratatui::text::Line;
 
 use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
 use crate::config::{ConfigManager, RaraConfig};
 use crate::state_db::{PersistedInteraction, PersistedPlanStep, PersistedSessionSummary, PersistedTurnEntry, StateDb};
+use super::markdown;
+use super::markdown_stream::MarkdownStreamCollector;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum HelpTab {
@@ -203,6 +207,40 @@ pub struct TranscriptTurn {
     pub entries: Vec<TranscriptEntry>,
 }
 
+pub struct AgentMarkdownStreamState {
+    raw_text: String,
+    cwd: PathBuf,
+    collector: MarkdownStreamCollector,
+    committed_lines: Vec<Line<'static>>,
+    display_lines: Vec<Line<'static>>,
+}
+
+impl AgentMarkdownStreamState {
+    fn new(cwd: PathBuf) -> Self {
+        Self {
+            raw_text: String::new(),
+            collector: MarkdownStreamCollector::new(None, &cwd),
+            committed_lines: Vec::new(),
+            display_lines: Vec::new(),
+            cwd,
+        }
+    }
+
+    fn push_delta(&mut self, delta: &str) {
+        self.raw_text.push_str(delta);
+        self.collector.push_delta(delta);
+        self.committed_lines
+            .extend(self.collector.commit_complete_lines());
+        self.display_lines.clear();
+        markdown::append_markdown(
+            &self.raw_text,
+            None,
+            Some(self.cwd.as_path()),
+            &mut self.display_lines,
+        );
+    }
+}
+
 pub struct TuiApp {
     pub input: String,
     pub committed_turns: Vec<TranscriptTurn>,
@@ -228,6 +266,7 @@ pub struct TuiApp {
     pub recent_sessions: Vec<PersistedSessionSummary>,
     pub resume_picker_idx: usize,
     pub transcript_scroll: usize,
+    pub agent_markdown_stream: Option<AgentMarkdownStreamState>,
     pub terminal_focused: bool,
     pub state_db: Option<Arc<StateDb>>,
     pub state_db_status: Option<String>,
@@ -273,6 +312,7 @@ impl TuiApp {
             recent_sessions: Vec::new(),
             resume_picker_idx: 0,
             transcript_scroll: 0,
+            agent_markdown_stream: None,
             terminal_focused: true,
             state_db: None,
             state_db_status: None,
@@ -414,6 +454,45 @@ impl TuiApp {
         self.push_entry(role, delta.to_string());
     }
 
+    pub fn append_agent_delta(&mut self, delta: &str) {
+        let cwd = if !self.snapshot.cwd.is_empty() {
+            PathBuf::from(self.snapshot.cwd.as_str())
+        } else {
+            std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+        };
+        let stream = self
+            .agent_markdown_stream
+            .get_or_insert_with(|| AgentMarkdownStreamState::new(cwd));
+        stream.push_delta(delta);
+        self.transcript_scroll = 0;
+    }
+
+    pub fn agent_stream_lines(&self) -> Option<&[Line<'static>]> {
+        self.agent_markdown_stream
+            .as_ref()
+            .map(|stream| stream.display_lines.as_slice())
+    }
+
+    pub fn finalize_agent_stream(&mut self, final_message: Option<String>) {
+        let fallback = self
+            .agent_markdown_stream
+            .take()
+            .map(|stream| stream.raw_text)
+            .filter(|text| !text.is_empty());
+        let Some(message) = final_message.or(fallback) else {
+            return;
+        };
+
+        if let Some(last) = self.active_turn.entries.last_mut() {
+            if last.role == "Agent" {
+                last.message = message;
+                self.transcript_scroll = 0;
+                return;
+            }
+        }
+        self.push_entry("Agent", message);
+    }
+
     pub fn push_notice(&mut self, message: impl Into<String>) {
         let message = message.into();
         self.notice = Some(message.clone());
@@ -425,6 +504,7 @@ impl TuiApp {
         self.active_turn.entries.clear();
         self.inserted_turns = 0;
         self.transcript_scroll = 0;
+        self.agent_markdown_stream = None;
         self.notice = Some("Cleared local transcript view.".into());
     }
 
@@ -554,6 +634,7 @@ impl TuiApp {
     }
 
     fn commit_active_turn(&mut self) {
+        self.finalize_agent_stream(None);
         if self.active_turn.entries.is_empty() {
             return;
         }
@@ -573,6 +654,7 @@ impl TuiApp {
         self.active_turn.entries.clear();
         self.inserted_turns = 0;
         self.transcript_scroll = 0;
+        self.agent_markdown_stream = None;
     }
 
     pub fn attach_state_db(&mut self, state_db: Arc<StateDb>) {


### PR DESCRIPTION
## Summary

- align the startup card with Codex-style width-constrained history rendering
- add a Codex login guide with explicit OAuth vs API key choice
- make Codex auth TTY-safe by steering SSH/headless sessions to API key instead of browser OAuth
- keep OAuth completion inside the TUI and continue with backend rebuild
- wrap inserted history content so startup/output stays inside the terminal viewport

## Why

The previous `main` flow still assumed a local desktop environment:

- Codex model selection could fall through to a broken auth path
- OAuth attempted to open a browser and wait on a localhost callback even in SSH sessions
- the startup card used a fixed-width frame that overflowed or left too much blank space
- inserted history content could render outside the visible viewport

This change brings the TUI behavior closer to Codex for startup, auth guidance, and terminal-safe output.

## Testing

- `cargo check`

