### PR TITLE
fix(llm): align codex stream event handling

### DIFF
--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -474,14 +474,10 @@ fn output_has_text_message(output: &[Value]) -> bool {
     })
 }
 
-fn codex_output_item_identity(item: &Value) -> Option<(&'static str, &str)> {
-    if let Some(call_id) = item.get("call_id").and_then(Value::as_str) {
-        return Some(("call_id", call_id));
-    }
-    if let Some(id) = item.get("id").and_then(Value::as_str) {
-        return Some(("id", id));
-    }
-    None
+fn codex_output_item_identity(item: &Value) -> Option<&str> {
+    item.get("call_id")
+        .or_else(|| item.get("id"))
+        .and_then(Value::as_str)
 }
 
 fn upsert_codex_output_item(output_items: &mut Vec<Value>, item: &Value) {

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -474,6 +474,33 @@ fn output_has_text_message(output: &[Value]) -> bool {
     })
 }
 
+fn codex_output_item_identity(item: &Value) -> Option<(&'static str, String)> {
+    if let Some(call_id) = item.get("call_id").and_then(Value::as_str) {
+        return Some(("call_id", call_id.to_string()));
+    }
+    if let Some(id) = item.get("id").and_then(Value::as_str) {
+        return Some(("id", id.to_string()));
+    }
+    None
+}
+
+fn upsert_codex_output_item(output_items: &mut Vec<Value>, item: &Value) {
+    let Some(identity) = codex_output_item_identity(item) else {
+        output_items.push(item.clone());
+        return;
+    };
+
+    if let Some(existing) = output_items.iter_mut().find(|existing| {
+        codex_output_item_identity(existing)
+            .map(|existing_identity| existing_identity == identity)
+            .unwrap_or(false)
+    }) {
+        *existing = item.clone();
+    } else {
+        output_items.push(item.clone());
+    }
+}
+
 pub(super) fn apply_codex_stream_event(
     payload: &Value,
     output_items: &mut Vec<Value>,
@@ -491,13 +518,15 @@ pub(super) fn apply_codex_stream_event(
             }
             Ok(false)
         }
-        Some("response.output_item.done") | Some("conversation.item.done") => {
+        Some("response.output_item.added")
+        | Some("response.output_item.done")
+        | Some("conversation.item.done") => {
             if let Some(item) = payload.get("item") {
-                output_items.push(item.clone());
+                upsert_codex_output_item(output_items, item);
             }
             Ok(false)
         }
-        Some("response.completed") => {
+        Some("response.done") | Some("response.completed") => {
             *usage = payload.get("response").and_then(|response| {
                 let usage = response.get("usage")?;
                 (!usage.is_null()).then(|| usage.clone())

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -491,7 +491,7 @@ pub(super) fn apply_codex_stream_event(
             }
             Ok(false)
         }
-        Some("response.output_item.done") => {
+        Some("response.output_item.done") | Some("conversation.item.done") => {
             if let Some(item) = payload.get("item") {
                 output_items.push(item.clone());
             }

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -474,12 +474,12 @@ fn output_has_text_message(output: &[Value]) -> bool {
     })
 }
 
-fn codex_output_item_identity(item: &Value) -> Option<(&'static str, String)> {
+fn codex_output_item_identity(item: &Value) -> Option<(&'static str, &str)> {
     if let Some(call_id) = item.get("call_id").and_then(Value::as_str) {
-        return Some(("call_id", call_id.to_string()));
+        return Some(("call_id", call_id));
     }
     if let Some(id) = item.get("id").and_then(Value::as_str) {
-        return Some(("id", id.to_string()));
+        return Some(("id", id));
     }
     None
 }
@@ -490,11 +490,10 @@ fn upsert_codex_output_item(output_items: &mut Vec<Value>, item: &Value) {
         return;
     };
 
-    if let Some(existing) = output_items.iter_mut().find(|existing| {
-        codex_output_item_identity(existing)
-            .map(|existing_identity| existing_identity == identity)
-            .unwrap_or(false)
-    }) {
+    if let Some(existing) = output_items
+        .iter_mut()
+        .find(|existing| codex_output_item_identity(existing) == Some(identity))
+    {
         *existing = item.clone();
     } else {
         output_items.push(item.clone());

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -362,6 +362,52 @@ fn codex_stream_output_item_added_is_upserted_by_done_item() {
 }
 
 #[test]
+fn codex_stream_output_item_matches_mixed_id_and_call_id() {
+    let mut output_items = Vec::new();
+    let mut usage = None;
+    let mut streamed_text = String::new();
+    let mut no_delta_callback: Option<&mut (dyn FnMut(String) + Send)> = None;
+
+    assert!(!apply_codex_stream_event(
+        &json!({
+            "type":"response.output_item.added",
+            "item":{
+                "id":"tool_1",
+                "type":"function_call",
+                "name":"bash",
+                "arguments":"{}"
+            }
+        }),
+        &mut output_items,
+        &mut usage,
+        &mut streamed_text,
+        &mut no_delta_callback,
+    )
+    .unwrap());
+
+    assert!(!apply_codex_stream_event(
+        &json!({
+            "type":"response.output_item.done",
+            "item":{
+                "call_id":"tool_1",
+                "type":"function_call",
+                "name":"bash",
+                "arguments":"{\"cmd\":\"pwd\"}"
+            }
+        }),
+        &mut output_items,
+        &mut usage,
+        &mut streamed_text,
+        &mut no_delta_callback,
+    )
+    .unwrap());
+
+    assert_eq!(output_items.len(), 1);
+    assert_eq!(output_items[0]["call_id"], "tool_1");
+    assert_eq!(output_items[0]["arguments"], "{\"cmd\":\"pwd\"}");
+}
+
+#[test]
 fn codex_stream_response_done_marks_completion() {
     let mut output_items = Vec::new();
     let mut usage = None;

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -268,6 +268,44 @@ fn codex_stream_events_collect_output_items_usage_and_text_deltas() {
 }
 
 #[test]
+fn codex_stream_conversation_item_done_is_treated_as_output_item() {
+    let mut output_items = Vec::new();
+    let mut usage = None;
+    let mut streamed_text = String::new();
+    let mut no_delta_callback: Option<&mut (dyn FnMut(String) + Send)> = None;
+
+    assert!(!apply_codex_stream_event(
+        &json!({
+            "type":"conversation.item.done",
+            "item":{
+                "type":"message",
+                "role":"assistant",
+                "content":[{"type":"output_text","text":"Hello from conversation item"}]
+            }
+        }),
+        &mut output_items,
+        &mut usage,
+        &mut streamed_text,
+        &mut no_delta_callback,
+    )
+    .unwrap());
+
+    let response = parse_codex_response(&super::openai_compatible::build_codex_stream_response(
+        output_items,
+        usage,
+        streamed_text,
+        "completed",
+    ))
+    .unwrap();
+
+    assert_eq!(response.content.len(), 1);
+    match &response.content[0] {
+        ContentBlock::Text { text } => assert_eq!(text, "Hello from conversation item"),
+        other => panic!("expected text block, got {other:?}"),
+    }
+}
+
+#[test]
 fn codex_stream_delta_is_used_when_done_item_has_no_text() {
     let response = parse_codex_response(&super::openai_compatible::build_codex_stream_response(
         vec![json!({

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -306,6 +306,88 @@ fn codex_stream_conversation_item_done_is_treated_as_output_item() {
 }
 
 #[test]
+fn codex_stream_output_item_added_is_upserted_by_done_item() {
+    let mut output_items = Vec::new();
+    let mut usage = None;
+    let mut streamed_text = String::new();
+    let mut no_delta_callback: Option<&mut (dyn FnMut(String) + Send)> = None;
+
+    assert!(!apply_codex_stream_event(
+        &json!({
+            "type":"response.output_item.added",
+            "item":{
+                "id":"msg_1",
+                "type":"message",
+                "role":"assistant",
+                "content":[{"type":"output_text","text":"partial"}]
+            }
+        }),
+        &mut output_items,
+        &mut usage,
+        &mut streamed_text,
+        &mut no_delta_callback,
+    )
+    .unwrap());
+
+    assert!(!apply_codex_stream_event(
+        &json!({
+            "type":"response.output_item.done",
+            "item":{
+                "id":"msg_1",
+                "type":"message",
+                "role":"assistant",
+                "content":[{"type":"output_text","text":"final"}]
+            }
+        }),
+        &mut output_items,
+        &mut usage,
+        &mut streamed_text,
+        &mut no_delta_callback,
+    )
+    .unwrap());
+
+    let response = parse_codex_response(&super::openai_compatible::build_codex_stream_response(
+        output_items,
+        usage,
+        streamed_text,
+        "completed",
+    ))
+    .unwrap();
+
+    assert_eq!(response.content.len(), 1);
+    match &response.content[0] {
+        ContentBlock::Text { text } => assert_eq!(text, "final"),
+        other => panic!("expected text block, got {other:?}"),
+    }
+}
+
+#[test]
+fn codex_stream_response_done_marks_completion() {
+    let mut output_items = Vec::new();
+    let mut usage = None;
+    let mut streamed_text = String::new();
+    let mut no_delta_callback: Option<&mut (dyn FnMut(String) + Send)> = None;
+
+    assert!(apply_codex_stream_event(
+        &json!({
+            "type":"response.done",
+            "response":{
+                "id":"resp-1",
+                "usage":{"input_tokens":5,"output_tokens":3}
+            }
+        }),
+        &mut output_items,
+        &mut usage,
+        &mut streamed_text,
+        &mut no_delta_callback,
+    )
+    .unwrap());
+
+    assert_eq!(usage.as_ref().unwrap()["input_tokens"], 5);
+    assert_eq!(usage.as_ref().unwrap()["output_tokens"], 3);
+}
+
+#[test]
 fn codex_stream_delta_is_used_when_done_item_has_no_text() {
     let response = parse_codex_response(&super::openai_compatible::build_codex_stream_response(
         vec![json!({


### PR DESCRIPTION
## Summary

- align Codex ChatGPT OAuth SSE handling with additional upstream event variants
- treat `response.output_item.added`, `response.output_item.done`, and `conversation.item.done` as the same output-item stream with id-based upsert
- accept `response.done` as a terminal completion event in addition to `response.completed`

## Testing

- `cargo test codex_stream -- --nocapture`
- `cargo check`
