### PR TITLE
refactor(llm): rename AnthropicResponse to LlmResponse

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -4,7 +4,7 @@ mod prompting;
 #[cfg(test)]
 mod tests;
 
-use crate::llm::LlmBackend;
+use crate::llm::{ContentBlock, LlmBackend};
 use crate::prompt::{self, PromptMode, PromptRuntimeConfig};
 use crate::session::SessionManager;
 use crate::tool::ToolManager;
@@ -50,32 +50,6 @@ pub enum BashApprovalMode {
 pub struct Message {
     pub role: String,
     pub content: Value,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct AnthropicResponse {
-    pub content: Vec<ContentBlock>,
-    pub stop_reason: Option<String>,
-    pub usage: Option<TokenUsage>,
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
-pub struct TokenUsage {
-    pub input_tokens: u32,
-    pub output_tokens: u32,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(tag = "type")]
-pub enum ContentBlock {
-    #[serde(rename = "text")]
-    Text { text: String },
-    #[serde(rename = "tool_use")]
-    ToolUse {
-        id: String,
-        name: String,
-        input: Value,
-    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -2,10 +2,11 @@ use super::planning::{
     parse_plan_block, parse_request_user_input_block, strip_continue_inspection_control,
 };
 use super::{
-    Agent, AgentExecutionMode, AnthropicResponse, ContentBlock, Message, PendingUserInput,
-    PlanStep, PlanStepStatus, RuntimeContinuationPhase, TokenUsage,
+    Agent, AgentExecutionMode, Message, PendingUserInput, PlanStep, PlanStepStatus,
+    RuntimeContinuationPhase,
 };
 use crate::llm::LlmBackend;
+use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 use crate::session::SessionManager;
 use crate::tool::{Tool, ToolError, ToolManager};
 use crate::tool_result::ToolResultStore;
@@ -72,13 +73,13 @@ impl Tool for PlanAgentStub {
 }
 
 struct SequencedBackend {
-    responses: Mutex<Vec<AnthropicResponse>>,
+    responses: Mutex<Vec<LlmResponse>>,
     observed_messages: Mutex<Vec<Vec<Message>>>,
     observed_tools: Mutex<Vec<Vec<String>>>,
 }
 
 impl SequencedBackend {
-    fn new(responses: Vec<AnthropicResponse>) -> Self {
+    fn new(responses: Vec<LlmResponse>) -> Self {
         Self {
             responses: Mutex::new(responses),
             observed_messages: Mutex::new(Vec::new()),
@@ -113,7 +114,7 @@ fn test_runtime_storage() -> (
 
 #[async_trait]
 impl LlmBackend for SequencedBackend {
-    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<AnthropicResponse> {
+    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         self.observed_messages
             .lock()
             .expect("lock")
@@ -144,7 +145,7 @@ impl LlmBackend for SequencedBackend {
 #[tokio::test]
 async fn appends_continuation_after_tool_result() {
     let backend = Arc::new(SequencedBackend::new(vec![
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::ToolUse {
                 id: "tool-1".to_string(),
                 name: "stub_tool".to_string(),
@@ -153,7 +154,7 @@ async fn appends_continuation_after_tool_result() {
             stop_reason: Some("tool_use".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "done".to_string(),
             }],
@@ -193,7 +194,7 @@ async fn appends_continuation_after_tool_result() {
 #[tokio::test]
 async fn resumes_after_plan_approval_via_structured_continuation() {
     let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
-    let backend = Arc::new(SequencedBackend::new(vec![AnthropicResponse {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
         content: vec![ContentBlock::Text {
             text: "Implemented the first plan step.".to_string(),
         }],
@@ -242,7 +243,7 @@ async fn resumes_after_plan_approval_via_structured_continuation() {
 
 #[tokio::test]
 async fn does_not_append_continuation_without_tools() {
-    let backend = Arc::new(SequencedBackend::new(vec![AnthropicResponse {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
         content: vec![ContentBlock::Text {
             text: "final".to_string(),
         }],
@@ -274,7 +275,7 @@ async fn does_not_append_continuation_without_tools() {
 #[tokio::test]
 async fn errors_when_tool_loop_exceeds_limit() {
     let responses = (0..=super::MAX_TOOL_ROUNDS_PER_TURN)
-        .map(|idx| AnthropicResponse {
+        .map(|idx| LlmResponse {
             content: vec![ContentBlock::ToolUse {
                 id: format!("tool-{idx}"),
                 name: "stub_tool".to_string(),
@@ -305,7 +306,7 @@ async fn errors_when_tool_loop_exceeds_limit() {
 
 #[tokio::test]
 async fn plan_mode_filters_write_tools_from_schema() {
-    let backend = Arc::new(SequencedBackend::new(vec![AnthropicResponse {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
         content: vec![ContentBlock::Text {
             text: "<plan>\n- [pending] Review the current project structure\n</plan>".to_string(),
         }],
@@ -340,7 +341,7 @@ async fn plan_mode_filters_write_tools_from_schema() {
 
 #[tokio::test]
 async fn accepts_shallow_initial_plan_as_structured_outcome() {
-    let backend = Arc::new(SequencedBackend::new(vec![AnthropicResponse {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
         content: vec![ContentBlock::Text {
             text: "<plan>\n- [pending] Inspect the repository structure\n</plan>\nStart with the top-level layout.".to_string(),
         }],
@@ -386,7 +387,7 @@ async fn last_query_plan_updated_tracks_only_the_final_planning_turn() {
     let workspace = Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone()));
 
     let backend = Arc::new(SequencedBackend::new(vec![
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "I inspected the top-level layout and still need a structured follow-up."
                     .to_string(),
@@ -394,7 +395,7 @@ async fn last_query_plan_updated_tracks_only_the_final_planning_turn() {
             stop_reason: Some("end_turn".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "<request_user_input>\nquestion: Which area should the plan focus on first?\noption: Prompt runtime | Tighten the planning prompt and continuation phases.\noption: TUI lifecycle | Improve the planning and approval interaction flow.\n</request_user_input>".to_string(),
             }],
@@ -423,7 +424,7 @@ async fn last_query_plan_updated_tracks_only_the_final_planning_turn() {
 
     assert!(!agent.last_query_produced_plan());
 
-    let backend = Arc::new(SequencedBackend::new(vec![AnthropicResponse {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
         content: vec![ContentBlock::Text {
             text: "<plan>\n- [pending] Inspect the repository structure\n- [pending] Review src/main.rs bootstrap flow\n</plan>\nReady for approval.".to_string(),
         }],
@@ -455,7 +456,7 @@ async fn last_query_plan_updated_tracks_only_the_final_planning_turn() {
 #[tokio::test]
 async fn continues_plan_mode_after_exploration_if_assistant_still_signals_more_work() {
     let backend = Arc::new(SequencedBackend::new(vec![
-        AnthropicResponse {
+        LlmResponse {
             content: vec![
                 ContentBlock::Text {
                     text: "<plan>\n- [pending] Inspect the repository structure\n</plan>\nStart with the top-level layout.".to_string(),
@@ -469,14 +470,14 @@ async fn continues_plan_mode_after_exploration_if_assistant_still_signals_more_w
             stop_reason: Some("tool_use".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "I have examined the overall structure and still need more inspection.\n<continue_inspection/>".to_string(),
             }],
             stop_reason: Some("end_turn".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "<plan>\n- [pending] Inspect src/main.rs bootstrap flow\n- [pending] Review the prompt runtime wiring\n</plan>\nThe inspection path is now complete."
                     .to_string(),
@@ -513,7 +514,7 @@ async fn continues_plan_mode_after_exploration_if_assistant_still_signals_more_w
 #[tokio::test]
 async fn continues_plan_mode_to_synthesize_plan_after_exploration_evidence() {
     let backend = Arc::new(SequencedBackend::new(vec![
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::ToolUse {
                 id: "tool-1".to_string(),
                 name: "list_files".to_string(),
@@ -522,7 +523,7 @@ async fn continues_plan_mode_to_synthesize_plan_after_exploration_evidence() {
             stop_reason: Some("tool_use".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "I inspected the repository structure and the current planning flow."
                     .to_string(),
@@ -530,7 +531,7 @@ async fn continues_plan_mode_to_synthesize_plan_after_exploration_evidence() {
             stop_reason: Some("end_turn".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "<plan>\n- [pending] Review planning continuation state\n- [pending] Tighten plan completion rules\n</plan>\nThe first pass exposed enough evidence to finalize the plan.".to_string(),
             }],
@@ -567,7 +568,7 @@ async fn continues_plan_mode_to_synthesize_plan_after_exploration_evidence() {
 #[tokio::test]
 async fn narration_only_planning_turn_requires_structured_followup() {
     let backend = Arc::new(SequencedBackend::new(vec![
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "I reviewed the prompt runtime and the workspace discovery flow."
                     .to_string(),
@@ -575,7 +576,7 @@ async fn narration_only_planning_turn_requires_structured_followup() {
             stop_reason: Some("end_turn".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "<plan>\n- [pending] Generalize instruction discovery\n- [pending] Preserve current cache behavior\n</plan>\nThe inspected code now supports a concrete refactor path.".to_string(),
             }],
@@ -615,7 +616,7 @@ async fn narration_only_planning_turn_requires_structured_followup() {
 #[tokio::test]
 async fn delegated_plan_agent_counts_as_planning_evidence() {
     let backend = Arc::new(SequencedBackend::new(vec![
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::ToolUse {
                 id: "tool-1".to_string(),
                 name: "plan_agent".to_string(),
@@ -624,14 +625,14 @@ async fn delegated_plan_agent_counts_as_planning_evidence() {
             stop_reason: Some("tool_use".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "The delegated planning pass inspected enough code context.".to_string(),
             }],
             stop_reason: Some("end_turn".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "<plan>\n- [pending] Review delegated planning evidence\n- [pending] Finalize the top-level plan\n</plan>\nReady for approval.".to_string(),
             }],
@@ -664,7 +665,7 @@ async fn delegated_plan_agent_counts_as_planning_evidence() {
 #[tokio::test]
 async fn continues_execute_mode_after_exploration_if_assistant_still_signals_more_work() {
     let backend = Arc::new(SequencedBackend::new(vec![
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::ToolUse {
                 id: "tool-1".to_string(),
                 name: "stub_tool".to_string(),
@@ -673,14 +674,14 @@ async fn continues_execute_mode_after_exploration_if_assistant_still_signals_mor
             stop_reason: Some("tool_use".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "I have checked the top-level structure and need one more inspection pass.\n<continue_inspection/>".to_string(),
             }],
             stop_reason: Some("end_turn".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "done".to_string(),
             }],
@@ -716,14 +717,14 @@ async fn continues_execute_mode_after_exploration_if_assistant_still_signals_mor
 #[tokio::test]
 async fn continues_execute_mode_when_assistant_requests_structured_followup_inspection() {
     let backend = Arc::new(SequencedBackend::new(vec![
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "I have checked the repository layout and need one more repo-inspection step.\n<continue_inspection/>".to_string(),
             }],
             stop_reason: Some("end_turn".to_string()),
             usage: Some(TokenUsage::default()),
         },
-        AnthropicResponse {
+        LlmResponse {
             content: vec![ContentBlock::Text {
                 text: "done".to_string(),
             }],

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -59,7 +59,7 @@ impl<'a> ContextAssembler<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::{AnthropicResponse, ContentBlock};
+    use crate::llm::{ContentBlock, LlmResponse};
     use anyhow::Result;
     use async_trait::async_trait;
     use rara_config::RaraConfig;
@@ -72,8 +72,8 @@ mod tests {
 
     #[async_trait]
     impl LlmBackend for BudgetBackend {
-        async fn ask(&self, _messages: &[Message], _tools: &[Value]) -> Result<AnthropicResponse> {
-            Ok(AnthropicResponse {
+        async fn ask(&self, _messages: &[Message], _tools: &[Value]) -> Result<LlmResponse> {
+            Ok(LlmResponse {
                 content: vec![ContentBlock::Text {
                     text: "ok".to_string(),
                 }],

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,6 +1,7 @@
 mod ollama;
 mod openai_compatible;
 mod shared;
+mod types;
 #[cfg(test)]
 mod tests;
 
@@ -8,3 +9,4 @@ pub use self::ollama::OllamaBackend;
 pub use self::openai_compatible::{CodexBackend, GeminiBackend, OpenAiCompatibleBackend};
 pub(crate) use self::shared::hashed_embedding;
 pub use self::shared::{ContextBudget, LlmBackend, MockLlm};
+pub use self::types::{ContentBlock, LlmResponse, TokenUsage};

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -5,7 +5,8 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use serde_json::{json, Value};
 
-use crate::agent::{AnthropicResponse, ContentBlock, Message};
+use crate::agent::Message;
+use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
 use super::shared::{
@@ -41,7 +42,7 @@ impl OllamaBackend {
 
 #[async_trait]
 impl LlmBackend for OllamaBackend {
-    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<AnthropicResponse> {
+    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         let endpoint = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
         let mut body = json!({
             "model": self.model,
@@ -102,13 +103,13 @@ impl LlmBackend for OllamaBackend {
             }
         }
 
-        Ok(AnthropicResponse {
+        Ok(LlmResponse {
             content,
             stop_reason: resp_json
                 .get("done_reason")
                 .and_then(Value::as_str)
                 .map(str::to_string),
-            usage: Some(crate::agent::TokenUsage {
+            usage: Some(TokenUsage {
                 input_tokens: resp_json
                     .get("prompt_eval_count")
                     .and_then(Value::as_u64)
@@ -126,7 +127,7 @@ impl LlmBackend for OllamaBackend {
         messages: &[Message],
         tools: &[Value],
         on_text_delta: &mut (dyn FnMut(String) + Send),
-    ) -> Result<AnthropicResponse> {
+    ) -> Result<LlmResponse> {
         let endpoint = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
         let mut body = json!({
             "model": self.model,
@@ -226,10 +227,10 @@ impl LlmBackend for OllamaBackend {
             });
         }
 
-        Ok(AnthropicResponse {
+        Ok(LlmResponse {
             content,
             stop_reason,
-            usage: Some(crate::agent::TokenUsage {
+            usage: Some(TokenUsage {
                 input_tokens,
                 output_tokens,
             }),

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -4,7 +4,8 @@ use codex_login::default_client::default_headers as codex_default_headers;
 use secrecy::{ExposeSecret, SecretString};
 use serde_json::{Value, json};
 
-use crate::agent::{AnthropicResponse, ContentBlock, Message};
+use crate::agent::Message;
+use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
 use super::shared::{
@@ -44,7 +45,7 @@ impl OpenAiCompatibleBackend {
 
 #[async_trait]
 impl LlmBackend for OpenAiCompatibleBackend {
-    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<AnthropicResponse> {
+    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         let openai_messages = to_openai_messages(messages);
         let openai_tools: Vec<Value> = tools
             .iter()
@@ -101,11 +102,11 @@ impl LlmBackend for OpenAiCompatibleBackend {
                 });
             }
         }
-        let usage = resp_json.get("usage").map(|u| crate::agent::TokenUsage {
+        let usage = resp_json.get("usage").map(|u| TokenUsage {
             input_tokens: u["prompt_tokens"].as_u64().unwrap_or(0) as u32,
             output_tokens: u["completion_tokens"].as_u64().unwrap_or(0) as u32,
         });
-        Ok(AnthropicResponse {
+        Ok(LlmResponse {
             content,
             stop_reason: resp_json["choices"][0]["finish_reason"]
                 .as_str()
@@ -276,7 +277,7 @@ impl CodexBackend {
 
 #[async_trait]
 impl LlmBackend for CodexBackend {
-    async fn ask(&self, m: &[Message], t: &[Value]) -> Result<AnthropicResponse> {
+    async fn ask(&self, m: &[Message], t: &[Value]) -> Result<LlmResponse> {
         let body =
             build_codex_responses_request(&self.model, m, t, self.reasoning_effort.as_deref());
         let responses_url = self.endpoint_url("responses");
@@ -503,7 +504,7 @@ fn extract_codex_tool_result_item(content: &Value) -> Option<Value> {
     }))
 }
 
-pub(super) fn parse_codex_response(resp_json: &Value) -> Result<AnthropicResponse> {
+pub(super) fn parse_codex_response(resp_json: &Value) -> Result<LlmResponse> {
     let mut content = Vec::new();
     if let Some(items) = resp_json.get("output").and_then(Value::as_array) {
         for item in items {
@@ -535,11 +536,11 @@ pub(super) fn parse_codex_response(resp_json: &Value) -> Result<AnthropicRespons
             }
         }
     }
-    let usage = resp_json.get("usage").map(|u| crate::agent::TokenUsage {
+    let usage = resp_json.get("usage").map(|u| TokenUsage {
         input_tokens: u["input_tokens"].as_u64().unwrap_or(0) as u32,
         output_tokens: u["output_tokens"].as_u64().unwrap_or(0) as u32,
     });
-    Ok(AnthropicResponse {
+    Ok(LlmResponse {
         content,
         stop_reason: resp_json
             .get("status")
@@ -572,7 +573,7 @@ pub struct GeminiBackend {
 
 #[async_trait]
 impl LlmBackend for GeminiBackend {
-    async fn ask(&self, _: &[Message], _: &[Value]) -> Result<AnthropicResponse> {
+    async fn ask(&self, _: &[Message], _: &[Value]) -> Result<LlmResponse> {
         Err(anyhow!("Gemini pending"))
     }
 

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -4,7 +4,8 @@ use serde_json::{json, Value};
 use std::time::Duration;
 use url::Url;
 
-use crate::agent::{AnthropicResponse, ContentBlock, Message};
+use crate::agent::Message;
+use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(super) struct AssistantToolUse {
@@ -22,13 +23,13 @@ pub struct ContextBudget {
 
 #[async_trait]
 pub trait LlmBackend: Send + Sync {
-    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<AnthropicResponse>;
+    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse>;
     async fn ask_streaming(
         &self,
         messages: &[Message],
         tools: &[Value],
         _on_text_delta: &mut (dyn FnMut(String) + Send),
-    ) -> Result<AnthropicResponse> {
+    ) -> Result<LlmResponse> {
         self.ask(messages, tools).await
     }
     async fn embed(&self, text: &str) -> Result<Vec<f32>>;
@@ -42,7 +43,7 @@ pub struct MockLlm;
 
 #[async_trait]
 impl LlmBackend for MockLlm {
-    async fn ask(&self, messages: &[Message], _tools: &[Value]) -> Result<AnthropicResponse> {
+    async fn ask(&self, messages: &[Message], _tools: &[Value]) -> Result<LlmResponse> {
         let last_msg_json = &messages.last().unwrap().content;
         let last_msg_text = if last_msg_json.is_array() {
             last_msg_json
@@ -53,12 +54,12 @@ impl LlmBackend for MockLlm {
         } else {
             last_msg_json.as_str().unwrap_or("")
         };
-        Ok(AnthropicResponse {
+        Ok(LlmResponse {
             content: vec![ContentBlock::Text {
                 text: format!("Mock Response: {}", last_msg_text),
             }],
             stop_reason: Some("end_turn".to_string()),
-            usage: Some(crate::agent::TokenUsage {
+            usage: Some(TokenUsage {
                 input_tokens: 10,
                 output_tokens: 20,
             }),

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -1,6 +1,7 @@
 use serde_json::json;
 
 use crate::agent::Message;
+use crate::llm::ContentBlock;
 
 use super::ollama::{
     apply_ollama_stream_event, build_ollama_options, ensure_ollama_stream_completed,
@@ -132,13 +133,13 @@ fn parses_codex_responses_output_into_text_and_tool_use_blocks() {
     assert_eq!(response.usage.unwrap().input_tokens, 11);
     assert_eq!(response.content.len(), 2);
     match &response.content[0] {
-        crate::agent::ContentBlock::Text { text } => {
+        ContentBlock::Text { text } => {
             assert_eq!(text, "Need to inspect a file.");
         }
         other => panic!("expected text block, got {other:?}"),
     }
     match &response.content[1] {
-        crate::agent::ContentBlock::ToolUse { id, name, input } => {
+        ContentBlock::ToolUse { id, name, input } => {
             assert_eq!(id, "call-1");
             assert_eq!(name, "read_file");
             assert_eq!(input, &json!({"path":"Cargo.toml"}));

--- a/src/llm/types.rs
+++ b/src/llm/types.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct LlmResponse {
+    pub content: Vec<ContentBlock>,
+    pub stop_reason: Option<String>,
+    pub usage: Option<TokenUsage>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct TokenUsage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+}

--- a/src/local_backend.rs
+++ b/src/local_backend.rs
@@ -13,9 +13,9 @@ use candle::{DType, Tensor};
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use serde_json::Value;
 
-use crate::agent::{AnthropicResponse, ContentBlock, Message, TokenUsage};
+use crate::agent::Message;
 use crate::config::RaraConfig;
-use crate::llm::{hashed_embedding, LlmBackend};
+use crate::llm::{ContentBlock, LlmBackend, LlmResponse, TokenUsage, hashed_embedding};
 
 use self::model::{
     build_hf_api, default_local_model_cache_dir as model_cache_dir, load_safetensors,
@@ -136,7 +136,7 @@ fn report_progress(progress: &Option<LocalProgressReporter>, message: String) {
 
 #[async_trait]
 impl LlmBackend for LocalLlmBackend {
-    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<AnthropicResponse> {
+    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         let runtime = Arc::clone(&self.runtime);
         let messages = messages.to_vec();
         let tools = tools.to_vec();
@@ -179,7 +179,7 @@ impl LlmBackend for LocalLlmBackend {
             }],
         };
 
-        Ok(AnthropicResponse {
+        Ok(LlmResponse {
             stop_reason: Some("end_turn".to_string()),
             content,
             usage: Some(TokenUsage {


### PR DESCRIPTION
## Summary

- rename the shared backend response envelope from `AnthropicResponse` to `LlmResponse`
- update the `LlmBackend` trait, backend implementations, and tests to use the generic name
- keep behavior unchanged; this is a naming cleanup to match current multi-backend usage

## Testing

- `cargo check`
- `cargo test context::assembler::tests -- --nocapture`
