### PR TITLE
feat(auth): reuse codex_login and add tui snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8245,6 +8245,7 @@ name = "rara-config"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dirs",
  "secrecy",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "accelerate-src"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,6 +25,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "agent-client-protocol"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,7 +45,7 @@ dependencies = [
  "anyhow",
  "async-broadcast",
  "async-trait",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "log",
  "serde",
@@ -38,7 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca68e7e55681ce56546c0cecc6bc8f20493d24b44c6d93ec46174f310730bba2"
 dependencies = [
  "anyhow",
- "derive_more",
+ "derive_more 2.1.1",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -85,6 +106,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocative"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fac2ce611db8b8cee9b2aa886ca03c924e9da5e5295d0dbd0526e5d0b0710f7"
+dependencies = [
+ "allocative_derive",
+ "bumpalo",
+ "ctor",
+ "hashbrown 0.14.5",
+ "num-bigint",
+]
+
+[[package]]
+name = "allocative_derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -397,7 +451,61 @@ dependencies = [
  "memchr",
  "num-traits",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -437,6 +545,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +596,24 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -457,6 +626,30 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -476,6 +669,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447ab28afbb345f5408b120702a44e5529ebf90b1796ec76e9528df8e288e6c2"
 dependencies = [
  "loom",
+]
+
+[[package]]
+name = "asynk-strim"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52697735bdaac441a29391a9e97102c74c6ef0f9b60a40cf109b1b404e29d2f6"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -509,6 +712,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +751,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bigdecimal"
@@ -650,12 +882,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -681,6 +935,16 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
 ]
 
 [[package]]
@@ -746,6 +1010,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -866,6 +1136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,9 +1170,26 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
 
 [[package]]
 name = "chrono"
@@ -920,6 +1216,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,7 +1250,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -960,10 +1272,463 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmp_any"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
+
+[[package]]
+name = "codex-api"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "async-channel",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "codex-client",
+ "codex-protocol",
+ "codex-utils-rustls-provider",
+ "eventsource-stream",
+ "futures",
+ "http",
+ "regex-lite",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "tungstenite",
+ "url",
+]
+
+[[package]]
+name = "codex-app-server-protocol"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "anyhow",
+ "clap",
+ "codex-experimental-api-macros",
+ "codex-protocol",
+ "codex-shell-command",
+ "codex-utils-absolute-path",
+ "inventory",
+ "rmcp",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "ts-rs",
+ "uuid",
+]
+
+[[package]]
+name = "codex-async-utils"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "async-trait",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "codex-client"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "codex-utils-rustls-provider",
+ "eventsource-stream",
+ "futures",
+ "http",
+ "opentelemetry",
+ "rand 0.9.2",
+ "reqwest",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "zstd",
+]
+
+[[package]]
+name = "codex-config"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "anyhow",
+ "codex-app-server-protocol",
+ "codex-execpolicy",
+ "codex-features",
+ "codex-model-provider-info",
+ "codex-network-proxy",
+ "codex-protocol",
+ "codex-utils-absolute-path",
+ "codex-utils-path",
+ "futures",
+ "multimap",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.9.12+spec-1.1.0",
+ "toml_edit 0.24.1+spec-1.1.0",
+ "tracing",
+ "wildmatch",
+]
+
+[[package]]
+name = "codex-execpolicy"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "anyhow",
+ "clap",
+ "codex-utils-absolute-path",
+ "multimap",
+ "serde",
+ "serde_json",
+ "shlex",
+ "starlark",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "codex-experimental-api-macros"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "codex-features"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "codex-otel",
+ "codex-protocol",
+ "schemars 0.8.22",
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "codex-keyring-store"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "keyring",
+ "tracing",
+]
+
+[[package]]
+name = "codex-login"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "codex-app-server-protocol",
+ "codex-client",
+ "codex-config",
+ "codex-keyring-store",
+ "codex-model-provider-info",
+ "codex-otel",
+ "codex-protocol",
+ "codex-terminal-detection",
+ "codex-utils-template",
+ "once_cell",
+ "os_info",
+ "rand 0.9.2",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tiny_http",
+ "tokio",
+ "tracing",
+ "url",
+ "urlencoding",
+ "webbrowser",
+]
+
+[[package]]
+name = "codex-model-provider-info"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "codex-api",
+ "codex-app-server-protocol",
+ "codex-protocol",
+ "http",
+ "schemars 0.8.22",
+ "serde",
+]
+
+[[package]]
+name = "codex-network-proxy"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "clap",
+ "codex-utils-absolute-path",
+ "codex-utils-home-dir",
+ "codex-utils-rustls-provider",
+ "globset",
+ "rama-core",
+ "rama-http",
+ "rama-http-backend",
+ "rama-net",
+ "rama-socks5",
+ "rama-tcp",
+ "rama-tls-rustls",
+ "rama-unix",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "codex-otel"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "chrono",
+ "codex-api",
+ "codex-app-server-protocol",
+ "codex-protocol",
+ "codex-utils-absolute-path",
+ "codex-utils-string",
+ "eventsource-stream",
+ "gethostname",
+ "http",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "os_info",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "strum_macros 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "codex-protocol"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "chardetng",
+ "chrono",
+ "codex-async-utils",
+ "codex-execpolicy",
+ "codex-network-proxy",
+ "codex-utils-absolute-path",
+ "codex-utils-image",
+ "codex-utils-string",
+ "codex-utils-template",
+ "encoding_rs",
+ "globset",
+ "icu_decimal",
+ "icu_locale_core",
+ "icu_provider",
+ "landlock",
+ "quick-xml",
+ "reqwest",
+ "schemars 0.8.22",
+ "seccompiler",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.27.2",
+ "strum_macros 0.28.0",
+ "sys-locale",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "ts-rs",
+ "uuid",
+]
+
+[[package]]
+name = "codex-shell-command"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "base64 0.22.1",
+ "codex-protocol",
+ "codex-utils-absolute-path",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "url",
+ "which 8.0.2",
+]
+
+[[package]]
+name = "codex-terminal-detection"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "codex-utils-absolute-path"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "dirs",
+ "dunce",
+ "schemars 0.8.22",
+ "serde",
+ "ts-rs",
+]
+
+[[package]]
+name = "codex-utils-cache"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "lru 0.16.3",
+ "sha1",
+ "tokio",
+]
+
+[[package]]
+name = "codex-utils-home-dir"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "codex-utils-absolute-path",
+ "dirs",
+]
+
+[[package]]
+name = "codex-utils-image"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "base64 0.22.1",
+ "codex-utils-cache",
+ "image",
+ "mime_guess",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "codex-utils-path"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "codex-utils-absolute-path",
+ "dunce",
+ "tempfile",
+]
+
+[[package]]
+name = "codex-utils-rustls-provider"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "rustls",
+]
+
+[[package]]
+name = "codex-utils-string"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+dependencies = [
+ "regex-lite",
+]
+
+[[package]]
+name = "codex-utils-template"
+version = "0.0.0"
+source = "git+https://github.com/openai/codex?rev=996aa23e4ce900468047ed3ec57d1e7271f8d6de#996aa23e4ce900468047ed3ec57d1e7271f8d6de"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -972,7 +1737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1025,8 +1790,31 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
 ]
 
 [[package]]
@@ -1050,10 +1838,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "convert_case"
@@ -1129,6 +1947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,7 +2013,7 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
- "derive_more",
+ "derive_more 2.1.1",
  "document-features",
  "futures-core",
  "mio",
@@ -1257,6 +2081,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "cudaforge"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,7 +2106,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "walkdir",
- "which",
+ "which 7.0.3",
 ]
 
 [[package]]
@@ -1326,7 +2160,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -1339,7 +2173,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -1387,6 +2221,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "datafusion"
@@ -1837,7 +2677,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1859,7 +2699,7 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "paste",
- "petgraph",
+ "petgraph 0.8.3",
  "tokio",
 ]
 
@@ -1993,6 +2833,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "debugserver-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf6834a70ed14e8e4e41882df27190bea150f1f6ecf461f1033f8739cd8af4a"
+dependencies = [
+ "schemafy",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "deepsize"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2019,6 +2899,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2920,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2061,11 +2966,33 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.1.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2074,13 +3001,19 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2112,6 +3045,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +3079,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +3097,16 @@ checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
  "objc2",
+]
+
+[[package]]
+name = "display_container"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a110a75c96bedec8e65823dea00a1d710288b7a369d95fd8a0f5127639466fa"
+dependencies = [
+ "either",
+ "indenter",
 ]
 
 [[package]]
@@ -2170,6 +3134,32 @@ name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dupe"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed2bc011db9c93fbc2b6cdb341a53737a55bafb46dbb74cf6764fc33a2fbf9c"
+dependencies = [
+ "dupe_derive",
+]
+
+[[package]]
+name = "dupe_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -2200,6 +3190,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,12 +3214,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "endian-type"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2239,6 +3277,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,6 +3294,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "esaxx-rs"
@@ -2291,6 +3344,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom 7.1.3",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,7 +3384,7 @@ checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set 0.5.3",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -2331,7 +3395,7 @@ checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -2351,6 +3415,29 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -2387,6 +3474,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
+name = "fixed_decimal"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c3c892f121fff406e5dd6b28c1b30096b95111c30701a899d4f2b18da6d1bd"
+dependencies = [
+ "displaydoc",
+ "smallvec",
+ "writeable",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +3513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
 ]
 
@@ -2428,6 +3527,18 @@ dependencies = [
  "num-traits",
  "rand 0.9.2",
  "rand_distr 0.5.1",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -2520,6 +3631,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsst"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,6 +3710,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,6 +3760,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2896,12 +4035,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2957,10 +4106,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax 0.8.10",
+]
 
 [[package]]
 name = "h2"
@@ -3009,6 +4181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -3042,6 +4215,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -3087,6 +4284,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.2",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "htmlescape"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,10 +4396,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -3172,6 +4454,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -3264,6 +4560,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_decimal"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288247df2e32aa776ac54fdd64de552149ac43cb840f2761811f0e8d09719dd4"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_decimal_data",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_plurals",
+ "icu_provider",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_decimal_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f14a5ca9e8af29eef62064f269078424283d90dbaffeac5225addf62aaabc22"
+
+[[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,10 +4605,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -3295,6 +4636,25 @@ name = "icu_normalizer_data"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_plurals"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a50023f1d49ad5c4333380328a0d4a19e4b9d6d842ec06639affd5ba47c8103"
+dependencies = [
+ "fixed_decimal",
+ "icu_locale",
+ "icu_plurals_data",
+ "icu_provider",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_plurals_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8485497155dc865f901decb93ecc20d3e467df67bfeceb91e3ba34e2b11e8e1d"
 
 [[package]]
 name = "icu_properties"
@@ -3324,6 +4684,8 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke 0.8.2",
  "zerofrom",
@@ -3365,6 +4727,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,10 +4789,10 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "web-time",
 ]
 
@@ -3407,6 +4803,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console 0.16.3",
+ "once_cell",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -3445,6 +4863,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,6 +4910,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,6 +4935,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3551,6 +5011,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,10 +5113,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "linux-keyutils",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zbus",
+ "zeroize",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lalrpop"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.5.3",
+ "diff",
+ "ena",
+ "is-terminal",
+ "itertools 0.10.5",
+ "lalrpop-util",
+ "petgraph 0.6.5",
+ "regex",
+ "regex-syntax 0.6.29",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "lance"
@@ -4166,6 +5739,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "landlock"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fefd6652c57d68aaa32544a4c0e642929725bdc1fd929367cdeb673ab81088"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4247,6 +5831,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4295,6 +5888,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4308,6 +5912,16 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -4349,6 +5963,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logos"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+dependencies = [
+ "beef",
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.6.29",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "loom"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,7 +5993,10 @@ checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
  "cfg-if",
  "generator",
+ "pin-utils",
  "scoped-tls",
+ "serde",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
 ]
@@ -4384,6 +6024,19 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "lz4"
@@ -4425,7 +6078,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -4455,6 +6108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4462,6 +6121,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
 
 [[package]]
 name = "matrixmultiply"
@@ -4485,6 +6150,12 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "measure_time"
@@ -4516,6 +6187,15 @@ name = "memmem"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -4634,10 +6314,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "murmurhash32"
@@ -4657,7 +6350,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -4678,6 +6371,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4685,9 +6411,21 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
 ]
 
 [[package]]
@@ -4854,6 +6592,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4862,6 +6621,51 @@ dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -4884,6 +6688,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4894,6 +6709,49 @@ dependencies = [
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -4956,7 +6814,7 @@ dependencies = [
  "sha2",
  "tar",
  "thiserror 1.0.69",
- "toml",
+ "toml 0.8.23",
  "ureq",
  "url",
  "uuid",
@@ -4964,10 +6822,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -5059,6 +6930,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "base64 0.22.1",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5080,6 +7050,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.30.1",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5133,6 +7129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "path_abs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5149,6 +7151,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -5203,6 +7215,16 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.13.1",
 ]
 
 [[package]]
@@ -5314,6 +7336,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5339,6 +7378,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5359,6 +7425,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -5378,6 +7446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5385,6 +7459,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -5419,6 +7502,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.11.0",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax 0.8.10",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5438,7 +7536,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
@@ -5468,6 +7566,21 @@ checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "psl"
+version = "2.1.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c0777260d32b76a8c3c197646707085d37e79d63b5872a29192c8d4f60f50b"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pulldown-cmark"
@@ -5526,12 +7639,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -5541,7 +7667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -5581,7 +7707,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -5615,6 +7741,336 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type 0.1.2",
+ "nibble_vec",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
+dependencies = [
+ "endian-type 0.2.0",
+ "nibble_vec",
+]
+
+[[package]]
+name = "rama-core"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b93751ab27c9d151e84c1100057eab3f2a6a1378bc31b62abd416ecb1847658"
+dependencies = [
+ "ahash",
+ "asynk-strim",
+ "bytes",
+ "futures",
+ "parking_lot",
+ "pin-project-lite",
+ "rama-error",
+ "rama-macros",
+ "rama-utils",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-graceful",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rama-dns"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e340fef2799277e204260b17af01bc23604712092eacd6defe40167f304baed8"
+dependencies = [
+ "ahash",
+ "hickory-resolver",
+ "rama-core",
+ "rama-net",
+ "rama-utils",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "rama-error"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c452aba1beb7e29b873ff32f304536164cffcc596e786921aea64e858ff8f40"
+
+[[package]]
+name = "rama-http"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453d60af031e23af2d48995e41b17023f6150044738680508b63671f8d7417dd"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "chrono",
+ "const_format",
+ "csv",
+ "http",
+ "http-range-header",
+ "httpdate",
+ "iri-string",
+ "matchit",
+ "parking_lot",
+ "percent-encoding",
+ "pin-project-lite",
+ "radix_trie 0.3.0",
+ "rama-core",
+ "rama-error",
+ "rama-http-headers",
+ "rama-http-types",
+ "rama-net",
+ "rama-utils",
+ "rand 0.9.2",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "rama-http-backend"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ff6a3c8ae690be8167e43777ba0bf6b0c8c2f6de165c538666affe2a32fd81"
+dependencies = [
+ "h2",
+ "pin-project-lite",
+ "rama-core",
+ "rama-http",
+ "rama-http-core",
+ "rama-http-headers",
+ "rama-http-types",
+ "rama-net",
+ "rama-tcp",
+ "rama-unix",
+ "rama-utils",
+ "tokio",
+]
+
+[[package]]
+name = "rama-http-core"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3822be6703e010afec0bcfeb5dbb6e5a3b23ca5689d9b1215b66ce6446653b77"
+dependencies = [
+ "ahash",
+ "atomic-waker",
+ "futures-channel",
+ "httparse",
+ "httpdate",
+ "indexmap 2.13.1",
+ "itoa",
+ "parking_lot",
+ "pin-project-lite",
+ "rama-core",
+ "rama-http",
+ "rama-http-types",
+ "rama-utils",
+ "slab",
+ "tokio",
+ "tokio-test",
+ "want",
+]
+
+[[package]]
+name = "rama-http-headers"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d74fe0cd9bd4440827dc6dc0f504cf66065396532e798891dee2c1b740b2285"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "chrono",
+ "const_format",
+ "httpdate",
+ "rama-core",
+ "rama-error",
+ "rama-http-types",
+ "rama-macros",
+ "rama-net",
+ "rama-utils",
+ "rand 0.9.2",
+ "serde",
+ "sha1",
+]
+
+[[package]]
+name = "rama-http-types"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dae655a72da5f2b97cfacb67960d8b28c5025e62707b4c8c5f0c5c9843a444"
+dependencies = [
+ "ahash",
+ "bytes",
+ "const_format",
+ "fnv",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "memchr",
+ "mime",
+ "mime_guess",
+ "nom 8.0.0",
+ "pin-project-lite",
+ "rama-core",
+ "rama-error",
+ "rama-macros",
+ "rama-utils",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+]
+
+[[package]]
+name = "rama-macros"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea18a110bcf21e35c5f194168e6914ccea45ffdd0fea51bc4b169fbeafef6428"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "rama-net"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28ee9e1e5d39264414b71f5c33e7fbb66b382c3fac456fe0daad39cf5509933"
+dependencies = [
+ "ahash",
+ "const_format",
+ "flume",
+ "hex",
+ "ipnet",
+ "itertools 0.14.0",
+ "md5",
+ "nom 8.0.0",
+ "parking_lot",
+ "pin-project-lite",
+ "psl",
+ "radix_trie 0.3.0",
+ "rama-core",
+ "rama-http-types",
+ "rama-macros",
+ "rama-utils",
+ "serde",
+ "sha2",
+ "socket2",
+ "tokio",
+]
+
+[[package]]
+name = "rama-socks5"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5468b263516daaf258de32542c1974b7cbe962363ad913dcb669f5d46db0ef3e"
+dependencies = [
+ "byteorder",
+ "rama-core",
+ "rama-net",
+ "rama-tcp",
+ "rama-udp",
+ "rama-utils",
+ "tokio",
+]
+
+[[package]]
+name = "rama-tcp"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe60cd604f91196b3659a1b28945add2e8b10bd0b4e6373c93d024fb3197704b"
+dependencies = [
+ "pin-project-lite",
+ "rama-core",
+ "rama-dns",
+ "rama-http-types",
+ "rama-net",
+ "rama-utils",
+ "rand 0.9.2",
+ "tokio",
+]
+
+[[package]]
+name = "rama-tls-rustls"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536d47f6b269fb20dffd45e4c04aa8b340698b3509326e3c36e444b4f33ce0d6"
+dependencies = [
+ "pin-project-lite",
+ "rama-core",
+ "rama-http-types",
+ "rama-net",
+ "rama-utils",
+ "rcgen",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots 1.0.6",
+ "x509-parser",
+]
+
+[[package]]
+name = "rama-udp"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ed05e0ecac73e084e92a3a8b1fbf16fdae8958c506f0f0eada180a2d99eef4"
+dependencies = [
+ "rama-core",
+ "rama-net",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "rama-unix"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91acb16d571428ba4cece072dfab90d2667cdfa910a7b3cb4530c3f31542d708"
+dependencies = [
+ "pin-project-lite",
+ "rama-core",
+ "rama-net",
+ "tokio",
+]
+
+[[package]]
+name = "rama-utils"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf28b18ba4a57f8334d7992d3f8020194ea359b246ae6f8f98b8df524c7a14ef"
+dependencies = [
+ "const_format",
+ "parking_lot",
+ "pin-project-lite",
+ "rama-macros",
+ "regex",
+ "serde",
+ "smallvec",
+ "smol_str",
+ "tokio",
+ "wildcard",
+]
 
 [[package]]
 name = "rand"
@@ -5696,6 +8152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5735,12 +8200,14 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "clap",
+ "codex-login",
  "crossterm",
  "dirs",
  "futures",
  "glob",
  "hf-hub",
  "indicatif",
+ "insta",
  "lancedb",
  "open",
  "owo-colors",
@@ -5760,13 +8227,13 @@ dependencies = [
  "sha2",
  "syntect",
  "tempfile",
- "textwrap",
+ "textwrap 0.16.2",
  "thiserror 2.0.18",
  "tiktoken-rs",
  "tokenizers",
  "tokio",
  "two-face",
- "unicode-width",
+ "unicode-width 0.2.2",
  "url",
  "urlencoding",
  "uuid",
@@ -5834,7 +8301,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5885,7 +8352,7 @@ dependencies = [
  "strum 0.27.2",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5932,6 +8399,20 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -6009,7 +8490,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -6020,7 +8501,7 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -6028,6 +8509,12 @@ name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -6044,6 +8531,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -6081,7 +8569,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -6093,8 +8588,43 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6153,6 +8683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6184,6 +8723,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -6202,7 +8742,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -6221,9 +8761,10 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6231,6 +8772,28 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.28.0",
+ "radix_trie 0.2.1",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ryu"
@@ -6278,6 +8841,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemafy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aea5ba40287dae331f2c48b64dbc8138541f5e97ee8793caa7948c1f31d86d5"
+dependencies = [
+ "Inflector",
+ "schemafy_core",
+ "schemafy_lib",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "schemafy_core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41781ae092f4fd52c9287efb74456aea0d3b90032d2ecad272bd14dbbcb0511b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e953db32579999ca98c451d80801b6f6a7ecba6127196c5387ec0774c528befa"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6295,11 +8912,24 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6327,6 +8957,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6334,6 +8973,38 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -6413,16 +9084,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acf96b1d9364968fce46ebb548f1c0e1d7eceae27bdff73865d42e6c7369d94"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.13.1",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.1",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -6452,6 +9148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -6495,6 +9200,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -6561,10 +9277,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
@@ -6592,12 +9324,25 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
 
 [[package]]
 name = "snafu"
@@ -6663,6 +9408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spm_precompiled"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6702,6 +9456,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "starlark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f53849859f05d9db705b221bd92eede93877fd426c1b4a3c3061403a5912a8f"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "bumpalo",
+ "cmp_any",
+ "debugserver-types",
+ "derivative",
+ "derive_more 1.0.0",
+ "display_container",
+ "dupe",
+ "either",
+ "erased-serde",
+ "hashbrown 0.14.5",
+ "inventory",
+ "itertools 0.13.0",
+ "maplit",
+ "memoffset 0.6.5",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "ref-cast",
+ "regex",
+ "rustyline",
+ "serde",
+ "serde_json",
+ "starlark_derive",
+ "starlark_map",
+ "starlark_syntax",
+ "static_assertions",
+ "strsim 0.10.0",
+ "textwrap 0.11.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "starlark_derive"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe58bc6c8b7980a1fe4c9f8f48200c3212db42ebfe21ae6a0336385ab53f082a"
+dependencies = [
+ "dupe",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "starlark_map"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92659970f120df0cc1c0bb220b33587b7a9a90e80d4eecc5c5af5debb950173d"
+dependencies = [
+ "allocative",
+ "dupe",
+ "equivalent",
+ "fxhash",
+ "hashbrown 0.14.5",
+ "serde",
+]
+
+[[package]]
+name = "starlark_syntax"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe53b3690d776aafd7cb6b9fed62d94f83280e3b87d88e3719cc0024638461b3"
+dependencies = [
+ "allocative",
+ "annotate-snippets",
+ "anyhow",
+ "derivative",
+ "derive_more 1.0.0",
+ "dupe",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "lsp-types",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "starlark_map",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6718,6 +9562,30 @@ name = "stfu8"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -6849,13 +9717,22 @@ dependencies = [
  "once_cell",
  "onig",
  "plist",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "serde",
  "serde_derive",
  "serde_json",
  "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -6996,7 +9873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
 dependencies = [
  "byteorder",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "utf8-ranges",
 ]
 
@@ -7076,6 +9953,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7114,7 +10011,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float 4.6.0",
@@ -7140,13 +10037,22 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7265,12 +10171,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -7312,7 +10231,7 @@ dependencies = [
  "rayon",
  "rayon-cond",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.10",
  "serde",
  "serde_json",
  "spm_precompiled",
@@ -7337,6 +10256,19 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-graceful"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45740b38b48641855471cd402922e89156bdfbd97b69b45eeff170369cc18c7d"
+dependencies = [
+ "loom",
+ "pin-project-lite",
+ "slab",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7382,6 +10314,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "git+https://github.com/openai-oss-forks/tokio-tungstenite?rev=132f5b39c862e3a970f731d709608b3e6276d5f6#132f5b39c862e3a970f731d709608b3e6276d5f6"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7401,9 +10359,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.13.1",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -7416,6 +10389,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7423,10 +10414,44 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.13.1",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.24.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+dependencies = [
+ "indexmap 2.13.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.13.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -7436,6 +10461,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7443,11 +10513,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.13.1",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7491,6 +10565,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7529,6 +10604,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7547,10 +10638,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax 0.8.10",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ts-rs"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4994acea2522cd2b3b85c1d9529a55991e3ad5e25cdcd3de9d505972c4379424"
+dependencies = [
+ "serde_json",
+ "thiserror 2.0.18",
+ "ts-rs-macros",
+ "uuid",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "termcolor",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "git+https://github.com/openai-oss-forks/tungstenite-rs?rev=9200079d3b54a1ff51072e24d81fd354f085156f#9200079d3b54a1ff51072e24d81fd354f085156f"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "flate2",
+ "headers",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "two-face"
@@ -7589,6 +10754,17 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "ug"
@@ -7639,6 +10815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7679,8 +10861,14 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -7699,6 +10887,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -7736,6 +10930,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -7743,6 +10938,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-ranges"
@@ -7968,6 +11169,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7984,6 +11201,12 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wezterm-bidi"
@@ -8028,7 +11251,7 @@ checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
  "ordered-float 4.6.0",
- "strsim",
+ "strsim 0.11.1",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
 ]
@@ -8068,6 +11291,36 @@ dependencies = [
  "rustix 1.1.4",
  "winsafe",
 ]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "wildcard"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b0540e91e49de3817c314da0dd3bc518093ceacc6ea5327cb0e1eb073e5189"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "wildmatch"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
 
 [[package]]
 name = "winapi"
@@ -8411,6 +11664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8520,6 +11782,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8527,6 +11808,16 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8542,6 +11833,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]
@@ -8592,6 +11892,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8637,6 +11999,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"
@@ -8647,6 +12023,7 @@ dependencies = [
  "displaydoc",
  "yoke 0.8.2",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -8655,6 +12032,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke 0.8.2",
  "zerofrom",
  "zerovec-derive",
@@ -8715,4 +12093,56 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,21 @@ two-face = { version = "0.5", default-features = false, features = ["syntect-def
 agent-client-protocol = { version = "0.10", features = ["unstable"] }
 hf-hub = "0.4"
 tokenizers = { version = "0.22", default-features = false, features = ["onig"] }
+codex-login = { git = "https://github.com/openai/codex", package = "codex-login", rev = "996aa23e4ce900468047ed3ec57d1e7271f8d6de" }
 candle = { git = "https://github.com/huggingface/candle", rev = "34625ab6d1567a0bc132ac6bc8dc2cce0e16d86d", package = "candle-core" }
 candle-nn = { git = "https://github.com/huggingface/candle", rev = "34625ab6d1567a0bc132ac6bc8dc2cce0e16d86d", package = "candle-nn" }
 candle-transformers = { git = "https://github.com/huggingface/candle", rev = "34625ab6d1567a0bc132ac6bc8dc2cce0e16d86d", package = "candle-transformers" }
 
 [dev-dependencies]
 tempfile = "3.17"
+insta = "1.43"
+
+[patch.crates-io]
+tokio-tungstenite = { git = "https://github.com/openai-oss-forks/tokio-tungstenite", rev = "132f5b39c862e3a970f731d709608b3e6276d5f6" }
+tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }
+
+[patch."ssh://git@github.com/openai-oss-forks/tungstenite-rs.git"]
+tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }
 
 [features]
 default = []

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+dirs.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,8 +1,26 @@
 use anyhow::Result;
+use dirs::home_dir;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
+use std::collections::{hash_map::DefaultHasher, BTreeMap};
 use std::fs;
-use std::path::PathBuf;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ProviderConfigState {
+    #[serde(
+        default,
+        serialize_with = "serialize_secret_option",
+        deserialize_with = "deserialize_secret_option"
+    )]
+    pub api_key: Option<SecretString>,
+    pub base_url: Option<String>,
+    pub model: Option<String>,
+    pub revision: Option<String>,
+    pub thinking: Option<bool>,
+    pub num_ctx: Option<u32>,
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct RaraConfig {
@@ -24,6 +42,8 @@ pub struct RaraConfig {
     pub append_system_prompt_file: Option<String>,
     pub compact_prompt: Option<String>,
     pub compact_prompt_file: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub provider_states: BTreeMap<String, ProviderConfigState>,
 }
 
 impl RaraConfig {
@@ -37,11 +57,164 @@ impl RaraConfig {
 
     pub fn set_api_key(&mut self, value: impl Into<String>) {
         self.api_key = Some(SecretString::from(value.into()));
+        self.sync_active_provider_state();
     }
 
     pub fn clear_api_key(&mut self) {
         self.api_key = None;
+        self.sync_active_provider_state();
     }
+
+    pub fn clear_provider_api_key(&mut self, provider: &str) {
+        if self.provider == provider {
+            self.clear_api_key();
+            return;
+        }
+        if let Some(state) = self.provider_states.get_mut(provider) {
+            state.api_key = None;
+        }
+    }
+
+    pub fn set_provider(&mut self, provider: impl Into<String>) {
+        self.sync_active_provider_state();
+        self.provider = provider.into();
+        self.reset_provider_scoped_fields();
+        if let Some(state) = self.provider_states.get(&self.provider).cloned() {
+            self.apply_provider_state(state);
+        }
+    }
+
+    pub fn set_base_url(&mut self, value: Option<String>) {
+        self.base_url = normalize_optional_string(value);
+        self.sync_active_provider_state();
+    }
+
+    pub fn set_model(&mut self, value: Option<String>) {
+        self.model = normalize_optional_string(value);
+        self.sync_active_provider_state();
+    }
+
+    pub fn set_revision(&mut self, value: Option<String>) {
+        self.revision = normalize_optional_string(value);
+        self.sync_active_provider_state();
+    }
+
+    pub fn set_thinking(&mut self, value: Option<bool>) {
+        self.thinking = value;
+        self.sync_active_provider_state();
+    }
+
+    pub fn set_num_ctx(&mut self, value: Option<u32>) {
+        self.num_ctx = value;
+        self.sync_active_provider_state();
+    }
+
+    fn sync_active_provider_state(&mut self) {
+        if self.provider.trim().is_empty() {
+            return;
+        }
+        self.provider_states
+            .insert(self.provider.clone(), self.current_provider_state());
+    }
+
+    fn current_provider_state(&self) -> ProviderConfigState {
+        ProviderConfigState {
+            api_key: self.api_key.clone(),
+            base_url: self.base_url.clone(),
+            model: self.model.clone(),
+            revision: self.revision.clone(),
+            thinking: self.thinking,
+            num_ctx: self.num_ctx,
+        }
+    }
+
+    fn apply_provider_state(&mut self, state: ProviderConfigState) {
+        self.api_key = state.api_key;
+        self.base_url = state.base_url;
+        self.model = state.model;
+        self.revision = state.revision;
+        self.thinking = state.thinking;
+        self.num_ctx = state.num_ctx;
+    }
+
+    fn reset_provider_scoped_fields(&mut self) {
+        self.api_key = None;
+        self.base_url = None;
+        self.model = None;
+        self.revision = None;
+        self.thinking = None;
+        self.num_ctx = None;
+    }
+}
+
+pub fn rara_home_dir() -> Result<PathBuf> {
+    Ok(home_dir()
+        .ok_or_else(|| anyhow::anyhow!("failed to resolve home directory for ~/.rara"))?
+        .join(".rara"))
+}
+
+pub fn ensure_rara_home_dir() -> Result<PathBuf> {
+    let rara_home = rara_home_dir()?;
+    fs::create_dir_all(&rara_home)?;
+    Ok(rara_home)
+}
+
+pub fn workspace_data_dir_for(root: &Path) -> Result<PathBuf> {
+    let rara_home = ensure_rara_home_dir()?;
+    workspace_data_dir_for_home(root, &rara_home)
+}
+
+pub fn workspace_data_dir_for_home(root: &Path, rara_home: &Path) -> Result<PathBuf> {
+    let canonical_root = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let slug = workspace_slug(&canonical_root);
+    let hash = stable_path_hash(&canonical_root);
+    let dir = rara_home
+        .join("workspaces")
+        .join(format!("{slug}-{hash:016x}"));
+    fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn workspace_slug(root: &Path) -> String {
+    let raw = root
+        .file_name()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or("workspace");
+    let mut slug = String::new();
+    let mut last_dash = false;
+    for ch in raw.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            last_dash = false;
+        } else if !last_dash {
+            slug.push('-');
+            last_dash = true;
+        }
+    }
+    let slug = slug.trim_matches('-');
+    if slug.is_empty() {
+        "workspace".to_string()
+    } else {
+        slug.chars().take(40).collect()
+    }
+}
+
+fn stable_path_hash(root: &Path) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    root.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
 }
 
 fn serialize_secret_option<S>(
@@ -73,12 +246,13 @@ pub struct ConfigManager {
 
 impl ConfigManager {
     pub fn new() -> Result<Self> {
-        let rara_dir = std::env::current_dir()?.join(".rara");
-        if !rara_dir.exists() {
-            fs::create_dir_all(&rara_dir)?;
-        }
+        Self::new_for_rara_home(ensure_rara_home_dir()?)
+    }
+
+    pub fn new_for_rara_home(rara_home: PathBuf) -> Result<Self> {
+        fs::create_dir_all(&rara_home)?;
         Ok(Self {
-            path: rara_dir.join("config.json"),
+            path: rara_home.join("config.json"),
         })
     }
 
@@ -108,7 +282,7 @@ impl ConfigManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{ConfigManager, RaraConfig};
+    use super::{workspace_data_dir_for_home, ConfigManager, RaraConfig};
     use std::fs;
     use tempfile::tempdir;
 
@@ -132,6 +306,59 @@ mod tests {
         let mut config = RaraConfig::default();
         config.set_api_key("");
         assert!(!config.has_api_key());
+    }
+
+    #[test]
+    fn provider_switch_restores_provider_specific_settings() {
+        let mut config = RaraConfig {
+            provider: "codex".to_string(),
+            ..Default::default()
+        };
+        config.set_api_key("sk-codex");
+        config.set_model(Some("codex".to_string()));
+        config.set_base_url(Some("http://localhost:8080".to_string()));
+
+        config.set_provider("ollama");
+        assert_eq!(config.provider, "ollama");
+        assert!(config.api_key().is_none());
+        assert!(config.model.is_none());
+        assert!(config.base_url.is_none());
+
+        config.set_model(Some("qwen3".to_string()));
+        config.set_base_url(Some("http://localhost:11434".to_string()));
+        config.set_num_ctx(Some(32768));
+
+        config.set_provider("codex");
+        assert_eq!(config.api_key(), Some("sk-codex"));
+        assert_eq!(config.model.as_deref(), Some("codex"));
+        assert_eq!(config.base_url.as_deref(), Some("http://localhost:8080"));
+        assert_eq!(config.num_ctx, None);
+
+        config.set_provider("ollama");
+        assert_eq!(config.model.as_deref(), Some("qwen3"));
+        assert_eq!(config.base_url.as_deref(), Some("http://localhost:11434"));
+        assert_eq!(config.num_ctx, Some(32768));
+    }
+
+    #[test]
+    fn config_manager_uses_rara_home() {
+        let dir = tempdir().expect("tempdir");
+        let manager =
+            ConfigManager::new_for_rara_home(dir.path().join(".rara")).expect("config manager");
+        assert_eq!(manager.path, dir.path().join(".rara").join("config.json"));
+    }
+
+    #[test]
+    fn workspace_data_dir_lives_under_global_rara_home() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("repo");
+        fs::create_dir_all(&root).expect("mkdir root");
+
+        let rara_home = temp.path().join(".rara-home");
+        let data_dir = workspace_data_dir_for_home(&root, &rara_home).expect("workspace data dir");
+
+        assert!(data_dir.starts_with(rara_home.join("workspaces")));
+        assert!(data_dir.exists());
     }
 
     #[test]

--- a/crates/instructions/src/workspace.rs
+++ b/crates/instructions/src/workspace.rs
@@ -1,5 +1,6 @@
 use crate::prompt::{PromptSource, PromptSourceKind};
 use anyhow::Result;
+use rara_config::workspace_data_dir_for;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -34,10 +35,7 @@ struct CachedEnvInfo {
 impl WorkspaceMemory {
     pub fn new() -> Result<Self> {
         let root = std::env::current_dir()?;
-        let rara_dir = root.join(".rara");
-        if !rara_dir.exists() {
-            fs::create_dir_all(&rara_dir)?;
-        }
+        let rara_dir = workspace_data_dir_for(&root)?;
         Ok(Self::from_paths(root, rara_dir))
     }
 
@@ -103,7 +101,7 @@ impl WorkspaceMemory {
             sources.push(PromptSource {
                 kind: PromptSourceKind::LocalInstruction,
                 label: "RARA Local Instruction".to_string(),
-                display_path: ".rara/instructions.md".to_string(),
+                display_path: rara_inst.display().to_string(),
                 content,
             });
         }
@@ -112,7 +110,7 @@ impl WorkspaceMemory {
             sources.push(PromptSource {
                 kind: PromptSourceKind::LocalMemory,
                 label: "Local Project Memory".to_string(),
-                display_path: ".rara/memory.md".to_string(),
+                display_path: memory.display().to_string(),
                 content,
             });
         }

--- a/docs/features/codex-auth-login.md
+++ b/docs/features/codex-auth-login.md
@@ -210,6 +210,10 @@ Implemented in the current pass:
 - logout now uses `codex_login::logout(...)`
 - RARA still persists the resulting provider credential into its local config
 - the TUI auth picker keeps the Codex-style selection-list UX
+- Codex auth storage now lives under `~/.rara/codex-auth` instead of a
+  project-local `.rara`
+- the main RARA config now lives under `~/.rara/config.json`, with
+  provider-scoped remembered state for multi-provider/model use
 - focused auth regression tests now cover:
   - stored API-key persistence
   - logout cleanup

--- a/docs/features/codex-auth-login.md
+++ b/docs/features/codex-auth-login.md
@@ -54,8 +54,8 @@ RARA now has a first implementation pass of Codex-style first-party auth:
   - API key
   - logout
 
-This implementation is still a thin local runtime in `src/oauth.rs`. It mirrors
-Codex behavior, but it does not yet directly reuse `codex_login`.
+This implementation now routes the core login actions through `codex_login`
+instead of keeping a separate local OAuth protocol mirror in RARA.
 
 Codex has a richer first-party login stack:
 
@@ -119,8 +119,8 @@ boundary.
 
 ### 1. First-Party Auth Manager
 
-RARA should keep evolving the current `OAuthManager` into a Codex-aligned auth
-manager that supports:
+RARA's `OAuthManager` should stay as a thin adaptation layer around
+`codex_login`, while continuing to expose a RARA-local surface for:
 
 - browser login;
 - device-code login;
@@ -201,25 +201,34 @@ Minimum validation for implementation:
 
 ## Current Checkpoint
 
-Implemented in the first pass:
+Implemented in the current pass:
 
-- Codex issuer/client-id based browser login
-- device-code login
-- stdin-fed API-key login
-- logout
-- TUI auth picker with selection-list UX instead of a browser-only action
+- browser login now uses `codex_login::run_login_server(...)`
+- device-code login now uses `codex_login::request_device_code(...)` and
+  `codex_login::complete_device_code_login(...)`
+- API-key login now uses `codex_login::login_with_api_key(...)`
+- logout now uses `codex_login::logout(...)`
+- RARA still persists the resulting provider credential into its local config
+- the TUI auth picker keeps the Codex-style selection-list UX
+- focused auth regression tests now cover:
+  - stored API-key persistence
+  - logout cleanup
+  - credential loading precedence
+  - auth-picker navigation
+- initial snapshot coverage now exists for:
+  - auth picker popup
+  - queued follow-up preview
+  - Updated Plan active-turn rendering
 
 Still intentionally left open:
 
-- direct reuse of `codex_login` primitives instead of a local mirror
+- fuller browser callback-path validation beyond the `codex_login` server bridge
+- broader snapshot coverage for more TUI popups and transcript-heavy surfaces
 - richer credential persistence semantics if Codex later requires more than the
   current stored access token/API key path
-- more complete tests around callback handling and TUI auth flow edges
 
 ## Follow-Up Work
 
-- Refactor `src/oauth.rs` toward a Codex-aligned auth manager.
-- Add device-code login and API-key login CLI/TUI surfaces.
-- Reuse `codex_login` primitives where practical instead of extending the
-  current bespoke flow.
+- Expand auth-path tests around browser callback handling and shared persistence.
+- Expand snapshot coverage across more Codex-style TUI surfaces.
 - Specify MCP/appserver OAuth separately if later appserver work truly needs it.

--- a/docs/features/rara-home-layout.md
+++ b/docs/features/rara-home-layout.md
@@ -1,0 +1,108 @@
+# RARA Home Layout
+
+## Summary
+
+RARA should not create a project-local `.rara` directory during normal runtime.
+
+Instead, runtime state should live under the user's home directory:
+
+- global config under `~/.rara`
+- workspace-scoped runtime data under `~/.rara/workspaces/<workspace-id>`
+
+This keeps repository working trees clean while still preserving per-workspace
+state.
+
+## Goals
+
+- Keep configuration and runtime state out of the project directory by default.
+- Preserve per-workspace isolation for:
+  - session history
+  - sqlite state
+  - sandbox profiles
+  - tool-result artifacts
+  - workspace memory files
+- Support multiple providers/models without flattening all provider-scoped
+  settings into one mutable config surface.
+
+## Non-Goals
+
+- Removing explicit test fixtures that intentionally create temporary `.rara`
+  directories.
+- Redesigning the entire persistence model into a thread-store boundary in the
+  same change.
+- Changing skill discovery semantics beyond runtime state placement.
+
+## Required Layout
+
+### Global Home
+
+RARA home is:
+
+- `~/.rara`
+
+It stores:
+
+- `config.json`
+- Codex auth state (currently `codex-auth/`)
+- future global caches or shared metadata
+
+### Workspace Data
+
+Each workspace gets a dedicated directory under:
+
+- `~/.rara/workspaces/<workspace-id>`
+
+The `<workspace-id>` should be stable for the same canonical workspace path and
+human-scannable enough to inspect manually. A slug-plus-hash identifier is
+acceptable.
+
+Workspace data currently includes:
+
+- `rollouts/`
+- `sessions/`
+- `state.sqlite3`
+- `sandbox/`
+- `tool-results/`
+- workspace memory files such as `instructions.md` and `memory.md`
+
+## Config Model
+
+Because RARA supports multiple providers and model families, config should not
+only behave like a single flat mutable profile.
+
+The global config should keep:
+
+- the currently selected provider
+- prompt-related global settings
+- provider-scoped remembered state for fields such as:
+  - API key
+  - base URL
+  - model
+  - revision
+  - thinking
+  - context size
+
+Switching providers should restore the remembered provider-scoped state when it
+exists, instead of forcing every provider switch to overwrite one shared set of
+fields.
+
+## Implementation Boundary
+
+The canonical helpers should live in `rara-config` and be reused by the runtime:
+
+- resolve/create `~/.rara`
+- derive/create a workspace data directory from a workspace root
+- manage provider-scoped remembered config state
+
+Other crates should not rebuild their own `.rara` path logic from
+`current_dir().join(".rara")`.
+
+## Validation
+
+Minimum validation:
+
+- config manager writes `config.json` under `~/.rara`
+- workspace data helpers resolve under `~/.rara/workspaces/...`
+- provider switching restores provider-scoped remembered settings
+- runtime surfaces that previously created project-local `.rara` now use the
+  shared helpers

--- a/docs/journal/2026-04-20-codex-auth-login-integration.md
+++ b/docs/journal/2026-04-20-codex-auth-login-integration.md
@@ -1,0 +1,57 @@
+# 2026-04-20 Codex Auth Login Integration
+
+## Summary
+
+RARA now uses `codex_login` directly for the main Codex auth paths instead of
+maintaining a parallel bespoke OAuth implementation in `src/oauth.rs`.
+
+This turns the earlier "Codex-style mirror" into a thin adaptation layer around
+Codex's own browser login, device-code login, API-key login, and logout
+primitives.
+
+## What Landed
+
+- `Cargo.toml`
+  - adds a direct `codex-login` dependency
+  - mirrors the upstream tungstenite workspace patches required for dependency
+    resolution
+- `src/oauth.rs`
+  - wraps `codex_login::run_login_server(...)`
+  - wraps `codex_login::request_device_code(...)`
+  - wraps `codex_login::complete_device_code_login(...)`
+  - wraps `codex_login::login_with_api_key(...)`
+  - wraps `codex_login::logout(...)`
+  - keeps a small RARA-local bridge that converts saved Codex auth state back
+    into the provider credential that RARA stores in its config
+- `src/main.rs`
+  - CLI `login`, `login --device-auth`, `login --with-api-key`, and `logout`
+    now all run through the new auth bridge
+- `src/tui/runtime/tasks.rs`, `src/tui/runtime/commands.rs`, `src/tui/mod.rs`
+  - TUI browser/device/API-key/login/logout flows now use the same bridge
+  - logout clears both the local RARA credential and the underlying Codex auth
+    storage
+
+## Validation
+
+Focused regression coverage now includes:
+
+- `oauth::tests`
+  - API-key persistence
+  - saved-credential loading precedence
+  - logout cleanup
+  - browser-login bridge metadata
+- `tui::tests::auth_mode_picker_prefers_selection_navigation`
+
+Initial `insta` snapshot coverage now exists for:
+
+- auth-mode picker popup
+- queued follow-up preview
+- Updated Plan active-turn rendering
+
+## Follow-Up
+
+- add broader callback-path validation if RARA needs more confidence around the
+  browser-login bridge itself
+- expand snapshot coverage across more popups and status-heavy transcript views
+- keep MCP/appserver auth as a separate later feature instead of folding it
+  back into first-party Codex login

--- a/docs/journal/2026-04-20-rara-home-layout.md
+++ b/docs/journal/2026-04-20-rara-home-layout.md
@@ -1,0 +1,32 @@
+# 2026-04-20 · RARA Home Layout
+
+## Summary
+
+Moved the default runtime path model away from project-local `.rara` and into a
+Codex-style home layout rooted at `~/.rara`.
+
+## Implemented
+
+- `rara-config`
+  - added helpers for:
+    - `~/.rara`
+    - workspace-scoped data directories under `~/.rara/workspaces/...`
+  - added provider-scoped remembered config state so provider/model/base URL/API
+    key changes do not flatten into one shared mutable profile
+- production defaults updated to use shared helpers for:
+  - config manager
+  - Codex auth storage
+  - session storage
+  - sqlite state DB
+  - sandbox profile storage
+  - tool-result storage
+  - workspace memory
+- focused tests updated so state DB persistence no longer depends on
+  `current_dir().join(".rara")`
+
+## Notes
+
+- Explicit temporary test fixtures that create `.rara` remain acceptable when a
+  test wants a self-contained fake runtime root.
+- The project tree should no longer be the default place where RARA creates
+  `.rara` during normal operation.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -44,7 +44,7 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Continue the internal-crate rollout after `rara-config`, `rara-instructions`, and `rara-skills`: move more skill runtime behavior behind `rara-skills`, then extract the next stable boundary instead of growing the root crate back toward a monolith.
 - [ ] Revisit direct reuse of `codex-core-skills` after the Codex-compatible root-discovery phase: keep `rara-skills` as the adaptation boundary, but replace more of the custom loader/render/invocation stack once the dependency surface is acceptable.
-- [ ] Refine instruction resolution so `AGENTS.md` / instruction files behave more like Codex and Claude Code: keep hierarchical lookup, then define clearer precedence and merge rules for nested project instructions versus local `.rara` instructions.
+- [ ] Refine instruction resolution so `AGENTS.md` / instruction files behave more like Codex and Claude Code: keep hierarchical lookup, then define clearer precedence and merge rules for nested project instructions versus workspace-local RARA instructions.
 - [ ] Continue splitting remaining oversized TUI files such as `src/tui/state.rs` and `src/tui/markdown_render.rs` so the 800-line guideline holds across the main interaction path.
 - [ ] Add module-level documentation for the agent lifecycle, tool loop, plan/update flow, and sandbox model so the runtime architecture is easier to reason about.
 - [ ] Add a security section to `AGENTS.md` or a dedicated security doc covering sandbox expectations, command execution rules, and secret-handling standards.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -11,8 +11,7 @@ Active backlog only. Keep this file small and current.
 
 ## LLM and Networking
 
-- [ ] Replace the current Codex-auth mirror in `src/oauth.rs` with direct reuse of the smallest useful `codex_login` primitives so browser login, device-code login, API-key login, and logout stop drifting from Codex behavior over time.
-- [ ] Broaden Codex-auth validation after the first parity pass: add callback-flow, persistence, and TUI auth-picker tests so the new browser/device/API-key/logout paths stay regression-tested.
+- [ ] Broaden Codex-auth validation beyond the current bridge tests: add stronger callback-flow coverage and more end-to-end persistence checks so the browser/device/API-key/logout paths stay regression-tested even as `codex_login` evolves.
 - [ ] Add an `AgentHub team mode` on top of ACP: for role-specialized worker sessions, use a small model first for intent routing and only hand the task to the larger worker model when the intent is relevant to that worker, instead of sending every ACP turn directly to the expensive model.
 - [ ] Deepen the `AgentHub team mode` spec before implementation: define the ACP session metadata, worker-role contract, router prompt/output schema, and the exact `skip` / `handle` response semantics so the worker runtime can be implemented without inventing a parallel protocol later.
 
@@ -20,7 +19,7 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Add a first-run onboarding flow that explains workspace, provider/model selection, local model download behavior, cache location, and tool loop expectations before the user lands in a blank chat.
 - [ ] Continue aligning the TUI status and transcript surfaces with Codex/Claude so runtime state stays visible without leaking bottom-pane chrome into transcript history.
-- [ ] Add Codex-style TUI snapshot coverage for popups, status surfaces, and transcript-heavy widgets so layout/text regressions are caught by golden snapshots instead of only narrow string assertions.
+- [ ] Expand the new Codex-style TUI snapshot coverage beyond the first auth-picker / queued-follow-up / Updated Plan snapshots so more popups, status surfaces, and transcript-heavy widgets are protected by golden tests.
 - [ ] Continue making tool-action transcript summaries more source-aware and file-aware so edit tools such as `write_file` / `replace` / `apply_patch` consistently show what they touched instead of only generic action labels.
 - [ ] Continue refining the live `bash` transcript path so command execution behaves more like Codex: keep the streamed stdout/stderr surface, then add richer lifecycle details such as clearer command-start/finish framing and better long-output folding.
 - [ ] Continue refining queued follow-up steering toward the full Codex contract: keep the new next-tool-boundary queue, then add the explicit interrupt/send-now path and clearer separation between pending steers and ordinary queued follow-ups.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -164,7 +164,9 @@ impl Agent {
             session_id: Uuid::new_v4().to_string(),
             total_input_tokens: 0,
             total_output_tokens: 0,
-            tool_result_store: ToolResultStore::new(default_tool_result_store_dir())
+            tool_result_store: ToolResultStore::new(
+                default_tool_result_store_dir().expect("tool result store dir"),
+            )
                 .expect("tool result store"),
             execution_mode: AgentExecutionMode::Execute,
             bash_approval_mode: BashApprovalMode::Always,

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,11 +160,16 @@ async fn main_impl() -> Result<()> {
                 bail!("choose either --device-auth or --with-api-key, not both");
             }
             if with_api_key {
-                let oauth_manager = oauth_manager.clone();
+                let oauth_reader = oauth_manager.clone();
                 let api_key =
-                    tokio::task::spawn_blocking(move || oauth_manager.read_api_key_from_stdin())
+                    tokio::task::spawn_blocking(move || oauth_reader.read_api_key_from_stdin())
                         .await??;
-                save_codex_credential(&mut config, &config_manager, api_key.expose_secret())?;
+                let credential = oauth_manager.save_api_key(api_key.expose_secret())?;
+                save_codex_credential(
+                    &mut config,
+                    &config_manager,
+                    credential.expose_secret(),
+                )?;
                 println!("Successfully saved Codex API key.");
             } else if device_auth {
                 let token = oauth_manager.request_device_code().await?;
@@ -172,35 +177,33 @@ async fn main_impl() -> Result<()> {
                     "Open this URL and enter the one-time code:\n{}\n\nCode: {}",
                     token.verification_url, token.user_code
                 );
-                let token = oauth_manager.complete_device_code_login(&token).await?;
+                let credential = oauth_manager.complete_device_code_login(&token).await?;
                 save_codex_credential(
                     &mut config,
                     &config_manager,
-                    token.access_token.expose_secret(),
+                    credential.expose_secret(),
                 )?;
                 println!("Successfully logged in with device code.");
             } else {
                 if std::env::var_os("SSH_CONNECTION").is_some() {
                     bail!("browser login is not reliable in SSH/headless sessions; use --device-auth or --with-api-key");
                 }
-                let (verifier, challenge) = oauth_manager.generate_pkce();
-                let (port, receiver) = oauth_manager.start_callback_server().await?;
-                let auth_url = oauth_manager.get_authorize_url(&challenge, port);
+                let session = oauth_manager.start_browser_login(true)?;
                 eprintln!(
-                    "Starting local login server on http://localhost:{port}.\nIf your browser did not open, navigate to this URL:\n\n{auth_url}"
+                    "Starting local login flow.\nIf your browser did not open, navigate to this URL:\n\n{}",
+                    session.auth_url()
                 );
-                let _ = open::that(&auth_url);
-                let code = receiver.await?;
-                let token = oauth_manager.exchange_code(&code, &verifier, port).await?;
+                let credential = session.complete(&oauth_manager).await?;
                 save_codex_credential(
                     &mut config,
                     &config_manager,
-                    token.access_token.expose_secret(),
+                    credential.expose_secret(),
                 )?;
                 println!("Successfully logged in.");
             }
         }
         Commands::Logout => {
+            let _ = oauth_manager.clear_saved_auth();
             config.clear_api_key();
             config_manager.save(&config)?;
             println!("Removed the saved Codex credential.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,19 +100,19 @@ async fn main_impl() -> Result<()> {
     let mut config = config_manager.load()?;
 
     if let Some(p) = cli.provider {
-        config.provider = p;
+        config.set_provider(p);
     }
     if let Some(k) = cli.api_key {
         config.set_api_key(k);
     }
     if let Some(b) = cli.base_url {
-        config.base_url = Some(b);
+        config.set_base_url(Some(b));
     }
     if let Some(m) = cli.model {
-        config.model = Some(m);
+        config.set_model(Some(m));
     }
     if let Some(r) = cli.revision {
-        config.revision = Some(r);
+        config.set_revision(Some(r));
     }
 
     let oauth_manager = OAuthManager::new()?;
@@ -203,10 +203,14 @@ async fn main_impl() -> Result<()> {
             }
         }
         Commands::Logout => {
-            let _ = oauth_manager.clear_saved_auth();
-            config.clear_api_key();
+            let removed = oauth_manager.clear_saved_auth()?;
+            config.clear_provider_api_key("codex");
             config_manager.save(&config)?;
-            println!("Removed the saved Codex credential.");
+            if removed {
+                println!("Removed the saved Codex credential.");
+            } else {
+                println!("No saved Codex credential was present.");
+            }
         }
         Commands::Tui => {
             let mut agent = Agent::new(tool_manager, backend_arc, vdb, session_manager, workspace);
@@ -222,10 +226,10 @@ fn save_codex_credential(
     config_manager: &ConfigManager,
     credential: &str,
 ) -> Result<()> {
+    config.set_provider("codex");
     config.set_api_key(credential.to_string());
-    config.provider = "codex".into();
     if config.model.is_none() {
-        config.model = Some("codex".into());
+        config.set_model(Some("codex".into()));
     }
     config_manager.save(config)
 }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -43,7 +43,7 @@ pub struct OAuthManager {
 
 impl OAuthManager {
     pub fn new() -> Result<Self> {
-        let config_dir = std::env::current_dir()?.join(".rara");
+        let config_dir = rara_config::ensure_rara_home_dir()?;
         Self::new_for_config_dir(config_dir)
     }
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,106 +1,60 @@
 use anyhow::{anyhow, Result};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use rand::{distributions::Alphanumeric, Rng};
-use secrecy::{ExposeSecret, SecretString};
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use codex_login::{
+    complete_device_code_login as codex_complete_device_code_login,
+    load_auth_dot_json, login_with_api_key as codex_login_with_api_key, logout as codex_logout,
+    request_device_code as codex_request_device_code, run_login_server as codex_run_login_server,
+    AuthCredentialsStoreMode, DeviceCode as CodexDeviceCode, LoginServer as CodexLoginServer,
+    ServerOptions, CLIENT_ID,
+};
+use secrecy::SecretString;
 use std::io::Read;
 use std::path::PathBuf;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::TcpListener;
 
-const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const ISSUER: &str = "https://auth.openai.com";
-const DEVICE_AUTH_MAX_WAIT_SECS: u64 = 15 * 60;
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct OAuthToken {
-    #[serde(
-        serialize_with = "serialize_secret",
-        deserialize_with = "deserialize_secret"
-    )]
-    pub access_token: SecretString,
-    #[serde(
-        default,
-        serialize_with = "serialize_secret_option",
-        deserialize_with = "deserialize_secret_option"
-    )]
-    pub refresh_token: Option<SecretString>,
-    #[serde(
-        default,
-        serialize_with = "serialize_secret_option",
-        deserialize_with = "deserialize_secret_option"
-    )]
-    pub id_token: Option<SecretString>,
-}
 
 #[derive(Debug, Clone)]
 pub struct DeviceCode {
     pub verification_url: String,
     pub user_code: String,
-    device_auth_id: String,
-    interval_secs: u64,
+    inner: CodexDeviceCode,
 }
 
-fn serialize_secret<S>(value: &SecretString, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    serializer.serialize_str(value.expose_secret())
+pub struct BrowserLoginSession {
+    auth_url: String,
+    inner: CodexLoginServer,
 }
 
-fn deserialize_secret<'de, D>(deserializer: D) -> Result<SecretString, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    String::deserialize(deserializer).map(SecretString::from)
-}
+impl BrowserLoginSession {
+    pub fn auth_url(&self) -> &str {
+        &self.auth_url
+    }
 
-fn serialize_secret_option<S>(
-    value: &Option<SecretString>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    Option::<String>::serialize(
-        &value
-            .as_ref()
-            .map(|secret| secret.expose_secret().to_string()),
-        serializer,
-    )
-}
-
-fn deserialize_secret_option<'de, D>(deserializer: D) -> Result<Option<SecretString>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = Option::<String>::deserialize(deserializer)?;
-    Ok(value.map(SecretString::from))
+    pub async fn complete(self, manager: &OAuthManager) -> Result<SecretString> {
+        self.inner.block_until_done().await?;
+        manager.load_saved_credential()
+    }
 }
 
 #[derive(Clone)]
 pub struct OAuthManager {
     pub config_dir: PathBuf,
+    codex_home: PathBuf,
 }
+
 impl OAuthManager {
     pub fn new() -> Result<Self> {
-        let d = std::env::current_dir()?.join(".rara");
-        if !d.exists() {
-            std::fs::create_dir_all(&d)?;
-        }
-        Ok(Self { config_dir: d })
+        let config_dir = std::env::current_dir()?.join(".rara");
+        Self::new_for_config_dir(config_dir)
     }
 
-    pub fn generate_pkce(&self) -> (String, String) {
-        let v: String = rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(128)
-            .map(char::from)
-            .collect();
-        let mut h = Sha256::new();
-        h.update(v.as_bytes());
-        (v, URL_SAFE_NO_PAD.encode(h.finalize()))
+    pub fn new_for_config_dir(config_dir: PathBuf) -> Result<Self> {
+        std::fs::create_dir_all(&config_dir)?;
+        let codex_home = config_dir.join("codex-auth");
+        std::fs::create_dir_all(&codex_home)?;
+        Ok(Self {
+            config_dir,
+            codex_home,
+        })
     }
 
     pub fn codex_issuer(&self) -> &'static str {
@@ -111,229 +65,196 @@ impl OAuthManager {
         CLIENT_ID
     }
 
-    pub async fn start_callback_server(
-        &self,
-    ) -> Result<(u16, tokio::sync::oneshot::Receiver<String>)> {
-        let l = TcpListener::bind("127.0.0.1:0").await?;
-        let p = l.local_addr()?.port();
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        tokio::spawn(async move {
-            if let Ok((mut s, _)) = l.accept().await {
-                let mut r = BufReader::new(&mut s);
-                let mut line = String::new();
-                if r.read_line(&mut line).await.is_ok() {
-                    if let Some(c) = line
-                        .split_whitespace()
-                        .nth(1)
-                        .and_then(|p| p.split("code=").nth(1))
-                        .and_then(|c| c.split('&').next())
-                    {
-                        let _ = s.write_all(b"HTTP/1.1 200 OK\r\n\r\nLogin Success").await;
-                        let _ = tx.send(c.to_string());
-                    }
-                }
-            }
-        });
-        Ok((p, rx))
-    }
-
-    pub async fn exchange_code(&self, code: &str, verifier: &str, port: u16) -> Result<OAuthToken> {
-        let params = [
-            ("grant_type", "authorization_code"),
-            ("code", code),
-            ("client_id", CLIENT_ID),
-            ("code_verifier", verifier),
-            (
-                "redirect_uri",
-                &format!("http://localhost:{}/callback", port),
-            ),
-        ];
-        let token_url = format!("{ISSUER}/oauth/token");
-        let res = reqwest::Client::new()
-            .post(token_url)
-            .form(&params)
-            .send()
-            .await?;
-        if !res.status().is_success() {
-            return Err(anyhow!(
-                "OAuth token exchange failed with status {}",
-                res.status()
-            ));
-        }
-        Ok(res.json().await?)
-    }
-
-    pub fn get_authorize_url(&self, challenge: &str, port: u16) -> String {
-        format!(
-            "{ISSUER}/oauth/authorize?response_type=code&client_id={}&code_challenge={}&code_challenge_method=S256&redirect_uri={}",
-            CLIENT_ID,
-            challenge,
-            urlencoding::encode(&format!("http://localhost:{}/callback", port))
-        )
-    }
-
-    pub async fn request_device_code(&self) -> Result<DeviceCode> {
-        #[derive(Serialize)]
-        struct UserCodeReq<'a> {
-            client_id: &'a str,
-        }
-
-        #[derive(Deserialize)]
-        struct UserCodeResp {
-            device_auth_id: String,
-            #[serde(alias = "user_code", alias = "usercode")]
-            user_code: String,
-            #[serde(default, deserialize_with = "deserialize_interval_secs")]
-            interval: u64,
-        }
-
-        let url = format!("{ISSUER}/api/accounts/deviceauth/usercode");
-        let body = serde_json::to_string(&UserCodeReq {
-            client_id: CLIENT_ID,
-        })?;
-        let response = reqwest::Client::new()
-            .post(url)
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            return Err(anyhow!(
-                "device code request failed with status {}",
-                response.status()
-            ));
-        }
-
-        let payload: UserCodeResp = response.json().await?;
-        Ok(DeviceCode {
-            verification_url: format!("{ISSUER}/codex/device"),
-            user_code: payload.user_code,
-            device_auth_id: payload.device_auth_id,
-            interval_secs: payload.interval.max(1),
+    pub fn start_browser_login(&self, open_browser: bool) -> Result<BrowserLoginSession> {
+        let mut options = self.server_options(open_browser);
+        options.port = 0;
+        let session = codex_run_login_server(options)?;
+        Ok(BrowserLoginSession {
+            auth_url: session.auth_url.clone(),
+            inner: session,
         })
     }
 
-    pub async fn complete_device_code_login(&self, device_code: &DeviceCode) -> Result<OAuthToken> {
-        #[derive(Serialize)]
-        struct TokenPollReq<'a> {
-            device_auth_id: &'a str,
-            user_code: &'a str,
-        }
+    pub async fn request_device_code(&self) -> Result<DeviceCode> {
+        let options = self.server_options(false);
+        let code = codex_request_device_code(&options).await?;
+        Ok(DeviceCode {
+            verification_url: code.verification_url.clone(),
+            user_code: code.user_code.clone(),
+            inner: code,
+        })
+    }
 
-        #[derive(Deserialize)]
-        struct CodeSuccessResp {
-            authorization_code: String,
-            code_verifier: String,
-        }
+    pub async fn complete_device_code_login(&self, device_code: &DeviceCode) -> Result<SecretString> {
+        let options = self.server_options(false);
+        codex_complete_device_code_login(options, device_code.inner.clone()).await?;
+        self.load_saved_credential()
+    }
 
-        let client = reqwest::Client::new();
-        let poll_url = format!("{ISSUER}/api/accounts/deviceauth/token");
-        let started = std::time::Instant::now();
-        let response = loop {
-            if started.elapsed().as_secs() >= DEVICE_AUTH_MAX_WAIT_SECS {
-                return Err(anyhow!("device code login timed out after 15 minutes"));
-            }
+    pub fn save_api_key(&self, api_key: &str) -> Result<SecretString> {
+        codex_login_with_api_key(
+            &self.codex_home,
+            api_key,
+            AuthCredentialsStoreMode::File,
+        )?;
+        self.load_saved_credential()
+    }
 
-            let body = serde_json::to_string(&TokenPollReq {
-                device_auth_id: &device_code.device_auth_id,
-                user_code: &device_code.user_code,
-            })?;
-            let response = client
-                .post(&poll_url)
-                .header("Content-Type", "application/json")
-                .body(body)
-                .send()
-                .await?;
-
-            if response.status().is_success() {
-                let code_response: CodeSuccessResp = response.json().await?;
-                break code_response;
-            }
-
-            if response.status() == reqwest::StatusCode::FORBIDDEN
-                || response.status() == reqwest::StatusCode::NOT_FOUND
-            {
-                tokio::time::sleep(std::time::Duration::from_secs(device_code.interval_secs)).await;
-                continue;
-            }
-
-            return Err(anyhow!(
-                "device code poll failed with status {}",
-                response.status()
-            ));
-        };
-
-        let redirect_uri = format!("{ISSUER}/deviceauth/callback");
-        let params = [
-            ("grant_type", "authorization_code"),
-            ("code", response.authorization_code.as_str()),
-            ("client_id", CLIENT_ID),
-            ("code_verifier", response.code_verifier.as_str()),
-            ("redirect_uri", redirect_uri.as_str()),
-        ];
-        let token_url = format!("{ISSUER}/oauth/token");
-        let result = client.post(token_url).form(&params).send().await?;
-        if !result.status().is_success() {
-            return Err(anyhow!(
-                "device code exchange failed with status {}",
-                result.status()
-            ));
-        }
-        Ok(result.json().await?)
+    pub fn clear_saved_auth(&self) -> Result<bool> {
+        Ok(codex_logout(
+            &self.codex_home,
+            AuthCredentialsStoreMode::File,
+        )?)
     }
 
     pub fn read_api_key_from_stdin(&self) -> Result<SecretString> {
-        use std::io::IsTerminal;
-
-        let mut stdin = std::io::stdin();
-        if stdin.is_terminal() {
-            return Err(anyhow!("--with-api-key expects the API key on stdin"));
+        eprintln!("Paste the Codex API key, then press Ctrl-D:");
+        let mut input = String::new();
+        std::io::stdin().read_to_string(&mut input)?;
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(anyhow!("API key input was empty"));
         }
-
-        let mut buffer = String::new();
-        stdin.read_to_string(&mut buffer)?;
-        let api_key = buffer.trim();
-        if api_key.is_empty() {
-            return Err(anyhow!("no API key provided via stdin"));
-        }
-        Ok(SecretString::from(api_key.to_string()))
-    }
-}
-
-fn deserialize_interval_secs<'de, D>(deserializer: D) -> Result<u64, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum IntervalValue {
-        Number(u64),
-        String(String),
+        Ok(SecretString::from(trimmed.to_string()))
     }
 
-    match IntervalValue::deserialize(deserializer)? {
-        IntervalValue::Number(value) => Ok(value),
-        IntervalValue::String(value) => value
-            .trim()
-            .parse::<u64>()
-            .map_err(serde::de::Error::custom),
+    fn server_options(&self, open_browser: bool) -> ServerOptions {
+        let mut options = ServerOptions::new(
+            self.codex_home.clone(),
+            CLIENT_ID.to_string(),
+            None,
+            AuthCredentialsStoreMode::File,
+        );
+        options.issuer = ISSUER.to_string();
+        options.open_browser = open_browser;
+        options
+    }
+
+    fn load_saved_credential(&self) -> Result<SecretString> {
+        let auth = load_auth_dot_json(&self.codex_home, AuthCredentialsStoreMode::File)?
+            .ok_or_else(|| anyhow!("Codex login finished but no credential was saved"))?;
+        if let Some(api_key) = auth.openai_api_key {
+            return Ok(SecretString::from(api_key));
+        }
+        if let Some(tokens) = auth.tokens {
+            return Ok(SecretString::from(tokens.access_token));
+        }
+        Err(anyhow!(
+            "Codex login finished but auth storage did not contain an API key or access token"
+        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::OAuthManager;
+    use super::*;
+    use secrecy::ExposeSecret;
+    use std::path::Path;
     use tempfile::tempdir;
 
-    #[test]
-    fn authorize_url_uses_codex_issuer() {
+    #[tokio::test]
+    async fn browser_login_session_uses_codex_issuer_and_client_id() {
         let temp = tempdir().expect("tempdir");
-        let manager = OAuthManager {
-            config_dir: temp.path().join(".rara"),
-        };
-        let url = manager.get_authorize_url("challenge", 1455);
-        assert!(url.starts_with("https://auth.openai.com/oauth/authorize"));
-        assert!(url.contains("client_id=app_EMoamEEZ73f0CkXaXp7hrann"));
+        let manager =
+            OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
+        let session = manager
+            .start_browser_login(false)
+            .expect("browser login session");
+
+        assert!(session.auth_url().starts_with("https://auth.openai.com/oauth/authorize?"));
+        assert!(session.auth_url().contains(CLIENT_ID));
+        session.inner.cancel();
+    }
+
+    #[test]
+    fn save_api_key_persists_via_codex_auth_storage() {
+        let temp = tempdir().expect("tempdir");
+        let manager =
+            OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
+
+        let stored = manager
+            .save_api_key("sk-test-123")
+            .expect("save api key");
+
+        assert_eq!(stored.expose_secret(), "sk-test-123");
+
+        let auth = load_auth_dot_json(auth_path(&manager), AuthCredentialsStoreMode::File)
+            .expect("load auth")
+            .expect("auth file");
+        assert_eq!(auth.openai_api_key.as_deref(), Some("sk-test-123"));
+        assert!(auth.tokens.is_none());
+    }
+
+    #[test]
+    fn load_saved_credential_prefers_api_key_then_access_token() {
+        let temp = tempdir().expect("tempdir");
+        let manager =
+            OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
+
+        codex_login::save_auth(
+            auth_path(&manager),
+            &codex_login::AuthDotJson {
+                auth_mode: None,
+                openai_api_key: Some("sk-direct".into()),
+                tokens: Some(codex_login::TokenData {
+                    id_token: valid_id_token_info(),
+                    access_token: "access".into(),
+                    refresh_token: "refresh".into(),
+                    account_id: None,
+                }),
+                last_refresh: None,
+                agent_identity: None,
+            },
+            AuthCredentialsStoreMode::File,
+        )
+        .expect("save auth");
+
+        let saved = manager.load_saved_credential().expect("load api key");
+        assert_eq!(saved.expose_secret(), "sk-direct");
+
+        codex_login::save_auth(
+            auth_path(&manager),
+            &codex_login::AuthDotJson {
+                auth_mode: None,
+                openai_api_key: None,
+                tokens: Some(codex_login::TokenData {
+                    id_token: valid_id_token_info(),
+                    access_token: "access-only".into(),
+                    refresh_token: "refresh".into(),
+                    account_id: None,
+                }),
+                last_refresh: None,
+                agent_identity: None,
+            },
+            AuthCredentialsStoreMode::File,
+        )
+        .expect("save token auth");
+
+        let saved = manager.load_saved_credential().expect("load access token");
+        assert_eq!(saved.expose_secret(), "access-only");
+    }
+
+    #[test]
+    fn logout_clears_codex_auth_storage() {
+        let temp = tempdir().expect("tempdir");
+        let manager =
+            OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
+        manager.save_api_key("sk-test-logout").expect("save api key");
+
+        let removed = manager.clear_saved_auth().expect("clear auth");
+        assert!(removed);
+
+        let auth = load_auth_dot_json(auth_path(&manager), AuthCredentialsStoreMode::File)
+            .expect("load auth after logout");
+        assert!(auth.is_none());
+    }
+
+    fn auth_path(manager: &OAuthManager) -> &Path {
+        manager.codex_home.as_path()
+    }
+
+    fn valid_id_token_info() -> codex_login::token_data::IdTokenInfo {
+        codex_login::token_data::parse_chatgpt_jwt_claims("eyJhbGciOiJub25lIn0.e30.signature")
+            .expect("valid id token")
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -274,7 +274,7 @@ fn cleanup_stale_profiles(profile_dir: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::SandboxManager;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
     use tempfile::tempdir;
 
     #[test]
@@ -328,16 +328,11 @@ mod tests {
         let stale_profile = profile_dir.join("sandbox-stale.sb");
         std::fs::write(&stale_profile, "(version 1)").expect("stale profile");
 
-        let current_dir = std::env::current_dir().expect("cwd");
-        std::env::set_current_dir(tempdir.path()).expect("switch cwd");
-        let manager = SandboxManager::new().expect("sandbox manager");
-        std::env::set_current_dir(current_dir).expect("restore cwd");
+        let manager = SandboxManager::new_for_rara_dir(rara_dir.clone()).expect("sandbox manager");
 
         assert!(
-            manager
-                .profile_dir
-                .ends_with(Path::new(".rara").join("sandbox")),
-            "sandbox manager should point at the workspace-local sandbox dir"
+            manager.profile_dir == rara_dir.join("sandbox"),
+            "sandbox manager should point at the configured sandbox dir"
         );
         assert!(
             !stale_profile.exists(),

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -32,7 +32,8 @@ const LINUX_RUNTIME_READ_ROOTS: &[&str] = &[
 impl SandboxManager {
     pub fn new() -> Result<Self> {
         let os = std::env::consts::OS.to_string();
-        let rara_dir = std::env::current_dir()?.join(".rara");
+        let root = std::env::current_dir()?;
+        let rara_dir = rara_config::workspace_data_dir_for(&root)?;
         Self::new_with_rara_dir(os, rara_dir)
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,7 +10,12 @@ pub struct SessionManager {
 
 impl SessionManager {
     pub fn new() -> Result<Self> {
-        let rara_dir = std::env::current_dir()?.join(".rara");
+        let root = std::env::current_dir()?;
+        let rara_dir = rara_config::workspace_data_dir_for(&root)?;
+        Self::new_for_rara_dir(rara_dir)
+    }
+
+    pub fn new_for_rara_dir(rara_dir: PathBuf) -> Result<Self> {
         let local_dir = rara_dir.join("rollouts");
         let legacy_storage_dir = rara_dir.join("sessions");
         if !local_dir.exists() {

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -70,7 +70,12 @@ pub struct StateDb {
 
 impl StateDb {
     pub fn new() -> Result<Self> {
-        let root_dir = std::env::current_dir()?.join(".rara");
+        let root = std::env::current_dir()?;
+        let root_dir = rara_config::workspace_data_dir_for(&root)?;
+        Self::new_for_root_dir(root_dir)
+    }
+
+    pub fn new_for_root_dir(root_dir: PathBuf) -> Result<Self> {
         if !root_dir.exists() {
             fs::create_dir_all(&root_dir)?;
         }
@@ -637,8 +642,7 @@ mod tests {
     #[test]
     fn persists_metadata_and_rollout_artifact() -> Result<()> {
         let temp = tempdir()?;
-        std::env::set_current_dir(temp.path())?;
-        let db = StateDb::new()?;
+        let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;
         db.upsert_session(
             "session-1",
             "/tmp/workspace",
@@ -724,8 +728,7 @@ mod tests {
     #[test]
     fn persists_interaction_payloads_for_restore() -> Result<()> {
         let temp = tempdir()?;
-        std::env::set_current_dir(temp.path())?;
-        let db = StateDb::new()?;
+        let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;
         db.upsert_session(
             "session-2",
             "/tmp/workspace",
@@ -776,8 +779,7 @@ mod tests {
     #[test]
     fn persists_structured_approval_payloads_for_restore() -> Result<()> {
         let temp = tempdir()?;
-        std::env::set_current_dir(temp.path())?;
-        let db = StateDb::new()?;
+        let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;
         db.upsert_session(
             "session-structured",
             "/tmp/workspace",
@@ -850,8 +852,7 @@ mod tests {
     #[test]
     fn persists_compact_state_for_restore() -> Result<()> {
         let temp = tempdir()?;
-        std::env::set_current_dir(temp.path())?;
-        let db = StateDb::new()?;
+        let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;
         db.upsert_session(
             "session-compact",
             "/tmp/workspace",

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::Result;
 use serde_json::{json, Value};
@@ -506,8 +506,9 @@ fn truncate_text(text: &str, max_chars: usize) -> String {
     collected
 }
 
-pub fn default_tool_result_store_dir() -> PathBuf {
-    Path::new(".rara").join("tool-results")
+pub fn default_tool_result_store_dir() -> Result<PathBuf> {
+    let root = std::env::current_dir()?;
+    Ok(rara_config::workspace_data_dir_for(&root)?.join("tool-results"))
 }
 
 #[cfg(test)]
@@ -518,7 +519,6 @@ mod tests {
     };
     use crate::agent::Message;
     use serde_json::json;
-    use std::path::Path;
 
     #[test]
     fn repairs_missing_tool_results() {
@@ -563,9 +563,8 @@ mod tests {
         assert!(output.contains("full_result_path="));
         assert!(output.contains("Fetched https://example.com"));
         assert!(tempdir.path().join("tool-1.json").exists());
-        assert_eq!(
-            default_tool_result_store_dir(),
-            Path::new(".rara").join("tool-results")
-        );
+        assert!(default_tool_result_store_dir()
+            .expect("default tool result dir")
+            .ends_with(std::path::Path::new("tool-results")));
     }
 }

--- a/src/tui/auth_mode_picker.rs
+++ b/src/tui/auth_mode_picker.rs
@@ -59,3 +59,49 @@ pub(crate) fn build_auth_mode_picker_view(app: &TuiApp, ssh_session: bool) -> Au
         footer,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+    use tempfile::tempdir;
+
+    use crate::config::ConfigManager;
+    use crate::tui::state::TuiApp;
+
+    use super::build_auth_mode_picker_view;
+
+    #[test]
+    fn auth_mode_picker_local_snapshot() {
+        let temp = tempdir().expect("tempdir");
+        let app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+
+        let popup = render_picker(&app, false);
+        assert_snapshot!("auth_mode_picker_local", popup);
+    }
+
+    #[test]
+    fn auth_mode_picker_ssh_snapshot() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.auth_mode_idx = 1;
+
+        let popup = render_picker(&app, true);
+        assert_snapshot!("auth_mode_picker_ssh", popup);
+    }
+
+    fn render_picker(app: &TuiApp, ssh_session: bool) -> String {
+        let view = build_auth_mode_picker_view(app, ssh_session);
+        format!(
+            "{}\n\n{}\n\n{}",
+            view.intro,
+            view.lines.join("\n"),
+            view.footer
+        )
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -448,11 +448,7 @@ async fn dispatch_event(
         }
         AppEvent::SaveBaseUrlInput => {
             let value = app.base_url_input.trim();
-            app.config.base_url = if value.is_empty() {
-                None
-            } else {
-                Some(value.to_string())
-            };
+            app.config.set_base_url((!value.is_empty()).then(|| value.to_string()));
             app.config_manager.save(&app.config)?;
             app.notice = Some(format!(
                 "Saved base URL: {}",
@@ -467,10 +463,10 @@ async fn dispatch_event(
             } else if app.is_busy() {
                 app.push_notice("Wait for the current task before saving the API key.");
             } else {
+                app.config.set_provider("codex");
                 app.config.set_api_key(value.to_string());
-                app.config.provider = "codex".into();
                 if app.config.model.is_none() {
-                    app.config.model = Some("codex".into());
+                    app.config.set_model(Some("codex".into()));
                 }
                 app.config_manager.save(&app.config)?;
                 app.notice = Some("Saved Codex API key. Rebuilding backend.".into());
@@ -513,11 +509,8 @@ async fn dispatch_event(
             }
             Some(Overlay::BaseUrlEditor) => {
                 let value = app.base_url_input.trim();
-                app.config.base_url = if value.is_empty() {
-                    None
-                } else {
-                    Some(value.to_string())
-                };
+                app.config
+                    .set_base_url((!value.is_empty()).then(|| value.to_string()));
                 app.config_manager.save(&app.config)?;
                 app.notice = Some(format!(
                     "Saved base URL: {}",
@@ -574,10 +567,14 @@ async fn dispatch_event(
                     if app.is_busy() {
                         app.push_notice("A task is already running. Wait for it to finish.");
                     } else {
-                        let _ = oauth_manager.clear_saved_auth();
-                        app.config.clear_api_key();
+                        let removed = oauth_manager.clear_saved_auth()?;
+                        app.config.clear_provider_api_key("codex");
                         app.config_manager.save(&app.config)?;
-                        app.notice = Some("Cleared the saved provider credential.".into());
+                        app.notice = Some(if removed {
+                            "Cleared the saved provider credential.".into()
+                        } else {
+                            "No saved provider credential was present.".into()
+                        });
                         if app.config.provider == "codex" {
                             start_rebuild_task(app);
                         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -574,6 +574,7 @@ async fn dispatch_event(
                     if app.is_busy() {
                         app.push_notice("A task is already running. Wait for it to finish.");
                     } else {
+                        let _ = oauth_manager.clear_saved_auth();
                         app.config.clear_api_key();
                         app.config_manager.save(&app.config)?;
                         app.notice = Some("Cleared the saved provider credential.".into());
@@ -873,9 +874,10 @@ mod tests {
         });
 
         let mut agent_slot = None;
-        let oauth_manager = Arc::new(crate::oauth::OAuthManager {
-            config_dir: temp.path().join(".rara"),
-        });
+        let oauth_manager = Arc::new(
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager"),
+        );
         let should_quit = super::handle_submit(&mut app, &mut agent_slot, &oauth_manager)
             .await
             .expect("submit");

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -426,6 +426,7 @@ fn wrapped_text_cursor_position(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use tempfile::tempdir;
 
     use crate::config::ConfigManager;
@@ -522,6 +523,28 @@ mod tests {
         assert!(rendered.contains("Queued follow-up messages"));
         assert!(rendered.contains("first follow-up"));
         assert!(rendered.contains("second follow-up"));
+    }
+
+    #[test]
+    fn queued_follow_up_preview_snapshot() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.begin_running_turn();
+        app.queue_follow_up_message_after_next_tool_boundary(
+            "apply the feedback to the auth picker and rerun focused tests",
+        );
+        app.queue_follow_up_message("then summarize the remaining TODOs");
+
+        let rendered = queued_follow_up_preview_lines(&app)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_snapshot!("queued_follow_up_preview", rendered);
     }
 
     #[test]

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -1055,6 +1055,7 @@ mod tests {
     use crate::tui::state::{
         RuntimePhase, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp,
     };
+    use insta::assert_snapshot;
     use tempfile::tempdir;
 
     use super::{ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell};
@@ -1255,6 +1256,45 @@ mod tests {
         assert!(rendered.contains("Read src/tools/vector.rs"));
         assert!(rendered.contains("I have inspected the repository structure."));
         assert!(rendered.contains("waiting for model response · 20s elapsed"));
+    }
+
+    #[test]
+    fn active_turn_cell_updated_plan_snapshot() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.runtime_phase = RuntimePhase::ProcessingResponse;
+        app.runtime_phase_detail = Some("waiting for model response · 3s elapsed".into());
+        app.active_turn = TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "You".into(),
+                message: "Read the local codebase and propose the next refactor".into(),
+            }],
+        };
+        app.record_planning_note("The auth flow should reuse codex_login instead of mirroring it.");
+        app.record_exploration_action("Read src/oauth.rs");
+        app.snapshot = RuntimeSnapshot {
+            plan_steps: vec![
+                ("completed".into(), "Inspect the current auth bridge".into()),
+                ("in_progress".into(), "Replace the bespoke OAuth flow".into()),
+                ("pending".into(), "Add snapshot tests for the auth picker".into()),
+            ],
+            plan_explanation: Some(
+                "Prefer direct Codex auth reuse before extending more TUI flows.".into(),
+            ),
+            ..RuntimeSnapshot::default()
+        };
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_snapshot!("active_turn_cell_updated_plan", rendered);
     }
 
     #[test]

--- a/src/tui/render/snapshots/rara__tui__render__bottom_pane__tests__queued_follow_up_preview.snap
+++ b/src/tui/render/snapshots/rara__tui__render__bottom_pane__tests__queued_follow_up_preview.snap
@@ -1,0 +1,9 @@
+---
+source: src/tui/render/bottom_pane.rs
+expression: rendered
+---
+› Messages to be submitted after next tool call
+  apply the feedback to the auth picker and rerun focused tests
+
+› Queued follow-up messages
+  then summarize the remaining TODOs

--- a/src/tui/render/snapshots/rara__tui__render__cells__tests__active_turn_cell_updated_plan.snap
+++ b/src/tui/render/snapshots/rara__tui__render__cells__tests__active_turn_cell_updated_plan.snap
@@ -1,0 +1,22 @@
+---
+source: src/tui/render/cells.rs
+expression: rendered
+---
+You: Read the local codebase and propose the next refactor
+
+ Exploring 
+  └ Read src/oauth.rs
+  └ waiting for model response · 3s elapsed
+
+ Planning 
+  └ The auth flow should reuse codex_login instead of mirroring it.
+  └ waiting for model response · 3s elapsed
+
+• Updated Plan
+  └ Prefer direct Codex auth reuse before extending more TUI flows.
+    ✔ Inspect the current auth bridge
+    □ Replace the bespoke OAuth flow
+    □ Add snapshot tests for the auth picker
+
+ Working 
+  waiting for model response · 3s elapsed

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -10,7 +10,7 @@ pub(super) async fn execute_local_command(
     command: LocalCommand,
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
-    _oauth_manager: &Arc<OAuthManager>,
+    oauth_manager: &Arc<OAuthManager>,
 ) -> anyhow::Result<bool> {
     app.remember_command(match command.kind {
         LocalCommandKind::Help => "help",
@@ -109,6 +109,7 @@ pub(super) async fn execute_local_command(
             if app.is_busy() {
                 app.push_notice("A task is already running. Wait for it to finish.");
             } else {
+                let _ = oauth_manager.clear_saved_auth();
                 app.config.clear_api_key();
                 app.config_manager.save(&app.config)?;
                 app.push_notice("Cleared the saved provider credential.");

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -109,10 +109,14 @@ pub(super) async fn execute_local_command(
             if app.is_busy() {
                 app.push_notice("A task is already running. Wait for it to finish.");
             } else {
-                let _ = oauth_manager.clear_saved_auth();
-                app.config.clear_api_key();
+                let removed = oauth_manager.clear_saved_auth()?;
+                app.config.clear_provider_api_key("codex");
                 app.config_manager.save(&app.config)?;
-                app.push_notice("Cleared the saved provider credential.");
+                app.push_notice(if removed {
+                    "Cleared the saved provider credential.".to_string()
+                } else {
+                    "No saved provider credential was present.".to_string()
+                });
                 if app.config.provider == "codex" {
                     start_rebuild_task(app);
                 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -336,6 +336,21 @@ pub(super) fn start_oauth_task(
     oauth_manager: Arc<OAuthManager>,
     mode: OAuthLoginMode,
 ) {
+    if matches!(mode, OAuthLoginMode::Browser) && super::super::is_ssh_session() {
+        app.set_runtime_phase(
+            RuntimePhase::Failed,
+            Some("browser oauth unavailable in ssh".into()),
+        );
+        app.push_notice(
+            "Browser login is unavailable in SSH/headless sessions. Choose device code or API key instead.",
+        );
+        app.push_entry(
+            "Runtime",
+            "Browser login is unavailable in SSH/headless sessions. Use device-code login or API key instead.",
+        );
+        return;
+    }
+
     let (sender, receiver) = mpsc::unbounded_channel();
     let mode_label = match mode {
         OAuthLoginMode::Browser => "browser login",
@@ -545,11 +560,11 @@ pub(super) async fn finish_running_task_if_ready(
         },
         TaskCompletion::OAuth { mode, result } => match result {
             Ok(credential) => {
+                app.config.set_provider("codex");
                 app.config
                     .set_api_key(credential.expose_secret().to_string());
-                app.config.provider = "codex".into();
                 if app.config.model.is_none() {
-                    app.config.model = Some("codex".into());
+                    app.config.set_model(Some("codex".into()));
                 }
                 app.config_manager.save(&app.config)?;
                 let saved_message = match mode {
@@ -616,27 +631,24 @@ async fn run_oauth_login(
     match mode {
         OAuthLoginMode::Browser => {
             let is_ssh = super::super::is_ssh_session();
-            let session = oauth_manager.start_browser_login(true)?;
-            let _ = sender.send(TuiEvent::Transcript {
-                role: "Runtime",
-                message: if is_ssh {
-                    format!(
-                        "SSH session detected. Browser login is not reliable from a remote shell because the callback listens on localhost.\nUse device-code login or API key instead, or open this URL from the same machine running the TUI:\n{}",
-                        session.auth_url()
-                    )
-                } else {
-                    format!(
-                        "Starting Codex browser login.\nOpen this URL if the browser does not launch automatically:\n{auth_url}"
-                        ,
-                        auth_url = session.auth_url()
-                    )
-                },
-            });
             if is_ssh {
+                let _ = sender.send(TuiEvent::Transcript {
+                    role: "Runtime",
+                    message: "SSH session detected. Browser login is unavailable because the callback listens on localhost.\nUse device-code login or API key instead."
+                        .into(),
+                });
                 return Err(anyhow!(
                     "browser login is unavailable in SSH/headless sessions; use device-code login or API key instead"
                 ));
             }
+            let session = oauth_manager.start_browser_login(true)?;
+            let _ = sender.send(TuiEvent::Transcript {
+                role: "Runtime",
+                message: format!(
+                    "Starting Codex browser login.\nOpen this URL if the browser does not launch automatically:\n{auth_url}",
+                    auth_url = session.auth_url()
+                ),
+            });
             let _ = sender.send(TuiEvent::Transcript {
                 role: "Runtime",
                 message: "Waiting for browser callback.".into(),
@@ -768,7 +780,10 @@ mod tests {
     use crate::tui::state::TuiApp;
     use tempfile::tempdir;
 
-    use super::should_suggest_planning_mode;
+    use super::{should_suggest_planning_mode, start_oauth_task};
+    use crate::oauth::OAuthManager;
+    use crate::tui::state::OAuthLoginMode;
+    use std::sync::Arc;
 
     #[test]
     fn suggests_planning_for_repo_review_requests() {
@@ -802,5 +817,34 @@ mod tests {
             &app,
             "What does this function do?"
         ));
+    }
+
+    #[test]
+    fn browser_oauth_is_rejected_before_task_start_in_ssh() {
+        let temp = tempdir().unwrap();
+        let old_ssh = std::env::var_os("SSH_CONNECTION");
+        std::env::set_var("SSH_CONNECTION", "test");
+
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        let oauth_manager = Arc::new(
+            OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager"),
+        );
+
+        start_oauth_task(&mut app, oauth_manager, OAuthLoginMode::Browser);
+
+        assert!(app.running_task.is_none());
+        assert!(app
+            .notice
+            .as_deref()
+            .is_some_and(|value| value.contains("Browser login is unavailable")));
+
+        if let Some(value) = old_ssh {
+            std::env::set_var("SSH_CONNECTION", value);
+        } else {
+            std::env::remove_var("SSH_CONNECTION");
+        }
     }
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -544,17 +544,21 @@ pub(super) async fn finish_running_task_if_ready(
             }
         },
         TaskCompletion::OAuth { mode, result } => match result {
-            Ok(access_token) => {
+            Ok(credential) => {
                 app.config
-                    .set_api_key(access_token.expose_secret().to_string());
+                    .set_api_key(credential.expose_secret().to_string());
                 app.config.provider = "codex".into();
                 if app.config.model.is_none() {
                     app.config.model = Some("codex".into());
                 }
                 app.config_manager.save(&app.config)?;
                 let saved_message = match mode {
-                    OAuthLoginMode::Browser => "Saved browser login token to local config.",
-                    OAuthLoginMode::DeviceCode => "Saved device-code login token to local config.",
+                    OAuthLoginMode::Browser => {
+                        "Saved Codex browser login credential to local config."
+                    }
+                    OAuthLoginMode::DeviceCode => {
+                        "Saved Codex device-code login credential to local config."
+                    }
                 };
                 app.setup_status = Some(saved_message.into());
                 app.notice = app.setup_status.clone();
@@ -611,19 +615,20 @@ async fn run_oauth_login(
 ) -> anyhow::Result<SecretString> {
     match mode {
         OAuthLoginMode::Browser => {
-            let (verifier, challenge) = oauth_manager.generate_pkce();
-            let (port, receiver) = oauth_manager.start_callback_server().await?;
-            let auth_url = oauth_manager.get_authorize_url(&challenge, port);
             let is_ssh = super::super::is_ssh_session();
+            let session = oauth_manager.start_browser_login(true)?;
             let _ = sender.send(TuiEvent::Transcript {
                 role: "Runtime",
                 message: if is_ssh {
                     format!(
-                        "SSH session detected. Browser login is not reliable from a remote shell because the callback listens on localhost:{port}.\nUse device-code login or API key instead, or open this URL from the same machine running the TUI:\n{auth_url}"
+                        "SSH session detected. Browser login is not reliable from a remote shell because the callback listens on localhost.\nUse device-code login or API key instead, or open this URL from the same machine running the TUI:\n{}",
+                        session.auth_url()
                     )
                 } else {
                     format!(
                         "Starting Codex browser login.\nOpen this URL if the browser does not launch automatically:\n{auth_url}"
+                        ,
+                        auth_url = session.auth_url()
                     )
                 },
             });
@@ -632,19 +637,15 @@ async fn run_oauth_login(
                     "browser login is unavailable in SSH/headless sessions; use device-code login or API key instead"
                 ));
             }
-            let _ = open::that(&auth_url);
-
             let _ = sender.send(TuiEvent::Transcript {
                 role: "Runtime",
                 message: "Waiting for browser callback.".into(),
             });
-            let code = receiver.await?;
             let _ = sender.send(TuiEvent::Transcript {
                 role: "Runtime",
                 message: "Received browser callback, exchanging token.".into(),
             });
-            let token = oauth_manager.exchange_code(&code, &verifier, port).await?;
-            Ok(token.access_token)
+            session.complete(&oauth_manager).await
         }
         OAuthLoginMode::DeviceCode => {
             let device_code = oauth_manager.request_device_code().await?;
@@ -655,10 +656,7 @@ async fn run_oauth_login(
                     device_code.verification_url, device_code.user_code
                 ),
             });
-            let token = oauth_manager
-                .complete_device_code_login(&device_code)
-                .await?;
-            Ok(token.access_token)
+            oauth_manager.complete_device_code_login(&device_code).await
         }
     }
 }

--- a/src/tui/snapshots/rara__tui__auth_mode_picker__tests__auth_mode_picker_local.snap
+++ b/src/tui/snapshots/rara__tui__auth_mode_picker__tests__auth_mode_picker_local.snap
@@ -1,0 +1,22 @@
+---
+source: src/tui/auth_mode_picker.rs
+expression: popup
+---
+Codex needs authentication before this preset can be used.
+
+Choose one auth mode below.
+
+Current model: -
+Provider: codex
+Credential status: not-required
+
+> Browser login
+    Best for local desktop sessions with a localhost callback.
+  Device code
+    Best for SSH/headless sessions. Open the URL elsewhere and enter the one-time code.
+  API key
+    Paste an existing Codex-compatible API key and save it locally.
+  Logout
+    Clear the saved provider credential and rebuild the current codex backend.
+
+Up/Down move  Enter choose  number keys jump  default: browser login  Esc back

--- a/src/tui/snapshots/rara__tui__auth_mode_picker__tests__auth_mode_picker_ssh.snap
+++ b/src/tui/snapshots/rara__tui__auth_mode_picker__tests__auth_mode_picker_ssh.snap
@@ -1,0 +1,24 @@
+---
+source: src/tui/auth_mode_picker.rs
+expression: popup
+---
+Codex needs authentication before this preset can be used.
+
+Choose one auth mode below.
+
+SSH session detected. Browser login on a remote shell usually cannot complete the localhost callback. Device-code login or API key is recommended in SSH/headless sessions.
+
+Current model: -
+Provider: codex
+Credential status: not-required
+
+  Browser login
+    Best for local desktop sessions with a localhost callback.
+> Device code
+    Best for SSH/headless sessions. Open the URL elsewhere and enter the one-time code.
+  API key
+    Paste an existing Codex-compatible API key and save it locally.
+  Logout
+    Clear the saved provider credential and rebuild the current codex backend.
+
+Up/Down move  Enter choose  number keys jump  default: device code  Esc back

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -486,10 +486,10 @@ impl TuiApp {
         let presets = current_model_presets(self.provider_picker_idx);
         let (_, provider, model) = presets[idx];
         self.model_picker_idx = idx;
-        self.config.provider = provider.to_string();
-        self.config.model = Some(model.to_string());
+        self.config.set_provider(provider.to_string());
+        self.config.set_model(Some(model.to_string()));
         if provider == "ollama" {
-            self.config.revision = None;
+            self.config.set_revision(None);
             if self
                 .config
                 .base_url
@@ -498,10 +498,11 @@ impl TuiApp {
                 .filter(|value| !value.is_empty())
                 .is_none()
             {
-                self.config.base_url = Some("http://localhost:11434".to_string());
+                self.config
+                    .set_base_url(Some("http://localhost:11434".to_string()));
             }
         } else if provider == "codex" {
-            self.config.revision = None;
+            self.config.set_revision(None);
             if self
                 .config
                 .base_url
@@ -510,11 +511,12 @@ impl TuiApp {
                 .filter(|value| !value.is_empty())
                 .is_none()
             {
-                self.config.base_url = Some("http://localhost:8080".to_string());
+                self.config
+                    .set_base_url(Some("http://localhost:8080".to_string()));
             }
         } else {
-            self.config.revision = Some("main".to_string());
-            self.config.base_url = None;
+            self.config.set_revision(Some("main".to_string()));
+            self.config.set_base_url(None);
         }
     }
 


### PR DESCRIPTION
## Summary

- replace the bespoke Codex auth mirror with a thin `codex_login` bridge
- route CLI and TUI browser/device-code/API-key/logout flows through the same auth path
- add focused auth regression tests and initial Codex-style TUI snapshot coverage

## Testing

- cargo check
- cargo test oauth::tests -- --nocapture
- cargo test tui::tests::auth_mode_picker_prefers_selection_navigation -- --nocapture
- env INSTA_UPDATE=always cargo test auth_mode_picker_local_snapshot -- --nocapture
- env INSTA_UPDATE=always cargo test auth_mode_picker_ssh_snapshot -- --nocapture
- env INSTA_UPDATE=always cargo test queued_follow_up_preview_snapshot -- --nocapture
- env INSTA_UPDATE=always cargo test active_turn_cell_updated_plan_snapshot -- --nocapture

## Notes

- keeps `codex/` as a local reference directory only; it is not part of this PR
- updates the Codex auth feature spec, journal, and remaining TODO wording to reflect the new baseline
