### PR TITLE
fix(llm): handle codex conversation item events

### DIFF
--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -491,7 +491,7 @@ pub(super) fn apply_codex_stream_event(
             }
             Ok(false)
         }
-        Some("response.output_item.done") => {
+        Some("response.output_item.done") | Some("conversation.item.done") => {
             if let Some(item) = payload.get("item") {
                 output_items.push(item.clone());
             }

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -268,6 +268,44 @@ fn codex_stream_events_collect_output_items_usage_and_text_deltas() {
 }
 
 #[test]
+fn codex_stream_conversation_item_done_is_treated_as_output_item() {
+    let mut output_items = Vec::new();
+    let mut usage = None;
+    let mut streamed_text = String::new();
+    let mut no_delta_callback: Option<&mut (dyn FnMut(String) + Send)> = None;
+
+    assert!(!apply_codex_stream_event(
+        &json!({
+            "type":"conversation.item.done",
+            "item":{
+                "type":"message",
+                "role":"assistant",
+                "content":[{"type":"output_text","text":"Hello from conversation item"}]
+            }
+        }),
+        &mut output_items,
+        &mut usage,
+        &mut streamed_text,
+        &mut no_delta_callback,
+    )
+    .unwrap());
+
+    let response = parse_codex_response(&super::openai_compatible::build_codex_stream_response(
+        output_items,
+        usage,
+        streamed_text,
+        "completed",
+    ))
+    .unwrap();
+
+    assert_eq!(response.content.len(), 1);
+    match &response.content[0] {
+        ContentBlock::Text { text } => assert_eq!(text, "Hello from conversation item"),
+        other => panic!("expected text block, got {other:?}"),
+    }
+}
+
+#[test]
 fn codex_stream_delta_is_used_when_done_item_has_no_text() {
     let response = parse_codex_response(&super::openai_compatible::build_codex_stream_response(
         vec![json!({


### PR DESCRIPTION
## Summary

- treat `conversation.item.done` as a final Codex output item during ChatGPT OAuth streaming
- keep final assistant text/tool items when the ChatGPT Codex SSE stream uses conversation events instead of `response.output_item.done`
- add a focused regression test for the `conversation.item.done` path

## Testing

- `cargo test codex_stream -- --nocapture`
- `cargo check`
