### PR TITLE
fix(codex): move system prompts into responses instructions

### DIFF
--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -359,7 +359,7 @@ pub(super) fn build_codex_responses_request(
         "store": false,
         "stream": false,
         "include": [],
-        "instructions": "",
+        "instructions": build_codex_instructions(messages),
         "text": Value::Null,
         "client_metadata": Value::Null,
     });
@@ -392,10 +392,21 @@ pub(super) fn to_codex_input_items(messages: &[Message]) -> Vec<Value> {
         match message.role.as_str() {
             "assistant" => items.extend(render_codex_assistant_items(&message.content)),
             "user" => items.extend(render_codex_user_items(&message.content)),
+            "system" => {}
             role => items.push(render_codex_message(role, &message.content, false)),
         }
     }
     items
+}
+
+fn build_codex_instructions(messages: &[Message]) -> String {
+    messages
+        .iter()
+        .filter(|message| message.role == "system")
+        .map(|message| render_openai_message_content(&message.content))
+        .filter(|text| !text.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
 }
 
 fn render_codex_message(role: &str, content: &Value, assistant_output: bool) -> Value {

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -65,16 +65,13 @@ fn converts_history_to_codex_responses_input_items() {
 
     let input = to_codex_input_items(&messages);
     assert_eq!(input[0]["type"], "message");
-    assert_eq!(input[0]["role"], "system");
-    assert_eq!(input[0]["content"][0]["type"], "input_text");
-    assert_eq!(input[1]["type"], "message");
-    assert_eq!(input[1]["role"], "assistant");
-    assert_eq!(input[1]["content"][0]["type"], "output_text");
-    assert_eq!(input[2]["type"], "function_call");
+    assert_eq!(input[0]["role"], "assistant");
+    assert_eq!(input[0]["content"][0]["type"], "output_text");
+    assert_eq!(input[1]["type"], "function_call");
+    assert_eq!(input[1]["call_id"], "tool-1");
+    assert_eq!(input[2]["type"], "function_call_output");
     assert_eq!(input[2]["call_id"], "tool-1");
-    assert_eq!(input[3]["type"], "function_call_output");
-    assert_eq!(input[3]["call_id"], "tool-1");
-    assert_eq!(input[3]["output"], "[package]");
+    assert_eq!(input[2]["output"], "[package]");
 }
 
 #[test]
@@ -151,16 +148,24 @@ fn parses_codex_responses_output_into_text_and_tool_use_blocks() {
 fn codex_responses_request_includes_reasoning_effort_when_selected() {
     let request = build_codex_responses_request(
         "gpt-5.4",
-        &[Message {
-            role: "user".to_string(),
-            content: json!("Hello"),
-        }],
+        &[
+            Message {
+                role: "system".to_string(),
+                content: json!("Follow project instructions."),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!("Hello"),
+            },
+        ],
         &[],
         Some("high"),
     );
 
     assert_eq!(request["model"], "gpt-5.4");
     assert_eq!(request["reasoning"]["effort"], "high");
+    assert_eq!(request["instructions"], "Follow project instructions.");
+    assert_eq!(request["input"][0]["role"], "user");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- move Codex `system` history into top-level Responses `instructions`
- stop emitting `role = system` items in Codex `input`
- update focused Codex responses tests to cover the new request shape

## Why

ChatGPT/Codex OAuth requests to `https://chatgpt.com/backend-api/codex/responses` reject `system` messages in the `input` array with:

- `System messages are not allowed`

Codex-style Responses requests should carry system guidance via the top-level `instructions` field instead.

## Testing

- `cargo test converts_history_to_codex_responses_input_items -- --nocapture`
- `cargo test codex_responses_request_includes_reasoning_effort_when_selected -- --nocapture`
- `cargo check`
