### PR TITLE
feat(tui): stabilize transcript rendering

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,6 +2,37 @@
 
 Active backlog only. Keep this file small and current.
 
+## Suggested Rollout Order
+
+From easier / lower-risk work toward harder / more structural work:
+
+1. Transcript and command-surface polish
+   - [ ] Add Claude-style repository context hints beneath the input area, especially the current GitHub PR link (when the workspace is on a PR branch or can be mapped to an open PR), so the active review context stays visible without manual lookup.
+   - [ ] Add Codex/Claude-style transcript role cards for `You` / `Agent` / `System`: use clearer card/background separation without mixing status chrome into committed transcript history.
+   - [ ] Bring the main response UI closer to Codex / Claude Code: tighten the `You` / `Agent` message-card hierarchy, keep active response blocks visually stable while streaming, and avoid falling back to generic transcript rows for states that should render as dedicated response cards.
+   - [ ] Rework the built-in command TUI (`/help`, `/model`, `/status`, command palette, setup overlays) to more closely match Codex / Claude Code: better information density, clearer keyboard affordances, stronger selection states, and less modal friction.
+
+2. Transcript stability and compactness
+   - [ ] Improve transcript rendering stability across long and streaming sessions: reduce scroll jumps and flicker, keep bottom anchoring stable while new content streams in, and prevent stale transient sections (`Exploring`, `Updated Plan`, busy chrome) from reappearing after their live phase has ended.
+   - [ ] Rework long `Exploring` / `Explored` handling to follow Codex more closely: keep live exploration compact, summarize committed exploration into a small source-aware digest (prefer actual `read`/inspection actions over noisy `list`/`glob`/search chatter), and avoid dumping long raw action traces into the main transcript.
+   - [ ] Decouple setup/help/model overlays from transcript layout so popups do not perturb history rendering: overlays should render as a pure top layer instead of changing transcript viewport sizing or causing history reflow/flicker when opened and closed.
+   - [ ] Expand the new Codex-style TUI snapshot coverage beyond the first auth-picker / queued-follow-up / Updated Plan snapshots so more popups, status surfaces, and transcript-heavy widgets are protected by golden tests.
+
+3. Rich Codex/Claude transcript parity
+   - [ ] Continue making tool-action transcript summaries more source-aware and file-aware so edit tools such as `write_file` / `replace` / `apply_patch` consistently show what they touched instead of only generic action labels.
+   - [ ] Continue refining the live `bash` transcript path so command execution behaves more like Codex: keep the streamed stdout/stderr surface, then add richer lifecycle details such as clearer command-start/finish framing and better long-output folding.
+   - [ ] Add a high-fidelity Claude Code / Codex transcript rendering pass: mirror the structured `write/update` tool presentation, inline diff display, approval cards, and message-card hierarchy as closely as practical instead of only loosely borrowing the style, and explicitly use Codex as the primary reference for `bash` / command lifecycle framing, stdout/stderr streaming, completion summaries, and output folding.
+
+4. Reasoning and model-surface alignment
+   - [ ] Add a Codex-style configurable `model_reasoning_summary` surface instead of a boolean thinking toggle: support model/provider-scoped configuration, show reasoning summaries only when the backend emits them, and keep the transcript/status behavior aligned with Codex (`none` / `auto` / richer summary modes) rather than exposing raw chain-of-thought.
+   - [ ] Continue refining queued follow-up steering toward the full Codex contract: keep the new next-tool-boundary queue, then add the explicit interrupt/send-now path and clearer separation between pending steers and ordinary queued follow-ups.
+
+5. Deeper runtime and architecture work
+   - [ ] Unify runtime assembly and startup boundaries across `src/main.rs` and `src/tui/runtime/tasks.rs`: introduce one shared runtime/builder entry point for backend/tool/session/workspace initialization, stop silently swallowing `SkillManager::load_all()` failures, move hard-coded persistence paths such as `data/lancedb` behind config/workspace path resolution, and keep the root crate split between thin entrypoints and explicit runtime-context assembly instead of letting `main.rs` keep parser/setup/dispatch responsibilities together.
+   - [ ] Implement the Stage 1 context-architecture boundary from `docs/features/context-architecture.md`: introduce explicit `ContextBudget` and `ContextAssembler` layers so stable instructions, workspace context, active turn context, memory selections, and compacted history stop being assembled implicitly across unrelated modules.
+   - [ ] Implement a local `ThreadStore` / `ThreadRecorder` boundary so thread metadata, rollout history, plan state, pending interactions, and future sub-agent lineage are persisted as structured items instead of reconstructed from flattened transcript text.
+   - [ ] Introduce a dedicated transcript viewport model that renders history from stable turn data plus scroll state instead of letting overlays and transient runtime sections implicitly drive layout; this should become the basis for future virtualization, stronger scroll anchoring, and less flicker under streaming updates.
+
 ## Security and Reliability
 
 - [ ] Replace the current string-based shell execution path in `src/tools/bash.rs` and `src/sandbox.rs` with a structured command model (`program`, `args`, `cwd`, `allow_net`) so `bash -c` / `sh -c` is no longer the default execution path.
@@ -28,10 +59,13 @@ Active backlog only. Keep this file small and current.
 - [ ] Design Graph RAG as a later retrieval layer on top of durable memory and extracted relationships instead of as a prompt hack: define graph nodes/edges, traversal outputs, and how graph results compose with vector retrieval.
 - [ ] Add a first-run onboarding flow that explains workspace, provider/model selection, local model download behavior, cache location, and tool loop expectations before the user lands in a blank chat.
 - [ ] Continue aligning the TUI status and transcript surfaces with Codex/Claude so runtime state stays visible without leaking bottom-pane chrome into transcript history.
+- [ ] Improve transcript rendering stability across long and streaming sessions: reduce scroll jumps and flicker, keep bottom anchoring stable while new content streams in, and prevent stale transient sections (`Exploring`, `Updated Plan`, busy chrome) from reappearing after their live phase has ended.
 - [ ] Add Claude-style repository context hints beneath the input area, especially the current GitHub PR link (when the workspace is on a PR branch or can be mapped to an open PR), so the active review context stays visible without manual lookup.
 - [ ] Rework the built-in command TUI (`/help`, `/model`, `/status`, command palette, setup overlays) to more closely match Codex / Claude Code: better information density, clearer keyboard affordances, stronger selection states, and less modal friction.
+- [ ] Add a Codex-style configurable `model_reasoning_summary` surface instead of a boolean thinking toggle: support model/provider-scoped configuration, show reasoning summaries only when the backend emits them, and keep the transcript/status behavior aligned with Codex (`none` / `auto` / richer summary modes) rather than exposing raw chain-of-thought.
 - [ ] Add Codex/Claude-style transcript role cards for `You` / `Agent` / `System`: use clearer card/background separation without mixing status chrome into committed transcript history.
 - [ ] Add a high-fidelity Claude Code / Codex transcript rendering pass: mirror the structured `write/update` tool presentation, inline diff display, approval cards, and message-card hierarchy as closely as practical instead of only loosely borrowing the style, and explicitly use Codex as the primary reference for `bash` / command lifecycle framing, stdout/stderr streaming, completion summaries, and output folding.
+- [ ] Rework long `Exploring` / `Explored` handling to follow Codex more closely: keep live exploration compact, summarize committed exploration into a small source-aware digest (prefer actual `read`/inspection actions over noisy `list`/`glob`/search chatter), and avoid dumping long raw action traces into the main transcript.
 - [ ] Expand the new Codex-style TUI snapshot coverage beyond the first auth-picker / queued-follow-up / Updated Plan snapshots so more popups, status surfaces, and transcript-heavy widgets are protected by golden tests.
 - [ ] Continue making tool-action transcript summaries more source-aware and file-aware so edit tools such as `write_file` / `replace` / `apply_patch` consistently show what they touched instead of only generic action labels.
 - [ ] Continue refining the live `bash` transcript path so command execution behaves more like Codex: keep the streamed stdout/stderr surface, then add richer lifecycle details such as clearer command-start/finish framing and better long-output folding.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -79,8 +79,10 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
     if let Some(agent_ref) = agent_slot.as_ref() {
         app.sync_snapshot(agent_ref);
     }
+    app.start_repo_context_detection();
 
     let result = loop {
+        app.finish_repo_context_task_if_ready().await;
         finish_running_task_if_ready(&mut app, &mut agent_slot).await?;
         clamp_command_palette_selection(&mut app);
         let size = terminal_size()?;
@@ -134,6 +136,9 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
         }
     };
 
+    if let Some(handle) = app.repo_context_task.take() {
+        handle.abort();
+    }
     teardown_terminal(terminal)?;
     result
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -2,6 +2,7 @@ mod bottom_pane;
 pub(crate) mod cells;
 mod history_pipeline;
 mod overlay;
+mod viewport;
 #[cfg(test)]
 mod tests;
 
@@ -19,6 +20,7 @@ use self::bottom_pane::render_bottom_pane;
 pub(crate) use self::cells::{ActiveCell, HistoryCell};
 use self::cells::{ActiveTurnCell, CommittedTurnCell, StartupCardCell};
 use self::overlay::render_overlay;
+use self::viewport::TranscriptViewport;
 use super::custom_terminal::Frame;
 use super::line_utils::prefix_lines;
 use super::state::{TranscriptEntry, TuiApp};
@@ -42,9 +44,8 @@ pub fn render(f: &mut Frame, app: &TuiApp) {
 }
 
 fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
-    let transcript_lines = renderable_transcript_lines(app, area.width);
-    let transcript_visual_row_count = transcript_visual_row_count(&transcript_lines, area.width);
-    if !app.has_any_transcript() && transcript_lines.is_empty() {
+    let viewport = transcript_viewport(app, area.width, area.height);
+    if !app.has_any_transcript() && viewport.lines.is_empty() {
         if app.startup_card_inserted {
             f.render_widget(Paragraph::new(Vec::<Line<'static>>::new()), area);
             return;
@@ -82,15 +83,18 @@ fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
         return;
     }
 
-    f.render_widget(
-        Paragraph::new(transcript_lines)
-            .wrap(Wrap { trim: false })
-            .scroll((
-                transcript_scroll_offset(app, area.height, transcript_visual_row_count),
-                0,
-            )),
-        area,
-    );
+    viewport.render(f, area);
+}
+
+pub(crate) fn transcript_viewport(
+    app: &TuiApp,
+    width: u16,
+    viewport_height: u16,
+) -> TranscriptViewport {
+    let lines = renderable_transcript_lines(app, width);
+    let visual_row_count = transcript_visual_row_count(&lines, width);
+    let scroll_offset = transcript_scroll_offset(app, viewport_height, visual_row_count);
+    TranscriptViewport::new(lines, scroll_offset)
 }
 
 fn renderable_transcript_lines(app: &TuiApp, width: u16) -> Vec<Line<'static>> {
@@ -210,19 +214,15 @@ pub(crate) fn current_turn_exploration_summary_from_entries(
             continue;
         }
         if let Some(action) = exploration_action_label(&entry.message) {
-            actions.push(action);
+            if !actions.iter().any(|existing| existing == &action) {
+                actions.push(action);
+            }
         }
     }
     if actions.is_empty() {
         return None;
     }
-
-    let lines = actions
-        .into_iter()
-        .map(|action| format!("└ {action}"))
-        .collect::<Vec<_>>();
-
-    Some(lines.join("\n"))
+    Some(compact_summary_lines(actions.as_slice(), 4, "more file(s) inspected"))
 }
 
 pub(crate) fn current_turn_tool_summary(
@@ -251,11 +251,64 @@ pub(crate) fn current_turn_tool_summary(
     Some(lines.join("\n"))
 }
 
+pub(crate) fn compact_summary_lines(
+    items: &[String],
+    max_visible: usize,
+    more_label: &str,
+) -> String {
+    if items.is_empty() {
+        return String::new();
+    }
+
+    let visible_count = items.len().min(max_visible);
+    let hidden_count = items.len().saturating_sub(visible_count);
+    let start = items.len().saturating_sub(visible_count);
+    let mut lines = items[start..]
+        .iter()
+        .map(|item| format!("└ {item}"))
+        .collect::<Vec<_>>();
+
+    if hidden_count > 0 {
+        lines.insert(0, format!("└ ... {hidden_count} {more_label}"));
+    }
+
+    lines.join("\n")
+}
+
+pub(crate) fn compact_summary_text(
+    summary: &str,
+    max_visible: usize,
+    more_label: &str,
+) -> String {
+    let items = summary
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            line.trim_start_matches("└")
+                .trim_start_matches("•")
+                .trim()
+                .to_string()
+        })
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+
+    if items.is_empty() {
+        return summary.trim().to_string();
+    }
+
+    compact_summary_lines(items.as_slice(), max_visible, more_label)
+}
+
 pub(crate) fn prefixed_message_lines(
     role: &str,
     message: &str,
     max_lines: usize,
 ) -> Vec<Line<'static>> {
+    if role == "You" {
+        return user_message_lines(message, max_lines);
+    }
+
     let message_lines = message.lines().collect::<Vec<_>>();
     if message_lines.is_empty() {
         return vec![Line::from(format!("{role}:"))];
@@ -283,16 +336,80 @@ pub(crate) fn prefixed_message_lines(
     lines
 }
 
+fn user_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let message_lines = message.lines().collect::<Vec<_>>();
+    if message_lines.is_empty() {
+        return vec![Line::from("›")];
+    }
+
+    let capped = if max_lines == usize::MAX {
+        message_lines.len()
+    } else {
+        max_lines
+    };
+
+    let mut lines = Vec::new();
+    if let Some(first) = message_lines.first() {
+        lines.push(Line::from(format!("› {first}")));
+    }
+    for line in message_lines.iter().skip(1).take(capped.saturating_sub(1)) {
+        lines.push(Line::from(format!("  {line}")));
+    }
+    if message_lines.len() > capped {
+        lines.push(Line::from(Span::styled(
+            format!("  ... {} more line(s)", message_lines.len() - capped),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    lines
+}
+
 pub(crate) fn formatted_message_lines(
     role: &str,
     message: &str,
     max_lines: usize,
     cwd: Option<&Path>,
 ) -> Vec<Line<'static>> {
-    if matches!(role, "Agent" | "System") {
+    if role == "Agent" {
+        return bulleted_markdown_message_lines(message, max_lines, cwd);
+    }
+    if role == "System" {
         return markdown_message_lines(role, message, max_lines, cwd);
     }
     prefixed_message_lines(role, message, max_lines)
+}
+
+fn bulleted_markdown_message_lines(
+    message: &str,
+    max_lines: usize,
+    cwd: Option<&Path>,
+) -> Vec<Line<'static>> {
+    let mut rendered = Vec::new();
+    super::markdown::append_markdown(message, None, cwd, &mut rendered);
+    let rendered_len = rendered.len();
+
+    if rendered.is_empty() {
+        return vec![Line::from("•")];
+    }
+
+    let capped = if max_lines == usize::MAX {
+        rendered.len()
+    } else {
+        max_lines.min(rendered.len())
+    };
+
+    let mut lines = prefix_lines(
+        rendered.into_iter().take(capped).collect(),
+        Span::styled("• ", Style::default().add_modifier(Modifier::DIM)),
+        Span::raw("  "),
+    );
+    if capped < rendered_len {
+        lines.push(Line::from(Span::styled(
+            format!("  ... {} more line(s)", rendered_len - capped),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    lines
 }
 
 fn markdown_message_lines(

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -240,9 +240,9 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
             .wrap(Wrap { trim: false }),
         chunks[0],
     );
-    let hint = composer_hint(app);
+    let hint = composer_hint_line(app);
     f.render_widget(
-        Paragraph::new(Span::styled(hint, Style::default().fg(Color::Gray)))
+        Paragraph::new(hint)
             .alignment(Alignment::Left),
         chunks[1],
     );
@@ -320,6 +320,15 @@ fn composer_hint(app: &TuiApp) -> &'static str {
     } else {
         "/compact summarize history  /plan enter planning mode  /quit exit"
     }
+}
+
+fn composer_hint_line(app: &TuiApp) -> Line<'static> {
+    let mut spans = vec![Span::styled(composer_hint(app), Style::default().fg(Color::Gray))];
+    if let Some(repo_context) = app.repo_context_hint() {
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(repo_context, Style::default().fg(Color::DarkGray)));
+    }
+    Line::from(spans)
 }
 
 fn render_footer(f: &mut Frame, app: &TuiApp, area: Rect) {
@@ -435,7 +444,8 @@ mod tests {
     };
 
     use super::{
-        activity_status_line, composer_hint, footer_summary_text, queued_follow_up_preview_lines,
+        activity_status_line, composer_hint, composer_hint_line, footer_summary_text,
+        queued_follow_up_preview_lines,
     };
 
     #[test]
@@ -563,5 +573,22 @@ mod tests {
             composer_hint(&app),
             "pending follow-up  will submit after next tool call"
         );
+    }
+
+    #[test]
+    fn composer_hint_line_includes_repo_context_when_available() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.repo_slug = Some("hawkingrei/rara".into());
+        app.current_pr_url = Some("https://github.com/hawkingrei/rara/pull/46".into());
+        app.snapshot.branch = "feat/test".into();
+
+        let rendered = composer_hint_line(&app).to_string();
+        assert!(rendered.contains("repo: hawkingrei/rara"));
+        assert!(rendered.contains("branch: feat/test"));
+        assert!(rendered.contains("PR: https://github.com/hawkingrei/rara/pull/46"));
     }
 }

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -467,7 +467,17 @@ impl ActiveCell for ActiveTurnCell<'_> {
             && matches!(
                 self.app.runtime_phase,
                 RuntimePhase::SendingPrompt | RuntimePhase::ProcessingResponse
-            );
+            )
+            && !has_exploration_summary
+            && !has_planning_summary
+            && !has_running_summary
+            && self.app.snapshot.plan_steps.is_empty()
+            && !suppress_planning_chatter
+            && !suppress_structured_plan_response
+            && self.app.pending_request_input().is_none()
+            && !self.app.has_pending_plan_approval()
+            && self.app.pending_command_approval().is_none()
+            && self.app.pending_planning_suggestion.is_none();
 
         if has_agent_stream
             && !suppress_intermediate_agent

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -20,7 +20,8 @@ use self::components::{
     RunningCell, UserCell, planning_suggestion_text,
 };
 use super::{
-    current_turn_exploration_summary, current_turn_exploration_summary_from_entries,
+    compact_summary_lines, compact_summary_text, current_turn_exploration_summary,
+    current_turn_exploration_summary_from_entries,
     current_turn_tool_summary,
     history_pipeline::{narrative_entries, ordered_completion_entries},
     wrapped_history_line_count,
@@ -135,9 +136,12 @@ impl HistoryCell for CommittedTurnCell<'_> {
         let has_tool_activity = entry_refs
             .iter()
             .any(|entry| matches!(entry.role.as_str(), "Tool" | "Tool Result" | "Tool Error" | "Tool Progress"));
-        if let Some(summary) = explicit_exploration.or_else(|| {
-            current_turn_exploration_summary_from_entries(entry_refs.as_slice(), false, None)
-        }) {
+        if let Some(summary) = explicit_exploration
+            .map(|summary| compact_summary_text(&summary, 4, "more exploration step(s)"))
+            .or_else(|| {
+                current_turn_exploration_summary_from_entries(entry_refs.as_slice(), false, None)
+            })
+        {
             cells.push(Box::new(ExploredCell::new(summary)));
         }
 
@@ -304,27 +308,33 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .map(|entry| entry.message.clone());
 
         let exploration_summary = if has_live_exploration {
-            let mut lines = self
+            let mut items = self
                 .app
                 .active_live
                 .exploration_actions
                 .iter()
-                .map(|action| format!("└ {action}"))
+                .cloned()
                 .collect::<Vec<_>>();
-            lines.extend(
+            items.extend(
                 self.app
                     .active_live
-                .exploration_notes
-                .iter()
-                .map(|note| format!("└ {note}")),
+                    .exploration_notes
+                    .iter()
+                    .cloned(),
             );
-            Some(lines.join("\n"))
+            Some(compact_summary_lines(
+                items.as_slice(),
+                4,
+                "more exploration step(s)",
+            ))
         } else if !turn_live {
             None
         } else {
-            explicit_exploration.or_else(|| {
-                current_turn_exploration_summary(self.app, current_turn.as_slice(), turn_live)
-            })
+            explicit_exploration
+                .map(|summary| compact_summary_text(&summary, 4, "more exploration step(s)"))
+                .or_else(|| {
+                    current_turn_exploration_summary(self.app, current_turn.as_slice(), turn_live)
+                })
         };
         let has_exploration_summary = exploration_summary.is_some();
         let exploration_active = turn_live && has_exploration_summary;
@@ -338,23 +348,28 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .map(|entry| entry.message.clone());
 
         let planning_summary = if has_live_planning {
-            let mut lines = self
+            let mut items = self
                 .app
                 .active_live
                 .planning_actions
                 .iter()
-                .map(|action| format!("└ {action}"))
+                .cloned()
                 .collect::<Vec<_>>();
-            lines.extend(
+            items.extend(
                 self.app
                     .active_live
-                .planning_notes
-                .iter()
-                .map(|note| format!("└ {note}")),
+                    .planning_notes
+                    .iter()
+                    .cloned(),
             );
-            Some(lines.join("\n"))
+            Some(compact_summary_lines(
+                items.as_slice(),
+                4,
+                "more planning step(s)",
+            ))
         } else {
             explicit_planning
+                .map(|summary| compact_summary_text(&summary, 4, "more planning step(s)"))
         };
         let has_planning_summary = planning_summary.is_some();
         if let Some(summary) = planning_summary {
@@ -367,16 +382,22 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .map(|entry| entry.message.clone());
 
         let running_summary = if has_live_running {
-            let lines = self
+            let items = self
                 .app
                 .active_live
                 .running_actions
                 .iter()
-                .map(|action| format!("└ {action}"))
+                .cloned()
                 .collect::<Vec<_>>();
-            Some(lines.join("\n"))
+            Some(compact_summary_lines(
+                items.as_slice(),
+                4,
+                "more running step(s)",
+            ))
         } else {
-            explicit_running.or_else(|| {
+            explicit_running
+                .map(|summary| compact_summary_text(&summary, 4, "more running step(s)"))
+                .or_else(|| {
                 current_turn_tool_summary(
                     current_turn.as_slice(),
                     turn_live,
@@ -442,6 +463,11 @@ impl ActiveCell for ActiveTurnCell<'_> {
             && latest_agent.is_some_and(contains_structured_planning_output);
 
         let responding_role = if turn_live { "Responding" } else { "Agent" };
+        let prefer_responding_chrome = turn_live
+            && matches!(
+                self.app.runtime_phase,
+                RuntimePhase::SendingPrompt | RuntimePhase::ProcessingResponse
+            );
 
         if has_agent_stream
             && !suppress_intermediate_agent
@@ -475,6 +501,13 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 agent_message,
                 usize::MAX,
                 self.cwd,
+            )));
+        } else if prefer_responding_chrome {
+            cells.push(Box::new(RespondingCell::working(
+                self.app
+                    .runtime_phase_detail
+                    .as_deref()
+                    .unwrap_or("waiting for model output"),
             )));
         } else if let Some(system_message) = latest_system {
             cells.push(Box::new(RespondingCell::from_message(

--- a/src/tui/render/cells_components.rs
+++ b/src/tui/render/cells_components.rs
@@ -397,10 +397,9 @@ impl HistoryCell for RespondingCell<'_> {
                 message,
                 max_lines,
             } => prefixed_message_lines(role, message, *max_lines),
-            RespondingCellContent::Working(detail) => vec![
-                Line::from(section_span("Working", Color::Yellow)),
-                Line::from(format!("  {detail}")),
-            ],
+            RespondingCellContent::Working(detail) => {
+                vec![Line::from("Responding"), Line::from(format!("  {detail}"))]
+            }
         }
     }
 }

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -47,7 +47,7 @@ fn active_turn_cell_keeps_sections_in_stable_order() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let you_idx = rendered.find("You: Inspect the codebase").unwrap();
+    let you_idx = rendered.find("› Inspect the codebase").unwrap();
     let running_idx = rendered.find(" Running ").unwrap();
     let plan_idx = rendered.find("Updated Plan").unwrap();
     let approval_idx = rendered.find(" Request Input ").unwrap();
@@ -74,7 +74,7 @@ fn active_turn_cell_renders_planning_suggestion_without_active_turn_entries() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("You: Review this repository and propose changes."));
+    assert!(rendered.contains("› Review this repository and propose changes."));
     assert!(rendered.contains(" Planning Suggested "));
     assert!(rendered.contains("Enter planning mode"));
     assert!(rendered.contains("Continue in execute mode"));
@@ -158,6 +158,109 @@ fn active_turn_cell_uses_stateful_live_exploration_sections() {
     assert!(rendered.contains("Read src/tools/vector.rs"));
     assert!(rendered.contains("I have inspected the repository structure."));
     assert!(!rendered.contains("waiting for model response · 20s elapsed"));
+}
+
+#[test]
+fn active_turn_cell_compacts_long_live_exploration_sections() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Inspect the repository".into(),
+        }],
+    };
+    for idx in 1..=5 {
+        app.record_exploration_action(format!("Read src/module_{idx}.rs"));
+    }
+    app.record_exploration_note("Cross-check the auth entrypoint.");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains(" Exploring "));
+    assert!(rendered.contains("... 2 more exploration step(s)"));
+    assert!(!rendered.contains("module_1.rs"));
+    assert!(!rendered.contains("module_2.rs"));
+    assert!(rendered.contains("module_3.rs"));
+    assert!(rendered.contains("module_5.rs"));
+    assert!(rendered.contains("Cross-check the auth entrypoint."));
+}
+
+#[test]
+fn active_turn_cell_compacts_long_live_planning_sections() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::ProcessingResponse;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Refine the plan".into(),
+        }],
+    };
+    for idx in 1..=5 {
+        app.record_planning_action(format!("Inspect planning module {idx}"));
+    }
+    app.record_planning_note("Reuse the shared auth bridge.");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains(" Planning "));
+    assert!(rendered.contains("... 2 more planning step(s)"));
+    assert!(!rendered.contains("planning module 1"));
+    assert!(!rendered.contains("planning module 2"));
+    assert!(rendered.contains("planning module 3"));
+    assert!(rendered.contains("planning module 5"));
+    assert!(rendered.contains("Reuse the shared auth bridge."));
+}
+
+#[test]
+fn active_turn_cell_compacts_long_live_running_sections() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Run the checks".into(),
+        }],
+    };
+    for idx in 1..=6 {
+        app.record_running_action(format!("Run task {idx}"));
+    }
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains(" Running "));
+    assert!(rendered.contains("... 2 more running step(s)"));
+    assert!(!rendered.contains("Run task 1"));
+    assert!(!rendered.contains("Run task 2"));
+    assert!(rendered.contains("Run task 3"));
+    assert!(rendered.contains("Run task 6"));
 }
 
 #[test]
@@ -390,7 +493,74 @@ fn active_turn_cell_uses_responding_label_while_busy() {
         .join("\n");
 
     assert!(rendered.contains("Responding"));
-    assert!(!rendered.contains("Agent\n  I have inspected"));
+    assert!(!rendered.contains("• I have inspected"));
+}
+
+#[test]
+fn active_turn_cell_prefers_responding_over_tool_result_while_processing_response() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::ProcessingResponse;
+    app.runtime_phase_detail = Some("waiting for model output".into());
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Review the repository".into(),
+            },
+            TranscriptEntry {
+                role: "Tool Result".into(),
+                message: "bash stdout: partial output".into(),
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains(" Responding ") || rendered.contains("Responding"));
+    assert!(!rendered.contains("Tool Result"));
+    assert!(!rendered.contains("bash stdout: partial output"));
+}
+
+#[test]
+fn active_turn_cell_prefers_responding_over_system_notice_while_sending_prompt() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::SendingPrompt;
+    app.runtime_phase_detail = Some("sending prompt to provider".into());
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Review the repository".into(),
+            },
+            TranscriptEntry {
+                role: "System".into(),
+                message: "temporary setup notice".into(),
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains(" Responding ") || rendered.contains("Responding"));
+    assert!(!rendered.contains("temporary setup notice"));
 }
 
 #[test]

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -106,7 +106,7 @@ fn active_turn_cell_hides_stale_updated_plan_after_plan_turn_finishes() {
         .join("\n");
 
     assert!(!rendered.contains("Updated Plan"));
-    assert!(rendered.contains("You: Implement the approved fix"));
+    assert!(rendered.contains("› Implement the approved fix"));
 }
 
 #[test]
@@ -138,7 +138,7 @@ fn active_turn_cell_hides_stale_exploring_after_live_phase_finishes() {
         .join("\n");
 
     assert!(!rendered.contains(" Exploring "));
-    assert!(rendered.contains("You: Inspect the repository"));
+    assert!(rendered.contains("› Inspect the repository"));
 }
 
 #[test]

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -28,9 +28,9 @@ fn committed_turn_cell_keeps_user_summary_and_agent_sections_in_order() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let you_idx = rendered.find("You: Review this repo").unwrap();
+    let you_idx = rendered.find("› Review this repo").unwrap();
     let ran_idx = rendered.find(" Ran ").unwrap();
-    let agent_idx = rendered.find("Agent\n  Final recommendation").unwrap();
+    let agent_idx = rendered.find("• Final recommendation").unwrap();
 
     assert!(!rendered.contains(" Explored "));
     assert!(ran_idx < agent_idx);
@@ -61,7 +61,7 @@ fn committed_turn_cell_ignores_routine_system_notices() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("Agent\n  Final recommendation"));
+    assert!(rendered.contains("• Final recommendation"));
     assert!(!rendered.contains("System"));
     assert!(!rendered.contains("prompt finished"));
 }
@@ -98,11 +98,11 @@ fn committed_turn_cell_renders_materialized_sidecar_sections() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let you_idx = rendered.find("You: Review the workspace logic").unwrap();
+    let you_idx = rendered.find("› Review the workspace logic").unwrap();
     let explored_idx = rendered.find(" Explored ").unwrap();
     let planning_idx = rendered.find(" Planned ").unwrap();
     let agent_idx = rendered
-        .find("Agent\n  Here is the final recommendation.")
+        .find("• Here is the final recommendation.")
         .unwrap();
 
     assert!(you_idx < explored_idx);
@@ -146,7 +146,7 @@ fn committed_turn_cell_places_completion_records_before_final_agent_message() {
     let explored_idx = rendered.find(" Explored ").unwrap();
     let approval_idx = rendered.find(" Shell Approval Completed ").unwrap();
     let agent_idx = rendered
-        .find("Agent\n  I approved the one-off shell step")
+        .find("• I approved the one-off shell step")
         .unwrap();
 
     assert!(explored_idx < approval_idx);
@@ -194,7 +194,7 @@ fn committed_turn_cell_orders_completion_records_by_interaction_kind() {
     let planning_question_idx = rendered.find(" Planning Question Answered ").unwrap();
     let generic_question_idx = rendered.find(" Question Answered ").unwrap();
     let agent_idx = rendered
-        .find("Agent\n  Here is the final narrative summary.")
+        .find("• Here is the final narrative summary.")
         .unwrap();
 
     assert!(shell_idx < plan_idx);

--- a/src/tui/render/cells_tests/snapshots/rara__tui__render__cells__tests__active_general__active_turn_cell_updated_plan.snap
+++ b/src/tui/render/cells_tests/snapshots/rara__tui__render__cells__tests__active_general__active_turn_cell_updated_plan.snap
@@ -2,7 +2,7 @@
 source: src/tui/render/cells_tests/active_general.rs
 expression: rendered
 ---
-You: Read the local codebase and propose the next refactor
+› Read the local codebase and propose the next refactor
 
  Plan Mode 
 

--- a/src/tui/render/cells_tests/snapshots/rara__tui__render__cells__tests__active_plan__active_turn_cell_plan_approval.snap
+++ b/src/tui/render/cells_tests/snapshots/rara__tui__render__cells__tests__active_plan__active_turn_cell_plan_approval.snap
@@ -2,7 +2,7 @@
 source: src/tui/render/cells_tests/active_plan.rs
 expression: rendered
 ---
-You: Review the codebase and propose changes
+› Review the codebase and propose changes
 
 • Updated Plan
   └ The current discovery path is hardcoded and should be generalized.

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -310,7 +310,7 @@ fn transcript_viewport_visible_window_keeps_partial_wrapped_line_offset() {
         .collect::<Vec<_>>();
 
     assert_eq!(inner_scroll, 1);
-    assert_eq!(rendered.len(), 2);
+    assert_eq!(rendered.len(), 1);
     assert!(rendered[0].contains("long first line"));
 }
 

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -4,14 +4,16 @@ use ratatui::text::Line;
 use tempfile::tempdir;
 
 use crate::config::ConfigManager;
-use crate::tui::state::{TranscriptEntry, TranscriptTurn, TuiApp};
+use crate::tui::state::{Overlay, TranscriptEntry, TranscriptTurn, TuiApp};
 
 use super::cells::HistoryCell;
 use super::{
-    committed_turn_cell, current_turn_exploration_summary_from_entries, current_turn_tool_summary,
-    desired_viewport_height, renderable_transcript_lines, transcript_scroll_offset,
+    committed_turn_cell, compact_summary_text, current_turn_exploration_summary_from_entries,
+    current_turn_tool_summary, desired_viewport_height, renderable_transcript_lines,
+    transcript_scroll_offset, transcript_viewport,
     transcript_visual_row_count,
 };
+use super::viewport::TranscriptViewport;
 
 #[test]
 fn committed_turn_does_not_truncate_agent_response() {
@@ -101,9 +103,9 @@ fn renderable_transcript_lines_include_committed_and_active_turns() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("You: Earlier prompt"));
+    assert!(rendered.contains("› Earlier prompt"));
     assert!(rendered.contains("Committed answer"));
-    assert!(rendered.contains("You: Current prompt"));
+    assert!(rendered.contains("› Current prompt"));
 }
 
 #[test]
@@ -217,6 +219,124 @@ fn renderable_transcript_lines_cache_is_invalidated_when_committed_turns_change(
 }
 
 #[test]
+fn transcript_viewport_is_independent_from_overlay_state() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.committed_turns.push(TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Earlier prompt".into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "Committed answer".into(),
+            },
+        ],
+    });
+    app.active_turn.entries.push(TranscriptEntry {
+        role: "You".into(),
+        message: "Current prompt".into(),
+    });
+
+    let base = transcript_viewport(&app, 80, 18);
+    app.overlay = Some(Overlay::Setup);
+    let with_overlay = transcript_viewport(&app, 80, 18);
+
+    let base_rendered = base
+        .lines
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+    let overlay_rendered = with_overlay
+        .lines
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(base_rendered, overlay_rendered);
+    assert_eq!(base.scroll_offset, with_overlay.scroll_offset);
+}
+
+#[test]
+fn transcript_viewport_keeps_manual_scroll_when_overlay_opens() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.committed_turns.push(TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Earlier prompt".into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: (1..=8)
+                    .map(|idx| format!("Line {idx}"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            },
+        ],
+    });
+    app.scroll_transcript(-3);
+
+    let base = transcript_viewport(&app, 60, 8);
+    app.overlay = Some(Overlay::Setup);
+    let with_overlay = transcript_viewport(&app, 60, 8);
+
+    assert_eq!(base.scroll_offset, with_overlay.scroll_offset);
+    assert_eq!(app.transcript_scroll, 3);
+}
+
+#[test]
+fn transcript_viewport_visible_window_keeps_partial_wrapped_line_offset() {
+    let viewport = TranscriptViewport::new(
+        vec![
+            Line::from("• This is a long first line that wraps across rows."),
+            Line::from("  Second line stays visible."),
+        ],
+        1,
+    );
+
+    let (lines, inner_scroll) = viewport.visible_window(12, 3);
+    let rendered = lines
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(inner_scroll, 1);
+    assert_eq!(rendered.len(), 2);
+    assert!(rendered[0].contains("long first line"));
+}
+
+#[test]
+fn transcript_viewport_visible_window_slices_to_visible_rows() {
+    let viewport = TranscriptViewport::new(
+        vec![
+            Line::from("› First"),
+            Line::from("• Second"),
+            Line::from("  Third"),
+            Line::from("  Fourth"),
+        ],
+        1,
+    );
+
+    let (lines, inner_scroll) = viewport.visible_window(80, 2);
+    let rendered = lines
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(inner_scroll, 0);
+    assert_eq!(rendered, vec!["• Second", "  Third"]);
+}
+
+#[test]
 fn exploration_summary_only_keeps_read_actions() {
     let entries = vec![
         TranscriptEntry {
@@ -250,4 +370,42 @@ fn exploration_summary_only_keeps_read_actions() {
     assert!(!rendered.contains("Glob src/**/*.rs"));
     assert!(!rendered.contains("Search planning mode src"));
     assert!(!rendered.contains("listing files"));
+}
+
+#[test]
+fn exploration_summary_compacts_long_read_lists() {
+    let entries = (1..=6)
+        .map(|idx| TranscriptEntry {
+            role: "Tool".into(),
+            message: format!("read_file src/module_{idx}.rs"),
+        })
+        .collect::<Vec<_>>();
+    let refs = entries.iter().collect::<Vec<_>>();
+
+    let rendered =
+        current_turn_exploration_summary_from_entries(refs.as_slice(), false, None)
+            .expect("exploration summary");
+    assert!(rendered.contains("... 2 more file(s) inspected"));
+    assert!(!rendered.contains("module_1.rs"));
+    assert!(!rendered.contains("module_2.rs"));
+    assert!(rendered.contains("module_3.rs"));
+    assert!(rendered.contains("module_6.rs"));
+}
+
+#[test]
+fn compact_summary_text_keeps_tail_of_long_explicit_blocks() {
+    let summary = [
+        "└ Read src/a.rs",
+        "└ Read src/b.rs",
+        "└ Read src/c.rs",
+        "└ Read src/d.rs",
+        "└ Read src/e.rs",
+    ]
+    .join("\n");
+
+    let rendered = compact_summary_text(&summary, 4, "more exploration step(s)");
+    assert!(rendered.contains("... 1 more exploration step(s)"));
+    assert!(!rendered.contains("src/a.rs"));
+    assert!(rendered.contains("src/b.rs"));
+    assert!(rendered.contains("src/e.rs"));
 }

--- a/src/tui/render/viewport.rs
+++ b/src/tui/render/viewport.rs
@@ -1,0 +1,76 @@
+use ratatui::{
+    layout::Rect,
+    text::Line,
+    widgets::{Paragraph, Wrap},
+};
+
+use crate::tui::custom_terminal::Frame;
+
+pub(crate) struct TranscriptViewport {
+    pub(crate) lines: Vec<Line<'static>>,
+    pub(crate) scroll_offset: u16,
+}
+
+impl TranscriptViewport {
+    pub(crate) fn new(lines: Vec<Line<'static>>, scroll_offset: u16) -> Self {
+        Self {
+            lines,
+            scroll_offset,
+        }
+    }
+
+    pub(crate) fn visible_window(&self, width: u16, height: u16) -> (Vec<Line<'static>>, u16) {
+        if self.lines.is_empty() || height == 0 {
+            return (Vec::new(), 0);
+        }
+
+        let wrap_width = usize::from(width.max(1));
+        let target_start = usize::from(self.scroll_offset);
+        let target_end = target_start.saturating_add(usize::from(height));
+
+        let mut row_cursor = 0usize;
+        let mut first_idx = None;
+        let mut first_inner_scroll = 0u16;
+        let mut last_exclusive_idx = self.lines.len();
+
+        for (idx, line) in self.lines.iter().enumerate() {
+            let line_rows = visual_rows_for_line(line, wrap_width);
+            let line_end = row_cursor.saturating_add(line_rows);
+
+            if first_idx.is_none() && line_end > target_start {
+                first_idx = Some(idx);
+                first_inner_scroll = target_start.saturating_sub(row_cursor) as u16;
+            }
+
+            if line_end >= target_end {
+                last_exclusive_idx = idx + 1;
+                break;
+            }
+
+            row_cursor = line_end;
+        }
+
+        let Some(first_idx) = first_idx else {
+            return (Vec::new(), 0);
+        };
+
+        (
+            self.lines[first_idx..last_exclusive_idx].to_vec(),
+            first_inner_scroll,
+        )
+    }
+
+    pub(crate) fn render(&self, f: &mut Frame, area: Rect) {
+        let (visible_lines, inner_scroll) = self.visible_window(area.width, area.height);
+        f.render_widget(
+            Paragraph::new(visible_lines)
+                .wrap(Wrap { trim: false })
+                .scroll((inner_scroll, 0)),
+            area,
+        );
+    }
+}
+
+fn visual_rows_for_line(line: &Line<'static>, wrap_width: usize) -> usize {
+    line.width().max(1).div_ceil(wrap_width)
+}

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -6,6 +6,7 @@ mod transcript;
 mod types;
 
 use std::cell::RefCell;
+use std::process::Command;
 
 pub use self::state_presets::{
     current_model_presets, selected_preset_idx_for_config, selected_provider_family_idx_for_config,
@@ -109,6 +110,8 @@ impl TuiApp {
 
     pub fn new(cm: ConfigManager) -> anyhow::Result<Self> {
         let cfg = cm.load()?;
+        let repo_slug = detect_repo_slug();
+        let current_pr_url = detect_current_pr_url();
         let overlay = if !cfg.has_api_key() && super::provider_requires_api_key(&cfg.provider) {
             if cfg.provider == "codex" {
                 Some(Overlay::AuthModePicker)
@@ -161,6 +164,8 @@ impl TuiApp {
             state_db: None,
             state_db_status: None,
             running_task: None,
+            repo_slug,
+            current_pr_url,
         })
     }
 
@@ -170,6 +175,39 @@ impl TuiApp {
 
     pub fn current_model_label(&self) -> &str {
         self.config.model.as_deref().unwrap_or("-")
+    }
+
+    pub fn repo_context_hint(&self) -> Option<String> {
+        let branch = self.snapshot.branch.trim();
+        let mut parts = Vec::new();
+
+        if let Some(repo_slug) = self
+            .repo_slug
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            parts.push(format!("repo: {repo_slug}"));
+        }
+
+        if !branch.is_empty() {
+            parts.push(format!("branch: {branch}"));
+        }
+
+        if let Some(pr_url) = self
+            .current_pr_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            parts.push(format!("PR: {pr_url}"));
+        }
+
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join("  "))
+        }
     }
 
     pub fn selected_preset_idx(&self) -> usize {
@@ -762,4 +800,40 @@ impl TuiApp {
         };
     }
 
+}
+
+fn command_stdout(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn detect_current_pr_url() -> Option<String> {
+    command_stdout("gh", &["pr", "view", "--json", "url", "-q", ".url"])
+}
+
+fn detect_repo_slug() -> Option<String> {
+    let remote = command_stdout("git", &["remote", "get-url", "origin"])?;
+    parse_repo_slug(remote.as_str())
+}
+
+pub(crate) fn parse_repo_slug(remote: &str) -> Option<String> {
+    let remote = remote.trim();
+    if remote.is_empty() {
+        return None;
+    }
+
+    let stripped = remote
+        .strip_prefix("git@github.com:")
+        .or_else(|| remote.strip_prefix("https://github.com/"))
+        .or_else(|| remote.strip_prefix("ssh://git@github.com/"))?;
+    Some(stripped.trim_end_matches(".git").to_string())
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -110,8 +110,6 @@ impl TuiApp {
 
     pub fn new(cm: ConfigManager) -> anyhow::Result<Self> {
         let cfg = cm.load()?;
-        let repo_slug = detect_repo_slug();
-        let current_pr_url = detect_current_pr_url();
         let overlay = if !cfg.has_api_key() && super::provider_requires_api_key(&cfg.provider) {
             if cfg.provider == "codex" {
                 Some(Overlay::AuthModePicker)
@@ -164,9 +162,37 @@ impl TuiApp {
             state_db: None,
             state_db_status: None,
             running_task: None,
-            repo_slug,
-            current_pr_url,
+            repo_context_task: None,
+            repo_slug: None,
+            current_pr_url: None,
         })
+    }
+
+    pub fn start_repo_context_detection(&mut self) {
+        if self.repo_context_task.is_some() {
+            return;
+        }
+
+        self.repo_context_task = Some(tokio::task::spawn_blocking(detect_repo_context));
+    }
+
+    pub async fn finish_repo_context_task_if_ready(&mut self) {
+        let should_finish = self
+            .repo_context_task
+            .as_ref()
+            .is_some_and(tokio::task::JoinHandle::is_finished);
+        if !should_finish {
+            return;
+        }
+
+        let handle = self
+            .repo_context_task
+            .take()
+            .expect("repo context task should exist");
+        if let Ok((repo_slug, current_pr_url)) = handle.await {
+            self.repo_slug = repo_slug;
+            self.current_pr_url = current_pr_url;
+        }
     }
 
     pub fn is_busy(&self) -> bool {
@@ -823,6 +849,10 @@ fn detect_current_pr_url() -> Option<String> {
 fn detect_repo_slug() -> Option<String> {
     let remote = command_stdout("git", &["remote", "get-url", "origin"])?;
     parse_repo_slug(remote.as_str())
+}
+
+fn detect_repo_context() -> (Option<String>, Option<String>) {
+    (detect_repo_slug(), detect_current_pr_url())
 }
 
 pub(crate) fn parse_repo_slug(remote: &str) -> Option<String> {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    input_requests_command_palette, state_db_status_error, ActivePendingInteractionKind,
-    InteractionKind, Overlay, PendingInteractionSnapshot, ProviderFamily, RuntimeSnapshot,
-    TranscriptEntry, TranscriptTurn, TuiApp,
+    input_requests_command_palette, parse_repo_slug, state_db_status_error,
+    ActivePendingInteractionKind, InteractionKind, Overlay, PendingInteractionSnapshot,
+    ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp,
 };
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
 use crate::config::{ConfigManager, RaraConfig};
@@ -76,6 +76,58 @@ fn prioritizes_active_pending_interaction_in_ui_order() {
         .expect("pending interaction");
     assert_eq!(active.kind, ActivePendingInteractionKind::PlanApproval);
     assert_eq!(active._snapshot.title, "Plan Ready");
+}
+
+#[test]
+fn parse_repo_slug_supports_common_github_remote_forms() {
+    assert_eq!(
+        parse_repo_slug("git@github.com:hawkingrei/rara.git").as_deref(),
+        Some("hawkingrei/rara")
+    );
+    assert_eq!(
+        parse_repo_slug("https://github.com/hawkingrei/rara.git").as_deref(),
+        Some("hawkingrei/rara")
+    );
+    assert_eq!(
+        parse_repo_slug("ssh://git@github.com/hawkingrei/rara.git").as_deref(),
+        Some("hawkingrei/rara")
+    );
+}
+
+#[test]
+fn push_entry_keeps_manual_transcript_scroll_position() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.transcript_scroll = 6;
+
+    app.push_entry("System", "background update");
+
+    assert_eq!(app.transcript_scroll, 6);
+}
+
+#[test]
+fn finalize_agent_stream_keeps_manual_transcript_scroll_position() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.transcript_scroll = 4;
+    app.active_turn.entries.push(TranscriptEntry {
+        role: "Agent".into(),
+        message: "draft".into(),
+    });
+
+    app.finalize_agent_stream(Some("final answer".into()));
+
+    assert_eq!(app.transcript_scroll, 4);
+    assert_eq!(
+        app.active_turn.entries.last().map(|entry| entry.message.as_str()),
+        Some("final answer")
+    );
 }
 
 #[test]

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -95,6 +95,19 @@ fn parse_repo_slug_supports_common_github_remote_forms() {
 }
 
 #[test]
+fn new_does_not_detect_repo_context_synchronously() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let app = TuiApp::new(cm).expect("app");
+
+    assert!(app.repo_context_task.is_none());
+    assert!(app.repo_slug.is_none());
+    assert!(app.current_pr_url.is_none());
+}
+
+#[test]
 fn push_entry_keeps_manual_transcript_scroll_position() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -6,6 +6,15 @@ use super::{PendingFollowUpMessage, RuntimePhase, TranscriptEntry, TranscriptTur
 use crate::redaction::redact_secrets;
 
 impl TuiApp {
+    fn reset_transcript_scroll_if_following_tail(&mut self) {
+        // Keep the transcript pinned to the tail only when the user has not
+        // manually scrolled upward. Once they scroll up, transcript mutations
+        // should avoid yanking the viewport back to the bottom.
+        if self.transcript_scroll == 0 {
+            self.transcript_scroll = 0;
+        }
+    }
+
     pub fn push_entry(&mut self, role: &'static str, message: impl Into<String>) {
         let message = match role {
             "System" | "Runtime" => redact_secrets(message.into()),
@@ -18,14 +27,14 @@ impl TuiApp {
             role: role.to_string(),
             message,
         });
-        self.transcript_scroll = 0;
+        self.reset_transcript_scroll_if_following_tail();
     }
 
     pub fn append_to_latest_entry(&mut self, role: &'static str, delta: &str) {
         if let Some(last) = self.active_turn.entries.last_mut() {
             if last.role == role {
                 last.message.push_str(delta);
-                self.transcript_scroll = 0;
+                self.reset_transcript_scroll_if_following_tail();
                 return;
             }
         }
@@ -42,7 +51,7 @@ impl TuiApp {
             .agent_markdown_stream
             .get_or_insert_with(|| super::AgentMarkdownStreamState::new(cwd));
         stream.push_delta(delta);
-        self.transcript_scroll = 0;
+        self.reset_transcript_scroll_if_following_tail();
     }
 
     pub fn agent_stream_lines(&self) -> Option<&[Line<'static>]> {
@@ -68,7 +77,7 @@ impl TuiApp {
         if let Some(last) = self.active_turn.entries.last_mut() {
             if last.role == "Agent" {
                 last.message = message;
-                self.transcript_scroll = 0;
+                self.reset_transcript_scroll_if_following_tail();
                 return;
             }
         }
@@ -81,7 +90,7 @@ impl TuiApp {
                 if last.role == "Agent" {
                     last.message = message;
                     self.invalidate_committed_render_cache();
-                    self.transcript_scroll = 0;
+                    self.reset_transcript_scroll_if_following_tail();
                     return;
                 }
             }
@@ -216,7 +225,7 @@ impl TuiApp {
         self.persist_turn(ordinal, &turn);
         self.committed_turns.push(turn);
         self.invalidate_committed_render_cache();
-        self.transcript_scroll = 0;
+        self.reset_transcript_scroll_if_following_tail();
         self.clear_active_live_sections();
     }
 

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -348,6 +348,7 @@ pub struct TuiApp {
     pub state_db: Option<Arc<StateDb>>,
     pub state_db_status: Option<String>,
     pub running_task: Option<RunningTask>,
+    pub repo_context_task: Option<JoinHandle<(Option<String>, Option<String>)>>,
     pub repo_slug: Option<String>,
     pub current_pr_url: Option<String>,
 }

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -348,4 +348,6 @@ pub struct TuiApp {
     pub state_db: Option<Arc<StateDb>>,
     pub state_db_status: Option<String>,
     pub running_task: Option<RunningTask>,
+    pub repo_slug: Option<String>,
+    pub current_pr_url: Option<String>,
 }


### PR DESCRIPTION
## Summary

- make transcript rendering more stable by introducing a dedicated viewport model
- compact long live `Exploring` / `Planning` / `Running` sections to reduce height churn
- align user/agent transcript presentation more closely with Codex-style prefixes
- add repo / branch / PR context hints below the composer, inspired by Claude Code
- record the next TUI parity follow-ups in `docs/todo.md`

## What Changed

- added `TranscriptViewport` and moved transcript rendering toward a viewport-driven path
- kept overlay state out of transcript viewport calculations
- preserved manual scroll position when transcript entries change
- updated live response rendering to prefer a stable `Responding` block during prompt send / model response phases
- changed transcript prefixes:
  - user messages now render as `› ...`
  - final agent messages now render as `• ...`
- compacted long live and explicit sidecar summaries using fixed-window tail summaries
- added Claude-style repo context hints for `repo`, `branch`, and optional `PR`

## Validation

- `cargo test tui::render::tests::renderable_transcript_lines_include_committed_and_active_turns -- --nocapture`
- `cargo test tui::render::cells::tests::committed -- --nocapture`
- `cargo test tui::render::cells::tests::active_general -- --nocapture`
- `cargo test tui::render::cells::tests::active_plan::active_turn_cell_renders_plan_approval_as_interaction_card -- --nocapture`
- `cargo test tui::render::tests::transcript_viewport -- --nocapture`
- `cargo test tui::render::cells::tests::active_general::active_turn_cell_compacts_long_live_ -- --nocapture`
- `cargo test tui::render::cells::tests::active_general::active_turn_cell_prefers_responding_ -- --nocapture`
- `cargo test tui::render::cells::tests::active_plan::active_turn_cell_keeps_responding_section_while_agent_stream_exists -- --nocapture`
- `cargo test tui::state::tests::push_entry_keeps_manual_transcript_scroll_position -- --nocapture`
- `cargo test tui::state::tests::finalize_agent_stream_keeps_manual_transcript_scroll_position -- --nocapture`
- `cargo test tui::state::tests::parse_repo_slug_supports_common_github_remote_forms -- --nocapture`
- `cargo test tui::render::bottom_pane::tests::composer_hint_line_includes_repo_context_when_available -- --nocapture`
- `cargo check`

## Notes

- untracked local artifacts such as `codex/` and `current-changes.*` were left out of this PR
