### PR TITLE
fix(llm): align codex tool schema export

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,9 +1,10 @@
+mod codex_tools_compat;
 mod ollama;
 mod openai_compatible;
 mod shared;
-mod types;
 #[cfg(test)]
 mod tests;
+mod types;
 
 pub use self::ollama::OllamaBackend;
 pub use self::openai_compatible::{CodexBackend, GeminiBackend, OpenAiCompatibleBackend};

--- a/src/llm/codex_tools_compat.rs
+++ b/src/llm/codex_tools_compat.rs
@@ -1,0 +1,291 @@
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::json;
+use serde_json::Value as JsonValue;
+use std::collections::BTreeMap;
+
+// Vendored from openai/codex codex-tools (rev 996aa23e4ce900468047ed3ec57d1e7271f8d6de),
+// trimmed to the minimum schema/export path needed by RARA:
+// - json_schema.rs
+// - responses_api.rs
+// - tool_definition.rs
+// - tool_spec.rs
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum JsonSchemaPrimitiveType {
+    String,
+    Number,
+    Boolean,
+    Integer,
+    Object,
+    Array,
+    Null,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum JsonSchemaType {
+    Single(JsonSchemaPrimitiveType),
+    Multiple(Vec<JsonSchemaPrimitiveType>),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct JsonSchema {
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub schema_type: Option<JsonSchemaType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<JsonValue>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Box<JsonSchema>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<BTreeMap<String, JsonSchema>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<Vec<String>>,
+    #[serde(
+        rename = "additionalProperties",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub additional_properties: Option<AdditionalProperties>,
+    #[serde(rename = "anyOf", skip_serializing_if = "Option::is_none")]
+    pub any_of: Option<Vec<JsonSchema>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum AdditionalProperties {
+    Boolean(bool),
+    Schema(Box<JsonSchema>),
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    pub input_schema: JsonSchema,
+    pub output_schema: Option<JsonValue>,
+    pub defer_loading: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct ResponsesApiTool {
+    pub name: String,
+    pub description: String,
+    pub strict: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub defer_loading: Option<bool>,
+    pub parameters: JsonSchema,
+    #[serde(skip)]
+    pub output_schema: Option<JsonValue>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum ToolSpec {
+    #[serde(rename = "function")]
+    Function(ResponsesApiTool),
+}
+
+pub fn create_tools_json_for_responses_api(
+    tools: &[ToolSpec],
+) -> Result<Vec<JsonValue>, serde_json::Error> {
+    let mut tools_json = Vec::with_capacity(tools.len());
+    for tool in tools {
+        tools_json.push(serde_json::to_value(tool)?);
+    }
+    Ok(tools_json)
+}
+
+pub fn tool_definition_to_responses_api_tool(tool_definition: ToolDefinition) -> ResponsesApiTool {
+    ResponsesApiTool {
+        name: tool_definition.name,
+        description: tool_definition.description,
+        strict: false,
+        defer_loading: tool_definition.defer_loading.then_some(true),
+        parameters: tool_definition.input_schema,
+        output_schema: tool_definition.output_schema,
+    }
+}
+
+pub fn parse_tool_input_schema(input_schema: &JsonValue) -> Result<JsonSchema, serde_json::Error> {
+    let mut input_schema = input_schema.clone();
+    sanitize_json_schema(&mut input_schema);
+    let schema: JsonSchema = serde_json::from_value(input_schema)?;
+    if matches!(
+        schema.schema_type,
+        Some(JsonSchemaType::Single(JsonSchemaPrimitiveType::Null))
+    ) {
+        return Err(singleton_null_schema_error());
+    }
+    Ok(schema)
+}
+
+fn sanitize_json_schema(value: &mut JsonValue) {
+    match value {
+        JsonValue::Bool(_) => {
+            *value = json!({ "type": "string" });
+        }
+        JsonValue::Array(values) => {
+            for value in values {
+                sanitize_json_schema(value);
+            }
+        }
+        JsonValue::Object(map) => {
+            if let Some(properties) = map.get_mut("properties") {
+                if let Some(properties_map) = properties.as_object_mut() {
+                    for value in properties_map.values_mut() {
+                        sanitize_json_schema(value);
+                    }
+                }
+            }
+            if let Some(items) = map.get_mut("items") {
+                sanitize_json_schema(items);
+            }
+            if let Some(additional_properties) = map.get_mut("additionalProperties") {
+                if !matches!(additional_properties, JsonValue::Bool(_)) {
+                    sanitize_json_schema(additional_properties);
+                }
+            }
+            if let Some(value) = map.get_mut("prefixItems") {
+                sanitize_json_schema(value);
+            }
+            if let Some(value) = map.get_mut("anyOf") {
+                sanitize_json_schema(value);
+            }
+
+            if let Some(const_value) = map.remove("const") {
+                map.insert("enum".to_string(), JsonValue::Array(vec![const_value]));
+            }
+
+            let mut schema_types = normalized_schema_types(map);
+
+            if schema_types.is_empty() && map.contains_key("anyOf") {
+                return;
+            }
+
+            if schema_types.is_empty() {
+                if map.contains_key("properties")
+                    || map.contains_key("required")
+                    || map.contains_key("additionalProperties")
+                {
+                    schema_types.push(JsonSchemaPrimitiveType::Object);
+                } else if map.contains_key("items") || map.contains_key("prefixItems") {
+                    schema_types.push(JsonSchemaPrimitiveType::Array);
+                } else if map.contains_key("enum") || map.contains_key("format") {
+                    schema_types.push(JsonSchemaPrimitiveType::String);
+                } else if map.contains_key("minimum")
+                    || map.contains_key("maximum")
+                    || map.contains_key("exclusiveMinimum")
+                    || map.contains_key("exclusiveMaximum")
+                    || map.contains_key("multipleOf")
+                {
+                    schema_types.push(JsonSchemaPrimitiveType::Number);
+                } else {
+                    schema_types.push(JsonSchemaPrimitiveType::String);
+                }
+            }
+
+            write_schema_types(map, &schema_types);
+            ensure_default_children_for_schema_types(map, &schema_types);
+        }
+        _ => {}
+    }
+}
+
+fn ensure_default_children_for_schema_types(
+    map: &mut serde_json::Map<String, JsonValue>,
+    schema_types: &[JsonSchemaPrimitiveType],
+) {
+    if schema_types.contains(&JsonSchemaPrimitiveType::Object) && !map.contains_key("properties") {
+        map.insert(
+            "properties".to_string(),
+            JsonValue::Object(serde_json::Map::new()),
+        );
+    }
+
+    if schema_types.contains(&JsonSchemaPrimitiveType::Array) && !map.contains_key("items") {
+        map.insert("items".to_string(), json!({ "type": "string" }));
+    }
+}
+
+fn normalized_schema_types(
+    map: &serde_json::Map<String, JsonValue>,
+) -> Vec<JsonSchemaPrimitiveType> {
+    let Some(schema_type) = map.get("type") else {
+        return Vec::new();
+    };
+
+    match schema_type {
+        JsonValue::String(schema_type) => schema_type_from_str(schema_type).into_iter().collect(),
+        JsonValue::Array(schema_types) => schema_types
+            .iter()
+            .filter_map(JsonValue::as_str)
+            .filter_map(schema_type_from_str)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn write_schema_types(
+    map: &mut serde_json::Map<String, JsonValue>,
+    schema_types: &[JsonSchemaPrimitiveType],
+) {
+    match schema_types {
+        [] => {
+            map.remove("type");
+        }
+        [schema_type] => {
+            map.insert(
+                "type".to_string(),
+                JsonValue::String(schema_type_name(*schema_type).to_string()),
+            );
+        }
+        _ => {
+            map.insert(
+                "type".to_string(),
+                JsonValue::Array(
+                    schema_types
+                        .iter()
+                        .map(|schema_type| {
+                            JsonValue::String(schema_type_name(*schema_type).to_string())
+                        })
+                        .collect(),
+                ),
+            );
+        }
+    }
+}
+
+fn schema_type_from_str(schema_type: &str) -> Option<JsonSchemaPrimitiveType> {
+    match schema_type {
+        "string" => Some(JsonSchemaPrimitiveType::String),
+        "number" => Some(JsonSchemaPrimitiveType::Number),
+        "boolean" => Some(JsonSchemaPrimitiveType::Boolean),
+        "integer" => Some(JsonSchemaPrimitiveType::Integer),
+        "object" => Some(JsonSchemaPrimitiveType::Object),
+        "array" => Some(JsonSchemaPrimitiveType::Array),
+        "null" => Some(JsonSchemaPrimitiveType::Null),
+        _ => None,
+    }
+}
+
+fn schema_type_name(schema_type: JsonSchemaPrimitiveType) -> &'static str {
+    match schema_type {
+        JsonSchemaPrimitiveType::String => "string",
+        JsonSchemaPrimitiveType::Number => "number",
+        JsonSchemaPrimitiveType::Boolean => "boolean",
+        JsonSchemaPrimitiveType::Integer => "integer",
+        JsonSchemaPrimitiveType::Object => "object",
+        JsonSchemaPrimitiveType::Array => "array",
+        JsonSchemaPrimitiveType::Null => "null",
+    }
+}
+
+fn singleton_null_schema_error() -> serde_json::Error {
+    serde_json::Error::io(std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        "tool input schema must not be a singleton null type",
+    ))
+}

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -498,7 +498,9 @@ pub(super) fn apply_codex_stream_event(
 fn to_codex_tools(tools: &[Value]) -> Result<Vec<Value>> {
     let mut tool_specs = Vec::with_capacity(tools.len());
     for tool in tools {
-        let tool_name = tool["name"].as_str().unwrap_or("unknown");
+        let tool_name = tool["name"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Codex tool is missing a 'name' field"))?;
         let input_schema = parse_tool_input_schema(&tool["input_schema"]).map_err(|error| {
             anyhow!("Failed to parse Codex tool schema for '{tool_name}': {error}")
         })?;

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -10,6 +10,11 @@ use crate::agent::Message;
 use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
+use super::codex_tools_compat::create_tools_json_for_responses_api;
+use super::codex_tools_compat::parse_tool_input_schema;
+use super::codex_tools_compat::tool_definition_to_responses_api_tool;
+use super::codex_tools_compat::ToolDefinition;
+use super::codex_tools_compat::ToolSpec;
 use super::shared::{
     collect_assistant_content, extract_message_text, extract_single_tool_result,
     http_client_for_target, model_context_budget, parse_tool_arguments,
@@ -339,11 +344,11 @@ pub(super) fn build_codex_responses_request(
     messages: &[Message],
     tools: &[Value],
     reasoning_effort: Option<&str>,
-) -> Value {
+) -> Result<Value> {
     let mut body = json!({
         "model": model,
         "input": to_codex_input_items(messages),
-        "tools": to_codex_tools(tools),
+        "tools": to_codex_tools(tools)?,
         "tool_choice": "auto",
         "parallel_tool_calls": true,
         "store": false,
@@ -359,7 +364,7 @@ pub(super) fn build_codex_responses_request(
     {
         body["reasoning"] = json!({ "effort": reasoning_effort });
     }
-    body
+    Ok(body)
 }
 
 impl CodexBackend {
@@ -374,7 +379,7 @@ impl CodexBackend {
             messages,
             tools,
             self.reasoning_effort.as_deref(),
-        );
+        )?;
         let responses_url = self.endpoint_url("responses");
         let mut request = self.client.post(&responses_url);
         for (name, value) in &codex_default_headers() {
@@ -490,18 +495,43 @@ pub(super) fn apply_codex_stream_event(
     }
 }
 
-fn to_codex_tools(tools: &[Value]) -> Vec<Value> {
-    tools
-        .iter()
-        .map(|tool| {
-            json!({
-                "type": "function",
-                "name": tool["name"],
-                "description": tool["description"],
-                "parameters": tool["input_schema"],
-            })
-        })
-        .collect()
+fn to_codex_tools(tools: &[Value]) -> Result<Vec<Value>> {
+    let mut tool_specs = Vec::with_capacity(tools.len());
+    for tool in tools {
+        let tool_name = tool["name"].as_str().unwrap_or("unknown");
+        let input_schema = parse_tool_input_schema(&tool["input_schema"]).map_err(|error| {
+            anyhow!("Failed to parse Codex tool schema for '{tool_name}': {error}")
+        })?;
+        let responses_tool = tool_definition_to_responses_api_tool(ToolDefinition {
+            name: tool_name.to_string(),
+            description: tool["description"].as_str().unwrap_or_default().to_string(),
+            input_schema,
+            output_schema: None,
+            defer_loading: false,
+        });
+        tool_specs.push(ToolSpec::Function(responses_tool));
+    }
+    let mut tools_json = create_tools_json_for_responses_api(&tool_specs)
+        .map_err(|error| anyhow!("Failed to serialize Codex tools for Responses API: {error}"))?;
+    for tool in &mut tools_json {
+        normalize_chatgpt_codex_function_schema(tool);
+    }
+    Ok(tools_json)
+}
+
+fn normalize_chatgpt_codex_function_schema(tool: &mut Value) {
+    let Some(parameters) = tool.get_mut("parameters").and_then(Value::as_object_mut) else {
+        return;
+    };
+    parameters.remove("anyOf");
+    parameters.remove("oneOf");
+    parameters.remove("allOf");
+    parameters.remove("not");
+    parameters.remove("enum");
+    parameters.insert("type".to_string(), Value::String("object".to_string()));
+    parameters
+        .entry("properties".to_string())
+        .or_insert_with(|| Value::Object(serde_json::Map::new()));
 }
 
 pub(super) fn to_codex_input_items(messages: &[Message]) -> Vec<Value> {

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -162,13 +162,52 @@ fn codex_responses_request_includes_reasoning_effort_when_selected() {
         ],
         &[],
         Some("high"),
-    );
+    )
+    .unwrap();
 
     assert_eq!(request["model"], "gpt-5.4");
     assert_eq!(request["stream"], true);
     assert_eq!(request["reasoning"]["effort"], "high");
     assert_eq!(request["instructions"], "Follow project instructions.");
     assert_eq!(request["input"][0]["role"], "user");
+}
+
+#[test]
+fn codex_responses_tools_use_upstream_schema_defaults_and_chatgpt_normalization() {
+    let request = build_codex_responses_request(
+        "gpt-5.4",
+        &[Message {
+            role: "user".to_string(),
+            content: json!("Hello"),
+        }],
+        &[json!({
+            "name": "team_create",
+            "description": "Create a team task graph",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "tasks": {
+                        "type": "array"
+                    },
+                    "command": { "type": "string" },
+                    "program": { "type": "string" }
+                },
+                "anyOf": [
+                    { "required": ["command"] },
+                    { "required": ["program"] }
+                ]
+            }
+        })],
+        None,
+    )
+    .unwrap();
+
+    let parameters = &request["tools"][0]["parameters"];
+    assert_eq!(request["tools"][0]["type"], "function");
+    assert_eq!(parameters["type"], "object");
+    assert!(parameters.get("anyOf").is_none());
+    assert_eq!(parameters["properties"]["tasks"]["type"], "array");
+    assert_eq!(parameters["properties"]["tasks"]["items"]["type"], "string");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- vendor the minimum upstream `codex-tools` schema/export path into `src/llm/codex_tools_compat.rs`
- route Codex Responses tool export through the vendored `parse_tool_input_schema -> ToolDefinition -> ResponsesApiTool -> ToolSpec` flow
- keep a narrow ChatGPT/Codex endpoint normalization pass that strips unsupported top-level combinators while preserving upstream defaults such as array `items`

## Why

Directly depending on `codex-tools` currently fails in `rara` because its dependency graph pulls in `temporal_rs` against an incompatible `icu_calendar` version in this workspace.

This change avoids maintaining a hand-written schema implementation while still aligning RARA with Codex's actual tool-schema pipeline.

## Validation

- `cargo test codex_responses_tools_use_upstream_schema_defaults_and_chatgpt_normalization -- --nocapture`
- `cargo check`
