### PR TITLE
fix(tui): route codex model flow by auth state

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 pub const DEFAULT_CODEX_BASE_URL: &str = "https://api.openai.com/v1";
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5-codex";
 pub const LEGACY_CODEX_BASE_URL: &str = "http://localhost:8080";
+pub const LEGACY_CODEX_MODEL: &str = "codex";
 
 pub fn should_reset_codex_base_url(url: Option<&str>) -> bool {
     url.map(str::trim)
@@ -122,7 +123,8 @@ impl RaraConfig {
         if should_reset_codex_base_url(self.base_url.as_deref()) {
             self.set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
         }
-        if self.model.is_none() {
+        let model = self.model.as_deref().map(str::trim).unwrap_or("");
+        if model.is_empty() || model == LEGACY_CODEX_MODEL {
             self.set_model(Some(DEFAULT_CODEX_MODEL.to_string()));
         }
     }
@@ -356,6 +358,21 @@ mod tests {
         assert_eq!(config.model.as_deref(), Some("qwen3"));
         assert_eq!(config.base_url.as_deref(), Some("http://localhost:11434"));
         assert_eq!(config.num_ctx, Some(32768));
+    }
+
+    #[test]
+    fn apply_codex_defaults_migrates_legacy_model_and_base_url() {
+        let mut config = RaraConfig {
+            provider: "codex".to_string(),
+            ..Default::default()
+        };
+        config.set_model(Some("codex".to_string()));
+        config.set_base_url(Some("http://localhost:8080".to_string()));
+
+        config.apply_codex_defaults();
+
+        assert_eq!(config.model.as_deref(), Some(super::DEFAULT_CODEX_MODEL));
+        assert_eq!(config.base_url.as_deref(), Some(super::DEFAULT_CODEX_BASE_URL));
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -13,7 +13,7 @@ pub const LEGACY_CODEX_BASE_URL: &str = "http://localhost:8080";
 
 pub fn should_reset_codex_base_url(url: Option<&str>) -> bool {
     url.map(str::trim)
-        .is_none_or(|value| value.is_empty() || value == LEGACY_CODEX_BASE_URL)
+        .map_or(true, |value| value.is_empty() || value == LEGACY_CODEX_BASE_URL)
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7,6 +7,15 @@ use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
+pub const DEFAULT_CODEX_BASE_URL: &str = "https://api.openai.com/v1";
+pub const DEFAULT_CODEX_MODEL: &str = "gpt-5-codex";
+pub const LEGACY_CODEX_BASE_URL: &str = "http://localhost:8080";
+
+pub fn should_reset_codex_base_url(url: Option<&str>) -> bool {
+    url.map(str::trim)
+        .is_none_or(|value| value.is_empty() || value == LEGACY_CODEX_BASE_URL)
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ProviderConfigState {
     #[serde(
@@ -107,6 +116,15 @@ impl RaraConfig {
     pub fn set_num_ctx(&mut self, value: Option<u32>) {
         self.num_ctx = value;
         self.sync_active_provider_state();
+    }
+
+    pub fn apply_codex_defaults(&mut self) {
+        if should_reset_codex_base_url(self.base_url.as_deref()) {
+            self.set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
+        }
+        if self.model.is_none() {
+            self.set_model(Some(DEFAULT_CODEX_MODEL.to_string()));
+        }
     }
 
     fn sync_active_provider_state(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ mod workspace;
 
 use crate::acp::{run_acp_stdio, RaraAcpAgent};
 use crate::agent::Agent;
-use crate::config::{ConfigManager, RaraConfig};
+use crate::config::{ConfigManager, RaraConfig, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
 use crate::llm::{
     CodexBackend, GeminiBackend, LlmBackend, MockLlm, OllamaBackend, OpenAiCompatibleBackend,
 };
@@ -46,15 +46,6 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 use secrecy::ExposeSecret;
 use std::sync::Arc;
-
-pub(crate) const DEFAULT_CODEX_BASE_URL: &str = "https://api.openai.com/v1";
-pub(crate) const DEFAULT_CODEX_MODEL: &str = "gpt-5-codex";
-pub(crate) const LEGACY_CODEX_BASE_URL: &str = "http://localhost:8080";
-
-pub(crate) fn should_reset_codex_base_url(url: Option<&str>) -> bool {
-    url.map(str::trim)
-        .is_none_or(|value| value.is_empty() || value == LEGACY_CODEX_BASE_URL)
-}
 
 #[derive(Parser)]
 #[command(name = "rara")]
@@ -225,12 +216,7 @@ fn save_codex_credential(
 ) -> Result<()> {
     config.set_provider("codex");
     config.set_api_key(credential.to_string());
-    if should_reset_codex_base_url(config.base_url.as_deref()) {
-        config.set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
-    }
-    if config.model.is_none() {
-        config.set_model(Some(DEFAULT_CODEX_MODEL.into()));
-    }
+    config.apply_codex_defaults();
     config_manager.save(config)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,9 @@ use clap::{Parser, Subcommand};
 use secrecy::ExposeSecret;
 use std::sync::Arc;
 
+pub(crate) const DEFAULT_CODEX_BASE_URL: &str = "https://api.openai.com/v1";
+pub(crate) const DEFAULT_CODEX_MODEL: &str = "gpt-5-codex";
+
 #[derive(Parser)]
 #[command(name = "rara")]
 #[command(about = "RARA: RARA Automates Rust Agents", long_about = None)]
@@ -216,8 +219,16 @@ fn save_codex_credential(
 ) -> Result<()> {
     config.set_provider("codex");
     config.set_api_key(credential.to_string());
+    let should_reset_base_url = config
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .is_none_or(|value| value.is_empty() || value == "http://localhost:8080");
+    if should_reset_base_url {
+        config.set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
+    }
     if config.model.is_none() {
-        config.set_model(Some("codex".into()));
+        config.set_model(Some(DEFAULT_CODEX_MODEL.into()));
     }
     config_manager.save(config)
 }
@@ -319,8 +330,11 @@ pub(crate) async fn build_backend_with_progress(
             config
                 .base_url
                 .clone()
-                .unwrap_or_else(|| "http://localhost:8080".to_string()),
-            config.model.clone().unwrap_or_else(|| "codex".to_string()),
+                .unwrap_or_else(|| DEFAULT_CODEX_BASE_URL.to_string()),
+            config
+                .model
+                .clone()
+                .unwrap_or_else(|| DEFAULT_CODEX_MODEL.to_string()),
         )?)),
         "openai-compatible" => Ok(Box::new(OpenAiCompatibleBackend::new(
             config.api_key.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,12 @@ use std::sync::Arc;
 
 pub(crate) const DEFAULT_CODEX_BASE_URL: &str = "https://api.openai.com/v1";
 pub(crate) const DEFAULT_CODEX_MODEL: &str = "gpt-5-codex";
+pub(crate) const LEGACY_CODEX_BASE_URL: &str = "http://localhost:8080";
+
+pub(crate) fn should_reset_codex_base_url(url: Option<&str>) -> bool {
+    url.map(str::trim)
+        .is_none_or(|value| value.is_empty() || value == LEGACY_CODEX_BASE_URL)
+}
 
 #[derive(Parser)]
 #[command(name = "rara")]
@@ -219,12 +225,7 @@ fn save_codex_credential(
 ) -> Result<()> {
     config.set_provider("codex");
     config.set_api_key(credential.to_string());
-    let should_reset_base_url = config
-        .base_url
-        .as_deref()
-        .map(str::trim)
-        .is_none_or(|value| value.is_empty() || value == "http://localhost:8080");
-    if should_reset_base_url {
+    if should_reset_codex_base_url(config.base_url.as_deref()) {
         config.set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
     }
     if config.model.is_none() {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -338,6 +338,7 @@ mod tests {
         )
         .expect("save token auth");
 
+        manager.invalidate_saved_auth_cache();
         assert!(manager.has_saved_auth().expect("token auth"));
     }
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -113,11 +113,12 @@ impl OAuthManager {
     }
 
     pub fn has_saved_auth(&self) -> Result<bool> {
-        if self.saved_auth_cache() {
-            return Ok(true);
+        if let Some(cached) = self.saved_auth_cache() {
+            return Ok(cached);
         }
         let Some(auth) = load_auth_dot_json(&self.codex_home, AuthCredentialsStoreMode::File)?
         else {
+            self.set_saved_auth_cache(false);
             return Ok(false);
         };
         let has_api_key = auth
@@ -129,9 +130,7 @@ impl OAuthManager {
             .as_ref()
             .is_some_and(|tokens| !tokens.access_token.trim().is_empty());
         let has_saved_auth = has_api_key || has_access_token;
-        if has_saved_auth {
-            self.set_saved_auth_cache(true);
-        }
+        self.set_saved_auth_cache(has_saved_auth);
         Ok(has_saved_auth)
     }
 
@@ -158,7 +157,7 @@ impl OAuthManager {
         options
     }
 
-    fn load_saved_credential(&self) -> Result<SecretString> {
+    pub fn load_saved_credential(&self) -> Result<SecretString> {
         let auth = load_auth_dot_json(&self.codex_home, AuthCredentialsStoreMode::File)?
             .ok_or_else(|| anyhow!("Codex login finished but no credential was saved"))?;
         if let Some(api_key) = auth.openai_api_key.filter(|value| !value.trim().is_empty()) {
@@ -177,12 +176,15 @@ impl OAuthManager {
         ))
     }
 
-    fn saved_auth_cache(&self) -> bool {
+    pub fn invalidate_saved_auth_cache(&self) {
+        self.clear_saved_auth_cache();
+    }
+
+    fn saved_auth_cache(&self) -> Option<bool> {
         self.saved_auth_available
             .lock()
             .ok()
             .and_then(|guard| *guard)
-            .unwrap_or(false)
     }
 
     fn set_saved_auth_cache(&self, value: bool) {
@@ -369,6 +371,32 @@ mod tests {
         assert!(err
             .to_string()
             .contains("did not contain an API key or access token"));
+    }
+
+    #[test]
+    fn has_saved_auth_refreshes_after_cache_invalidation() {
+        let temp = tempdir().expect("tempdir");
+        let manager =
+            OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
+
+        assert!(!manager.has_saved_auth().expect("no auth"));
+
+        codex_login::save_auth(
+            auth_path(&manager),
+            &codex_login::AuthDotJson {
+                auth_mode: None,
+                openai_api_key: Some("sk-direct".into()),
+                tokens: None,
+                last_refresh: None,
+                agent_identity: None,
+            },
+            AuthCredentialsStoreMode::File,
+        )
+        .expect("save auth");
+
+        assert!(!manager.has_saved_auth().expect("stale false cache"));
+        manager.invalidate_saved_auth_cache();
+        assert!(manager.has_saved_auth().expect("refreshed auth"));
     }
 
     fn auth_path(manager: &OAuthManager) -> &Path {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use codex_login::{
-    complete_device_code_login as codex_complete_device_code_login,
-    load_auth_dot_json, login_with_api_key as codex_login_with_api_key, logout as codex_logout,
+    complete_device_code_login as codex_complete_device_code_login, load_auth_dot_json,
+    login_with_api_key as codex_login_with_api_key, logout as codex_logout,
     request_device_code as codex_request_device_code, run_login_server as codex_run_login_server,
     AuthCredentialsStoreMode, DeviceCode as CodexDeviceCode, LoginServer as CodexLoginServer,
     ServerOptions, CLIENT_ID,
@@ -85,18 +85,17 @@ impl OAuthManager {
         })
     }
 
-    pub async fn complete_device_code_login(&self, device_code: &DeviceCode) -> Result<SecretString> {
+    pub async fn complete_device_code_login(
+        &self,
+        device_code: &DeviceCode,
+    ) -> Result<SecretString> {
         let options = self.server_options(false);
         codex_complete_device_code_login(options, device_code.inner.clone()).await?;
         self.load_saved_credential()
     }
 
     pub fn save_api_key(&self, api_key: &str) -> Result<SecretString> {
-        codex_login_with_api_key(
-            &self.codex_home,
-            api_key,
-            AuthCredentialsStoreMode::File,
-        )?;
+        codex_login_with_api_key(&self.codex_home, api_key, AuthCredentialsStoreMode::File)?;
         self.load_saved_credential()
     }
 
@@ -105,6 +104,22 @@ impl OAuthManager {
             &self.codex_home,
             AuthCredentialsStoreMode::File,
         )?)
+    }
+
+    pub fn has_saved_auth(&self) -> Result<bool> {
+        let Some(auth) = load_auth_dot_json(&self.codex_home, AuthCredentialsStoreMode::File)?
+        else {
+            return Ok(false);
+        };
+        let has_api_key = auth
+            .openai_api_key
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+        let has_access_token = auth
+            .tokens
+            .as_ref()
+            .is_some_and(|tokens| !tokens.access_token.trim().is_empty());
+        Ok(has_api_key || has_access_token)
     }
 
     pub fn read_api_key_from_stdin(&self) -> Result<SecretString> {
@@ -161,7 +176,9 @@ mod tests {
             .start_browser_login(false)
             .expect("browser login session");
 
-        assert!(session.auth_url().starts_with("https://auth.openai.com/oauth/authorize?"));
+        assert!(session
+            .auth_url()
+            .starts_with("https://auth.openai.com/oauth/authorize?"));
         assert!(session.auth_url().contains(CLIENT_ID));
         session.inner.cancel();
     }
@@ -172,9 +189,7 @@ mod tests {
         let manager =
             OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
 
-        let stored = manager
-            .save_api_key("sk-test-123")
-            .expect("save api key");
+        let stored = manager.save_api_key("sk-test-123").expect("save api key");
 
         assert_eq!(stored.expose_secret(), "sk-test-123");
 
@@ -239,7 +254,9 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let manager =
             OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
-        manager.save_api_key("sk-test-logout").expect("save api key");
+        manager
+            .save_api_key("sk-test-logout")
+            .expect("save api key");
 
         let removed = manager.clear_saved_auth().expect("clear auth");
         assert!(removed);
@@ -247,6 +264,41 @@ mod tests {
         let auth = load_auth_dot_json(auth_path(&manager), AuthCredentialsStoreMode::File)
             .expect("load auth after logout");
         assert!(auth.is_none());
+    }
+
+    #[test]
+    fn has_saved_auth_detects_api_key_and_access_token_storage() {
+        let temp = tempdir().expect("tempdir");
+        let manager =
+            OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
+
+        assert!(!manager.has_saved_auth().expect("no auth"));
+
+        manager.save_api_key("sk-test-123").expect("save api key");
+        assert!(manager.has_saved_auth().expect("api key auth"));
+
+        manager.clear_saved_auth().expect("clear auth");
+        assert!(!manager.has_saved_auth().expect("cleared auth"));
+
+        codex_login::save_auth(
+            auth_path(&manager),
+            &codex_login::AuthDotJson {
+                auth_mode: None,
+                openai_api_key: None,
+                tokens: Some(codex_login::TokenData {
+                    id_token: valid_id_token_info(),
+                    access_token: "access-only".into(),
+                    refresh_token: "refresh".into(),
+                    account_id: None,
+                }),
+                last_refresh: None,
+                agent_identity: None,
+            },
+            AuthCredentialsStoreMode::File,
+        )
+        .expect("save token auth");
+
+        assert!(manager.has_saved_auth().expect("token auth"));
     }
 
     fn auth_path(manager: &OAuthManager) -> &Path {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -9,6 +9,7 @@ use codex_login::{
 use secrecy::SecretString;
 use std::io::Read;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 const ISSUER: &str = "https://auth.openai.com";
 
@@ -39,6 +40,7 @@ impl BrowserLoginSession {
 pub struct OAuthManager {
     pub config_dir: PathBuf,
     codex_home: PathBuf,
+    saved_auth_available: Arc<Mutex<Option<bool>>>,
 }
 
 impl OAuthManager {
@@ -54,6 +56,7 @@ impl OAuthManager {
         Ok(Self {
             config_dir,
             codex_home,
+            saved_auth_available: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -96,17 +99,23 @@ impl OAuthManager {
 
     pub fn save_api_key(&self, api_key: &str) -> Result<SecretString> {
         codex_login_with_api_key(&self.codex_home, api_key, AuthCredentialsStoreMode::File)?;
+        self.set_saved_auth_cache(true);
         self.load_saved_credential()
     }
 
     pub fn clear_saved_auth(&self) -> Result<bool> {
-        Ok(codex_logout(
+        let removed = codex_logout(
             &self.codex_home,
             AuthCredentialsStoreMode::File,
-        )?)
+        )?;
+        self.clear_saved_auth_cache();
+        Ok(removed)
     }
 
     pub fn has_saved_auth(&self) -> Result<bool> {
+        if self.saved_auth_cache() {
+            return Ok(true);
+        }
         let Some(auth) = load_auth_dot_json(&self.codex_home, AuthCredentialsStoreMode::File)?
         else {
             return Ok(false);
@@ -119,7 +128,11 @@ impl OAuthManager {
             .tokens
             .as_ref()
             .is_some_and(|tokens| !tokens.access_token.trim().is_empty());
-        Ok(has_api_key || has_access_token)
+        let has_saved_auth = has_api_key || has_access_token;
+        if has_saved_auth {
+            self.set_saved_auth_cache(true);
+        }
+        Ok(has_saved_auth)
     }
 
     pub fn read_api_key_from_stdin(&self) -> Result<SecretString> {
@@ -149,14 +162,36 @@ impl OAuthManager {
         let auth = load_auth_dot_json(&self.codex_home, AuthCredentialsStoreMode::File)?
             .ok_or_else(|| anyhow!("Codex login finished but no credential was saved"))?;
         if let Some(api_key) = auth.openai_api_key {
+            self.set_saved_auth_cache(true);
             return Ok(SecretString::from(api_key));
         }
         if let Some(tokens) = auth.tokens {
+            self.set_saved_auth_cache(true);
             return Ok(SecretString::from(tokens.access_token));
         }
         Err(anyhow!(
             "Codex login finished but auth storage did not contain an API key or access token"
         ))
+    }
+
+    fn saved_auth_cache(&self) -> bool {
+        self.saved_auth_available
+            .lock()
+            .ok()
+            .and_then(|guard| *guard)
+            .unwrap_or(false)
+    }
+
+    fn set_saved_auth_cache(&self, value: bool) {
+        if let Ok(mut guard) = self.saved_auth_available.lock() {
+            *guard = Some(value);
+        }
+    }
+
+    fn clear_saved_auth_cache(&self) {
+        if let Ok(mut guard) = self.saved_auth_available.lock() {
+            *guard = None;
+        }
     }
 }
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -161,11 +161,14 @@ impl OAuthManager {
     fn load_saved_credential(&self) -> Result<SecretString> {
         let auth = load_auth_dot_json(&self.codex_home, AuthCredentialsStoreMode::File)?
             .ok_or_else(|| anyhow!("Codex login finished but no credential was saved"))?;
-        if let Some(api_key) = auth.openai_api_key {
+        if let Some(api_key) = auth.openai_api_key.filter(|value| !value.trim().is_empty()) {
             self.set_saved_auth_cache(true);
             return Ok(SecretString::from(api_key));
         }
-        if let Some(tokens) = auth.tokens {
+        if let Some(tokens) = auth
+            .tokens
+            .filter(|tokens| !tokens.access_token.trim().is_empty())
+        {
             self.set_saved_auth_cache(true);
             return Ok(SecretString::from(tokens.access_token));
         }
@@ -334,6 +337,38 @@ mod tests {
         .expect("save token auth");
 
         assert!(manager.has_saved_auth().expect("token auth"));
+    }
+
+    #[test]
+    fn load_saved_credential_rejects_blank_values() {
+        let temp = tempdir().expect("tempdir");
+        let manager =
+            OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
+
+        codex_login::save_auth(
+            auth_path(&manager),
+            &codex_login::AuthDotJson {
+                auth_mode: None,
+                openai_api_key: Some("   ".into()),
+                tokens: Some(codex_login::TokenData {
+                    id_token: valid_id_token_info(),
+                    access_token: "   ".into(),
+                    refresh_token: "refresh".into(),
+                    account_id: None,
+                }),
+                last_refresh: None,
+                agent_identity: None,
+            },
+            AuthCredentialsStoreMode::File,
+        )
+        .expect("save auth");
+
+        let err = manager
+            .load_saved_credential()
+            .expect_err("blank credentials should be rejected");
+        assert!(err
+            .to_string()
+            .contains("did not contain an API key or access token"));
     }
 
     fn auth_path(manager: &OAuthManager) -> &Path {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -392,6 +392,9 @@ async fn dispatch_event(
             if matches!(app.overlay, Some(Overlay::Setup)) {
                 app.select_local_model(app.model_picker_idx);
             } else if matches!(app.overlay, Some(Overlay::ModelPicker)) && !app.is_busy() {
+                if app.selected_provider_family() == self::state::ProviderFamily::Codex {
+                    let _ = sync_codex_credential_from_auth_store(app, oauth_manager.as_ref())?;
+                }
                 if should_open_codex_auth_guide(app, oauth_manager.as_ref()) {
                     app.select_local_model(app.model_picker_idx);
                     app.open_overlay(Overlay::AuthModePicker);
@@ -569,7 +572,7 @@ async fn dispatch_event(
                 if app.is_busy() {
                     app.push_notice("A task is already running. Wait for it to finish.");
                 } else {
-                    open_provider_family_overlay(app, oauth_manager.as_ref());
+                    open_provider_family_overlay(app, oauth_manager.as_ref())?;
                 }
             }
             Some(Overlay::ResumePicker) => {
@@ -603,6 +606,9 @@ async fn dispatch_event(
                 if app.is_busy() {
                     app.push_notice("A task is already running. Wait for it to finish.");
                 } else {
+                    if app.selected_provider_family() == self::state::ProviderFamily::Codex {
+                        let _ = sync_codex_credential_from_auth_store(app, oauth_manager.as_ref())?;
+                    }
                     app.select_local_model(app.model_picker_idx);
                     if should_open_codex_auth_guide(app, oauth_manager.as_ref()) {
                         app.open_overlay(Overlay::AuthModePicker);
@@ -891,6 +897,31 @@ fn clamp_command_palette_selection(app: &mut TuiApp) {
     }
 }
 
+fn sync_codex_credential_from_auth_store(
+    app: &mut TuiApp,
+    oauth_manager: &OAuthManager,
+) -> anyhow::Result<bool> {
+    oauth_manager.invalidate_saved_auth_cache();
+    if !oauth_manager.has_saved_auth()? {
+        return Ok(false);
+    }
+
+    let credential = oauth_manager.load_saved_credential()?;
+    let previous_provider = app.config.provider.clone();
+
+    app.config.set_provider("codex");
+    app.config
+        .set_api_key(credential.expose_secret().to_string());
+    app.config.apply_codex_defaults();
+    app.config_manager.save(&app.config)?;
+
+    if previous_provider != "codex" {
+        app.config.set_provider(previous_provider);
+    }
+
+    Ok(true)
+}
+
 fn codex_auth_is_available(app: &TuiApp, oauth_manager: &OAuthManager) -> bool {
     if app.config.provider == "codex" && app.config.has_api_key() {
         return true;
@@ -907,17 +938,31 @@ fn codex_auth_is_available(app: &TuiApp, oauth_manager: &OAuthManager) -> bool {
     oauth_manager.has_saved_auth().is_ok_and(|saved| saved)
 }
 
-fn open_provider_family_overlay(app: &mut TuiApp, oauth_manager: &OAuthManager) {
+fn open_provider_family_overlay(
+    app: &mut TuiApp,
+    oauth_manager: &OAuthManager,
+) -> anyhow::Result<()> {
+    let has_synced_codex_auth = if matches!(
+        app.selected_provider_family(),
+        self::state::ProviderFamily::Codex
+    ) {
+        sync_codex_credential_from_auth_store(app, oauth_manager)?
+    } else {
+        false
+    };
+
     if matches!(
         app.selected_provider_family(),
         self::state::ProviderFamily::Codex
-    ) && !codex_auth_is_available(app, oauth_manager)
+    ) && !has_synced_codex_auth
+        && !codex_auth_is_available(app, oauth_manager)
     {
         app.config.set_provider("codex");
         app.open_overlay(Overlay::AuthModePicker);
     } else {
         app.open_overlay(Overlay::ModelPicker);
     }
+    Ok(())
 }
 
 fn should_open_codex_auth_guide(app: &TuiApp, oauth_manager: &OAuthManager) -> bool {
@@ -932,13 +977,15 @@ fn should_open_codex_auth_guide(app: &TuiApp, oauth_manager: &OAuthManager) -> b
 mod tests {
     use super::{
         classify_pending_plan_approval_input, codex_auth_is_available, dispatch_event,
-        map_key_to_event, open_provider_family_overlay, PendingPlanApprovalAction,
+        map_key_to_event, open_provider_family_overlay, sync_codex_credential_from_auth_store,
+        PendingPlanApprovalAction,
     };
     use crate::config::ConfigManager;
     use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
     use crate::tui::app_event::AppEvent;
     use crate::tui::state::{Overlay, ProviderFamily, RunningTask, TaskKind, TuiApp};
     use crossterm::event::KeyCode;
+    use secrecy::ExposeSecret;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
     use tempfile::tempdir;
@@ -1170,7 +1217,7 @@ mod tests {
 
         assert_eq!(app.selected_provider_family(), ProviderFamily::Codex);
 
-        open_provider_family_overlay(&mut app, &oauth_manager);
+        open_provider_family_overlay(&mut app, &oauth_manager).expect("open overlay");
         assert_eq!(app.config.provider, "codex");
         assert!(matches!(app.overlay, Some(Overlay::AuthModePicker)));
     }
@@ -1190,7 +1237,7 @@ mod tests {
             .expect("save api key");
         app.provider_picker_idx = 0;
 
-        open_provider_family_overlay(&mut app, &oauth_manager);
+        open_provider_family_overlay(&mut app, &oauth_manager).expect("open overlay");
         assert!(matches!(app.overlay, Some(Overlay::ModelPicker)));
     }
 
@@ -1214,8 +1261,39 @@ mod tests {
 
         assert!(codex_auth_is_available(&app, &oauth_manager));
 
-        open_provider_family_overlay(&mut app, &oauth_manager);
+        open_provider_family_overlay(&mut app, &oauth_manager).expect("open overlay");
         assert!(matches!(app.overlay, Some(Overlay::ModelPicker)));
+    }
+
+    #[test]
+    fn codex_auth_store_is_synced_into_config_before_model_flow() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager =
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager");
+        oauth_manager
+            .save_api_key("sk-test-codex")
+            .expect("save api key");
+
+        app.config.set_provider("ollama");
+        app.provider_picker_idx = 0;
+
+        assert!(
+            sync_codex_credential_from_auth_store(&mut app, &oauth_manager).expect("sync auth")
+        );
+        assert_eq!(
+            app.config
+                .provider_states
+                .get("codex")
+                .and_then(|state| state.api_key.as_ref())
+                .map(|value| value.expose_secret()),
+            Some("sk-test-codex")
+        );
+        assert_eq!(app.config.provider, "ollama");
     }
 
     #[tokio::test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -26,7 +26,7 @@ use crossterm::{
     terminal::size as terminal_size,
 };
 use futures::StreamExt;
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 use tokio::time::{interval, Duration};
 
 use crate::agent::Agent;
@@ -901,22 +901,83 @@ fn sync_codex_credential_from_auth_store(
     app: &mut TuiApp,
     oauth_manager: &OAuthManager,
 ) -> anyhow::Result<bool> {
-    oauth_manager.invalidate_saved_auth_cache();
+    let codex_state = app.config.provider_states.get("codex");
+    let has_ready_codex_state = codex_state
+        .and_then(|state| state.api_key.as_ref())
+        .is_some_and(|api_key| !api_key.expose_secret().trim().is_empty())
+        && codex_state
+            .and_then(|state| state.model.as_deref())
+            .map(str::trim)
+            .is_some_and(|model| !model.is_empty() && model != crate::config::LEGACY_CODEX_MODEL)
+        && codex_state
+            .map(|state| !crate::config::should_reset_codex_base_url(state.base_url.as_deref()))
+            .unwrap_or(false);
+    if has_ready_codex_state {
+        return Ok(true);
+    }
+
     if !oauth_manager.has_saved_auth()? {
         return Ok(false);
     }
 
     let credential = oauth_manager.load_saved_credential()?;
-    let previous_provider = app.config.provider.clone();
+    let credential = credential.expose_secret().trim().to_string();
+    let mut changed = false;
 
-    app.config.set_provider("codex");
-    app.config
-        .set_api_key(credential.expose_secret().to_string());
-    app.config.apply_codex_defaults();
-    app.config_manager.save(&app.config)?;
+    if app.config.provider == "codex" {
+        let current_key = app
+            .config
+            .api_key
+            .as_ref()
+            .map(|value| value.expose_secret().trim());
+        if current_key != Some(credential.as_str()) {
+            app.config.set_api_key(credential.clone());
+            changed = true;
+        }
+        let current_model = app.config.model.as_deref().map(str::trim).unwrap_or("");
+        if current_model.is_empty() || current_model == crate::config::LEGACY_CODEX_MODEL {
+            app.config
+                .set_model(Some(crate::config::DEFAULT_CODEX_MODEL.to_string()));
+            changed = true;
+        }
+        if crate::config::should_reset_codex_base_url(app.config.base_url.as_deref()) {
+            app.config
+                .set_base_url(Some(crate::config::DEFAULT_CODEX_BASE_URL.to_string()));
+            changed = true;
+        }
+    } else {
+        let mut codex_state = app
+            .config
+            .provider_states
+            .get("codex")
+            .cloned()
+            .unwrap_or_default();
+        let current_key = codex_state
+            .api_key
+            .as_ref()
+            .map(|value| value.expose_secret().trim());
+        if current_key != Some(credential.as_str()) {
+            codex_state.api_key = Some(SecretString::from(credential));
+            changed = true;
+        }
+        let current_model = codex_state.model.as_deref().map(str::trim).unwrap_or("");
+        if current_model.is_empty() || current_model == crate::config::LEGACY_CODEX_MODEL {
+            codex_state.model = Some(crate::config::DEFAULT_CODEX_MODEL.to_string());
+            changed = true;
+        }
+        if crate::config::should_reset_codex_base_url(codex_state.base_url.as_deref()) {
+            codex_state.base_url = Some(crate::config::DEFAULT_CODEX_BASE_URL.to_string());
+            changed = true;
+        }
+        if changed {
+            app.config
+                .provider_states
+                .insert("codex".to_string(), codex_state);
+        }
+    }
 
-    if previous_provider != "codex" {
-        app.config.set_provider(previous_provider);
+    if changed {
+        app.config_manager.save(&app.config)?;
     }
 
     Ok(true)
@@ -942,19 +1003,20 @@ fn open_provider_family_overlay(
     app: &mut TuiApp,
     oauth_manager: &OAuthManager,
 ) -> anyhow::Result<()> {
-    let has_synced_codex_auth = if matches!(
+    let entering_codex_family = matches!(
         app.selected_provider_family(),
         self::state::ProviderFamily::Codex
-    ) {
+    );
+    if entering_codex_family {
+        oauth_manager.invalidate_saved_auth_cache();
+    }
+    let has_synced_codex_auth = if entering_codex_family {
         sync_codex_credential_from_auth_store(app, oauth_manager)?
     } else {
         false
     };
 
-    if matches!(
-        app.selected_provider_family(),
-        self::state::ProviderFamily::Codex
-    ) && !has_synced_codex_auth
+    if entering_codex_family && !has_synced_codex_auth
         && !codex_auth_is_available(app, oauth_manager)
     {
         app.config.set_provider("codex");
@@ -1294,6 +1356,17 @@ mod tests {
             Some("sk-test-codex")
         );
         assert_eq!(app.config.provider, "ollama");
+
+        let persisted = app.config_manager.load().expect("load saved config");
+        assert_eq!(persisted.provider, "ollama");
+        assert_eq!(
+            persisted
+                .provider_states
+                .get("codex")
+                .and_then(|state| state.api_key.as_ref())
+                .map(|value| value.expose_secret()),
+            Some("sk-test-codex")
+        );
     }
 
     #[tokio::test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -31,7 +31,7 @@ use tokio::time::{interval, Duration};
 use crate::agent::Agent;
 use crate::oauth::OAuthManager;
 use crate::state_db::StateDb;
-use crate::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
+use crate::{should_reset_codex_base_url, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
 
 use self::app_event::AppEvent;
 use self::command::{palette_command_by_index, palette_commands, parse_local_command};
@@ -522,21 +522,14 @@ async fn dispatch_event(
                 app.close_overlay();
             } else {
                 app.config.set_api_key(value.to_string());
-                if app.config.provider == "codex" && app.config.model.is_none() {
-                    app.config.set_model(Some(DEFAULT_CODEX_MODEL.into()));
-                }
-                if app.config.provider == "codex"
-                    && app
-                        .config
-                        .base_url
-                        .as_deref()
-                        .map(str::trim)
-                        .is_none_or(|current| {
-                            current.is_empty() || current == "http://localhost:8080"
-                        })
-                {
-                    app.config
-                        .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
+                if app.config.provider == "codex" {
+                    if app.config.model.is_none() {
+                        app.config.set_model(Some(DEFAULT_CODEX_MODEL.into()));
+                    }
+                    if should_reset_codex_base_url(app.config.base_url.as_deref()) {
+                        app.config
+                            .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
+                    }
                 }
                 app.config_manager.save(&app.config)?;
                 if app.config.provider == "codex" {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -31,7 +31,6 @@ use tokio::time::{interval, Duration};
 use crate::agent::Agent;
 use crate::oauth::OAuthManager;
 use crate::state_db::StateDb;
-use crate::{should_reset_codex_base_url, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
 
 use self::app_event::AppEvent;
 use self::command::{palette_command_by_index, palette_commands, parse_local_command};
@@ -523,13 +522,7 @@ async fn dispatch_event(
             } else {
                 app.config.set_api_key(value.to_string());
                 if app.config.provider == "codex" {
-                    if app.config.model.is_none() {
-                        app.config.set_model(Some(DEFAULT_CODEX_MODEL.into()));
-                    }
-                    if should_reset_codex_base_url(app.config.base_url.as_deref()) {
-                        app.config
-                            .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
-                    }
+                    app.config.apply_codex_defaults();
                 }
                 app.config_manager.save(&app.config)?;
                 if app.config.provider == "codex" {
@@ -901,7 +894,7 @@ fn codex_auth_is_available(app: &TuiApp, oauth_manager: &OAuthManager) -> bool {
     if app.config.provider == "codex" && app.config.has_api_key() {
         return true;
     }
-    oauth_manager.has_saved_auth().unwrap_or(false)
+    oauth_manager.has_saved_auth().is_ok_and(|saved| saved)
 }
 
 fn open_provider_family_overlay(app: &mut TuiApp, oauth_manager: &OAuthManager) {
@@ -931,9 +924,9 @@ mod tests {
         map_key_to_event, open_provider_family_overlay, PendingPlanApprovalAction,
     };
     use crate::config::ConfigManager;
+    use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
     use crate::tui::app_event::AppEvent;
     use crate::tui::state::{Overlay, ProviderFamily, RunningTask, TaskKind, TuiApp};
-    use crate::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
     use crossterm::event::KeyCode;
     use std::sync::Arc;
     use std::time::{Duration, Instant};

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -31,6 +31,7 @@ use tokio::time::{interval, Duration};
 use crate::agent::Agent;
 use crate::oauth::OAuthManager;
 use crate::state_db::StateDb;
+use crate::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
 
 use self::app_event::AppEvent;
 use self::command::{palette_command_by_index, palette_commands, parse_local_command};
@@ -45,8 +46,7 @@ use self::session_restore::{
     provider_requires_api_key, restore_latest_session, restore_session_by_id,
 };
 use self::state::{
-    current_model_presets, HelpTab, LocalCommandKind, Overlay, TaskKind, TuiApp,
-    PROVIDER_FAMILIES,
+    current_model_presets, HelpTab, LocalCommandKind, Overlay, TaskKind, TuiApp, PROVIDER_FAMILIES,
 };
 use self::terminal_ui::{
     build_terminal, flush_committed_history, handle_paste, is_ssh_session, teardown_terminal,
@@ -392,7 +392,7 @@ async fn dispatch_event(
             if matches!(app.overlay, Some(Overlay::Setup)) {
                 app.select_local_model(app.model_picker_idx);
             } else if matches!(app.overlay, Some(Overlay::ModelPicker)) && !app.is_busy() {
-                if should_open_codex_auth_guide(app) {
+                if should_open_codex_auth_guide(app, oauth_manager.as_ref()) {
                     app.select_local_model(app.model_picker_idx);
                     app.open_overlay(Overlay::AuthModePicker);
                 } else {
@@ -523,7 +523,20 @@ async fn dispatch_event(
             } else {
                 app.config.set_api_key(value.to_string());
                 if app.config.provider == "codex" && app.config.model.is_none() {
-                    app.config.set_model(Some("codex".into()));
+                    app.config.set_model(Some(DEFAULT_CODEX_MODEL.into()));
+                }
+                if app.config.provider == "codex"
+                    && app
+                        .config
+                        .base_url
+                        .as_deref()
+                        .map(str::trim)
+                        .is_none_or(|current| {
+                            current.is_empty() || current == "http://localhost:8080"
+                        })
+                {
+                    app.config
+                        .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
                 }
                 app.config_manager.save(&app.config)?;
                 if app.config.provider == "codex" {
@@ -569,7 +582,7 @@ async fn dispatch_event(
                 if app.is_busy() {
                     app.push_notice("A task is already running. Wait for it to finish.");
                 } else {
-                    app.open_overlay(Overlay::ModelPicker);
+                    open_provider_family_overlay(app, oauth_manager.as_ref());
                 }
             }
             Some(Overlay::ResumePicker) => {
@@ -604,7 +617,7 @@ async fn dispatch_event(
                     app.push_notice("A task is already running. Wait for it to finish.");
                 } else {
                     app.select_local_model(app.model_picker_idx);
-                    if should_open_codex_auth_guide(app) {
+                    if should_open_codex_auth_guide(app, oauth_manager.as_ref()) {
                         app.open_overlay(Overlay::AuthModePicker);
                     } else {
                         start_rebuild_task(app);
@@ -891,23 +904,43 @@ fn clamp_command_palette_selection(app: &mut TuiApp) {
     }
 }
 
-fn should_open_codex_auth_guide(app: &TuiApp) -> bool {
+fn codex_auth_is_available(app: &TuiApp, oauth_manager: &OAuthManager) -> bool {
+    if app.config.provider == "codex" && app.config.has_api_key() {
+        return true;
+    }
+    oauth_manager.has_saved_auth().unwrap_or(false)
+}
+
+fn open_provider_family_overlay(app: &mut TuiApp, oauth_manager: &OAuthManager) {
+    if matches!(
+        app.selected_provider_family(),
+        self::state::ProviderFamily::Codex
+    ) && !codex_auth_is_available(app, oauth_manager)
+    {
+        app.open_overlay(Overlay::AuthModePicker);
+    } else {
+        app.open_overlay(Overlay::ModelPicker);
+    }
+}
+
+fn should_open_codex_auth_guide(app: &TuiApp, oauth_manager: &OAuthManager) -> bool {
     let presets = current_model_presets(app.provider_picker_idx);
     let Some((_, provider, _)) = presets.get(app.model_picker_idx) else {
         return false;
     };
-    *provider == "codex" && !app.config.has_api_key()
+    *provider == "codex" && !codex_auth_is_available(app, oauth_manager)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_pending_plan_approval_input, dispatch_event, map_key_to_event,
-        PendingPlanApprovalAction,
+        classify_pending_plan_approval_input, codex_auth_is_available, dispatch_event,
+        map_key_to_event, open_provider_family_overlay, PendingPlanApprovalAction,
     };
     use crate::config::ConfigManager;
     use crate::tui::app_event::AppEvent;
-    use crate::tui::state::{Overlay, RunningTask, TaskKind, TuiApp};
+    use crate::tui::state::{Overlay, ProviderFamily, RunningTask, TaskKind, TuiApp};
+    use crate::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
     use crossterm::event::KeyCode;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -1105,5 +1138,92 @@ mod tests {
             .notice
             .as_deref()
             .is_some_and(|value| value.contains("Cleared API key")));
+    }
+
+    #[test]
+    fn codex_auth_detection_uses_saved_auth_storage() {
+        let temp = tempdir().expect("tempdir");
+        let app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager =
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager");
+
+        assert!(!codex_auth_is_available(&app, &oauth_manager));
+
+        oauth_manager
+            .save_api_key("sk-test-codex")
+            .expect("save api key");
+        assert!(codex_auth_is_available(&app, &oauth_manager));
+    }
+
+    #[test]
+    fn codex_provider_family_routes_to_auth_picker_without_saved_login() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager =
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager");
+        app.provider_picker_idx = 0;
+
+        assert_eq!(app.selected_provider_family(), ProviderFamily::Codex);
+
+        open_provider_family_overlay(&mut app, &oauth_manager);
+        assert!(matches!(app.overlay, Some(Overlay::AuthModePicker)));
+    }
+
+    #[test]
+    fn codex_provider_family_routes_to_model_picker_with_saved_login() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager =
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager");
+        oauth_manager
+            .save_api_key("sk-test-codex")
+            .expect("save api key");
+        app.provider_picker_idx = 0;
+
+        open_provider_family_overlay(&mut app, &oauth_manager);
+        assert!(matches!(app.overlay, Some(Overlay::ModelPicker)));
+    }
+
+    #[tokio::test]
+    async fn save_api_key_input_sets_codex_defaults_before_rebuild() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.config.set_provider("codex");
+        app.open_overlay(Overlay::ApiKeyEditor);
+        app.api_key_input = "sk-codex".into();
+
+        let oauth_manager = Arc::new(
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager"),
+        );
+        let mut agent_slot = None;
+
+        let should_quit = dispatch_event(
+            AppEvent::SaveApiKeyInput,
+            &mut app,
+            &mut agent_slot,
+            &oauth_manager,
+        )
+        .await
+        .expect("save codex api key");
+
+        assert!(!should_quit);
+        assert_eq!(app.config.model.as_deref(), Some(DEFAULT_CODEX_MODEL));
+        assert_eq!(app.config.base_url.as_deref(), Some(DEFAULT_CODEX_BASE_URL));
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -26,6 +26,7 @@ use crossterm::{
     terminal::size as terminal_size,
 };
 use futures::StreamExt;
+use secrecy::ExposeSecret;
 use tokio::time::{interval, Duration};
 
 use crate::agent::Agent;
@@ -894,6 +895,15 @@ fn codex_auth_is_available(app: &TuiApp, oauth_manager: &OAuthManager) -> bool {
     if app.config.provider == "codex" && app.config.has_api_key() {
         return true;
     }
+    if app
+        .config
+        .provider_states
+        .get("codex")
+        .and_then(|state| state.api_key.as_ref())
+        .is_some_and(|api_key| !api_key.expose_secret().trim().is_empty())
+    {
+        return true;
+    }
     oauth_manager.has_saved_auth().is_ok_and(|saved| saved)
 }
 
@@ -903,6 +913,7 @@ fn open_provider_family_overlay(app: &mut TuiApp, oauth_manager: &OAuthManager) 
         self::state::ProviderFamily::Codex
     ) && !codex_auth_is_available(app, oauth_manager)
     {
+        app.config.set_provider("codex");
         app.open_overlay(Overlay::AuthModePicker);
     } else {
         app.open_overlay(Overlay::ModelPicker);
@@ -1160,6 +1171,7 @@ mod tests {
         assert_eq!(app.selected_provider_family(), ProviderFamily::Codex);
 
         open_provider_family_overlay(&mut app, &oauth_manager);
+        assert_eq!(app.config.provider, "codex");
         assert!(matches!(app.overlay, Some(Overlay::AuthModePicker)));
     }
 
@@ -1177,6 +1189,30 @@ mod tests {
             .save_api_key("sk-test-codex")
             .expect("save api key");
         app.provider_picker_idx = 0;
+
+        open_provider_family_overlay(&mut app, &oauth_manager);
+        assert!(matches!(app.overlay, Some(Overlay::ModelPicker)));
+    }
+
+    #[test]
+    fn codex_provider_family_uses_saved_codex_provider_state() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager =
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager");
+
+        app.config.set_provider("ollama");
+        app.config.set_api_key("sk-ollama");
+        app.config.set_provider("codex");
+        app.config.set_api_key("sk-codex");
+        app.config.set_provider("ollama");
+        app.provider_picker_idx = 0;
+
+        assert!(codex_auth_is_available(&app, &oauth_manager));
 
         open_provider_family_overlay(&mut app, &oauth_manager);
         assert!(matches!(app.overlay, Some(Overlay::ModelPicker)));

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -336,6 +336,7 @@ pub(super) fn start_oauth_task(
     oauth_manager: Arc<OAuthManager>,
     mode: OAuthLoginMode,
 ) {
+    oauth_manager.invalidate_saved_auth_cache();
     if matches!(mode, OAuthLoginMode::Browser) && super::super::is_ssh_session() {
         app.set_runtime_phase(
             RuntimePhase::Failed,

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -25,6 +25,7 @@ use crate::tools::web::WebFetchTool;
 use crate::tools::workspace::UpdateProjectMemoryTool;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
+use crate::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
 
 use super::super::state::{
     OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp, TuiEvent,
@@ -534,8 +535,7 @@ pub(super) async fn finish_running_task_if_ready(
                     app.current_model_label()
                 ));
                 app.notice = app.setup_status.clone();
-                let queued_follow_up_messages =
-                    std::mem::take(&mut app.queued_follow_up_messages);
+                let queued_follow_up_messages = std::mem::take(&mut app.queued_follow_up_messages);
                 let pending_follow_up_messages =
                     std::mem::take(&mut app.pending_follow_up_messages);
                 app.reset_transcript();
@@ -564,7 +564,17 @@ pub(super) async fn finish_running_task_if_ready(
                 app.config
                     .set_api_key(credential.expose_secret().to_string());
                 if app.config.model.is_none() {
-                    app.config.set_model(Some("codex".into()));
+                    app.config.set_model(Some(DEFAULT_CODEX_MODEL.into()));
+                }
+                if app
+                    .config
+                    .base_url
+                    .as_deref()
+                    .map(str::trim)
+                    .is_none_or(|current| current.is_empty() || current == "http://localhost:8080")
+                {
+                    app.config
+                        .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
                 }
                 app.config_manager.save(&app.config)?;
                 let saved_message = match mode {

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -25,7 +25,7 @@ use crate::tools::web::WebFetchTool;
 use crate::tools::workspace::UpdateProjectMemoryTool;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
-use crate::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
+use crate::{should_reset_codex_base_url, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
 
 use super::super::state::{
     OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp, TuiEvent,
@@ -566,13 +566,7 @@ pub(super) async fn finish_running_task_if_ready(
                 if app.config.model.is_none() {
                     app.config.set_model(Some(DEFAULT_CODEX_MODEL.into()));
                 }
-                if app
-                    .config
-                    .base_url
-                    .as_deref()
-                    .map(str::trim)
-                    .is_none_or(|current| current.is_empty() || current == "http://localhost:8080")
-                {
+                if should_reset_codex_base_url(app.config.base_url.as_deref()) {
                     app.config
                         .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
                 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -25,7 +25,6 @@ use crate::tools::web::WebFetchTool;
 use crate::tools::workspace::UpdateProjectMemoryTool;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
-use crate::{should_reset_codex_base_url, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
 
 use super::super::state::{
     OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp, TuiEvent,
@@ -563,13 +562,7 @@ pub(super) async fn finish_running_task_if_ready(
                 app.config.set_provider("codex");
                 app.config
                     .set_api_key(credential.expose_secret().to_string());
-                if app.config.model.is_none() {
-                    app.config.set_model(Some(DEFAULT_CODEX_MODEL.into()));
-                }
-                if should_reset_codex_base_url(app.config.base_url.as_deref()) {
-                    app.config
-                        .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
-                }
+                app.config.apply_codex_defaults();
                 app.config_manager.save(&app.config)?;
                 let saved_message = match mode {
                     OAuthLoginMode::Browser => {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -23,6 +23,7 @@ use crate::state_db::{
 use crate::tool::ToolOutputStream;
 use crate::tools::bash::BashCommandInput;
 use crate::tui::is_ssh_session;
+use crate::DEFAULT_CODEX_BASE_URL;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum HelpTab {
@@ -543,7 +544,7 @@ impl TuiApp {
                 .is_none()
             {
                 self.config
-                    .set_base_url(Some("http://localhost:8080".to_string()));
+                    .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
             }
         } else if provider == "openai-compatible" {
             if self
@@ -1535,6 +1536,7 @@ mod tests {
         TuiApp,
     };
     use crate::config::{ConfigManager, RaraConfig};
+    use crate::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
     use tempfile::tempdir;
 
     #[test]
@@ -1707,7 +1709,8 @@ mod tests {
         app.select_local_model(0);
 
         assert_eq!(app.config.provider, "codex");
-        assert_eq!(app.config.model.as_deref(), Some("codex"));
+        assert_eq!(app.config.model.as_deref(), Some(DEFAULT_CODEX_MODEL));
+        assert_eq!(app.config.base_url.as_deref(), Some(DEFAULT_CODEX_BASE_URL));
     }
 
     #[test]

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -23,7 +23,7 @@ use crate::state_db::{
 use crate::tool::ToolOutputStream;
 use crate::tools::bash::BashCommandInput;
 use crate::tui::is_ssh_session;
-use crate::DEFAULT_CODEX_BASE_URL;
+use crate::{should_reset_codex_base_url, DEFAULT_CODEX_BASE_URL};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum HelpTab {
@@ -539,9 +539,7 @@ impl TuiApp {
                 .config
                 .base_url
                 .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .is_none()
+                .is_none_or(|value| should_reset_codex_base_url(Some(value)))
             {
                 self.config
                     .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -14,6 +14,7 @@ pub use self::state_presets::{
 use super::markdown_stream::MarkdownStreamCollector;
 use super::queued_input::PendingFollowUpMessage;
 use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
+use crate::config::DEFAULT_CODEX_BASE_URL;
 use crate::config::{ConfigManager, RaraConfig};
 use crate::redaction::redact_secrets;
 use crate::state_db::{
@@ -23,7 +24,6 @@ use crate::state_db::{
 use crate::tool::ToolOutputStream;
 use crate::tools::bash::BashCommandInput;
 use crate::tui::is_ssh_session;
-use crate::{should_reset_codex_base_url, DEFAULT_CODEX_BASE_URL};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum HelpTab {
@@ -535,12 +535,7 @@ impl TuiApp {
         } else if provider == "codex" {
             self.config.set_model(Some(model.to_string()));
             self.config.set_revision(None);
-            if self
-                .config
-                .base_url
-                .as_deref()
-                .is_none_or(|value| should_reset_codex_base_url(Some(value)))
-            {
+            if crate::config::should_reset_codex_base_url(self.config.base_url.as_deref()) {
                 self.config
                     .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
             }
@@ -1534,7 +1529,7 @@ mod tests {
         TuiApp,
     };
     use crate::config::{ConfigManager, RaraConfig};
-    use crate::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
+    use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
     use tempfile::tempdir;
 
     #[test]

--- a/src/tui/state/state_presets.rs
+++ b/src/tui/state/state_presets.rs
@@ -2,9 +2,10 @@ use crate::config::RaraConfig;
 
 use super::ProviderFamily;
 
-pub const CODEX_MODEL_PRESETS: [(&str, &str, &str); 2] = [
-    ("Codex (OAuth)", "codex", "codex"),
-    ("Codex (API Key)", "codex", "codex"),
+pub const CODEX_MODEL_PRESETS: [(&str, &str, &str); 3] = [
+    ("GPT-5 Codex", "codex", "gpt-5-codex"),
+    ("GPT-5.1 Codex mini", "codex", "gpt-5.1-codex-mini"),
+    ("GPT-5.1 Codex max", "codex", "gpt-5.1-codex-max"),
 ];
 
 pub const OPENAI_COMPATIBLE_MODEL_PRESETS: [(&str, &str, &str); 1] =


### PR DESCRIPTION
## Summary

- route the Codex `/model` flow by real auth state instead of only checking `config.has_api_key()`
- replace the fake Codex auth-mode presets with real Codex model presets
- stop defaulting Codex rebuilds to `http://localhost:8080` and seed the remote Codex defaults after login

## Changes

- add `OAuthManager::has_saved_auth()` so the TUI can detect Codex login state from the local auth store
- open `AuthModePicker` directly when the selected provider family is Codex and no saved auth is present
- keep the Codex flow on `ModelPicker` when a saved Codex credential already exists
- set Codex defaults to:
  - base URL: `https://api.openai.com/v1`
  - model: `gpt-5-codex`
- replace the old Codex pseudo-presets with real model choices:
  - `GPT-5 Codex`
  - `GPT-5.1 Codex mini`
  - `GPT-5.1 Codex max`

## Testing

- `cargo test oauth::tests -- --nocapture`
- `cargo test tui::state::tests::codex_preset_keeps_the_codex_model_label -- --nocapture`
- `cargo test tui::tests::codex_provider_family_routes_to_auth_picker_without_saved_login -- --nocapture`
- `cargo test tui::tests::codex_provider_family_routes_to_model_picker_with_saved_login -- --nocapture`
- `cargo test tui::tests::save_api_key_input_sets_codex_defaults_before_rebuild -- --nocapture`
- `cargo test tui::tests::codex_auth_detection_uses_saved_auth_storage -- --nocapture`
- `cargo check`
