### PR TITLE
fix(auth): improve Codex device-code login TUI flow

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -44,7 +44,10 @@ use self::runtime::{
 use self::session_restore::{
     provider_requires_api_key, restore_latest_session, restore_session_by_id,
 };
-use self::state::{current_model_presets, HelpTab, Overlay, TaskKind, TuiApp, PROVIDER_FAMILIES};
+use self::state::{
+    current_model_presets, HelpTab, LocalCommandKind, Overlay, TaskKind, TuiApp,
+    PROVIDER_FAMILIES,
+};
 use self::terminal_ui::{
     build_terminal, flush_committed_history, handle_paste, is_ssh_session, teardown_terminal,
     update_terminal_viewport,
@@ -98,6 +101,9 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
                     Some(Ok(event)) => match translate_event(event, &app) {
                         Some(UiEvent::App(event)) => {
                             if dispatch_event(event, &mut app, &mut agent_slot, &oauth_manager).await? {
+                                if let Some(task) = app.running_task.take() {
+                                    task.handle.abort();
+                                }
                                 break Ok(());
                             }
                         }
@@ -544,6 +550,7 @@ async fn dispatch_event(
                     } else if is_ssh_session() {
                         app.push_notice("Browser login is unavailable in SSH/headless sessions. Choose device code or API key instead.");
                     } else {
+                        app.close_overlay();
                         start_oauth_task(
                             app,
                             Arc::clone(oauth_manager),
@@ -555,6 +562,7 @@ async fn dispatch_event(
                     if app.is_busy() {
                         app.push_notice("A task is already running. Wait for it to finish.");
                     } else {
+                        app.close_overlay();
                         start_oauth_task(
                             app,
                             Arc::clone(oauth_manager),
@@ -611,6 +619,11 @@ async fn handle_submit(
             return Ok(false);
         }
         if trimmed.starts_with('/') {
+            if let Some(command) = parse_local_command(trimmed) {
+                if matches!(command.kind, LocalCommandKind::Quit) {
+                    return execute_local_command(command, app, agent_slot, oauth_manager).await;
+                }
+            }
             app.push_notice(
                 "A task is already running. Wait for it to finish before running a slash command.",
             );
@@ -889,6 +902,43 @@ mod tests {
             .as_deref()
             .is_some_and(|value| value.contains("Queued for after the next tool call boundary")));
         assert_eq!(app.pending_follow_up_preview(), Some("continue with the follow-up"));
+
+        if let Some(task) = app.running_task.take() {
+            task.handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn busy_submit_allows_quit_command() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.input = "/quit".into();
+
+        let (_sender, receiver) = mpsc::unbounded_channel();
+        app.running_task = Some(RunningTask {
+            kind: TaskKind::OAuth,
+            receiver,
+            handle: tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                unreachable!()
+            }),
+            started_at: Instant::now(),
+            next_heartbeat_after_secs: u64::MAX,
+        });
+
+        let mut agent_slot = None;
+        let oauth_manager = Arc::new(
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager"),
+        );
+        let should_quit = super::handle_submit(&mut app, &mut agent_slot, &oauth_manager)
+            .await
+            .expect("submit");
+
+        assert!(should_quit);
 
         if let Some(task) = app.running_task.take() {
             task.handle.abort();

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -126,9 +126,14 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
             } else if role == "Runtime" {
                 let detail = message.lines().next().unwrap_or(role).trim().to_string();
                 let lower = detail.to_ascii_lowercase();
-                if lower.contains("device-code login")
+                if lower.contains("waiting for device-code confirmation")
+                    || lower.contains("polling device code")
+                {
+                    app.set_runtime_phase(RuntimePhase::OAuthPollingDeviceCode, Some(detail));
+                } else if lower.contains("device-code login")
                     || lower.contains("one-time code")
                     || lower.contains("open this url in a browser")
+                    || lower.starts_with("code:")
                 {
                     app.set_runtime_phase(RuntimePhase::OAuthDeviceCodePrompt, Some(detail));
                 } else if lower.contains("waiting for browser callback") {
@@ -928,12 +933,15 @@ use crate::redaction::redact_secrets;
 #[cfg(test)]
 mod tests {
     use super::{
-        format_apply_patch_result, format_apply_patch_use, format_tool_progress,
+        apply_tui_event, format_apply_patch_result, format_apply_patch_use, format_tool_progress,
         format_tool_result, limit_tool_progress_entry, planning_note_lines,
         subagent_request_input,
     };
+    use crate::config::ConfigManager;
     use crate::tool::ToolOutputStream;
+    use crate::tui::state::{RuntimePhase, TuiApp, TuiEvent};
     use serde_json::json;
+    use tempfile::tempdir;
 
     #[test]
     fn parses_delegated_request_input_from_subagent_result() {
@@ -1045,5 +1053,32 @@ mod tests {
         assert!(message.contains("... live output truncated ..."));
         assert!(!message.lines().any(|line| line == "line 1"));
         assert!(message.contains("line 20"));
+    }
+
+    #[test]
+    fn runtime_device_code_messages_update_prompt_and_polling_phases() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+
+        apply_tui_event(
+            &mut app,
+            TuiEvent::Transcript {
+                role: "Runtime",
+                message: "Open this URL in a browser and enter the one-time code:\nhttps://example.test\n\nCode: ABCD".into(),
+            },
+        );
+        assert_eq!(app.runtime_phase, RuntimePhase::OAuthDeviceCodePrompt);
+
+        apply_tui_event(
+            &mut app,
+            TuiEvent::Transcript {
+                role: "Runtime",
+                message: "Waiting for device-code confirmation.".into(),
+            },
+        );
+        assert_eq!(app.runtime_phase, RuntimePhase::OAuthPollingDeviceCode);
     }
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -660,13 +660,21 @@ async fn run_oauth_login(
             session.complete(&oauth_manager).await
         }
         OAuthLoginMode::DeviceCode => {
+            let _ = sender.send(TuiEvent::Transcript {
+                role: "Runtime",
+                message: "Requesting Codex device code from OpenAI.".into(),
+            });
             let device_code = oauth_manager.request_device_code().await?;
             let _ = sender.send(TuiEvent::Transcript {
                 role: "Runtime",
                 message: format!(
-                    "Starting Codex device-code login.\nOpen this URL in a browser and enter the one-time code:\n{}\n\nCode: {}",
+                    "Open this URL in a browser and enter the one-time code:\n{}\n\nCode: {}",
                     device_code.verification_url, device_code.user_code
                 ),
+            });
+            let _ = sender.send(TuiEvent::Transcript {
+                role: "Runtime",
+                message: "Waiting for device-code confirmation.".into(),
             });
             oauth_manager.complete_device_code_login(&device_code).await
         }


### PR DESCRIPTION
## Summary

This PR isolates the Codex login TUI fixes into a standalone change.

It fixes three concrete problems in the Codex auth flow:

- close the auth-mode picker before starting browser or device-code login so runtime transcript updates are visible immediately
- split device-code login into clearer runtime stages: requesting device code, showing the verification URL and one-time code, then waiting for confirmation
- allow `/quit` while an OAuth task is running and abort the active task before leaving the TUI

## Why

In the previous behavior, device-code login could look stalled because the picker overlay stayed open and the runtime status never advanced beyond the initial start message.

There was also no practical way to exit once an OAuth task was in progress because busy-mode slash-command handling blocked `/quit`.

## Testing

- `cargo test busy_submit_allows_quit_command -- --nocapture`
- `cargo test runtime_device_code_messages_update_prompt_and_polling_phases -- --nocapture`
- `cargo check`
