### PR TITLE
fix(tui): treat natural replies as plan approval

### DIFF
--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -48,6 +48,7 @@ pub(super) enum RuntimeContinuationPhase {
     ToolResultsAvailable,
     PlanContinuationRequired,
     ExecutionContinuationRequired,
+    PlanApproved,
 }
 
 #[derive(Serialize)]
@@ -329,6 +330,41 @@ impl Agent {
         }
     }
 
+    pub async fn resume_after_plan_approval_with_events<F>(
+        &mut self,
+        continue_planning: bool,
+        output_mode: AgentOutputMode,
+        mut report: F,
+    ) -> Result<()>
+    where
+        F: FnMut(AgentEvent) + Send,
+    {
+        self.pending_user_input = None;
+        self.pending_approval = None;
+
+        if continue_planning {
+            self.execution_mode = AgentExecutionMode::Plan;
+            report(AgentEvent::Status(
+                "Continuing plan refinement from the current plan state.".to_string(),
+            ));
+            self.history.push(self.runtime_continuation_message(
+                RuntimeContinuationPhase::PlanContinuationRequired,
+                0,
+            ));
+        } else {
+            self.execution_mode = AgentExecutionMode::Execute;
+            report(AgentEvent::Status(
+                "Plan approved. Continuing with implementation.".to_string(),
+            ));
+            self.history.push(self.runtime_continuation_message(
+                RuntimeContinuationPhase::PlanApproved,
+                0,
+            ));
+        }
+
+        self.run_agent_loop(output_mode, &mut report).await
+    }
+
     pub(super) fn capture_plan_from_text(&mut self, text: &str) -> bool {
         let Some((steps, explanation)) = parse_plan_block(text) else {
             self.pending_user_input = parse_request_user_input_block(text);
@@ -566,6 +602,7 @@ impl RuntimeContinuationPhase {
             Self::ToolResultsAvailable => "tool_results_available",
             Self::PlanContinuationRequired => "plan_continuation_required",
             Self::ExecutionContinuationRequired => "execution_continuation_required",
+            Self::PlanApproved => "plan_approved",
         }
     }
 
@@ -592,6 +629,13 @@ impl RuntimeContinuationPhase {
                 "Keep gathering the next relevant code context now.",
                 "If you mentioned a next file or next inspection step, call the tool for it directly.",
                 "Only stop when you can provide concrete, evidence-based suggestions or when structured user input is required.",
+                "Do not ask the user to continue.",
+            ],
+            Self::PlanApproved => vec![
+                "The user approved the current plan. Continue the same task immediately.",
+                "Implement the approved plan using the existing plan state and repository context.",
+                "Do not restate the plan back to the user unless a short reminder is necessary.",
+                "Start with the next concrete implementation step or tool call.",
                 "Do not ask the user to continue.",
             ],
         }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -73,6 +73,21 @@ impl SequencedBackend {
     }
 }
 
+fn test_runtime_storage() -> (tempfile::TempDir, Arc<SessionManager>, Arc<WorkspaceMemory>, std::path::PathBuf) {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().to_path_buf();
+    let rara_dir = root.join(".rara");
+    std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+    std::fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+    std::fs::create_dir_all(rara_dir.join("tool-results")).expect("tool results");
+    let session_manager = Arc::new(SessionManager {
+        storage_dir: rara_dir.join("rollouts"),
+        legacy_storage_dir: rara_dir.join("sessions"),
+    });
+    let workspace = Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone()));
+    (temp, session_manager, workspace, rara_dir)
+}
+
 #[async_trait]
 impl LlmBackend for SequencedBackend {
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<AnthropicResponse> {
@@ -139,6 +154,56 @@ async fn appends_continuation_after_tool_result() {
     assert!(second_round.iter().any(|message| {
         message.content.to_string().contains("tool_result")
     }));
+}
+
+#[tokio::test]
+async fn resumes_after_plan_approval_via_structured_continuation() {
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let backend = Arc::new(SequencedBackend::new(vec![AnthropicResponse {
+        content: vec![ContentBlock::Text {
+            text: "Implemented the first plan step.".to_string(),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        Arc::new(VectorDB::new("data/lancedb")),
+        session_manager,
+        workspace,
+    );
+    agent.tool_result_store =
+        ToolResultStore::new(rara_dir.join("tool-results")).expect("tool result store");
+    agent.set_execution_mode(AgentExecutionMode::Plan);
+    agent.current_plan = vec![PlanStep {
+        step: "Modify workspace instruction discovery".to_string(),
+        status: PlanStepStatus::Pending,
+    }];
+
+    agent
+        .resume_after_plan_approval_with_events(false, super::AgentOutputMode::Silent, |_| {})
+        .await
+        .expect("resume should succeed");
+
+    let observed = backend.observed_messages.lock().expect("lock");
+    assert_eq!(observed.len(), 1);
+    let runtime_texts = observed[0]
+        .iter()
+        .filter_map(|message| message.content.as_array())
+        .flat_map(|blocks| blocks.iter())
+        .filter_map(|block| block.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>();
+    assert!(runtime_texts
+        .iter()
+        .any(|text| text.contains("\"phase\": \"plan_approved\"")));
+    assert!(runtime_texts
+        .iter()
+        .any(|text| text.contains("\"mode\": \"execute\"")));
+    assert!(!runtime_texts
+        .iter()
+        .any(|text| text.contains("Implement the approved plan using the current repository state")));
 }
 
 #[tokio::test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -584,6 +584,11 @@ async fn handle_submit(
     }
 
     let input = std::mem::take(&mut app.input);
+    if app.has_pending_plan_approval() && !input.trim_start().starts_with('/') {
+        if handle_pending_plan_approval_submit(app, agent_slot, input.trim()).await? {
+            return Ok(false);
+        }
+    }
     if let Some(command) = parse_local_command(&input) {
         if execute_local_command(command, app, agent_slot, oauth_manager).await? {
             return Ok(true);
@@ -607,6 +612,118 @@ async fn handle_submit(
     Ok(false)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PendingPlanApprovalAction {
+    StartImplementation,
+    ContinuePlanning,
+}
+
+fn classify_pending_plan_approval_input(input: &str) -> Option<PendingPlanApprovalAction> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lowered = trimmed.to_ascii_lowercase();
+    let continue_planning_keywords = [
+        "继续规划",
+        "继续计划",
+        "继续 refine",
+        "refine plan",
+        "continue planning",
+        "keep planning",
+        "revise plan",
+        "调整计划",
+        "完善计划",
+    ];
+    if continue_planning_keywords.iter().any(|keyword| {
+        lowered.contains(&keyword.to_ascii_lowercase()) || trimmed.contains(keyword)
+    }) {
+        return Some(PendingPlanApprovalAction::ContinuePlanning);
+    }
+
+    let approve_keywords = [
+        "继续",
+        "继续吧",
+        "好的",
+        "好",
+        "开始",
+        "开始吧",
+        "执行",
+        "执行吧",
+        "实现",
+        "实现吧",
+        "可以",
+        "行",
+        "ok",
+        "okay",
+        "yes",
+        "y",
+        "go",
+        "proceed",
+        "continue",
+        "ship it",
+    ];
+    if approve_keywords.iter().any(|keyword| {
+        lowered == keyword.to_ascii_lowercase() || trimmed == *keyword
+    }) {
+        return Some(PendingPlanApprovalAction::StartImplementation);
+    }
+
+    None
+}
+
+async fn handle_pending_plan_approval_submit(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    input: &str,
+) -> anyhow::Result<bool> {
+    let Some(action) = classify_pending_plan_approval_input(input) else {
+        app.push_notice(
+            "A plan is waiting for approval. Press 1/2 or type '继续' to implement, '继续规划' to refine the plan.",
+        );
+        return Ok(true);
+    };
+
+    match action {
+        PendingPlanApprovalAction::StartImplementation => {
+            app.set_pending_plan_approval(false);
+            app.set_agent_execution_mode(AgentExecutionMode::Execute);
+            if let Some(agent) = agent_slot.as_mut() {
+                agent.set_execution_mode(AgentExecutionMode::Execute);
+            }
+            if let Some(agent) = agent_slot.take() {
+                start_query_task(
+                    app,
+                    "Implement the approved plan using the current repository state.".to_string(),
+                    agent,
+                );
+            } else {
+                app.push_notice("No active agent is available to start implementation.");
+            }
+        }
+        PendingPlanApprovalAction::ContinuePlanning => {
+            app.set_pending_plan_approval(false);
+            app.set_agent_execution_mode(AgentExecutionMode::Plan);
+            if let Some(agent) = agent_slot.as_mut() {
+                agent.set_execution_mode(AgentExecutionMode::Plan);
+            }
+            if let Some(agent) = agent_slot.take() {
+                start_query_task(
+                    app,
+                    "Continue refining the plan and fill in any missing implementation details."
+                        .to_string(),
+                    agent,
+                );
+            } else {
+                app.push_notice("No active agent is available to continue planning.");
+            }
+        }
+    }
+
+    Ok(true)
+}
+
 fn clamp_command_palette_selection(app: &mut TuiApp) {
     let len = palette_commands(app, app.input.trim_start().trim_start_matches('/')).len();
     if len == 0 {
@@ -622,4 +739,33 @@ fn should_open_codex_auth_guide(app: &TuiApp) -> bool {
         return false;
     };
     *provider == "codex" && !app.config.has_api_key()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_pending_plan_approval_input, PendingPlanApprovalAction};
+
+    #[test]
+    fn pending_plan_approval_treats_generic_continue_as_approval() {
+        assert_eq!(
+            classify_pending_plan_approval_input("继续吧"),
+            Some(PendingPlanApprovalAction::StartImplementation)
+        );
+        assert_eq!(
+            classify_pending_plan_approval_input("ok"),
+            Some(PendingPlanApprovalAction::StartImplementation)
+        );
+    }
+
+    #[test]
+    fn pending_plan_approval_supports_explicit_refine_signal() {
+        assert_eq!(
+            classify_pending_plan_approval_input("继续规划"),
+            Some(PendingPlanApprovalAction::ContinuePlanning)
+        );
+        assert_eq!(
+            classify_pending_plan_approval_input("continue planning"),
+            Some(PendingPlanApprovalAction::ContinuePlanning)
+        );
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -34,7 +34,8 @@ use self::event_stream::{translate_event, UiEvent};
 use self::render::{desired_viewport_height, render};
 use self::runtime::{
     execute_local_command, finish_running_task_if_ready, should_suggest_planning_mode,
-    start_oauth_task, start_pending_approval_task, start_query_task, start_rebuild_task,
+    start_oauth_task, start_pending_approval_task, start_plan_approval_resume_task,
+    start_query_task, start_rebuild_task,
 };
 use self::session_restore::{
     provider_requires_api_key, restore_latest_session, restore_session_by_id,
@@ -384,33 +385,13 @@ async fn dispatch_event(
             } else if app.has_pending_plan_approval() {
                 match idx {
                     0 => {
-                        app.set_pending_plan_approval(false);
-                        app.set_agent_execution_mode(AgentExecutionMode::Execute);
-                        if let Some(agent) = agent_slot.as_mut() {
-                            agent.set_execution_mode(AgentExecutionMode::Execute);
-                        }
                         if let Some(agent) = agent_slot.take() {
-                            start_query_task(
-                                app,
-                                "Implement the approved plan using the current repository state."
-                                    .to_string(),
-                                agent,
-                            );
+                            start_plan_approval_resume_task(app, false, agent);
                         }
                     }
                     1 => {
-                        app.set_pending_plan_approval(false);
-                        app.set_agent_execution_mode(AgentExecutionMode::Plan);
-                        if let Some(agent) = agent_slot.as_mut() {
-                            agent.set_execution_mode(AgentExecutionMode::Plan);
-                        }
                         if let Some(agent) = agent_slot.take() {
-                            start_query_task(
-                                app,
-                                "Continue refining the plan and fill in any missing implementation details."
-                                    .to_string(),
-                                agent,
-                            );
+                            start_plan_approval_resume_task(app, true, agent);
                         }
                     }
                     _ => {
@@ -687,34 +668,15 @@ async fn handle_pending_plan_approval_submit(
 
     match action {
         PendingPlanApprovalAction::StartImplementation => {
-            app.set_pending_plan_approval(false);
-            app.set_agent_execution_mode(AgentExecutionMode::Execute);
-            if let Some(agent) = agent_slot.as_mut() {
-                agent.set_execution_mode(AgentExecutionMode::Execute);
-            }
             if let Some(agent) = agent_slot.take() {
-                start_query_task(
-                    app,
-                    "Implement the approved plan using the current repository state.".to_string(),
-                    agent,
-                );
+                start_plan_approval_resume_task(app, false, agent);
             } else {
                 app.push_notice("No active agent is available to start implementation.");
             }
         }
         PendingPlanApprovalAction::ContinuePlanning => {
-            app.set_pending_plan_approval(false);
-            app.set_agent_execution_mode(AgentExecutionMode::Plan);
-            if let Some(agent) = agent_slot.as_mut() {
-                agent.set_execution_mode(AgentExecutionMode::Plan);
-            }
             if let Some(agent) = agent_slot.take() {
-                start_query_task(
-                    app,
-                    "Continue refining the plan and fill in any missing implementation details."
-                        .to_string(),
-                    agent,
-                );
+                start_plan_approval_resume_task(app, true, agent);
             } else {
                 app.push_notice("No active agent is available to continue planning.");
             }

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -30,6 +30,14 @@ pub fn start_pending_approval_task(app: &mut TuiApp, selection: BashApprovalMode
     tasks::start_pending_approval_task(app, selection, agent);
 }
 
+pub fn start_plan_approval_resume_task(
+    app: &mut TuiApp,
+    continue_planning: bool,
+    agent: Agent,
+) {
+    tasks::start_plan_approval_resume_task(app, continue_planning, agent);
+}
+
 pub fn start_rebuild_task(app: &mut TuiApp) {
     tasks::start_rebuild_task(app);
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -205,6 +205,60 @@ pub(super) fn start_pending_approval_task(
     });
 }
 
+pub(super) fn start_plan_approval_resume_task(
+    app: &mut TuiApp,
+    continue_planning: bool,
+    mut agent: Agent,
+) {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    app.clear_active_live_sections();
+    app.set_pending_plan_approval(false);
+    app.notice = Some(if continue_planning {
+        "Continuing plan refinement.".into()
+    } else {
+        "Plan approved. Continuing with implementation.".into()
+    });
+    app.set_runtime_phase(
+        RuntimePhase::ProcessingResponse,
+        Some(if continue_planning {
+            "resuming plan refinement".into()
+        } else {
+            "resuming approved plan".into()
+        }),
+    );
+
+    agent.set_execution_mode(if continue_planning {
+        crate::agent::AgentExecutionMode::Plan
+    } else {
+        crate::agent::AgentExecutionMode::Execute
+    });
+    app.set_agent_execution_mode(agent.execution_mode);
+
+    let handle = tokio::spawn(async move {
+        let tx = sender.clone();
+        let result = agent
+            .resume_after_plan_approval_with_events(
+                continue_planning,
+                AgentOutputMode::Silent,
+                move |event| {
+                    if let Some(event) = convert_agent_event(event) {
+                        let _ = tx.send(event);
+                    }
+                },
+            )
+            .await;
+        TaskCompletion::Query { agent, result }
+    });
+
+    app.running_task = Some(RunningTask {
+        kind: TaskKind::Query,
+        receiver,
+        handle,
+        started_at: Instant::now(),
+        next_heartbeat_after_secs: 2,
+    });
+}
+
 pub(super) fn start_rebuild_task(app: &mut TuiApp) {
     let (sender, receiver) = mpsc::unbounded_channel();
     let config = app.config.clone();


### PR DESCRIPTION
## Summary

- treat natural free-text confirmations like `继续吧` or `ok` as structured plan approval when a plan is waiting for approval
- keep explicit refine signals like `继续规划` mapped to continued planning instead of execution
- avoid sending pending-plan approval replies back through the normal prompt path

## Testing

- `cargo test tui::tests -- --nocapture`
- `cargo check`
