### PR TITLE
fix(auth): route codex oauth to responses backend

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -2,13 +2,14 @@ use anyhow::Result;
 use dirs::home_dir;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use std::collections::{hash_map::DefaultHasher, BTreeMap};
+use std::collections::{BTreeMap, hash_map::DefaultHasher};
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 pub const DEFAULT_CODEX_BASE_URL: &str = "https://api.openai.com/v1";
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.4";
+pub const DEFAULT_CODEX_CHATGPT_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 pub const LEGACY_CODEX_BASE_URL: &str = "http://localhost:8080";
 pub const LEGACY_CODEX_MODEL: &str = "codex";
 pub const LEGACY_CODEX_MODEL_V1: &str = "gpt-5-codex";
@@ -27,6 +28,15 @@ pub fn should_reset_codex_model(model: Option<&str>) -> bool {
                 value,
                 LEGACY_CODEX_MODEL | LEGACY_CODEX_MODEL_V1 | LEGACY_CODEX_MODEL_V1_MINI
             )
+    })
+}
+
+pub fn should_apply_codex_base_url(url: Option<&str>, expected: &str) -> bool {
+    url.map(str::trim).map_or(true, |value| {
+        value.is_empty()
+            || value == LEGACY_CODEX_BASE_URL
+            || ((value == DEFAULT_CODEX_BASE_URL || value == DEFAULT_CODEX_CHATGPT_BASE_URL)
+                && value != expected)
     })
 }
 
@@ -140,8 +150,12 @@ impl RaraConfig {
     }
 
     pub fn apply_codex_defaults(&mut self) {
-        if should_reset_codex_base_url(self.base_url.as_deref()) {
-            self.set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
+        self.apply_codex_defaults_for_base_url(DEFAULT_CODEX_BASE_URL);
+    }
+
+    pub fn apply_codex_defaults_for_base_url(&mut self, base_url: &str) {
+        if should_apply_codex_base_url(self.base_url.as_deref(), base_url) {
+            self.set_base_url(Some(base_url.to_string()));
         }
         if should_reset_codex_model(self.model.as_deref()) {
             self.set_model(Some(DEFAULT_CODEX_MODEL.to_string()));
@@ -324,7 +338,7 @@ impl ConfigManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{workspace_data_dir_for_home, ConfigManager, RaraConfig};
+    use super::{ConfigManager, RaraConfig, workspace_data_dir_for_home};
     use std::fs;
     use tempfile::tempdir;
 
@@ -401,6 +415,24 @@ mod tests {
             config.base_url.as_deref(),
             Some(super::DEFAULT_CODEX_BASE_URL)
         );
+    }
+
+    #[test]
+    fn apply_codex_defaults_for_base_url_switches_between_known_codex_defaults() {
+        let mut config = RaraConfig {
+            provider: "codex".to_string(),
+            base_url: Some(super::DEFAULT_CODEX_BASE_URL.to_string()),
+            model: Some(super::DEFAULT_CODEX_MODEL.to_string()),
+            ..Default::default()
+        };
+
+        config.apply_codex_defaults_for_base_url(super::DEFAULT_CODEX_CHATGPT_BASE_URL);
+
+        assert_eq!(
+            config.base_url.as_deref(),
+            Some(super::DEFAULT_CODEX_CHATGPT_BASE_URL)
+        );
+        assert_eq!(config.model.as_deref(), Some(super::DEFAULT_CODEX_MODEL));
     }
 
     #[test]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,0 +1,5 @@
+//! Placeholder for the staged context architecture module.
+//!
+//! The initial integration for the context subsystem lands in separate PRs.
+//! This module exists so branches that already reference `mod context;`
+//! continue to compile until the staged implementation is merged.

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -1,15 +1,16 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use codex_login::default_client::default_headers as codex_default_headers;
 use secrecy::{ExposeSecret, SecretString};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::agent::{AnthropicResponse, ContentBlock, Message};
 use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
 use super::shared::{
-    collect_assistant_content, extract_message_text, extract_single_tool_result,
-    http_client_for_target, model_context_budget, parse_tool_arguments,
-    render_openai_message_content, ContextBudget, LlmBackend,
+    ContextBudget, LlmBackend, collect_assistant_content, extract_message_text,
+    extract_single_tool_result, http_client_for_target, model_context_budget, parse_tool_arguments,
+    render_openai_message_content,
 };
 
 pub struct OpenAiCompatibleBackend {
@@ -243,8 +244,11 @@ fn extract_tool_result_message(content: &Value) -> Option<Value> {
 }
 
 pub struct CodexBackend {
-    inner: OpenAiCompatibleBackend,
     reasoning_effort: Option<String>,
+    client: reqwest::Client,
+    api_key: Option<SecretString>,
+    base_url: String,
+    model: String,
 }
 
 impl CodexBackend {
@@ -255,29 +259,38 @@ impl CodexBackend {
         reasoning_effort: Option<String>,
     ) -> Result<Self> {
         Ok(Self {
-            inner: OpenAiCompatibleBackend::new(api_key, base_url, model)?,
+            client: http_client_for_target(&base_url)?,
+            api_key,
+            base_url,
+            model,
             reasoning_effort,
         })
+    }
+
+    fn endpoint_url(&self, path: &str) -> String {
+        let base = self.base_url.trim_end_matches('/');
+        let path = path.trim_start_matches('/');
+        format!("{base}/{path}")
     }
 }
 
 #[async_trait]
 impl LlmBackend for CodexBackend {
     async fn ask(&self, m: &[Message], t: &[Value]) -> Result<AnthropicResponse> {
-        let body = build_codex_responses_request(
-            &self.inner.model,
-            m,
-            t,
-            self.reasoning_effort.as_deref(),
-        );
-        let responses_url = self.inner.endpoint_url("responses");
-        let mut request = self.inner.client.post(&responses_url);
-        if let Some(api_key) = self.inner.api_key.as_ref().map(SecretString::expose_secret) {
+        let body =
+            build_codex_responses_request(&self.model, m, t, self.reasoning_effort.as_deref());
+        let responses_url = self.endpoint_url("responses");
+        let mut request = self.client.post(&responses_url);
+        for (name, value) in &codex_default_headers() {
+            request = request.header(name, value);
+        }
+        if let Some(api_key) = self.api_key.as_ref().map(SecretString::expose_secret) {
             if !api_key.is_empty() {
                 request = request.header("Authorization", format!("Bearer {api_key}"));
             }
         }
         let res = request.json(&body).send().await?;
+
         if !res.status().is_success() {
             return Err(anyhow!(
                 "API Error at {}: {}",
@@ -285,12 +298,19 @@ impl LlmBackend for CodexBackend {
                 redact_secrets(res.text().await?)
             ));
         }
+
         let resp_json: Value = res.json().await?;
         parse_codex_response(&resp_json)
     }
 
     async fn embed(&self, t: &str) -> Result<Vec<f32>> {
-        self.inner.embed(t).await
+        OpenAiCompatibleBackend::new(
+            self.api_key.clone(),
+            self.base_url.clone(),
+            self.model.clone(),
+        )?
+        .embed(t)
+        .await
     }
 
     async fn summarize(&self, m: &[Message], instruction: &str) -> Result<String> {
@@ -304,15 +324,23 @@ impl LlmBackend for CodexBackend {
             .content
             .into_iter()
             .filter_map(|block| match block {
-                ContentBlock::Text { text } => Some(text),
-                ContentBlock::ToolUse { .. } => None,
+                ContentBlock::Text { text } if !text.trim().is_empty() => Some(text),
+                _ => None,
             })
             .collect::<Vec<_>>()
             .join("\n\n"))
     }
 
     fn context_budget(&self, messages: &[Message], tools: &[Value]) -> Option<ContextBudget> {
-        self.inner.context_budget(messages, tools)
+        model_context_budget(self.model.as_str()).or_else(|| {
+            let inner = OpenAiCompatibleBackend::new(
+                self.api_key.clone(),
+                self.base_url.clone(),
+                self.model.clone(),
+            )
+            .ok()?;
+            inner.context_budget(messages, tools)
+        })
     }
 }
 
@@ -322,7 +350,30 @@ pub(super) fn build_codex_responses_request(
     tools: &[Value],
     reasoning_effort: Option<&str>,
 ) -> Value {
-    let codex_tools = tools
+    let mut body = json!({
+        "model": model,
+        "input": to_codex_input_items(messages),
+        "tools": to_codex_tools(tools),
+        "tool_choice": "auto",
+        "parallel_tool_calls": true,
+        "store": false,
+        "stream": false,
+        "include": [],
+        "instructions": "",
+        "text": Value::Null,
+        "client_metadata": Value::Null,
+    });
+    if let Some(reasoning_effort) = reasoning_effort
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        body["reasoning"] = json!({ "effort": reasoning_effort });
+    }
+    body
+}
+
+fn to_codex_tools(tools: &[Value]) -> Vec<Value> {
+    tools
         .iter()
         .map(|tool| {
             json!({
@@ -332,25 +383,7 @@ pub(super) fn build_codex_responses_request(
                 "parameters": tool["input_schema"],
             })
         })
-        .collect::<Vec<_>>();
-
-    let mut body = json!({
-        "model": model,
-        "input": to_codex_input_items(messages),
-        "tools": codex_tools,
-        "tool_choice": "auto",
-        "parallel_tool_calls": false,
-        "store": false,
-        "stream": false,
-        "include": [],
-    });
-    if let Some(reasoning_effort) = reasoning_effort
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        body["reasoning"] = json!({ "effort": reasoning_effort });
-    }
-    body
+        .collect()
 }
 
 pub(super) fn to_codex_input_items(messages: &[Message]) -> Vec<Value> {

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -316,9 +316,11 @@ fn applies_ollama_stream_event_deltas_and_tool_calls() {
 fn rejects_ollama_streams_without_final_done_event() {
     let error = ensure_ollama_stream_completed(false, "http://localhost:11434/api/chat")
         .expect_err("missing done event should fail");
-    assert!(error
-        .to_string()
-        .contains("ended before the final done event"));
+    assert!(
+        error
+            .to_string()
+            .contains("ended before the final done event")
+    );
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod acp;
 mod agent;
 mod codex_model_catalog;
 mod config;
+mod context;
 mod llm;
 mod local_backend;
 mod oauth;
@@ -20,12 +21,15 @@ mod workspace;
 
 use crate::acp::{run_acp_stdio, RaraAcpAgent};
 use crate::agent::Agent;
-use crate::config::{ConfigManager, RaraConfig, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
+use crate::config::{
+    ConfigManager, RaraConfig, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL,
+    DEFAULT_CODEX_MODEL,
+};
 use crate::llm::{
     CodexBackend, GeminiBackend, LlmBackend, MockLlm, OllamaBackend, OpenAiCompatibleBackend,
 };
 use crate::local_backend::{LocalLlmBackend, LocalProgressReporter};
-use crate::oauth::OAuthManager;
+use crate::oauth::{OAuthManager, SavedCodexAuthMode};
 use crate::redaction::redact_secrets;
 use crate::sandbox::SandboxManager;
 use crate::session::SessionManager;
@@ -166,7 +170,12 @@ async fn main_impl() -> Result<()> {
                     tokio::task::spawn_blocking(move || oauth_reader.read_api_key_from_stdin())
                         .await??;
                 let credential = oauth_manager.save_api_key(api_key.expose_secret())?;
-                save_codex_credential(&mut config, &config_manager, credential.expose_secret())?;
+                save_codex_credential(
+                    &mut config,
+                    &config_manager,
+                    &oauth_manager,
+                    credential.expose_secret(),
+                )?;
                 println!("Successfully saved Codex API key.");
             } else if device_auth {
                 let token = oauth_manager.request_device_code().await?;
@@ -175,7 +184,12 @@ async fn main_impl() -> Result<()> {
                     token.verification_url, token.user_code
                 );
                 let credential = oauth_manager.complete_device_code_login(&token).await?;
-                save_codex_credential(&mut config, &config_manager, credential.expose_secret())?;
+                save_codex_credential(
+                    &mut config,
+                    &config_manager,
+                    &oauth_manager,
+                    credential.expose_secret(),
+                )?;
                 println!("Successfully logged in with device code.");
             } else {
                 if std::env::var_os("SSH_CONNECTION").is_some() {
@@ -187,7 +201,12 @@ async fn main_impl() -> Result<()> {
                     session.auth_url()
                 );
                 let credential = session.complete(&oauth_manager).await?;
-                save_codex_credential(&mut config, &config_manager, credential.expose_secret())?;
+                save_codex_credential(
+                    &mut config,
+                    &config_manager,
+                    &oauth_manager,
+                    credential.expose_secret(),
+                )?;
                 println!("Successfully logged in.");
             }
         }
@@ -213,11 +232,16 @@ async fn main_impl() -> Result<()> {
 fn save_codex_credential(
     config: &mut RaraConfig,
     config_manager: &ConfigManager,
+    oauth_manager: &OAuthManager,
     credential: &str,
 ) -> Result<()> {
     config.set_provider("codex");
     config.set_api_key(credential.to_string());
-    config.apply_codex_defaults();
+    let base_url = match oauth_manager.saved_auth_mode()? {
+        Some(SavedCodexAuthMode::Chatgpt) => DEFAULT_CODEX_CHATGPT_BASE_URL,
+        _ => DEFAULT_CODEX_BASE_URL,
+    };
+    config.apply_codex_defaults_for_base_url(base_url);
     config_manager.save(config)
 }
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -3,8 +3,8 @@ use codex_login::{
     complete_device_code_login as codex_complete_device_code_login, load_auth_dot_json,
     login_with_api_key as codex_login_with_api_key, logout as codex_logout,
     request_device_code as codex_request_device_code, run_login_server as codex_run_login_server,
-    AuthCredentialsStoreMode, DeviceCode as CodexDeviceCode, LoginServer as CodexLoginServer,
-    ServerOptions, CLIENT_ID,
+    AuthCredentialsStoreMode, AuthDotJson, DeviceCode as CodexDeviceCode,
+    LoginServer as CodexLoginServer, ServerOptions, CLIENT_ID,
 };
 use secrecy::SecretString;
 use std::io::Read;
@@ -12,6 +12,12 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 const ISSUER: &str = "https://auth.openai.com";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SavedCodexAuthMode {
+    ApiKey,
+    Chatgpt,
+}
 
 #[derive(Debug, Clone)]
 pub struct DeviceCode {
@@ -142,6 +148,14 @@ impl OAuthManager {
         Ok(SecretString::from(trimmed.to_string()))
     }
 
+    pub fn saved_auth_mode(&self) -> Result<Option<SavedCodexAuthMode>> {
+        let Some(auth) = load_auth_dot_json(&self.codex_home, AuthCredentialsStoreMode::File)?
+        else {
+            return Ok(None);
+        };
+        Ok(detect_saved_auth_mode(&auth))
+    }
+
     fn server_options(&self, open_browser: bool) -> ServerOptions {
         let mut options = ServerOptions::new(
             self.codex_home.clone(),
@@ -157,16 +171,24 @@ impl OAuthManager {
     pub fn load_saved_credential(&self) -> Result<SecretString> {
         let auth = load_auth_dot_json(&self.codex_home, AuthCredentialsStoreMode::File)?
             .ok_or_else(|| anyhow!("Codex login finished but no credential was saved"))?;
-        if let Some(api_key) = auth.openai_api_key.filter(|value| !value.trim().is_empty()) {
-            self.set_saved_auth_cache(true);
-            return Ok(SecretString::from(api_key));
-        }
-        if let Some(tokens) = auth
-            .tokens
-            .filter(|tokens| !tokens.access_token.trim().is_empty())
-        {
-            self.set_saved_auth_cache(true);
-            return Ok(SecretString::from(tokens.access_token));
+        match detect_saved_auth_mode(&auth) {
+            Some(SavedCodexAuthMode::ApiKey) => {
+                if let Some(api_key) = auth.openai_api_key.filter(|value| !value.trim().is_empty())
+                {
+                    self.set_saved_auth_cache(true);
+                    return Ok(SecretString::from(api_key));
+                }
+            }
+            Some(SavedCodexAuthMode::Chatgpt) => {
+                if let Some(tokens) = auth
+                    .tokens
+                    .filter(|tokens| !tokens.access_token.trim().is_empty())
+                {
+                    self.set_saved_auth_cache(true);
+                    return Ok(SecretString::from(tokens.access_token));
+                }
+            }
+            None => {}
         }
         Err(anyhow!(
             "Codex login finished but auth storage did not contain an API key or access token"
@@ -199,6 +221,34 @@ impl OAuthManager {
             *guard = None;
         }
     }
+}
+
+fn detect_saved_auth_mode(auth: &AuthDotJson) -> Option<SavedCodexAuthMode> {
+    let explicit_mode = auth.auth_mode.as_ref().map(|mode| format!("{mode:?}"));
+    if explicit_mode.as_deref() == Some("ApiKey") {
+        return Some(SavedCodexAuthMode::ApiKey);
+    }
+    if explicit_mode
+        .as_deref()
+        .is_some_and(|mode| mode.starts_with("Chatgpt"))
+    {
+        return Some(SavedCodexAuthMode::Chatgpt);
+    }
+    if auth
+        .tokens
+        .as_ref()
+        .is_some_and(|tokens| !tokens.access_token.trim().is_empty())
+    {
+        return Some(SavedCodexAuthMode::Chatgpt);
+    }
+    if auth
+        .openai_api_key
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        return Some(SavedCodexAuthMode::ApiKey);
+    }
+    None
 }
 
 #[cfg(test)]
@@ -242,7 +292,7 @@ mod tests {
     }
 
     #[test]
-    fn load_saved_credential_prefers_api_key_then_access_token() {
+    fn load_saved_credential_prefers_access_token_for_chatgpt_auth() {
         let temp = tempdir().expect("tempdir");
         let manager =
             OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
@@ -265,8 +315,12 @@ mod tests {
         )
         .expect("save auth");
 
-        let saved = manager.load_saved_credential().expect("load api key");
-        assert_eq!(saved.expose_secret(), "sk-direct");
+        let saved = manager.load_saved_credential().expect("load chatgpt token");
+        assert_eq!(saved.expose_secret(), "access");
+        assert_eq!(
+            manager.saved_auth_mode().expect("auth mode"),
+            Some(SavedCodexAuthMode::Chatgpt)
+        );
 
         codex_login::save_auth(
             auth_path(&manager),
@@ -288,6 +342,33 @@ mod tests {
 
         let saved = manager.load_saved_credential().expect("load access token");
         assert_eq!(saved.expose_secret(), "access-only");
+    }
+
+    #[test]
+    fn load_saved_credential_uses_api_key_for_api_key_auth() {
+        let temp = tempdir().expect("tempdir");
+        let manager =
+            OAuthManager::new_for_config_dir(temp.path().join(".rara")).expect("oauth manager");
+
+        codex_login::save_auth(
+            auth_path(&manager),
+            &codex_login::AuthDotJson {
+                auth_mode: None,
+                openai_api_key: Some("sk-direct".into()),
+                tokens: None,
+                last_refresh: None,
+                agent_identity: None,
+            },
+            AuthCredentialsStoreMode::File,
+        )
+        .expect("save auth");
+
+        let saved = manager.load_saved_credential().expect("load api key");
+        assert_eq!(saved.expose_secret(), "sk-direct");
+        assert_eq!(
+            manager.saved_auth_mode().expect("auth mode"),
+            Some(SavedCodexAuthMode::ApiKey)
+        );
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -567,7 +567,8 @@ async fn dispatch_event(
             } else {
                 app.config.set_api_key(value.to_string());
                 if app.config.provider == "codex" {
-                    app.config.apply_codex_defaults();
+                    app.config
+                        .apply_codex_defaults_for_base_url(crate::config::DEFAULT_CODEX_BASE_URL);
                 }
                 app.config_manager.save(&app.config)?;
                 if app.config.provider == "codex" {
@@ -980,6 +981,12 @@ fn sync_codex_credential_from_auth_store(
 
     let credential = oauth_manager.load_saved_credential()?;
     let credential = credential.expose_secret().trim().to_string();
+    let expected_base_url = match oauth_manager.saved_auth_mode()? {
+        Some(crate::oauth::SavedCodexAuthMode::Chatgpt) => {
+            crate::config::DEFAULT_CODEX_CHATGPT_BASE_URL
+        }
+        _ => crate::config::DEFAULT_CODEX_BASE_URL,
+    };
     let mut changed = false;
 
     if app.config.provider == "codex" {
@@ -997,9 +1004,11 @@ fn sync_codex_credential_from_auth_store(
                 .set_model(Some(crate::config::DEFAULT_CODEX_MODEL.to_string()));
             changed = true;
         }
-        if crate::config::should_reset_codex_base_url(app.config.base_url.as_deref()) {
-            app.config
-                .set_base_url(Some(crate::config::DEFAULT_CODEX_BASE_URL.to_string()));
+        if crate::config::should_apply_codex_base_url(
+            app.config.base_url.as_deref(),
+            expected_base_url,
+        ) {
+            app.config.set_base_url(Some(expected_base_url.to_string()));
             changed = true;
         }
     } else {
@@ -1021,8 +1030,11 @@ fn sync_codex_credential_from_auth_store(
             codex_state.model = Some(crate::config::DEFAULT_CODEX_MODEL.to_string());
             changed = true;
         }
-        if crate::config::should_reset_codex_base_url(codex_state.base_url.as_deref()) {
-            codex_state.base_url = Some(crate::config::DEFAULT_CODEX_BASE_URL.to_string());
+        if crate::config::should_apply_codex_base_url(
+            codex_state.base_url.as_deref(),
+            expected_base_url,
+        ) {
+            codex_state.base_url = Some(expected_base_url.to_string());
             changed = true;
         }
         if changed {
@@ -1123,7 +1135,9 @@ mod tests {
     };
     use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
     use crate::config::ConfigManager;
-    use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
+    use crate::config::{
+        DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL,
+    };
     use crate::tui::app_event::AppEvent;
     use crate::tui::state::{Overlay, ProviderFamily, RunningTask, TaskKind, TuiApp};
     use crossterm::event::KeyCode;
@@ -1541,6 +1555,59 @@ mod tests {
                 .and_then(|state| state.api_key.as_ref())
                 .map(|value| value.expose_secret()),
             Some("sk-test-codex")
+        );
+    }
+
+    #[test]
+    fn codex_chatgpt_auth_store_sets_chatgpt_base_url_before_model_flow() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager =
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager");
+        codex_login::save_auth(
+            &temp.path().join(".rara").join("codex-auth"),
+            &codex_login::AuthDotJson {
+                auth_mode: None,
+                openai_api_key: Some("sk-from-oauth".into()),
+                tokens: Some(codex_login::TokenData {
+                    id_token: codex_login::token_data::parse_chatgpt_jwt_claims(
+                        "eyJhbGciOiJub25lIn0.e30.signature",
+                    )
+                    .expect("valid id token"),
+                    access_token: "oauth-access-token".into(),
+                    refresh_token: "refresh".into(),
+                    account_id: None,
+                }),
+                last_refresh: None,
+                agent_identity: None,
+            },
+            codex_login::AuthCredentialsStoreMode::File,
+        )
+        .expect("save auth");
+
+        app.config.set_provider("ollama");
+
+        assert!(
+            sync_codex_credential_from_auth_store(&mut app, &oauth_manager).expect("sync auth")
+        );
+        assert_eq!(
+            app.config
+                .provider_states
+                .get("codex")
+                .and_then(|state| state.api_key.as_ref())
+                .map(|value| value.expose_secret()),
+            Some("oauth-access-token")
+        );
+        assert_eq!(
+            app.config
+                .provider_states
+                .get("codex")
+                .and_then(|state| state.base_url.as_deref()),
+            Some(DEFAULT_CODEX_CHATGPT_BASE_URL)
         );
     }
 

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -563,7 +563,12 @@ pub(super) async fn finish_running_task_if_ready(
                 app.config.set_provider("codex");
                 app.config
                     .set_api_key(credential.expose_secret().to_string());
-                app.config.apply_codex_defaults();
+                let base_url = match mode {
+                    OAuthLoginMode::Browser | OAuthLoginMode::DeviceCode => {
+                        crate::config::DEFAULT_CODEX_CHATGPT_BASE_URL
+                    }
+                };
+                app.config.apply_codex_defaults_for_base_url(base_url);
                 app.config_manager.save(&app.config)?;
                 let saved_message = match mode {
                     OAuthLoginMode::Browser => {


### PR DESCRIPTION
## Summary

- route Codex OAuth / ChatGPT auth to the ChatGPT Codex provider base URL
- keep API key auth on the OpenAI API base URL
- restore a Codex-specific `/responses` backend instead of reusing `chat/completions`
- add focused regression coverage for auth-mode credential loading and Codex responses mapping

## Testing

- cargo check
- cargo test load_saved_credential_prefers_access_token_for_chatgpt_auth -- --nocapture
- cargo test load_saved_credential_uses_api_key_for_api_key_auth -- --nocapture
- cargo test codex_chatgpt_auth_store_sets_chatgpt_base_url_before_model_flow -- --nocapture
- cargo test converts_history_to_codex_responses_input_items -- --nocapture
- cargo test parses_codex_responses_output_into_text_and_tool_use_blocks -- --nocapture
