### PR TITLE
fix(tui): dedupe final agent replies

### DIFF
--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -336,4 +336,50 @@ fn finalize_agent_stream_updates_latest_committed_turn_when_final_text_arrives_l
             .map(|entry| entry.message.as_str()),
         Some("你好！有什么我可以帮你的？")
     );
+    assert_eq!(
+        app.committed_turns
+            .last()
+            .map(|turn| turn.entries.iter().filter(|entry| entry.role == "Agent").count()),
+        Some(1)
+    );
+}
+
+#[test]
+fn finalize_agent_stream_replaces_earlier_agent_entries_in_active_turn() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "你好".into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "你好".into(),
+            },
+            TranscriptEntry {
+                role: "System".into(),
+                message: "temporary runtime detail".into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "你好！".into(),
+            },
+        ],
+    };
+
+    app.finalize_agent_stream(Some("你好！有什么我可以帮你的？".into()));
+
+    let agent_entries = app
+        .active_turn
+        .entries
+        .iter()
+        .filter(|entry| entry.role == "Agent")
+        .collect::<Vec<_>>();
+    assert_eq!(agent_entries.len(), 1);
+    assert_eq!(agent_entries[0].message, "你好！有什么我可以帮你的？");
 }

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -6,6 +6,24 @@ use super::{PendingFollowUpMessage, RuntimePhase, TranscriptEntry, TranscriptTur
 use crate::redaction::redact_secrets;
 
 impl TuiApp {
+    fn replace_turn_agent_message(turn: &mut TranscriptTurn, message: String) -> bool {
+        let Some(last_agent_idx) = turn.entries.iter().rposition(|entry| entry.role == "Agent") else {
+            return false;
+        };
+
+        turn.entries[last_agent_idx].message = message;
+
+        let mut retained = Vec::with_capacity(turn.entries.len());
+        for (idx, entry) in turn.entries.drain(..).enumerate() {
+            if entry.role == "Agent" && idx != last_agent_idx {
+                continue;
+            }
+            retained.push(entry);
+        }
+        turn.entries = retained;
+        true
+    }
+
     fn reset_transcript_scroll_if_following_tail(&mut self) {
         // Keep the transcript pinned to the tail only when the user has not
         // manually scrolled upward. Once they scroll up, transcript mutations
@@ -74,21 +92,13 @@ impl TuiApp {
             return;
         };
 
-        if let Some(last) = self.active_turn.entries.last_mut() {
-            if last.role == "Agent" {
-                last.message = message;
-                self.reset_transcript_scroll_if_following_tail();
-                return;
-            }
+        if Self::replace_turn_agent_message(&mut self.active_turn, message.clone()) {
+            self.reset_transcript_scroll_if_following_tail();
+            return;
         }
         if self.active_turn.entries.is_empty() {
-            if let Some(last) = self
-                .committed_turns
-                .last_mut()
-                .and_then(|turn| turn.entries.last_mut())
-            {
-                if last.role == "Agent" {
-                    last.message = message;
+            if let Some(turn) = self.committed_turns.last_mut() {
+                if Self::replace_turn_agent_message(turn, message.clone()) {
                     self.invalidate_committed_render_cache();
                     self.reset_transcript_scroll_if_following_tail();
                     return;


### PR DESCRIPTION
## Summary

- dedupe multiple `Agent` narrative entries within the same turn when the final reply arrives
- canonicalize both active-turn and committed-turn late-finalization paths to keep only one final `Agent` reply
- add focused transcript tests for active-turn and late committed-turn replacement

## Testing

- cargo test tui::state::tests::finalize_agent_stream_ -- --nocapture
- cargo check
