### PR TITLE
feat(runtime): unify bootstrap and reasoning summary config

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -10,6 +10,9 @@ use std::path::{Path, PathBuf};
 pub const DEFAULT_CODEX_BASE_URL: &str = "https://api.openai.com/v1";
 pub const DEFAULT_CODEX_MODEL: &str = "gpt-5.4";
 pub const DEFAULT_CODEX_CHATGPT_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+pub const DEFAULT_REASONING_SUMMARY: &str = "auto";
+pub const REASONING_SUMMARY_NONE: &str = "none";
+pub const REASONING_SUMMARY_DETAILED: &str = "detailed";
 pub const LEGACY_CODEX_BASE_URL: &str = "http://localhost:8080";
 pub const LEGACY_CODEX_MODEL: &str = "codex";
 pub const LEGACY_CODEX_MODEL_V1: &str = "gpt-5-codex";
@@ -51,6 +54,7 @@ pub struct ProviderConfigState {
     pub base_url: Option<String>,
     pub model: Option<String>,
     pub reasoning_effort: Option<String>,
+    pub reasoning_summary: Option<String>,
     pub revision: Option<String>,
     pub thinking: Option<bool>,
     pub num_ctx: Option<u32>,
@@ -68,6 +72,7 @@ pub struct RaraConfig {
     pub base_url: Option<String>,
     pub model: Option<String>,
     pub reasoning_effort: Option<String>,
+    pub reasoning_summary: Option<String>,
     pub revision: Option<String>,
     pub thinking: Option<bool>,
     pub num_ctx: Option<u32>,
@@ -134,6 +139,11 @@ impl RaraConfig {
         self.sync_active_provider_state();
     }
 
+    pub fn set_reasoning_summary(&mut self, value: Option<String>) {
+        self.reasoning_summary = normalize_reasoning_summary(value);
+        self.sync_active_provider_state();
+    }
+
     pub fn set_revision(&mut self, value: Option<String>) {
         self.revision = normalize_optional_string(value);
         self.sync_active_provider_state();
@@ -162,6 +172,15 @@ impl RaraConfig {
         }
     }
 
+    pub fn migrate_legacy_provider_state(&mut self) {
+        self.reasoning_summary =
+            migrate_reasoning_summary(self.reasoning_summary.take(), self.thinking);
+        for state in self.provider_states.values_mut() {
+            state.reasoning_summary =
+                migrate_reasoning_summary(state.reasoning_summary.take(), state.thinking);
+        }
+    }
+
     fn sync_active_provider_state(&mut self) {
         if self.provider.trim().is_empty() {
             return;
@@ -176,6 +195,7 @@ impl RaraConfig {
             base_url: self.base_url.clone(),
             model: self.model.clone(),
             reasoning_effort: self.reasoning_effort.clone(),
+            reasoning_summary: self.reasoning_summary.clone(),
             revision: self.revision.clone(),
             thinking: self.thinking,
             num_ctx: self.num_ctx,
@@ -187,6 +207,7 @@ impl RaraConfig {
         self.base_url = state.base_url;
         self.model = state.model;
         self.reasoning_effort = state.reasoning_effort;
+        self.reasoning_summary = state.reasoning_summary;
         self.revision = state.revision;
         self.thinking = state.thinking;
         self.num_ctx = state.num_ctx;
@@ -197,6 +218,7 @@ impl RaraConfig {
         self.base_url = None;
         self.model = None;
         self.reasoning_effort = None;
+        self.reasoning_summary = Some(DEFAULT_REASONING_SUMMARY.to_string());
         self.revision = None;
         self.thinking = None;
         self.num_ctx = None;
@@ -273,6 +295,31 @@ fn normalize_optional_string(value: Option<String>) -> Option<String> {
     })
 }
 
+fn normalize_reasoning_summary(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let normalized = value.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "" => None,
+            DEFAULT_REASONING_SUMMARY | REASONING_SUMMARY_NONE | REASONING_SUMMARY_DETAILED => {
+                Some(normalized)
+            }
+            _ => Some(DEFAULT_REASONING_SUMMARY.to_string()),
+        }
+    })
+}
+
+fn migrate_reasoning_summary(
+    reasoning_summary: Option<String>,
+    legacy_thinking: Option<bool>,
+) -> Option<String> {
+    normalize_reasoning_summary(reasoning_summary).or_else(|| {
+        Some(match legacy_thinking {
+            Some(false) => REASONING_SUMMARY_NONE.to_string(),
+            Some(true) | None => DEFAULT_REASONING_SUMMARY.to_string(),
+        })
+    })
+}
+
 fn serialize_secret_option<S>(
     value: &Option<SecretString>,
     serializer: S,
@@ -314,8 +361,13 @@ impl ConfigManager {
 
     pub fn load(&self) -> Result<RaraConfig> {
         match fs::read_to_string(&self.path) {
-            Ok(content) => serde_json::from_str(&content)
-                .map_err(|err| anyhow::anyhow!("failed to parse {}: {err}", self.path.display())),
+            Ok(content) => {
+                let mut config: RaraConfig = serde_json::from_str(&content).map_err(|err| {
+                    anyhow::anyhow!("failed to parse {}: {err}", self.path.display())
+                })?;
+                config.migrate_legacy_provider_state();
+                Ok(config)
+            }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::default_config()),
             Err(err) => Err(err.into()),
         }
@@ -330,6 +382,7 @@ impl ConfigManager {
     fn default_config() -> RaraConfig {
         RaraConfig {
             provider: "mock".to_string(),
+            reasoning_summary: Some(DEFAULT_REASONING_SUMMARY.to_string()),
             thinking: Some(true),
             ..Default::default()
         }
@@ -373,6 +426,7 @@ mod tests {
         config.set_api_key("sk-codex");
         config.set_model(Some("codex".to_string()));
         config.set_reasoning_effort(Some("high".to_string()));
+        config.set_reasoning_summary(Some("detailed".to_string()));
         config.set_base_url(Some("http://localhost:8080".to_string()));
 
         config.set_provider("ollama");
@@ -389,14 +443,58 @@ mod tests {
         assert_eq!(config.api_key(), Some("sk-codex"));
         assert_eq!(config.model.as_deref(), Some("codex"));
         assert_eq!(config.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(config.reasoning_summary.as_deref(), Some("detailed"));
         assert_eq!(config.base_url.as_deref(), Some("http://localhost:8080"));
         assert_eq!(config.num_ctx, None);
 
         config.set_provider("ollama");
         assert_eq!(config.model.as_deref(), Some("qwen3"));
         assert_eq!(config.reasoning_effort, None);
+        assert_eq!(
+            config.reasoning_summary.as_deref(),
+            Some(super::DEFAULT_REASONING_SUMMARY)
+        );
         assert_eq!(config.base_url.as_deref(), Some("http://localhost:11434"));
         assert_eq!(config.num_ctx, Some(32768));
+    }
+
+    #[test]
+    fn load_migrates_legacy_thinking_to_reasoning_summary() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("config.json");
+        fs::write(
+            &path,
+            r#"{
+  "provider": "codex",
+  "thinking": false,
+  "provider_states": {
+    "codex": {
+      "thinking": true
+    }
+  }
+}"#,
+        )
+        .expect("write config");
+        let manager = ConfigManager { path };
+
+        let config = manager.load().expect("load config");
+
+        assert_eq!(config.reasoning_summary.as_deref(), Some(super::REASONING_SUMMARY_NONE));
+        assert_eq!(
+            config.provider_states["codex"].reasoning_summary.as_deref(),
+            Some(super::DEFAULT_REASONING_SUMMARY)
+        );
+    }
+
+    #[test]
+    fn invalid_reasoning_summary_normalizes_to_auto() {
+        let mut config = RaraConfig::default();
+        config.set_reasoning_summary(Some("verbose".to_string()));
+
+        assert_eq!(
+            config.reasoning_summary.as_deref(),
+            Some(super::DEFAULT_REASONING_SUMMARY)
+        );
     }
 
     #[test]

--- a/docs/features/openai-compatible-model-config.md
+++ b/docs/features/openai-compatible-model-config.md
@@ -48,7 +48,7 @@ Switching between providers must preserve and restore provider-local settings in
 - `base_url`
 - `model`
 - `revision`
-- `thinking`
+- `reasoning_summary`
 - `num_ctx`
 
 This allows the user to switch between Codex, Ollama, local models, and generic OpenAI-compatible endpoints without losing per-provider connection details.

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -12,6 +12,7 @@ to align with the prompt-management patterns used by mature coding agents.
 - Prompt source discovery from workspace and runtime state.
 - Prompt override and append behavior from config.
 - Dedicated prompt handling for context compaction.
+- Shared runtime bootstrap wiring for prompt runtime inputs.
 
 ## Non-Goals
 
@@ -77,6 +78,17 @@ The effective prompt is assembled in this order:
 - `Agent::build_system_prompt()` must delegate to the prompt runtime instead of hand-building the
   prompt inline.
 - Compaction must pass the dedicated compact instruction down to every backend summarization path.
+
+### 4) Runtime Bootstrap Contract
+
+- Runtime/bootstrap callers must initialize workspace, prompt runtime config, skills, and tools
+  through one shared entrypoint instead of wiring those pieces independently in `main.rs` and TUI
+  rebuild paths.
+- The shared bootstrap entrypoint is `initialize_rara_context(...)` in `src/runtime_context.rs`.
+- Bootstrap warnings from prompt/runtime configuration or skill loading must remain visible to the
+  caller instead of being silently dropped.
+- Workspace-scoped persistence paths used by bootstrap-owned tools should derive from the resolved
+  workspace data directory rather than hard-coded literals such as `data/lancedb`.
 
 ## Validation Matrix
 

--- a/docs/features/rara-home-layout.md
+++ b/docs/features/rara-home-layout.md
@@ -79,7 +79,8 @@ The global config should keep:
   - base URL
   - model
   - revision
-  - thinking
+  - reasoning summary mode
+  - provider-specific thinking/runtime toggles where applicable
   - context size
 
 Switching providers should restore the remembered provider-scoped state when it

--- a/docs/journal/2026-04-24-reasoning-summary-config.md
+++ b/docs/journal/2026-04-24-reasoning-summary-config.md
@@ -1,0 +1,41 @@
+# 2026-04-24 Reasoning Summary Config Migration
+
+## Summary
+
+RARA now has a provider-scoped `reasoning_summary` config field with a default
+of `auto`.
+
+This is the first step away from the older generic `thinking: bool` toggle for
+hosted-provider/runtime surfaces.
+
+## What Changed
+
+- Added `reasoning_summary` to provider-scoped config state in `rara-config`.
+- Default config now sets `reasoning_summary = "auto"`.
+- Legacy configs that only had `thinking: true/false` are migrated on load:
+  - `true` -> `auto`
+  - `false` -> `none`
+- `/status` now reports the effective `reasoning_summary` value explicitly.
+
+## Scope Boundary
+
+This checkpoint only establishes the configuration contract and migration.
+
+It does not yet:
+
+- expose a dedicated picker/editor for reasoning-summary modes;
+- wire reasoning-summary requests into each backend;
+- remove provider-specific `thinking` behavior used by Ollama runtime paths.
+
+## Validation
+
+- `cargo test -p rara-config -- --nocapture`
+- `cargo check`
+
+## Follow-Up
+
+- Surface `reasoning_summary` in provider/model switching flows.
+- Add a dedicated runtime/UI contract for reasoning summaries in transcript and
+  status surfaces.
+- Finish retiring the old generic `thinking` toggle from provider-agnostic
+  config surfaces.

--- a/docs/journal/2026-04-24-runtime-bootstrap.md
+++ b/docs/journal/2026-04-24-runtime-bootstrap.md
@@ -1,0 +1,33 @@
+# 2026-04-24 Runtime Bootstrap Consolidation
+
+## Summary
+
+RARA now routes runtime/bootstrap assembly through a shared `initialize_rara_context(...)`
+entrypoint in `src/runtime_context.rs` instead of duplicating backend/tool/workspace setup in
+`src/main.rs` and `src/tui/runtime/tasks/builder.rs`.
+
+## What Changed
+
+- Added a shared runtime bootstrap path in `src/runtime_context.rs`.
+- Moved backend selection, workspace/session/vector DB setup, prompt runtime config, skill loading,
+  and tool registration behind the shared entrypoint.
+- Updated `src/main.rs` to use helper command handlers and call `initialize_rara_context(...)`
+  for `ask`, `tui`, and ACP startup.
+- Updated the TUI rebuild path to reuse the same bootstrap entrypoint and surface bootstrap
+  warnings back into the UI.
+- Switched vector-memory bootstrap wiring from a hard-coded `data/lancedb` path to the workspace
+  data dir (`<workspace>/.rara/lancedb`).
+- Stopped silently swallowing `SkillManager::load_all()` failures during bootstrap; warnings are
+  now collected and surfaced to the caller.
+
+## Validation
+
+- `cargo check`
+- `cargo test runtime_context::tests -- --nocapture`
+
+## Follow-Up
+
+- Keep shrinking `src/main.rs` until it is mostly CLI/config dispatch and no longer owns auth-flow
+  branching inline.
+- Continue toward a richer runtime context contract that can also carry stable instructions,
+  compacted history, and context observability for `/context`.

--- a/docs/journal/2026-04-24-shared-runtime-context.md
+++ b/docs/journal/2026-04-24-shared-runtime-context.md
@@ -1,0 +1,36 @@
+# 2026-04-24 Shared Runtime Context Contract
+
+## Summary
+
+RARA now has a shared runtime-context view that the agent can expose to other
+surfaces instead of forcing TUI state to reconstruct prompt, plan, and
+compaction details field by field.
+
+## What Changed
+
+- Added `SharedRuntimeContext` and related view structs in
+  `src/context/runtime.rs`.
+- Added `Agent::shared_runtime_context()` in `src/agent/context_view.rs`.
+- Updated TUI snapshot sync to consume the shared runtime-context contract
+  instead of rebuilding prompt/plan/compaction fields directly from scattered
+  agent state.
+
+## Why
+
+This is the first concrete step toward the context-architecture spec:
+
+- one runtime-owned object describes the effective prompt view;
+- plan state and compaction state are grouped with that runtime context;
+- TUI status surfaces now depend on a shared contract instead of open-coded
+  extraction logic.
+
+## Validation
+
+- `cargo check`
+- `cargo test agent::tests::context_view -- --nocapture`
+
+## Follow-Up
+
+- Extend the shared runtime context so session restore can consume the same
+  contract instead of reconstructing adjacent state independently.
+- Add a dedicated `/context` surface on top of this shared contract.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,101 +4,79 @@ Active backlog only. Keep this file small and current.
 
 ## Suggested Rollout Order
 
-From easier / lower-risk work toward harder / more structural work:
+From higher-leverage structural work toward later UX parity work:
 
-1. Transcript and command-surface polish
-   - [ ] Add Claude-style repository context hints beneath the input area, especially the current GitHub PR link (when the workspace is on a PR branch or can be mapped to an open PR), so the active review context stays visible without manual lookup.
-   - [ ] Add Codex/Claude-style transcript role cards for `You` / `Agent` / `System`: use clearer card/background separation without mixing status chrome into committed transcript history.
-   - [ ] Bring the main response UI closer to Codex / Claude Code: tighten the `You` / `Agent` message-card hierarchy, keep active response blocks visually stable while streaming, and avoid falling back to generic transcript rows for states that should render as dedicated response cards.
-   - [ ] Rework the built-in command TUI (`/help`, `/model`, `/status`, command palette, setup overlays) to more closely match Codex / Claude Code: better information density, clearer keyboard affordances, stronger selection states, and less modal friction.
+1. Runtime bootstrap and context contracts
+2. Configuration and provider-surface cleanup
+3. Workspace / skill observability and cache correctness
+4. Memory / retrieval / thread persistence
+5. TUI transcript parity and command-surface polish
 
-2. Transcript stability and compactness
-   - [ ] Improve transcript rendering stability across long and streaming sessions: reduce scroll jumps and flicker, keep bottom anchoring stable while new content streams in, and prevent stale transient sections (`Exploring`, `Updated Plan`, busy chrome) from reappearing after their live phase has ended.
-   - [ ] Rework long `Exploring` / `Explored` handling to follow Codex more closely: keep live exploration compact, summarize committed exploration into a small source-aware digest (prefer actual `read`/inspection actions over noisy `list`/`glob`/search chatter), and avoid dumping long raw action traces into the main transcript.
-   - [ ] Decouple setup/help/model overlays from transcript layout so popups do not perturb history rendering: overlays should render as a pure top layer instead of changing transcript viewport sizing or causing history reflow/flicker when opened and closed.
-   - [ ] Expand the new Codex-style TUI snapshot coverage beyond the first auth-picker / queued-follow-up / Updated Plan snapshots so more popups, status surfaces, and transcript-heavy widgets are protected by golden tests.
+## Architecture / Runtime
 
-3. Rich Codex/Claude transcript parity
-   - [ ] Continue making tool-action transcript summaries more source-aware and file-aware so edit tools such as `write_file` / `replace` / `apply_patch` consistently show what they touched instead of only generic action labels.
-   - [ ] Continue refining the live `bash` transcript path so command execution behaves more like Codex: keep the streamed stdout/stderr surface, then add richer lifecycle details such as clearer command-start/finish framing and better long-output folding.
-   - [ ] Add a high-fidelity Claude Code / Codex transcript rendering pass: mirror the structured `write/update` tool presentation, inline diff display, approval cards, and message-card hierarchy as closely as practical instead of only loosely borrowing the style, and explicitly use Codex as the primary reference for `bash` / command lifecycle framing, stdout/stderr streaming, completion summaries, and output folding.
+- [ ] Make agent, TUI, and session restore consume the same context assembly contract instead of rebuilding overlapping runtime state in parallel.
+- [ ] Add context assembly observability so a turn can explain which prompt/context sources were injected, where they came from, and in what order.
+- [ ] Add a Claude-style `/context` surface that exposes the effective runtime context clearly: active instructions, workspace sources, compacted history/memory inputs, and why they were included for the current turn.
+- [ ] Refactor `src/main.rs` into smaller bootstrap modules for CLI parsing, backend construction, runtime bootstrap, and tool registration.
+- [ ] Extract `create_full_tool_manager` and related runtime builders out of `src/main.rs` so the entrypoint stops owning all dependency wiring directly.
 
-4. Reasoning and model-surface alignment
-   - [ ] Add a Codex-style configurable `model_reasoning_summary` surface instead of a boolean thinking toggle: support model/provider-scoped configuration, show reasoning summaries only when the backend emits them, and keep the transcript/status behavior aligned with Codex (`none` / `auto` / richer summary modes) rather than exposing raw chain-of-thought.
-   - [ ] Continue refining queued follow-up steering toward the full Codex contract: keep the new next-tool-boundary queue, then add the explicit interrupt/send-now path and clearer separation between pending steers and ordinary queued follow-ups.
+## Configuration / Provider Surface
 
-5. Deeper runtime and architecture work
-   - [ ] Unify runtime assembly and startup boundaries across `src/main.rs` and `src/tui/runtime/tasks.rs`: introduce one shared runtime/builder entry point for backend/tool/session/workspace initialization, stop silently swallowing `SkillManager::load_all()` failures, move hard-coded persistence paths such as `data/lancedb` behind config/workspace path resolution, and keep the root crate split between thin entrypoints and explicit runtime-context assembly instead of letting `main.rs` keep parser/setup/dispatch responsibilities together.
-   - [ ] Implement the Stage 1 context-architecture boundary from `docs/features/context-architecture.md`: introduce explicit `ContextBudget` and `ContextAssembler` layers so stable instructions, workspace context, active turn context, memory selections, and compacted history stop being assembled implicitly across unrelated modules.
-   - [ ] Implement a local `ThreadStore` / `ThreadRecorder` boundary so thread metadata, rollout history, plan state, pending interactions, and future sub-agent lineage are persisted as structured items instead of reconstructed from flattened transcript text.
-   - [ ] Introduce a dedicated transcript viewport model that renders history from stable turn data plus scroll state instead of letting overlays and transient runtime sections implicitly drive layout; this should become the basis for future virtualization, stronger scroll anchoring, and less flicker under streaming updates.
+- [ ] Replace provider-scoped `thinking: bool` with a Codex-style reasoning summary configuration model plus config migration.
+- [ ] Surface provider-scoped reasoning configuration in `/status` and provider/model switching flows, including where the effective value came from.
+- [ ] Align Codex endpoint selection with auth mode so ChatGPT/Codex login and OpenAI API key sessions do not blindly share the same provider URL.
+- [ ] Split Codex-specific persisted auth/config back out to `~/.codex` while keeping provider-agnostic RARA config and runtime/session state under `~/.rara`.
 
-## Security and Reliability
+## Workspace / Skills / Prompt Sources
 
-- [ ] Replace the current string-based shell execution path in `src/tools/bash.rs` and `src/sandbox.rs` with a structured command model (`program`, `args`, `cwd`, `allow_net`) so `bash -c` / `sh -c` is no longer the default execution path.
-- [ ] Move API key handling in `src/llm.rs` and config paths to `secrecy::SecretString`, and audit error/reporting paths so secrets are never echoed in logs or panic messages.
-- [ ] Replace `.expect(...)` on provider credential/model setup with structured `anyhow::Context` errors that remain useful without leaking sensitive values.
-- [ ] Review path and command validation around `bash`, file tools, and sandbox handoff; define a stricter validation policy instead of relying on minimal escaping.
+- [ ] Expand focused tests around workspace prompt-source discovery and cache invalidation across cwd changes, git branch changes, nested workspaces, and outside-workspace fallback.
+- [ ] Define and document `WorkspaceMemory` cache invalidation rules for prompt files and environment info instead of relying on implicit behavior.
+- [ ] Unify `discover_prompt_sources()` and TUI `/status` source reporting so displayed prompt sources match the actual injected sources.
+- [ ] Define and surface skill precedence/override behavior across home, repo, nested repo roots, and workspace-local skill roots.
+- [ ] Extend `SkillManager::list_summaries()` (or equivalent status output) with source precedence and overridden-skill visibility so conflicts are debuggable.
 
-## LLM and Networking
+## Memory / Retrieval / Persistence
 
-- [ ] Broaden Codex-auth validation beyond the current bridge tests: add stronger callback-flow coverage and more end-to-end persistence checks so the browser/device/API-key/logout paths stay regression-tested even as `codex_login` evolves.
-- [ ] Split Codex-specific persisted auth/config back out to `~/.codex` while keeping provider-agnostic RARA config, workspace runtime state, and session data under `~/.rara`.
-- [ ] Align Codex endpoint selection with auth mode: ChatGPT/Codex login and OpenAI API key sessions should not share the same provider URL blindly, even though both currently reuse the Responses-shaped backend contract.
-- [ ] Add an `AgentHub team mode` on top of ACP: for role-specialized worker sessions, use a small model first for intent routing and only hand the task to the larger worker model when the intent is relevant to that worker, instead of sending every ACP turn directly to the expensive model.
-- [ ] Deepen the `AgentHub team mode` spec before implementation: define the ACP session metadata, worker-role contract, router prompt/output schema, and the exact `skip` / `handle` response semantics so the worker runtime can be implemented without inventing a parallel protocol later.
+- [ ] Implement the Stage 1 context-architecture boundary from `docs/features/context-architecture.md`: explicit `ContextBudget` and `ContextAssembler` layers instead of implicit context assembly across unrelated modules.
+- [ ] Implement a local `ThreadStore` / `ThreadRecorder` boundary so thread metadata, rollout history, plan state, and pending interactions are persisted as structured items.
+- [ ] Make compaction a first-class runtime event with persisted summaries, token counters, and boundary metadata.
+- [ ] Define thread-scoped and workspace-scoped `MemoryRecord` storage plus promotion rules so durable findings are not mixed with transient turn context.
+- [ ] Replace the current placeholder retrieval path with real vector retrieval over Lance/LanceDB, including metadata-aware ranking for thread and workspace memory selection.
+- [ ] Add the retrieval orchestration layer described in `docs/features/context-architecture.md` so thread recall, vector recall, and later graph recall compose into one bounded `MemorySelection`.
+- [ ] Design Graph RAG as a later retrieval layer on top of durable memory and extracted relationships instead of as prompt-only glue.
 
-## Memory and Retrieval
+## TUI / UX Parity
 
-- [ ] Implement the Stage 1 context-architecture boundary from `docs/features/context-architecture.md`: introduce explicit `ContextBudget` and `ContextAssembler` layers so stable instructions, workspace context, active turn context, memory selections, and compacted history stop being assembled implicitly across unrelated modules.
-- [ ] Implement a local `ThreadStore` / `ThreadRecorder` boundary so thread metadata, rollout history, plan state, pending interactions, and future sub-agent lineage are persisted as structured items instead of reconstructed from flattened transcript text.
-- [ ] Make compaction a first-class runtime event: persist compacted summary items, before/after token counts, and replacement metadata so long threads can resume cleanly without replaying unbounded raw history.
-- [ ] Define thread-scoped and workspace-scoped `MemoryRecord` storage plus promotion rules so durable findings, preferences, and repo facts stop being mixed with transient turn context.
-- [ ] Replace the current placeholder retrieval path with real vector retrieval over Lance/LanceDB, including metadata-aware ranking for thread memory and workspace memory selections before injection into context.
-- [ ] Add the retrieval orchestration layer described in `docs/features/context-architecture.md`: a `Retriever` boundary that can merge thread recall, workspace vector recall, and later graph-based recall into one bounded `MemorySelection`.
-- [ ] Design Graph RAG as a later retrieval layer on top of durable memory and extracted relationships instead of as a prompt hack: define graph nodes/edges, traversal outputs, and how graph results compose with vector retrieval.
-- [ ] Add a first-run onboarding flow that explains workspace, provider/model selection, local model download behavior, cache location, and tool loop expectations before the user lands in a blank chat.
-- [ ] Continue aligning the TUI status and transcript surfaces with Codex/Claude so runtime state stays visible without leaking bottom-pane chrome into transcript history.
-- [ ] Improve transcript rendering stability across long and streaming sessions: reduce scroll jumps and flicker, keep bottom anchoring stable while new content streams in, and prevent stale transient sections (`Exploring`, `Updated Plan`, busy chrome) from reappearing after their live phase has ended.
-- [ ] Add Claude-style repository context hints beneath the input area, especially the current GitHub PR link (when the workspace is on a PR branch or can be mapped to an open PR), so the active review context stays visible without manual lookup.
-- [ ] Rework the built-in command TUI (`/help`, `/model`, `/status`, command palette, setup overlays) to more closely match Codex / Claude Code: better information density, clearer keyboard affordances, stronger selection states, and less modal friction.
-- [ ] Add a Codex-style configurable `model_reasoning_summary` surface instead of a boolean thinking toggle: support model/provider-scoped configuration, show reasoning summaries only when the backend emits them, and keep the transcript/status behavior aligned with Codex (`none` / `auto` / richer summary modes) rather than exposing raw chain-of-thought.
-- [ ] Add Codex/Claude-style transcript role cards for `You` / `Agent` / `System`: use clearer card/background separation without mixing status chrome into committed transcript history.
-- [ ] Add a high-fidelity Claude Code / Codex transcript rendering pass: mirror the structured `write/update` tool presentation, inline diff display, approval cards, and message-card hierarchy as closely as practical instead of only loosely borrowing the style, and explicitly use Codex as the primary reference for `bash` / command lifecycle framing, stdout/stderr streaming, completion summaries, and output folding.
-- [ ] Rework long `Exploring` / `Explored` handling to follow Codex more closely: keep live exploration compact, summarize committed exploration into a small source-aware digest (prefer actual `read`/inspection actions over noisy `list`/`glob`/search chatter), and avoid dumping long raw action traces into the main transcript.
-- [ ] Expand the new Codex-style TUI snapshot coverage beyond the first auth-picker / queued-follow-up / Updated Plan snapshots so more popups, status surfaces, and transcript-heavy widgets are protected by golden tests.
-- [ ] Continue making tool-action transcript summaries more source-aware and file-aware so edit tools such as `write_file` / `replace` / `apply_patch` consistently show what they touched instead of only generic action labels.
-- [ ] Continue refining the live `bash` transcript path so command execution behaves more like Codex: keep the streamed stdout/stderr surface, then add richer lifecycle details such as clearer command-start/finish framing and better long-output folding.
-- [ ] Continue refining queued follow-up steering toward the full Codex contract: keep the new next-tool-boundary queue, then add the explicit interrupt/send-now path and clearer separation between pending steers and ordinary queued follow-ups.
-- [ ] Harden local model prompting contracts for Gemma 4 and Qwen3: chat template handling, stop sequences, and tool-call JSON framing should be explicit and regression-tested.
-- [ ] Replace the current hash-based local embedding fallback with a real embedding backend so project memory retrieval quality is good enough for normal coding sessions.
-- [ ] Replace the mock `VectorDB` implementation in `src/vectordb.rs` with real LanceDB-backed search/upsert behavior, or feature-gate the memory tools until the backend is real.
-- [ ] Implement the ACP runtime path end to end: `RaraAcpAgent::prompt` and `run_acp_stdio` should execute the real tool/backend loop instead of returning placeholder responses, because AgentHub integration will use ACP as the worker boundary.
-- [ ] Implement the Gemini backend instead of keeping the current `Gemini pending` stub so the configured provider is a real option.
-- [ ] Implement session context retrieval on top of the existing session storage and vector/session managers instead of returning `no_context_found`.
-- [ ] Implement the vector memory tools against the real backend and LanceDB path instead of using placeholder save/retrieve responses.
-- [ ] Implement real parallel `team_create` execution instead of the current mocked result payload.
-- [ ] Evaluate and add a `thread-store`-style persistence boundary so thread/session metadata, rollout history, resume, archive, and future remote-backed thread storage do not stay split across unrelated local state surfaces.
+- [ ] Continue improving transcript rendering stability across long and streaming sessions: reduce scroll jumps and flicker, strengthen bottom anchoring, and prevent stale transient sections from reappearing after their live phase ends.
+- [ ] Rework long `Exploring` / `Explored` handling to follow Codex more closely: keep live exploration compact and summarize committed exploration into a source-aware digest instead of dumping long raw traces.
+- [ ] Decouple setup/help/model overlays from transcript layout so overlays behave as a pure top layer and do not perturb history viewport sizing.
+- [ ] After exit, print a Codex/Claude-style resume hint that tells the user how to restore the session quickly (for example the exact `resume` command or session identifier to use).
+- [ ] Add Claude-style repository context hints beneath the input area, especially the current GitHub PR link when the workspace maps to an open PR.
+- [ ] Add Codex/Claude-style transcript role cards for `You` / `Agent` / `System` without mixing status chrome into committed transcript history.
+- [ ] Bring the main response UI closer to Codex / Claude Code: stabilize active response blocks while streaming and avoid falling back to generic transcript rows for states that should stay in dedicated response cards.
+- [ ] Rework the built-in command TUI (`/help`, `/model`, `/status`, command palette, setup overlays) to more closely match Codex / Claude Code.
+- [ ] Continue making tool-action transcript summaries more source-aware and file-aware so edit tools (`write_file`, `replace`, `apply_patch`) consistently show what they touched.
+- [ ] Continue refining the live `bash` transcript path so command execution behaves more like Codex: clearer lifecycle framing, streamed stdout/stderr handling, and better long-output folding.
+- [ ] Add a high-fidelity Claude Code / Codex transcript rendering pass for `write/update`, inline diff display, approval cards, and message-card hierarchy.
+- [ ] Expand TUI snapshot coverage for transcript-heavy widgets, overlays, status surfaces, and auth/model picker flows.
 
-## Performance and Runtime
+## Security / Reliability / Performance
 
-- [ ] Rework token accounting in `src/agent.rs` so repeated checks do not need to re-encode the full history every time.
+- [ ] Replace the current string-based shell execution path in `src/tools/bash.rs` and `src/sandbox.rs` with a structured command model (`program`, `args`, `cwd`, `allow_net`).
+- [ ] Move API key handling in config/backend paths to `secrecy::SecretString` end to end and audit error/reporting paths so secrets are never echoed.
+- [ ] Replace `.expect(...)` around provider credential/model setup with structured `anyhow::Context` errors that remain useful without leaking sensitive values.
+- [ ] Review path and command validation around `bash`, file tools, and sandbox handoff instead of relying on minimal escaping.
+- [ ] Rework token accounting in `src/agent.rs` so repeated checks do not need to re-encode full history every time.
 - [ ] Replace the fixed 100ms TUI event polling loop in `src/tui/mod.rs` with a more event-driven wakeup model when the app is idle.
-- [ ] Add terminal panic/teardown guards so alternate-screen/raw-mode cleanup is more robust on unexpected failures.
-- [ ] Reduce per-frame TUI render allocations in `src/tui/render/cells.rs`: avoid rebuilding `Vec`s and boxed trait objects on every `display_lines()` call, likely by letting history/active cells append into an existing buffer instead of returning freshly allocated collections.
+- [ ] Add stronger terminal panic/teardown guards so alternate-screen/raw-mode cleanup is robust on unexpected failures.
 
-## Code Organization and Docs
+## Code Organization / Docs
 
-- [ ] Unify runtime assembly and startup boundaries across `src/main.rs` and `src/tui/runtime/tasks.rs`: introduce one shared runtime/builder entry point for backend/tool/session/workspace initialization, stop silently swallowing `SkillManager::load_all()` failures, move hard-coded persistence paths such as `data/lancedb` behind config/workspace path resolution, and keep the root crate split between thin entrypoints and explicit runtime-context assembly instead of letting `main.rs` keep parser/setup/dispatch responsibilities together.
-- [ ] Continue the internal-crate rollout after `rara-config`, `rara-instructions`, and `rara-skills`: move more skill runtime behavior behind `rara-skills`, then extract the next stable boundary instead of growing the root crate back toward a monolith.
-- [ ] Revisit direct reuse of `codex-core-skills` after the Codex-compatible root-discovery phase: keep `rara-skills` as the adaptation boundary, but replace more of the custom loader/render/invocation stack once the dependency surface is acceptable.
-- [ ] Refine instruction resolution so `AGENTS.md` / instruction files behave more like Codex and Claude Code: keep hierarchical lookup, then define clearer precedence and merge rules for nested project instructions versus workspace-local RARA instructions.
 - [ ] Continue splitting the remaining near-limit runtime/TUI files so the 800-line guideline keeps holding in practice, especially `src/tui/runtime/events/helpers.rs`, `src/tui/custom_terminal.rs`, `src/tui/command.rs`, and `src/agent/planning.rs`.
-- [ ] Add module-level documentation for the agent lifecycle, tool loop, plan/update flow, and sandbox model so the runtime architecture is easier to reason about.
-- [ ] Add a security section to `AGENTS.md` or a dedicated security doc covering sandbox expectations, command execution rules, and secret-handling standards.
-- [ ] Add comments around the non-obvious continuation / plan / current-turn rendering logic so future refactors do not regress the Codex-style workflow.
-- [ ] Replace remaining magic numbers in the TUI/runtime path with named constants where the values encode policy rather than layout convenience.
-- [ ] Decide whether config hot-reload is a real roadmap item; if yes, add a scoped design and file-watcher implementation plan instead of leaving it implicit.
+- [ ] Add module-level documentation for the agent lifecycle, tool loop, context assembly, plan/update flow, and sandbox model.
+- [ ] Add comments around non-obvious continuation / plan / current-turn rendering logic so future refactors do not regress the Codex-style workflow.
+- [ ] Replace remaining policy-like magic numbers in the TUI/runtime path with named constants.
+- [ ] Split backlog planning between architecture/runtime work and TUI/UX parity work if this file starts accumulating duplicate or umbrella-incompatible items again.
 
 ## Maintenance Rules
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,4 +1,5 @@
 mod compact;
+mod context_view;
 mod planning;
 mod prompting;
 #[cfg(test)]

--- a/src/agent/context_view.rs
+++ b/src/agent/context_view.rs
@@ -1,0 +1,53 @@
+use super::*;
+use crate::context::{
+    CompactionContextView, PlanContextView, PromptContextView, SharedRuntimeContext,
+};
+
+impl Agent {
+    pub fn shared_runtime_context(&self) -> SharedRuntimeContext {
+        let (cwd, branch) = self.workspace.get_env_info();
+        let effective_prompt = self.effective_prompt();
+
+        SharedRuntimeContext {
+            cwd,
+            branch,
+            session_id: self.session_id.clone(),
+            history_len: self.history.len(),
+            total_input_tokens: self.total_input_tokens,
+            total_output_tokens: self.total_output_tokens,
+            prompt: PromptContextView::from_effective_prompt(
+                effective_prompt,
+                self.prompt_config().warnings.clone(),
+            ),
+            plan: PlanContextView::from_agent_state(
+                self.execution_mode_label(),
+                self.current_plan
+                    .iter()
+                    .map(|step| (step.status.clone(), step.step.clone())),
+                self.plan_explanation.clone(),
+            ),
+            compaction: CompactionContextView {
+                estimated_history_tokens: self.compact_state.estimated_history_tokens,
+                context_window_tokens: self.compact_state.context_window_tokens,
+                compact_threshold_tokens: self.compact_state.compact_threshold_tokens,
+                reserved_output_tokens: self.compact_state.reserved_output_tokens,
+                compaction_count: self.compact_state.compaction_count,
+                last_compaction_before_tokens: self.compact_state.last_compaction_before_tokens,
+                last_compaction_after_tokens: self.compact_state.last_compaction_after_tokens,
+                last_compaction_recent_files: self.compact_state.last_compaction_recent_files.clone(),
+                last_compaction_boundary_version: self
+                    .compact_state
+                    .last_compaction_boundary
+                    .map(|boundary| boundary.version),
+                last_compaction_boundary_before_tokens: self
+                    .compact_state
+                    .last_compaction_boundary
+                    .map(|boundary| boundary.before_tokens),
+                last_compaction_boundary_recent_file_count: self
+                    .compact_state
+                    .last_compaction_boundary
+                    .map(|boundary| boundary.recent_file_count),
+            },
+        }
+    }
+}

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1,3 +1,4 @@
 mod compaction;
+mod context_view;
 mod planning;
 mod support;

--- a/src/agent/tests/context_view.rs
+++ b/src/agent/tests/context_view.rs
@@ -1,0 +1,102 @@
+use super::support::{test_runtime_storage, SequencedBackend};
+use crate::agent::{Agent, AgentExecutionMode, Message, PlanStep, PlanStepStatus};
+use crate::llm::{ContentBlock, LlmResponse};
+use crate::prompt::PromptRuntimeConfig;
+use crate::tool::ToolManager;
+use crate::vectordb::VectorDB;
+use serde_json::json;
+use std::sync::Arc;
+
+#[test]
+fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::Text {
+            text: "ok".to_string(),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: None,
+    }]));
+
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").display().to_string())),
+        session_manager,
+        workspace,
+    );
+    agent.set_prompt_config(PromptRuntimeConfig {
+        append_system_prompt: Some("appendix".to_string()),
+        warnings: vec!["missing prompt file".to_string()],
+        ..PromptRuntimeConfig::default()
+    });
+    agent.execution_mode = AgentExecutionMode::Plan;
+    agent.current_plan = vec![
+        PlanStep {
+            step: "inspect auth flow".to_string(),
+            status: PlanStepStatus::Completed,
+        },
+        PlanStep {
+            step: "replace bootstrap path".to_string(),
+            status: PlanStepStatus::Pending,
+        },
+    ];
+    agent.plan_explanation = Some("Prefer one shared bootstrap path.".to_string());
+    agent.total_input_tokens = 11;
+    agent.total_output_tokens = 7;
+    agent.compact_state.estimated_history_tokens = 1234;
+    agent.compact_state.context_window_tokens = Some(8192);
+    agent.compact_state.compact_threshold_tokens = 7000;
+    agent.compact_state.reserved_output_tokens = 1024;
+    agent.compact_state.compaction_count = 2;
+    agent.compact_state.last_compaction_before_tokens = Some(5000);
+    agent.compact_state.last_compaction_after_tokens = Some(2100);
+    agent.compact_state.last_compaction_recent_files =
+        vec!["src/main.rs".to_string(), "src/runtime_context.rs".to_string()];
+    agent.compact_state.last_compaction_boundary = Some(crate::agent::CompactBoundaryMetadata {
+        version: 3,
+        before_tokens: 5000,
+        recent_file_count: 2,
+    });
+    agent.history.push(Message {
+        role: "user".to_string(),
+        content: json!([{"type":"text","text":"hello"}]),
+    });
+
+    let runtime = agent.shared_runtime_context();
+
+    assert_eq!(runtime.history_len, 1);
+    assert_eq!(runtime.total_input_tokens, 11);
+    assert_eq!(runtime.total_output_tokens, 7);
+    assert_eq!(runtime.prompt.base_prompt_kind, "default");
+    assert!(runtime
+        .prompt
+        .section_keys
+        .contains(&"append_system_prompt".to_string()));
+    assert!(runtime
+        .prompt
+        .warnings
+        .contains(&"missing prompt file".to_string()));
+    assert_eq!(runtime.plan.execution_mode, "plan");
+    assert_eq!(
+        runtime.plan.steps,
+        vec![
+            ("completed".to_string(), "inspect auth flow".to_string()),
+            ("pending".to_string(), "replace bootstrap path".to_string()),
+        ]
+    );
+    assert_eq!(
+        runtime.plan.explanation.as_deref(),
+        Some("Prefer one shared bootstrap path.")
+    );
+    assert_eq!(runtime.compaction.estimated_history_tokens, 1234);
+    assert_eq!(runtime.compaction.context_window_tokens, Some(8192));
+    assert_eq!(runtime.compaction.last_compaction_boundary_version, Some(3));
+    assert_eq!(
+        runtime.compaction.last_compaction_recent_files,
+        vec![
+            "src/main.rs".to_string(),
+            "src/runtime_context.rs".to_string()
+        ]
+    );
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -4,5 +4,9 @@
 //! lightweight enough for branches that only need `mod context;` to compile.
 
 mod assembler;
+mod runtime;
 
 pub use self::assembler::{AssembledContext, ContextAssembler};
+pub use self::runtime::{
+    CompactionContextView, PlanContextView, PromptContextView, SharedRuntimeContext,
+};

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -1,0 +1,90 @@
+use crate::agent::PlanStepStatus;
+use crate::prompt::EffectivePrompt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptContextView {
+    pub base_prompt_kind: String,
+    pub section_keys: Vec<String>,
+    pub source_status_lines: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl PromptContextView {
+    pub fn from_effective_prompt(
+        effective_prompt: EffectivePrompt,
+        warnings: Vec<String>,
+    ) -> Self {
+        Self {
+            base_prompt_kind: effective_prompt.base_prompt_kind.label().to_string(),
+            section_keys: effective_prompt
+                .section_keys
+                .iter()
+                .map(|key| (*key).to_string())
+                .collect(),
+            source_status_lines: effective_prompt
+                .sources
+                .iter()
+                .map(|source| source.status_line())
+                .collect(),
+            warnings,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanContextView {
+    pub execution_mode: String,
+    pub steps: Vec<(String, String)>,
+    pub explanation: Option<String>,
+}
+
+impl PlanContextView {
+    pub fn from_agent_state(
+        execution_mode: &str,
+        steps: impl Iterator<Item = (PlanStepStatus, String)>,
+        explanation: Option<String>,
+    ) -> Self {
+        Self {
+            execution_mode: execution_mode.to_string(),
+            steps: steps
+                .map(|(status, step)| {
+                    let status = match status {
+                        PlanStepStatus::Pending => "pending",
+                        PlanStepStatus::InProgress => "in_progress",
+                        PlanStepStatus::Completed => "completed",
+                    };
+                    (status.to_string(), step)
+                })
+                .collect(),
+            explanation,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactionContextView {
+    pub estimated_history_tokens: usize,
+    pub context_window_tokens: Option<usize>,
+    pub compact_threshold_tokens: usize,
+    pub reserved_output_tokens: usize,
+    pub compaction_count: usize,
+    pub last_compaction_before_tokens: Option<usize>,
+    pub last_compaction_after_tokens: Option<usize>,
+    pub last_compaction_recent_files: Vec<String>,
+    pub last_compaction_boundary_version: Option<u32>,
+    pub last_compaction_boundary_before_tokens: Option<usize>,
+    pub last_compaction_boundary_recent_file_count: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SharedRuntimeContext {
+    pub cwd: String,
+    pub branch: String,
+    pub session_id: String,
+    pub history_len: usize,
+    pub total_input_tokens: u32,
+    pub total_output_tokens: u32,
+    pub prompt: PromptContextView,
+    pub plan: PlanContextView,
+    pub compaction: CompactionContextView,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod local_backend;
 mod oauth;
 mod prompt;
 mod redaction;
+mod runtime_context;
 mod sandbox;
 mod session;
 mod skill;
@@ -20,37 +21,15 @@ mod vectordb;
 mod workspace;
 
 use crate::acp::{run_acp_stdio, RaraAcpAgent};
-use crate::agent::Agent;
 use crate::config::{
     ConfigManager, RaraConfig, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL,
-    DEFAULT_CODEX_MODEL,
 };
-use crate::llm::{
-    CodexBackend, GeminiBackend, LlmBackend, MockLlm, OllamaBackend, OpenAiCompatibleBackend,
-};
-use crate::local_backend::{LocalLlmBackend, LocalProgressReporter};
+use crate::llm::{LlmBackend, MockLlm};
 use crate::oauth::{OAuthManager, SavedCodexAuthMode};
 use crate::redaction::redact_secrets;
-use crate::sandbox::SandboxManager;
-use crate::session::SessionManager;
-use crate::skill::SkillManager;
-use crate::tool::ToolManager;
-use crate::tools::agent::{AgentTool, ExploreAgentTool, PlanAgentTool, TeamCreateTool};
-use crate::tools::bash::BashTool;
-use crate::tools::context::RetrieveSessionContextTool;
-use crate::tools::file::{ListFilesTool, ReadFileTool, ReplaceTool, WriteFileTool};
-use crate::tools::patch::ApplyPatchTool;
-use crate::tools::search::{GlobTool, GrepTool};
-use crate::tools::skill::SkillTool;
-use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
-use crate::tools::web::WebFetchTool;
-use crate::tools::workspace::UpdateProjectMemoryTool;
-use crate::vectordb::VectorDB;
-use crate::workspace::WorkspaceMemory;
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use clap::{Parser, Subcommand};
 use secrecy::ExposeSecret;
-use std::sync::Arc;
 
 #[derive(Parser)]
 #[command(name = "rara")]
@@ -121,112 +100,132 @@ async fn main_impl() -> Result<()> {
     }
 
     let oauth_manager = OAuthManager::new()?;
-    let vdb = Arc::new(VectorDB::new("data/lancedb"));
-    let session_manager = Arc::new(SessionManager::new()?);
-    let workspace = Arc::new(WorkspaceMemory::new()?);
-    let sandbox_manager = Arc::new(SandboxManager::new()?);
-
-    let mut skill_manager = SkillManager::new();
-    let _ = skill_manager.load_all();
-    let skill_manager_arc = Arc::new(skill_manager);
-
-    let backend = build_backend(&config).await?;
-    let backend_arc: Arc<dyn LlmBackend> = backend.into();
-
-    let tool_manager = create_full_tool_manager(
-        backend_arc.clone(),
-        vdb.clone(),
-        session_manager.clone(),
-        workspace.clone(),
-        sandbox_manager.clone(),
-        skill_manager_arc.clone(),
-        prompt::PromptRuntimeConfig::from_config(&config),
-    );
 
     match cli.command.unwrap_or(Commands::Tui) {
-        Commands::Acp => {
-            let backend_builder = Box::new(move || Box::new(MockLlm) as Box<dyn LlmBackend>);
-            let acp_agent = RaraAcpAgent {
-                tool_manager,
-                backend_builder,
-            };
-            run_acp_stdio(acp_agent).await?;
-        }
-        Commands::Ask { prompt } => {
-            let mut agent = Agent::new(tool_manager, backend_arc, vdb, session_manager, workspace);
-            agent.set_prompt_config(prompt::PromptRuntimeConfig::from_config(&config));
-            agent.query(prompt).await?;
-        }
+        Commands::Acp => run_acp_command(&config).await?,
+        Commands::Ask { prompt } => run_ask_command(&config, prompt).await?,
         Commands::Login {
             device_auth,
             with_api_key,
-        } => {
-            if device_auth && with_api_key {
-                bail!("choose either --device-auth or --with-api-key, not both");
-            }
-            if with_api_key {
-                let oauth_reader = oauth_manager.clone();
-                let api_key =
-                    tokio::task::spawn_blocking(move || oauth_reader.read_api_key_from_stdin())
-                        .await??;
-                let credential = oauth_manager.save_api_key(api_key.expose_secret())?;
-                save_codex_credential(
-                    &mut config,
-                    &config_manager,
-                    &oauth_manager,
-                    credential.expose_secret(),
-                )?;
-                println!("Successfully saved Codex API key.");
-            } else if device_auth {
-                let token = oauth_manager.request_device_code().await?;
-                eprintln!(
-                    "Open this URL and enter the one-time code:\n{}\n\nCode: {}",
-                    token.verification_url, token.user_code
-                );
-                let credential = oauth_manager.complete_device_code_login(&token).await?;
-                save_codex_credential(
-                    &mut config,
-                    &config_manager,
-                    &oauth_manager,
-                    credential.expose_secret(),
-                )?;
-                println!("Successfully logged in with device code.");
-            } else {
-                if std::env::var_os("SSH_CONNECTION").is_some() {
-                    bail!("browser login is not reliable in SSH/headless sessions; use --device-auth or --with-api-key");
-                }
-                let session = oauth_manager.start_browser_login(true)?;
-                eprintln!(
-                    "Starting local login flow.\nIf your browser did not open, navigate to this URL:\n\n{}",
-                    session.auth_url()
-                );
-                let credential = session.complete(&oauth_manager).await?;
-                save_codex_credential(
-                    &mut config,
-                    &config_manager,
-                    &oauth_manager,
-                    credential.expose_secret(),
-                )?;
-                println!("Successfully logged in.");
-            }
-        }
-        Commands::Logout => {
-            let removed = oauth_manager.clear_saved_auth()?;
-            config.clear_provider_api_key("codex");
-            config_manager.save(&config)?;
-            if removed {
-                println!("Removed the saved Codex credential.");
-            } else {
-                println!("No saved Codex credential was present.");
-            }
-        }
-        Commands::Tui => {
-            let mut agent = Agent::new(tool_manager, backend_arc, vdb, session_manager, workspace);
-            agent.set_prompt_config(prompt::PromptRuntimeConfig::from_config(&config));
-            crate::tui::run_tui(agent, oauth_manager).await?;
-        }
+        } => run_login_command(
+            &mut config,
+            &config_manager,
+            &oauth_manager,
+            device_auth,
+            with_api_key,
+        )
+        .await?,
+        Commands::Logout => run_logout_command(&mut config, &config_manager, &oauth_manager)?,
+        Commands::Tui => run_tui_command(&config, oauth_manager).await?,
     }
     Ok(())
+}
+
+async fn run_acp_command(config: &RaraConfig) -> Result<()> {
+    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+    emit_bootstrap_warnings(&bootstrap.warnings);
+    let backend_builder = Box::new(move || Box::new(MockLlm) as Box<dyn LlmBackend>);
+    let acp_agent = RaraAcpAgent {
+        tool_manager: bootstrap.tool_manager,
+        backend_builder,
+    };
+    run_acp_stdio(acp_agent).await
+}
+
+async fn run_ask_command(config: &RaraConfig, prompt: String) -> Result<()> {
+    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+    emit_bootstrap_warnings(&bootstrap.warnings);
+    let mut agent = bootstrap.into_agent();
+    agent.query(prompt).await
+}
+
+async fn run_tui_command(config: &RaraConfig, oauth_manager: OAuthManager) -> Result<()> {
+    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+    emit_bootstrap_warnings(&bootstrap.warnings);
+    let agent = bootstrap.into_agent();
+    crate::tui::run_tui(agent, oauth_manager).await
+}
+
+async fn run_login_command(
+    config: &mut RaraConfig,
+    config_manager: &ConfigManager,
+    oauth_manager: &OAuthManager,
+    device_auth: bool,
+    with_api_key: bool,
+) -> Result<()> {
+    if device_auth && with_api_key {
+        bail!("choose either --device-auth or --with-api-key, not both");
+    }
+    if with_api_key {
+        let oauth_reader = oauth_manager.clone();
+        let api_key = tokio::task::spawn_blocking(move || oauth_reader.read_api_key_from_stdin())
+            .await??;
+        let credential = oauth_manager.save_api_key(api_key.expose_secret())?;
+        save_codex_credential(
+            config,
+            config_manager,
+            oauth_manager,
+            credential.expose_secret(),
+        )?;
+        println!("Successfully saved Codex API key.");
+        return Ok(());
+    }
+    if device_auth {
+        let token = oauth_manager.request_device_code().await?;
+        eprintln!(
+            "Open this URL and enter the one-time code:\n{}\n\nCode: {}",
+            token.verification_url, token.user_code
+        );
+        let credential = oauth_manager.complete_device_code_login(&token).await?;
+        save_codex_credential(
+            config,
+            config_manager,
+            oauth_manager,
+            credential.expose_secret(),
+        )?;
+        println!("Successfully logged in with device code.");
+        return Ok(());
+    }
+
+    if std::env::var_os("SSH_CONNECTION").is_some() {
+        bail!("browser login is not reliable in SSH/headless sessions; use --device-auth or --with-api-key");
+    }
+    let session = oauth_manager.start_browser_login(true)?;
+    eprintln!(
+        "Starting local login flow.\nIf your browser did not open, navigate to this URL:\n\n{}",
+        session.auth_url()
+    );
+    let credential = session.complete(oauth_manager).await?;
+    save_codex_credential(
+        config,
+        config_manager,
+        oauth_manager,
+        credential.expose_secret(),
+    )?;
+    println!("Successfully logged in.");
+    Ok(())
+}
+
+fn run_logout_command(
+    config: &mut RaraConfig,
+    config_manager: &ConfigManager,
+    oauth_manager: &OAuthManager,
+) -> Result<()> {
+    let removed = oauth_manager.clear_saved_auth()?;
+    config.clear_provider_api_key("codex");
+    config_manager.save(config)?;
+    if removed {
+        println!("Removed the saved Codex credential.");
+    } else {
+        println!("No saved Codex credential was present.");
+    }
+    Ok(())
+}
+
+fn emit_bootstrap_warnings(warnings: &[String]) {
+    for warning in warnings {
+        eprintln!("{}", redact_secrets(format!("Warning: {warning}")));
+    }
 }
 
 fn save_codex_credential(
@@ -243,183 +242,4 @@ fn save_codex_credential(
     };
     config.apply_codex_defaults_for_base_url(base_url);
     config_manager.save(config)
-}
-
-fn create_full_tool_manager(
-    backend: Arc<dyn LlmBackend>,
-    vdb: Arc<VectorDB>,
-    session_manager: Arc<SessionManager>,
-    workspace: Arc<WorkspaceMemory>,
-    sandbox: Arc<SandboxManager>,
-    skill_manager: Arc<SkillManager>,
-    prompt_config: prompt::PromptRuntimeConfig,
-) -> ToolManager {
-    let mut tm = ToolManager::new();
-    tm.register(Box::new(BashTool {
-        sandbox: sandbox.clone(),
-    }));
-    tm.register(Box::new(ReadFileTool));
-    tm.register(Box::new(ApplyPatchTool));
-    tm.register(Box::new(WriteFileTool));
-    tm.register(Box::new(ListFilesTool));
-    tm.register(Box::new(ReplaceTool));
-    tm.register(Box::new(WebFetchTool));
-    tm.register(Box::new(GlobTool));
-    tm.register(Box::new(GrepTool));
-    tm.register(Box::new(RememberExperienceTool {
-        backend: backend.clone(),
-        db_uri: "data/lancedb".into(),
-    }));
-    tm.register(Box::new(RetrieveExperienceTool {
-        backend: backend.clone(),
-        db_uri: "data/lancedb".into(),
-    }));
-    tm.register(Box::new(RetrieveSessionContextTool {
-        backend: backend.clone(),
-        vdb: vdb.clone(),
-        session_manager: session_manager.clone(),
-    }));
-    tm.register(Box::new(UpdateProjectMemoryTool {
-        workspace: workspace.clone(),
-    }));
-    tm.register(Box::new(SkillTool {
-        skill_manager: skill_manager.clone(),
-    }));
-    tm.register(Box::new(AgentTool {
-        backend: backend.clone(),
-        vdb: vdb.clone(),
-        session_manager: session_manager.clone(),
-        workspace: workspace.clone(),
-        prompt_config: prompt_config.clone(),
-    }));
-    tm.register(Box::new(ExploreAgentTool {
-        backend: backend.clone(),
-        vdb: vdb.clone(),
-        session_manager: session_manager.clone(),
-        workspace: workspace.clone(),
-        prompt_config: prompt_config.clone(),
-    }));
-    tm.register(Box::new(PlanAgentTool {
-        backend: backend.clone(),
-        vdb: vdb.clone(),
-        session_manager: session_manager.clone(),
-        workspace: workspace.clone(),
-        prompt_config,
-    }));
-    tm.register(Box::new(TeamCreateTool {
-        backend: backend.clone(),
-        vdb: vdb.clone(),
-        session_manager: session_manager.clone(),
-        workspace: workspace.clone(),
-    }));
-    tm
-}
-
-pub(crate) async fn build_backend(config: &RaraConfig) -> Result<Box<dyn LlmBackend>> {
-    build_backend_with_progress(config, None).await
-}
-
-pub(crate) async fn build_backend_with_progress(
-    config: &RaraConfig,
-    progress: Option<LocalProgressReporter>,
-) -> Result<Box<dyn LlmBackend>> {
-    match config.provider.as_str() {
-        "kimi" => Ok(Box::new(OpenAiCompatibleBackend::new(
-            Some(
-                config
-                    .api_key
-                    .clone()
-                    .context("API key required for Kimi provider")?,
-            ),
-            "https://api.moonshot.cn/v1".to_string(),
-            config
-                .model
-                .clone()
-                .unwrap_or_else(|| "moonshot-v1-8k".to_string()),
-        )?)),
-        "codex" => Ok(Box::new(CodexBackend::new(
-            config.api_key.clone(),
-            config
-                .base_url
-                .clone()
-                .unwrap_or_else(|| DEFAULT_CODEX_BASE_URL.to_string()),
-            config
-                .model
-                .clone()
-                .unwrap_or_else(|| DEFAULT_CODEX_MODEL.to_string()),
-            config.reasoning_effort.clone(),
-        )?)),
-        "openai-compatible" => Ok(Box::new(OpenAiCompatibleBackend::new(
-            config.api_key.clone(),
-            config
-                .base_url
-                .clone()
-                .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
-            config
-                .model
-                .clone()
-                .unwrap_or_else(|| "gpt-4o-mini".to_string()),
-        )?)),
-        "ollama" | "ollama-native" => Ok(Box::new(OllamaBackend::new(
-            config
-                .base_url
-                .clone()
-                .unwrap_or_else(|| "http://localhost:11434".to_string()),
-            config.model.clone().unwrap_or_else(|| "gemma4".to_string()),
-            config.thinking.unwrap_or(true),
-            config.num_ctx,
-        )?)),
-        "ollama-openai" => Ok(Box::new(OpenAiCompatibleBackend::new(
-            config.api_key.clone(),
-            config
-                .base_url
-                .clone()
-                .unwrap_or_else(|| "http://localhost:11434".to_string()),
-            config.model.clone().unwrap_or_else(|| "gemma4".to_string()),
-        )?)),
-        "gemini" => Ok(Box::new(GeminiBackend {
-            api_key: config
-                .api_key
-                .clone()
-                .context("API key required for Gemini provider")?,
-            model: config
-                .model
-                .clone()
-                .unwrap_or_else(|| "gemini-1.5-pro".to_string()),
-        })),
-        "gemma4" | "qwen3" | "qwn3" | "local" | "local-candle" => {
-            let config = config.clone();
-            let progress = progress.clone();
-            let backend = tokio::task::spawn_blocking(move || {
-                LocalLlmBackend::from_config_with_progress(&config, progress)
-            })
-            .await??;
-            Ok(Box::new(backend))
-        }
-        "mock" => Ok(Box::new(MockLlm)),
-        other => bail!("Unsupported provider '{other}'"),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::build_backend_with_progress;
-    use crate::config::RaraConfig;
-
-    #[tokio::test]
-    async fn unsupported_provider_returns_error() {
-        let config = RaraConfig {
-            provider: "does-not-exist".to_string(),
-            ..Default::default()
-        };
-
-        let err = match build_backend_with_progress(&config, None).await {
-            Ok(_) => panic!("unsupported provider should fail"),
-            Err(err) => err,
-        };
-
-        assert!(err
-            .to_string()
-            .contains("Unsupported provider 'does-not-exist'"));
-    }
 }

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use anyhow::{bail, Context, Result};
 
 use crate::agent::Agent;
-use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, RaraConfig};
+use crate::config::{
+    DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, RaraConfig, REASONING_SUMMARY_NONE,
+};
 use crate::llm::{
     CodexBackend, GeminiBackend, LlmBackend, MockLlm, OllamaBackend, OpenAiCompatibleBackend,
 };
@@ -92,13 +94,6 @@ pub(crate) async fn initialize_rara_context(
     })
 }
 
-pub(crate) async fn build_runtime_bootstrap(
-    config: &RaraConfig,
-    progress: Option<LocalProgressReporter>,
-) -> Result<RuntimeBootstrap> {
-    initialize_rara_context(config, progress).await
-}
-
 pub(crate) async fn build_backend(config: &RaraConfig) -> Result<Box<dyn LlmBackend>> {
     build_backend_with_progress(config, None).await
 }
@@ -149,8 +144,11 @@ pub(crate) async fn build_backend_with_progress(
                 .base_url
                 .clone()
                 .unwrap_or_else(|| "http://localhost:11434".to_string()),
-            config.model.clone().unwrap_or_else(|| "gemma4".to_string()),
-            config.thinking.unwrap_or(true),
+            config
+                .model
+                .clone()
+                .context("Model required for Ollama provider")?,
+            ollama_thinking_enabled(config),
             config.num_ctx,
         )?)),
         "ollama-openai" => Ok(Box::new(OpenAiCompatibleBackend::new(
@@ -159,7 +157,10 @@ pub(crate) async fn build_backend_with_progress(
                 .base_url
                 .clone()
                 .unwrap_or_else(|| "http://localhost:11434".to_string()),
-            config.model.clone().unwrap_or_else(|| "gemma4".to_string()),
+            config
+                .model
+                .clone()
+                .context("Model required for Ollama OpenAI provider")?,
         )?)),
         "gemini" => Ok(Box::new(GeminiBackend {
             api_key: config
@@ -269,12 +270,20 @@ fn vector_db_uri_for_workspace(workspace: &WorkspaceMemory) -> String {
     workspace.rara_dir.join("lancedb").display().to_string()
 }
 
+fn ollama_thinking_enabled(config: &RaraConfig) -> bool {
+    match config.reasoning_summary.as_deref() {
+        Some(REASONING_SUMMARY_NONE) => false,
+        _ => config.thinking.unwrap_or(true),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        build_backend_with_progress, initialize_rara_context, vector_db_uri_for_workspace,
+        build_backend_with_progress, initialize_rara_context, ollama_thinking_enabled,
+        vector_db_uri_for_workspace,
     };
-    use crate::config::RaraConfig;
+    use crate::config::{RaraConfig, DEFAULT_REASONING_SUMMARY, REASONING_SUMMARY_NONE};
     use crate::workspace::WorkspaceMemory;
     use tempfile::tempdir;
 
@@ -325,5 +334,63 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Unsupported provider 'does-not-exist'"));
+    }
+
+    #[tokio::test]
+    async fn ollama_requires_explicit_model_selection() {
+        let config = RaraConfig {
+            provider: "ollama".to_string(),
+            model: None,
+            ..Default::default()
+        };
+
+        let err = match build_backend_with_progress(&config, None).await {
+            Ok(_) => panic!("ollama without model should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("Model required for Ollama provider"));
+    }
+
+    #[tokio::test]
+    async fn ollama_openai_requires_explicit_model_selection() {
+        let config = RaraConfig {
+            provider: "ollama-openai".to_string(),
+            model: None,
+            ..Default::default()
+        };
+
+        let err = match build_backend_with_progress(&config, None).await {
+            Ok(_) => panic!("ollama-openai without model should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err
+            .to_string()
+            .contains("Model required for Ollama OpenAI provider"));
+    }
+
+    #[test]
+    fn ollama_thinking_respects_reasoning_summary_none() {
+        let config = RaraConfig {
+            provider: "ollama".into(),
+            thinking: Some(true),
+            reasoning_summary: Some(REASONING_SUMMARY_NONE.to_string()),
+            ..Default::default()
+        };
+
+        assert!(!ollama_thinking_enabled(&config));
+    }
+
+    #[test]
+    fn ollama_thinking_defaults_on_for_auto_reasoning_summary() {
+        let config = RaraConfig {
+            provider: "ollama".into(),
+            thinking: None,
+            reasoning_summary: Some(DEFAULT_REASONING_SUMMARY.to_string()),
+            ..Default::default()
+        };
+
+        assert!(ollama_thinking_enabled(&config));
     }
 }

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -1,0 +1,329 @@
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+
+use crate::agent::Agent;
+use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, RaraConfig};
+use crate::llm::{
+    CodexBackend, GeminiBackend, LlmBackend, MockLlm, OllamaBackend, OpenAiCompatibleBackend,
+};
+use crate::local_backend::{LocalLlmBackend, LocalProgressReporter};
+use crate::prompt::PromptRuntimeConfig;
+use crate::sandbox::SandboxManager;
+use crate::session::SessionManager;
+use crate::skill::SkillManager;
+use crate::tool::ToolManager;
+use crate::tools::agent::{AgentTool, ExploreAgentTool, PlanAgentTool, TeamCreateTool};
+use crate::tools::bash::BashTool;
+use crate::tools::context::RetrieveSessionContextTool;
+use crate::tools::file::{ListFilesTool, ReadFileTool, ReplaceTool, WriteFileTool};
+use crate::tools::patch::ApplyPatchTool;
+use crate::tools::search::{GlobTool, GrepTool};
+use crate::tools::skill::SkillTool;
+use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
+use crate::tools::web::WebFetchTool;
+use crate::tools::workspace::UpdateProjectMemoryTool;
+use crate::vectordb::VectorDB;
+use crate::workspace::WorkspaceMemory;
+
+pub(crate) struct RuntimeBootstrap {
+    pub backend: Arc<dyn LlmBackend>,
+    pub vdb: Arc<VectorDB>,
+    pub session_manager: Arc<SessionManager>,
+    pub workspace: Arc<WorkspaceMemory>,
+    pub tool_manager: ToolManager,
+    pub prompt_config: PromptRuntimeConfig,
+    pub warnings: Vec<String>,
+}
+
+impl RuntimeBootstrap {
+    pub(crate) fn into_agent(self) -> Agent {
+        let (agent, _) = self.into_parts();
+        agent
+    }
+
+    pub(crate) fn into_parts(self) -> (Agent, Vec<String>) {
+        let mut agent = Agent::new(
+            self.tool_manager,
+            self.backend,
+            self.vdb,
+            self.session_manager,
+            self.workspace,
+        );
+        agent.set_prompt_config(self.prompt_config);
+        (agent, self.warnings)
+    }
+}
+
+pub(crate) async fn initialize_rara_context(
+    config: &RaraConfig,
+    progress: Option<LocalProgressReporter>,
+) -> Result<RuntimeBootstrap> {
+    let backend = build_backend_with_progress(config, progress).await?;
+    let backend: Arc<dyn LlmBackend> = backend.into();
+
+    let workspace = Arc::new(WorkspaceMemory::new()?);
+    let vdb = Arc::new(VectorDB::new(&vector_db_uri_for_workspace(&workspace)));
+    let session_manager = Arc::new(SessionManager::new()?);
+    let sandbox_manager = Arc::new(SandboxManager::new()?);
+
+    let prompt_config = PromptRuntimeConfig::from_config(config);
+    let mut warnings = prompt_config.warnings.clone();
+    let skill_manager = load_skill_manager(&mut warnings);
+
+    let tool_manager = create_full_tool_manager(
+        backend.clone(),
+        vdb.clone(),
+        session_manager.clone(),
+        workspace.clone(),
+        sandbox_manager,
+        skill_manager,
+        prompt_config.clone(),
+    );
+
+    Ok(RuntimeBootstrap {
+        backend,
+        vdb,
+        session_manager,
+        workspace,
+        tool_manager,
+        prompt_config,
+        warnings,
+    })
+}
+
+pub(crate) async fn build_runtime_bootstrap(
+    config: &RaraConfig,
+    progress: Option<LocalProgressReporter>,
+) -> Result<RuntimeBootstrap> {
+    initialize_rara_context(config, progress).await
+}
+
+pub(crate) async fn build_backend(config: &RaraConfig) -> Result<Box<dyn LlmBackend>> {
+    build_backend_with_progress(config, None).await
+}
+
+pub(crate) async fn build_backend_with_progress(
+    config: &RaraConfig,
+    progress: Option<LocalProgressReporter>,
+) -> Result<Box<dyn LlmBackend>> {
+    match config.provider.as_str() {
+        "kimi" => Ok(Box::new(OpenAiCompatibleBackend::new(
+            Some(
+                config
+                    .api_key
+                    .clone()
+                    .context("API key required for Kimi provider")?,
+            ),
+            "https://api.moonshot.cn/v1".to_string(),
+            config
+                .model
+                .clone()
+                .unwrap_or_else(|| "moonshot-v1-8k".to_string()),
+        )?)),
+        "codex" => Ok(Box::new(CodexBackend::new(
+            config.api_key.clone(),
+            config
+                .base_url
+                .clone()
+                .unwrap_or_else(|| DEFAULT_CODEX_BASE_URL.to_string()),
+            config
+                .model
+                .clone()
+                .unwrap_or_else(|| DEFAULT_CODEX_MODEL.to_string()),
+            config.reasoning_effort.clone(),
+        )?)),
+        "openai-compatible" => Ok(Box::new(OpenAiCompatibleBackend::new(
+            config.api_key.clone(),
+            config
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+            config
+                .model
+                .clone()
+                .unwrap_or_else(|| "gpt-4o-mini".to_string()),
+        )?)),
+        "ollama" | "ollama-native" => Ok(Box::new(OllamaBackend::new(
+            config
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "http://localhost:11434".to_string()),
+            config.model.clone().unwrap_or_else(|| "gemma4".to_string()),
+            config.thinking.unwrap_or(true),
+            config.num_ctx,
+        )?)),
+        "ollama-openai" => Ok(Box::new(OpenAiCompatibleBackend::new(
+            config.api_key.clone(),
+            config
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "http://localhost:11434".to_string()),
+            config.model.clone().unwrap_or_else(|| "gemma4".to_string()),
+        )?)),
+        "gemini" => Ok(Box::new(GeminiBackend {
+            api_key: config
+                .api_key
+                .clone()
+                .context("API key required for Gemini provider")?,
+            model: config
+                .model
+                .clone()
+                .unwrap_or_else(|| "gemini-1.5-pro".to_string()),
+        })),
+        "gemma4" | "qwen3" | "qwn3" | "local" | "local-candle" => {
+            let config = config.clone();
+            let progress = progress.clone();
+            let backend = tokio::task::spawn_blocking(move || {
+                LocalLlmBackend::from_config_with_progress(&config, progress)
+            })
+            .await??;
+            Ok(Box::new(backend))
+        }
+        "mock" => Ok(Box::new(MockLlm)),
+        other => bail!("Unsupported provider '{other}'"),
+    }
+}
+
+fn create_full_tool_manager(
+    backend: Arc<dyn LlmBackend>,
+    vdb: Arc<VectorDB>,
+    session_manager: Arc<SessionManager>,
+    workspace: Arc<WorkspaceMemory>,
+    sandbox: Arc<SandboxManager>,
+    skill_manager: Arc<SkillManager>,
+    prompt_config: PromptRuntimeConfig,
+) -> ToolManager {
+    let mut tm = ToolManager::new();
+    let vector_db_uri = vector_db_uri_for_workspace(&workspace);
+
+    tm.register(Box::new(BashTool {
+        sandbox: sandbox.clone(),
+    }));
+    tm.register(Box::new(ReadFileTool));
+    tm.register(Box::new(ApplyPatchTool));
+    tm.register(Box::new(WriteFileTool));
+    tm.register(Box::new(ListFilesTool));
+    tm.register(Box::new(ReplaceTool));
+    tm.register(Box::new(WebFetchTool));
+    tm.register(Box::new(GlobTool));
+    tm.register(Box::new(GrepTool));
+    tm.register(Box::new(RememberExperienceTool {
+        backend: backend.clone(),
+        db_uri: vector_db_uri.clone(),
+    }));
+    tm.register(Box::new(RetrieveExperienceTool {
+        backend: backend.clone(),
+        db_uri: vector_db_uri,
+    }));
+    tm.register(Box::new(RetrieveSessionContextTool {
+        backend: backend.clone(),
+        vdb: vdb.clone(),
+        session_manager: session_manager.clone(),
+    }));
+    tm.register(Box::new(UpdateProjectMemoryTool {
+        workspace: workspace.clone(),
+    }));
+    tm.register(Box::new(SkillTool {
+        skill_manager: skill_manager.clone(),
+    }));
+    tm.register(Box::new(AgentTool {
+        backend: backend.clone(),
+        vdb: vdb.clone(),
+        session_manager: session_manager.clone(),
+        workspace: workspace.clone(),
+        prompt_config: prompt_config.clone(),
+    }));
+    tm.register(Box::new(ExploreAgentTool {
+        backend: backend.clone(),
+        vdb: vdb.clone(),
+        session_manager: session_manager.clone(),
+        workspace: workspace.clone(),
+        prompt_config: prompt_config.clone(),
+    }));
+    tm.register(Box::new(PlanAgentTool {
+        backend: backend.clone(),
+        vdb: vdb.clone(),
+        session_manager: session_manager.clone(),
+        workspace: workspace.clone(),
+        prompt_config,
+    }));
+    tm.register(Box::new(TeamCreateTool {
+        backend,
+        vdb,
+        session_manager,
+        workspace,
+    }));
+    tm
+}
+
+fn load_skill_manager(warnings: &mut Vec<String>) -> Arc<SkillManager> {
+    let mut skill_manager = SkillManager::new();
+    if let Err(err) = skill_manager.load_all() {
+        warnings.push(format!("Skill loading failed: {err}"));
+    }
+    Arc::new(skill_manager)
+}
+
+fn vector_db_uri_for_workspace(workspace: &WorkspaceMemory) -> String {
+    workspace.rara_dir.join("lancedb").display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_backend_with_progress, initialize_rara_context, vector_db_uri_for_workspace,
+    };
+    use crate::config::RaraConfig;
+    use crate::workspace::WorkspaceMemory;
+    use tempfile::tempdir;
+
+    #[test]
+    fn vector_db_uri_is_workspace_scoped() {
+        let temp = tempdir().expect("tempdir");
+        let workspace =
+            WorkspaceMemory::from_paths(temp.path().join("repo"), temp.path().join(".rara"));
+
+        assert_eq!(
+            vector_db_uri_for_workspace(&workspace),
+            temp.path().join(".rara").join("lancedb").display().to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn initialize_rara_context_surfaces_prompt_runtime_warnings() {
+        let config = RaraConfig {
+            provider: "mock".into(),
+            system_prompt_file: Some("missing-system-prompt.md".into()),
+            ..Default::default()
+        };
+
+        let bootstrap = initialize_rara_context(&config, None)
+            .await
+            .expect("bootstrap");
+
+        assert!(
+            bootstrap
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("system prompt"))
+        );
+    }
+
+    #[tokio::test]
+    async fn unsupported_provider_returns_error() {
+        let config = RaraConfig {
+            provider: "does-not-exist".to_string(),
+            ..Default::default()
+        };
+
+        let err = match build_backend_with_progress(&config, None).await {
+            Ok(_) => panic!("unsupported provider should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err
+            .to_string()
+            .contains("Unsupported provider 'does-not-exist'"));
+    }
+}

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -270,8 +270,13 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
             "off"
         }
     } else {
-        "default"
+        "-"
     };
+    let reasoning_summary = app
+        .config
+        .reasoning_summary
+        .as_deref()
+        .unwrap_or(rara_config::DEFAULT_REASONING_SUMMARY);
     let (device, dtype) = if is_local_provider(&app.config.provider) {
         crate::local_backend::local_runtime_target()
             .unwrap_or_else(|_| ("unavailable".to_string(), "unavailable".to_string()))
@@ -279,7 +284,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
         ("remote".to_string(), "-".to_string())
     };
     format!(
-        "provider={}\nmodel={}\nbase_url={}\nrevision={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\nthinking={}\nreasoning_effort={}\ndevice={}\ndtype={}\nfocused={}\nphase={}\ndetail={}",
+        "provider={}\nmodel={}\nbase_url={}\nrevision={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\nthinking={}\nreasoning_summary={}\nreasoning_effort={}\ndevice={}\ndtype={}\nfocused={}\nphase={}\ndetail={}",
         app.config.provider,
         app.current_model_label(),
         app.config.base_url.as_deref().unwrap_or("-"),
@@ -289,6 +294,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
         mode,
         api_key_status(&app.config),
         thinking,
+        reasoning_summary,
         app.current_reasoning_effort_label(),
         device,
         dtype,

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -472,8 +472,8 @@ pub(super) async fn finish_running_task_if_ready(
             }
         }
         TaskCompletion::Rebuild { result } => match result {
-            Ok(agent) => {
-                let mut agent = agent;
+            Ok(rebuilt) => {
+                let mut agent = rebuilt.agent;
                 agent.set_execution_mode(app.agent_execution_mode);
                 agent.set_bash_approval_mode(app.bash_approval_mode);
                 app.config_manager.save(&app.config)?;
@@ -496,6 +496,9 @@ pub(super) async fn finish_running_task_if_ready(
                 app.close_overlay();
                 app.set_runtime_phase(RuntimePhase::BackendReady, Some("backend ready".into()));
                 app.push_entry("Runtime", app.setup_status.clone().unwrap_or_default());
+                for warning in rebuilt.warnings {
+                    app.push_notice(warning);
+                }
                 app.finalize_active_turn();
                 try_start_queued_follow_up(app, agent_slot);
             }

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -1,121 +1,13 @@
-use std::sync::Arc;
-
-use crate::agent::Agent;
-use crate::llm::LlmBackend;
-use crate::sandbox::SandboxManager;
-use crate::session::SessionManager;
-use crate::skill::SkillManager;
-use crate::tool::ToolManager;
-use crate::tools::agent::{AgentTool, ExploreAgentTool, PlanAgentTool, TeamCreateTool};
-use crate::tools::bash::BashTool;
-use crate::tools::context::RetrieveSessionContextTool;
-use crate::tools::file::{ListFilesTool, ReadFileTool, ReplaceTool, WriteFileTool};
-use crate::tools::patch::ApplyPatchTool;
-use crate::tools::search::{GlobTool, GrepTool};
-use crate::tools::skill::SkillTool;
-use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
-use crate::tools::web::WebFetchTool;
-use crate::tools::workspace::UpdateProjectMemoryTool;
-use crate::vectordb::VectorDB;
-use crate::workspace::WorkspaceMemory;
+use crate::tui::state::RebuildSuccess;
 
 pub(super) async fn rebuild_agent_with_progress(
     config: &crate::config::RaraConfig,
     progress: Option<crate::local_backend::LocalProgressReporter>,
-) -> anyhow::Result<Agent> {
-    let backend = crate::build_backend_with_progress(config, progress).await?;
-    let backend_arc: Arc<dyn LlmBackend> = backend.into();
-
-    let vdb = Arc::new(VectorDB::new("data/lancedb"));
-    let session_manager = Arc::new(SessionManager::new()?);
-    let workspace = Arc::new(WorkspaceMemory::new()?);
-    let sandbox_manager = Arc::new(SandboxManager::new()?);
-
-    let mut skill_manager = SkillManager::new();
-    let _ = skill_manager.load_all();
-    let skill_manager_arc = Arc::new(skill_manager);
-
-    let tool_manager = create_full_tool_manager(
-        backend_arc.clone(),
-        vdb.clone(),
-        session_manager.clone(),
-        workspace.clone(),
-        sandbox_manager.clone(),
-        skill_manager_arc,
-        crate::prompt::PromptRuntimeConfig::from_config(config),
-    );
-
-    let mut agent = Agent::new(tool_manager, backend_arc, vdb, session_manager, workspace);
-    agent.set_prompt_config(crate::prompt::PromptRuntimeConfig::from_config(config));
-    Ok(agent)
-}
-
-fn create_full_tool_manager(
-    backend: Arc<dyn LlmBackend>,
-    vdb: Arc<VectorDB>,
-    session_manager: Arc<SessionManager>,
-    workspace: Arc<WorkspaceMemory>,
-    sandbox: Arc<SandboxManager>,
-    skill_manager: Arc<SkillManager>,
-    prompt_config: crate::prompt::PromptRuntimeConfig,
-) -> ToolManager {
-    let mut tm = ToolManager::new();
-    tm.register(Box::new(BashTool {
-        sandbox: sandbox.clone(),
-    }));
-    tm.register(Box::new(ReadFileTool));
-    tm.register(Box::new(ApplyPatchTool));
-    tm.register(Box::new(WriteFileTool));
-    tm.register(Box::new(ListFilesTool));
-    tm.register(Box::new(ReplaceTool));
-    tm.register(Box::new(WebFetchTool));
-    tm.register(Box::new(GlobTool));
-    tm.register(Box::new(GrepTool));
-    tm.register(Box::new(RememberExperienceTool {
-        backend: backend.clone(),
-        db_uri: "data/lancedb".into(),
-    }));
-    tm.register(Box::new(RetrieveExperienceTool {
-        backend: backend.clone(),
-        db_uri: "data/lancedb".into(),
-    }));
-    tm.register(Box::new(RetrieveSessionContextTool {
-        backend: backend.clone(),
-        vdb: vdb.clone(),
-        session_manager: session_manager.clone(),
-    }));
-    tm.register(Box::new(UpdateProjectMemoryTool {
-        workspace: workspace.clone(),
-    }));
-    tm.register(Box::new(SkillTool {
-        skill_manager: skill_manager.clone(),
-    }));
-    tm.register(Box::new(AgentTool {
-        backend: backend.clone(),
-        vdb: vdb.clone(),
-        session_manager: session_manager.clone(),
-        workspace: workspace.clone(),
-        prompt_config: prompt_config.clone(),
-    }));
-    tm.register(Box::new(ExploreAgentTool {
-        backend: backend.clone(),
-        vdb: vdb.clone(),
-        session_manager: session_manager.clone(),
-        workspace: workspace.clone(),
-        prompt_config: prompt_config.clone(),
-    }));
-    tm.register(Box::new(PlanAgentTool {
-        backend: backend.clone(),
-        vdb: vdb.clone(),
-        session_manager: session_manager.clone(),
-        workspace: workspace.clone(),
-        prompt_config,
-    }));
-    tm.register(Box::new(TeamCreateTool {
-        backend,
-        vdb,
-        session_manager,
-        workspace,
-    }));
-    tm
+) -> anyhow::Result<RebuildSuccess> {
+    let bootstrap = crate::runtime_context::initialize_rara_context(config, progress).await?;
+    let (agent, warnings) = bootstrap.into_parts();
+    Ok(RebuildSuccess {
+        agent,
+        warnings,
+    })
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -13,11 +13,11 @@ pub use self::state_presets::{
 };
 pub use self::types::{
     ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
-    AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, HelpTab,
-    InteractionKind, LocalCommand, LocalCommandKind, OAuthLoginMode, Overlay,
+    AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, HelpTab, InteractionKind,
+    LocalCommand, LocalCommandKind, OAuthLoginMode, Overlay,
     PendingApprovalSnapshot, PendingInteractionSnapshot, ProviderFamily, RunningTask,
-    RuntimePhase, RuntimeSnapshot, TaskCompletion, TaskKind, TranscriptEntry, TranscriptTurn,
-    TuiApp, TuiEvent, PROVIDER_FAMILIES,
+    RebuildSuccess, RuntimePhase, RuntimeSnapshot, TaskCompletion, TaskKind, TranscriptEntry,
+    TranscriptTurn, TuiApp, TuiEvent, PROVIDER_FAMILIES,
 };
 use self::types::CommittedTranscriptRenderCache;
 use super::queued_input::PendingFollowUpMessage;
@@ -439,8 +439,7 @@ impl TuiApp {
     }
 
     pub fn sync_snapshot(&mut self, agent: &Agent) {
-        let (cwd, branch) = agent.workspace.get_env_info();
-        let effective_prompt = agent.effective_prompt();
+        let runtime_context = agent.shared_runtime_context();
         let existing_plan_completion = self
             .completed_interaction(InteractionKind::PlanApproval)
             .cloned();
@@ -528,59 +527,37 @@ impl TuiApp {
             );
         }
         self.snapshot = RuntimeSnapshot {
-            cwd,
-            branch,
-            session_id: agent.session_id.clone(),
-            history_len: agent.history.len(),
-            total_input_tokens: agent.total_input_tokens,
-            total_output_tokens: agent.total_output_tokens,
-            estimated_history_tokens: agent.compact_state.estimated_history_tokens,
-            context_window_tokens: agent.compact_state.context_window_tokens,
-            compact_threshold_tokens: agent.compact_state.compact_threshold_tokens,
-            reserved_output_tokens: agent.compact_state.reserved_output_tokens,
-            compaction_count: agent.compact_state.compaction_count,
-            last_compaction_before_tokens: agent.compact_state.last_compaction_before_tokens,
-            last_compaction_after_tokens: agent.compact_state.last_compaction_after_tokens,
-            last_compaction_recent_files: agent.compact_state.last_compaction_recent_files.clone(),
-            last_compaction_boundary_version: agent
-                .compact_state
-                .last_compaction_boundary
-                .map(|boundary| boundary.version),
-            last_compaction_boundary_before_tokens: agent
-                .compact_state
-                .last_compaction_boundary
-                .map(|boundary| boundary.before_tokens),
-            last_compaction_boundary_recent_file_count: agent
-                .compact_state
-                .last_compaction_boundary
-                .map(|boundary| boundary.recent_file_count),
-            plan_steps: agent
-                .current_plan
-                .iter()
-                .map(|step| {
-                    let status = match step.status {
-                        crate::agent::PlanStepStatus::Pending => "pending",
-                        crate::agent::PlanStepStatus::InProgress => "in_progress",
-                        crate::agent::PlanStepStatus::Completed => "completed",
-                    };
-                    (status.to_string(), step.step.clone())
-                })
-                .collect(),
-            plan_explanation: agent.plan_explanation.clone(),
+            cwd: runtime_context.cwd,
+            branch: runtime_context.branch,
+            session_id: runtime_context.session_id,
+            history_len: runtime_context.history_len,
+            total_input_tokens: runtime_context.total_input_tokens,
+            total_output_tokens: runtime_context.total_output_tokens,
+            estimated_history_tokens: runtime_context.compaction.estimated_history_tokens,
+            context_window_tokens: runtime_context.compaction.context_window_tokens,
+            compact_threshold_tokens: runtime_context.compaction.compact_threshold_tokens,
+            reserved_output_tokens: runtime_context.compaction.reserved_output_tokens,
+            compaction_count: runtime_context.compaction.compaction_count,
+            last_compaction_before_tokens: runtime_context.compaction.last_compaction_before_tokens,
+            last_compaction_after_tokens: runtime_context.compaction.last_compaction_after_tokens,
+            last_compaction_recent_files: runtime_context.compaction.last_compaction_recent_files,
+            last_compaction_boundary_version: runtime_context
+                .compaction
+                .last_compaction_boundary_version,
+            last_compaction_boundary_before_tokens: runtime_context
+                .compaction
+                .last_compaction_boundary_before_tokens,
+            last_compaction_boundary_recent_file_count: runtime_context
+                .compaction
+                .last_compaction_boundary_recent_file_count,
+            plan_steps: runtime_context.plan.steps,
+            plan_explanation: runtime_context.plan.explanation,
             pending_interactions,
             completed_interactions,
-            prompt_base_kind: effective_prompt.base_prompt_kind.label().to_string(),
-            prompt_section_keys: effective_prompt
-                .section_keys
-                .iter()
-                .map(|key| (*key).to_string())
-                .collect(),
-            prompt_source_status_lines: effective_prompt
-                .sources
-                .iter()
-                .map(|source| source.status_line())
-                .collect(),
-            prompt_warnings: agent.prompt_config().warnings.clone(),
+            prompt_base_kind: runtime_context.prompt.base_prompt_kind,
+            prompt_section_keys: runtime_context.prompt.section_keys,
+            prompt_source_status_lines: runtime_context.prompt.source_status_lines,
+            prompt_warnings: runtime_context.prompt.warnings,
         };
         self.agent_execution_mode = agent.execution_mode;
         self.bash_approval_mode = agent.bash_approval_mode;

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -202,12 +202,17 @@ pub enum TaskCompletion {
         result: anyhow::Result<bool>,
     },
     Rebuild {
-        result: anyhow::Result<Agent>,
+        result: anyhow::Result<RebuildSuccess>,
     },
     OAuth {
         mode: OAuthLoginMode,
         result: anyhow::Result<secrecy::SecretString>,
     },
+}
+
+pub struct RebuildSuccess {
+    pub agent: Agent,
+    pub warnings: Vec<String>,
 }
 
 pub enum TuiEvent {


### PR DESCRIPTION
## Summary

- unify runtime bootstrap behind `initialize_rara_context(...)` so `main.rs` and TUI rebuilds share the same backend/workspace/tool/session setup path
- introduce a shared runtime context contract for prompt/plan/compaction views and have TUI snapshots consume it directly
- replace provider-scoped `thinking: bool` as the generic reasoning surface with provider-scoped `reasoning_summary`, defaulting to concise `auto` with legacy migration

## Testing

- `cargo test runtime_context::tests -- --nocapture`
- `cargo test agent::tests::context_view -- --nocapture`
- `cargo test -p rara-config -- --nocapture`
- `cargo check`
