### PR TITLE
feat(tui): unify interaction pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ The current product direction is to make local inference a first-class path inst
 - Local models should plug into the same `LlmBackend` contract used by hosted providers.
 - TUI interaction should converge toward one unified prompt surface instead of growing separate setup-only flows for common actions.
 - Prefer smaller modules over long files; as a rule of thumb, avoid letting a single source file grow beyond roughly 800 lines unless there is a strong reason not to split it.
+- If an implementation would push a source file toward or past that limit, proactively split the file instead of continuing to accumulate new logic in place.
 - Non-trivial behavior changes should add or update focused tests when practical.
 - Before implementing any non-trivial behavior change, first inspect the relevant Codex and Claude Code implementations, extract the interaction or runtime pattern that applies, write a short plan for how RARA should mirror or adapt it, and only then start implementation.
 

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1,4 +1,4 @@
-use crate::agent::{Agent, AgentExecutionMode, Message, PlanStep};
+use crate::agent::{Agent, AgentExecutionMode, Message, PendingUserInput, PlanStep};
 use crate::llm::LlmBackend;
 use crate::prompt::PromptRuntimeConfig;
 use crate::session::SessionManager;
@@ -99,6 +99,10 @@ impl Tool for AgentTool {
             "name": name,
             "status": result.status,
             "summary": result.summary,
+            "request_user_input": result
+                .request_user_input
+                .as_ref()
+                .map(serialize_pending_user_input),
         }))
     }
 }
@@ -148,6 +152,10 @@ impl Tool for ExploreAgentTool {
         Ok(json!({
             "status": result.status,
             "summary": result.summary,
+            "request_user_input": result
+                .request_user_input
+                .as_ref()
+                .map(serialize_pending_user_input),
         }))
     }
 }
@@ -202,6 +210,10 @@ impl Tool for PlanAgentTool {
                 .as_ref()
                 .map(|steps| serialize_plan_steps(steps)),
             "plan_explanation": result.plan_explanation,
+            "request_user_input": result
+                .request_user_input
+                .as_ref()
+                .map(serialize_pending_user_input),
         }))
     }
 }
@@ -249,6 +261,7 @@ struct SubAgentResult {
     summary: String,
     plan: Option<Vec<PlanStep>>,
     plan_explanation: Option<String>,
+    request_user_input: Option<PendingUserInput>,
 }
 
 async fn run_sub_agent(
@@ -277,6 +290,7 @@ async fn run_sub_agent(
         summary: latest_assistant_text(&sub).unwrap_or_else(|| "Sub-agent finished.".to_string()),
         plan: (!sub.current_plan.is_empty()).then_some(sub.current_plan.clone()),
         plan_explanation: sub.plan_explanation.clone(),
+        request_user_input: sub.pending_user_input.clone(),
     })
 }
 
@@ -351,6 +365,14 @@ fn serialize_plan_steps(steps: &[PlanStep]) -> Vec<Value> {
             })
         })
         .collect()
+}
+
+fn serialize_pending_user_input(request: &PendingUserInput) -> Value {
+    json!({
+        "question": request.question,
+        "options": request.options,
+        "note": request.note,
+    })
 }
 
 #[cfg(test)]

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -521,69 +521,6 @@ pub fn status_plan_text(app: &TuiApp) -> String {
     }
 }
 
-pub fn status_plan_approval_text(app: &TuiApp) -> String {
-    let plan_summary = if app.snapshot.plan_steps.is_empty() {
-        "No structured plan captured yet.".to_string()
-    } else {
-        app.snapshot
-            .plan_steps
-            .iter()
-            .enumerate()
-            .take(5)
-            .map(|(idx, (_, step))| format!("{}. {}", idx + 1, step))
-            .collect::<Vec<_>>()
-            .join("\n")
-    };
-
-    let explanation = app
-        .snapshot
-        .plan_explanation
-        .as_deref()
-        .unwrap_or("Review the proposed implementation plan before starting code changes.");
-
-    format!(
-        "ready to implement:\n{}\n\nsummary:\n{}\n\noptions:\n1. Start implementation now\n2. Continue planning",
-        plan_summary, explanation
-    )
-}
-
-pub fn status_planning_suggestion_text(app: &TuiApp) -> String {
-    let _ = app.pending_planning_suggestion.as_deref();
-    "suggestion:\nThis looks like a non-trivial task. Enter planning mode first so RARA can analyze the repository, refine the approach, and only stop once a concrete plan is ready.\n\noptions:\n1. Enter planning mode\n2. Continue in execute mode".to_string()
-}
-
-pub fn status_request_user_input_text(app: &TuiApp) -> String {
-    let Some((question, options, note)) = app.snapshot.pending_question.as_ref() else {
-        return "No pending structured question.".to_string();
-    };
-
-    let options_text = if options.is_empty() {
-        "No predefined options.".to_string()
-    } else {
-        options
-            .iter()
-            .enumerate()
-            .map(|(idx, (label, description))| {
-                if description.is_empty() {
-                    format!("{}. {}", idx + 1, label)
-                } else {
-                    format!("{}. {} — {}", idx + 1, label, description)
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    };
-
-    if let Some(note) = note {
-        format!(
-            "question:\n{}\n\noptions:\n{}\n\nnote:\n{}",
-            question, options_text, note
-        )
-    } else {
-        format!("question:\n{}\n\noptions:\n{}", question, options_text)
-    }
-}
-
 pub fn current_turn_preview(app: &TuiApp, limit: usize) -> String {
     if app.active_turn.entries.is_empty() {
         return "No active turn yet.".to_string();

--- a/src/tui/interaction_text.rs
+++ b/src/tui/interaction_text.rs
@@ -1,0 +1,120 @@
+use super::state::{ActivePendingInteractionKind, TuiApp};
+
+pub fn status_plan_approval_text(app: &TuiApp) -> String {
+    let plan_summary = if app.snapshot.plan_steps.is_empty() {
+        "No structured plan captured yet.".to_string()
+    } else {
+        app.snapshot
+            .plan_steps
+            .iter()
+            .enumerate()
+            .take(5)
+            .map(|(idx, (_, step))| format!("{}. {}", idx + 1, step))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let explanation = app
+        .snapshot
+        .plan_explanation
+        .as_deref()
+        .unwrap_or("Review the proposed implementation plan before starting code changes.");
+
+    format!(
+        "ready to implement:\n{}\n\nsummary:\n{}\n\noptions:\n1. Start implementation now\n2. Continue planning",
+        plan_summary, explanation
+    )
+}
+
+pub fn status_active_pending_interaction_text(app: &TuiApp) -> Option<(&'static str, String)> {
+    let pending = app.active_pending_interaction()?;
+    let title = match pending.kind {
+        ActivePendingInteractionKind::PlanApproval => " Plan Approval ",
+        ActivePendingInteractionKind::ShellApproval => " Shell Approval ",
+        ActivePendingInteractionKind::PlanningQuestion => " Planning Question ",
+        ActivePendingInteractionKind::ExplorationQuestion => " Exploration Question ",
+        ActivePendingInteractionKind::SubAgentQuestion => " Sub-agent Question ",
+        ActivePendingInteractionKind::RequestInput => " Request Input ",
+    };
+    let text = match pending.kind {
+        ActivePendingInteractionKind::PlanApproval => status_plan_approval_text(app),
+        ActivePendingInteractionKind::ShellApproval => status_command_approval_text(app),
+        ActivePendingInteractionKind::PlanningQuestion
+        | ActivePendingInteractionKind::ExplorationQuestion
+        | ActivePendingInteractionKind::SubAgentQuestion
+        | ActivePendingInteractionKind::RequestInput => status_request_user_input_text(app),
+    };
+    Some((title, text))
+}
+
+pub fn status_planning_suggestion_text(app: &TuiApp) -> String {
+    let _ = app.pending_planning_suggestion.as_deref();
+    "suggestion:\nThis looks like a non-trivial task. Enter planning mode first so RARA can analyze the repository, refine the approach, and only stop once a concrete plan is ready.\n\noptions:\n1. Enter planning mode\n2. Continue in execute mode".to_string()
+}
+
+pub fn status_request_user_input_text(app: &TuiApp) -> String {
+    let Some(interaction) = app.pending_request_input() else {
+        return "No pending structured question.".to_string();
+    };
+
+    let options_text = if interaction.options.is_empty() {
+        "No predefined options.".to_string()
+    } else {
+        interaction
+            .options
+            .iter()
+            .enumerate()
+            .map(|(idx, (label, description))| {
+                if description.is_empty() {
+                    format!("{}. {}", idx + 1, label)
+                } else {
+                    format!("{}. {} — {}", idx + 1, label, description)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let source_block = interaction
+        .source
+        .as_deref()
+        .map(|source| format!("source:\n{source}\n\n"))
+        .unwrap_or_default();
+
+    if let Some(note) = interaction.note.as_deref() {
+        format!(
+            "{}question:\n{}\n\noptions:\n{}\n\nnote:\n{}",
+            source_block, interaction.title, options_text, note
+        )
+    } else {
+        format!(
+            "{}question:\n{}\n\noptions:\n{}",
+            source_block, interaction.title, options_text
+        )
+    }
+}
+
+pub fn status_command_approval_text(app: &TuiApp) -> String {
+    let Some(interaction) = app.pending_command_approval() else {
+        return "No pending shell approval.".to_string();
+    };
+    let Some(approval) = interaction.approval.as_ref() else {
+        return "No pending shell approval.".to_string();
+    };
+
+    let cwd = approval
+        .payload
+        .cwd
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(".");
+    let env_count = approval.payload.env.len();
+
+    format!(
+        "command:\n{}\n\ncwd:\n{}\n\nnetwork:\n{}\n\nenv:\n{} override(s)\n\noptions:\n1. Approve once\n2. Approve for session\n3. Keep as suggestion",
+        approval.command,
+        cwd,
+        if approval.allow_net { "allowed" } else { "disabled" },
+        env_count,
+    )
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -239,16 +239,9 @@ fn map_key_to_event(key: KeyCode, app: &TuiApp) -> AppEvent {
             }
             KeyCode::Char('3')
                 if app.input.is_empty()
-                    && matches!(
-                        app.active_pending_interaction().map(|pending| pending.kind),
-                        Some(
-                            self::state::ActivePendingInteractionKind::ShellApproval
-                                | self::state::ActivePendingInteractionKind::PlanningQuestion
-                                | self::state::ActivePendingInteractionKind::ExplorationQuestion
-                                | self::state::ActivePendingInteractionKind::SubAgentQuestion
-                                | self::state::ActivePendingInteractionKind::RequestInput
-                        )
-                    ) => AppEvent::SelectPendingOption(2),
+                    && app.active_pending_interaction().is_some_and(|pending| {
+                        pending.kind != self::state::ActivePendingInteractionKind::PlanApproval
+                    }) => AppEvent::SelectPendingOption(2),
             KeyCode::Char('s') => AppEvent::OpenOverlay(Overlay::Setup),
             KeyCode::Backspace => AppEvent::Backspace,
             KeyCode::Char(c) => AppEvent::InputChar(c),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,6 +3,7 @@ mod command;
 mod custom_terminal;
 mod event_stream;
 mod highlight;
+mod interaction_text;
 mod insert_history;
 mod line_utils;
 mod markdown;
@@ -224,25 +225,30 @@ fn map_key_to_event(key: KeyCode, app: &TuiApp) -> AppEvent {
             KeyCode::PageDown if app.input.is_empty() => AppEvent::ScrollTranscript(8),
             KeyCode::Char('1')
                 if app.input.is_empty()
-                    && (app.snapshot.pending_question.is_some()
-                        || app.has_pending_plan_approval()
+                    && (app.active_pending_interaction().is_some()
                         || app.has_pending_planning_suggestion()) =>
             {
                 AppEvent::SelectPendingOption(0)
             }
             KeyCode::Char('2')
                 if app.input.is_empty()
-                    && (app.snapshot.pending_question.is_some()
-                        || app.has_pending_plan_approval()
+                    && (app.active_pending_interaction().is_some()
                         || app.has_pending_planning_suggestion()) =>
             {
                 AppEvent::SelectPendingOption(1)
             }
             KeyCode::Char('3')
-                if app.input.is_empty() && app.snapshot.pending_question.is_some() =>
-            {
-                AppEvent::SelectPendingOption(2)
-            }
+                if app.input.is_empty()
+                    && matches!(
+                        app.active_pending_interaction().map(|pending| pending.kind),
+                        Some(
+                            self::state::ActivePendingInteractionKind::ShellApproval
+                                | self::state::ActivePendingInteractionKind::PlanningQuestion
+                                | self::state::ActivePendingInteractionKind::ExplorationQuestion
+                                | self::state::ActivePendingInteractionKind::SubAgentQuestion
+                                | self::state::ActivePendingInteractionKind::RequestInput
+                        )
+                    ) => AppEvent::SelectPendingOption(2),
             KeyCode::Char('s') => AppEvent::OpenOverlay(Overlay::Setup),
             KeyCode::Backspace => AppEvent::Backspace,
             KeyCode::Char(c) => AppEvent::InputChar(c),
@@ -382,39 +388,50 @@ async fn dispatch_event(
                         );
                     }
                 }
-            } else if app.has_pending_plan_approval() {
-                match idx {
-                    0 => {
+            } else if let Some(pending) = app.active_pending_interaction() {
+                match pending.kind {
+                    self::state::ActivePendingInteractionKind::PlanApproval => match idx {
+                        0 => {
+                            if let Some(agent) = agent_slot.take() {
+                                start_plan_approval_resume_task(app, false, agent);
+                            }
+                        }
+                        1 => {
+                            if let Some(agent) = agent_slot.take() {
+                                start_plan_approval_resume_task(app, true, agent);
+                            }
+                        }
+                        _ => {
+                            app.push_notice(
+                                "Select 1 to implement now or 2 to continue planning.",
+                            );
+                        }
+                    },
+                    self::state::ActivePendingInteractionKind::ShellApproval => {
                         if let Some(agent) = agent_slot.take() {
-                            start_plan_approval_resume_task(app, false, agent);
+                            let selection = match idx {
+                                0 => BashApprovalMode::Once,
+                                1 => BashApprovalMode::Always,
+                                _ => BashApprovalMode::Suggestion,
+                            };
+                            start_pending_approval_task(app, selection, agent);
                         }
                     }
-                    1 => {
-                        if let Some(agent) = agent_slot.take() {
-                            start_plan_approval_resume_task(app, true, agent);
+                    self::state::ActivePendingInteractionKind::PlanningQuestion
+                    | self::state::ActivePendingInteractionKind::ExplorationQuestion
+                    | self::state::ActivePendingInteractionKind::SubAgentQuestion
+                    | self::state::ActivePendingInteractionKind::RequestInput => {
+                        if let Some(label) = app.pending_question_option_label(idx) {
+                            if let Some(agent) = agent_slot.as_mut() {
+                                agent.consume_pending_user_input(&label);
+                                app.sync_snapshot(agent);
+                            }
+                            app.input = label;
+                            if handle_submit(app, agent_slot, oauth_manager).await? {
+                                return Ok(true);
+                            }
                         }
                     }
-                    _ => {
-                        app.push_notice("Select 1 to implement now or 2 to continue planning.");
-                    }
-                }
-            } else if app.has_pending_approval() {
-                if let Some(agent) = agent_slot.take() {
-                    let selection = match idx {
-                        0 => BashApprovalMode::Once,
-                        1 => BashApprovalMode::Always,
-                        _ => BashApprovalMode::Suggestion,
-                    };
-                    start_pending_approval_task(app, selection, agent);
-                }
-            } else if let Some(label) = app.pending_question_option_label(idx) {
-                if let Some(agent) = agent_slot.as_mut() {
-                    agent.consume_pending_user_input(&label);
-                    app.sync_snapshot(agent);
-                }
-                app.input = label;
-                if handle_submit(app, agent_slot, oauth_manager).await? {
-                    return Ok(true);
                 }
             }
         }
@@ -578,8 +595,37 @@ async fn handle_submit(
         app.push_notice(format!("Unknown command '{}'. Use /help.", input.trim()));
     } else if let Some(agent) = agent_slot.take() {
         let mut agent = agent;
-        if app.snapshot.pending_question.is_some() {
-            agent.consume_pending_user_input(input.trim());
+        if app.pending_request_input().is_some() {
+            if app.has_local_pending_request_input() {
+                let interaction = app.pending_request_input().cloned();
+                if let Some(interaction) = interaction {
+                    let source = interaction
+                        .source
+                        .clone()
+                        .unwrap_or_else(|| "sub-agent".to_string());
+                    let answer = input.trim().to_string();
+                    app.record_completed_interaction(
+                        crate::tui::state::InteractionKind::RequestInput,
+                        interaction.title.clone(),
+                        format!("Answered with: {}", answer),
+                        interaction.source.clone(),
+                    );
+                    app.clear_local_request_input();
+                    let mut prompt = format!(
+                        "Continue the same task. A delegated {source} requested additional user input.\nQuestion: {}\nAnswer: {}",
+                        interaction.title, answer
+                    );
+                    if let Some(note) = interaction.note.as_deref() {
+                        if !note.trim().is_empty() {
+                            prompt.push_str(&format!("\nContext: {}", note.trim()));
+                        }
+                    }
+                    start_query_task(app, prompt, agent);
+                    return Ok(false);
+                }
+            } else {
+                agent.consume_pending_user_input(input.trim());
+            }
         }
         let prompt = input.trim().to_string();
         if should_suggest_planning_mode(app, prompt.as_str()) {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -16,10 +16,11 @@ use super::command::{
     api_key_status, command_detail_text, command_spec_by_index, current_turn_preview,
     download_status_text, general_help_text, help_text, matching_commands, model_help_text,
     palette_command_by_index, palette_commands, quick_actions_text, recent_transcript_preview,
-    status_plan_text, status_prompt_sources_text, status_request_user_input_text,
-    status_resources_text, status_runtime_text, status_workspace_text,
+    status_plan_text, status_prompt_sources_text, status_resources_text, status_runtime_text,
+    status_workspace_text,
 };
 use super::custom_terminal::Frame;
+use super::interaction_text::status_active_pending_interaction_text;
 use super::line_utils::prefix_lines;
 use super::state::{
     current_model_presets, HelpTab, Overlay, TaskKind, TranscriptEntry, TuiApp, PROVIDER_FAMILIES,
@@ -595,12 +596,23 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
         "slash command  Enter run  Esc close"
     } else if app.is_busy() {
         "busy  wait for the current task to finish"
-    } else if app.has_pending_approval() {
-        "approval pending  1 once  2 always  3 suggestion"
     } else if app.has_pending_planning_suggestion() {
         "planning suggested  1 enter planning mode  2 continue in execute mode"
-    } else if app.snapshot.pending_question.is_some() {
-        "question pending  press 1/2/3 or type a reply"
+    } else if let Some(pending) = app.active_pending_interaction() {
+        match pending.kind {
+            crate::tui::state::ActivePendingInteractionKind::PlanApproval => {
+                "plan approval pending  1 start implementation  2 continue planning"
+            }
+            crate::tui::state::ActivePendingInteractionKind::ShellApproval => {
+                "shell approval pending  1 once  2 session  3 suggestion"
+            }
+            crate::tui::state::ActivePendingInteractionKind::PlanningQuestion
+            | crate::tui::state::ActivePendingInteractionKind::ExplorationQuestion
+            | crate::tui::state::ActivePendingInteractionKind::SubAgentQuestion
+            | crate::tui::state::ActivePendingInteractionKind::RequestInput => {
+                "question pending  press 1/2/3 or type a reply"
+            }
+        }
     } else if app.agent_execution_mode_label() == "plan" {
         "planning mode  analyze, refine, or finalize a plan"
     } else {
@@ -1032,13 +1044,14 @@ fn render_status_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(chunks[3]);
+    let (interaction_title, interaction_text) =
+        status_active_pending_interaction_text(app).unwrap_or((
+            " Request Input ",
+            "No pending interaction.".to_string(),
+        ));
     f.render_widget(
-        Paragraph::new(status_request_user_input_text(app))
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" Request Input "),
-            )
+        Paragraph::new(interaction_text)
+            .block(Block::default().borders(Borders::ALL).title(interaction_title))
             .wrap(Wrap { trim: false }),
         lower[0],
     );

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -147,12 +147,23 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
         "slash command  Enter run  Esc close"
     } else if app.is_busy() {
         "busy  wait for the current task to finish"
-    } else if app.has_pending_approval() {
-        "approval pending  1 once  2 always  3 suggestion"
     } else if app.has_pending_planning_suggestion() {
         "planning suggested  1 enter planning mode  2 continue in execute mode"
-    } else if app.snapshot.pending_question.is_some() {
-        "question pending  press 1/2/3 or type a reply"
+    } else if let Some(pending) = app.active_pending_interaction() {
+        match pending.kind {
+            crate::tui::state::ActivePendingInteractionKind::PlanApproval => {
+                "plan approval pending  1 start implementation  2 continue planning"
+            }
+            crate::tui::state::ActivePendingInteractionKind::ShellApproval => {
+                "shell approval pending  1 once  2 session  3 suggestion"
+            }
+            crate::tui::state::ActivePendingInteractionKind::PlanningQuestion
+            | crate::tui::state::ActivePendingInteractionKind::ExplorationQuestion
+            | crate::tui::state::ActivePendingInteractionKind::SubAgentQuestion
+            | crate::tui::state::ActivePendingInteractionKind::RequestInput => {
+                "question pending  press 1/2/3 or type a reply"
+            }
+        }
     } else if app.agent_execution_mode_label() == "plan" {
         "planning mode  analyze, refine, or finalize a plan"
     } else {

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -1,15 +1,18 @@
 use std::path::Path;
 
 use ratatui::{
-    style::Color,
+    style::{Color, Modifier, Style},
     text::{Line, Span},
 };
 
-use crate::tui::command::{
-    status_plan_text, status_planning_suggestion_text, status_request_user_input_text,
+use crate::tui::command::status_plan_text;
+use crate::tui::interaction_text::{
+    status_command_approval_text, status_plan_approval_text, status_planning_suggestion_text,
+    status_request_user_input_text,
 };
 use crate::tui::state::{
-    contains_structured_planning_output, RuntimePhase, TranscriptEntry, TuiApp,
+    contains_structured_planning_output, ActivePendingInteractionKind, RuntimePhase,
+    TranscriptEntry, TuiApp,
 };
 
 use super::{
@@ -33,6 +36,62 @@ pub(crate) trait ActiveCell {
 fn trim_trailing_empty_lines(lines: &mut Vec<Line<'static>>) {
     while matches!(lines.last(), Some(line) if line.spans.iter().all(|span| span.content == "")) {
         lines.pop();
+    }
+}
+
+#[derive(Clone, Copy)]
+enum InteractionCompletionKind {
+    ShellApprovalCompleted,
+    PlanDecision,
+    QuestionAnswered,
+    PlanningQuestionAnswered,
+    ExplorationQuestionAnswered,
+    SubAgentQuestionAnswered,
+}
+
+impl InteractionCompletionKind {
+    fn from_role(role: &str) -> Option<Self> {
+        match role {
+            "Shell Approval Completed" => Some(Self::ShellApprovalCompleted),
+            "Plan Decision" => Some(Self::PlanDecision),
+            "Question Answered" => Some(Self::QuestionAnswered),
+            "Planning Question Answered" => Some(Self::PlanningQuestionAnswered),
+            "Exploration Question Answered" => Some(Self::ExplorationQuestionAnswered),
+            "Sub-agent Question Answered" => Some(Self::SubAgentQuestionAnswered),
+            _ => None,
+        }
+    }
+
+    fn title(self) -> &'static str {
+        match self {
+            Self::ShellApprovalCompleted => "Shell Approval Completed",
+            Self::PlanDecision => "Plan Decision",
+            Self::QuestionAnswered => "Question Answered",
+            Self::PlanningQuestionAnswered => "Planning Question Answered",
+            Self::ExplorationQuestionAnswered => "Exploration Question Answered",
+            Self::SubAgentQuestionAnswered => "Sub-agent Question Answered",
+        }
+    }
+
+    fn color(self) -> Color {
+        match self {
+            Self::PlanDecision => Color::LightBlue,
+            Self::ShellApprovalCompleted
+            | Self::QuestionAnswered
+            | Self::PlanningQuestionAnswered
+            | Self::ExplorationQuestionAnswered
+            | Self::SubAgentQuestionAnswered => Color::LightGreen,
+        }
+    }
+}
+
+fn completion_role_color(role: &str) -> Option<Color> {
+    InteractionCompletionKind::from_role(role).map(InteractionCompletionKind::color)
+}
+
+fn completion_role_kind(role: &str) -> Option<InteractionCompletionKind> {
+    match role {
+        _ => InteractionCompletionKind::from_role(role),
     }
 }
 
@@ -233,6 +292,55 @@ impl HistoryCell for ApprovalCell {
     }
 }
 
+#[derive(Clone, Copy)]
+enum PendingInteractionKind {
+    PlanApproval,
+    ShellApproval,
+    PlanningQuestion,
+    ExplorationQuestion,
+    SubAgentQuestion,
+    RequestInput,
+}
+
+impl PendingInteractionKind {
+    fn title(self) -> &'static str {
+        match self {
+            Self::PlanApproval => "Awaiting Approval",
+            Self::ShellApproval => "Shell Approval",
+            Self::PlanningQuestion => "Planning Question",
+            Self::ExplorationQuestion => "Exploration Question",
+            Self::SubAgentQuestion => "Sub-agent Question",
+            Self::RequestInput => "Request Input",
+        }
+    }
+
+    fn color(self) -> Color {
+        match self {
+            Self::PlanApproval | Self::PlanningQuestion => Color::LightBlue,
+            Self::ShellApproval | Self::ExplorationQuestion => Color::Yellow,
+            Self::SubAgentQuestion | Self::RequestInput => Color::LightGreen,
+        }
+    }
+}
+
+struct PendingInteractionCell {
+    inner: ApprovalCell,
+}
+
+impl PendingInteractionCell {
+    fn new(kind: PendingInteractionKind, lines: Vec<String>) -> Self {
+        Self {
+            inner: ApprovalCell::new(kind.title(), kind.color(), lines),
+        }
+    }
+}
+
+impl HistoryCell for PendingInteractionCell {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
+        self.inner.display_lines(width)
+    }
+}
+
 struct PlanningSuggestionCell {
     text: String,
 }
@@ -259,25 +367,49 @@ impl HistoryCell for PlanningSuggestionCell {
 }
 
 struct CompletionCell {
-    title: &'static str,
+    title: String,
     color: Color,
     summary: String,
 }
 
 impl CompletionCell {
-    fn new(title: &'static str, color: Color, summary: impl Into<String>) -> Self {
+    fn new(title: impl Into<String>, color: Color, summary: impl Into<String>) -> Self {
         Self {
-            title,
+            title: title.into(),
             color,
             summary: summary.into(),
         }
     }
 }
 
+struct CommittedInteractionCell {
+    inner: CompletionCell,
+}
+
+impl CommittedInteractionCell {
+    fn new(kind: InteractionCompletionKind, summary: impl Into<String>) -> Self {
+        Self {
+            inner: CompletionCell::new(kind.title(), kind.color(), summary),
+        }
+    }
+}
+
+impl HistoryCell for CommittedInteractionCell {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
+        self.inner.display_lines(width)
+    }
+}
+
 impl HistoryCell for CompletionCell {
     fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
         vec![
-            Line::from(section_span(self.title, self.color)),
+            Line::from(Span::styled(
+                format!(" {} ", self.title),
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(self.color)
+                    .add_modifier(Modifier::BOLD),
+            )),
             Line::from(format!("  {}", self.summary)),
         ]
     }
@@ -484,32 +616,55 @@ impl HistoryCell for CommittedTurnCell<'_> {
         }
 
         let entry_refs = self.entries.iter().collect::<Vec<_>>();
+        let explicit_exploration = self
+            .entries
+            .iter()
+            .find(|entry| entry.role == "Exploring")
+            .map(|entry| entry.message.clone());
+        let explicit_planning = self
+            .entries
+            .iter()
+            .find(|entry| entry.role == "Planning")
+            .map(|entry| entry.message.clone());
+        let explicit_running = self
+            .entries
+            .iter()
+            .find(|entry| entry.role == "Running")
+            .map(|entry| entry.message.clone());
         let has_tool_activity = entry_refs
             .iter()
             .any(|entry| matches!(entry.role.as_str(), "Tool" | "Tool Result" | "Tool Error"));
-        if let Some(summary) =
+        if let Some(summary) = explicit_exploration.or_else(|| {
             current_turn_exploration_summary_from_entries(entry_refs.as_slice(), false, None)
-        {
+        }) {
             cells.push(Box::new(ExploredCell::new(summary)));
         }
 
-        if let Some(summary) = current_turn_tool_summary(entry_refs.as_slice(), false, None) {
+        if let Some(summary) = explicit_planning {
+            cells.push(Box::new(PlanningCell::new(summary, false)));
+        }
+
+        if let Some(summary) =
+            explicit_running.or_else(|| current_turn_tool_summary(entry_refs.as_slice(), false, None))
+        {
             cells.push(Box::new(RanCell::new(summary)));
         }
 
-        let tail_entries: Vec<&TranscriptEntry> = if has_tool_activity {
+        let completion_entries: Vec<&TranscriptEntry> = self
+            .entries
+            .iter()
+            .filter(|entry| completion_role_color(entry.role.as_str()).is_some())
+            .collect();
+        let narrative_entries: Vec<&TranscriptEntry> = if has_tool_activity {
             self.entries
                 .iter()
                 .rev()
-                .filter(|entry| {
+                .find(|entry| {
                     entry.role == "Agent"
                         || (entry.role == "System"
                             && is_renderable_system_message(entry.message.as_str()))
                 })
-                .take(1)
-                .collect::<Vec<_>>()
                 .into_iter()
-                .rev()
                 .collect()
         } else {
             self.entries
@@ -522,7 +677,16 @@ impl HistoryCell for CommittedTurnCell<'_> {
                 .collect()
         };
 
-        for entry in tail_entries {
+        for entry in completion_entries {
+            if let Some(kind) = completion_role_kind(entry.role.as_str()) {
+                cells.push(Box::new(CommittedInteractionCell::new(
+                    kind,
+                    entry.message.clone(),
+                )));
+            }
+        }
+
+        for entry in narrative_entries {
             let max_lines = if entry.role == "Agent" { usize::MAX } else { 4 };
             cells.push(Box::new(MessageCell::new(
                 &entry.role,
@@ -612,10 +776,15 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .rev()
             .find(|entry| entry.role == "Tool Result" || entry.role == "Tool Error")
             .map(|entry| (entry.role.as_str(), entry.message.as_str()));
+        let latest_completion = current_turn
+            .iter()
+            .rev()
+            .find(|entry| completion_role_color(entry.role.as_str()).is_some());
         let mut cells: Vec<Box<dyn HistoryCell + '_>> = Vec::new();
         let has_live_exploration = !self.app.active_live.exploration_actions.is_empty()
             || !self.app.active_live.exploration_notes.is_empty();
-        let has_live_planning = !self.app.active_live.planning_actions.is_empty();
+        let has_live_planning = !self.app.active_live.planning_actions.is_empty()
+            || !self.app.active_live.planning_notes.is_empty();
         let has_live_running = !self.app.active_live.running_actions.is_empty();
 
         if !user_message.is_empty() {
@@ -668,6 +837,13 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 .iter()
                 .map(|action| format!("└ {action}"))
                 .collect::<Vec<_>>();
+            lines.extend(
+                self.app
+                    .active_live
+                    .planning_notes
+                    .iter()
+                    .map(|note| format!("└ {note}")),
+            );
             if turn_live {
                 lines.push(format!(
                     "└ {}",
@@ -725,19 +901,73 @@ impl ActiveCell for ActiveTurnCell<'_> {
             )));
         }
 
-        if self.app.snapshot.pending_question.is_some() {
-            let (title, color) = if self.app.has_pending_approval() {
-                ("Approval", Color::Yellow)
-            } else {
-                ("Request Input", Color::LightGreen)
+        if let Some(pending) = self.app.active_pending_interaction() {
+            let (kind, mut request_lines) = match pending.kind {
+                ActivePendingInteractionKind::PlanApproval => (
+                    PendingInteractionKind::PlanApproval,
+                    status_plan_approval_text(self.app)
+                        .lines()
+                        .take(10)
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>(),
+                ),
+                ActivePendingInteractionKind::ShellApproval => (
+                    PendingInteractionKind::ShellApproval,
+                    status_command_approval_text(self.app)
+                        .lines()
+                        .take(10)
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>(),
+                ),
+                ActivePendingInteractionKind::PlanningQuestion => (
+                    PendingInteractionKind::PlanningQuestion,
+                    status_request_user_input_text(self.app)
+                        .lines()
+                        .take(8)
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>(),
+                ),
+                ActivePendingInteractionKind::ExplorationQuestion => (
+                    PendingInteractionKind::ExplorationQuestion,
+                    status_request_user_input_text(self.app)
+                        .lines()
+                        .take(8)
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>(),
+                ),
+                ActivePendingInteractionKind::SubAgentQuestion => (
+                    PendingInteractionKind::SubAgentQuestion,
+                    status_request_user_input_text(self.app)
+                        .lines()
+                        .take(8)
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>(),
+                ),
+                ActivePendingInteractionKind::RequestInput => (
+                    PendingInteractionKind::RequestInput,
+                    status_request_user_input_text(self.app)
+                        .lines()
+                        .take(8)
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>(),
+                ),
             };
-            let mut request_lines = status_request_user_input_text(self.app)
-                .lines()
-                .take(8)
-                .map(ToString::to_string)
-                .collect::<Vec<_>>();
-            request_lines.push("shortcuts: press 1/2/3 to answer immediately".to_string());
-            cells.push(Box::new(ApprovalCell::new(title, color, request_lines)));
+            match pending.kind {
+                ActivePendingInteractionKind::PlanApproval => request_lines.push(
+                    "shortcuts: press 1 to start implementation, 2 to continue planning"
+                        .to_string(),
+                ),
+                ActivePendingInteractionKind::ShellApproval => request_lines.push(
+                    "shortcuts: press 1 to approve once, 2 to approve for session, 3 to keep as suggestion"
+                        .to_string(),
+                ),
+                ActivePendingInteractionKind::PlanningQuestion
+                | ActivePendingInteractionKind::ExplorationQuestion
+                | ActivePendingInteractionKind::SubAgentQuestion
+                | ActivePendingInteractionKind::RequestInput => request_lines
+                    .push("shortcuts: press 1/2/3 to answer immediately".to_string()),
+            }
+            cells.push(Box::new(PendingInteractionCell::new(kind, request_lines)));
         }
 
         if self.app.pending_planning_suggestion.is_some() {
@@ -746,20 +976,51 @@ impl ActiveCell for ActiveTurnCell<'_> {
             )));
         }
 
-        if let Some((title, summary)) = self.app.snapshot.completed_approval.as_ref() {
-            cells.push(Box::new(CompletionCell::new(
-                "Approval Completed",
-                Color::LightGreen,
-                format!("{title}: {summary}"),
-            )));
-        }
+        if latest_completion.is_none() {
+            if let Some(interaction) = self
+                .app
+                .completed_interaction(crate::tui::state::InteractionKind::Approval)
+            {
+                cells.push(Box::new(CommittedInteractionCell::new(
+                    InteractionCompletionKind::ShellApprovalCompleted,
+                    format!("{}: {}", interaction.title, interaction.summary),
+                )));
+            }
 
-        if let Some((title, summary)) = self.app.snapshot.completed_question.as_ref() {
-            cells.push(Box::new(CompletionCell::new(
-                "Question Answered",
-                Color::LightGreen,
-                format!("{title}: {summary}"),
-            )));
+            if let Some(interaction) = self
+                .app
+                .completed_interaction(crate::tui::state::InteractionKind::RequestInput)
+            {
+                let kind = match interaction.source.as_deref() {
+                    Some("plan_agent") => InteractionCompletionKind::PlanningQuestionAnswered,
+                    Some("explore_agent") => {
+                        InteractionCompletionKind::ExplorationQuestionAnswered
+                    }
+                    Some(_) => InteractionCompletionKind::SubAgentQuestionAnswered,
+                    None => InteractionCompletionKind::QuestionAnswered,
+                };
+                cells.push(Box::new(CommittedInteractionCell::new(
+                    kind,
+                    format!("{}: {}", interaction.title, interaction.summary),
+                )));
+            }
+
+            if let Some(interaction) = self
+                .app
+                .completed_interaction(crate::tui::state::InteractionKind::PlanApproval)
+            {
+                cells.push(Box::new(CommittedInteractionCell::new(
+                    InteractionCompletionKind::PlanDecision,
+                    format!("{}: {}", interaction.title, interaction.summary),
+                )));
+            }
+        } else if let Some(entry) = latest_completion {
+            if let Some(kind) = completion_role_kind(entry.role.as_str()) {
+                cells.push(Box::new(CommittedInteractionCell::new(
+                    kind,
+                    entry.message.clone(),
+                )));
+            }
         }
 
         let suppress_intermediate_agent = turn_live
@@ -774,7 +1035,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
         ) && has_exploration_summary
             && latest_agent.is_some_and(|message| !contains_structured_planning_output(message))
             && self.app.snapshot.plan_steps.is_empty()
-            && self.app.snapshot.pending_question.is_none()
+            && self.app.pending_request_input().is_none()
             && !self.app.has_pending_plan_approval();
 
         let responding_role = if turn_live { "Responding" } else { "Agent" };
@@ -914,11 +1175,15 @@ mod tests {
         };
         app.snapshot = RuntimeSnapshot {
             plan_steps: vec![("pending".into(), "Review architecture".into())],
-            pending_question: Some((
-                "Approve plan".into(),
-                vec![("1".into(), "Implement".into())],
-                None,
-            )),
+            pending_interactions: vec![crate::tui::state::PendingInteractionSnapshot {
+                kind: crate::tui::state::InteractionKind::RequestInput,
+                title: "Approve plan".into(),
+                summary: String::new(),
+                options: vec![("1".into(), "Implement".into())],
+                note: None,
+                approval: None,
+                source: None,
+            }],
             ..RuntimeSnapshot::default()
         };
 
@@ -1131,6 +1396,7 @@ mod tests {
             }],
         };
         app.record_planning_action("Delegate plan refinement: refine the plan");
+        app.record_planning_note("Sub-agent summary: reuse the workspace traversal helper");
 
         let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
             .display_lines(100)
@@ -1141,6 +1407,7 @@ mod tests {
 
         assert!(rendered.contains(" Planning "));
         assert!(rendered.contains("Delegate plan refinement: refine the plan"));
+        assert!(rendered.contains("Sub-agent summary: reuse the workspace traversal helper"));
     }
 
     #[test]
@@ -1170,5 +1437,265 @@ mod tests {
         assert!(rendered.contains("Agent\n  Final recommendation"));
         assert!(!rendered.contains("System"));
         assert!(!rendered.contains("prompt finished"));
+    }
+
+    #[test]
+    fn committed_turn_cell_renders_materialized_sidecar_sections() {
+        let entries = vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Review the workspace logic".into(),
+            },
+            TranscriptEntry {
+                role: "Exploring".into(),
+                message: "Delegate repository exploration: inspect instruction discovery\nSub-agent summary: current discovery is hardcoded".into(),
+            },
+            TranscriptEntry {
+                role: "Planning".into(),
+                message: "Delegate plan refinement: generalize instruction discovery\nSub-agent summary: reuse the workspace traversal helper".into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "Here is the final recommendation.".into(),
+            },
+        ];
+
+        let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let you_idx = rendered.find("You: Review the workspace logic").unwrap();
+        let explored_idx = rendered.find(" Explored ").unwrap();
+        let planning_idx = rendered.find(" Planned ").unwrap();
+        let agent_idx = rendered.find("Agent\n  Here is the final recommendation.").unwrap();
+
+        assert!(you_idx < explored_idx);
+        assert!(explored_idx < planning_idx);
+        assert!(planning_idx < agent_idx);
+        assert!(rendered.contains("Sub-agent summary: current discovery is hardcoded"));
+        assert!(rendered.contains("Sub-agent summary: reuse the workspace traversal helper"));
+    }
+
+    #[test]
+    fn committed_turn_cell_places_completion_records_before_final_agent_message() {
+        let entries = vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Inspect the repo and decide whether to run the migration".into(),
+            },
+            TranscriptEntry {
+                role: "Exploring".into(),
+                message: "└ Read crates/instructions/src/workspace.rs".into(),
+            },
+            TranscriptEntry {
+                role: "Shell Approval Completed".into(),
+                message: "Bash approval: Approved once for command: bash ./scripts/migrate.sh"
+                    .into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "I approved the one-off shell step and can now continue with the final recommendation.".into(),
+            },
+        ];
+
+        let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let explored_idx = rendered.find(" Explored ").unwrap();
+        let approval_idx = rendered.find(" Shell Approval Completed ").unwrap();
+        let agent_idx = rendered
+            .find("Agent\n  I approved the one-off shell step")
+            .unwrap();
+
+        assert!(explored_idx < approval_idx);
+        assert!(approval_idx < agent_idx);
+    }
+
+    #[test]
+    fn active_turn_cell_renders_plan_approval_as_interaction_card() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.active_turn = TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "You".into(),
+                message: "Review the codebase and propose changes".into(),
+            }],
+        };
+        app.snapshot.plan_steps = vec![
+            ("pending".into(), "Generalize instruction discovery".into()),
+            ("pending".into(), "Preserve cache and path resolution behavior".into()),
+        ];
+        app.snapshot.plan_explanation = Some("The current discovery path is hardcoded and should be generalized.".into());
+        app.set_pending_plan_approval(true);
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains(" Awaiting Approval "));
+        assert!(rendered.contains("Start implementation now"));
+        assert!(rendered.contains("Continue planning"));
+        assert!(rendered.contains("Generalize instruction discovery"));
+    }
+
+    #[test]
+    fn active_turn_cell_renders_shell_approval_as_interaction_card() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.active_turn = TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "You".into(),
+                message: "Run the migration helper".into(),
+            }],
+        };
+        app.snapshot.pending_interactions.push(
+            crate::tui::state::PendingInteractionSnapshot {
+                kind: crate::tui::state::InteractionKind::Approval,
+                title: "Pending Approval".into(),
+                summary: "bash ./scripts/migrate.sh".into(),
+                options: Vec::new(),
+                note: None,
+                approval: Some(crate::tui::state::PendingApprovalSnapshot {
+                    tool_use_id: "toolu_123".into(),
+                    command: "bash ./scripts/migrate.sh".into(),
+                    allow_net: false,
+                    payload: crate::tools::bash::BashCommandInput {
+                        command: None,
+                        program: Some("bash".into()),
+                        args: vec!["./scripts/migrate.sh".into()],
+                        cwd: Some("/repo".into()),
+                        env: Default::default(),
+                        allow_net: false,
+                    },
+                }),
+                source: None,
+            },
+        );
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains(" Shell Approval "));
+        assert!(rendered.contains("command:"));
+        assert!(rendered.contains("cwd:"));
+        assert!(rendered.contains("bash ./scripts/migrate.sh"));
+    }
+
+    #[test]
+    fn active_turn_cell_renders_completed_plan_decision() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.active_turn = TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "You".into(),
+                message: "Review the codebase and propose changes".into(),
+            }],
+        };
+        app.record_completed_interaction(
+            crate::tui::state::InteractionKind::PlanApproval,
+            "Plan Decision",
+            "Approved and started implementation",
+            None,
+        );
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains(" Plan Decision "));
+        assert!(rendered.contains("Approved and started implementation"));
+    }
+
+    #[test]
+    fn active_turn_cell_labels_delegated_plan_questions() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.active_turn = TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "You".into(),
+                message: "Review the codebase and propose changes".into(),
+            }],
+        };
+        app.record_local_request_input(
+            "plan_agent",
+            "Which discovery strategy should we keep?",
+            vec![
+                ("Minimal".into(), "Keep root-only files.".into()),
+                ("Generic".into(), "Scan all instruction markdown files.".into()),
+            ],
+            Some("A product decision is needed before editing.".into()),
+        );
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains(" Planning Question "));
+        assert!(rendered.contains("source:"));
+        assert!(rendered.contains("plan_agent"));
+        assert!(rendered.contains("Which discovery strategy should we keep?"));
+    }
+
+    #[test]
+    fn active_turn_cell_labels_delegated_completed_questions() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.active_turn = TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "You".into(),
+                message: "Review the codebase and propose changes".into(),
+            }],
+        };
+        app.record_completed_interaction(
+            crate::tui::state::InteractionKind::RequestInput,
+            "Which discovery strategy should we keep?",
+            "Answered with: Generic",
+            Some("plan_agent".into()),
+        );
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains(" Planning Question Answered "));
+        assert!(rendered.contains("Answered with: Generic"));
     }
 }

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -10,12 +10,13 @@ use super::super::command::{
     api_key_status, command_detail_text, command_spec_by_index, current_turn_preview,
     download_status_text, general_help_text, help_text, matching_commands, model_help_text,
     palette_command_by_index, palette_commands, quick_actions_text, recent_transcript_preview,
-    status_plan_text, status_prompt_sources_text, status_request_user_input_text,
-    status_resources_text, status_runtime_text, status_workspace_text,
+    status_plan_text, status_prompt_sources_text, status_resources_text, status_runtime_text,
+    status_workspace_text,
 };
 use super::super::state::{
     current_model_presets, CommandSpec, HelpTab, Overlay, PROVIDER_FAMILIES, TuiApp,
 };
+use super::super::interaction_text::status_active_pending_interaction_text;
 use super::bottom_pane::editor_cursor_position;
 
 pub(super) fn render_overlay(
@@ -357,9 +358,14 @@ fn render_status_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(chunks[3]);
+    let (interaction_title, interaction_text) =
+        status_active_pending_interaction_text(app).unwrap_or((
+            " Request Input ",
+            "No pending interaction.".to_string(),
+        ));
     f.render_widget(
-        Paragraph::new(status_request_user_input_text(app))
-            .block(Block::default().borders(Borders::ALL).title(" Request Input "))
+        Paragraph::new(interaction_text)
+            .block(Block::default().borders(Borders::ALL).title(interaction_title))
             .wrap(Wrap { trim: false }),
         lower[0],
     );

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -30,6 +30,45 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                     } else if let Some(action) = tool_action_label(&message) {
                         app.record_running_action(action);
                     }
+                } else if let Some(note) = exploration_result_note(&message) {
+                    app.record_exploration_note(note);
+                    app.set_runtime_phase(
+                        RuntimePhase::RunningTool,
+                        Some(message.lines().next().unwrap_or(role).trim().to_string()),
+                    );
+                    return;
+                } else if let Some(note) = planning_result_note(&message) {
+                    app.record_planning_note(note);
+                    app.set_runtime_phase(
+                        RuntimePhase::RunningTool,
+                        Some(message.lines().next().unwrap_or(role).trim().to_string()),
+                    );
+                    if let Some(request) = subagent_request_input(&message) {
+                        app.record_local_request_input(
+                            "plan_agent",
+                            request.question,
+                            request.options,
+                            request.note,
+                        );
+                    }
+                    return;
+                } else if let Some(request) = subagent_request_input(&message) {
+                    let source = if message.starts_with("explore_agent ") {
+                        "explore_agent"
+                    } else {
+                        "plan_agent"
+                    };
+                    app.record_local_request_input(
+                        source,
+                        request.question,
+                        request.options,
+                        request.note,
+                    );
+                    app.set_runtime_phase(
+                        RuntimePhase::RunningTool,
+                        Some(message.lines().next().unwrap_or(role).trim().to_string()),
+                    );
+                    return;
                 }
                 app.set_runtime_phase(
                     RuntimePhase::RunningTool,
@@ -337,6 +376,43 @@ fn format_tool_use(name: &str, input: &serde_json::Value) -> String {
 }
 
 fn format_tool_result(name: &str, content: &str) -> String {
+    if matches!(name, "explore_agent" | "plan_agent") {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
+            let summary = value
+                .get("summary")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| first_non_empty_line(content));
+            let mut rendered = format!("{name} {summary}");
+            if let Some(request) = value.get("request_user_input") {
+                if let Some(question) = request.get("question").and_then(serde_json::Value::as_str) {
+                    rendered.push_str(&format!("\nrequest_user_input: {}", question.trim()));
+                }
+                if let Some(options) = request.get("options").and_then(serde_json::Value::as_array) {
+                    for option in options {
+                        if let Some((label, description)) = option
+                            .as_array()
+                            .and_then(|pair| {
+                                Some((
+                                    pair.first()?.as_str()?,
+                                    pair.get(1).and_then(serde_json::Value::as_str).unwrap_or(""),
+                                ))
+                            })
+                        {
+                            rendered.push_str(&format!("\noption: {} | {}", label.trim(), description.trim()));
+                        }
+                    }
+                }
+                if let Some(note) = request.get("note").and_then(serde_json::Value::as_str) {
+                    if !note.trim().is_empty() {
+                        rendered.push_str(&format!("\nnote: {}", note.trim()));
+                    }
+                }
+            }
+            return rendered;
+        }
+        return format!("{name} {}", first_non_empty_line(content));
+    }
     if name == "bash" {
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
             let exit_code = value
@@ -385,6 +461,67 @@ fn format_tool_result(name: &str, content: &str) -> String {
     format!("{name}: {content}")
 }
 
+fn exploration_result_note(message: &str) -> Option<String> {
+    message
+        .strip_prefix("explore_agent ")
+        .map(|summary| {
+            let first_line = summary.lines().next().unwrap_or(summary).trim();
+            format!("Sub-agent summary: {first_line}")
+        })
+}
+
+fn planning_result_note(message: &str) -> Option<String> {
+    message
+        .strip_prefix("plan_agent ")
+        .map(|summary| {
+            let first_line = summary.lines().next().unwrap_or(summary).trim();
+            format!("Sub-agent summary: {first_line}")
+        })
+}
+
+struct DelegatedRequestInput {
+    question: String,
+    options: Vec<(String, String)>,
+    note: Option<String>,
+}
+
+fn subagent_request_input(message: &str) -> Option<DelegatedRequestInput> {
+    if !(message.starts_with("explore_agent ") || message.starts_with("plan_agent ")) {
+        return None;
+    }
+
+    let mut question = None;
+    let mut options = Vec::new();
+    let mut note = None;
+    for line in message.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        if let Some(value) = line.strip_prefix("request_user_input:") {
+            question = Some(value.trim().to_string());
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("option:") {
+            let value = value.trim();
+            if let Some((label, description)) = value.split_once('|') {
+                options.push((label.trim().to_string(), description.trim().to_string()));
+            } else {
+                options.push((value.to_string(), String::new()));
+            }
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("note:") {
+            let value = value.trim();
+            if !value.is_empty() {
+                note = Some(value.to_string());
+            }
+        }
+    }
+
+    Some(DelegatedRequestInput {
+        question: question?,
+        options,
+        note,
+    })
+}
+
 fn first_non_empty_line(text: &str) -> &str {
     text.lines()
         .find(|line| !line.trim().is_empty())
@@ -404,3 +541,25 @@ pub(super) fn format_error_chain(err: &anyhow::Error) -> String {
     lines.join("\n")
 }
 use crate::redaction::redact_secrets;
+
+#[cfg(test)]
+mod tests {
+    use super::subagent_request_input;
+
+    #[test]
+    fn parses_delegated_request_input_from_subagent_result() {
+        let parsed = subagent_request_input(
+            "plan_agent refine the workspace logic\nrequest_user_input: Which discovery strategy should we keep?\noption: Minimal | Keep the current root-level files.\noption: Generic | Scan all instruction markdown files.\nnote: We need one product decision before editing.",
+        )
+        .expect("delegated request input should parse");
+
+        assert_eq!(parsed.question, "Which discovery strategy should we keep?");
+        assert_eq!(parsed.options.len(), 2);
+        assert_eq!(parsed.options[0].0, "Minimal");
+        assert_eq!(parsed.options[1].0, "Generic");
+        assert_eq!(
+            parsed.note.as_deref(),
+            Some("We need one product decision before editing.")
+        );
+    }
+}

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -76,7 +76,7 @@ pub(super) fn should_suggest_planning_mode(app: &TuiApp, prompt: &str) -> bool {
     if app.is_busy()
         || app.has_pending_plan_approval()
         || app.has_pending_approval()
-        || app.snapshot.pending_question.is_some()
+        || app.pending_request_input().is_some()
         || matches!(
             app.agent_execution_mode,
             crate::agent::AgentExecutionMode::Plan
@@ -213,6 +213,16 @@ pub(super) fn start_plan_approval_resume_task(
     let (sender, receiver) = mpsc::unbounded_channel();
     app.clear_active_live_sections();
     app.set_pending_plan_approval(false);
+    app.record_completed_interaction(
+        crate::tui::state::InteractionKind::PlanApproval,
+        "Plan Decision",
+        if continue_planning {
+            "Continued planning"
+        } else {
+            "Approved and started implementation"
+        },
+        None,
+    );
     app.notice = Some(if continue_planning {
         "Continuing plan refinement.".into()
     } else {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -116,15 +116,19 @@ pub struct RuntimeSnapshot {
     pub last_compaction_after_tokens: Option<usize>,
     pub plan_steps: Vec<(String, String)>,
     pub plan_explanation: Option<String>,
-    pub pending_question: Option<(String, Vec<(String, String)>, Option<String>)>,
-    pub pending_approval: Option<PendingApprovalSnapshot>,
-    pub pending_plan_approval: bool,
-    pub completed_question: Option<(String, String)>,
-    pub completed_approval: Option<(String, String)>,
+    pub pending_interactions: Vec<PendingInteractionSnapshot>,
+    pub completed_interactions: Vec<CompletedInteractionSnapshot>,
     pub prompt_base_kind: String,
     pub prompt_section_keys: Vec<String>,
     pub prompt_source_status_lines: Vec<String>,
     pub prompt_warnings: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InteractionKind {
+    RequestInput,
+    Approval,
+    PlanApproval,
 }
 
 #[derive(Default, Clone)]
@@ -133,6 +137,53 @@ pub struct PendingApprovalSnapshot {
     pub command: String,
     pub allow_net: bool,
     pub payload: BashCommandInput,
+}
+
+#[derive(Clone)]
+pub struct PendingInteractionSnapshot {
+    pub kind: InteractionKind,
+    pub title: String,
+    pub summary: String,
+    pub options: Vec<(String, String)>,
+    pub note: Option<String>,
+    pub approval: Option<PendingApprovalSnapshot>,
+    pub source: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActivePendingInteractionKind {
+    PlanApproval,
+    ShellApproval,
+    PlanningQuestion,
+    ExplorationQuestion,
+    SubAgentQuestion,
+    RequestInput,
+}
+
+pub struct ActivePendingInteraction<'a> {
+    pub kind: ActivePendingInteractionKind,
+    pub _snapshot: &'a PendingInteractionSnapshot,
+}
+
+#[derive(Clone)]
+pub struct CompletedInteractionSnapshot {
+    pub kind: InteractionKind,
+    pub title: String,
+    pub summary: String,
+    pub source: Option<String>,
+}
+
+fn completed_interaction_role(kind: InteractionKind, source: Option<&str>) -> &'static str {
+    match kind {
+        InteractionKind::Approval => "Shell Approval Completed",
+        InteractionKind::PlanApproval => "Plan Decision",
+        InteractionKind::RequestInput => match source {
+            Some("plan_agent") => "Planning Question Answered",
+            Some("explore_agent") => "Exploration Question Answered",
+            Some(_) => "Sub-agent Question Answered",
+            None => "Question Answered",
+        },
+    }
 }
 
 pub enum TaskKind {
@@ -232,6 +283,7 @@ pub struct ActiveLiveSections {
     pub exploration_actions: Vec<String>,
     pub exploration_notes: Vec<String>,
     pub planning_actions: Vec<String>,
+    pub planning_notes: Vec<String>,
     pub running_actions: Vec<String>,
 }
 
@@ -263,7 +315,6 @@ pub struct TuiApp {
     pub agent_markdown_stream: Option<AgentMarkdownStreamState>,
     pub active_live: ActiveLiveSections,
     pub pending_planning_suggestion: Option<String>,
-    pub pending_plan_approval: bool,
     pub terminal_focused: bool,
     pub state_db: Option<Arc<StateDb>>,
     pub state_db_status: Option<String>,
@@ -283,6 +334,52 @@ fn state_db_status_error(prefix: &str, message: impl Into<String>) -> String {
 }
 
 impl TuiApp {
+    fn ensure_completed_interaction_entry(
+        &mut self,
+        kind: InteractionKind,
+        title: &str,
+        summary: &str,
+        source: Option<&str>,
+    ) {
+        let role = completed_interaction_role(kind, source).to_string();
+        let message = format!("{title}: {summary}");
+        let exists = self
+            .active_turn
+            .entries
+            .iter()
+            .any(|entry| entry.role == role && entry.message == message);
+        if !exists {
+            self.active_turn.entries.push(TranscriptEntry { role, message });
+        }
+    }
+
+    fn plan_approval_interaction(&self) -> PendingInteractionSnapshot {
+        PendingInteractionSnapshot {
+            kind: InteractionKind::PlanApproval,
+            title: "Plan Ready".to_string(),
+            summary: self
+                .snapshot
+                .plan_explanation
+                .clone()
+                .unwrap_or_else(|| "Review the proposed plan before implementation.".to_string()),
+            options: Vec::new(),
+            note: None,
+            approval: None,
+            source: None,
+        }
+    }
+
+    fn set_plan_approval_interaction(&mut self, pending: bool) {
+        self.snapshot
+            .pending_interactions
+            .retain(|item| item.kind != InteractionKind::PlanApproval);
+        if pending {
+            self.snapshot
+                .pending_interactions
+                .push(self.plan_approval_interaction());
+        }
+    }
+
     pub fn new(cm: ConfigManager) -> anyhow::Result<Self> {
         let cfg = cm.load()?;
         let overlay = if !cfg.has_api_key() && super::provider_requires_api_key(&cfg.provider) {
@@ -324,7 +421,6 @@ impl TuiApp {
             agent_markdown_stream: None,
             active_live: ActiveLiveSections::default(),
             pending_planning_suggestion: None,
-            pending_plan_approval: false,
             terminal_focused: true,
             state_db: None,
             state_db_status: None,
@@ -393,6 +489,87 @@ impl TuiApp {
     pub fn sync_snapshot(&mut self, agent: &Agent) {
         let (cwd, branch) = agent.workspace.get_env_info();
         let effective_prompt = agent.effective_prompt();
+        let existing_plan_completion = self
+            .completed_interaction(InteractionKind::PlanApproval)
+            .cloned();
+        let existing_pending_plan_approval =
+            self.pending_plan_approval_interaction().cloned();
+        let existing_local_request_completion = self
+            .snapshot
+            .completed_interactions
+            .iter()
+            .find(|item| {
+                item.kind == InteractionKind::RequestInput
+                    && item.source.as_deref().is_some()
+            })
+            .cloned();
+        let existing_local_request_inputs = self
+            .snapshot
+            .pending_interactions
+            .iter()
+            .filter(|item| {
+                item.kind == InteractionKind::RequestInput
+                    && item.source.as_deref().is_some()
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut pending_interactions = Vec::new();
+        if let Some(question) = agent.pending_user_input.as_ref() {
+            pending_interactions.push(PendingInteractionSnapshot {
+                kind: InteractionKind::RequestInput,
+                title: question.question.clone(),
+                summary: question.note.clone().unwrap_or_default(),
+                options: question.options.clone(),
+                note: question.note.clone(),
+                approval: None,
+                source: None,
+            });
+        }
+        if agent.pending_user_input.is_none() {
+            pending_interactions.extend(existing_local_request_inputs);
+        }
+        if let Some(item) = existing_pending_plan_approval {
+            pending_interactions.push(item);
+        }
+        if let Some(pending) = agent.pending_approval.as_ref() {
+            pending_interactions.push(PendingInteractionSnapshot {
+                kind: InteractionKind::Approval,
+                title: "Pending Approval".to_string(),
+                summary: pending.request.summary(),
+                options: Vec::new(),
+                note: None,
+                approval: Some(PendingApprovalSnapshot {
+                    tool_use_id: pending.tool_use_id.clone(),
+                    command: pending.request.summary(),
+                    allow_net: pending.request.allow_net,
+                    payload: pending.request.clone(),
+                }),
+                source: None,
+            });
+        }
+        let mut completed_interactions = Vec::new();
+        if let Some(item) = agent.completed_user_input.as_ref() {
+            completed_interactions.push(CompletedInteractionSnapshot {
+                kind: InteractionKind::RequestInput,
+                title: item.title.clone(),
+                summary: item.summary.clone(),
+                source: None,
+            });
+        }
+        if let Some(item) = agent.completed_approval.as_ref() {
+            completed_interactions.push(CompletedInteractionSnapshot {
+                kind: InteractionKind::Approval,
+                title: item.title.clone(),
+                summary: item.summary.clone(),
+                source: None,
+            });
+        }
+        if let Some(item) = existing_local_request_completion {
+            completed_interactions.push(item);
+        }
+        if let Some(item) = existing_plan_completion {
+            completed_interactions.push(item);
+        }
         self.snapshot = RuntimeSnapshot {
             cwd,
             branch,
@@ -417,33 +594,11 @@ impl TuiApp {
                         crate::agent::PlanStepStatus::Completed => "completed",
                     };
                     (status.to_string(), step.step.clone())
-                })
+            })
                 .collect(),
             plan_explanation: agent.plan_explanation.clone(),
-            pending_question: agent.pending_user_input.as_ref().map(|question| {
-                (
-                    question.question.clone(),
-                    question.options.clone(),
-                    question.note.clone(),
-                )
-            }),
-            pending_approval: agent.pending_approval.as_ref().map(|pending| {
-                PendingApprovalSnapshot {
-                    tool_use_id: pending.tool_use_id.clone(),
-                    command: pending.request.summary(),
-                    allow_net: pending.request.allow_net,
-                    payload: pending.request.clone(),
-                }
-            }),
-            pending_plan_approval: self.pending_plan_approval,
-            completed_question: agent
-                .completed_user_input
-                .as_ref()
-                .map(|item| (item.title.clone(), item.summary.clone())),
-            completed_approval: agent
-                .completed_approval
-                .as_ref()
-                .map(|item| (item.title.clone(), item.summary.clone())),
+            pending_interactions,
+            completed_interactions,
             prompt_base_kind: effective_prompt.base_prompt_kind.label().to_string(),
             prompt_section_keys: effective_prompt
                 .section_keys
@@ -457,6 +612,14 @@ impl TuiApp {
                 .collect(),
             prompt_warnings: agent.prompt_config().warnings.clone(),
         };
+        for interaction in &self.snapshot.completed_interactions.clone() {
+            self.ensure_completed_interaction_entry(
+                interaction.kind,
+                interaction.title.as_str(),
+                interaction.summary.as_str(),
+                interaction.source.as_deref(),
+            );
+        }
         self.agent_execution_mode = agent.execution_mode;
         self.bash_approval_mode = agent.bash_approval_mode;
         self.persist_runtime_state();
@@ -541,7 +704,7 @@ impl TuiApp {
         self.agent_markdown_stream = None;
         self.clear_active_live_sections();
         self.pending_planning_suggestion = None;
-        self.pending_plan_approval = false;
+        self.set_plan_approval_interaction(false);
         self.notice = Some("Cleared local transcript view.".into());
     }
 
@@ -639,15 +802,13 @@ impl TuiApp {
     }
 
     pub fn pending_question_option_label(&self, index: usize) -> Option<String> {
-        self.snapshot
-            .pending_question
-            .as_ref()
-            .and_then(|(_, options, _)| options.get(index))
+        self.pending_request_input()
+            .and_then(|interaction| interaction.options.get(index))
             .map(|(label, _)| label.clone())
     }
 
     pub fn has_pending_approval(&self) -> bool {
-        self.snapshot.pending_approval.is_some()
+        self.pending_command_approval().is_some()
     }
 
     pub fn has_pending_planning_suggestion(&self) -> bool {
@@ -672,12 +833,133 @@ impl TuiApp {
     }
 
     pub fn has_pending_plan_approval(&self) -> bool {
-        self.pending_plan_approval
+        self.pending_plan_approval_interaction().is_some()
+    }
+
+    pub fn active_pending_interaction(&self) -> Option<ActivePendingInteraction<'_>> {
+        if let Some(snapshot) = self.pending_plan_approval_interaction() {
+            return Some(ActivePendingInteraction {
+                kind: ActivePendingInteractionKind::PlanApproval,
+                _snapshot: snapshot,
+            });
+        }
+        if let Some(snapshot) = self.pending_command_approval() {
+            return Some(ActivePendingInteraction {
+                kind: ActivePendingInteractionKind::ShellApproval,
+                _snapshot: snapshot,
+            });
+        }
+        if let Some(snapshot) = self.pending_request_input() {
+            let kind = match snapshot.source.as_deref() {
+                Some("plan_agent") => ActivePendingInteractionKind::PlanningQuestion,
+                Some("explore_agent") => ActivePendingInteractionKind::ExplorationQuestion,
+                Some(_) => ActivePendingInteractionKind::SubAgentQuestion,
+                None => ActivePendingInteractionKind::RequestInput,
+            };
+            return Some(ActivePendingInteraction {
+                kind,
+                _snapshot: snapshot,
+            });
+        }
+        None
     }
 
     pub fn set_pending_plan_approval(&mut self, pending: bool) {
-        self.pending_plan_approval = pending;
-        self.snapshot.pending_plan_approval = pending;
+        self.set_plan_approval_interaction(pending);
+        self.persist_runtime_state();
+    }
+
+    pub fn pending_request_input(&self) -> Option<&PendingInteractionSnapshot> {
+        self.snapshot
+            .pending_interactions
+            .iter()
+            .find(|item| item.kind == InteractionKind::RequestInput)
+    }
+
+    pub fn has_local_pending_request_input(&self) -> bool {
+        self.pending_request_input()
+            .and_then(|item| item.source.as_deref())
+            .is_some()
+    }
+
+    pub fn pending_command_approval(&self) -> Option<&PendingInteractionSnapshot> {
+        self.snapshot
+            .pending_interactions
+            .iter()
+            .find(|item| item.kind == InteractionKind::Approval)
+    }
+
+    pub fn pending_plan_approval_interaction(&self) -> Option<&PendingInteractionSnapshot> {
+        self.snapshot
+            .pending_interactions
+            .iter()
+            .find(|item| item.kind == InteractionKind::PlanApproval)
+    }
+
+    pub fn completed_interaction(
+        &self,
+        kind: InteractionKind,
+    ) -> Option<&CompletedInteractionSnapshot> {
+        self.snapshot
+            .completed_interactions
+            .iter()
+            .find(|item| item.kind == kind)
+    }
+
+    pub fn record_completed_interaction(
+        &mut self,
+        kind: InteractionKind,
+        title: impl Into<String>,
+        summary: impl Into<String>,
+        source: Option<String>,
+    ) {
+        let title = title.into();
+        let summary = summary.into();
+        self.snapshot
+            .completed_interactions
+            .retain(|item| item.kind != kind);
+        self.snapshot
+            .completed_interactions
+            .push(CompletedInteractionSnapshot {
+                kind,
+                title: title.clone(),
+                summary: summary.clone(),
+                source: source.clone(),
+            });
+        self.ensure_completed_interaction_entry(kind, title.as_str(), summary.as_str(), source.as_deref());
+        self.persist_runtime_state();
+    }
+
+    pub fn record_local_request_input(
+        &mut self,
+        source: impl Into<String>,
+        title: impl Into<String>,
+        options: Vec<(String, String)>,
+        note: Option<String>,
+    ) {
+        self.snapshot.pending_interactions.retain(|item| {
+            !(item.kind == InteractionKind::RequestInput && item.source.as_deref().is_some())
+        });
+        let title = title.into();
+        self.snapshot
+            .pending_interactions
+            .push(PendingInteractionSnapshot {
+                kind: InteractionKind::RequestInput,
+                title: title.clone(),
+                summary: note.clone().unwrap_or_default(),
+                options,
+                note,
+                approval: None,
+                source: Some(source.into()),
+            });
+        self.notice = Some(format!("{title}"));
+        self.persist_runtime_state();
+    }
+
+    pub fn clear_local_request_input(&mut self) {
+        self.snapshot.pending_interactions.retain(|item| {
+            !(item.kind == InteractionKind::RequestInput && item.source.as_deref().is_some())
+        });
         self.persist_runtime_state();
     }
 
@@ -709,8 +991,46 @@ impl TuiApp {
             .sum()
     }
 
+    fn materialize_active_live_entries(&mut self) {
+        let sections = [
+            (
+                "Exploring",
+                self.active_live
+                    .exploration_actions
+                    .iter()
+                    .chain(self.active_live.exploration_notes.iter())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            ),
+            (
+                "Planning",
+                self.active_live
+                    .planning_actions
+                    .iter()
+                    .chain(self.active_live.planning_notes.iter())
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            ),
+            (
+                "Running",
+                self.active_live.running_actions.to_vec(),
+            ),
+        ];
+
+        for (role, lines) in sections {
+            if lines.is_empty() {
+                continue;
+            }
+            self.active_turn.entries.push(TranscriptEntry {
+                role: role.to_string(),
+                message: lines.join("\n"),
+            });
+        }
+    }
+
     fn commit_active_turn(&mut self) {
         self.finalize_agent_stream(None);
+        self.materialize_active_live_entries();
         if self.active_turn.entries.is_empty() {
             self.clear_active_live_sections();
             return;
@@ -788,6 +1108,18 @@ impl TuiApp {
         }
     }
 
+    pub fn record_planning_note(&mut self, note: impl Into<String>) {
+        let note = note.into();
+        if !self
+            .active_live
+            .planning_notes
+            .iter()
+            .any(|item| item == &note)
+        {
+            self.active_live.planning_notes.push(note);
+        }
+    }
+
     pub fn attach_state_db(&mut self, state_db: Arc<StateDb>) {
         let status = state_db.path().display().to_string();
         self.recent_sessions = state_db.list_recent_sessions(20).unwrap_or_default();
@@ -846,71 +1178,73 @@ impl TuiApp {
         }
 
         let mut interactions = Vec::new();
-        if let Some((question, options, note)) = self.snapshot.pending_question.as_ref() {
-            let options_summary = options
-                .iter()
-                .map(|(label, _)| label.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
-            let summary = match note {
-                Some(note) if !note.is_empty() => format!("{options_summary} | {note}"),
-                _ => options_summary,
+        for interaction in &self.snapshot.pending_interactions {
+            match interaction.kind {
+                InteractionKind::RequestInput => {
+                    let options_summary = interaction
+                        .options
+                        .iter()
+                        .map(|(label, _)| label.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let summary = match interaction.note.as_deref() {
+                        Some(note) if !note.is_empty() => format!("{options_summary} | {note}"),
+                        _ => options_summary,
+                    };
+                    interactions.push(PersistedInteraction {
+                        kind: "request_input".to_string(),
+                        status: "pending".to_string(),
+                        title: interaction.title.clone(),
+                        summary,
+                        payload: Some(json!({
+                            "question": interaction.title,
+                            "options": interaction.options,
+                            "note": interaction.note,
+                            "source": interaction.source,
+                        })),
+                    });
+                }
+                InteractionKind::PlanApproval => {
+                    interactions.push(PersistedInteraction {
+                        kind: "plan_approval".to_string(),
+                        status: "pending".to_string(),
+                        title: interaction.title.clone(),
+                        summary: interaction.summary.clone(),
+                        payload: None,
+                    });
+                }
+                InteractionKind::Approval => {
+                    if let Some(approval) = interaction.approval.as_ref() {
+                        interactions.push(PersistedInteraction {
+                            kind: "approval".to_string(),
+                            status: "pending".to_string(),
+                            title: interaction.title.clone(),
+                            summary: approval.command.clone(),
+                            payload: Some(json!({
+                                "tool_use_id": approval.tool_use_id,
+                                "command": approval.command,
+                                "allow_net": approval.allow_net,
+                                "program": approval.payload.program,
+                                "args": approval.payload.args,
+                                "cwd": approval.payload.cwd,
+                                "env": approval.payload.env,
+                            })),
+                        });
+                    }
+                }
+            }
+        }
+        for interaction in &self.snapshot.completed_interactions {
+            let kind = match interaction.kind {
+                InteractionKind::RequestInput => "request_input",
+                InteractionKind::Approval => "approval",
+                InteractionKind::PlanApproval => "plan_approval",
             };
             interactions.push(PersistedInteraction {
-                kind: "request_input".to_string(),
-                status: "pending".to_string(),
-                title: question.clone(),
-                summary,
-                payload: Some(json!({
-                    "question": question,
-                    "options": options,
-                    "note": note,
-                })),
-            });
-        }
-        if self.snapshot.pending_plan_approval {
-            interactions.push(PersistedInteraction {
-                kind: "plan_approval".to_string(),
-                status: "pending".to_string(),
-                title: "Plan Ready".to_string(),
-                summary: self.snapshot.plan_explanation.clone().unwrap_or_else(|| {
-                    "Review the proposed plan before implementation.".to_string()
-                }),
-                payload: None,
-            });
-        }
-        if let Some(approval) = self.snapshot.pending_approval.as_ref() {
-            interactions.push(PersistedInteraction {
-                kind: "approval".to_string(),
-                status: "pending".to_string(),
-                title: "Pending Approval".to_string(),
-                summary: approval.command.clone(),
-                payload: Some(json!({
-                    "tool_use_id": approval.tool_use_id,
-                    "command": approval.command,
-                    "allow_net": approval.allow_net,
-                    "program": approval.payload.program,
-                    "args": approval.payload.args,
-                    "cwd": approval.payload.cwd,
-                    "env": approval.payload.env,
-                })),
-            });
-        }
-        if let Some((title, summary)) = self.snapshot.completed_question.as_ref() {
-            interactions.push(PersistedInteraction {
-                kind: "request_input".to_string(),
+                kind: kind.to_string(),
                 status: "completed".to_string(),
-                title: title.clone(),
-                summary: summary.clone(),
-                payload: None,
-            });
-        }
-        if let Some((title, summary)) = self.snapshot.completed_approval.as_ref() {
-            interactions.push(PersistedInteraction {
-                kind: "approval".to_string(),
-                status: "completed".to_string(),
-                title: title.clone(),
-                summary: summary.clone(),
+                title: interaction.title.clone(),
+                summary: interaction.summary.clone(),
                 payload: None,
             });
         }
@@ -951,7 +1285,12 @@ impl TuiApp {
 
 #[cfg(test)]
 mod tests {
-    use super::{input_requests_command_palette, state_db_status_error};
+    use super::{
+        input_requests_command_palette, state_db_status_error, ActivePendingInteractionKind,
+        InteractionKind, PendingInteractionSnapshot, RuntimeSnapshot, TuiApp,
+    };
+    use crate::config::{ConfigManager, RaraConfig};
+    use tempfile::tempdir;
 
     #[test]
     fn detects_slash_command_input() {
@@ -973,5 +1312,53 @@ mod tests {
         assert!(rendered.contains("[REDACTED_SECRET]"));
         assert!(!rendered.contains("supersecretvalue"));
         assert!(!rendered.contains("abcdefghijklmnopqrstuvwxyz"));
+    }
+
+    #[test]
+    fn prioritizes_active_pending_interaction_in_ui_order() {
+        let dir = tempdir().expect("tempdir");
+        let cm = ConfigManager {
+            path: dir.path().join("config.json"),
+        };
+        let mut app = TuiApp::new(cm).expect("app");
+        app.config = RaraConfig::default();
+        app.snapshot = RuntimeSnapshot {
+            pending_interactions: vec![
+                PendingInteractionSnapshot {
+                    kind: InteractionKind::RequestInput,
+                    title: "Question".to_string(),
+                    summary: String::new(),
+                    options: Vec::new(),
+                    note: None,
+                    approval: None,
+                    source: Some("plan_agent".to_string()),
+                },
+                PendingInteractionSnapshot {
+                    kind: InteractionKind::Approval,
+                    title: "Pending Approval".to_string(),
+                    summary: "run cargo test".to_string(),
+                    options: Vec::new(),
+                    note: None,
+                    approval: None,
+                    source: None,
+                },
+                PendingInteractionSnapshot {
+                    kind: InteractionKind::PlanApproval,
+                    title: "Plan Ready".to_string(),
+                    summary: "Review the plan.".to_string(),
+                    options: Vec::new(),
+                    note: None,
+                    approval: None,
+                    source: None,
+                },
+            ],
+            ..RuntimeSnapshot::default()
+        };
+
+        let active = app
+            .active_pending_interaction()
+            .expect("pending interaction");
+        assert_eq!(active.kind, ActivePendingInteractionKind::PlanApproval);
+        assert_eq!(active._snapshot.title, "Plan Ready");
     }
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -347,6 +347,11 @@ impl TuiApp {
             .active_turn
             .entries
             .iter()
+            .chain(
+                self.committed_turns
+                    .iter()
+                    .flat_map(|turn| turn.entries.iter()),
+            )
             .any(|entry| entry.role == role && entry.message == message);
         if !exists {
             self.active_turn.entries.push(TranscriptEntry { role, message });
@@ -570,6 +575,14 @@ impl TuiApp {
         if let Some(item) = existing_plan_completion {
             completed_interactions.push(item);
         }
+        for interaction in &completed_interactions {
+            self.ensure_completed_interaction_entry(
+                interaction.kind,
+                interaction.title.as_str(),
+                interaction.summary.as_str(),
+                interaction.source.as_deref(),
+            );
+        }
         self.snapshot = RuntimeSnapshot {
             cwd,
             branch,
@@ -612,14 +625,6 @@ impl TuiApp {
                 .collect(),
             prompt_warnings: agent.prompt_config().warnings.clone(),
         };
-        for interaction in &self.snapshot.completed_interactions.clone() {
-            self.ensure_completed_interaction_entry(
-                interaction.kind,
-                interaction.title.as_str(),
-                interaction.summary.as_str(),
-                interaction.source.as_deref(),
-            );
-        }
         self.agent_execution_mode = agent.execution_mode;
         self.bash_approval_mode = agent.bash_approval_mode;
         self.persist_runtime_state();


### PR DESCRIPTION
## Summary

- unify pending and completed TUI interactions around a single interaction pipeline
- make sub-agent questions and approvals surface as source-aware interaction cards
- split pending interaction/status formatting out of `src/tui/command.rs`

## What Changed

- add state-backed active pending interaction selection and use it as the source of truth for TUI rendering and hotkeys
- materialize completed interaction records into transcript history with stable typed cells
- render plan approval, shell approval, and delegated request-input interactions as typed cards
- surface delegated `plan_agent` / `explore_agent` request-input events through the main-thread interaction flow
- add `src/tui/interaction_text.rs` and reduce `src/tui/command.rs` below the 800-line guideline
- document the proactive file-splitting rule in `AGENTS.md`

## Validation

- `cargo check`
- `cargo test tui::state::tests -- --nocapture`
- `cargo test tui::render::cells::tests -- --nocapture`
- `cargo test tui::tests -- --nocapture`
- `cargo test tools::agent::tests -- --nocapture`
- `cargo test tui::runtime::events::tests -- --nocapture`
