### PR TITLE
feat(tui): improve tool transcript follow-ups

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -20,6 +20,9 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Add a first-run onboarding flow that explains workspace, provider/model selection, local model download behavior, cache location, and tool loop expectations before the user lands in a blank chat.
 - [ ] Continue aligning the TUI status and transcript surfaces with Codex/Claude so runtime state stays visible without leaking bottom-pane chrome into transcript history.
+- [ ] Continue making tool-action transcript summaries more source-aware and file-aware so edit tools such as `write_file` / `replace` / `apply_patch` consistently show what they touched instead of only generic action labels.
+- [ ] Turn `bash` execution into a real evented TUI transcript path so long-running commands can stream stdout/stderr live instead of only surfacing a post-hoc result summary.
+- [ ] Upgrade queued follow-up messages from "run after the current task finishes" to a true "submit after the next tool call boundary" steer path, matching the Codex-style pending input contract more closely.
 - [ ] Harden local model prompting contracts for Gemma 4 and Qwen3: chat template handling, stop sequences, and tool-call JSON framing should be explicit and regression-tested.
 - [ ] Replace the current hash-based local embedding fallback with a real embedding backend so project memory retrieval quality is good enough for normal coding sessions.
 - [ ] Replace the mock `VectorDB` implementation in `src/vectordb.rs` with real LanceDB-backed search/upsert behavior, or feature-gate the memory tools until the backend is real.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -258,7 +258,12 @@ impl Agent {
         F: FnMut(AgentEvent) + Send,
     {
         report(AgentEvent::Status("Sending prompt to model.".to_string()));
-        let mut messages = self.history.clone();
+        let mut messages = self
+            .history
+            .iter()
+            .filter(|message| !is_compact_boundary_message(message))
+            .cloned()
+            .collect::<Vec<_>>();
         messages.insert(
             0,
             Message {
@@ -564,4 +569,13 @@ impl Agent {
         }
         Ok(tool_results)
     }
+}
+
+fn is_compact_boundary_message(message: &Message) -> bool {
+    message.role == "system"
+        && message
+            .content
+            .get("type")
+            .and_then(Value::as_str)
+            == Some("compact_boundary")
 }

--- a/src/agent/compact.rs
+++ b/src/agent/compact.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::llm::ContextBudget;
+use std::sync::OnceLock;
 
 const RECENT_FILE_CARRY_OVER_LIMIT: usize = 5;
 const RECENT_FILE_EXCERPT_LIMIT: usize = 3;
@@ -213,7 +214,7 @@ impl Agent {
 }
 
 fn estimate_history_tokens(history: &[Message]) -> Result<usize> {
-    let bpe = tiktoken_rs::cl100k_base()?;
+    let bpe = tokenizer()?;
     Ok(history
         .iter()
         .map(|message| estimate_message_tokens_with_bpe(message, &bpe))
@@ -221,7 +222,7 @@ fn estimate_history_tokens(history: &[Message]) -> Result<usize> {
 }
 
 fn estimate_message_tokens(message: &Message) -> Result<usize> {
-    let bpe = tiktoken_rs::cl100k_base()?;
+    let bpe = tokenizer()?;
     estimate_message_tokens_with_bpe(message, &bpe)
 }
 
@@ -229,9 +230,22 @@ fn estimate_message_tokens_with_bpe(
     message: &Message,
     bpe: &tiktoken_rs::CoreBPE,
 ) -> Result<usize> {
-    Ok(bpe
-        .encode_with_special_tokens(&message.content.to_string())
-        .len())
+    let rendered;
+    let content = if let Some(text) = message.content.as_str() {
+        text
+    } else {
+        rendered = message.content.to_string();
+        rendered.as_str()
+    };
+    Ok(bpe.encode_with_special_tokens(content).len())
+}
+
+fn tokenizer() -> Result<&'static tiktoken_rs::CoreBPE> {
+    static BPE: OnceLock<std::result::Result<tiktoken_rs::CoreBPE, String>> = OnceLock::new();
+    match BPE.get_or_init(|| tiktoken_rs::cl100k_base().map_err(|err| err.to_string())) {
+        Ok(bpe) => Ok(bpe),
+        Err(err) => Err(anyhow::anyhow!(err.clone())),
+    }
 }
 
 fn collect_recent_files(history: &[Message], limit: usize) -> Vec<String> {

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -34,6 +34,8 @@ impl ToolResultStore {
         let summary = summarize_tool_result(tool_name, input, result);
         let inline = match tool_name {
             "apply_patch" => compact_apply_patch(result),
+            "write_file" => compact_write_file(result),
+            "replace" => compact_replace(result),
             "list_files" => compact_list_files(input, result),
             "read_file" => compact_read_file(input, result),
             "glob" => compact_glob(result),
@@ -41,9 +43,10 @@ impl ToolResultStore {
             "web_fetch" => compact_web_fetch(input, result),
             _ => compact_generic(&summary, result),
         };
-        let full_rendered = serde_json::to_string_pretty(result).unwrap_or_else(|_| result.to_string());
-        let should_persist =
-            full_rendered.chars().count() > INLINE_CHAR_BUDGET || inline.chars().count() > INLINE_CHAR_BUDGET;
+        let full_rendered =
+            serde_json::to_string_pretty(result).unwrap_or_else(|_| result.to_string());
+        let should_persist = full_rendered.chars().count() > INLINE_CHAR_BUDGET
+            || inline.chars().count() > INLINE_CHAR_BUDGET;
 
         if !should_persist {
             return Ok(inline);
@@ -97,10 +100,12 @@ pub fn repair_tool_result_history(history: &[Message]) -> Vec<Message> {
             if let Some(items) = message.content.as_array() {
                 for item in items {
                     if item.get("type").and_then(Value::as_str) == Some("tool_result") {
-                        let Some(tool_use_id) = item.get("tool_use_id").and_then(Value::as_str) else {
+                        let Some(tool_use_id) = item.get("tool_use_id").and_then(Value::as_str)
+                        else {
                             continue;
                         };
-                        if let Some(pos) = pending_tool_uses.iter().position(|id| id == tool_use_id) {
+                        if let Some(pos) = pending_tool_uses.iter().position(|id| id == tool_use_id)
+                        {
                             pending_tool_uses.remove(pos);
                             kept_blocks.push(item.clone());
                         }
@@ -161,9 +166,11 @@ fn extract_tool_use_ids(content: &Value) -> Vec<String> {
 }
 
 fn has_tool_result_blocks(content: &Value) -> bool {
-    content
-        .as_array()
-        .is_some_and(|items| items.iter().any(|item| item.get("type").and_then(Value::as_str) == Some("tool_result")))
+    content.as_array().is_some_and(|items| {
+        items
+            .iter()
+            .any(|item| item.get("type").and_then(Value::as_str) == Some("tool_result"))
+    })
 }
 
 fn compact_list_files(input: &Value, result: &Value) -> String {
@@ -182,14 +189,15 @@ fn compact_list_files(input: &Value, result: &Value) -> String {
 }
 
 fn compact_read_file(input: &Value, result: &Value) -> String {
-    let content = result.get("content").and_then(Value::as_str).unwrap_or_default();
+    let content = result
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
     let total_chars = content.chars().count();
     let preview = truncate_text(content, INLINE_CHAR_BUDGET.min(LARGE_PREVIEW_HEAD));
     let summary = summarize_tool_result("read_file", input, result);
     if preview.chars().count() < total_chars {
-        format!(
-            "{summary}\nContent preview:\n{preview}\n... truncated."
-        )
+        format!("{summary}\nContent preview:\n{preview}\n... truncated.")
     } else {
         format!("{summary}\nContent:\n{preview}")
     }
@@ -228,9 +236,15 @@ fn compact_grep(result: &Value) -> String {
         .iter()
         .take(MATCH_PREVIEW_LIMIT)
         .map(|entry| {
-            let file = entry.get("file").and_then(Value::as_str).unwrap_or("<unknown>");
+            let file = entry
+                .get("file")
+                .and_then(Value::as_str)
+                .unwrap_or("<unknown>");
             let line = entry.get("line").and_then(Value::as_u64).unwrap_or(0);
-            let content = entry.get("content").and_then(Value::as_str).unwrap_or_default();
+            let content = entry
+                .get("content")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
             format!("{file}:{line}: {content}")
         })
         .collect::<Vec<_>>()
@@ -245,7 +259,10 @@ fn compact_grep(result: &Value) -> String {
 }
 
 fn compact_web_fetch(input: &Value, result: &Value) -> String {
-    let content = result.get("content").and_then(Value::as_str).unwrap_or_default();
+    let content = result
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
     let total_chars = content.chars().count();
     let preview = truncate_text(content, LARGE_PREVIEW_HEAD);
     let summary = summarize_tool_result("web_fetch", input, result);
@@ -257,7 +274,10 @@ fn compact_web_fetch(input: &Value, result: &Value) -> String {
 }
 
 fn compact_apply_patch(result: &Value) -> String {
-    let status = result.get("status").and_then(Value::as_str).unwrap_or("unknown");
+    let status = result
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
     let files_changed = result
         .get("files_changed")
         .and_then(Value::as_u64)
@@ -291,7 +311,67 @@ fn compact_apply_patch(result: &Value) -> String {
 
 fn compact_generic(summary: &str, result: &Value) -> String {
     let rendered = serde_json::to_string_pretty(result).unwrap_or_else(|_| result.to_string());
-    format!("{summary}\nPayload:\n{}", truncate_text(&rendered, LARGE_PREVIEW_HEAD))
+    format!(
+        "{summary}\nPayload:\n{}",
+        truncate_text(&rendered, LARGE_PREVIEW_HEAD)
+    )
+}
+
+fn compact_write_file(result: &Value) -> String {
+    let path = result
+        .get("path")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let operation = result
+        .get("operation")
+        .and_then(Value::as_str)
+        .unwrap_or("updated");
+    let line_count = result
+        .get("line_count")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let bytes_written = result
+        .get("bytes_written")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let mut rendered =
+        format!("write_file {operation} {path}\nlines={line_count} bytes={bytes_written}");
+    if let Some(previous_bytes) = result.get("previous_bytes").and_then(Value::as_u64) {
+        let previous_lines = result
+            .get("previous_line_count")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        rendered.push_str(&format!(
+            "\nprevious_lines={previous_lines} previous_bytes={previous_bytes}"
+        ));
+    }
+    rendered
+}
+
+fn compact_replace(result: &Value) -> String {
+    let path = result
+        .get("path")
+        .and_then(Value::as_str)
+        .unwrap_or("<unknown>");
+    let replacements = result
+        .get("replacements")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    let line_delta = result
+        .get("line_delta")
+        .and_then(Value::as_i64)
+        .unwrap_or_default();
+    let old_preview = result
+        .get("old_preview")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let new_preview = result
+        .get("new_preview")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    format!(
+        "replace {path}\nreplacements={replacements} line_delta={line_delta}\nold={old_preview}\nnew={new_preview}"
+    )
 }
 
 fn summarize_tool_result(tool_name: &str, input: &Value, result: &Value) -> String {
@@ -305,7 +385,10 @@ fn summarize_tool_result(tool_name: &str, input: &Value, result: &Value) -> Stri
             format!("Listed {total} path(s) under {root}.")
         }
         "read_file" => {
-            let path = input.get("path").and_then(Value::as_str).unwrap_or("<unknown>");
+            let path = input
+                .get("path")
+                .and_then(Value::as_str)
+                .unwrap_or("<unknown>");
             let total_chars = result
                 .get("content")
                 .and_then(Value::as_str)
@@ -346,7 +429,10 @@ fn summarize_tool_result(tool_name: &str, input: &Value, result: &Value) -> Stri
             format!("Grep found {total} match(es).")
         }
         "web_fetch" => {
-            let url = input.get("url").and_then(Value::as_str).unwrap_or("<unknown>");
+            let url = input
+                .get("url")
+                .and_then(Value::as_str)
+                .unwrap_or("<unknown>");
             let total_chars = result
                 .get("content")
                 .and_then(Value::as_str)
@@ -355,7 +441,10 @@ fn summarize_tool_result(tool_name: &str, input: &Value, result: &Value) -> Stri
             format!("Fetched {url} ({total_chars} chars).")
         }
         "apply_patch" => {
-            let status = result.get("status").and_then(Value::as_str).unwrap_or("unknown");
+            let status = result
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
             let files_changed = result
                 .get("files_changed")
                 .and_then(Value::as_u64)
@@ -365,6 +454,38 @@ fn summarize_tool_result(tool_name: &str, input: &Value, result: &Value) -> Stri
                 .and_then(Value::as_u64)
                 .unwrap_or_default();
             format!("Patch {status}: {files_changed} file(s), {hunks_applied} hunk(s).")
+        }
+        "write_file" => {
+            let path = result
+                .get("path")
+                .and_then(Value::as_str)
+                .or_else(|| input.get("path").and_then(Value::as_str))
+                .unwrap_or("<unknown>");
+            let operation = result
+                .get("operation")
+                .and_then(Value::as_str)
+                .unwrap_or("updated");
+            let line_count = result
+                .get("line_count")
+                .and_then(Value::as_u64)
+                .unwrap_or_default();
+            let bytes_written = result
+                .get("bytes_written")
+                .and_then(Value::as_u64)
+                .unwrap_or_default();
+            format!("Write file {path}: {operation} ({line_count} lines, {bytes_written} bytes).")
+        }
+        "replace" => {
+            let path = result
+                .get("path")
+                .and_then(Value::as_str)
+                .or_else(|| input.get("path").and_then(Value::as_str))
+                .unwrap_or("<unknown>");
+            let replacements = result
+                .get("replacements")
+                .and_then(Value::as_u64)
+                .unwrap_or_default();
+            format!("Replace in {path}: {replacements} replacement(s).")
         }
         _ => {
             let keys = result
@@ -391,7 +512,10 @@ pub fn default_tool_result_store_dir() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{compact_read_file, default_tool_result_store_dir, repair_tool_result_history, ToolResultStore};
+    use super::{
+        compact_read_file, default_tool_result_store_dir, repair_tool_result_history,
+        ToolResultStore,
+    };
     use crate::agent::Message;
     use serde_json::json;
     use std::path::Path;
@@ -439,6 +563,9 @@ mod tests {
         assert!(output.contains("full_result_path="));
         assert!(output.contains("Fetched https://example.com"));
         assert!(tempdir.path().join("tool-1.json").exists());
-        assert_eq!(default_tool_result_store_dir(), Path::new(".rara").join("tool-results"));
+        assert_eq!(
+            default_tool_result_store_dir(),
+            Path::new(".rara").join("tool-results")
+        );
     }
 }

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -1,6 +1,6 @@
 use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
@@ -8,8 +8,12 @@ use walkdir::WalkDir;
 pub struct ReadFileTool;
 #[async_trait]
 impl Tool for ReadFileTool {
-    fn name(&self) -> &str { "read_file" }
-    fn description(&self) -> &str { "Read the content of a file" }
+    fn name(&self) -> &str {
+        "read_file"
+    }
+    fn description(&self) -> &str {
+        "Read the content of a file"
+    }
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",
@@ -22,12 +26,20 @@ impl Tool for ReadFileTool {
         })
     }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
-        let p = i["path"].as_str().ok_or(ToolError::InvalidInput("path".into()))?;
+        let p = i["path"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("path".into()))?;
         let content = fs::read_to_string(p)?;
         let lines = content.lines().collect::<Vec<_>>();
         let total_lines = lines.len();
-        let start_line = i.get("start_line").and_then(Value::as_u64).map(|v| v as usize);
-        let end_line = i.get("end_line").and_then(Value::as_u64).map(|v| v as usize);
+        let start_line = i
+            .get("start_line")
+            .and_then(Value::as_u64)
+            .map(|v| v as usize);
+        let end_line = i
+            .get("end_line")
+            .and_then(Value::as_u64)
+            .map(|v| v as usize);
 
         let sliced_content = match (start_line, end_line) {
             (None, None) => content,
@@ -35,10 +47,14 @@ impl Tool for ReadFileTool {
                 let start = start.unwrap_or(1);
                 let end = end.unwrap_or(total_lines.max(1));
                 if start == 0 || end == 0 {
-                    return Err(ToolError::InvalidInput("start_line/end_line must be >= 1".into()));
+                    return Err(ToolError::InvalidInput(
+                        "start_line/end_line must be >= 1".into(),
+                    ));
                 }
                 if start > end {
-                    return Err(ToolError::InvalidInput("start_line must be <= end_line".into()));
+                    return Err(ToolError::InvalidInput(
+                        "start_line must be <= end_line".into(),
+                    ));
                 }
                 if total_lines == 0 {
                     String::new()
@@ -62,8 +78,12 @@ impl Tool for ReadFileTool {
 pub struct WriteFileTool;
 #[async_trait]
 impl Tool for WriteFileTool {
-    fn name(&self) -> &str { "write_file" }
-    fn description(&self) -> &str { "Write content to a file" }
+    fn name(&self) -> &str {
+        "write_file"
+    }
+    fn description(&self) -> &str {
+        "Write content to a file"
+    }
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",
@@ -75,17 +95,40 @@ impl Tool for WriteFileTool {
         })
     }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
-        let p = i["path"].as_str().ok_or(ToolError::InvalidInput("path".into()))?;
-        let c = i["content"].as_str().ok_or(ToolError::InvalidInput("content".into()))?;
-        fs::write(p, c)?; Ok(json!({ "status": "ok" }))
+        let p = i["path"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("path".into()))?;
+        let c = i["content"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("content".into()))?;
+        let existing = fs::read_to_string(p).ok();
+        let operation = if existing.is_some() {
+            "overwritten"
+        } else {
+            "created"
+        };
+        fs::write(p, c)?;
+        Ok(json!({
+            "status": "ok",
+            "path": p,
+            "operation": operation,
+            "bytes_written": c.len(),
+            "line_count": c.lines().count(),
+            "previous_bytes": existing.as_ref().map(|value| value.len()),
+            "previous_line_count": existing.as_ref().map(|value| value.lines().count()),
+        }))
     }
 }
 
 pub struct ReplaceTool;
 #[async_trait]
 impl Tool for ReplaceTool {
-    fn name(&self) -> &str { "replace" }
-    fn description(&self) -> &str { "Replace a specific string in a file" }
+    fn name(&self) -> &str {
+        "replace"
+    }
+    fn description(&self) -> &str {
+        "Replace a specific string in a file"
+    }
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",
@@ -98,20 +141,43 @@ impl Tool for ReplaceTool {
         })
     }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
-        let p = i["path"].as_str().ok_or(ToolError::InvalidInput("path".into()))?;
-        let o = i["old_string"].as_str().ok_or(ToolError::InvalidInput("old".into()))?;
-        let n = i["new_string"].as_str().ok_or(ToolError::InvalidInput("new".into()))?;
+        let p = i["path"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("path".into()))?;
+        let o = i["old_string"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("old".into()))?;
+        let n = i["new_string"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("new".into()))?;
         let c = fs::read_to_string(p)?;
-        if c.matches(o).count() != 1 { return Err(ToolError::ExecutionFailed("String not unique".into())); }
-        fs::write(p, c.replace(o, n))?; Ok(json!({ "status": "ok" }))
+        if c.matches(o).count() != 1 {
+            return Err(ToolError::ExecutionFailed("String not unique".into()));
+        }
+        let updated = c.replace(o, n);
+        fs::write(p, &updated)?;
+        Ok(json!({
+            "status": "ok",
+            "path": p,
+            "replacements": 1,
+            "old_preview": preview_snippet(o),
+            "new_preview": preview_snippet(n),
+            "old_bytes": o.len(),
+            "new_bytes": n.len(),
+            "line_delta": updated.lines().count() as i64 - c.lines().count() as i64,
+        }))
     }
 }
 
 pub struct ListFilesTool;
 #[async_trait]
 impl Tool for ListFilesTool {
-    fn name(&self) -> &str { "list_files" }
-    fn description(&self) -> &str { "Recursively list files" }
+    fn name(&self) -> &str {
+        "list_files"
+    }
+    fn description(&self) -> &str {
+        "Recursively list files"
+    }
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",
@@ -123,7 +189,9 @@ impl Tool for ListFilesTool {
         })
     }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
-        let p = i["path"].as_str().ok_or(ToolError::InvalidInput("path".into()))?;
+        let p = i["path"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("path".into()))?;
         let include_ignored = i
             .get("include_ignored")
             .and_then(Value::as_bool)
@@ -157,9 +225,19 @@ fn is_ignored_path(path: &Path) -> bool {
     })
 }
 
+fn preview_snippet(value: &str) -> String {
+    let mut preview = value.replace('\n', "\\n");
+    const MAX_PREVIEW: usize = 80;
+    if preview.chars().count() > MAX_PREVIEW {
+        preview = preview.chars().take(MAX_PREVIEW).collect::<String>();
+        preview.push_str("...");
+    }
+    preview
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{ListFilesTool, ReadFileTool};
+    use super::{ListFilesTool, ReadFileTool, ReplaceTool, WriteFileTool};
     use crate::tool::Tool;
     use serde_json::json;
 
@@ -208,5 +286,54 @@ mod tests {
 
         assert!(rendered.contains("src/main.rs"));
         assert!(!rendered.contains("target/debug/app"));
+    }
+
+    #[tokio::test]
+    async fn write_file_reports_created_or_overwritten() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.txt");
+
+        let tool = WriteFileTool;
+        let created = tool
+            .call(json!({
+                "path": path.display().to_string(),
+                "content": "hello\nworld\n"
+            }))
+            .await
+            .expect("write created");
+        assert_eq!(created["operation"], "created");
+        assert_eq!(created["line_count"], 2);
+
+        let overwritten = tool
+            .call(json!({
+                "path": path.display().to_string(),
+                "content": "updated\n"
+            }))
+            .await
+            .expect("write overwritten");
+        assert_eq!(overwritten["operation"], "overwritten");
+        assert_eq!(overwritten["previous_line_count"], 2);
+    }
+
+    #[tokio::test]
+    async fn replace_reports_preview_and_line_delta() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("sample.txt");
+        std::fs::write(&path, "hello old value\n").expect("write sample");
+
+        let tool = ReplaceTool;
+        let result = tool
+            .call(json!({
+                "path": path.display().to_string(),
+                "old_string": "old value",
+                "new_string": "new\nvalue"
+            }))
+            .await
+            .expect("replace content");
+
+        assert_eq!(result["replacements"], 1);
+        assert_eq!(result["old_preview"], "old value");
+        assert_eq!(result["new_preview"], "new\\nvalue");
+        assert_eq!(result["line_delta"], 1);
     }
 }

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -2,6 +2,7 @@ use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 use walkdir::WalkDir;
 
@@ -101,7 +102,7 @@ impl Tool for WriteFileTool {
         let c = i["content"]
             .as_str()
             .ok_or(ToolError::InvalidInput("content".into()))?;
-        let existing = fs::read_to_string(p).ok();
+        let existing = existing_file_summary(p)?;
         let operation = if existing.is_some() {
             "overwritten"
         } else {
@@ -114,8 +115,8 @@ impl Tool for WriteFileTool {
             "operation": operation,
             "bytes_written": c.len(),
             "line_count": c.lines().count(),
-            "previous_bytes": existing.as_ref().map(|value| value.len()),
-            "previous_line_count": existing.as_ref().map(|value| value.lines().count()),
+            "previous_bytes": existing.as_ref().map(|(bytes, _)| *bytes),
+            "previous_line_count": existing.as_ref().map(|(_, line_count)| *line_count),
         }))
     }
 }
@@ -233,6 +234,24 @@ fn preview_snippet(value: &str) -> String {
         preview.push_str("...");
     }
     preview
+}
+
+fn existing_file_summary(path: &str) -> Result<Option<(u64, usize)>, ToolError> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(ToolError::Io(err)),
+    };
+
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut line_count = 0usize;
+    for line in reader.lines() {
+        line?;
+        line_count += 1;
+    }
+
+    Ok(Some((metadata.len(), line_count)))
 }
 
 #[cfg(test)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,8 +3,8 @@ mod command;
 mod custom_terminal;
 mod event_stream;
 mod highlight;
-mod interaction_text;
 mod insert_history;
+mod interaction_text;
 mod line_utils;
 mod markdown;
 mod markdown_render;
@@ -242,7 +242,10 @@ fn map_key_to_event(key: KeyCode, app: &TuiApp) -> AppEvent {
                 if app.input.is_empty()
                     && app.active_pending_interaction().is_some_and(|pending| {
                         pending.kind != self::state::ActivePendingInteractionKind::PlanApproval
-                    }) => AppEvent::SelectPendingOption(2),
+                    }) =>
+            {
+                AppEvent::SelectPendingOption(2)
+            }
             KeyCode::Char('s') => AppEvent::OpenOverlay(Overlay::Setup),
             KeyCode::Backspace => AppEvent::Backspace,
             KeyCode::Char(c) => AppEvent::InputChar(c),
@@ -396,9 +399,7 @@ async fn dispatch_event(
                             }
                         }
                         _ => {
-                            app.push_notice(
-                                "Select 1 to implement now or 2 to continue planning.",
-                            );
+                            app.push_notice("Select 1 to implement now or 2 to continue planning.");
                         }
                     },
                     self::state::ActivePendingInteractionKind::ShellApproval => {
@@ -571,7 +572,26 @@ async fn handle_submit(
         return Ok(false);
     }
     if app.is_busy() {
-        app.push_notice("A task is already running. Wait for it to finish.");
+        let input = std::mem::take(&mut app.input);
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Ok(false);
+        }
+        if trimmed.starts_with('/') {
+            app.push_notice(
+                "A task is already running. Wait for it to finish before running a slash command.",
+            );
+        } else {
+            let queued = app.queue_follow_up_message(trimmed.to_string());
+            let suffix = if queued > 1 {
+                format!(" {queued} follow-up messages are queued.")
+            } else {
+                " 1 follow-up message is queued.".to_string()
+            };
+            app.notice = Some(format!(
+                "Queued for after the current task finishes.{suffix}"
+            ));
+        }
         return Ok(false);
     }
 
@@ -657,9 +677,10 @@ fn classify_pending_plan_approval_input(input: &str) -> Option<PendingPlanApprov
         "调整计划",
         "完善计划",
     ];
-    if continue_planning_keywords.iter().any(|keyword| {
-        lowered.contains(&keyword.to_ascii_lowercase()) || trimmed.contains(keyword)
-    }) {
+    if continue_planning_keywords
+        .iter()
+        .any(|keyword| lowered.contains(&keyword.to_ascii_lowercase()) || trimmed.contains(keyword))
+    {
         return Some(PendingPlanApprovalAction::ContinuePlanning);
     }
 
@@ -685,9 +706,10 @@ fn classify_pending_plan_approval_input(input: &str) -> Option<PendingPlanApprov
         "continue",
         "ship it",
     ];
-    if approve_keywords.iter().any(|keyword| {
-        lowered == keyword.to_ascii_lowercase() || trimmed == *keyword
-    }) {
+    if approve_keywords
+        .iter()
+        .any(|keyword| lowered == keyword.to_ascii_lowercase() || trimmed == *keyword)
+    {
         return Some(PendingPlanApprovalAction::StartImplementation);
     }
 
@@ -746,6 +768,13 @@ fn should_open_codex_auth_guide(app: &TuiApp) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{classify_pending_plan_approval_input, PendingPlanApprovalAction};
+    use crate::config::ConfigManager;
+    use crate::oauth::OAuthManager;
+    use crate::tui::state::{RunningTask, TaskKind, TuiApp};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+    use tempfile::tempdir;
+    use tokio::sync::mpsc;
 
     #[test]
     fn pending_plan_approval_treats_generic_continue_as_approval() {
@@ -769,5 +798,47 @@ mod tests {
             classify_pending_plan_approval_input("continue planning"),
             Some(PendingPlanApprovalAction::ContinuePlanning)
         );
+    }
+
+    #[tokio::test]
+    async fn busy_submit_queues_follow_up_message() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.input = "continue with the follow-up".into();
+
+        let (_sender, receiver) = mpsc::unbounded_channel();
+        app.running_task = Some(RunningTask {
+            kind: TaskKind::Query,
+            receiver,
+            handle: tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                unreachable!()
+            }),
+            started_at: Instant::now(),
+            next_heartbeat_after_secs: 2,
+        });
+
+        let mut agent_slot = None;
+        let oauth_manager = Arc::new(OAuthManager::new().expect("oauth manager"));
+        let should_quit = super::handle_submit(&mut app, &mut agent_slot, &oauth_manager)
+            .await
+            .expect("submit");
+
+        assert!(!should_quit);
+        assert_eq!(
+            app.queued_follow_up_preview(),
+            Some("continue with the follow-up")
+        );
+        assert!(app
+            .notice
+            .as_deref()
+            .is_some_and(|value| value.contains("Queued for after the current task")));
+
+        if let Some(task) = app.running_task.take() {
+            task.handle.abort();
+        }
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -769,7 +769,6 @@ fn should_open_codex_auth_guide(app: &TuiApp) -> bool {
 mod tests {
     use super::{classify_pending_plan_approval_input, PendingPlanApprovalAction};
     use crate::config::ConfigManager;
-    use crate::oauth::OAuthManager;
     use crate::tui::state::{RunningTask, TaskKind, TuiApp};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -822,7 +821,9 @@ mod tests {
         });
 
         let mut agent_slot = None;
-        let oauth_manager = Arc::new(OAuthManager::new().expect("oauth manager"));
+        let oauth_manager = Arc::new(crate::oauth::OAuthManager {
+            config_dir: temp.path().join(".rara"),
+        });
         let should_quit = super::handle_submit(&mut app, &mut agent_slot, &oauth_manager)
             .await
             .expect("submit");

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -412,7 +412,14 @@ fn tool_action_label(message: &str) -> Option<String> {
                 rest.as_str()
             }
         )),
-        "apply_patch" => Some("Apply patch".to_string()),
+        "apply_patch" => Some(format!(
+            "Apply patch {}",
+            if rest.is_empty() {
+                "changes"
+            } else {
+                rest.as_str()
+            }
+        )),
         "write_file" => Some(format!(
             "Write {}",
             if rest.is_empty() {
@@ -1377,7 +1384,7 @@ mod tests {
     use crate::tui::state::TranscriptEntry;
 
     use super::cells::HistoryCell;
-    use super::{committed_turn_cell, desired_viewport_height};
+    use super::{committed_turn_cell, current_turn_tool_summary, desired_viewport_height};
 
     #[test]
     fn committed_turn_does_not_truncate_agent_response() {
@@ -1423,5 +1430,17 @@ mod tests {
         let height = desired_viewport_height(&app, 120, 24);
         assert!(height > 5);
         assert!(height < 24);
+    }
+
+    #[test]
+    fn tool_summary_includes_apply_patch_target_files() {
+        let entries = vec![TranscriptEntry {
+            role: "Tool".into(),
+            message: "apply_patch src/tui/render.rs, src/tui/runtime/events.rs".into(),
+        }];
+        let refs = entries.iter().collect::<Vec<_>>();
+
+        let rendered = current_turn_tool_summary(&refs, false, None).expect("tool summary");
+        assert!(rendered.contains("Apply patch src/tui/render.rs, src/tui/runtime/events.rs"));
     }
 }

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -134,13 +134,21 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
     }
 
     if app.is_busy() {
+        let mut detail = app
+            .runtime_phase_detail
+            .as_deref()
+            .unwrap_or("waiting for model response")
+            .to_string();
+        if app.has_queued_follow_up_messages() {
+            detail.push_str(&format!(
+                " · {} queued follow-up",
+                app.queued_follow_up_count()
+            ));
+        }
         return (
             "Working",
             Color::Yellow,
-            app.runtime_phase_detail
-                .as_deref()
-                .unwrap_or("waiting for model response")
-                .to_string(),
+            detail,
         );
     }
 
@@ -183,7 +191,9 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(2), Constraint::Length(1)])
         .split(area);
-    let composer_lines = if app.input.is_empty() {
+    let composer_lines = if app.input.is_empty() && app.has_queued_follow_up_messages() {
+        queued_follow_up_preview_lines(app)
+    } else if app.input.is_empty() {
         vec![Line::from(vec![
             Span::styled("› ", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
             Span::styled(
@@ -218,6 +228,8 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
     );
     let hint = if app.input.trim_start().starts_with('/') {
         "slash command  Enter run  Esc close"
+    } else if app.has_queued_follow_up_messages() {
+        "queued follow-up pending  current task will finish before submission"
     } else if app.is_busy() {
         "busy  wait for the current task to finish"
     } else if app.has_pending_planning_suggestion() {
@@ -235,6 +247,35 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
         chunks[1],
     );
     Some(composer_cursor_position(app.input.as_str(), chunks[0]))
+}
+
+fn queued_follow_up_preview_lines(app: &TuiApp) -> Vec<Line<'static>> {
+    let preview = app
+        .queued_follow_up_preview()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("Queued follow-up");
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("› ", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "Queued for after the current task:",
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]),
+        Line::from(vec![Span::raw("  "), Span::raw(preview.to_string())]),
+    ];
+    let remaining = app.queued_follow_up_count().saturating_sub(1);
+    if remaining > 0 {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                format!("... {remaining} more queued"),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+    lines
 }
 
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
@@ -348,7 +389,7 @@ mod tests {
         InteractionKind, PendingInteractionSnapshot, RuntimePhase, RuntimeSnapshot, TuiApp,
     };
 
-    use super::{activity_status_line, footer_summary_text};
+    use super::{activity_status_line, footer_summary_text, queued_follow_up_preview_lines};
 
     #[test]
     fn footer_summary_text_prefers_minimal_idle_context() {
@@ -410,5 +451,40 @@ mod tests {
         let (label, _, detail) = activity_status_line(&app);
         assert_eq!(label, "Plan Approval");
         assert!(detail.contains("review the proposed plan"));
+    }
+
+    #[test]
+    fn queued_follow_up_preview_shows_first_message_and_remainder() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.queue_follow_up_message("first follow-up");
+        app.queue_follow_up_message("second follow-up");
+
+        let rendered = queued_follow_up_preview_lines(&app)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Queued for after the current task"));
+        assert!(rendered.contains("first follow-up"));
+        assert!(rendered.contains("1 more queued"));
+    }
+
+    #[test]
+    fn queued_follow_up_hint_overrides_busy_hint() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.runtime_phase = RuntimePhase::ProcessingResponse;
+        app.queue_follow_up_message("follow-up");
+
+        let (_, _, detail) = activity_status_line(&app);
+        assert!(detail.contains("queued follow-up"));
     }
 }

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -226,21 +226,7 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
             .wrap(Wrap { trim: false }),
         chunks[0],
     );
-    let hint = if app.input.trim_start().starts_with('/') {
-        "slash command  Enter run  Esc close"
-    } else if app.has_queued_follow_up_messages() {
-        "queued follow-up pending  current task will finish before submission"
-    } else if app.is_busy() {
-        "busy  wait for the current task to finish"
-    } else if app.has_pending_planning_suggestion() {
-        "planning suggested  1 enter planning mode  2 continue in execute mode"
-    } else if let Some(pending) = app.active_pending_interaction() {
-        pending_interaction_hint_text(pending.kind)
-    } else if app.agent_execution_mode_label() == "plan" {
-        "planning mode  analyze, refine, or finalize a plan"
-    } else {
-        "/compact summarize history  /plan enter planning mode  /quit exit"
-    };
+    let hint = composer_hint(app);
     f.render_widget(
         Paragraph::new(Span::styled(hint, Style::default().fg(Color::Gray)))
             .alignment(Alignment::Left),
@@ -276,6 +262,24 @@ fn queued_follow_up_preview_lines(app: &TuiApp) -> Vec<Line<'static>> {
         ]));
     }
     lines
+}
+
+fn composer_hint(app: &TuiApp) -> &'static str {
+    if app.input.trim_start().starts_with('/') {
+        "slash command  Enter run  Esc close"
+    } else if app.has_queued_follow_up_messages() {
+        "queued follow-up pending  current task will finish before submission"
+    } else if app.is_busy() {
+        "busy  wait for the current task to finish"
+    } else if app.has_pending_planning_suggestion() {
+        "planning suggested  1 enter planning mode  2 continue in execute mode"
+    } else if let Some(pending) = app.active_pending_interaction() {
+        pending_interaction_hint_text(pending.kind)
+    } else if app.agent_execution_mode_label() == "plan" {
+        "planning mode  analyze, refine, or finalize a plan"
+    } else {
+        "/compact summarize history  /plan enter planning mode  /quit exit"
+    }
 }
 
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
@@ -389,7 +393,9 @@ mod tests {
         InteractionKind, PendingInteractionSnapshot, RuntimePhase, RuntimeSnapshot, TuiApp,
     };
 
-    use super::{activity_status_line, footer_summary_text, queued_follow_up_preview_lines};
+    use super::{
+        activity_status_line, composer_hint, footer_summary_text, queued_follow_up_preview_lines,
+    };
 
     #[test]
     fn footer_summary_text_prefers_minimal_idle_context() {
@@ -484,7 +490,9 @@ mod tests {
         app.runtime_phase = RuntimePhase::ProcessingResponse;
         app.queue_follow_up_message("follow-up");
 
-        let (_, _, detail) = activity_status_line(&app);
-        assert!(detail.contains("queued follow-up"));
+        assert_eq!(
+            composer_hint(&app),
+            "queued follow-up pending  current task will finish before submission"
+        );
     }
 }

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -243,7 +243,14 @@ fn tool_action_label(message: &str) -> Option<String> {
                 rest.as_str()
             }
         )),
-        "apply_patch" => Some("Apply patch".to_string()),
+        "apply_patch" => Some(format!(
+            "Apply patch {}",
+            if rest.is_empty() {
+                "changes"
+            } else {
+                rest.as_str()
+            }
+        )),
         "write_file" => Some(format!(
             "Write {}",
             if rest.is_empty() {
@@ -409,9 +416,40 @@ fn format_tool_use(name: &str, input: &serde_json::Value) -> String {
             .and_then(serde_json::Value::as_str)
             .map(|url| format!("web_fetch {url}"))
             .unwrap_or_else(|| format!("{name} {input}")),
-        "apply_patch" => "apply_patch".to_string(),
+        "apply_patch" => format_apply_patch_use(input),
         _ => format!("{name} {input}"),
     }
+}
+
+fn format_apply_patch_use(input: &serde_json::Value) -> String {
+    let Some(patch) = input.get("patch").and_then(serde_json::Value::as_str) else {
+        return "apply_patch".to_string();
+    };
+
+    let files = apply_patch_targets(patch);
+    if files.is_empty() {
+        "apply_patch".to_string()
+    } else {
+        format!("apply_patch {}", files.join(", "))
+    }
+}
+
+fn apply_patch_targets(patch: &str) -> Vec<String> {
+    let mut files = Vec::new();
+    for line in patch.lines().map(str::trim) {
+        let path = line
+            .strip_prefix("*** Add File: ")
+            .or_else(|| line.strip_prefix("*** Delete File: "))
+            .or_else(|| line.strip_prefix("*** Update File: "))
+            .or_else(|| line.strip_prefix("*** Move to: "));
+        let Some(path) = path else {
+            continue;
+        };
+        if !files.iter().any(|existing| existing == path) {
+            files.push(path.to_string());
+        }
+    }
+    files
 }
 
 fn format_tool_result(name: &str, content: &str) -> String {
@@ -468,13 +506,31 @@ fn format_tool_result(name: &str, content: &str) -> String {
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or_default();
             let mut summary = format!("bash exit_code={exit_code}");
-            if !stdout.trim().is_empty() {
-                summary.push_str(&format!("\nstdout: {}", first_non_empty_line(stdout)));
+            if let Some(stdout_preview) = output_tail_preview(stdout) {
+                summary.push_str(&format!("\nstdout:\n{stdout_preview}"));
             }
-            if !stderr.trim().is_empty() {
-                summary.push_str(&format!("\nstderr: {}", first_non_empty_line(stderr)));
+            if let Some(stderr_preview) = output_tail_preview(stderr) {
+                summary.push_str(&format!("\nstderr:\n{stderr_preview}"));
             }
             return summary;
+        }
+    }
+
+    if name == "apply_patch" {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
+            return format_apply_patch_result(&value);
+        }
+    }
+
+    if name == "write_file" {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
+            return format_write_file_result(&value);
+        }
+    }
+
+    if name == "replace" {
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
+            return format_replace_result(&value);
         }
     }
 
@@ -498,6 +554,176 @@ fn format_tool_result(name: &str, content: &str) -> String {
     }
 
     format!("{name}: {content}")
+}
+
+fn format_apply_patch_result(value: &serde_json::Value) -> String {
+    let status = value
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let files_changed = value
+        .get("files_changed")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default();
+    let added = value
+        .get("line_delta")
+        .and_then(|delta| delta.get("added"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default();
+    let removed = value
+        .get("line_delta")
+        .and_then(|delta| delta.get("removed"))
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default();
+
+    let mut lines = vec![format!(
+        "apply_patch {status} {files_changed} file(s) (+{added} -{removed})"
+    )];
+
+    append_path_group(&mut lines, "updated", value.get("updated_files"));
+    append_path_group(&mut lines, "created", value.get("created_files"));
+    append_path_group(&mut lines, "deleted", value.get("deleted_files"));
+
+    if let Some(moves) = value
+        .get("moved_files")
+        .and_then(serde_json::Value::as_array)
+    {
+        let rendered = moves
+            .iter()
+            .filter_map(|entry| {
+                let from = entry.get("from").and_then(serde_json::Value::as_str)?;
+                let to = entry.get("to").and_then(serde_json::Value::as_str)?;
+                Some(format!("{from} -> {to}"))
+            })
+            .collect::<Vec<_>>();
+        if !rendered.is_empty() {
+            lines.push(format!("moved: {}", rendered.join(", ")));
+        }
+    }
+
+    if let Some(summary) = value.get("summary").and_then(serde_json::Value::as_array) {
+        let preview = summary
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .take(4)
+            .collect::<Vec<_>>();
+        if !preview.is_empty() {
+            let remaining = summary.len().saturating_sub(preview.len());
+            lines.push("changes:".to_string());
+            for line in preview {
+                lines.push(format!("  {line}"));
+            }
+            if remaining > 0 {
+                lines.push(format!("  ... {remaining} more change(s)"));
+            }
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn append_path_group(lines: &mut Vec<String>, label: &str, value: Option<&serde_json::Value>) {
+    let Some(paths) = value.and_then(serde_json::Value::as_array) else {
+        return;
+    };
+    let rendered = paths
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .take(4)
+        .collect::<Vec<_>>();
+    if rendered.is_empty() {
+        return;
+    }
+    lines.push(format!("{label}: {}", rendered.join(", ")));
+    let remaining = paths.len().saturating_sub(rendered.len());
+    if remaining > 0 {
+        lines.push(format!("  ... {remaining} more"));
+    }
+}
+
+fn output_tail_preview(output: &str) -> Option<String> {
+    let lines = output
+        .lines()
+        .map(str::trim_end)
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    if lines.is_empty() {
+        return None;
+    }
+
+    let preview = lines
+        .iter()
+        .rev()
+        .take(6)
+        .copied()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>();
+    Some(preview.join("\n"))
+}
+
+fn format_write_file_result(value: &serde_json::Value) -> String {
+    let path = value
+        .get("path")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("<unknown>");
+    let operation = value
+        .get("operation")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("updated");
+    let line_count = value
+        .get("line_count")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default();
+    let bytes_written = value
+        .get("bytes_written")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default();
+
+    let mut lines = vec![format!(
+        "write_file {operation} {path} ({line_count} lines, {bytes_written} bytes)"
+    )];
+
+    if let Some(previous_bytes) = value
+        .get("previous_bytes")
+        .and_then(serde_json::Value::as_u64)
+    {
+        let previous_lines = value
+            .get("previous_line_count")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_default();
+        lines.push(format!(
+            "previous: {previous_lines} lines, {previous_bytes} bytes"
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn format_replace_result(value: &serde_json::Value) -> String {
+    let path = value
+        .get("path")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("<unknown>");
+    let replacements = value
+        .get("replacements")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default();
+    let line_delta = value
+        .get("line_delta")
+        .and_then(serde_json::Value::as_i64)
+        .unwrap_or_default();
+    let mut lines = vec![format!(
+        "replace {path} {replacements} replacement(s) (Δlines={line_delta})"
+    )];
+    if let Some(old_preview) = value.get("old_preview").and_then(serde_json::Value::as_str) {
+        lines.push(format!("old: {old_preview}"));
+    }
+    if let Some(new_preview) = value.get("new_preview").and_then(serde_json::Value::as_str) {
+        lines.push(format!("new: {new_preview}"));
+    }
+    lines.join("\n")
 }
 
 fn exploration_result_note(message: &str) -> Option<String> {
@@ -583,7 +809,11 @@ use crate::redaction::redact_secrets;
 
 #[cfg(test)]
 mod tests {
-    use super::{planning_note_lines, subagent_request_input};
+    use super::{
+        format_apply_patch_result, format_apply_patch_use, format_tool_result, planning_note_lines,
+        subagent_request_input,
+    };
+    use serde_json::json;
 
     #[test]
     fn parses_delegated_request_input_from_subagent_result() {
@@ -611,5 +841,50 @@ mod tests {
             notes,
             vec!["The current discovery is hardcoded to root-level markdown files.".to_string()]
         );
+    }
+
+    #[test]
+    fn formats_apply_patch_tool_use_with_target_files() {
+        let rendered = format_apply_patch_use(&json!({
+            "patch": "*** Begin Patch\n*** Update File: src/tui/render.rs\n@@\n-old\n+new\n*** Update File: src/tui/runtime/events.rs\n@@\n-old\n+new\n*** End Patch"
+        }));
+        assert_eq!(rendered, "apply_patch src/tui/render.rs, src/tui/runtime/events.rs");
+    }
+
+    #[test]
+    fn formats_apply_patch_tool_result_as_diff_summary() {
+        let rendered = format_apply_patch_result(&json!({
+            "status": "ok",
+            "files_changed": 2,
+            "line_delta": { "added": 12, "removed": 3 },
+            "updated_files": ["src/tui/render.rs"],
+            "created_files": ["src/tui/render/bottom_pane.rs"],
+            "summary": [
+                "updated src/tui/render.rs",
+                "created src/tui/render/bottom_pane.rs"
+            ]
+        }));
+
+        assert!(rendered.contains("apply_patch ok 2 file(s) (+12 -3)"));
+        assert!(rendered.contains("updated: src/tui/render.rs"));
+        assert!(rendered.contains("created: src/tui/render/bottom_pane.rs"));
+        assert!(rendered.contains("changes:"));
+    }
+
+    #[test]
+    fn formats_bash_tool_result_with_output_tail() {
+        let rendered = format_tool_result(
+            "bash",
+            &json!({
+                "exit_code": 0,
+                "stdout": "line 1\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\n",
+                "stderr": "warn 1\nwarn 2\n"
+            })
+            .to_string(),
+        );
+
+        assert!(rendered.contains("bash exit_code=0"));
+        assert!(rendered.contains("stdout:\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7"));
+        assert!(rendered.contains("stderr:\nwarn 1\nwarn 2"));
     }
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -41,6 +41,31 @@ fn restore_execute_mode_after_plan_turn(app: &mut TuiApp, agent: &mut Agent) {
     }
 }
 
+fn try_start_queued_follow_up(app: &mut TuiApp, agent_slot: &mut Option<Agent>) {
+    if app.running_task.is_some()
+        || app.active_pending_interaction().is_some()
+        || app.has_pending_planning_suggestion()
+    {
+        return;
+    }
+
+    let Some(prompt) = app.pop_queued_follow_up_message() else {
+        return;
+    };
+    let Some(agent) = agent_slot.take() else {
+        app.queue_follow_up_message(prompt);
+        return;
+    };
+
+    let remaining = app.queued_follow_up_count();
+    app.notice = Some(if remaining > 0 {
+        format!("Running queued follow-up. {remaining} more queued.")
+    } else {
+        "Running queued follow-up.".to_string()
+    });
+    start_query_task(app, prompt, agent);
+}
+
 pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agent) {
     let (sender, receiver) = mpsc::unbounded_channel();
     app.clear_pending_planning_suggestion();
@@ -388,6 +413,7 @@ pub(super) async fn finish_running_task_if_ready(
                         app.finalize_active_turn();
                         app.notice = Some("Prompt finished.".into());
                         app.set_runtime_phase(RuntimePhase::Idle, Some("prompt finished".into()));
+                        try_start_queued_follow_up(app, agent_slot);
                     }
                 }
                 Err(err) => {
@@ -441,6 +467,7 @@ pub(super) async fn finish_running_task_if_ready(
                     }
                     app.finalize_active_turn();
                     app.set_runtime_phase(RuntimePhase::Idle, Some("history compacted".into()));
+                    try_start_queued_follow_up(app, agent_slot);
                 }
                 Ok(false) => {
                     app.clear_active_live_sections();
@@ -449,6 +476,7 @@ pub(super) async fn finish_running_task_if_ready(
                     app.push_notice(message);
                     app.finalize_active_turn();
                     app.set_runtime_phase(RuntimePhase::Idle, Some("compact skipped".into()));
+                    try_start_queued_follow_up(app, agent_slot);
                 }
                 Err(err) => {
                     app.clear_active_live_sections();
@@ -471,7 +499,10 @@ pub(super) async fn finish_running_task_if_ready(
                     app.current_model_label()
                 ));
                 app.notice = app.setup_status.clone();
+                let queued_follow_up_messages =
+                    std::mem::take(&mut app.queued_follow_up_messages);
                 app.reset_transcript();
+                app.queued_follow_up_messages = queued_follow_up_messages;
                 *agent_slot = Some(agent);
                 if let Some(agent) = agent_slot.as_ref() {
                     app.sync_snapshot(agent);
@@ -480,6 +511,7 @@ pub(super) async fn finish_running_task_if_ready(
                 app.set_runtime_phase(RuntimePhase::BackendReady, Some("backend ready".into()));
                 app.push_entry("Runtime", app.setup_status.clone().unwrap_or_default());
                 app.finalize_active_turn();
+                try_start_queued_follow_up(app, agent_slot);
             }
             Err(err) => {
                 app.set_runtime_phase(RuntimePhase::Failed, Some("backend rebuild failed".into()));

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -320,6 +320,7 @@ pub struct TuiApp {
     pub agent_markdown_stream: Option<AgentMarkdownStreamState>,
     pub active_live: ActiveLiveSections,
     pub pending_planning_suggestion: Option<String>,
+    pub queued_follow_up_messages: Vec<String>,
     pub terminal_focused: bool,
     pub state_db: Option<Arc<StateDb>>,
     pub state_db_status: Option<String>,
@@ -433,6 +434,7 @@ impl TuiApp {
             agent_markdown_stream: None,
             active_live: ActiveLiveSections::default(),
             pending_planning_suggestion: None,
+            queued_follow_up_messages: Vec::new(),
             terminal_focused: true,
             state_db: None,
             state_db_status: None,
@@ -726,6 +728,7 @@ impl TuiApp {
         self.agent_markdown_stream = None;
         self.clear_active_live_sections();
         self.pending_planning_suggestion = None;
+        self.queued_follow_up_messages.clear();
         self.set_plan_approval_interaction(false);
         self.notice = Some("Cleared local transcript view.".into());
     }
@@ -835,6 +838,34 @@ impl TuiApp {
 
     pub fn has_pending_planning_suggestion(&self) -> bool {
         self.pending_planning_suggestion.is_some()
+    }
+
+    pub fn has_queued_follow_up_messages(&self) -> bool {
+        !self.queued_follow_up_messages.is_empty()
+    }
+
+    pub fn queued_follow_up_count(&self) -> usize {
+        self.queued_follow_up_messages.len()
+    }
+
+    pub fn queued_follow_up_preview(&self) -> Option<&str> {
+        self.queued_follow_up_messages.first().map(String::as_str)
+    }
+
+    pub fn queue_follow_up_message(&mut self, message: impl Into<String>) -> usize {
+        let message = message.into();
+        if !message.trim().is_empty() {
+            self.queued_follow_up_messages.push(message);
+        }
+        self.queued_follow_up_messages.len()
+    }
+
+    pub fn pop_queued_follow_up_message(&mut self) -> Option<String> {
+        if self.queued_follow_up_messages.is_empty() {
+            None
+        } else {
+            Some(self.queued_follow_up_messages.remove(0))
+        }
     }
 
     pub fn queue_planning_suggestion(&mut self, prompt: impl Into<String>) {
@@ -1393,5 +1424,24 @@ mod tests {
             .expect("pending interaction");
         assert_eq!(active.kind, ActivePendingInteractionKind::PlanApproval);
         assert_eq!(active._snapshot.title, "Plan Ready");
+    }
+
+    #[test]
+    fn queued_follow_up_messages_preserve_fifo_order() {
+        let dir = tempdir().expect("tempdir");
+        let cm = ConfigManager {
+            path: dir.path().join("config.json"),
+        };
+        let mut app = TuiApp::new(cm).expect("app");
+
+        assert_eq!(app.queue_follow_up_message("first"), 1);
+        assert_eq!(app.queue_follow_up_message("second"), 2);
+        assert_eq!(app.queued_follow_up_preview(), Some("first"));
+        assert_eq!(app.pop_queued_follow_up_message().as_deref(), Some("first"));
+        assert_eq!(
+            app.pop_queued_follow_up_message().as_deref(),
+            Some("second")
+        );
+        assert_eq!(app.pop_queued_follow_up_message(), None);
     }
 }


### PR DESCRIPTION
## Summary

This PR improves the TUI tool transcript and queued follow-up experience in three areas:

- make edit-tool transcript entries more file-aware and diff-aware
- allow natural follow-up messages to queue while a task is still running
- remove the unfinished `search_files` stub from the exposed tool surface so models use `grep` and `glob`

## What Changed

- TUI tool transcript:
  - `apply_patch` tool-use lines now include touched file paths
  - `apply_patch` tool-result lines now render a diff-style summary with file groups and line deltas
  - `write_file` and `replace` tool results now render file-aware summaries with previews
  - `bash` tool results now show a tail preview of stdout/stderr instead of only a single first line

- Queued follow-up messages:
  - submitting a normal message while a task is running now queues a follow-up instead of rejecting it
  - the bottom pane shows a queued preview and a dedicated hint
  - queued follow-ups automatically start after the current task completes, unless a structured interaction is pending

- Tool surface cleanup:
  - removed `SearchFilesTool`
  - removed `search_files` references from the main tool managers and related transcript/compact code
  - models now consistently use `grep` and `glob`

## Validation

- `cargo fmt`
- `cargo check`
- `cargo test tui::state::tests -- --nocapture`
- `cargo test tui::tests -- --nocapture`
- `cargo test tui::runtime::events::tests -- --nocapture`
- `cargo test queued_follow_up_preview_shows_first_message_and_remainder -- --nocapture`
- `cargo test queued_follow_up_hint_overrides_busy_hint -- --nocapture`

## Follow-up

- true Codex-style "submit after the next tool call boundary" steering is still open; this PR implements the smaller "run after the current task finishes" queue first
- real evented `bash` live transcript output is still tracked in `docs/todo.md`
