### PR TITLE
docs(team): define ACP-first runtime spec

### DIFF
--- a/docs/features/agenthub-team-mode.md
+++ b/docs/features/agenthub-team-mode.md
@@ -1,25 +1,26 @@
-# Team Runtime Mode
+# AgentHub Team Mode
 
 ## Problem
 
-RARA already has delegated planning and exploration tools, but it does not have a worker-side
-runtime mode that can cheaply reject irrelevant work before handing every turn to a larger and
-more expensive model.
+RARA already has delegated planning and exploration tools, but it does not have an ACP-backed
+AgentHub worker runtime that can cheaply reject irrelevant work before handing every turn to a
+larger and more expensive model.
 
-For multi-worker or role-specialized sessions, this means every incoming turn currently pays the
-full worker-model cost even when the request is clearly meant for a different worker.
+For multi-worker or role-specialized AgentHub sessions, this means every incoming turn currently
+pays the full worker-model cost even when the request is clearly meant for a different worker.
 
-This spec is intentionally written for the future `hawkingrei/agenthub` integration path:
+This spec is intentionally written for the future `hawkingrei/agenthub` integration path and is
+intentionally distinct from any future local-only team mode:
 
 - RARA acts as the worker runtime;
 - AgentHub provides the higher-level leader / team orchestration;
-- RARA team mode decides whether the local worker should spend its expensive model budget on the
-  current request.
+- RARA AgentHub team mode decides whether the local worker should spend its expensive model budget
+  on the current request.
 - The integration boundary is ACP, not a RARA-specific mailbox or custom RPC layer.
 
 ## Scope
 
-- An ACP-oriented `team` runtime mode for worker sessions.
+- An ACP-oriented `AgentHub team mode` for worker sessions.
 - A lightweight router model that classifies whether the current request is relevant to the worker.
 - A worker-model handoff when the router says the request is relevant.
 
@@ -36,17 +37,17 @@ This spec is intentionally written for the future `hawkingrei/agenthub` integrat
 ### 0) ACP Boundary First
 
 - AgentHub should talk to RARA through ACP session and prompt requests.
-- Team mode is therefore a worker-runtime concern inside ACP request handling, not a parallel CLI
-  surface with a separate protocol.
+- AgentHub team mode is therefore a worker-runtime concern inside ACP request handling, not a
+  parallel CLI surface with a separate protocol.
 - The first implementation target is:
   - ACP prompt arrives;
   - team router evaluates worker relevance;
   - relevant prompts go to the expensive worker backend;
   - irrelevant prompts return a structured worker decline through ACP.
 
-### 1) Team Runtime Wrapper
+### 1) AgentHub Team Runtime Wrapper
 
-- Team mode wraps the normal worker backend with a routing backend.
+- AgentHub team mode wraps the normal worker backend with a routing backend.
 - The routing backend runs before the expensive worker backend on:
   - `ask`
   - `ask_streaming`
@@ -63,8 +64,8 @@ This spec is intentionally written for the future `hawkingrei/agenthub` integrat
 
 ### 3) Router Backend Selection
 
-- Team mode is enabled by CLI/runtime configuration and must also be representable in ACP session
-  initialization.
+- AgentHub team mode is enabled by CLI/runtime configuration and must also be representable in ACP
+  session initialization.
 - The router backend uses the same provider and credentials as the worker backend where possible.
 - The router model may be provided explicitly by CLI.
 - If not provided, RARA derives a provider-specific small-model default when one is known.
@@ -94,8 +95,8 @@ The router must return strict JSON:
 
 ### 3) ACP Response Semantics
 
-- Team-mode routing decisions must be reflected in ACP prompt handling rather than hidden in local
-  CLI-only state.
+- AgentHub team-mode routing decisions must be reflected in ACP prompt handling rather than hidden
+  in local CLI-only state.
 - `skip` should produce a structured worker decline/deferral response suitable for AgentHub to
   re-route or ignore.
 - `handle` should continue the normal ACP-backed worker turn.
@@ -118,4 +119,4 @@ The router must return strict JSON:
 - Add TUI/router observability.
 - Route sub-agent or worker approvals through the same team runtime boundary.
 - Complete the ACP runtime path so AgentHub can actually use RARA as a worker runtime.
-- Integrate the ACP-backed worker-local team runtime with AgentHub leader / worker orchestration.
+- Integrate the ACP-backed AgentHub team runtime with AgentHub leader / worker orchestration.

--- a/docs/features/team-runtime-mode.md
+++ b/docs/features/team-runtime-mode.md
@@ -1,0 +1,121 @@
+# Team Runtime Mode
+
+## Problem
+
+RARA already has delegated planning and exploration tools, but it does not have a worker-side
+runtime mode that can cheaply reject irrelevant work before handing every turn to a larger and
+more expensive model.
+
+For multi-worker or role-specialized sessions, this means every incoming turn currently pays the
+full worker-model cost even when the request is clearly meant for a different worker.
+
+This spec is intentionally written for the future `hawkingrei/agenthub` integration path:
+
+- RARA acts as the worker runtime;
+- AgentHub provides the higher-level leader / team orchestration;
+- RARA team mode decides whether the local worker should spend its expensive model budget on the
+  current request.
+- The integration boundary is ACP, not a RARA-specific mailbox or custom RPC layer.
+
+## Scope
+
+- An ACP-oriented `team` runtime mode for worker sessions.
+- A lightweight router model that classifies whether the current request is relevant to the worker.
+- A worker-model handoff when the router says the request is relevant.
+
+## Non-Goals
+
+- Full multi-worker orchestration.
+- A custom leader / worker mailbox transport outside ACP.
+- Automatic worker spawning or balancing.
+- TUI-specific visualization of router decisions.
+- Full AgentHub protocol integration in the first phase.
+
+## Architecture
+
+### 0) ACP Boundary First
+
+- AgentHub should talk to RARA through ACP session and prompt requests.
+- Team mode is therefore a worker-runtime concern inside ACP request handling, not a parallel CLI
+  surface with a separate protocol.
+- The first implementation target is:
+  - ACP prompt arrives;
+  - team router evaluates worker relevance;
+  - relevant prompts go to the expensive worker backend;
+  - irrelevant prompts return a structured worker decline through ACP.
+
+### 1) Team Runtime Wrapper
+
+- Team mode wraps the normal worker backend with a routing backend.
+- The routing backend runs before the expensive worker backend on:
+  - `ask`
+  - `ask_streaming`
+- If the router says the request is relevant, the worker backend handles the turn normally.
+- If the router says the request is irrelevant, the wrapper returns a short assistant response
+  without calling the expensive worker backend.
+
+### 2) Worker Identity
+
+- Team mode requires a worker role string.
+- The worker role must be available from ACP session/runtime configuration.
+- The router prompt evaluates the latest user request against that role.
+- The first phase assumes a single worker role per process.
+
+### 3) Router Backend Selection
+
+- Team mode is enabled by CLI/runtime configuration and must also be representable in ACP session
+  initialization.
+- The router backend uses the same provider and credentials as the worker backend where possible.
+- The router model may be provided explicitly by CLI.
+- If not provided, RARA derives a provider-specific small-model default when one is known.
+- Providers without a safe default must require an explicit router model.
+
+## Contracts
+
+### 1) Routing Contract
+
+The router must return strict JSON:
+
+```json
+{
+  "decision": "handle" | "skip",
+  "reason": "short explanation"
+}
+```
+
+- `handle` means the worker backend should continue.
+- `skip` means the worker should decline the turn without calling the expensive worker backend.
+
+### 2) Failure Mode
+
+- If the router output is malformed or unusable, team mode must fail open and let the worker backend
+  handle the request.
+- This avoids losing valid work because of a cheap-model routing mistake.
+
+### 3) ACP Response Semantics
+
+- Team-mode routing decisions must be reflected in ACP prompt handling rather than hidden in local
+  CLI-only state.
+- `skip` should produce a structured worker decline/deferral response suitable for AgentHub to
+  re-route or ignore.
+- `handle` should continue the normal ACP-backed worker turn.
+
+## Validation Matrix
+
+- `cargo check`
+- focused routing tests:
+  - router says `skip` -> worker backend is not called
+  - router says `handle` -> worker backend is called
+  - malformed router output -> worker backend still handles the request
+- CLI/backend wiring tests for router model selection
+- ACP-level tests:
+  - ACP prompt path respects team routing
+  - irrelevant ACP worker prompt returns a structured decline
+  - relevant ACP worker prompt reaches the worker backend
+
+## Follow-Up
+
+- Add TUI/router observability.
+- Route sub-agent or worker approvals through the same team runtime boundary.
+- Complete the ACP runtime path so AgentHub can actually use RARA as a worker runtime.
+- Integrate the ACP-backed worker-local team runtime with AgentHub leader / worker orchestration.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -13,7 +13,7 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Add explicit HTTP timeouts to all networked backends in `src/llm.rs` so provider calls fail predictably instead of hanging indefinitely.
 - [ ] Extract shared message-mapping helpers across OpenAI-compatible and Ollama backends to reduce duplication and keep tool-call behavior consistent.
-- [ ] Add a real `team` runtime mode behind a CLI flag: in team mode, use a small model first for intent routing and only hand the task to the larger model when the intent is relevant to that worker, instead of sending every turn directly to the expensive model.
+- [ ] Add an AgentHub-oriented `team` runtime mode on top of ACP: for role-specialized worker sessions, use a small model first for intent routing and only hand the task to the larger worker model when the intent is relevant to that worker, instead of sending every ACP turn directly to the expensive model.
 
 ## Memory and Retrieval
 
@@ -22,7 +22,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Harden local model prompting contracts for Gemma 4 and Qwen3: chat template handling, stop sequences, and tool-call JSON framing should be explicit and regression-tested.
 - [ ] Replace the current hash-based local embedding fallback with a real embedding backend so project memory retrieval quality is good enough for normal coding sessions.
 - [ ] Replace the mock `VectorDB` implementation in `src/vectordb.rs` with real LanceDB-backed search/upsert behavior, or feature-gate the memory tools until the backend is real.
-- [ ] Implement the ACP runtime path end to end: `RaraAcpAgent::prompt` and `run_acp_stdio` should execute the real tool/backend loop instead of returning placeholder responses.
+- [ ] Implement the ACP runtime path end to end: `RaraAcpAgent::prompt` and `run_acp_stdio` should execute the real tool/backend loop instead of returning placeholder responses, because AgentHub integration will use ACP as the worker boundary.
 - [ ] Implement the Gemini backend instead of keeping the current `Gemini pending` stub so the configured provider is a real option.
 - [ ] Implement session context retrieval on top of the existing session storage and vector/session managers instead of returning `no_context_found`.
 - [ ] Implement the vector memory tools against the real backend and LanceDB path instead of using placeholder save/retrieve responses.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -14,6 +14,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Add explicit HTTP timeouts to all networked backends in `src/llm.rs` so provider calls fail predictably instead of hanging indefinitely.
 - [ ] Extract shared message-mapping helpers across OpenAI-compatible and Ollama backends to reduce duplication and keep tool-call behavior consistent.
 - [ ] Add an AgentHub-oriented `team` runtime mode on top of ACP: for role-specialized worker sessions, use a small model first for intent routing and only hand the task to the larger worker model when the intent is relevant to that worker, instead of sending every ACP turn directly to the expensive model.
+- [ ] Deepen the AgentHub/ACP team runtime spec before implementation: define the ACP session metadata, worker-role contract, router prompt/output schema, and the exact `skip` / `handle` response semantics so the worker runtime can be implemented without inventing a parallel protocol later.
 
 ## Memory and Retrieval
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -13,8 +13,8 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Add explicit HTTP timeouts to all networked backends in `src/llm.rs` so provider calls fail predictably instead of hanging indefinitely.
 - [ ] Extract shared message-mapping helpers across OpenAI-compatible and Ollama backends to reduce duplication and keep tool-call behavior consistent.
-- [ ] Add an AgentHub-oriented `team` runtime mode on top of ACP: for role-specialized worker sessions, use a small model first for intent routing and only hand the task to the larger worker model when the intent is relevant to that worker, instead of sending every ACP turn directly to the expensive model.
-- [ ] Deepen the AgentHub/ACP team runtime spec before implementation: define the ACP session metadata, worker-role contract, router prompt/output schema, and the exact `skip` / `handle` response semantics so the worker runtime can be implemented without inventing a parallel protocol later.
+- [ ] Add an `AgentHub team mode` on top of ACP: for role-specialized worker sessions, use a small model first for intent routing and only hand the task to the larger worker model when the intent is relevant to that worker, instead of sending every ACP turn directly to the expensive model.
+- [ ] Deepen the `AgentHub team mode` spec before implementation: define the ACP session metadata, worker-role contract, router prompt/output schema, and the exact `skip` / `handle` response semantics so the worker runtime can be implemented without inventing a parallel protocol later.
 
 ## Memory and Retrieval
 


### PR DESCRIPTION
## Summary

- add an ACP-first team runtime spec for future agenthub integration
- clarify that team-mode routing should live on the ACP prompt path, not a custom mailbox path
- update TODO wording to keep the ACP dependency explicit

## Why

- agenthub integration will use ACP as the worker boundary
- documenting the ACP contract first avoids building a parallel team runtime that would have to be replaced later

## Testing

- docs only
