### PR TITLE
fix(llm): route codex through responses api

### DIFF
--- a/docs/features/codex-auth-login.md
+++ b/docs/features/codex-auth-login.md
@@ -214,6 +214,9 @@ Implemented in the current pass:
   project-local `.rara`
 - the main RARA config now lives under `~/.rara/config.json`, with
   provider-scoped remembered state for multi-provider/model use
+- the Codex runtime path no longer reuses the generic OpenAI-compatible
+  `chat/completions` backend; Codex requests now target the Responses API at
+  `/v1/responses`, matching upstream `codex-rs`
 - focused auth regression tests now cover:
   - stored API-key persistence
   - logout cleanup

--- a/docs/journal/2026-04-22-codex-responses-backend.md
+++ b/docs/journal/2026-04-22-codex-responses-backend.md
@@ -1,0 +1,55 @@
+# 2026-04-22 Codex Responses Backend
+
+## Summary
+
+RARA's `codex` provider had still been routed through the generic
+OpenAI-compatible `chat/completions` path even after Codex auth/login had been
+aligned to `codex_login`.
+
+That mismatch meant:
+
+- Codex auth could succeed,
+- the TUI could route into Codex model selection,
+- but actual prompt execution still hit `/v1/chat/completions` instead of the
+  upstream Codex Responses API contract.
+
+This checkpoint switches the Codex provider to a dedicated `/v1/responses`
+request path, aligned with local `codex-rs`.
+
+## Upstream Alignment
+
+The local `codex-rs` inspection showed:
+
+- `codex-rs/model-provider-info` only supports `wire_api = "responses"`
+- the old `chat` wire API is explicitly removed
+- `codex-rs/cli/src/responses_cmd.rs` uses `codex_api::ResponsesClient`
+
+RARA now mirrors that protocol boundary instead of treating Codex as a plain
+OpenAI-compatible chat-completions provider.
+
+## What Landed
+
+- `src/llm/openai_compatible.rs`
+  - `CodexBackend` no longer delegates `ask()` and `summarize()` to the generic
+    `OpenAiCompatibleBackend`
+  - Codex requests now target `POST /v1/responses`
+  - RARA history is converted into Responses-style input items:
+    - user/system messages -> `message` with `input_text`
+    - assistant text -> `message` with `output_text`
+    - assistant tool uses -> `function_call`
+    - tool results -> `function_call_output`
+  - Responses output is converted back into RARA's internal content model:
+    - output text -> `ContentBlock::Text`
+    - function calls -> `ContentBlock::ToolUse`
+- `src/llm/tests.rs`
+  - added focused regression coverage for:
+    - message history -> Responses input conversion
+    - Responses output -> RARA content parsing
+
+## Validation
+
+Focused verification for this checkpoint:
+
+- `cargo test converts_history_to_codex_responses_input_items -- --nocapture`
+- `cargo test parses_codex_responses_output_into_text_and_tool_use_blocks -- --nocapture`
+- `cargo check`

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -257,7 +257,24 @@ impl CodexBackend {
 #[async_trait]
 impl LlmBackend for CodexBackend {
     async fn ask(&self, m: &[Message], t: &[Value]) -> Result<AnthropicResponse> {
-        self.inner.ask(m, t).await
+        let body = build_codex_responses_request(&self.inner.model, m, t);
+        let responses_url = self.inner.endpoint_url("responses");
+        let mut request = self.inner.client.post(&responses_url);
+        if let Some(api_key) = self.inner.api_key.as_ref().map(SecretString::expose_secret) {
+            if !api_key.is_empty() {
+                request = request.header("Authorization", format!("Bearer {api_key}"));
+            }
+        }
+        let res = request.json(&body).send().await?;
+        if !res.status().is_success() {
+            return Err(anyhow!(
+                "API Error at {}: {}",
+                sanitize_url_for_display(&responses_url),
+                redact_secrets(res.text().await?)
+            ));
+        }
+        let resp_json: Value = res.json().await?;
+        parse_codex_response(&resp_json)
     }
 
     async fn embed(&self, t: &str) -> Result<Vec<f32>> {
@@ -265,11 +282,182 @@ impl LlmBackend for CodexBackend {
     }
 
     async fn summarize(&self, m: &[Message], instruction: &str) -> Result<String> {
-        self.inner.summarize(m, instruction).await
+        let mut messages = m.to_vec();
+        messages.push(Message {
+            role: "user".to_string(),
+            content: json!(instruction),
+        });
+        let response = self.ask(&messages, &[]).await?;
+        Ok(response
+            .content
+            .into_iter()
+            .filter_map(|block| match block {
+                ContentBlock::Text { text } => Some(text),
+                ContentBlock::ToolUse { .. } => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n"))
     }
 
     fn context_budget(&self, messages: &[Message], tools: &[Value]) -> Option<ContextBudget> {
         self.inner.context_budget(messages, tools)
+    }
+}
+
+fn build_codex_responses_request(model: &str, messages: &[Message], tools: &[Value]) -> Value {
+    let codex_tools = tools
+        .iter()
+        .map(|tool| {
+            json!({
+                "type": "function",
+                "name": tool["name"],
+                "description": tool["description"],
+                "parameters": tool["input_schema"],
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "model": model,
+        "input": to_codex_input_items(messages),
+        "tools": codex_tools,
+        "tool_choice": "auto",
+        "parallel_tool_calls": false,
+        "store": false,
+        "stream": false,
+        "include": [],
+    })
+}
+
+pub(super) fn to_codex_input_items(messages: &[Message]) -> Vec<Value> {
+    let mut items = Vec::new();
+    for message in messages {
+        match message.role.as_str() {
+            "assistant" => items.extend(render_codex_assistant_items(&message.content)),
+            "user" => {
+                if let Some(tool_result) = extract_codex_tool_result_item(&message.content) {
+                    items.push(tool_result);
+                } else {
+                    items.push(render_codex_message(
+                        message.role.as_str(),
+                        &message.content,
+                        false,
+                    ));
+                }
+            }
+            role => items.push(render_codex_message(role, &message.content, false)),
+        }
+    }
+    items
+}
+
+fn render_codex_message(role: &str, content: &Value, assistant_output: bool) -> Value {
+    let text = render_openai_message_content(content);
+    let content_item_type = if assistant_output {
+        "output_text"
+    } else {
+        "input_text"
+    };
+    json!({
+        "type": "message",
+        "role": role,
+        "content": [{
+            "type": content_item_type,
+            "text": text,
+        }],
+    })
+}
+
+fn render_codex_assistant_items(content: &Value) -> Vec<Value> {
+    let (text_parts, assistant_tool_uses) = collect_assistant_content(content);
+    let mut items = Vec::new();
+    if !text_parts.is_empty() {
+        items.push(render_codex_message(
+            "assistant",
+            &Value::String(text_parts.join("\n\n")),
+            true,
+        ));
+    }
+    for tool_use in assistant_tool_uses {
+        items.push(json!({
+            "type": "function_call",
+            "name": tool_use.name,
+            "arguments": serde_json::to_string(&tool_use.input)
+                .unwrap_or_else(|_| "{}".to_string()),
+            "call_id": tool_use.id,
+        }));
+    }
+    items
+}
+
+fn extract_codex_tool_result_item(content: &Value) -> Option<Value> {
+    let (tool_use_id, tool_content) = extract_single_tool_result(content)?;
+    Some(json!({
+        "type": "function_call_output",
+        "call_id": tool_use_id,
+        "output": tool_content,
+    }))
+}
+
+pub(super) fn parse_codex_response(resp_json: &Value) -> Result<AnthropicResponse> {
+    let mut content = Vec::new();
+    if let Some(items) = resp_json.get("output").and_then(Value::as_array) {
+        for item in items {
+            match item.get("type").and_then(Value::as_str) {
+                Some("message") => {
+                    if let Some(text) = extract_codex_output_text(item.get("content")) {
+                        if !text.trim().is_empty() {
+                            content.push(ContentBlock::Text { text });
+                        }
+                    }
+                }
+                Some("function_call") => {
+                    let id = item
+                        .get("call_id")
+                        .or_else(|| item.get("id"))
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let name = item
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let input =
+                        parse_tool_arguments(item.get("arguments").unwrap_or(&Value::Null))?;
+                    content.push(ContentBlock::ToolUse { id, name, input });
+                }
+                _ => {}
+            }
+        }
+    }
+    let usage = resp_json.get("usage").map(|u| crate::agent::TokenUsage {
+        input_tokens: u["input_tokens"].as_u64().unwrap_or(0) as u32,
+        output_tokens: u["output_tokens"].as_u64().unwrap_or(0) as u32,
+    });
+    Ok(AnthropicResponse {
+        content,
+        stop_reason: resp_json
+            .get("status")
+            .and_then(Value::as_str)
+            .map(|s| s.to_string()),
+        usage,
+    })
+}
+
+fn extract_codex_output_text(content: Option<&Value>) -> Option<String> {
+    let items = content?.as_array()?;
+    let texts = items
+        .iter()
+        .filter_map(|item| match item.get("type").and_then(Value::as_str) {
+            Some("output_text") => item.get("text").and_then(Value::as_str).map(str::to_string),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if texts.is_empty() {
+        None
+    } else {
+        Some(texts.join("\n\n"))
     }
 }
 

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -334,17 +334,7 @@ pub(super) fn to_codex_input_items(messages: &[Message]) -> Vec<Value> {
     for message in messages {
         match message.role.as_str() {
             "assistant" => items.extend(render_codex_assistant_items(&message.content)),
-            "user" => {
-                if let Some(tool_result) = extract_codex_tool_result_item(&message.content) {
-                    items.push(tool_result);
-                } else {
-                    items.push(render_codex_message(
-                        message.role.as_str(),
-                        &message.content,
-                        false,
-                    ));
-                }
-            }
+            "user" => items.extend(render_codex_user_items(&message.content)),
             role => items.push(render_codex_message(role, &message.content, false)),
         }
     }
@@ -390,8 +380,65 @@ fn render_codex_assistant_items(content: &Value) -> Vec<Value> {
     items
 }
 
+fn render_codex_user_items(content: &Value) -> Vec<Value> {
+    let Some(raw_items) = content.as_array() else {
+        return vec![render_codex_message("user", content, false)];
+    };
+
+    let mut rendered = Vec::new();
+    let mut text_parts = Vec::new();
+    let flush_text = |rendered: &mut Vec<Value>, text_parts: &mut Vec<String>| {
+        if !text_parts.is_empty() {
+            rendered.push(render_codex_message(
+                "user",
+                &Value::String(text_parts.join("\n\n")),
+                false,
+            ));
+            text_parts.clear();
+        }
+    };
+
+    for item in raw_items {
+        match item.get("type").and_then(Value::as_str) {
+            Some("tool_result") => {
+                flush_text(&mut rendered, &mut text_parts);
+                if let Some(tool_result) = extract_codex_tool_result_item(item) {
+                    rendered.push(tool_result);
+                }
+            }
+            Some("text") => {
+                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                    if !text.trim().is_empty() {
+                        text_parts.push(text.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    flush_text(&mut rendered, &mut text_parts);
+
+    if rendered.is_empty() {
+        vec![render_codex_message("user", content, false)]
+    } else {
+        rendered
+    }
+}
+
 fn extract_codex_tool_result_item(content: &Value) -> Option<Value> {
-    let (tool_use_id, tool_content) = extract_single_tool_result(content)?;
+    let tool_use_id = content
+        .get("tool_use_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let tool_content = content
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    if tool_use_id.is_empty() {
+        return None;
+    }
     Some(json!({
         "type": "function_call_output",
         "call_id": tool_use_id,

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -76,6 +76,32 @@ fn converts_history_to_codex_responses_input_items() {
 }
 
 #[test]
+fn preserves_mixed_user_text_and_multiple_tool_results_for_codex_inputs() {
+    let messages = vec![Message {
+        role: "user".to_string(),
+        content: json!([
+            {"type":"text","text":"First result follows."},
+            {"type":"tool_result","tool_use_id":"tool-1","content":"alpha"},
+            {"type":"text","text":"Second result follows."},
+            {"type":"tool_result","tool_use_id":"tool-2","content":"beta"}
+        ]),
+    }];
+
+    let input = to_codex_input_items(&messages);
+    assert_eq!(input.len(), 4);
+    assert_eq!(input[0]["type"], "message");
+    assert_eq!(input[0]["content"][0]["text"], "First result follows.");
+    assert_eq!(input[1]["type"], "function_call_output");
+    assert_eq!(input[1]["call_id"], "tool-1");
+    assert_eq!(input[1]["output"], "alpha");
+    assert_eq!(input[2]["type"], "message");
+    assert_eq!(input[2]["content"][0]["text"], "Second result follows.");
+    assert_eq!(input[3]["type"], "function_call_output");
+    assert_eq!(input[3]["call_id"], "tool-2");
+    assert_eq!(input[3]["output"], "beta");
+}
+
+#[test]
 fn parses_codex_responses_output_into_text_and_tool_use_blocks() {
     let response = parse_codex_response(&json!({
         "status": "completed",

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -6,7 +6,7 @@ use super::ollama::{
     apply_ollama_stream_event, build_ollama_options, ensure_ollama_stream_completed,
     suggest_ollama_num_ctx, to_ollama_messages,
 };
-use super::openai_compatible::to_openai_messages;
+use super::openai_compatible::{parse_codex_response, to_codex_input_items, to_openai_messages};
 use super::shared::{
     extract_message_text, model_context_budget, parse_tool_arguments, should_bypass_proxy,
 };
@@ -37,6 +37,86 @@ fn converts_assistant_tool_history_to_openai_messages() {
     );
     assert_eq!(openai_messages[1]["role"], "tool");
     assert_eq!(openai_messages[1]["tool_call_id"], "tool-1");
+}
+
+#[test]
+fn converts_history_to_codex_responses_input_items() {
+    let messages = vec![
+        Message {
+            role: "system".to_string(),
+            content: json!("Follow the repo rules."),
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: json!([
+                {"type":"text","text":"Need a tool."},
+                {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"Cargo.toml"}}
+            ]),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([
+                {"type":"tool_result","tool_use_id":"tool-1","content":"[package]"}
+            ]),
+        },
+    ];
+
+    let input = to_codex_input_items(&messages);
+    assert_eq!(input[0]["type"], "message");
+    assert_eq!(input[0]["role"], "system");
+    assert_eq!(input[0]["content"][0]["type"], "input_text");
+    assert_eq!(input[1]["type"], "message");
+    assert_eq!(input[1]["role"], "assistant");
+    assert_eq!(input[1]["content"][0]["type"], "output_text");
+    assert_eq!(input[2]["type"], "function_call");
+    assert_eq!(input[2]["call_id"], "tool-1");
+    assert_eq!(input[3]["type"], "function_call_output");
+    assert_eq!(input[3]["call_id"], "tool-1");
+    assert_eq!(input[3]["output"], "[package]");
+}
+
+#[test]
+fn parses_codex_responses_output_into_text_and_tool_use_blocks() {
+    let response = parse_codex_response(&json!({
+        "status": "completed",
+        "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7
+        },
+        "output": [
+            {
+                "type": "message",
+                "content": [
+                    {"type": "output_text", "text": "Need to inspect a file."}
+                ]
+            },
+            {
+                "type": "function_call",
+                "call_id": "call-1",
+                "name": "read_file",
+                "arguments": "{\"path\":\"Cargo.toml\"}"
+            }
+        ]
+    }))
+    .unwrap();
+
+    assert_eq!(response.stop_reason, Some("completed".to_string()));
+    assert_eq!(response.usage.unwrap().input_tokens, 11);
+    assert_eq!(response.content.len(), 2);
+    match &response.content[0] {
+        crate::agent::ContentBlock::Text { text } => {
+            assert_eq!(text, "Need to inspect a file.");
+        }
+        other => panic!("expected text block, got {other:?}"),
+    }
+    match &response.content[1] {
+        crate::agent::ContentBlock::ToolUse { id, name, input } => {
+            assert_eq!(id, "call-1");
+            assert_eq!(name, "read_file");
+            assert_eq!(input, &json!({"path":"Cargo.toml"}));
+        }
+        other => panic!("expected tool_use block, got {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- route the Codex provider through `/v1/responses` instead of generic `chat/completions`
- map RARA message/tool history into Responses-style input items and parse Responses output back into `ContentBlock`
- record the Codex runtime contract update in the auth feature spec and journal

## Why

Codex auth/login had already been aligned to `codex_login`, but the actual Codex runtime path in `rara` still reused the generic OpenAI-compatible `chat/completions` backend.

That mismatch meant Codex login could succeed while actual prompts were still sent over the wrong wire protocol. Local `codex-rs` has already removed the old chat wire API and routes Codex through `/v1/responses`.

## Validation

- `cargo test converts_history_to_codex_responses_input_items -- --nocapture`
- `cargo test parses_codex_responses_output_into_text_and_tool_use_blocks -- --nocapture`
- `cargo check`
