### PR TITLE
fix(llm): preserve codex streamed final text

### DIFF
--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -404,6 +404,7 @@ impl CodexBackend {
         let mut output_items = Vec::new();
         let mut usage = None;
         let mut completed = false;
+        let mut streamed_text = String::new();
 
         while let Some(event) = stream.next().await {
             let event =
@@ -417,6 +418,7 @@ impl CodexBackend {
                 &payload,
                 &mut output_items,
                 &mut usage,
+                &mut streamed_text,
                 &mut on_text_delta,
             )?;
         }
@@ -430,12 +432,30 @@ impl CodexBackend {
         parse_codex_response(&build_codex_stream_response(
             output_items,
             usage,
+            streamed_text,
             "completed",
         ))
     }
 }
 
-fn build_codex_stream_response(output: Vec<Value>, usage: Option<Value>, status: &str) -> Value {
+pub(super) fn build_codex_stream_response(
+    mut output: Vec<Value>,
+    usage: Option<Value>,
+    streamed_text: String,
+    status: &str,
+) -> Value {
+    if !streamed_text.trim().is_empty() && !output_has_text_message(&output) {
+        output.insert(
+            0,
+            json!({
+                "type": "message",
+                "content": [{
+                    "type": "output_text",
+                    "text": streamed_text,
+                }]
+            }),
+        );
+    }
     let mut response = serde_json::Map::new();
     response.insert("status".to_string(), Value::String(status.to_string()));
     response.insert("output".to_string(), Value::Array(output));
@@ -445,15 +465,26 @@ fn build_codex_stream_response(output: Vec<Value>, usage: Option<Value>, status:
     Value::Object(response)
 }
 
+fn output_has_text_message(output: &[Value]) -> bool {
+    output.iter().any(|item| {
+        item.get("type").and_then(Value::as_str) == Some("message")
+            && extract_codex_output_text(item.get("content"))
+                .map(|text| !text.trim().is_empty())
+                .unwrap_or(false)
+    })
+}
+
 pub(super) fn apply_codex_stream_event(
     payload: &Value,
     output_items: &mut Vec<Value>,
     usage: &mut Option<Value>,
+    streamed_text: &mut String,
     on_text_delta: &mut Option<&mut (dyn FnMut(String) + Send)>,
 ) -> Result<bool> {
     match payload.get("type").and_then(Value::as_str) {
         Some("response.output_text.delta") => {
             if let Some(delta) = payload.get("delta").and_then(Value::as_str) {
+                streamed_text.push_str(delta);
                 if let Some(callback) = on_text_delta.as_mut() {
                     callback(delta.to_string());
                 }

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -214,6 +214,7 @@ fn codex_responses_tools_use_upstream_schema_defaults_and_chatgpt_normalization(
 fn codex_stream_events_collect_output_items_usage_and_text_deltas() {
     let mut output_items = Vec::new();
     let mut usage = None;
+    let mut streamed_text = String::new();
     let mut deltas = Vec::new();
 
     let mut on_delta = |delta: String| deltas.push(delta);
@@ -222,6 +223,7 @@ fn codex_stream_events_collect_output_items_usage_and_text_deltas() {
         &json!({"type":"response.output_text.delta","delta":"Hello"}),
         &mut output_items,
         &mut usage,
+        &mut streamed_text,
         &mut on_delta_option,
     )
     .unwrap());
@@ -237,6 +239,7 @@ fn codex_stream_events_collect_output_items_usage_and_text_deltas() {
         }),
         &mut output_items,
         &mut usage,
+        &mut streamed_text,
         &mut no_delta_callback,
     )
     .unwrap());
@@ -251,15 +254,37 @@ fn codex_stream_events_collect_output_items_usage_and_text_deltas() {
         }),
         &mut output_items,
         &mut usage,
+        &mut streamed_text,
         &mut no_delta_callback,
     )
     .unwrap());
 
     assert_eq!(deltas, vec!["Hello".to_string()]);
+    assert_eq!(streamed_text, "Hello");
     assert_eq!(output_items.len(), 1);
     assert_eq!(output_items[0]["type"], "message");
     assert_eq!(usage.as_ref().unwrap()["input_tokens"], 11);
     assert_eq!(usage.as_ref().unwrap()["output_tokens"], 7);
+}
+
+#[test]
+fn codex_stream_delta_is_used_when_done_item_has_no_text() {
+    let response = parse_codex_response(&super::openai_compatible::build_codex_stream_response(
+        vec![json!({
+            "type": "reasoning",
+            "summary": []
+        })],
+        None,
+        "Hello from stream".to_string(),
+        "completed",
+    ))
+    .unwrap();
+
+    assert_eq!(response.content.len(), 1);
+    match &response.content[0] {
+        ContentBlock::Text { text } => assert_eq!(text, "Hello from stream"),
+        other => panic!("expected text block, got {other:?}"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- preserve streamed Codex text as a final fallback assistant message when the SSE stream only emits `response.output_text.delta`
- keep the existing structured `response.output_item.done` path authoritative when it already contains final message text
- add a regression test for the case where the delta stream has text but the completed output items do not

## Why

In the TUI, Codex text was visible while streaming, but the final assistant message could end up empty when the stream produced deltas without a text-bearing `response.output_item.done`. That left the transcript with visible incremental output and an empty final agent reply.

## Validation

- `cargo test codex_stream -- --nocapture`
- `cargo check`
