### PR TITLE
fix(tui): tighten plan transcript and approval cards

### DIFF
--- a/docs/features/planning-mode.md
+++ b/docs/features/planning-mode.md
@@ -46,6 +46,8 @@ When planning mode needs to continue, runtime records a structured continuation 
 - planning mode should render as a dedicated planning workflow, not as ordinary execution with extra chatter;
 - non-structured planning narration should be folded into planning/exploration sidecars instead of rendering as a separate responding block;
 - structured plans should render as an `Updated Plan` checklist object with a separate note/explanation and stable step status markers;
+- runtime heartbeat text such as `waiting for model response` or elapsed-time notices should stay in the activity/status surfaces instead of being repeated inside planning, exploration, or updated-plan transcript cells;
+- when execution resumes from an approved plan, only the currently active plan step may be auto-completed at successful turn end; pending later steps must not be marked complete optimistically;
 - pending plan approval and planning questions should appear as interaction cards;
 - status panels, overlays, and transcript cells should reuse the same plan formatting instead of diverging into separate text-only summaries;
 - approval or answers should resume the same workflow rather than starting a brand-new free-form chat turn.

--- a/docs/journal/2026-04-19-planning-mode-contract.md
+++ b/docs/journal/2026-04-19-planning-mode-contract.md
@@ -35,3 +35,6 @@ That behavior was weaker than both Claude Code plan mode and Codex collaboration
 - added focused tests for planning-sidecar rendering and chatter filtering.
 - moved plan rendering onto a dedicated `Updated Plan` formatter so transcript cells, status panels, and overlays now show the same checklist-style plan object instead of separate `steps:/note:` text blocks;
 - reduced bottom-pane noise so planning and pending-interaction states behave more like Codex's single-status source instead of duplicating transcript information.
+- stopped injecting runtime heartbeat text into planning/exploration/running transcript sidecars once those sections already exist; heartbeat now stays in the activity/status area instead of showing up as fake plan content.
+- stopped rehydrating stale completed plan/question/approval interactions from snapshot state into each new active turn; only explicit transcript completion entries now render as completion cards.
+- tightened execute-mode plan progression so successful turn completion only closes the active in-progress step rather than pessimistically marking every remaining pending step as completed.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -440,7 +440,7 @@ impl Agent {
                     ));
                     continue;
                 }
-                self.complete_remaining_plan_steps();
+                self.complete_active_plan_step();
                 break;
             }
             *tool_rounds += 1;

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -518,16 +518,18 @@ impl Agent {
         }
     }
 
-    pub(super) fn complete_remaining_plan_steps(&mut self) {
+    pub(super) fn complete_active_plan_step(&mut self) {
         if !matches!(self.execution_mode, AgentExecutionMode::Execute)
             || self.current_plan.is_empty()
         {
             return;
         }
-        for step in &mut self.current_plan {
-            if !matches!(step.status, PlanStepStatus::Completed) {
-                step.status = PlanStepStatus::Completed;
-            }
+        if let Some(step) = self
+            .current_plan
+            .iter_mut()
+            .find(|step| matches!(step.status, PlanStepStatus::InProgress))
+        {
+            step.status = PlanStepStatus::Completed;
         }
     }
 

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -847,7 +847,7 @@ fn advances_plan_steps_during_execute_mode() {
 }
 
 #[test]
-fn completes_remaining_plan_steps_on_finish() {
+fn completes_only_active_plan_step_on_finish() {
     let mut agent = Agent::new(
         ToolManager::new(),
         Arc::new(SequencedBackend::new(Vec::new())),
@@ -871,12 +871,11 @@ fn completes_remaining_plan_steps_on_finish() {
         },
     ];
 
-    agent.complete_remaining_plan_steps();
+    agent.complete_active_plan_step();
 
-    assert!(agent
-        .current_plan
-        .iter()
-        .all(|step| step.status == PlanStepStatus::Completed));
+    assert_eq!(agent.current_plan[0].status, PlanStepStatus::Completed);
+    assert_eq!(agent.current_plan[1].status, PlanStepStatus::Completed);
+    assert_eq!(agent.current_plan[2].status, PlanStepStatus::Pending);
 }
 
 #[tokio::test]

--- a/src/tui/interaction_text.rs
+++ b/src/tui/interaction_text.rs
@@ -41,15 +41,13 @@ pub fn pending_interaction_hint_text(kind: ActivePendingInteractionKind) -> &'st
 
 pub fn status_plan_approval_text(app: &TuiApp) -> String {
     let _ = app;
-    format!(
-        "review the updated plan before implementation:\n\noptions:\n1. Start implementation now\n2. Continue planning"
-    )
+    "Would you like to start implementation with this plan?\n\n1. Start implementation now\n2. Continue planning".to_string()
 }
 
 pub fn pending_interaction_shortcut_text(kind: ActivePendingInteractionKind) -> &'static str {
     match kind {
         ActivePendingInteractionKind::PlanApproval => {
-            "shortcuts: press 1 to start implementation, 2 to continue planning"
+            "Press 1 to start implementation or 2 to continue planning."
         }
         ActivePendingInteractionKind::ShellApproval => {
             "shortcuts: press 1 to approve once, 2 to approve for session, 3 to keep as suggestion"

--- a/src/tui/plan_display.rs
+++ b/src/tui/plan_display.rs
@@ -31,15 +31,11 @@ impl PlanStepKind {
 
     fn style(self) -> Style {
         match self {
-            Self::Completed => Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::CROSSED_OUT | Modifier::DIM),
-            Self::InProgress => Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-            Self::Pending => Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::DIM),
+            Self::Completed => {
+                Style::default().add_modifier(Modifier::CROSSED_OUT | Modifier::DIM)
+            }
+            Self::InProgress => Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Self::Pending => Style::default().add_modifier(Modifier::DIM),
         }
     }
 }
@@ -79,13 +75,8 @@ pub(crate) fn updated_plan_lines(
     }
 
     let mut lines = vec![Line::from(vec![
-        Span::styled("• ", Style::default().fg(Color::DarkGray)),
-        Span::styled(
-            "Updated Plan",
-            Style::default()
-                .fg(Color::LightBlue)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled("• ", Style::default().add_modifier(Modifier::DIM)),
+        Span::styled("Updated Plan", Style::default().add_modifier(Modifier::BOLD)),
     ])];
 
     let mut detail_lines = Vec::new();
@@ -93,9 +84,7 @@ pub(crate) fn updated_plan_lines(
     if let Some(note) = explanation.map(str::trim).filter(|note| !note.is_empty()) {
         detail_lines.push(Line::from(Span::styled(
             note.to_string(),
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::DIM | Modifier::ITALIC),
+            Style::default().add_modifier(Modifier::DIM | Modifier::ITALIC),
         )));
     }
 
@@ -109,7 +98,7 @@ pub(crate) fn updated_plan_lines(
 
     lines.extend(prefix_lines(
         detail_lines,
-        Span::styled("  └ ", Style::default().fg(Color::DarkGray)),
+        Span::styled("  └ ", Style::default().add_modifier(Modifier::DIM)),
         Span::raw("    "),
     ));
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -174,8 +174,8 @@ fn exploration_note_lines(current_turn: &[&TranscriptEntry]) -> Vec<String> {
 
 pub(crate) fn current_turn_exploration_summary_from_entries(
     current_turn: &[&TranscriptEntry],
-    show_live_detail: bool,
-    live_detail: Option<&str>,
+    _show_live_detail: bool,
+    _live_detail: Option<&str>,
 ) -> Option<String> {
     let mut actions = Vec::new();
     for entry in current_turn {
@@ -199,20 +199,13 @@ pub(crate) fn current_turn_exploration_summary_from_entries(
         lines.push(format!("└ {note}"));
     }
 
-    if show_live_detail {
-        lines.push(format!(
-            "└ {}",
-            live_detail.unwrap_or("waiting for more exploration output")
-        ));
-    }
-
     Some(lines.join("\n"))
 }
 
 pub(crate) fn current_turn_tool_summary(
     current_turn: &[&TranscriptEntry],
-    show_live_detail: bool,
-    live_detail: Option<&str>,
+    _show_live_detail: bool,
+    _live_detail: Option<&str>,
 ) -> Option<String> {
     let actions = current_turn
         .iter()
@@ -227,17 +220,10 @@ pub(crate) fn current_turn_tool_summary(
         return None;
     }
 
-    let mut lines = actions
+    let lines = actions
         .into_iter()
         .map(|action| format!("└ {action}"))
         .collect::<Vec<_>>();
-
-    if show_live_detail {
-        lines.push(format!(
-            "└ {}",
-            live_detail.unwrap_or("waiting for tool output")
-        ));
-    }
 
     Some(lines.join("\n"))
 }

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -72,7 +72,7 @@ fn render_activity_bar(f: &mut Frame, app: &TuiApp, area: Rect) {
 
     if app.agent_execution_mode_label() == "plan" && !label_already_reflects_planning {
         spans.push(Span::raw("  "));
-        spans.push(badge("mode", "plan", Color::LightBlue));
+        spans.push(badge("mode", "plan", Color::Cyan));
     }
     if !detail.is_empty() {
         spans.push(Span::raw("  "));
@@ -99,10 +99,10 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
 
     if let Some(pending) = app.active_pending_interaction() {
         let (label, color) = match pending.kind {
-            ActivePendingInteractionKind::PlanApproval => ("Plan Approval", Color::LightBlue),
+            ActivePendingInteractionKind::PlanApproval => ("Plan Approval", Color::Cyan),
             ActivePendingInteractionKind::ShellApproval => ("Shell Approval", Color::Yellow),
             ActivePendingInteractionKind::PlanningQuestion => {
-                ("Planning Question", Color::LightBlue)
+                ("Planning Question", Color::Cyan)
             }
             ActivePendingInteractionKind::ExplorationQuestion => {
                 ("Exploration Question", Color::Yellow)
@@ -114,7 +114,7 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
         };
         let detail = match pending.kind {
             ActivePendingInteractionKind::PlanApproval => {
-                "review the proposed plan and choose the next step".to_string()
+                "choose whether to start implementation or continue planning".to_string()
             }
             ActivePendingInteractionKind::ShellApproval => app
                 .pending_command_approval()
@@ -136,7 +136,7 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
     if app.has_pending_planning_suggestion() {
         return (
             "Planning Suggested",
-            Color::LightBlue,
+            Color::Cyan,
             "enter planning mode first or continue in execute mode".to_string(),
         );
     }
@@ -159,7 +159,7 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
     if app.agent_execution_mode_label() == "plan" {
         return (
             "Planning",
-            Color::LightBlue,
+            Color::Cyan,
             "analyze, refine, or finalize a plan".to_string(),
         );
     }
@@ -499,7 +499,8 @@ mod tests {
 
         let (label, _, detail) = activity_status_line(&app);
         assert_eq!(label, "Plan Approval");
-        assert!(detail.contains("review the proposed plan"));
+        assert!(detail.contains("start implementation"));
+        assert!(detail.contains("continue planning"));
     }
 
     #[test]

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -827,6 +827,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
         } else {
             explicit_planning
         };
+        let has_planning_summary = planning_summary.is_some();
         if let Some(summary) = planning_summary {
             cells.push(Box::new(PlanningCell::new(summary, turn_live)));
         }
@@ -949,7 +950,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             )));
         } else if turn_live
             && !has_exploration_summary
-            && !has_live_planning
+            && !has_planning_summary
             && !has_running_summary
             && self.app.pending_request_input().is_none()
             && !self.app.has_pending_plan_approval()

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -11,8 +11,8 @@ use crate::tui::interaction_text::{
 };
 use crate::tui::plan_display::updated_plan_lines;
 use crate::tui::state::{
-    contains_structured_planning_output, ActivePendingInteractionKind, InteractionKind,
-    RuntimePhase, TranscriptEntry, TuiApp,
+    contains_structured_planning_output, ActivePendingInteractionKind, RuntimePhase,
+    TranscriptEntry, TuiApp,
 };
 
 use super::{
@@ -52,19 +52,6 @@ enum InteractionCompletionKind {
 }
 
 impl InteractionCompletionKind {
-    fn from_completed_interaction(kind: InteractionKind, source: Option<&str>) -> Self {
-        match kind {
-            InteractionKind::Approval => Self::ShellApprovalCompleted,
-            InteractionKind::PlanApproval => Self::PlanDecision,
-            InteractionKind::RequestInput => match source {
-                Some("plan_agent") => Self::PlanningQuestionAnswered,
-                Some("explore_agent") => Self::ExplorationQuestionAnswered,
-                Some(_) => Self::SubAgentQuestionAnswered,
-                None => Self::QuestionAnswered,
-            },
-        }
-    }
-
     fn from_role(role: &str) -> Option<Self> {
         match role {
             "Shell Approval Completed" => Some(Self::ShellApprovalCompleted),
@@ -90,7 +77,7 @@ impl InteractionCompletionKind {
 
     fn color(self) -> Color {
         match self {
-            Self::PlanDecision => Color::LightBlue,
+            Self::PlanDecision => Color::Cyan,
             Self::ShellApprovalCompleted
             | Self::QuestionAnswered
             | Self::PlanningQuestionAnswered
@@ -214,9 +201,9 @@ struct PlanningCell {
 impl PlanningCell {
     fn new(summary: impl Into<String>, active: bool) -> Self {
         let (title, color) = if active {
-            ("Planning", Color::LightBlue)
+            ("Planning", Color::Cyan)
         } else {
-            ("Planned", Color::LightBlue)
+            ("Planned", Color::Cyan)
         };
         Self {
             inner: SummaryCell::new(title, color, summary),
@@ -312,7 +299,7 @@ impl PendingInteractionCell {
     fn new(kind: ActivePendingInteractionKind, lines: Vec<String>) -> Self {
         let color = match kind {
             ActivePendingInteractionKind::PlanApproval
-            | ActivePendingInteractionKind::PlanningQuestion => Color::LightBlue,
+            | ActivePendingInteractionKind::PlanningQuestion => Color::Cyan,
             ActivePendingInteractionKind::ShellApproval
             | ActivePendingInteractionKind::ExplorationQuestion => Color::Yellow,
             ActivePendingInteractionKind::SubAgentQuestion
@@ -344,7 +331,7 @@ impl HistoryCell for PlanningSuggestionCell {
     fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
         let mut lines = vec![Line::from(section_span(
             "Planning Suggested",
-            Color::LightBlue,
+            Color::Cyan,
         ))];
         lines.extend(
             self.text
@@ -408,7 +395,7 @@ struct PlanModeCell;
 
 impl HistoryCell for PlanModeCell {
     fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
-        vec![Line::from(section_span("Plan Mode", Color::LightBlue))]
+        vec![Line::from(section_span("Plan Mode", Color::Cyan))]
     }
 }
 
@@ -800,19 +787,10 @@ impl ActiveCell for ActiveTurnCell<'_> {
             lines.extend(
                 self.app
                     .active_live
-                    .exploration_notes
-                    .iter()
-                    .map(|note| format!("└ {note}")),
+                .exploration_notes
+                .iter()
+                .map(|note| format!("└ {note}")),
             );
-            if turn_live {
-                lines.push(format!(
-                    "└ {}",
-                    self.app
-                        .runtime_phase_detail
-                        .as_deref()
-                        .unwrap_or("waiting for more exploration output")
-                ));
-            }
             Some(lines.join("\n"))
         } else {
             explicit_exploration.or_else(|| {
@@ -841,19 +819,10 @@ impl ActiveCell for ActiveTurnCell<'_> {
             lines.extend(
                 self.app
                     .active_live
-                    .planning_notes
-                    .iter()
-                    .map(|note| format!("└ {note}")),
+                .planning_notes
+                .iter()
+                .map(|note| format!("└ {note}")),
             );
-            if turn_live {
-                lines.push(format!(
-                    "└ {}",
-                    self.app
-                        .runtime_phase_detail
-                        .as_deref()
-                        .unwrap_or("waiting for plan output")
-                ));
-            }
             Some(lines.join("\n"))
         } else {
             explicit_planning
@@ -868,22 +837,13 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .map(|entry| entry.message.clone());
 
         let running_summary = if has_live_running {
-            let mut lines = self
+            let lines = self
                 .app
                 .active_live
                 .running_actions
                 .iter()
                 .map(|action| format!("└ {action}"))
                 .collect::<Vec<_>>();
-            if turn_live {
-                lines.push(format!(
-                    "└ {}",
-                    self.app
-                        .runtime_phase_detail
-                        .as_deref()
-                        .unwrap_or("waiting for tool output")
-                ));
-            }
             Some(lines.join("\n"))
         } else {
             explicit_running.or_else(|| {
@@ -894,7 +854,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 )
             })
         };
-        let running_active = turn_live && running_summary.is_some();
+        let has_running_summary = running_summary.is_some();
+        let running_active = turn_live && has_running_summary;
         if let Some(summary) = running_summary {
             cells.push(Box::new(RunningCell::new(summary, running_active)));
         }
@@ -924,46 +885,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             )));
         }
 
-        if latest_completion.is_none() {
-            if let Some(interaction) = self
-                .app
-                .completed_interaction(crate::tui::state::InteractionKind::Approval)
-            {
-                cells.push(Box::new(CommittedInteractionCell::new(
-                    InteractionCompletionKind::from_completed_interaction(
-                        InteractionKind::Approval,
-                        interaction.source.as_deref(),
-                    ),
-                    format!("{}: {}", interaction.title, interaction.summary),
-                )));
-            }
-
-            if let Some(interaction) = self
-                .app
-                .completed_interaction(crate::tui::state::InteractionKind::RequestInput)
-            {
-                cells.push(Box::new(CommittedInteractionCell::new(
-                    InteractionCompletionKind::from_completed_interaction(
-                        InteractionKind::RequestInput,
-                        interaction.source.as_deref(),
-                    ),
-                    format!("{}: {}", interaction.title, interaction.summary),
-                )));
-            }
-
-            if let Some(interaction) = self
-                .app
-                .completed_interaction(crate::tui::state::InteractionKind::PlanApproval)
-            {
-                cells.push(Box::new(CommittedInteractionCell::new(
-                    InteractionCompletionKind::from_completed_interaction(
-                        InteractionKind::PlanApproval,
-                        interaction.source.as_deref(),
-                    ),
-                    format!("{}: {}", interaction.title, interaction.summary),
-                )));
-            }
-        } else if let Some(entry) = latest_completion {
+        if let Some(entry) = latest_completion {
             if let Some(kind) = completion_role_kind(entry.role.as_str()) {
                 cells.push(Box::new(CommittedInteractionCell::new(
                     kind,
@@ -986,15 +908,25 @@ impl ActiveCell for ActiveTurnCell<'_> {
             && self.app.snapshot.plan_steps.is_empty()
             && self.app.pending_request_input().is_none()
             && !self.app.has_pending_plan_approval();
+        let suppress_structured_plan_response = !self.app.snapshot.plan_steps.is_empty()
+            && latest_agent.is_some_and(contains_structured_planning_output);
 
         let responding_role = if turn_live { "Responding" } else { "Agent" };
 
         if let Some(stream_lines) = streaming_agent_lines
-            .filter(|_| !suppress_intermediate_agent && !suppress_planning_chatter)
+            .filter(|_| {
+                !suppress_intermediate_agent
+                    && !suppress_planning_chatter
+                    && !suppress_structured_plan_response
+            })
         {
             cells.push(Box::new(RespondingCell::from_stream(stream_lines)));
         } else if let Some(agent_message) =
-            latest_agent.filter(|_| !suppress_intermediate_agent && !suppress_planning_chatter)
+            latest_agent.filter(|_| {
+                !suppress_intermediate_agent
+                    && !suppress_planning_chatter
+                    && !suppress_structured_plan_response
+            })
         {
             cells.push(Box::new(RespondingCell::from_message(
                 responding_role,
@@ -1015,7 +947,16 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 tool_result,
                 14,
             )));
-        } else if turn_live {
+        } else if turn_live
+            && !has_exploration_summary
+            && !has_live_planning
+            && !has_running_summary
+            && self.app.pending_request_input().is_none()
+            && !self.app.has_pending_plan_approval()
+            && self.app.pending_command_approval().is_none()
+            && self.app.pending_planning_suggestion.is_none()
+            && self.app.snapshot.plan_steps.is_empty()
+        {
             cells.push(Box::new(RespondingCell::working(
                 self.app
                     .runtime_phase_detail
@@ -1221,7 +1162,7 @@ mod tests {
         assert!(rendered.contains(
             "I have inspected the repository structure and will now inspect the core modules."
         ));
-        assert!(rendered.contains("waiting for model response · 12s elapsed"));
+        assert!(!rendered.contains("waiting for model response · 12s elapsed"));
     }
 
     #[test]
@@ -1255,7 +1196,7 @@ mod tests {
         );
         assert!(rendered.contains("Read src/tools/vector.rs"));
         assert!(rendered.contains("I have inspected the repository structure."));
-        assert!(rendered.contains("waiting for model response · 20s elapsed"));
+        assert!(!rendered.contains("waiting for model response · 20s elapsed"));
     }
 
     #[test]
@@ -1295,6 +1236,47 @@ mod tests {
             .join("\n");
 
         assert_snapshot!("active_turn_cell_updated_plan", rendered);
+    }
+
+    #[test]
+    fn active_turn_cell_hides_structured_plan_response_once_plan_card_exists() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
+        app.runtime_phase = RuntimePhase::ProcessingResponse;
+        app.active_turn = TranscriptTurn {
+            entries: vec![
+                TranscriptEntry {
+                    role: "You".into(),
+                    message: "Plan the next refactor".into(),
+                },
+                TranscriptEntry {
+                    role: "Agent".into(),
+                    message: "<plan>\n- [completed] Inspect the auth flow\n- [in_progress] Reuse codex_login\n- [pending] Add auth picker snapshots\n</plan>\nPrefer direct auth reuse before expanding more TUI flows.".into(),
+                },
+            ],
+        };
+        app.snapshot.plan_steps = vec![
+            ("completed".into(), "Inspect the auth flow".into()),
+            ("in_progress".into(), "Reuse codex_login".into()),
+            ("pending".into(), "Add auth picker snapshots".into()),
+        ];
+        app.snapshot.plan_explanation =
+            Some("Prefer direct auth reuse before expanding more TUI flows.".into());
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Updated Plan"));
+        assert!(!rendered.contains("Responding"));
+        assert!(!rendered.contains("<plan>"));
     }
 
     #[test]
@@ -1670,6 +1652,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
 
+        assert_snapshot!("active_turn_cell_plan_approval", rendered);
         assert!(rendered.contains(" Awaiting Approval "));
         assert!(rendered.contains("Updated Plan"));
         assert!(rendered.contains("Start implementation now"));
@@ -1797,6 +1780,43 @@ mod tests {
 
         assert!(rendered.contains(" Plan Decision "));
         assert!(rendered.contains("Approved and started implementation"));
+    }
+
+    #[test]
+    fn active_turn_cell_does_not_repeat_stale_plan_decision_from_snapshot() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.active_turn = TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "You".into(),
+                message: "Approve the plan".into(),
+            }],
+        };
+        app.record_completed_interaction(
+            crate::tui::state::InteractionKind::PlanApproval,
+            "Plan Decision",
+            "Approved and started implementation",
+            None,
+        );
+        app.finalize_active_turn();
+        app.active_turn = TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "You".into(),
+                message: "Continue with the next task".into(),
+            }],
+        };
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!rendered.contains(" Plan Decision "));
     }
 
     #[test]

--- a/src/tui/render/snapshots/rara__tui__render__cells__tests__active_turn_cell_plan_approval.snap
+++ b/src/tui/render/snapshots/rara__tui__render__cells__tests__active_turn_cell_plan_approval.snap
@@ -1,0 +1,18 @@
+---
+source: src/tui/render/cells.rs
+assertion_line: 1655
+expression: rendered
+---
+You: Review the codebase and propose changes
+
+• Updated Plan
+  └ The current discovery path is hardcoded and should be generalized.
+    □ Generalize instruction discovery
+    □ Preserve cache and path resolution behavior
+
+ Awaiting Approval 
+  Would you like to start implementation with this plan?
+  
+  1. Start implementation now
+  2. Continue planning
+  Press 1 to start implementation or 2 to continue planning.

--- a/src/tui/render/snapshots/rara__tui__render__cells__tests__active_turn_cell_updated_plan.snap
+++ b/src/tui/render/snapshots/rara__tui__render__cells__tests__active_turn_cell_updated_plan.snap
@@ -6,17 +6,12 @@ You: Read the local codebase and propose the next refactor
 
  Exploring 
   └ Read src/oauth.rs
-  └ waiting for model response · 3s elapsed
 
  Planning 
   └ The auth flow should reuse codex_login instead of mirroring it.
-  └ waiting for model response · 3s elapsed
 
 • Updated Plan
   └ Prefer direct Codex auth reuse before extending more TUI flows.
     ✔ Inspect the current auth bridge
     □ Replace the bespoke OAuth flow
     □ Add snapshot tests for the auth picker
-
- Working 
-  waiting for model response · 3s elapsed


### PR DESCRIPTION
## Summary
- tighten plan lifecycle so successful execution only completes the active in-progress step
- remove runtime heartbeat noise and duplicate structured plan prose from plan transcript surfaces
- align `Updated Plan` and `Awaiting Approval` cards closer to Codex-style TUI semantics

## Testing
- cargo test agent::tests::completes_only_active_plan_step_on_finish -- --nocapture
- cargo test tui::render::cells::tests::active_turn_cell_renders_plan_approval_as_interaction_card -- --nocapture
- cargo test tui::render::bottom_pane::tests::activity_status_line_prefers_pending_interactions -- --nocapture
- cargo test tui::render::cells::tests -- --nocapture
- cargo test tui::render::bottom_pane::tests -- --nocapture
- cargo check
