### PR TITLE
fix(tui): tighten queued follow-up and plan visibility

### DIFF
--- a/.tmp-pr44.md
+++ b/.tmp-pr44.md
@@ -1,0 +1,14 @@
+## Summary
+
+- align queued follow-up status hints with the Codex-style wording
+- hide stale `Updated Plan` cards after plan mode finishes unless approval is still pending
+- add focused tests for queued follow-up hints and stale plan visibility
+
+## Testing
+
+- `cargo test queued_follow_up_hint_overrides_busy_hint -- --nocapture`
+- `cargo test queued_follow_up_preview_shows_first_message_and_remainder -- --nocapture`
+- `cargo test queued_follow_up_preview_snapshot -- --nocapture`
+- `cargo test active_plan_visibility_requires_plan_mode_or_approval -- --nocapture`
+- `cargo test active_turn_cell_hides_stale_updated_plan_after_plan_turn_finishes -- --nocapture`
+- `cargo check`

--- a/src/tui/plan_display.rs
+++ b/src/tui/plan_display.rs
@@ -41,10 +41,21 @@ impl PlanStepKind {
 }
 
 pub(crate) fn status_plan_text(app: &TuiApp) -> String {
+    if !should_show_updated_plan(app) {
+        return "No active structured plan.".to_string();
+    }
     updated_plan_text(
         app.snapshot.plan_steps.as_slice(),
         app.snapshot.plan_explanation.as_deref(),
     )
+}
+
+pub(crate) fn should_show_updated_plan(app: &TuiApp) -> bool {
+    if app.snapshot.plan_steps.is_empty() {
+        return false;
+    }
+
+    app.agent_execution_mode_label() == "plan" || app.has_pending_plan_approval()
 }
 
 pub(crate) fn updated_plan_text(steps: &[(String, String)], explanation: Option<&str>) -> String {
@@ -107,7 +118,12 @@ pub(crate) fn updated_plan_lines(
 
 #[cfg(test)]
 mod tests {
-    use super::{updated_plan_lines, updated_plan_text};
+    use tempfile::tempdir;
+
+    use crate::config::ConfigManager;
+    use crate::tui::state::TuiApp;
+
+    use super::{should_show_updated_plan, updated_plan_lines, updated_plan_text};
 
     #[test]
     fn updated_plan_text_formats_note_and_checklist() {
@@ -147,5 +163,20 @@ mod tests {
         assert!(rendered.contains("Updated Plan"));
         assert!(rendered.contains("Do not claim execution in planning mode."));
         assert!(rendered.contains("□ Capture the next implementation step"));
+    }
+
+    #[test]
+    fn active_plan_visibility_requires_plan_mode_or_approval() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.snapshot.plan_steps = vec![("pending".into(), "Inspect core modules".into())];
+
+        assert!(!should_show_updated_plan(&app));
+
+        app.set_pending_plan_approval(true);
+        assert!(should_show_updated_plan(&app));
     }
 }

--- a/src/tui/plan_display.rs
+++ b/src/tui/plan_display.rs
@@ -55,7 +55,10 @@ pub(crate) fn should_show_updated_plan(app: &TuiApp) -> bool {
         return false;
     }
 
-    app.agent_execution_mode_label() == "plan" || app.has_pending_plan_approval()
+    matches!(
+        app.agent_execution_mode,
+        crate::agent::AgentExecutionMode::Plan
+    ) || app.has_pending_plan_approval()
 }
 
 pub(crate) fn updated_plan_text(steps: &[(String, String)], explanation: Option<&str>) -> String {

--- a/src/tui/queued_input.rs
+++ b/src/tui/queued_input.rs
@@ -13,9 +13,9 @@ pub fn queued_follow_up_heading() -> &'static str {
 }
 
 pub fn pending_follow_up_hint() -> &'static str {
-    "queued follow-up pending  will submit after the next tool/result boundary"
+    "pending follow-up  will submit after next tool call"
 }
 
 pub fn queued_follow_up_hint() -> &'static str {
-    "queued follow-up pending  current task will finish before submission"
+    "queued follow-up  will submit after current turn"
 }

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -561,7 +561,7 @@ mod tests {
 
         assert_eq!(
             composer_hint(&app),
-            "queued follow-up pending  will submit after the next tool/result boundary"
+            "pending follow-up  will submit after next tool call"
         );
     }
 }

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -793,6 +793,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 .map(|note| format!("└ {note}")),
             );
             Some(lines.join("\n"))
+        } else if !turn_live {
+            None
         } else {
             explicit_exploration.or_else(|| {
                 current_turn_exploration_summary(self.app, current_turn.as_slice(), turn_live)
@@ -1778,6 +1780,38 @@ mod tests {
 
         assert!(!rendered.contains("Updated Plan"));
         assert!(rendered.contains("You: Implement the approved fix"));
+    }
+
+    #[test]
+    fn active_turn_cell_hides_stale_exploring_after_live_phase_finishes() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.runtime_phase = RuntimePhase::Idle;
+        app.active_turn = TranscriptTurn {
+            entries: vec![
+                TranscriptEntry {
+                    role: "You".into(),
+                    message: "Inspect the repository".into(),
+                },
+                TranscriptEntry {
+                    role: "Exploring".into(),
+                    message: "└ Read src/main.rs".into(),
+                },
+            ],
+        };
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!rendered.contains(" Exploring "));
+        assert!(rendered.contains("You: Inspect the repository"));
     }
 
     #[test]

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -768,7 +768,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
             cells.push(Box::new(UserCell::new(user_message)));
         }
 
-        if self.app.agent_execution_mode_label() == "plan" {
+        if self.app.agent_execution_mode_label() == "plan" && !self.app.has_pending_plan_approval()
+        {
             cells.push(Box::new(PlanModeCell));
         }
 

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -1061,6 +1061,7 @@ mod tests {
             path: temp.path().join("config.json"),
         })
         .expect("build tui app");
+        app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
         app.runtime_phase = RuntimePhase::RunningTool;
         app.runtime_phase_detail = Some("waiting for tool output".into());
         app.active_turn = TranscriptTurn {
@@ -1220,6 +1221,7 @@ mod tests {
             path: temp.path().join("config.json"),
         })
         .expect("build tui app");
+        app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
         app.runtime_phase = RuntimePhase::ProcessingResponse;
         app.runtime_phase_detail = Some("waiting for model response · 3s elapsed".into());
         app.active_turn = TranscriptTurn {
@@ -1676,6 +1678,7 @@ mod tests {
             path: temp.path().join("config.json"),
         })
         .expect("build tui app");
+        app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
         app.active_turn = TranscriptTurn {
             entries: vec![TranscriptEntry {
                 role: "You".into(),
@@ -1715,6 +1718,7 @@ mod tests {
             path: temp.path().join("config.json"),
         })
         .expect("build tui app");
+        app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
         app.active_turn = TranscriptTurn {
             entries: vec![TranscriptEntry {
                 role: "You".into(),

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -9,7 +9,7 @@ use crate::tui::interaction_text::{
     pending_interaction_card_title, pending_interaction_detail_text,
     pending_interaction_shortcut_text, status_planning_suggestion_text,
 };
-use crate::tui::plan_display::updated_plan_lines;
+use crate::tui::plan_display::{should_show_updated_plan, updated_plan_lines};
 use crate::tui::state::{
     contains_structured_planning_output, ActivePendingInteractionKind, RuntimePhase,
     TranscriptEntry, TuiApp,
@@ -862,7 +862,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             cells.push(Box::new(RunningCell::new(summary, running_active)));
         }
 
-        if !self.app.snapshot.plan_steps.is_empty() {
+        if should_show_updated_plan(self.app) {
             cells.push(Box::new(PlanSummaryCell::new(
                 self.app.snapshot.plan_steps.clone(),
                 self.app.snapshot.plan_explanation.clone(),
@@ -1747,6 +1747,33 @@ mod tests {
         assert!(rendered.contains("✔ Inspect the current plan UI"));
         assert!(rendered.contains("□ Introduce a dedicated plan formatter"));
         assert!(rendered.contains("□ Unify status and transcript rendering"));
+    }
+
+    #[test]
+    fn active_turn_cell_hides_stale_updated_plan_after_plan_turn_finishes() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.active_turn = TranscriptTurn {
+            entries: vec![TranscriptEntry {
+                role: "You".into(),
+                message: "Implement the approved fix".into(),
+            }],
+        };
+        app.snapshot.plan_steps = vec![("pending".into(), "Inspect the config loading flow".into())];
+        app.snapshot.plan_explanation = Some("This should not keep rendering after plan exit.".into());
+
+        let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(!rendered.contains("Updated Plan"));
+        assert!(rendered.contains("You: Implement the approved fix"));
     }
 
     #[test]

--- a/src/tui/render/snapshots/rara__tui__render__cells__tests__active_turn_cell_updated_plan.snap
+++ b/src/tui/render/snapshots/rara__tui__render__cells__tests__active_turn_cell_updated_plan.snap
@@ -4,6 +4,8 @@ expression: rendered
 ---
 You: Read the local codebase and propose the next refactor
 
+ Plan Mode 
+
  Exploring 
   └ Read src/oauth.rs
 


### PR DESCRIPTION
## Summary

- align queued follow-up status hints with the Codex-style wording
- hide stale `Updated Plan` cards after plan mode finishes unless approval is still pending
- add focused tests for queued follow-up hints and stale plan visibility

## Testing

- `cargo test queued_follow_up_hint_overrides_busy_hint -- --nocapture`
- `cargo test queued_follow_up_preview_shows_first_message_and_remainder -- --nocapture`
- `cargo test queued_follow_up_preview_snapshot -- --nocapture`
- `cargo test active_plan_visibility_requires_plan_mode_or_approval -- --nocapture`
- `cargo test active_turn_cell_hides_stale_updated_plan_after_plan_turn_finishes -- --nocapture`
- `cargo check`
