### PR TITLE
fix(tui): render committed transcript turns

### DIFF
--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -51,6 +51,7 @@ pub fn render(f: &mut Frame, app: &TuiApp) {
 
 fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
     let transcript_lines = renderable_transcript_lines(app, area.width);
+    let transcript_line_count = transcript_lines.len();
     if !app.has_any_transcript() && transcript_lines.is_empty() {
         if app.startup_card_inserted {
             f.render_widget(Paragraph::new(Vec::<Line<'static>>::new()), area);
@@ -92,15 +93,35 @@ fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_widget(
         Paragraph::new(transcript_lines)
             .wrap(Wrap { trim: false })
-            .scroll((app.transcript_scroll as u16, 0)),
+            .scroll((transcript_scroll_offset(app, area.height, transcript_line_count), 0)),
         area,
     );
 }
 
 fn renderable_transcript_lines(app: &TuiApp, width: u16) -> Vec<Line<'static>> {
+    let mut lines = committed_transcript_lines(app, width);
+
+    let mut active_lines = active_turn_cell(app).display_lines(width);
+    if !active_lines.is_empty() {
+        if !lines.is_empty() {
+            lines.push(Line::from(""));
+        }
+        lines.append(&mut active_lines);
+    }
+
+    lines
+}
+
+fn committed_transcript_lines(app: &TuiApp, width: u16) -> Vec<Line<'static>> {
+    {
+        let cache = app.committed_render_cache.borrow();
+        if cache.generation == app.committed_render_generation && cache.width == width {
+            return cache.lines.clone();
+        }
+    }
+
     let cwd = (!app.snapshot.cwd.is_empty()).then(|| Path::new(app.snapshot.cwd.as_str()));
     let mut lines = Vec::new();
-
     for turn in &app.committed_turns {
         let mut turn_lines = committed_turn_lines(turn.entries.as_slice(), cwd, width);
         if turn_lines.is_empty() {
@@ -112,15 +133,17 @@ fn renderable_transcript_lines(app: &TuiApp, width: u16) -> Vec<Line<'static>> {
         lines.append(&mut turn_lines);
     }
 
-    let mut active_lines = active_turn_cell(app).display_lines(width);
-    if !active_lines.is_empty() {
-        if !lines.is_empty() {
-            lines.push(Line::from(""));
-        }
-        lines.append(&mut active_lines);
-    }
-
+    let mut cache = app.committed_render_cache.borrow_mut();
+    cache.generation = app.committed_render_generation;
+    cache.width = width;
+    cache.lines = lines.clone();
     lines
+}
+
+fn transcript_scroll_offset(app: &TuiApp, viewport_height: u16, transcript_line_count: usize) -> u16 {
+    let max_offset = transcript_line_count.saturating_sub(viewport_height as usize);
+    let top_offset = max_offset.saturating_sub(app.transcript_scroll);
+    top_offset.min(u16::MAX as usize) as u16
 }
 
 pub fn committed_turn_cell<'a>(
@@ -1578,7 +1601,7 @@ mod tests {
     use super::cells::HistoryCell;
     use super::{
         committed_turn_cell, current_turn_tool_summary, desired_viewport_height,
-        renderable_transcript_lines,
+        renderable_transcript_lines, transcript_scroll_offset,
     };
 
     #[test]
@@ -1672,5 +1695,57 @@ mod tests {
         assert!(rendered.contains("You: Earlier prompt"));
         assert!(rendered.contains("Committed answer"));
         assert!(rendered.contains("You: Current prompt"));
+    }
+
+    #[test]
+    fn transcript_scroll_offset_keeps_zero_sticky_to_bottom() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.transcript_scroll = 0;
+
+        assert_eq!(transcript_scroll_offset(&app, 3, 10), 7);
+
+        app.scroll_transcript(-2);
+        assert_eq!(transcript_scroll_offset(&app, 3, 10), 5);
+    }
+
+    #[test]
+    fn renderable_transcript_lines_cache_is_invalidated_when_committed_turns_change() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.restore_committed_turns(vec![TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "Agent".into(),
+                message: "First answer".into(),
+            }],
+        }]);
+
+        let first = renderable_transcript_lines(&app, 100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(first.contains("First answer"));
+
+        app.restore_committed_turns(vec![TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "Agent".into(),
+                message: "Second answer".into(),
+            }],
+        }]);
+
+        let second = renderable_transcript_lines(&app, 100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(!second.contains("First answer"));
+        assert!(second.contains("Second answer"));
     }
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -51,7 +51,7 @@ pub fn render(f: &mut Frame, app: &TuiApp) {
 
 fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
     let transcript_lines = renderable_transcript_lines(app, area.width);
-    let transcript_line_count = transcript_lines.len();
+    let transcript_visual_row_count = transcript_visual_row_count(&transcript_lines, area.width);
     if !app.has_any_transcript() && transcript_lines.is_empty() {
         if app.startup_card_inserted {
             f.render_widget(Paragraph::new(Vec::<Line<'static>>::new()), area);
@@ -93,7 +93,10 @@ fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_widget(
         Paragraph::new(transcript_lines)
             .wrap(Wrap { trim: false })
-            .scroll((transcript_scroll_offset(app, area.height, transcript_line_count), 0)),
+            .scroll((
+                transcript_scroll_offset(app, area.height, transcript_visual_row_count),
+                0,
+            )),
         area,
     );
 }
@@ -146,6 +149,13 @@ fn transcript_scroll_offset(app: &TuiApp, viewport_height: u16, transcript_line_
     top_offset.min(u16::MAX as usize) as u16
 }
 
+fn transcript_visual_row_count(lines: &[Line<'static>], width: u16) -> usize {
+    let wrap_width = width.max(1) as usize;
+    lines.iter()
+        .map(|line| line.width().max(1).div_ceil(wrap_width))
+        .sum()
+}
+
 pub fn committed_turn_cell<'a>(
     entries: &'a [TranscriptEntry],
     cwd: Option<&'a Path>,
@@ -189,39 +199,6 @@ fn current_turn_exploration_summary(
     )
 }
 
-fn exploration_note_lines(current_turn: &[&TranscriptEntry]) -> Vec<String> {
-    let mut notes = Vec::new();
-    for entry in current_turn {
-        if entry.role != "Agent" {
-            continue;
-        }
-        for line in entry
-            .message
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty())
-        {
-            if line.starts_with("/search ")
-                || line.starts_with("/compact ")
-                || line.starts_with("/plan ")
-                || line.starts_with("/quit ")
-                || line.starts_with("key=")
-                || line.starts_with("history=")
-                || line.starts_with("tokens=")
-                || line.starts_with("ctx~=")
-                || line.starts_with("waiting for model response")
-            {
-                continue;
-            }
-            if notes.last().is_some_and(|existing| existing == line) {
-                continue;
-            }
-            notes.push(line.to_string());
-        }
-    }
-    notes
-}
-
 pub(crate) fn current_turn_exploration_summary_from_entries(
     current_turn: &[&TranscriptEntry],
     _show_live_detail: bool,
@@ -240,14 +217,10 @@ pub(crate) fn current_turn_exploration_summary_from_entries(
         return None;
     }
 
-    let mut lines = actions
+    let lines = actions
         .into_iter()
         .map(|action| format!("└ {action}"))
         .collect::<Vec<_>>();
-
-    for note in exploration_note_lines(current_turn) {
-        lines.push(format!("└ {note}"));
-    }
 
     Some(lines.join("\n"))
 }
@@ -399,30 +372,10 @@ fn exploration_action_label(message: &str) -> Option<String> {
     let name = parts.next()?;
     let rest = parts.collect::<Vec<_>>().join(" ");
     match name {
-        "list_files" => Some(format!(
-            "List {}",
-            if rest.is_empty() { "." } else { rest.as_str() }
-        )),
         "read_file" => Some(format!(
             "Read {}",
             if rest.is_empty() {
                 "file"
-            } else {
-                rest.as_str()
-            }
-        )),
-        "glob" => Some(format!(
-            "Glob {}",
-            if rest.is_empty() {
-                "workspace"
-            } else {
-                rest.as_str()
-            }
-        )),
-        "grep" => Some(format!(
-            "Search {}",
-            if rest.is_empty() {
-                "workspace"
             } else {
                 rest.as_str()
             }
@@ -1590,6 +1543,7 @@ pub(crate) fn display_width(value: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use ratatui::text::Line;
     use tempfile::tempdir;
 
     use crate::config::ConfigManager;
@@ -1601,7 +1555,8 @@ mod tests {
     use super::cells::HistoryCell;
     use super::{
         committed_turn_cell, current_turn_tool_summary, desired_viewport_height,
-        renderable_transcript_lines, transcript_scroll_offset,
+        current_turn_exploration_summary_from_entries, renderable_transcript_lines,
+        transcript_scroll_offset, transcript_visual_row_count,
     };
 
     #[test]
@@ -1713,6 +1668,23 @@ mod tests {
     }
 
     #[test]
+    fn transcript_scroll_offset_uses_wrapped_visual_height() {
+        let temp = tempdir().expect("tempdir");
+        let app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        let lines = vec![
+            Line::from("Agent"),
+            Line::from("  This is a long streamed response that should wrap across rows."),
+        ];
+
+        let visual_rows = transcript_visual_row_count(&lines, 12);
+        assert!(visual_rows > lines.len());
+        assert_eq!(transcript_scroll_offset(&app, 3, visual_rows), visual_rows as u16 - 3);
+    }
+
+    #[test]
     fn renderable_transcript_lines_cache_is_invalidated_when_committed_turns_change() {
         let temp = tempdir().expect("tempdir");
         let mut app = TuiApp::new(ConfigManager {
@@ -1747,5 +1719,41 @@ mod tests {
             .join("\n");
         assert!(!second.contains("First answer"));
         assert!(second.contains("Second answer"));
+    }
+
+    #[test]
+    fn exploration_summary_only_keeps_read_actions() {
+        let entries = vec![
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "list_files .".into(),
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "glob src/**/*.rs".into(),
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "grep planning mode src".into(),
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "read_file src/main.rs".into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "I will start by listing files and then inspect the main entrypoint.".into(),
+            },
+        ];
+        let refs = entries.iter().collect::<Vec<_>>();
+
+        let rendered =
+            current_turn_exploration_summary_from_entries(refs.as_slice(), false, None)
+                .expect("exploration summary");
+        assert!(rendered.contains("Read src/main.rs"));
+        assert!(!rendered.contains("List ."));
+        assert!(!rendered.contains("Glob src/**/*.rs"));
+        assert!(!rendered.contains("Search planning mode src"));
+        assert!(!rendered.contains("listing files"));
     }
 }

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -735,6 +735,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Agent")
             .map(|entry| entry.message.as_str());
         let streaming_agent_lines = self.app.agent_stream_lines();
+        let has_agent_stream = self.app.has_agent_stream();
         let latest_system = current_turn
             .iter()
             .rev()
@@ -914,21 +915,33 @@ impl ActiveCell for ActiveTurnCell<'_> {
 
         let responding_role = if turn_live { "Responding" } else { "Agent" };
 
-        if let Some(stream_lines) = streaming_agent_lines
-            .filter(|_| {
+        if has_agent_stream
+            && !suppress_intermediate_agent
+            && !suppress_planning_chatter
+            && !suppress_structured_plan_response
+        {
+            if let Some(stream_lines) = streaming_agent_lines {
+                cells.push(Box::new(RespondingCell::from_stream(stream_lines)));
+            } else if let Some(agent_message) = latest_agent {
+                cells.push(Box::new(RespondingCell::from_message(
+                    responding_role,
+                    agent_message,
+                    usize::MAX,
+                    self.cwd,
+                )));
+            } else {
+                cells.push(Box::new(RespondingCell::working(
+                    self.app
+                        .runtime_phase_detail
+                        .as_deref()
+                        .unwrap_or("streaming model output"),
+                )));
+            }
+        } else if let Some(agent_message) = latest_agent.filter(|_| {
                 !suppress_intermediate_agent
                     && !suppress_planning_chatter
                     && !suppress_structured_plan_response
-            })
-        {
-            cells.push(Box::new(RespondingCell::from_stream(stream_lines)));
-        } else if let Some(agent_message) =
-            latest_agent.filter(|_| {
-                !suppress_intermediate_agent
-                    && !suppress_planning_chatter
-                    && !suppress_structured_plan_response
-            })
-        {
+            }) {
             cells.push(Box::new(RespondingCell::from_message(
                 responding_role,
                 agent_message,
@@ -1817,6 +1830,39 @@ mod tests {
 
         assert!(rendered.contains(" Plan Decision "));
         assert!(rendered.contains("Approved and started implementation"));
+    }
+
+    #[test]
+    fn active_turn_cell_keeps_responding_section_while_agent_stream_exists() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.active_turn = TranscriptTurn {
+            entries: vec![
+                TranscriptEntry {
+                    role: "You".into(),
+                    message: "你好".into(),
+                },
+                TranscriptEntry {
+                    role: "Tool Result".into(),
+                    message: "bash stdout: partial".into(),
+                },
+            ],
+        };
+        app.set_runtime_phase(RuntimePhase::ProcessingResponse, Some("streaming model output".into()));
+        app.append_agent_delta("你好");
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Responding"));
+        assert!(!rendered.contains("Working"));
     }
 
     #[test]

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -1046,13 +1046,12 @@ mod tests {
             .join("\n");
 
         let you_idx = rendered.find("You: Review this repo").unwrap();
-        let explored_idx = rendered.find(" Explored ").unwrap();
         let ran_idx = rendered.find(" Ran ").unwrap();
         let agent_idx = rendered.find("Agent\n  Final recommendation").unwrap();
 
-        assert!(you_idx < explored_idx);
-        assert!(explored_idx < ran_idx);
+        assert!(!rendered.contains(" Explored "));
         assert!(ran_idx < agent_idx);
+        assert!(you_idx < ran_idx);
     }
 
     #[test]
@@ -1102,13 +1101,12 @@ mod tests {
             .join("\n");
 
         let you_idx = rendered.find("You: Inspect the codebase").unwrap();
-        let exploring_idx = rendered.find(" Exploring ").unwrap();
         let running_idx = rendered.find(" Running ").unwrap();
         let plan_idx = rendered.find("Updated Plan").unwrap();
         let approval_idx = rendered.find(" Request Input ").unwrap();
 
-        assert!(you_idx < exploring_idx);
-        assert!(exploring_idx < running_idx);
+        assert!(!rendered.contains(" Exploring "));
+        assert!(you_idx < running_idx);
         assert!(running_idx < plan_idx);
         assert!(plan_idx < approval_idx);
     }
@@ -1175,7 +1173,7 @@ mod tests {
             "rendered_exploration_notes=\n{rendered}"
         );
         assert!(rendered.contains("Read src/main.rs"));
-        assert!(rendered.contains(
+        assert!(!rendered.contains(
             "I have inspected the repository structure and will now inspect the core modules."
         ));
         assert!(!rendered.contains("waiting for model response · 12s elapsed"));

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -901,6 +901,10 @@ impl TuiApp {
             .map(|stream| stream.display_lines.as_slice())
     }
 
+    pub fn has_agent_stream(&self) -> bool {
+        self.agent_markdown_stream.is_some()
+    }
+
     pub fn finalize_agent_stream(&mut self, final_message: Option<String>) {
         let fallback = self
             .agent_markdown_stream
@@ -916,6 +920,20 @@ impl TuiApp {
                 last.message = message;
                 self.transcript_scroll = 0;
                 return;
+            }
+        }
+        if self.active_turn.entries.is_empty() {
+            if let Some(last) = self
+                .committed_turns
+                .last_mut()
+                .and_then(|turn| turn.entries.last_mut())
+            {
+                if last.role == "Agent" {
+                    last.message = message;
+                    self.invalidate_committed_render_cache();
+                    self.transcript_scroll = 0;
+                    return;
+                }
             }
         }
         self.push_entry("Agent", message);
@@ -1908,5 +1926,37 @@ mod tests {
         app.open_overlay(Overlay::ModelNameEditor);
 
         assert_eq!(app.model_name_input, "custom-model");
+    }
+
+    #[test]
+    fn finalize_agent_stream_updates_latest_committed_turn_when_final_text_arrives_late() {
+        let dir = tempdir().expect("tempdir");
+        let cm = ConfigManager {
+            path: dir.path().join("config.json"),
+        };
+        let mut app = TuiApp::new(cm).expect("app");
+        app.committed_turns.push(super::TranscriptTurn {
+            entries: vec![
+                super::TranscriptEntry {
+                    role: "You".into(),
+                    message: "你好".into(),
+                },
+                super::TranscriptEntry {
+                    role: "Agent".into(),
+                    message: "你好！".into(),
+                },
+            ],
+        });
+
+        app.finalize_agent_stream(Some("你好！有什么我可以帮你的？".into()));
+
+        assert!(app.active_turn.entries.is_empty());
+        assert_eq!(
+            app.committed_turns
+                .last()
+                .and_then(|turn| turn.entries.last())
+                .map(|entry| entry.message.as_str()),
+            Some("你好！有什么我可以帮你的？")
+        );
     }
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -2,6 +2,7 @@ mod state_presets;
 
 use ratatui::text::Line;
 use serde_json::json;
+use std::cell::RefCell;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -287,6 +288,13 @@ pub struct TranscriptTurn {
     pub entries: Vec<TranscriptEntry>,
 }
 
+#[derive(Default)]
+pub(crate) struct CommittedTranscriptRenderCache {
+    pub generation: u64,
+    pub width: u16,
+    pub lines: Vec<Line<'static>>,
+}
+
 pub struct AgentMarkdownStreamState {
     raw_text: String,
     collector: MarkdownStreamCollector,
@@ -351,6 +359,8 @@ pub struct TuiApp {
     pub recent_commands: Vec<String>,
     pub recent_sessions: Vec<PersistedSessionSummary>,
     pub resume_picker_idx: usize,
+    pub committed_render_generation: u64,
+    pub committed_render_cache: RefCell<CommittedTranscriptRenderCache>,
     pub transcript_scroll: usize,
     pub agent_markdown_stream: Option<AgentMarkdownStreamState>,
     pub active_live: ActiveLiveSections,
@@ -471,6 +481,8 @@ impl TuiApp {
             recent_commands: Vec::new(),
             recent_sessions: Vec::new(),
             resume_picker_idx: 0,
+            committed_render_generation: 0,
+            committed_render_cache: RefCell::new(CommittedTranscriptRenderCache::default()),
             transcript_scroll: 0,
             agent_markdown_stream: None,
             active_live: ActiveLiveSections::default(),
@@ -919,6 +931,7 @@ impl TuiApp {
         self.committed_turns.clear();
         self.active_turn.entries.clear();
         self.inserted_turns = 0;
+        self.invalidate_committed_render_cache();
         self.transcript_scroll = 0;
         self.agent_markdown_stream = None;
         self.clear_active_live_sections();
@@ -1392,6 +1405,7 @@ impl TuiApp {
         let ordinal = self.committed_turns.len();
         self.persist_turn(ordinal, &turn);
         self.committed_turns.push(turn);
+        self.invalidate_committed_render_cache();
         self.transcript_scroll = 0;
         self.clear_active_live_sections();
     }
@@ -1404,9 +1418,15 @@ impl TuiApp {
         self.committed_turns = turns;
         self.active_turn.entries.clear();
         self.inserted_turns = 0;
+        self.invalidate_committed_render_cache();
         self.transcript_scroll = 0;
         self.agent_markdown_stream = None;
         self.clear_active_live_sections();
+    }
+
+    pub(crate) fn invalidate_committed_render_cache(&mut self) {
+        self.committed_render_generation = self.committed_render_generation.wrapping_add(1);
+        *self.committed_render_cache.borrow_mut() = CommittedTranscriptRenderCache::default();
     }
 
     pub fn clear_active_live_sections(&mut self) {


### PR DESCRIPTION
## Summary

- render committed transcript turns in the main TUI transcript view instead of only rendering the active turn
- keep the current active turn appended after committed history so a finished response no longer flashes and disappears
- add a focused render regression test that locks the committed-history + active-turn contract

## Testing

- `cargo test tui::render::tests::renderable_transcript_lines_include_committed_and_active_turns -- --nocapture`
- `cargo check`
