### PR TITLE
feat(context): add structured context compression

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -416,7 +416,28 @@ fn plan_mode_prompt() -> &'static str {
 }
 
 fn default_compact_prompt() -> String {
-    "Summarize the earlier conversation for continued coding work.\nPreserve the current objective, key constraints, important repository findings, plan state, pending approvals or user-input questions, concrete file paths already inspected or edited, and any unresolved risks.\nKeep the summary compact and directly usable for the next turn.".to_string()
+    "Summarize the earlier conversation for continued coding work using this exact markdown structure:\n\
+## User Intent\n\
+- Preserve the current user goal as close to the user's wording as practical.\n\
+## Constraints\n\
+- Keep key technical, product, and workflow constraints.\n\
+## Repository Findings\n\
+- Capture the concrete findings that matter for the next turn.\n\
+## Files Touched Or Inspected\n\
+- List concrete file paths already inspected or edited.\n\
+## Plan State\n\
+- Preserve the current plan state and what is already done versus still pending.\n\
+## Pending Interactions\n\
+- Preserve approvals, questions, or other pending interaction state.\n\
+## Unresolved Risks\n\
+- Preserve unresolved technical risks, blockers, or uncertainty.\n\
+## Next Best Action\n\
+- End with the single most useful next action for continuing the task.\n\
+\n\
+Do not write a generic prose recap.\n\
+Do not assume the user can see compacted tool output.\n\
+Keep the summary compact, concrete, and directly reusable by the next turn."
+        .to_string()
 }
 
 fn section(title: &str, items: &[&str]) -> String {
@@ -504,6 +525,15 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(build_compact_instruction(&runtime), "custom compact");
+    }
+
+    #[test]
+    fn default_compact_prompt_uses_structured_schema() {
+        let prompt = super::default_compact_prompt();
+        assert!(prompt.contains("## User Intent"));
+        assert!(prompt.contains("## Files Touched Or Inspected"));
+        assert!(prompt.contains("## Next Best Action"));
+        assert!(prompt.contains("Do not write a generic prose recap."));
     }
 
     #[test]

--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -1,0 +1,97 @@
+# Context Compression
+
+## Problem
+
+RARA already compacts long conversations, but the current compaction output is still a generic
+summary blob. That makes the result less stable than Claude Code style context compression, where
+important state is preserved through a predictable structure instead of depending on free-form
+summaries.
+
+For long coding sessions, this increases the risk of losing:
+
+- the exact user objective;
+- concrete file paths already inspected or edited;
+- current plan state;
+- pending approvals or questions;
+- unresolved risks and the immediate next action.
+
+## Scope
+
+- The compact prompt contract and default compression schema.
+- The compacted history marker that gets written back into `Agent.history`.
+- Recent-file carry-over and compact observability in `/status`.
+- Limited recent-file excerpt carry-over for the most recent `read_file` results.
+- Compact-boundary metadata persistence across session save/restore.
+- Focused tests for compaction prompt and stored summary shape.
+
+## Non-Goals
+
+- Full recent-file snippet reattachment after compaction.
+- Token-cache aware prompt reuse.
+- Provider-specific remote compaction APIs.
+
+## Architecture
+
+### 1) Structured Compact Prompt
+
+- The default compact prompt should require a stable markdown schema instead of a generic prose
+  summary.
+- The first phase keeps the schema simple and directly usable by the next turn.
+
+### 2) Required Compression Sections
+
+The default compact output should preserve, in order:
+
+1. `User Intent`
+2. `Constraints`
+3. `Repository Findings`
+4. `Files Touched Or Inspected`
+5. `Plan State`
+6. `Pending Interactions`
+7. `Unresolved Risks`
+8. `Next Best Action`
+
+### 3) Stored History Shape
+
+- After compaction, RARA should store a clearly labeled structured summary in history instead of a
+  generic `"SUMMARY OF PREVIOUS CONVERSATION"` marker.
+- The stored marker should make it obvious to both runtime and future debugging that this is a
+  compaction artifact with a stable schema.
+- RARA should also write a compact boundary record ahead of the summary so later tooling can detect
+  compaction boundaries without scraping free-form summary text.
+- Compact boundary metadata should also be mirrored into persisted session state so resume flows and
+  status views can recover the latest compaction boundary without reparsing full history.
+
+## Contracts
+
+### 1) Preservation Rules
+
+- Preserve the current objective as close to the user's wording as practical.
+- Preserve concrete file paths when they were already inspected or edited.
+- Preserve a small amount of recent `read_file` content so the next turn does not depend only on file
+  names.
+- Preserve the current plan and any pending approval or request-user-input state.
+- Preserve the immediate next useful action instead of ending with a vague recap.
+
+### 2) Failure Tolerance
+
+- If the model returns imperfect formatting, compaction still succeeds.
+- The structure is a prompt contract, not a hard parser contract in the first phase.
+
+## Validation Matrix
+
+- `cargo check`
+- focused prompt tests for the default compact schema
+- focused agent tests ensuring manual compaction stores the structured marker
+
+## Open Risks
+
+- Recent-file excerpt carry-over is still limited to recent `read_file` results; `grep` and
+  `search` evidence are not yet restored the same way.
+- Token accounting still relies on full-history re-estimation at some boundaries.
+- Session restore mirrors compact boundary metadata, but it does not yet persist the full recent-file
+  excerpt payload separately from history.
+
+## Source Journals
+
+- [2026-04-19-context-compression](../journal/2026-04-19-context-compression.md)

--- a/docs/journal/2026-04-19-context-compression.md
+++ b/docs/journal/2026-04-19-context-compression.md
@@ -1,0 +1,44 @@
+# 2026-04-19 Context Compression
+
+## Summary
+
+Started aligning RARA compaction with Claude-style structured context compression.
+
+This phase tightens the compression contract so compacted history is schema-oriented rather than a
+generic free-form summary blob, and it carries recent file paths plus basic compact observability
+into the runtime status view.
+
+## Changes
+
+- Added a stable feature spec for context compression.
+- Upgraded the default compact prompt to require a fixed sectioned markdown schema.
+- Changed the stored compaction marker in history to a structured-summary label.
+- Added a machine-readable compact boundary record ahead of the stored summary.
+- Carried recent inspected file paths forward after compaction.
+- Carried a small set of recent `read_file` excerpts forward with line-range metadata when available.
+- Exposed recent compact carry-over in `/status`.
+- Switched the common history append/replace paths to keep `estimated_history_tokens` incrementally
+  updated instead of waiting for the next full compact pass.
+- Mirrored compact-boundary metadata into persisted session state so restore flows can recover the
+  latest compaction boundary and compact counters.
+
+## Why
+
+This gives long-running coding sessions a more stable compression boundary and makes future
+follow-up work easier:
+
+- compact observability;
+- stronger plan / approval preservation across long sessions.
+
+## Validation
+
+- `cargo check`
+- compact prompt unit tests
+- compact history unit tests
+
+## Follow-Up
+
+- Add richer recent-file carry-over such as snippets or line references.
+- Persist richer compact carry-over artifacts beyond boundary metadata, especially for recent file
+  excerpts.
+- Reduce repeated full-history token estimation during long sessions.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -43,7 +43,7 @@ pub enum BashApprovalMode {
     Suggestion,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Message {
     pub role: String,
     pub content: Value,
@@ -202,7 +202,10 @@ impl Agent {
         self.inspection_progress = InspectionProgress::default();
         self.last_query_plan_updated = false;
         self.compact_if_needed_with_reporter(&mut report).await?;
-        self.replace_history(repair_tool_result_history(&self.history));
+        let repaired_history = repair_tool_result_history(&self.history);
+        if repaired_history != self.history {
+            self.replace_history(repaired_history);
+        }
         self.clear_completed_interactions();
 
         self.push_history_message(Message {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -20,7 +20,7 @@ use serde_json::{json, Value};
 use std::sync::Arc;
 use uuid::Uuid;
 
-pub use self::compact::CompactState;
+pub use self::compact::{latest_compact_boundary_metadata, CompactBoundaryMetadata, CompactState};
 use self::planning::{tool_result_message, InspectionProgress, RuntimeContinuationPhase};
 pub use self::planning::{
     CompletedInteraction, PendingApproval, PendingUserInput, PlanStep, PlanStepStatus,
@@ -86,7 +86,10 @@ pub enum AgentEvent {
     Status(String),
     AssistantText(String),
     AssistantDelta(String),
-    ToolUse { name: String, input: Value },
+    ToolUse {
+        name: String,
+        input: Value,
+    },
     ToolResult {
         name: String,
         content: String,
@@ -136,7 +139,7 @@ pub struct Agent {
 
 impl Agent {
     pub fn new(
-        tool_manager: ToolManager, 
+        tool_manager: ToolManager,
         llm_backend: Arc<dyn LlmBackend>,
         vdb: Arc<VectorDB>,
         session_manager: Arc<SessionManager>,
@@ -170,11 +173,17 @@ impl Agent {
     }
 
     pub async fn query(&mut self, prompt: String) -> Result<()> {
-        self.query_with_mode(prompt, AgentOutputMode::Terminal).await
+        self.query_with_mode(prompt, AgentOutputMode::Terminal)
+            .await
     }
 
-    pub async fn query_with_mode(&mut self, prompt: String, output_mode: AgentOutputMode) -> Result<()> {
-        self.query_with_mode_and_events(prompt, output_mode, |_| {}).await
+    pub async fn query_with_mode(
+        &mut self,
+        prompt: String,
+        output_mode: AgentOutputMode,
+    ) -> Result<()> {
+        self.query_with_mode_and_events(prompt, output_mode, |_| {})
+            .await
     }
 
     pub async fn query_with_mode_and_events<F>(
@@ -193,10 +202,10 @@ impl Agent {
         self.inspection_progress = InspectionProgress::default();
         self.last_query_plan_updated = false;
         self.compact_if_needed_with_reporter(&mut report).await?;
-        self.history = repair_tool_result_history(&self.history);
+        self.replace_history(repair_tool_result_history(&self.history));
         self.clear_completed_interactions();
-        
-        self.history.push(Message {
+
+        self.push_history_message(Message {
             role: "user".to_string(),
             content: json!([{"type": "text", "text": prompt.clone()}]),
         });
@@ -208,16 +217,28 @@ impl Agent {
             &mut plan_continuations,
             &mut execute_continuations,
         )
-            .await?;
+        .await?;
 
-        self.session_manager.save_session(&self.session_id, &self.history)?;
-        let turn_text = format!("User: {}\nAgent Response: {:?}", prompt, self.history.last().unwrap().content);
+        self.session_manager
+            .save_session(&self.session_id, &self.history)?;
+        let turn_text = format!(
+            "User: {}\nAgent Response: {:?}",
+            prompt,
+            self.history.last().unwrap().content
+        );
         if let Ok(vector) = self.llm_backend.embed(&turn_text).await {
-            let _ = self.vdb.upsert_turn("conversations", MemoryMetadata {
-                session_id: self.session_id.clone(),
-                turn_index: turn_start_idx as u32,
-                text: turn_text,
-            }, vector).await;
+            let _ = self
+                .vdb
+                .upsert_turn(
+                    "conversations",
+                    MemoryMetadata {
+                        session_id: self.session_id.clone(),
+                        turn_index: turn_start_idx as u32,
+                        text: turn_text,
+                    },
+                    vector,
+                )
+                .await;
         }
         Ok(())
     }
@@ -309,7 +330,11 @@ impl Agent {
         })
     }
 
-    async fn run_agent_loop<F>(&mut self, output_mode: AgentOutputMode, report: &mut F) -> Result<()>
+    async fn run_agent_loop<F>(
+        &mut self,
+        output_mode: AgentOutputMode,
+        report: &mut F,
+    ) -> Result<()>
     where
         F: FnMut(AgentEvent) + Send,
     {
@@ -323,7 +348,7 @@ impl Agent {
             &mut plan_continuations,
             &mut execute_continuations,
         )
-            .await
+        .await
     }
 
     async fn run_agent_loop_with_limit<F>(
@@ -339,11 +364,9 @@ impl Agent {
     {
         loop {
             self.ensure_active_plan_step();
-            let turn_output = self
-                .run_model_turn(output_mode, report)
-                .await?;
+            let turn_output = self.run_model_turn(output_mode, report).await?;
             self.last_query_plan_updated = turn_output.plan_updated;
-            self.history.push(turn_output.assistant_message);
+            self.push_history_message(turn_output.assistant_message);
 
             if turn_output.tool_calls.is_empty() {
                 if self.should_continue_plan_without_tools(
@@ -357,7 +380,7 @@ impl Agent {
                         "Plan needs more repository inspection. Continuing in read-only mode."
                             .to_string(),
                     ));
-                    self.history.push(self.runtime_continuation_message(
+                    self.push_history_message(self.runtime_continuation_message(
                         RuntimeContinuationPhase::PlanContinuationRequired,
                         *tool_rounds,
                     ));
@@ -373,7 +396,7 @@ impl Agent {
                         "Repository review needs more code inspection. Continuing the same turn."
                             .to_string(),
                     ));
-                    self.history.push(self.runtime_continuation_message(
+                    self.push_history_message(self.runtime_continuation_message(
                         RuntimeContinuationPhase::ExecutionContinuationRequired,
                         *tool_rounds,
                     ));
@@ -412,23 +435,27 @@ impl Agent {
     {
         let mut tool_results = Vec::new();
         for tool_call in tool_calls {
-            if tool_call.name == "bash" && matches!(self.bash_approval_mode, BashApprovalMode::Suggestion) {
-                let request = BashCommandInput::from_value(tool_call.input.clone())
-                    .unwrap_or_else(|_| BashCommandInput {
-                        command: tool_call
-                            .input
-                            .get("command")
-                            .and_then(Value::as_str)
-                            .map(str::to_string),
-                        program: None,
-                        args: Vec::new(),
-                        cwd: None,
-                        env: Default::default(),
-                        allow_net: tool_call
-                            .input
-                            .get("allow_net")
-                            .and_then(Value::as_bool)
-                            .unwrap_or(false),
+            if tool_call.name == "bash"
+                && matches!(self.bash_approval_mode, BashApprovalMode::Suggestion)
+            {
+                let request =
+                    BashCommandInput::from_value(tool_call.input.clone()).unwrap_or_else(|_| {
+                        BashCommandInput {
+                            command: tool_call
+                                .input
+                                .get("command")
+                                .and_then(Value::as_str)
+                                .map(str::to_string),
+                            program: None,
+                            args: Vec::new(),
+                            cwd: None,
+                            env: Default::default(),
+                            allow_net: tool_call
+                                .input
+                                .get("allow_net")
+                                .and_then(Value::as_bool)
+                                .unwrap_or(false),
+                        }
                     });
                 let summary = request.summary();
                 self.pending_approval = Some(PendingApproval {
@@ -440,15 +467,18 @@ impl Agent {
                     options: vec![
                         (
                             "Run once".to_string(),
-                            "Execute this command now and then return to suggestion mode.".to_string(),
+                            "Execute this command now and then return to suggestion mode."
+                                .to_string(),
                         ),
                         (
                             "Always allow bash".to_string(),
-                            "Execute now and keep bash approval open for later commands.".to_string(),
+                            "Execute now and keep bash approval open for later commands."
+                                .to_string(),
                         ),
                         (
                             "Suggestion only".to_string(),
-                            "Do not run the command automatically. Continue with a safer path.".to_string(),
+                            "Do not run the command automatically. Continue with a safer path."
+                                .to_string(),
                         ),
                     ],
                     note: Some(format!("command: {}", summary)),
@@ -469,11 +499,7 @@ impl Agent {
                     content: error_text.clone(),
                     is_error: true,
                 });
-                tool_results.push(tool_result_message(
-                    &tool_call.id,
-                    error_text,
-                    true,
-                ));
+                tool_results.push(tool_result_message(&tool_call.id, error_text, true));
                 continue;
             }
             if let Some(tool) = self.tool_manager.get_tool(&tool_call.name) {
@@ -496,11 +522,7 @@ impl Agent {
                             content: result_text.clone(),
                             is_error: false,
                         });
-                        tool_results.push(tool_result_message(
-                            &tool_call.id,
-                            result_text,
-                            false,
-                        ));
+                        tool_results.push(tool_result_message(&tool_call.id, result_text, false));
                     }
                     Err(e) => {
                         let error_text = format!("Error: {}", e);
@@ -509,16 +531,11 @@ impl Agent {
                             content: error_text.clone(),
                             is_error: true,
                         });
-                        tool_results.push(tool_result_message(
-                            &tool_call.id,
-                            error_text,
-                            true,
-                        ));
+                        tool_results.push(tool_result_message(&tool_call.id, error_text, true));
                     }
                 }
             }
         }
         Ok(tool_results)
     }
-
 }

--- a/src/agent/compact.rs
+++ b/src/agent/compact.rs
@@ -1,6 +1,26 @@
 use super::*;
 use crate::llm::ContextBudget;
 
+const RECENT_FILE_CARRY_OVER_LIMIT: usize = 5;
+const RECENT_FILE_EXCERPT_LIMIT: usize = 3;
+const RECENT_FILE_EXCERPT_CHAR_LIMIT: usize = 600;
+const COMPACT_BOUNDARY_KIND: &str = "compact_boundary";
+const COMPACT_BOUNDARY_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CompactBoundaryMetadata {
+    pub version: u32,
+    pub before_tokens: usize,
+    pub recent_file_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RecentFileExcerpt {
+    path: String,
+    line_range: Option<(usize, usize)>,
+    snippet: String,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct CompactState {
     pub estimated_history_tokens: usize,
@@ -10,6 +30,8 @@ pub struct CompactState {
     pub compaction_count: usize,
     pub last_compaction_before_tokens: Option<usize>,
     pub last_compaction_after_tokens: Option<usize>,
+    pub last_compaction_recent_files: Vec<String>,
+    pub last_compaction_boundary: Option<CompactBoundaryMetadata>,
 }
 
 impl Agent {
@@ -28,7 +50,8 @@ impl Agent {
     where
         F: FnMut(AgentEvent) + Send,
     {
-        self.compact_history_with_reporter(true, &mut report).await?;
+        self.compact_history_with_reporter(true, &mut report)
+            .await?;
         Ok(self.compact_state.last_compaction_before_tokens.is_some())
     }
 
@@ -39,14 +62,21 @@ impl Agent {
         let current_tokens = estimate_history_tokens(&self.history)?;
         let compact_budget = self.current_compact_budget();
         self.compact_state.estimated_history_tokens = current_tokens;
-        self.compact_state.context_window_tokens =
-            compact_budget.as_ref().map(|budget| budget.context_window_tokens);
-        self.compact_state.compact_threshold_tokens =
-            compact_budget.as_ref().map(|budget| budget.compact_threshold_tokens).unwrap_or(10_000);
-        self.compact_state.reserved_output_tokens =
-            compact_budget.as_ref().map(|budget| budget.reserved_output_tokens).unwrap_or(0);
+        self.compact_state.context_window_tokens = compact_budget
+            .as_ref()
+            .map(|budget| budget.context_window_tokens);
+        self.compact_state.compact_threshold_tokens = compact_budget
+            .as_ref()
+            .map(|budget| budget.compact_threshold_tokens)
+            .unwrap_or(10_000);
+        self.compact_state.reserved_output_tokens = compact_budget
+            .as_ref()
+            .map(|budget| budget.reserved_output_tokens)
+            .unwrap_or(0);
         self.compact_state.last_compaction_before_tokens = None;
         self.compact_state.last_compaction_after_tokens = None;
+        self.compact_state.last_compaction_recent_files.clear();
+        self.compact_state.last_compaction_boundary = None;
 
         let threshold = self.compact_state.compact_threshold_tokens;
         if !force && current_tokens <= threshold {
@@ -71,19 +101,67 @@ impl Agent {
                 &prompt::build_compact_instruction(&self.prompt_config),
             )
             .await?;
-        let mut new_history = vec![Message {
-            role: "system".to_string(),
-            content: json!(format!("SUMMARY OF PREVIOUS CONVERSATION: {}", summary)),
-        }];
+        let recent_files =
+            collect_recent_files(&self.history[..split_idx], RECENT_FILE_CARRY_OVER_LIMIT);
+        let recent_file_excerpts = collect_recent_file_excerpts(
+            &self.history[..split_idx],
+            RECENT_FILE_EXCERPT_LIMIT,
+            RECENT_FILE_EXCERPT_CHAR_LIMIT,
+        );
+        let mut new_history = vec![
+            build_compact_boundary_message(current_tokens, recent_files.len()),
+            Message {
+                role: "system".to_string(),
+                content: json!(format!(
+                    "STRUCTURED SUMMARY OF PREVIOUS CONVERSATION:\n{}",
+                    summary
+                )),
+            },
+        ];
+        if !recent_files.is_empty() {
+            let recent_files_block = recent_files
+                .iter()
+                .map(|path| format!("- {path}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            new_history.push(Message {
+                role: "system".to_string(),
+                content: json!(format!(
+                    "RECENT FILES FROM COMPACTED HISTORY:\n{}",
+                    recent_files_block
+                )),
+            });
+        }
+        if !recent_file_excerpts.is_empty() {
+            let excerpt_block = recent_file_excerpts
+                .iter()
+                .map(render_recent_file_excerpt)
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            new_history.push(Message {
+                role: "system".to_string(),
+                content: json!(format!(
+                    "RECENT FILE EXCERPTS FROM COMPACTED HISTORY:\n{}",
+                    excerpt_block
+                )),
+            });
+        }
         new_history.extend_from_slice(&self.history[split_idx..]);
-        self.history = new_history;
-        self.session_manager.save_session(&self.session_id, &self.history)?;
+        self.replace_history(new_history);
+        self.session_manager
+            .save_session(&self.session_id, &self.history)?;
 
-        let compacted_tokens = estimate_history_tokens(&self.history)?;
+        let compacted_tokens = self.compact_state.estimated_history_tokens;
         self.compact_state.estimated_history_tokens = compacted_tokens;
         self.compact_state.compaction_count += 1;
         self.compact_state.last_compaction_before_tokens = Some(current_tokens);
         self.compact_state.last_compaction_after_tokens = Some(compacted_tokens);
+        self.compact_state.last_compaction_recent_files = recent_files;
+        self.compact_state.last_compaction_boundary = Some(CompactBoundaryMetadata {
+            version: COMPACT_BOUNDARY_VERSION,
+            before_tokens: current_tokens,
+            recent_file_count: self.compact_state.last_compaction_recent_files.len(),
+        });
         Ok(())
     }
 
@@ -91,12 +169,255 @@ impl Agent {
         let tools = self.visible_tool_schemas();
         self.llm_backend.context_budget(&self.history, &tools)
     }
+
+    pub(super) fn push_history_message(&mut self, message: Message) {
+        self.record_history_message_tokens(&message);
+        self.history.push(message);
+    }
+
+    pub(super) fn extend_history_messages(&mut self, messages: Vec<Message>) {
+        self.record_history_messages_tokens(&messages);
+        self.history.extend(messages);
+    }
+
+    pub(super) fn replace_history(&mut self, history: Vec<Message>) {
+        self.history = history;
+        self.recompute_history_token_estimate();
+    }
+
+    fn record_history_message_tokens(&mut self, message: &Message) {
+        if let Ok(tokens) = estimate_message_tokens(message) {
+            self.compact_state.estimated_history_tokens += tokens;
+        } else {
+            self.recompute_history_token_estimate();
+        }
+    }
+
+    fn record_history_messages_tokens(&mut self, messages: &[Message]) {
+        let mut total = 0usize;
+        for message in messages {
+            match estimate_message_tokens(message) {
+                Ok(tokens) => total += tokens,
+                Err(_) => {
+                    self.recompute_history_token_estimate();
+                    return;
+                }
+            }
+        }
+        self.compact_state.estimated_history_tokens += total;
+    }
+
+    fn recompute_history_token_estimate(&mut self) {
+        self.compact_state.estimated_history_tokens =
+            estimate_history_tokens(&self.history).unwrap_or_default();
+    }
 }
 
 fn estimate_history_tokens(history: &[Message]) -> Result<usize> {
     let bpe = tiktoken_rs::cl100k_base()?;
     Ok(history
         .iter()
-        .map(|message| bpe.encode_with_special_tokens(&message.content.to_string()).len())
-        .sum())
+        .map(|message| estimate_message_tokens_with_bpe(message, &bpe))
+        .sum::<Result<usize>>()?)
+}
+
+fn estimate_message_tokens(message: &Message) -> Result<usize> {
+    let bpe = tiktoken_rs::cl100k_base()?;
+    estimate_message_tokens_with_bpe(message, &bpe)
+}
+
+fn estimate_message_tokens_with_bpe(
+    message: &Message,
+    bpe: &tiktoken_rs::CoreBPE,
+) -> Result<usize> {
+    Ok(bpe
+        .encode_with_special_tokens(&message.content.to_string())
+        .len())
+}
+
+fn collect_recent_files(history: &[Message], limit: usize) -> Vec<String> {
+    let mut collected = Vec::new();
+    for message in history.iter().rev() {
+        if message.role != "assistant" {
+            continue;
+        }
+        let Some(items) = message.content.as_array() else {
+            continue;
+        };
+        for item in items.iter().rev() {
+            if item.get("type").and_then(Value::as_str) != Some("tool_use") {
+                continue;
+            }
+            let Some(tool_name) = item.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(input) = item.get("input").and_then(Value::as_object) else {
+                continue;
+            };
+            let Some(path) = input.get("path").and_then(Value::as_str) else {
+                continue;
+            };
+            if !matches!(
+                tool_name,
+                "read_file" | "list_files" | "write_file" | "replace" | "search_files"
+            ) {
+                continue;
+            }
+            let normalized = path.replace('\\', "/");
+            if !collected.iter().any(|existing| existing == &normalized) {
+                collected.push(normalized);
+            }
+            if collected.len() >= limit {
+                return collected;
+            }
+        }
+    }
+    collected
+}
+
+fn collect_recent_file_excerpts(
+    history: &[Message],
+    limit: usize,
+    char_limit: usize,
+) -> Vec<RecentFileExcerpt> {
+    use std::collections::HashMap;
+
+    let mut pending_reads = HashMap::<String, (String, Option<(usize, usize)>)>::new();
+    let mut excerpts = Vec::new();
+
+    for message in history {
+        match message.role.as_str() {
+            "assistant" => {
+                let Some(items) = message.content.as_array() else {
+                    continue;
+                };
+                for item in items {
+                    if item.get("type").and_then(Value::as_str) != Some("tool_use") {
+                        continue;
+                    }
+                    if item.get("name").and_then(Value::as_str) != Some("read_file") {
+                        continue;
+                    }
+                    let Some(tool_use_id) = item.get("id").and_then(Value::as_str) else {
+                        continue;
+                    };
+                    let Some(input) = item.get("input").and_then(Value::as_object) else {
+                        continue;
+                    };
+                    let Some(path) = input.get("path").and_then(Value::as_str) else {
+                        continue;
+                    };
+                    let line_range = match (
+                        input.get("start_line").and_then(Value::as_u64),
+                        input.get("end_line").and_then(Value::as_u64),
+                    ) {
+                        (Some(start), Some(end)) => Some((start as usize, end as usize)),
+                        (Some(start), None) => Some((start as usize, start as usize)),
+                        _ => None,
+                    };
+                    pending_reads.insert(
+                        tool_use_id.to_string(),
+                        (path.replace('\\', "/"), line_range),
+                    );
+                }
+            }
+            "user" => {
+                let Some(items) = message.content.as_array() else {
+                    continue;
+                };
+                for item in items {
+                    if item.get("type").and_then(Value::as_str) != Some("tool_result") {
+                        continue;
+                    }
+                    let Some(tool_use_id) = item.get("tool_use_id").and_then(Value::as_str) else {
+                        continue;
+                    };
+                    let Some((path, line_range)) = pending_reads.remove(tool_use_id) else {
+                        continue;
+                    };
+                    let snippet = item
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .map(|content| truncate_excerpt(content, char_limit).trim().to_string())
+                        .filter(|content| !content.is_empty());
+                    let Some(snippet) = snippet else {
+                        continue;
+                    };
+                    if excerpts
+                        .iter()
+                        .any(|existing: &RecentFileExcerpt| existing.path == path)
+                    {
+                        continue;
+                    }
+                    excerpts.push(RecentFileExcerpt {
+                        path,
+                        line_range,
+                        snippet,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if excerpts.len() > limit {
+        excerpts = excerpts[excerpts.len() - limit..].to_vec();
+    }
+    excerpts.reverse();
+    excerpts
+}
+
+fn render_recent_file_excerpt(excerpt: &RecentFileExcerpt) -> String {
+    let header = match excerpt.line_range {
+        Some((start, end)) if start != end => {
+            format!("### {} (lines {}-{})", excerpt.path, start, end)
+        }
+        Some((line, _)) => format!("### {} (line {})", excerpt.path, line),
+        None => format!("### {}", excerpt.path),
+    };
+    format!("{header}\n```text\n{}\n```", excerpt.snippet)
+}
+
+fn truncate_excerpt(text: &str, max_chars: usize) -> String {
+    let total = text.chars().count();
+    if total <= max_chars {
+        return text.to_string();
+    }
+    let truncated = text.chars().take(max_chars).collect::<String>();
+    format!("{truncated}\n... truncated.")
+}
+
+fn build_compact_boundary_message(before_tokens: usize, recent_file_count: usize) -> Message {
+    Message {
+        role: "system".to_string(),
+        content: json!({
+            "type": COMPACT_BOUNDARY_KIND,
+            "version": COMPACT_BOUNDARY_VERSION,
+            "before_tokens": before_tokens,
+            "recent_file_count": recent_file_count,
+        }),
+    }
+}
+
+pub fn latest_compact_boundary_metadata(history: &[Message]) -> Option<CompactBoundaryMetadata> {
+    history.iter().rev().find_map(|message| {
+        let content = message.content.as_object()?;
+        if content.get("type").and_then(Value::as_str) != Some(COMPACT_BOUNDARY_KIND) {
+            return None;
+        }
+        Some(CompactBoundaryMetadata {
+            version: content
+                .get("version")
+                .and_then(Value::as_u64)
+                .unwrap_or(COMPACT_BOUNDARY_VERSION as u64) as u32,
+            before_tokens: content
+                .get("before_tokens")
+                .and_then(Value::as_u64)
+                .unwrap_or_default() as usize,
+            recent_file_count: content
+                .get("recent_file_count")
+                .and_then(Value::as_u64)
+                .unwrap_or_default() as usize,
+        })
+    })
 }

--- a/src/agent/compact.rs
+++ b/src/agent/compact.rs
@@ -152,7 +152,6 @@ impl Agent {
             .save_session(&self.session_id, &self.history)?;
 
         let compacted_tokens = self.compact_state.estimated_history_tokens;
-        self.compact_state.estimated_history_tokens = compacted_tokens;
         self.compact_state.compaction_count += 1;
         self.compact_state.last_compaction_before_tokens = Some(current_tokens);
         self.compact_state.last_compaction_after_tokens = Some(compacted_tokens);
@@ -259,7 +258,12 @@ fn collect_recent_files(history: &[Message], limit: usize) -> Vec<String> {
             };
             if !matches!(
                 tool_name,
-                "read_file" | "list_files" | "write_file" | "replace" | "search_files"
+                "read_file"
+                    | "list_files"
+                    | "write_file"
+                    | "replace"
+                    | "search_files"
+                    | "apply_patch"
             ) {
                 continue;
             }
@@ -343,12 +347,7 @@ fn collect_recent_file_excerpts(
                     let Some(snippet) = snippet else {
                         continue;
                     };
-                    if excerpts
-                        .iter()
-                        .any(|existing: &RecentFileExcerpt| existing.path == path)
-                    {
-                        continue;
-                    }
+                    excerpts.retain(|existing: &RecentFileExcerpt| existing.path != path);
                     excerpts.push(RecentFileExcerpt {
                         path,
                         line_range,

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -1,6 +1,6 @@
 use super::*;
-use anyhow::anyhow;
 use crate::tools::bash::BashCommandInput;
+use anyhow::anyhow;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlanStepStatus {
@@ -213,18 +213,21 @@ impl Agent {
                     content: error_text.clone(),
                     is_error: true,
                 });
-                self.history.push(tool_result_message(&pending.tool_use_id, error_text, true));
-                self.history.push(
-                    self.runtime_continuation_message(
-                        RuntimeContinuationPhase::ToolResultsAvailable,
-                        0,
-                    ),
-                );
+                self.push_history_message(tool_result_message(
+                    &pending.tool_use_id,
+                    error_text,
+                    true,
+                ));
+                self.push_history_message(self.runtime_continuation_message(
+                    RuntimeContinuationPhase::ToolResultsAvailable,
+                    0,
+                ));
                 self.run_agent_loop(output_mode, &mut report).await?;
             }
         }
 
-        self.session_manager.save_session(&self.session_id, &self.history)?;
+        self.session_manager
+            .save_session(&self.session_id, &self.history)?;
         Ok(())
     }
 
@@ -247,7 +250,9 @@ impl Agent {
             .tool_manager
             .get_tool("bash")
             .ok_or_else(|| anyhow!("bash tool is unavailable"))?;
-        report(AgentEvent::Status("Running approved bash command.".to_string()));
+        report(AgentEvent::Status(
+            "Running approved bash command.".to_string(),
+        ));
         match tool.call(input.clone()).await {
             Ok(result) => {
                 let result_text = self.tool_result_store.compact_result(
@@ -261,7 +266,7 @@ impl Agent {
                     content: result_text.clone(),
                     is_error: false,
                 });
-                self.history.push(tool_result_message(
+                self.push_history_message(tool_result_message(
                     &pending.tool_use_id,
                     result_text,
                     false,
@@ -274,14 +279,14 @@ impl Agent {
                     content: error_text.clone(),
                     is_error: true,
                 });
-                self.history.push(tool_result_message(
+                self.push_history_message(tool_result_message(
                     &pending.tool_use_id,
                     error_text,
                     true,
                 ));
             }
         }
-        self.history.push(
+        self.push_history_message(
             self.runtime_continuation_message(RuntimeContinuationPhase::ToolResultsAvailable, 1),
         );
         if !keep_always {
@@ -298,11 +303,11 @@ impl Agent {
     ) where
         F: FnMut(AgentEvent) + Send,
     {
-        self.history.extend(tool_results);
+        self.extend_history_messages(tool_results);
         report(AgentEvent::Status(
             "Tool results recorded. Advancing to the next agent step.".to_string(),
         ));
-        self.history.push(self.runtime_continuation_message(
+        self.push_history_message(self.runtime_continuation_message(
             RuntimeContinuationPhase::ToolResultsAvailable,
             tool_rounds,
         ));
@@ -347,7 +352,7 @@ impl Agent {
             report(AgentEvent::Status(
                 "Continuing plan refinement from the current plan state.".to_string(),
             ));
-            self.history.push(self.runtime_continuation_message(
+            self.push_history_message(self.runtime_continuation_message(
                 RuntimeContinuationPhase::PlanContinuationRequired,
                 0,
             ));
@@ -356,10 +361,9 @@ impl Agent {
             report(AgentEvent::Status(
                 "Plan approved. Continuing with implementation.".to_string(),
             ));
-            self.history.push(self.runtime_continuation_message(
-                RuntimeContinuationPhase::PlanApproved,
-                0,
-            ));
+            self.push_history_message(
+                self.runtime_continuation_message(RuntimeContinuationPhase::PlanApproved, 0),
+            );
         }
 
         self.run_agent_loop(output_mode, &mut report).await
@@ -393,12 +397,10 @@ impl Agent {
             && !self.inspection_progress.has_minimum_review_evidence();
         let needs_plan_synthesis = tool_rounds > 0 && has_inspection_evidence && !plan_updated;
         matches!(self.execution_mode, AgentExecutionMode::Plan)
-            && (
-                continue_inspection
-                    || shallow_initial_plan
-                    || still_missing_inspection_evidence
-                    || needs_plan_synthesis
-            )
+            && (continue_inspection
+                || shallow_initial_plan
+                || still_missing_inspection_evidence
+                || needs_plan_synthesis)
             && plan_continuations < MAX_PLAN_CONTINUATIONS_PER_TURN
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
@@ -421,7 +423,9 @@ impl Agent {
     }
 
     pub(super) fn ensure_active_plan_step(&mut self) {
-        if !matches!(self.execution_mode, AgentExecutionMode::Execute) || self.current_plan.is_empty() {
+        if !matches!(self.execution_mode, AgentExecutionMode::Execute)
+            || self.current_plan.is_empty()
+        {
             return;
         }
         if self
@@ -441,7 +445,9 @@ impl Agent {
     }
 
     pub(super) fn advance_plan_step(&mut self) {
-        if !matches!(self.execution_mode, AgentExecutionMode::Execute) || self.current_plan.is_empty() {
+        if !matches!(self.execution_mode, AgentExecutionMode::Execute)
+            || self.current_plan.is_empty()
+        {
             return;
         }
         if let Some(step) = self
@@ -461,7 +467,9 @@ impl Agent {
     }
 
     pub(super) fn complete_remaining_plan_steps(&mut self) {
-        if !matches!(self.execution_mode, AgentExecutionMode::Execute) || self.current_plan.is_empty() {
+        if !matches!(self.execution_mode, AgentExecutionMode::Execute)
+            || self.current_plan.is_empty()
+        {
             return;
         }
         for step in &mut self.current_plan {
@@ -554,7 +562,10 @@ pub(super) fn parse_plan_block(text: &str) -> Option<(Vec<PlanStep>, Option<Stri
     }
 
     let explanation = text[end + "</plan>".len()..].trim();
-    Some((steps, (!explanation.is_empty()).then(|| explanation.to_string())))
+    Some((
+        steps,
+        (!explanation.is_empty()).then(|| explanation.to_string()),
+    ))
 }
 
 pub(super) fn parse_request_user_input_block(text: &str) -> Option<PendingUserInput> {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -933,3 +933,60 @@ async fn manual_compact_carries_recent_files_forward() {
     assert!(excerpts.contains("### src/main.rs"));
     assert!(excerpts.contains("fn main() {}"));
 }
+
+#[tokio::test]
+async fn manual_compact_prefers_latest_excerpt_and_tracks_apply_patch() {
+    let backend = Arc::new(SequencedBackend::new(Vec::new()));
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new("data/lancedb")),
+        Arc::new(SessionManager::new().expect("session manager")),
+        Arc::new(WorkspaceMemory::new().expect("workspace memory")),
+    );
+    agent.history = vec![
+        Message {
+            role: "assistant".to_string(),
+            content: json!([
+                {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/main.rs","start_line":1,"end_line":2}},
+                {"type":"tool_use","id":"tool-2","name":"apply_patch","input":{"path":"src/lib.rs"}}
+            ]),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([
+                {"type":"tool_result","tool_use_id":"tool-1","content":"old snippet"},
+                {"type":"tool_result","tool_use_id":"tool-2","content":"patch applied"}
+            ]),
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: json!([
+                {"type":"tool_use","id":"tool-3","name":"read_file","input":{"path":"src/main.rs","start_line":10,"end_line":12}}
+            ]),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([
+                {"type":"tool_result","tool_use_id":"tool-3","content":"new snippet"}
+            ]),
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: json!("I updated the inspection notes."),
+        },
+    ];
+
+    let compacted = agent
+        .compact_now_with_reporter(|_| {})
+        .await
+        .expect("compact should succeed");
+
+    assert!(compacted);
+    let recent_files = agent.history[2].content.to_string();
+    assert!(recent_files.contains("src/lib.rs"));
+    let excerpts = agent.history[3].content.to_string();
+    assert!(excerpts.contains("new snippet"));
+    assert!(!excerpts.contains("old snippet"));
+    assert!(excerpts.contains("lines 10-12"));
+}

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -21,9 +21,15 @@ struct StubTool;
 
 #[async_trait]
 impl Tool for StubTool {
-    fn name(&self) -> &str { "stub_tool" }
-    fn description(&self) -> &str { "Return a simple structured result" }
-    fn input_schema(&self) -> Value { json!({"type":"object"}) }
+    fn name(&self) -> &str {
+        "stub_tool"
+    }
+    fn description(&self) -> &str {
+        "Return a simple structured result"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type":"object"})
+    }
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({ "status": "ok", "value": 42 }))
     }
@@ -33,9 +39,15 @@ struct ListFilesStub;
 
 #[async_trait]
 impl Tool for ListFilesStub {
-    fn name(&self) -> &str { "list_files" }
-    fn description(&self) -> &str { "Return a simple list result" }
-    fn input_schema(&self) -> Value { json!({"type":"object"}) }
+    fn name(&self) -> &str {
+        "list_files"
+    }
+    fn description(&self) -> &str {
+        "Return a simple list result"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type":"object"})
+    }
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({ "path": ".", "entries": [] }))
     }
@@ -45,9 +57,15 @@ struct PlanAgentStub;
 
 #[async_trait]
 impl Tool for PlanAgentStub {
-    fn name(&self) -> &str { "plan_agent" }
-    fn description(&self) -> &str { "Return a delegated planning result" }
-    fn input_schema(&self) -> Value { json!({"type":"object"}) }
+    fn name(&self) -> &str {
+        "plan_agent"
+    }
+    fn description(&self) -> &str {
+        "Return a delegated planning result"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type":"object"})
+    }
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({ "status": "ok", "summary": "delegated inspection complete" }))
     }
@@ -73,7 +91,12 @@ impl SequencedBackend {
     }
 }
 
-fn test_runtime_storage() -> (tempfile::TempDir, Arc<SessionManager>, Arc<WorkspaceMemory>, std::path::PathBuf) {
+fn test_runtime_storage() -> (
+    tempfile::TempDir,
+    Arc<SessionManager>,
+    Arc<WorkspaceMemory>,
+    std::path::PathBuf,
+) {
     let temp = tempdir().expect("tempdir");
     let root = temp.path().to_path_buf();
     let rara_dir = root.join(".rara");
@@ -91,7 +114,10 @@ fn test_runtime_storage() -> (tempfile::TempDir, Arc<SessionManager>, Arc<Worksp
 #[async_trait]
 impl LlmBackend for SequencedBackend {
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<AnthropicResponse> {
-        self.observed_messages.lock().expect("lock").push(messages.to_vec());
+        self.observed_messages
+            .lock()
+            .expect("lock")
+            .push(messages.to_vec());
         self.observed_tools.lock().expect("lock").push(
             tools
                 .iter()
@@ -149,11 +175,14 @@ async fn appends_continuation_after_tool_result() {
     let observed = backend.observed_messages.lock().expect("lock");
     assert_eq!(observed.len(), 2);
     let second_round = &observed[1];
-    let continuation = agent.runtime_continuation_message(RuntimeContinuationPhase::ToolResultsAvailable, 1);
-    assert!(second_round.iter().any(|message| message.content == continuation.content));
-    assert!(second_round.iter().any(|message| {
-        message.content.to_string().contains("tool_result")
-    }));
+    let continuation =
+        agent.runtime_continuation_message(RuntimeContinuationPhase::ToolResultsAvailable, 1);
+    assert!(second_round
+        .iter()
+        .any(|message| message.content == continuation.content));
+    assert!(second_round
+        .iter()
+        .any(|message| { message.content.to_string().contains("tool_result") }));
 }
 
 #[tokio::test]
@@ -201,9 +230,9 @@ async fn resumes_after_plan_approval_via_structured_continuation() {
     assert!(runtime_texts
         .iter()
         .any(|text| text.contains("\"mode\": \"execute\"")));
-    assert!(!runtime_texts
-        .iter()
-        .any(|text| text.contains("Implement the approved plan using the current repository state")));
+    assert!(!runtime_texts.iter().any(
+        |text| text.contains("Implement the approved plan using the current repository state")
+    ));
 }
 
 #[tokio::test]
@@ -231,10 +260,10 @@ async fn does_not_append_continuation_without_tools() {
 
     let observed = backend.observed_messages.lock().expect("lock");
     assert_eq!(observed.len(), 1);
-    assert!(!agent
-        .history
-        .iter()
-        .any(|message| message.content.to_string().contains("\"phase\": \"tool_results_available\"")));
+    assert!(!agent.history.iter().any(|message| message
+        .content
+        .to_string()
+        .contains("\"phase\": \"tool_results_available\"")));
 }
 
 #[tokio::test]
@@ -266,9 +295,7 @@ async fn errors_when_tool_loop_exceeds_limit() {
         .query_with_mode("loop".to_string(), super::AgentOutputMode::Silent)
         .await
         .expect_err("query should fail");
-    assert!(error
-        .to_string()
-        .contains("Tool loop exceeded"));
+    assert!(error.to_string().contains("Tool loop exceeded"));
 }
 
 #[tokio::test]
@@ -294,7 +321,10 @@ async fn plan_mode_filters_write_tools_from_schema() {
     agent.set_execution_mode(AgentExecutionMode::Plan);
 
     agent
-        .query_with_mode("review-current-project".to_string(), super::AgentOutputMode::Silent)
+        .query_with_mode(
+            "review-current-project".to_string(),
+            super::AgentOutputMode::Silent,
+        )
         .await
         .expect("query should succeed");
 
@@ -340,10 +370,10 @@ async fn continues_plan_mode_after_shallow_initial_plan() {
 
     let observed = backend.observed_messages.lock().expect("lock");
     assert_eq!(observed.len(), 2);
-    assert!(agent
-        .history
-        .iter()
-        .any(|message| message.content.to_string().contains("plan_continuation_required")));
+    assert!(agent.history.iter().any(|message| message
+        .content
+        .to_string()
+        .contains("plan_continuation_required")));
 }
 
 #[tokio::test]
@@ -385,7 +415,8 @@ async fn last_query_plan_updated_tracks_only_the_final_planning_turn() {
         session_manager.clone(),
         workspace.clone(),
     );
-    agent.tool_result_store = ToolResultStore::new(rara_dir.join("tool-results")).expect("tool result store");
+    agent.tool_result_store =
+        ToolResultStore::new(rara_dir.join("tool-results")).expect("tool result store");
     agent.set_execution_mode(AgentExecutionMode::Plan);
 
     agent
@@ -412,7 +443,8 @@ async fn last_query_plan_updated_tracks_only_the_final_planning_turn() {
         session_manager,
         workspace,
     );
-    agent.tool_result_store = ToolResultStore::new(rara_dir.join("tool-results")).expect("tool result store");
+    agent.tool_result_store =
+        ToolResultStore::new(rara_dir.join("tool-results")).expect("tool result store");
     agent.set_execution_mode(AgentExecutionMode::Plan);
 
     agent
@@ -474,10 +506,10 @@ async fn continues_plan_mode_after_exploration_if_assistant_still_signals_more_w
 
     let observed = backend.observed_messages.lock().expect("lock");
     assert_eq!(observed.len(), 3);
-    assert!(agent
-        .history
-        .iter()
-        .any(|message| message.content.to_string().contains("plan_continuation_required")));
+    assert!(agent.history.iter().any(|message| message
+        .content
+        .to_string()
+        .contains("plan_continuation_required")));
 }
 
 #[tokio::test]
@@ -526,10 +558,10 @@ async fn continues_plan_mode_to_synthesize_plan_after_exploration_evidence() {
 
     let observed = backend.observed_messages.lock().expect("lock");
     assert_eq!(observed.len(), 3);
-    assert!(agent
-        .history
-        .iter()
-        .any(|message| message.content.to_string().contains("plan_continuation_required")));
+    assert!(agent.history.iter().any(|message| message
+        .content
+        .to_string()
+        .contains("plan_continuation_required")));
     assert_eq!(agent.current_plan.len(), 2);
 }
 
@@ -582,7 +614,6 @@ async fn delegated_plan_agent_counts_as_planning_evidence() {
     assert_eq!(agent.current_plan.len(), 2);
 }
 
-
 #[tokio::test]
 async fn continues_execute_mode_after_exploration_if_assistant_still_signals_more_work() {
     let backend = Arc::new(SequencedBackend::new(vec![
@@ -629,10 +660,10 @@ async fn continues_execute_mode_after_exploration_if_assistant_still_signals_mor
 
     let observed = backend.observed_messages.lock().expect("lock");
     assert_eq!(observed.len(), 3);
-    assert!(agent
-        .history
-        .iter()
-        .any(|message| message.content.to_string().contains("execution_continuation_required")));
+    assert!(agent.history.iter().any(|message| message
+        .content
+        .to_string()
+        .contains("execution_continuation_required")));
 }
 
 #[tokio::test]
@@ -670,17 +701,16 @@ async fn continues_execute_mode_when_assistant_requests_structured_followup_insp
 
     let observed = backend.observed_messages.lock().expect("lock");
     assert_eq!(observed.len(), 2);
-    assert!(agent
-        .history
-        .iter()
-        .any(|message| message.content.to_string().contains("execution_continuation_required")));
+    assert!(agent.history.iter().any(|message| message
+        .content
+        .to_string()
+        .contains("execution_continuation_required")));
 }
 
 #[test]
 fn strips_continue_inspection_control_tag() {
-    let (cleaned, requested) = strip_continue_inspection_control(
-        "Need one more inspection pass.\n<continue_inspection/>",
-    );
+    let (cleaned, requested) =
+        strip_continue_inspection_control("Need one more inspection pass.\n<continue_inspection/>");
     assert!(requested);
     assert_eq!(cleaned, "Need one more inspection pass.\n");
 
@@ -830,8 +860,76 @@ async fn manual_compact_replaces_older_history_with_summary() {
 
     assert!(compacted);
     assert_eq!(agent.compact_state.compaction_count, 1);
-    assert!(agent.history[0]
+    assert_eq!(agent.history[0].role, "system");
+    let boundary = agent.history[0]
+        .content
+        .as_object()
+        .expect("compact boundary");
+    assert_eq!(
+        boundary.get("type").and_then(serde_json::Value::as_str),
+        Some("compact_boundary")
+    );
+    assert!(agent.history[1]
         .content
         .to_string()
-        .contains("SUMMARY OF PREVIOUS CONVERSATION"));
+        .contains("STRUCTURED SUMMARY OF PREVIOUS CONVERSATION"));
+}
+
+#[tokio::test]
+async fn manual_compact_carries_recent_files_forward() {
+    let backend = Arc::new(SequencedBackend::new(Vec::new()));
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new("data/lancedb")),
+        Arc::new(SessionManager::new().expect("session manager")),
+        Arc::new(WorkspaceMemory::new().expect("workspace memory")),
+    );
+    agent.history = vec![
+        Message {
+            role: "assistant".to_string(),
+            content: json!([
+                {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/main.rs"}},
+                {"type":"tool_use","id":"tool-2","name":"list_files","input":{"path":"src/agent"}}
+            ]),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([
+                {"type":"tool_result","tool_use_id":"tool-1","content":"fn main() {}"},
+                {"type":"tool_result","tool_use_id":"tool-2","content":"planning.rs"}
+            ]),
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: json!("I inspected the relevant files."),
+        },
+    ];
+
+    let compacted = agent
+        .compact_now_with_reporter(|_| {})
+        .await
+        .expect("compact should succeed");
+
+    assert!(compacted);
+    assert_eq!(agent.history[2].role, "system");
+    assert_eq!(agent.history[3].role, "system");
+    let boundary = agent.history[0]
+        .content
+        .as_object()
+        .expect("compact boundary");
+    assert_eq!(
+        boundary
+            .get("recent_file_count")
+            .and_then(serde_json::Value::as_u64),
+        Some(2)
+    );
+    let recent_files = agent.history[2].content.to_string();
+    assert!(recent_files.contains("RECENT FILES FROM COMPACTED HISTORY"));
+    assert!(recent_files.contains("src/main.rs"));
+    assert!(recent_files.contains("src/agent"));
+    let excerpts = agent.history[3].content.to_string();
+    assert!(excerpts.contains("RECENT FILE EXCERPTS FROM COMPACTED HISTORY"));
+    assert!(excerpts.contains("### src/main.rs"));
+    assert!(excerpts.contains("fn main() {}"));
 }

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -46,6 +46,20 @@ pub struct PersistedSessionSummary {
     pub branch: String,
     pub updated_at: i64,
     pub preview: String,
+    pub compaction_count: usize,
+    pub last_compaction_before_tokens: Option<usize>,
+    pub last_compaction_after_tokens: Option<usize>,
+    pub last_compaction_recent_file_count: Option<usize>,
+    pub last_compaction_boundary_version: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PersistedCompactState {
+    pub compaction_count: usize,
+    pub last_compaction_before_tokens: Option<usize>,
+    pub last_compaction_after_tokens: Option<usize>,
+    pub last_compaction_recent_file_count: Option<usize>,
+    pub last_compaction_boundary_version: Option<u32>,
 }
 
 pub struct StateDb {
@@ -99,14 +113,18 @@ impl StateDb {
         plan_explanation: Option<&str>,
         history_len: usize,
         transcript_len: usize,
+        compact_state: &PersistedCompactState,
     ) -> Result<()> {
         let now = epoch_seconds();
         let conn = self.conn.lock().expect("state db mutex poisoned");
         conn.execute(
             "INSERT INTO sessions (
                 id, cwd, branch, provider, model, base_url, agent_mode, bash_approval,
-                plan_explanation, history_len, transcript_len, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                plan_explanation, history_len, transcript_len, compaction_count,
+                last_compaction_before_tokens, last_compaction_after_tokens,
+                last_compaction_recent_file_count, last_compaction_boundary_version,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 cwd = excluded.cwd,
                 branch = excluded.branch,
@@ -118,6 +136,11 @@ impl StateDb {
                 plan_explanation = excluded.plan_explanation,
                 history_len = excluded.history_len,
                 transcript_len = excluded.transcript_len,
+                compaction_count = excluded.compaction_count,
+                last_compaction_before_tokens = excluded.last_compaction_before_tokens,
+                last_compaction_after_tokens = excluded.last_compaction_after_tokens,
+                last_compaction_recent_file_count = excluded.last_compaction_recent_file_count,
+                last_compaction_boundary_version = excluded.last_compaction_boundary_version,
                 updated_at = excluded.updated_at",
             params![
                 session_id,
@@ -131,6 +154,19 @@ impl StateDb {
                 plan_explanation,
                 history_len as i64,
                 transcript_len as i64,
+                compact_state.compaction_count as i64,
+                compact_state
+                    .last_compaction_before_tokens
+                    .map(|value| value as i64),
+                compact_state
+                    .last_compaction_after_tokens
+                    .map(|value| value as i64),
+                compact_state
+                    .last_compaction_recent_file_count
+                    .map(|value| value as i64),
+                compact_state
+                    .last_compaction_boundary_version
+                    .map(|value| value as i64),
                 now,
                 now
             ],
@@ -141,7 +177,10 @@ impl StateDb {
     pub fn replace_plan_steps(&self, session_id: &str, steps: &[PersistedPlanStep]) -> Result<()> {
         let mut conn = self.conn.lock().expect("state db mutex poisoned");
         let tx = conn.transaction()?;
-        tx.execute("DELETE FROM plan_steps WHERE session_id = ?", params![session_id])?;
+        tx.execute(
+            "DELETE FROM plan_steps WHERE session_id = ?",
+            params![session_id],
+        )?;
         for step in steps {
             tx.execute(
                 "INSERT INTO plan_steps (session_id, step_index, status, step, updated_at)
@@ -166,7 +205,10 @@ impl StateDb {
     ) -> Result<()> {
         let mut conn = self.conn.lock().expect("state db mutex poisoned");
         let tx = conn.transaction()?;
-        tx.execute("DELETE FROM interactions WHERE session_id = ?", params![session_id])?;
+        tx.execute(
+            "DELETE FROM interactions WHERE session_id = ?",
+            params![session_id],
+        )?;
         for interaction in interactions {
             tx.execute(
                 "INSERT INTO interactions (session_id, kind, status, title, summary, payload_json, updated_at)
@@ -235,7 +277,9 @@ impl StateDb {
         session_id: &str,
         ordinal: usize,
     ) -> Result<Vec<PersistedTurnEntry>> {
-        let path = self.rollout_root().join(self.artifact_relative_path(session_id, ordinal));
+        let path = self
+            .rollout_root()
+            .join(self.artifact_relative_path(session_id, ordinal));
         if !path.exists() {
             return Ok(Vec::new());
         }
@@ -334,6 +378,40 @@ impl StateDb {
         Ok(explanation)
     }
 
+    pub fn load_session_compact_state(&self, session_id: &str) -> Result<PersistedCompactState> {
+        let conn = self.conn.lock().expect("state db mutex poisoned");
+        let compact_state = conn.query_row(
+            "SELECT compaction_count, last_compaction_before_tokens,
+                    last_compaction_after_tokens, last_compaction_recent_file_count,
+                    last_compaction_boundary_version
+             FROM sessions
+             WHERE id = ?",
+            params![session_id],
+            |row| {
+                Ok(PersistedCompactState {
+                    compaction_count: row.get::<_, i64>(0)? as usize,
+                    last_compaction_before_tokens: row
+                        .get::<_, Option<i64>>(1)?
+                        .map(|value| value as usize),
+                    last_compaction_after_tokens: row
+                        .get::<_, Option<i64>>(2)?
+                        .map(|value| value as usize),
+                    last_compaction_recent_file_count: row
+                        .get::<_, Option<i64>>(3)?
+                        .map(|value| value as usize),
+                    last_compaction_boundary_version: row
+                        .get::<_, Option<i64>>(4)?
+                        .map(|value| value as u32),
+                })
+            },
+        );
+        match compact_state {
+            Ok(compact_state) => Ok(compact_state),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(PersistedCompactState::default()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
     pub fn latest_session_id(&self) -> Result<Option<String>> {
         let conn = self.conn.lock().expect("state db mutex poisoned");
         let session_id = conn.query_row(
@@ -352,6 +430,9 @@ impl StateDb {
         let conn = self.conn.lock().expect("state db mutex poisoned");
         let mut stmt = conn.prepare(
             "SELECT s.id, s.provider, s.model, s.branch, s.updated_at,
+                    s.compaction_count, s.last_compaction_before_tokens,
+                    s.last_compaction_after_tokens, s.last_compaction_recent_file_count,
+                    s.last_compaction_boundary_version,
                     COALESCE((
                         SELECT preview FROM turns
                         WHERE session_id = s.id
@@ -369,7 +450,20 @@ impl StateDb {
                 model: row.get(2)?,
                 branch: row.get(3)?,
                 updated_at: row.get(4)?,
-                preview: row.get(5)?,
+                preview: row.get(10)?,
+                compaction_count: row.get::<_, i64>(5)? as usize,
+                last_compaction_before_tokens: row
+                    .get::<_, Option<i64>>(6)?
+                    .map(|value| value as usize),
+                last_compaction_after_tokens: row
+                    .get::<_, Option<i64>>(7)?
+                    .map(|value| value as usize),
+                last_compaction_recent_file_count: row
+                    .get::<_, Option<i64>>(8)?
+                    .map(|value| value as usize),
+                last_compaction_boundary_version: row
+                    .get::<_, Option<i64>>(9)?
+                    .map(|value| value as u32),
             })
         })?;
         let mut sessions = Vec::new();
@@ -415,6 +509,11 @@ impl StateDb {
                 plan_explanation TEXT,
                 history_len INTEGER NOT NULL DEFAULT 0,
                 transcript_len INTEGER NOT NULL DEFAULT 0,
+                compaction_count INTEGER NOT NULL DEFAULT 0,
+                last_compaction_before_tokens INTEGER,
+                last_compaction_after_tokens INTEGER,
+                last_compaction_recent_file_count INTEGER,
+                last_compaction_boundary_version INTEGER,
                 created_at INTEGER NOT NULL,
                 updated_at INTEGER NOT NULL
             );
@@ -460,6 +559,31 @@ impl StateDb {
             ",
         )?;
         ensure_column(&conn, "sessions", "plan_explanation", "TEXT")?;
+        ensure_column(
+            &conn,
+            "sessions",
+            "compaction_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
+        ensure_column(
+            &conn,
+            "sessions",
+            "last_compaction_before_tokens",
+            "INTEGER",
+        )?;
+        ensure_column(&conn, "sessions", "last_compaction_after_tokens", "INTEGER")?;
+        ensure_column(
+            &conn,
+            "sessions",
+            "last_compaction_recent_file_count",
+            "INTEGER",
+        )?;
+        ensure_column(
+            &conn,
+            "sessions",
+            "last_compaction_boundary_version",
+            "INTEGER",
+        )?;
         ensure_column(&conn, "interactions", "payload_json", "TEXT")?;
         Ok(())
     }
@@ -503,7 +627,9 @@ fn ensure_column(conn: &Connection, table: &str, column: &str, definition: &str)
 
 #[cfg(test)]
 mod tests {
-    use super::{PersistedInteraction, PersistedPlanStep, PersistedTurnEntry, StateDb};
+    use super::{
+        PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedTurnEntry, StateDb,
+    };
     use anyhow::Result;
     use rusqlite::Connection;
     use tempfile::tempdir;
@@ -525,6 +651,7 @@ mod tests {
             Some("Inspect the repository and summarize issues."),
             4,
             3,
+            &PersistedCompactState::default(),
         )?;
         db.replace_plan_steps(
             "session-1",
@@ -587,10 +714,7 @@ mod tests {
         assert_eq!(interaction_count, 1);
         assert_eq!(summary.event_count, 2);
 
-        let artifact = db
-            .rollout_root()
-            .join("session-1")
-            .join("000000.json");
+        let artifact = db.rollout_root().join("session-1").join("000000.json");
         assert!(artifact.exists());
         let loaded = db.load_turn_entries("session-1", 0)?;
         assert_eq!(loaded.len(), 2);
@@ -614,6 +738,7 @@ mod tests {
             None,
             2,
             1,
+            &PersistedCompactState::default(),
         )?;
         db.replace_interactions(
             "session-2",
@@ -633,9 +758,18 @@ mod tests {
         let interactions = db.load_interactions("session-2")?;
         assert_eq!(interactions.len(), 1);
         let payload = interactions[0].payload.as_ref().expect("payload");
-        assert_eq!(payload.get("tool_use_id").and_then(|v| v.as_str()), Some("tool-42"));
-        assert_eq!(payload.get("command").and_then(|v| v.as_str()), Some("cargo test"));
-        assert_eq!(payload.get("allow_net").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(
+            payload.get("tool_use_id").and_then(|v| v.as_str()),
+            Some("tool-42")
+        );
+        assert_eq!(
+            payload.get("command").and_then(|v| v.as_str()),
+            Some("cargo test")
+        );
+        assert_eq!(
+            payload.get("allow_net").and_then(|v| v.as_bool()),
+            Some(true)
+        );
         Ok(())
     }
 
@@ -656,6 +790,7 @@ mod tests {
             None,
             2,
             1,
+            &PersistedCompactState::default(),
         )?;
         db.replace_interactions(
             "session-structured",
@@ -678,8 +813,14 @@ mod tests {
         let interactions = db.load_interactions("session-structured")?;
         assert_eq!(interactions.len(), 1);
         let payload = interactions[0].payload.as_ref().expect("payload");
-        assert_eq!(payload.get("tool_use_id").and_then(|v| v.as_str()), Some("tool-99"));
-        assert_eq!(payload.get("program").and_then(|v| v.as_str()), Some("cargo"));
+        assert_eq!(
+            payload.get("tool_use_id").and_then(|v| v.as_str()),
+            Some("tool-99")
+        );
+        assert_eq!(
+            payload.get("program").and_then(|v| v.as_str()),
+            Some("cargo")
+        );
         assert_eq!(
             payload
                 .get("args")
@@ -688,7 +829,10 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("check")
         );
-        assert_eq!(payload.get("cwd").and_then(|v| v.as_str()), Some("/tmp/workspace"));
+        assert_eq!(
+            payload.get("cwd").and_then(|v| v.as_str()),
+            Some("/tmp/workspace")
+        );
         assert_eq!(
             payload
                 .get("env")
@@ -696,7 +840,56 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("debug")
         );
-        assert_eq!(payload.get("allow_net").and_then(|v| v.as_bool()), Some(false));
+        assert_eq!(
+            payload.get("allow_net").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn persists_compact_state_for_restore() -> Result<()> {
+        let temp = tempdir()?;
+        std::env::set_current_dir(temp.path())?;
+        let db = StateDb::new()?;
+        db.upsert_session(
+            "session-compact",
+            "/tmp/workspace",
+            "main",
+            "ollama",
+            "gemma4",
+            Some("http://localhost:11434"),
+            "execute",
+            "suggestion",
+            None,
+            6,
+            2,
+            &PersistedCompactState {
+                compaction_count: 3,
+                last_compaction_before_tokens: Some(12_000),
+                last_compaction_after_tokens: Some(4_200),
+                last_compaction_recent_file_count: Some(2),
+                last_compaction_boundary_version: Some(1),
+            },
+        )?;
+
+        let compact_state = db.load_session_compact_state("session-compact")?;
+        assert_eq!(compact_state.compaction_count, 3);
+        assert_eq!(compact_state.last_compaction_before_tokens, Some(12_000));
+        assert_eq!(compact_state.last_compaction_after_tokens, Some(4_200));
+        assert_eq!(compact_state.last_compaction_recent_file_count, Some(2));
+        assert_eq!(compact_state.last_compaction_boundary_version, Some(1));
+
+        let sessions = db.list_recent_sessions(5)?;
+        let summary = sessions
+            .iter()
+            .find(|item| item.session_id == "session-compact")
+            .expect("session summary");
+        assert_eq!(summary.compaction_count, 3);
+        assert_eq!(summary.last_compaction_before_tokens, Some(12_000));
+        assert_eq!(summary.last_compaction_after_tokens, Some(4_200));
+        assert_eq!(summary.last_compaction_recent_file_count, Some(2));
+        assert_eq!(summary.last_compaction_boundary_version, Some(1));
         Ok(())
     }
 }

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -329,13 +329,40 @@ pub fn status_resources_text(app: &TuiApp) -> String {
         (Some(before), Some(after)) => format!("{before} -> {after}"),
         _ => "-".to_string(),
     };
+    let recent_compact_files = if app.snapshot.last_compaction_recent_files.is_empty() {
+        "-".to_string()
+    } else {
+        app.snapshot.last_compaction_recent_files.join(", ")
+    };
+    let recent_compact_file_count = app.snapshot.last_compaction_recent_files.len();
+    let last_compact_ratio = match (
+        app.snapshot.last_compaction_before_tokens,
+        app.snapshot.last_compaction_after_tokens,
+    ) {
+        (Some(before), Some(after)) if before > 0 => format!("{:.2}", after as f64 / before as f64),
+        _ => "-".to_string(),
+    };
+    let compact_boundary = match (
+        app.snapshot.last_compaction_boundary_version,
+        app.snapshot.last_compaction_boundary_before_tokens,
+        app.snapshot.last_compaction_boundary_recent_file_count,
+    ) {
+        (Some(version), Some(before), Some(file_count)) => {
+            format!("v{version} (before_tokens={before}, recent_file_count={file_count})")
+        }
+        _ => "-".to_string(),
+    };
     format!(
-        "tokens={} in / {} out\ncontext_estimate={}\ncompactions={} (last: {})\ncache={}\nstate_db={}",
+        "tokens={} in / {} out\ncontext_estimate={}\ncompactions={} (last: {}, ratio: {})\ncompact_boundary={}\nrecent_compact_file_count={}\nrecent_compact_files={}\ncache={}\nstate_db={}",
         app.snapshot.total_input_tokens,
         app.snapshot.total_output_tokens,
         context,
         app.snapshot.compaction_count,
         last_compact,
+        last_compact_ratio,
+        compact_boundary,
+        recent_compact_file_count,
+        recent_compact_files,
         cache,
         state_db,
     )
@@ -609,8 +636,12 @@ pub fn normalize_command_token(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        matching_commands, normalize_command_token, parse_local_command, LocalCommandKind,
+        matching_commands, normalize_command_token, parse_local_command, status_resources_text,
+        LocalCommandKind,
     };
+    use crate::config::ConfigManager;
+    use crate::tui::state::{RuntimeSnapshot, TuiApp};
+    use tempfile::tempdir;
 
     #[test]
     fn parses_model_command_argument() {
@@ -688,5 +719,35 @@ mod tests {
             .map(|spec| spec.name)
             .collect::<Vec<_>>();
         assert_eq!(names.first().copied(), Some("model"));
+    }
+
+    #[test]
+    fn status_resources_text_includes_recent_compacted_files() {
+        let dir = tempdir().expect("tempdir");
+        let cm = ConfigManager {
+            path: dir.path().join("config.json"),
+        };
+        let mut app = TuiApp::new(cm).expect("app");
+        app.snapshot = RuntimeSnapshot {
+            compaction_count: 2,
+            last_compaction_before_tokens: Some(12_000),
+            last_compaction_after_tokens: Some(4_500),
+            last_compaction_recent_files: vec![
+                "src/agent/compact.rs".to_string(),
+                "crates/instructions/src/prompt.rs".to_string(),
+            ],
+            last_compaction_boundary_version: Some(1),
+            last_compaction_boundary_before_tokens: Some(12_000),
+            last_compaction_boundary_recent_file_count: Some(2),
+            ..RuntimeSnapshot::default()
+        };
+
+        let rendered = status_resources_text(&app);
+        assert!(rendered.contains("compactions=2 (last: 12000 -> 4500, ratio: 0.38)"));
+        assert!(rendered.contains("compact_boundary=v1 (before_tokens=12000, recent_file_count=2)"));
+        assert!(rendered.contains("recent_compact_file_count=2"));
+        assert!(rendered.contains(
+            "recent_compact_files=src/agent/compact.rs, crates/instructions/src/prompt.rs"
+        ));
     }
 }

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use crate::agent::{
-    Agent, CompletedInteraction, PendingApproval, PendingUserInput, PlanStep, PlanStepStatus,
+    latest_compact_boundary_metadata, Agent, CompactBoundaryMetadata, CompletedInteraction,
+    PendingApproval, PendingUserInput, PlanStep, PlanStepStatus,
 };
 use crate::state_db::StateDb;
 use crate::tools::bash::BashCommandInput;
@@ -36,6 +37,25 @@ pub(super) fn restore_session_by_id(
         agent.history = history;
         agent.session_id = session_id.to_string();
     }
+    let persisted_compact_state = state_db.load_session_compact_state(session_id)?;
+    agent.compact_state.compaction_count = persisted_compact_state.compaction_count;
+    agent.compact_state.last_compaction_before_tokens =
+        persisted_compact_state.last_compaction_before_tokens;
+    agent.compact_state.last_compaction_after_tokens =
+        persisted_compact_state.last_compaction_after_tokens;
+    agent.compact_state.last_compaction_boundary =
+        match persisted_compact_state.last_compaction_boundary_version {
+            Some(version) => Some(CompactBoundaryMetadata {
+                version,
+                before_tokens: persisted_compact_state
+                    .last_compaction_before_tokens
+                    .unwrap_or_default(),
+                recent_file_count: persisted_compact_state
+                    .last_compaction_recent_file_count
+                    .unwrap_or_default(),
+            }),
+            None => latest_compact_boundary_metadata(&agent.history),
+        };
     let persisted_steps = state_db.load_plan_steps(session_id)?;
     if !persisted_steps.is_empty() {
         agent.current_plan = persisted_steps

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -16,7 +16,8 @@ use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
 use crate::config::{ConfigManager, RaraConfig};
 use crate::redaction::redact_secrets;
 use crate::state_db::{
-    PersistedInteraction, PersistedPlanStep, PersistedSessionSummary, PersistedTurnEntry, StateDb,
+    PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedSessionSummary,
+    PersistedTurnEntry, StateDb,
 };
 use crate::tools::bash::BashCommandInput;
 
@@ -114,6 +115,10 @@ pub struct RuntimeSnapshot {
     pub compaction_count: usize,
     pub last_compaction_before_tokens: Option<usize>,
     pub last_compaction_after_tokens: Option<usize>,
+    pub last_compaction_recent_files: Vec<String>,
+    pub last_compaction_boundary_version: Option<u32>,
+    pub last_compaction_boundary_before_tokens: Option<usize>,
+    pub last_compaction_boundary_recent_file_count: Option<usize>,
     pub plan_steps: Vec<(String, String)>,
     pub plan_explanation: Option<String>,
     pub pending_interactions: Vec<PendingInteractionSnapshot>,
@@ -354,7 +359,9 @@ impl TuiApp {
             )
             .any(|entry| entry.role == role && entry.message == message);
         if !exists {
-            self.active_turn.entries.push(TranscriptEntry { role, message });
+            self.active_turn
+                .entries
+                .push(TranscriptEntry { role, message });
         }
     }
 
@@ -497,15 +504,13 @@ impl TuiApp {
         let existing_plan_completion = self
             .completed_interaction(InteractionKind::PlanApproval)
             .cloned();
-        let existing_pending_plan_approval =
-            self.pending_plan_approval_interaction().cloned();
+        let existing_pending_plan_approval = self.pending_plan_approval_interaction().cloned();
         let existing_local_request_completion = self
             .snapshot
             .completed_interactions
             .iter()
             .find(|item| {
-                item.kind == InteractionKind::RequestInput
-                    && item.source.as_deref().is_some()
+                item.kind == InteractionKind::RequestInput && item.source.as_deref().is_some()
             })
             .cloned();
         let existing_local_request_inputs = self
@@ -513,8 +518,7 @@ impl TuiApp {
             .pending_interactions
             .iter()
             .filter(|item| {
-                item.kind == InteractionKind::RequestInput
-                    && item.source.as_deref().is_some()
+                item.kind == InteractionKind::RequestInput && item.source.as_deref().is_some()
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -597,6 +601,19 @@ impl TuiApp {
             compaction_count: agent.compact_state.compaction_count,
             last_compaction_before_tokens: agent.compact_state.last_compaction_before_tokens,
             last_compaction_after_tokens: agent.compact_state.last_compaction_after_tokens,
+            last_compaction_recent_files: agent.compact_state.last_compaction_recent_files.clone(),
+            last_compaction_boundary_version: agent
+                .compact_state
+                .last_compaction_boundary
+                .map(|boundary| boundary.version),
+            last_compaction_boundary_before_tokens: agent
+                .compact_state
+                .last_compaction_boundary
+                .map(|boundary| boundary.before_tokens),
+            last_compaction_boundary_recent_file_count: agent
+                .compact_state
+                .last_compaction_boundary
+                .map(|boundary| boundary.recent_file_count),
             plan_steps: agent
                 .current_plan
                 .iter()
@@ -607,7 +624,7 @@ impl TuiApp {
                         crate::agent::PlanStepStatus::Completed => "completed",
                     };
                     (status.to_string(), step.step.clone())
-            })
+                })
                 .collect(),
             plan_explanation: agent.plan_explanation.clone(),
             pending_interactions,
@@ -931,7 +948,12 @@ impl TuiApp {
                 summary: summary.clone(),
                 source: source.clone(),
             });
-        self.ensure_completed_interaction_entry(kind, title.as_str(), summary.as_str(), source.as_deref());
+        self.ensure_completed_interaction_entry(
+            kind,
+            title.as_str(),
+            summary.as_str(),
+            source.as_deref(),
+        );
         self.persist_runtime_state();
     }
 
@@ -1016,10 +1038,7 @@ impl TuiApp {
                     .cloned()
                     .collect::<Vec<_>>(),
             ),
-            (
-                "Running",
-                self.active_live.running_actions.to_vec(),
-            ),
+            ("Running", self.active_live.running_actions.to_vec()),
         ];
 
         for (role, lines) in sections {
@@ -1160,6 +1179,15 @@ impl TuiApp {
             self.snapshot.plan_explanation.as_deref(),
             self.snapshot.history_len,
             self.transcript_entry_count(),
+            &PersistedCompactState {
+                compaction_count: self.snapshot.compaction_count,
+                last_compaction_before_tokens: self.snapshot.last_compaction_before_tokens,
+                last_compaction_after_tokens: self.snapshot.last_compaction_after_tokens,
+                last_compaction_recent_file_count: Some(
+                    self.snapshot.last_compaction_recent_files.len(),
+                ),
+                last_compaction_boundary_version: self.snapshot.last_compaction_boundary_version,
+            },
         ) {
             self.state_db_status = Some(state_db_status_error("write failed", err.to_string()));
             return;


### PR DESCRIPTION
## Summary

Align RARA context compression more closely with Claude Code style structured compaction.

## Changes

- replace the generic compact summary prompt with a structured compression schema
- add compact boundary metadata and persist it through session save/restore
- carry recent compacted file paths and limited read-file excerpts forward
- expose compact observability in `/status`
- incrementally update history token estimates on common history write paths

## Validation

- `cargo fmt`
- `cargo check`
- `cargo test state_db::tests -- --nocapture --test-threads=1`
- `cargo test agent::tests::manual_compact_replaces_older_history_with_summary -- --nocapture`
- `cargo test agent::tests::manual_compact_carries_recent_files_forward -- --nocapture`
- `cargo test tui::command::tests::status_resources_text_includes_recent_compacted_files -- --nocapture`

## Notes

- `state_db` tests still need `--test-threads=1` because they share `current_dir()` and sqlite state.
- This phase persists compact boundary metadata, but it does not yet persist full recent-file excerpt payloads separately from history.
