### PR TITLE
feat(tui): add context command and command parity

### DIFF
--- a/.tmp-pr50.md
+++ b/.tmp-pr50.md
@@ -1,0 +1,27 @@
+## Summary
+
+- add a Claude-style `/context` command and overlay for inspecting active runtime context
+- align slash-command surfaces toward Codex/Claude behavior with alphabetical display ordering
+- tighten live transcript rendering for responding cards, exploration ordering, and resume hints
+
+## What Changed
+
+- add `/context` parsing, help text, command execution, and context modal rendering
+- sort built-in command display surfaces alphabetically without changing implementation order
+- make command palette and help command lists use stateful scrolling behavior
+- render live responding output as a stable response card
+- preserve `Exploring -> Agent -> Exploring` ordering instead of merging exploration blocks
+- add `rara resume [session_id]` and print an exact resume hint when exiting TUI
+
+## Validation
+
+- `cargo test parses_context_command -- --nocapture`
+- `cargo test palette_commands_are_sorted_alphabetically_for_empty_query -- --nocapture`
+- `cargo test help_text_lists_built_in_commands_alphabetically -- --nocapture`
+- `cargo test status_context_text_includes_prompt_sources_and_plan_state -- --nocapture`
+- `cargo test active_turn_cell_preserves_exploration_agent_exploration_order -- --nocapture`
+- `cargo test active_turn_cell_renders_live_response_as_card -- --nocapture`
+- `cargo test resume_hint_includes_exact_command -- --nocapture`
+- `cargo test clap_parses_resume_command_with_optional_session_id -- --nocapture`
+- `cargo test command_palette_state_scrolls_to_selected_item -- --nocapture`
+- `cargo check`

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,14 @@ struct Cli {
     revision: Option<String>,
 }
 
-#[derive(Subcommand)]
+#[derive(Subcommand, Debug)]
 enum Commands {
     Acp,
     Ask {
         prompt: String,
+    },
+    Resume {
+        session_id: Option<String>,
     },
     Login {
         #[arg(long)]
@@ -104,6 +107,9 @@ async fn main_impl() -> Result<()> {
     match cli.command.unwrap_or(Commands::Tui) {
         Commands::Acp => run_acp_command(&config).await?,
         Commands::Ask { prompt } => run_ask_command(&config, prompt).await?,
+        Commands::Resume { session_id } => {
+            run_tui_command(&config, oauth_manager, session_id).await?
+        }
         Commands::Login {
             device_auth,
             with_api_key,
@@ -116,7 +122,7 @@ async fn main_impl() -> Result<()> {
         )
         .await?,
         Commands::Logout => run_logout_command(&mut config, &config_manager, &oauth_manager)?,
-        Commands::Tui => run_tui_command(&config, oauth_manager).await?,
+        Commands::Tui => run_tui_command(&config, oauth_manager, None).await?,
     }
     Ok(())
 }
@@ -139,11 +145,23 @@ async fn run_ask_command(config: &RaraConfig, prompt: String) -> Result<()> {
     agent.query(prompt).await
 }
 
-async fn run_tui_command(config: &RaraConfig, oauth_manager: OAuthManager) -> Result<()> {
+async fn run_tui_command(
+    config: &RaraConfig,
+    oauth_manager: OAuthManager,
+    resume_session_id: Option<String>,
+) -> Result<()> {
     let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
     emit_bootstrap_warnings(&bootstrap.warnings);
     let agent = bootstrap.into_agent();
-    crate::tui::run_tui(agent, oauth_manager).await
+    let resumed_session_id = crate::tui::run_tui(agent, oauth_manager, resume_session_id).await?;
+    if let Some(session_id) = resumed_session_id {
+        println!("{}", resume_hint(&session_id));
+    }
+    Ok(())
+}
+
+fn resume_hint(session_id: &str) -> String {
+    format!("Resume this session with: rara resume {session_id}")
 }
 
 async fn run_login_command(
@@ -220,6 +238,38 @@ fn run_logout_command(
         println!("No saved Codex credential was present.");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resume_hint_includes_exact_command() {
+        assert_eq!(
+            resume_hint("session-123"),
+            "Resume this session with: rara resume session-123"
+        );
+    }
+
+    #[test]
+    fn clap_parses_resume_command_with_optional_session_id() {
+        let cli = Cli::try_parse_from(["rara", "resume", "session-123"]).expect("parse resume");
+        match cli.command.expect("command") {
+            Commands::Resume { session_id } => {
+                assert_eq!(session_id.as_deref(), Some("session-123"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+
+        let cli = Cli::try_parse_from(["rara", "resume"]).expect("parse resume without id");
+        match cli.command.expect("command") {
+            Commands::Resume { session_id } => {
+                assert_eq!(session_id, None);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
 }
 
 fn emit_bootstrap_warnings(warnings: &[String]) {

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -168,12 +168,10 @@ pub fn recommended_commands(app: &TuiApp) -> Vec<&'static CommandSpec> {
             "status", "help", "clear", "setup",
         ]
     };
-    let mut commands = names
+    names
         .iter()
         .filter_map(|name| command_spec_by_name(name))
-        .collect::<Vec<_>>();
-    commands.sort_by_key(|spec| spec.name);
-    commands
+        .collect()
 }
 
 pub fn recent_command_specs(app: &TuiApp) -> Vec<&'static CommandSpec> {
@@ -348,6 +346,22 @@ pub fn status_context_text(app: &TuiApp) -> String {
             .join("\n")
     };
 
+    let last_boundary = if let Some(version) = app.snapshot.last_compaction_boundary_version {
+        let before = app
+            .snapshot
+            .last_compaction_boundary_before_tokens
+            .map(|tokens| tokens.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let files = app
+            .snapshot
+            .last_compaction_boundary_recent_file_count
+            .map(|count| count.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        format!("v{version} before_tokens={before} recent_file_count={files}")
+    } else {
+        "-".to_string()
+    };
+
     let mut sections = vec![
         format!(
             "Current Session\n  cwd: {}\n  branch: {}\n  session: {}\n  history messages: {}\n  transcript entries: {}",
@@ -384,21 +398,7 @@ pub fn status_context_text(app: &TuiApp) -> String {
                 .last_compaction_after_tokens
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "-".to_string()),
-            app.snapshot
-                .last_compaction_boundary_version
-                .map(|value| format!(
-                    "v{} before_tokens={} recent_file_count={}",
-                    value,
-                    app.snapshot
-                        .last_compaction_boundary_before_tokens
-                        .map(|tokens| tokens.to_string())
-                        .unwrap_or_else(|| "-".to_string()),
-                    app.snapshot
-                        .last_compaction_boundary_recent_file_count
-                        .map(|count| count.to_string())
-                        .unwrap_or_else(|| "-".to_string())
-                ))
-                .unwrap_or_else(|| "-".to_string())
+            last_boundary
         ),
         format!("Pending Interaction\n{}", pending_interactions),
     ];

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -1,11 +1,11 @@
 use crate::config::RaraConfig;
 
 use super::state::{
-    current_model_presets, CommandSpec, LocalCommand, LocalCommandKind, ProviderFamily, TuiApp,
-    PROVIDER_FAMILIES,
+    current_model_presets, CommandSpec, LocalCommand, LocalCommandKind, PendingInteractionSnapshot,
+    ProviderFamily, TuiApp, PROVIDER_FAMILIES,
 };
 
-pub const COMMAND_SPECS: [CommandSpec; 13] = [
+pub const COMMAND_SPECS: [CommandSpec; 14] = [
     CommandSpec {
         category: "Session",
         name: "help",
@@ -19,6 +19,13 @@ pub const COMMAND_SPECS: [CommandSpec; 13] = [
         usage: "/status",
         summary: "Show current provider, model, revision, workspace, and runtime counters.",
         detail: "Open a runtime status modal with provider, model, revision, workspace, session, token counters, and cache location.",
+    },
+    CommandSpec {
+        category: "Session",
+        name: "context",
+        usage: "/context",
+        summary: "Inspect the effective runtime context for the current turn.",
+        detail: "Open a context modal that explains the effective prompt sources, active sections, workspace/runtime state, plan state, compaction metadata, and pending interaction inputs for the current turn.",
     },
     CommandSpec {
         category: "Session",
@@ -113,6 +120,7 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
     let kind = match name {
         "help" => LocalCommandKind::Help,
         "status" => LocalCommandKind::Status,
+        "context" => LocalCommandKind::Context,
         "clear" => LocalCommandKind::Clear,
         "resume" => LocalCommandKind::Resume,
         "plan" => LocalCommandKind::Plan,
@@ -153,17 +161,19 @@ pub fn command_spec_by_name(name: &str) -> Option<&'static CommandSpec> {
 
 pub fn recommended_commands(app: &TuiApp) -> Vec<&'static CommandSpec> {
     let names: &[&str] = if app.is_busy() {
-        &["status", "help", "clear"]
+        &["status", "context", "help", "clear"]
     } else {
         &[
-            "compact", "resume", "plan", "approval", "model", "base-url", "login", "logout",
+            "compact", "resume", "plan", "approval", "context", "model", "base-url", "login", "logout",
             "status", "help", "clear", "setup",
         ]
     };
-    names
+    let mut commands = names
         .iter()
         .filter_map(|name| command_spec_by_name(name))
-        .collect()
+        .collect::<Vec<_>>();
+    commands.sort_by_key(|spec| spec.name);
+    commands
 }
 
 pub fn recent_command_specs(app: &TuiApp) -> Vec<&'static CommandSpec> {
@@ -184,8 +194,11 @@ pub fn palette_commands(app: &TuiApp, query: &str) -> Vec<&'static CommandSpec> 
             commands.push(spec);
         }
     }
+    commands.sort_by_key(|spec| spec.name);
     if commands.is_empty() {
-        COMMAND_SPECS.iter().collect()
+        let mut commands = COMMAND_SPECS.iter().collect::<Vec<_>>();
+        commands.sort_by_key(|spec| spec.name);
+        commands
     } else {
         commands
     }
@@ -204,7 +217,7 @@ pub fn command_detail_text(spec: &CommandSpec) -> String {
 }
 
 pub fn general_help_text() -> &'static str {
-    "RARA uses a single composer as the control surface.\n\nNormal input goes to the current agent.\nSlash commands stay local and open overlays or update runtime state.\n\nCompaction:\n  /compact forces one history compaction pass\n\nModes:\n  /plan enters planning mode for the current task\n  RARA may suggest planning mode first for non-trivial repository work\n  /approval toggles bash approval between suggestion and always\n\nAuth:\n  /login opens the provider auth picker\n  /logout clears the saved provider credential\n\nEditing:\n  apply_patch is the default tool for updating existing files\n  write_file is for new files or full rewrites\n  replace is only a simple fallback for unique string swaps\n\nKeyboard:\n  Enter submit current composer input\n  Esc close the current overlay only\n  Up/Down or j/k move inside lists\n  1/2/3 switch help tabs or choose guided model options\n\nExit:\n  /quit or /exit leave the TUI."
+    "RARA uses a single composer as the control surface.\n\nNormal input goes to the current agent.\nSlash commands stay local and open overlays or update runtime state.\n\nCompaction:\n  /compact forces one history compaction pass\n\nContext:\n  /context shows the effective runtime context for the current turn\n\nModes:\n  /plan enters planning mode for the current task\n  RARA may suggest planning mode first for non-trivial repository work\n  /approval toggles bash approval between suggestion and always\n\nAuth:\n  /login opens the provider auth picker\n  /logout clears the saved provider credential\n\nEditing:\n  apply_patch is the default tool for updating existing files\n  write_file is for new files or full rewrites\n  replace is only a simple fallback for unique string swaps\n\nKeyboard:\n  Enter submit current composer input\n  Esc close the current overlay only\n  Up/Down or j/k move inside lists\n  1/2/3 switch help tabs or choose guided model options\n\nExit:\n  /quit or /exit leave the TUI."
 }
 
 fn command_score(spec: &CommandSpec, query: &str) -> Option<u8> {
@@ -244,8 +257,10 @@ fn subsequence_match(haystack: &str, needle: &str) -> bool {
 }
 
 pub fn help_text() -> String {
-    let commands = COMMAND_SPECS
-        .iter()
+    let mut specs = COMMAND_SPECS.iter().collect::<Vec<_>>();
+    specs.sort_by_key(|spec| spec.name);
+    let commands = specs
+        .into_iter()
         .map(|spec| format!("  {}  {}", spec.usage, spec.summary))
         .collect::<Vec<_>>()
         .join("\n");
@@ -253,6 +268,144 @@ pub fn help_text() -> String {
         "Built-in commands:\n{}\n\nCompaction:\n  /compact   summarize older conversation history now\n\nSessions:\n  /resume    reopen a recent local session\n\nModes:\n  /plan      enter planning mode for the current task\n  RARA may suggest planning mode for non-trivial tasks\n  /approval  toggle bash approval mode\n\nAuth:\n  /login     open the provider auth picker\n  /logout    clear the saved provider credential\n\nEditing:\n  apply_patch  preferred for editing existing files\n  write_file   use for new files or full rewrites\n  replace      simple fallback for unique string replacement\n\nKeyboard:\n  Enter submit\n  Esc close current overlay\n  S open setup\n\nExit:\n  /quit\n  /exit\n\nModel switching:\n  /model\n\nProvider URL:\n  /base-url",
         commands
     )
+}
+
+fn format_pending_interaction(snapshot: &PendingInteractionSnapshot) -> String {
+    let kind = match snapshot.kind {
+        super::state::InteractionKind::RequestInput => "request_input",
+        super::state::InteractionKind::Approval => "approval",
+        super::state::InteractionKind::PlanApproval => "plan_approval",
+    };
+    let mut lines = vec![format!(
+        "- kind={kind} title={} summary={}",
+        snapshot.title,
+        if snapshot.summary.is_empty() {
+            "-"
+        } else {
+            snapshot.summary.as_str()
+        }
+    )];
+    if !snapshot.options.is_empty() {
+        lines.push(format!("  options={}", snapshot.options.len()));
+    }
+    if let Some(source) = snapshot.source.as_deref() {
+        lines.push(format!("  source={source}"));
+    }
+    if let Some(note) = snapshot.note.as_deref() {
+        lines.push(format!("  note={note}"));
+    }
+    lines.join("\n")
+}
+
+pub fn status_context_text(app: &TuiApp) -> String {
+    let active_sections = if app.snapshot.prompt_section_keys.is_empty() {
+        "-".to_string()
+    } else {
+        app.snapshot.prompt_section_keys.join(", ")
+    };
+    let prompt_sources = if app.snapshot.prompt_source_status_lines.is_empty() {
+        "  - No prompt sources discovered.".to_string()
+    } else {
+        app.snapshot
+            .prompt_source_status_lines
+            .iter()
+            .map(|line| format!("  - {line}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let prompt_warnings = if app.snapshot.prompt_warnings.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "Warnings:\n{}",
+            app.snapshot
+                .prompt_warnings
+                .iter()
+                .map(|warning| format!("  - {warning}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ))
+    };
+    let plan_lines = if app.snapshot.plan_steps.is_empty() {
+        "  - No active plan steps.".to_string()
+    } else {
+        app.snapshot
+            .plan_steps
+            .iter()
+            .map(|(status, step)| format!("  - [{status}] {step}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let pending_interactions = if app.snapshot.pending_interactions.is_empty() {
+        "  - None.".to_string()
+    } else {
+        app.snapshot
+            .pending_interactions
+            .iter()
+            .map(format_pending_interaction)
+            .map(|entry| format!("  {entry}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let mut sections = vec![
+        format!(
+            "Current Session\n  cwd: {}\n  branch: {}\n  session: {}\n  history messages: {}\n  transcript entries: {}",
+            app.snapshot.cwd,
+            app.snapshot.branch,
+            app.snapshot.session_id,
+            app.snapshot.history_len,
+            app.transcript_entry_count(),
+        ),
+        format!(
+            "Included Now\n  base prompt: {}\n  active sections: {}\n  sources:\n{}",
+            app.snapshot.prompt_base_kind, active_sections, prompt_sources
+        ),
+        format!(
+            "Plan State\n  explanation: {}\n{}",
+            app.snapshot.plan_explanation.as_deref().unwrap_or("-"),
+            plan_lines
+        ),
+        format!(
+            "Compaction State\n  estimated history tokens: {}\n  context window: {}\n  threshold: {}\n  reserved output: {}\n  compactions: {}\n  last compaction: {} -> {}\n  last boundary: {}",
+            app.snapshot.estimated_history_tokens,
+            app.snapshot
+                .context_window_tokens
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            app.snapshot.compact_threshold_tokens,
+            app.snapshot.reserved_output_tokens,
+            app.snapshot.compaction_count,
+            app.snapshot
+                .last_compaction_before_tokens
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            app.snapshot
+                .last_compaction_after_tokens
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
+            app.snapshot
+                .last_compaction_boundary_version
+                .map(|value| format!(
+                    "v{} before_tokens={} recent_file_count={}",
+                    value,
+                    app.snapshot
+                        .last_compaction_boundary_before_tokens
+                        .map(|tokens| tokens.to_string())
+                        .unwrap_or_else(|| "-".to_string()),
+                    app.snapshot
+                        .last_compaction_boundary_recent_file_count
+                        .map(|count| count.to_string())
+                        .unwrap_or_else(|| "-".to_string())
+                ))
+                .unwrap_or_else(|| "-".to_string())
+        ),
+        format!("Pending Interaction\n{}", pending_interactions),
+    ];
+    if let Some(warnings) = prompt_warnings {
+        sections.insert(2, warnings);
+    }
+    sections.join("\n\n")
 }
 
 pub fn status_runtime_text(app: &TuiApp) -> String {
@@ -494,14 +647,15 @@ fn download_stage_index(stage: &str) -> usize {
 }
 
 pub fn quick_actions_text() -> &'static str {
-    "/help      browse commands and keyboard hints\n\
-     /model     open guided model switching\n\
+    "/approval  toggle bash approval mode\n\
      /base-url  open the provider URL editor\n\
-     /status    inspect runtime and workspace\n\
-     /plan      enter planning mode for the current task\n\
-     /approval  toggle bash approval mode\n\
      /clear     reset the visible transcript\n\
+     /context   inspect effective runtime context\n\
+     /help      browse commands and keyboard hints\n\
+     /model     open guided model switching\n\
+     /plan      enter planning mode for the current task\n\
      /setup     open fallback setup\n\
+     /status    inspect runtime and workspace\n\
      /quit      leave the TUI"
 }
 
@@ -646,8 +800,8 @@ pub fn normalize_command_token(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        matching_commands, normalize_command_token, parse_local_command, status_resources_text,
-        LocalCommandKind,
+        help_text, matching_commands, normalize_command_token, palette_commands,
+        parse_local_command, status_context_text, status_resources_text, LocalCommandKind,
     };
     use crate::config::ConfigManager;
     use crate::tui::state::{RuntimeSnapshot, TuiApp};
@@ -658,6 +812,13 @@ mod tests {
         let command = parse_local_command("/model anything").expect("command should parse");
         assert!(matches!(command.kind, LocalCommandKind::Model));
         assert_eq!(command.arg.as_deref(), Some("anything"));
+    }
+
+    #[test]
+    fn parses_context_command() {
+        let command = parse_local_command("/context").expect("command should parse");
+        assert!(matches!(command.kind, LocalCommandKind::Context));
+        assert!(command.arg.is_none());
     }
 
     #[test]
@@ -743,6 +904,38 @@ mod tests {
     }
 
     #[test]
+    fn palette_commands_are_sorted_alphabetically_for_empty_query() {
+        let dir = tempdir().expect("tempdir");
+        let app = TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app");
+
+        let names = palette_commands(&app, "")
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect::<Vec<_>>();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn help_text_lists_built_in_commands_alphabetically() {
+        let rendered = help_text();
+        let approval_idx = rendered.find("/approval").expect("approval");
+        let base_url_idx = rendered.find("/base-url").expect("base-url");
+        let clear_idx = rendered.find("/clear").expect("clear");
+        let compact_idx = rendered.find("/compact").expect("compact");
+        let context_idx = rendered.find("/context").expect("context");
+
+        assert!(approval_idx < base_url_idx);
+        assert!(base_url_idx < clear_idx);
+        assert!(clear_idx < compact_idx);
+        assert!(compact_idx < context_idx);
+    }
+
+    #[test]
     fn status_resources_text_includes_recent_compacted_files() {
         let dir = tempdir().expect("tempdir");
         let cm = ConfigManager {
@@ -770,5 +963,33 @@ mod tests {
         assert!(rendered.contains(
             "recent_compact_files=src/agent/compact.rs, crates/instructions/src/prompt.rs"
         ));
+    }
+
+    #[test]
+    fn status_context_text_includes_prompt_sources_and_plan_state() {
+        let dir = tempdir().expect("tempdir");
+        let cm = ConfigManager {
+            path: dir.path().join("config.json"),
+        };
+        let mut app = TuiApp::new(cm).expect("app");
+        app.snapshot = RuntimeSnapshot {
+            cwd: "/workspace/rara".into(),
+            branch: "main".into(),
+            session_id: "session-123".into(),
+            prompt_base_kind: "codex".into(),
+            prompt_section_keys: vec!["stable_instructions".into(), "workspace".into()],
+            prompt_source_status_lines: vec![
+                "AGENTS.md from workspace root".into(),
+                "workspace instruction file".into(),
+            ],
+            plan_steps: vec![("pending".into(), "Implement /context".into())],
+            ..RuntimeSnapshot::default()
+        };
+
+        let rendered = status_context_text(&app);
+        assert!(rendered.contains("Current Session"));
+        assert!(rendered.contains("Included Now"));
+        assert!(rendered.contains("AGENTS.md from workspace root"));
+        assert!(rendered.contains("[pending] Implement /context"));
     }
 }

--- a/src/tui/custom_terminal.rs
+++ b/src/tui/custom_terminal.rs
@@ -41,7 +41,7 @@ use ratatui::layout::Rect;
 use ratatui::layout::Size;
 use ratatui::style::Color;
 use ratatui::style::Modifier;
-use ratatui::widgets::Widget;
+use ratatui::widgets::{StatefulWidget, Widget};
 use unicode_width::UnicodeWidthStr;
 
 /// Returns the display width of a cell symbol, ignoring OSC escape sequences.
@@ -122,6 +122,15 @@ impl Frame<'_> {
 
     pub fn render_widget<W: Widget>(&mut self, widget: W, area: Rect) {
         widget.render(area, self.buffer);
+    }
+
+    pub fn render_stateful_widget<W: StatefulWidget>(
+        &mut self,
+        widget: W,
+        area: Rect,
+        state: &mut W::State,
+    ) {
+        widget.render(area, self.buffer, state);
     }
 
     /// After drawing this frame, make the cursor visible and put it at the specified (x, y)

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -25,6 +25,10 @@ pub(super) fn map_key_to_event(key: KeyCode, app: &TuiApp) -> AppEvent {
             KeyCode::Esc | KeyCode::Enter => AppEvent::CloseOverlay,
             _ => AppEvent::Noop,
         },
+        Some(Overlay::Context) => match key {
+            KeyCode::Esc | KeyCode::Enter => AppEvent::CloseOverlay,
+            _ => AppEvent::Noop,
+        },
         Some(Overlay::Setup) => match key {
             KeyCode::Esc => AppEvent::CloseOverlay,
             KeyCode::Char('1') => AppEvent::SetModelSelection(0),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -57,7 +57,11 @@ use self::terminal_ui::{
 use crate::agent::AgentExecutionMode;
 use crate::agent::BashApprovalMode;
 
-pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Result<()> {
+pub async fn run_tui(
+    agent: Agent,
+    oauth_manager: OAuthManager,
+    resume_session_id: Option<String>,
+) -> anyhow::Result<Option<String>> {
     enable_raw_mode()?;
     let initial_size = terminal_size()?;
     let mut app = TuiApp::new(crate::config::ConfigManager::new()?)?;
@@ -67,8 +71,12 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
     match StateDb::new() {
         Ok(state_db) => {
             let state_db = Arc::new(state_db);
-            restore_latest_session(&state_db, &mut app, &mut agent_slot)?;
-            app.attach_state_db(state_db);
+            app.attach_state_db(Arc::clone(&state_db));
+            if let Some(session_id) = resume_session_id.as_deref() {
+                restore_session_by_id(session_id, &mut app, &mut agent_slot)?;
+            } else {
+                restore_latest_session(&state_db, &mut app, &mut agent_slot)?;
+            }
         }
         Err(err) => app.set_state_db_error(err.to_string()),
     }
@@ -81,7 +89,7 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
     }
     app.start_repo_context_detection();
 
-    let result = loop {
+    let result: anyhow::Result<()> = loop {
         app.finish_repo_context_task_if_ready().await;
         finish_running_task_if_ready(&mut app, &mut agent_slot).await?;
         clamp_command_palette_selection(&mut app);
@@ -140,7 +148,16 @@ pub async fn run_tui(agent: Agent, oauth_manager: OAuthManager) -> anyhow::Resul
         handle.abort();
     }
     teardown_terminal(terminal)?;
-    result
+    result?;
+
+    let session_id = agent_slot
+        .as_ref()
+        .map(|agent| agent.session_id.clone())
+        .filter(|session_id| !session_id.is_empty())
+        .or_else(|| {
+            (!app.snapshot.session_id.is_empty()).then(|| app.snapshot.session_id.clone())
+        });
+    Ok(session_id)
 }
 
 

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -39,9 +39,85 @@ pub(crate) trait ActiveCell {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>>;
 }
 
+enum OrderedActiveSegment<'a> {
+    Exploration(Vec<String>),
+    Agent(&'a str),
+}
+
 fn trim_trailing_empty_lines(lines: &mut Vec<Line<'static>>) {
     while matches!(lines.last(), Some(line) if line.spans.iter().all(|span| span.content == "")) {
         lines.pop();
+    }
+}
+
+fn ordered_exploration_agent_segments<'a>(
+    current_turn: &[&'a TranscriptEntry],
+) -> Option<Vec<OrderedActiveSegment<'a>>> {
+    let mut segments = Vec::new();
+    let mut exploration_items = Vec::new();
+    let mut saw_interleaving = false;
+
+    let flush_exploration =
+        |segments: &mut Vec<OrderedActiveSegment<'a>>, items: &mut Vec<String>| {
+            if !items.is_empty() {
+                segments.push(OrderedActiveSegment::Exploration(std::mem::take(items)));
+            }
+        };
+
+    for entry in current_turn {
+        match entry.role.as_str() {
+            "Tool" => {
+                if let Some(action) = super::exploration_action_label(&entry.message) {
+                    if !exploration_items.iter().any(|existing| existing == &action) {
+                        exploration_items.push(action);
+                    }
+                }
+            }
+            "Exploring" => {
+                for item in entry
+                    .message
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(|line| {
+                        line.trim_start_matches("└")
+                            .trim_start_matches("•")
+                            .trim()
+                            .to_string()
+                    })
+                    .filter(|line| !line.is_empty())
+                {
+                    if !exploration_items.iter().any(|existing| existing == &item) {
+                        exploration_items.push(item);
+                    }
+                }
+            }
+            "Agent" => {
+                if !exploration_items.is_empty() {
+                    saw_interleaving = true;
+                    flush_exploration(&mut segments, &mut exploration_items);
+                }
+                segments.push(OrderedActiveSegment::Agent(entry.message.as_str()));
+            }
+            _ => {}
+        }
+    }
+
+    flush_exploration(&mut segments, &mut exploration_items);
+
+    let exploration_group_count = segments
+        .iter()
+        .filter(|segment| matches!(segment, OrderedActiveSegment::Exploration(_)))
+        .count();
+    let agent_count = segments
+        .iter()
+        .filter(|segment| matches!(segment, OrderedActiveSegment::Agent(_)))
+        .count();
+
+    if saw_interleaving && exploration_group_count >= 2 && agent_count >= 1 {
+        Some(segments)
+    } else {
+        None
     }
 }
 
@@ -302,12 +378,45 @@ impl ActiveCell for ActiveTurnCell<'_> {
             cells.push(Box::new(PlanModeCell));
         }
 
+        let ordered_exploration_agent_segments = if !has_live_exploration
+            && !has_live_planning
+            && !has_live_running
+        {
+            ordered_exploration_agent_segments(current_turn.as_slice())
+        } else {
+            None
+        };
+        let uses_ordered_exploration_agent_segments =
+            ordered_exploration_agent_segments.is_some();
+
+        if let Some(segments) = ordered_exploration_agent_segments.as_ref() {
+            for segment in segments {
+                match segment {
+                    OrderedActiveSegment::Exploration(items) => {
+                        let summary =
+                            compact_summary_lines(items.as_slice(), 4, "more exploration step(s)");
+                        cells.push(Box::new(ExploringCell::new(summary, turn_live)));
+                    }
+                    OrderedActiveSegment::Agent(message) => {
+                        cells.push(Box::new(MessageCell::new(
+                            "Agent",
+                            message,
+                            usize::MAX,
+                            self.cwd,
+                        )));
+                    }
+                }
+            }
+        }
+
         let explicit_exploration = current_turn
             .iter()
             .find(|entry| entry.role == "Exploring")
             .map(|entry| entry.message.clone());
 
-        let exploration_summary = if has_live_exploration {
+        let exploration_summary = if uses_ordered_exploration_agent_segments {
+            None
+        } else if has_live_exploration {
             let mut items = self
                 .app
                 .active_live
@@ -479,7 +588,10 @@ impl ActiveCell for ActiveTurnCell<'_> {
             && self.app.pending_command_approval().is_none()
             && self.app.pending_planning_suggestion.is_none();
 
-        if has_agent_stream
+        if uses_ordered_exploration_agent_segments {
+            // Preserve chronological "explore -> agent -> explore" segments without
+            // reintroducing the latest agent/tool fallback below.
+        } else if has_agent_stream
             && !suppress_intermediate_agent
             && !suppress_planning_chatter
             && !suppress_structured_plan_response

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -105,16 +105,11 @@ fn ordered_exploration_agent_segments<'a>(
 
     flush_exploration(&mut segments, &mut exploration_items);
 
-    let exploration_group_count = segments
-        .iter()
-        .filter(|segment| matches!(segment, OrderedActiveSegment::Exploration(_)))
-        .count();
-    let agent_count = segments
-        .iter()
-        .filter(|segment| matches!(segment, OrderedActiveSegment::Agent(_)))
-        .count();
+    let simple_exploration_then_agent = segments.len() == 2
+        && matches!(segments.first(), Some(OrderedActiveSegment::Exploration(_)))
+        && matches!(segments.last(), Some(OrderedActiveSegment::Agent(_)));
 
-    if saw_interleaving && exploration_group_count >= 2 && agent_count >= 1 {
+    if saw_interleaving || (segments.len() > 1 && !simple_exploration_then_agent) {
         Some(segments)
     } else {
         None

--- a/src/tui/render/cells_components.rs
+++ b/src/tui/render/cells_components.rs
@@ -381,11 +381,23 @@ impl<'a> RespondingCell<'a> {
 }
 
 impl HistoryCell for RespondingCell<'_> {
-    fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
         match &self.content {
-            RespondingCellContent::Stream(stream_lines) => {
-                rendered_markdown_lines("Responding", stream_lines, usize::MAX)
-            }
+            RespondingCellContent::Stream(stream_lines) => responding_card_lines(
+                "Responding",
+                markdown_body_lines(stream_lines, usize::MAX),
+                width,
+            ),
+            RespondingCellContent::Message {
+                role,
+                message,
+                max_lines,
+                cwd,
+            } if *role == "Responding" => responding_card_lines(
+                "Responding",
+                formatted_message_lines("Agent", message, *max_lines, *cwd),
+                width,
+            ),
             RespondingCellContent::Message {
                 role,
                 message,
@@ -398,10 +410,47 @@ impl HistoryCell for RespondingCell<'_> {
                 max_lines,
             } => prefixed_message_lines(role, message, *max_lines),
             RespondingCellContent::Working(detail) => {
-                vec![Line::from("Responding"), Line::from(format!("  {detail}"))]
+                responding_card_lines("Responding", vec![Line::from((*detail).to_string())], width)
             }
         }
     }
+}
+
+fn markdown_body_lines(rendered: &[Line<'static>], max_lines: usize) -> Vec<Line<'static>> {
+    let mut lines = rendered_markdown_lines("Responding", rendered, max_lines);
+    if !lines.is_empty() {
+        lines.remove(0);
+    }
+    if lines.is_empty() {
+        lines.push(Line::from(String::new()));
+    }
+    lines
+}
+
+fn responding_card_lines(
+    title: &'static str,
+    mut body_lines: Vec<Line<'static>>,
+    width: u16,
+) -> Vec<Line<'static>> {
+    if body_lines.is_empty() {
+        body_lines.push(Line::from(String::new()));
+    }
+
+    let available_inner_width = usize::from(width.saturating_sub(4).max(1));
+    let inner_width = body_lines
+        .iter()
+        .map(|line| {
+            line.iter()
+                .map(|span| display_width(span.content.as_ref()))
+                .sum::<usize>()
+        })
+        .max()
+        .unwrap_or(1)
+        .clamp(1, available_inner_width.max(1));
+
+    let mut lines = vec![Line::from(section_span(title, Color::Cyan))];
+    lines.extend(with_border(body_lines, inner_width));
+    lines
 }
 
 pub(super) struct MessageCell<'a> {

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -514,6 +514,47 @@ fn active_turn_cell_preserves_exploration_agent_exploration_order() {
 }
 
 #[test]
+fn active_turn_cell_preserves_agent_then_exploration_order() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Inspect the bootstrap path".into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "I have narrowed this down to the runtime bootstrap path.".into(),
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "read_file src/runtime_context.rs".into(),
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let agent = rendered
+        .find("• I have narrowed this down to the runtime bootstrap path.")
+        .unwrap();
+    let exploring = rendered.find(" Exploring ").unwrap();
+
+    assert!(rendered.contains("Read src/runtime_context.rs"));
+    assert!(agent < exploring);
+}
+
+#[test]
 fn active_turn_cell_uses_responding_label_while_busy() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -462,6 +462,58 @@ fn active_turn_cell_uses_explicit_sidecar_entries_when_live_state_is_empty() {
 }
 
 #[test]
+fn active_turn_cell_preserves_exploration_agent_exploration_order() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Inspect the repository".into(),
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "read_file src/main.rs".into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "The main entrypoint is thin; I will inspect the runtime bootstrap next."
+                    .into(),
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "read_file src/runtime_context.rs".into(),
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let first_exploring = rendered.find(" Exploring ").unwrap();
+    let agent = rendered
+        .find("• The main entrypoint is thin; I will inspect the runtime bootstrap next.")
+        .unwrap();
+    let second_exploring = rendered[first_exploring + 1..]
+        .find(" Exploring ")
+        .map(|idx| first_exploring + 1 + idx)
+        .unwrap();
+
+    assert!(rendered.contains("Read src/main.rs"));
+    assert!(rendered.contains("Read src/runtime_context.rs"));
+    assert!(first_exploring < agent);
+    assert!(agent < second_exploring);
+}
+
+#[test]
 fn active_turn_cell_uses_responding_label_while_busy() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
@@ -493,7 +545,46 @@ fn active_turn_cell_uses_responding_label_while_busy() {
         .join("\n");
 
     assert!(rendered.contains("Responding"));
-    assert!(!rendered.contains("• I have inspected"));
+    assert!(rendered.contains("╭"));
+    assert!(rendered.contains("╰"));
+    assert!(rendered.contains("• I have inspected"));
+    assert!(!rendered.contains("Agent:"));
+}
+
+#[test]
+fn active_turn_cell_renders_live_response_as_card() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::ProcessingResponse;
+    app.runtime_phase_detail = Some("waiting for model response".into());
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Review this repository".into(),
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "I have inspected the main module and will continue with the tool layer."
+                    .into(),
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains(" Responding ") || rendered.contains("Responding"));
+    assert!(rendered.contains("╭"));
+    assert!(rendered.contains("╰"));
+    assert!(rendered.contains("• I have inspected the main module"));
 }
 
 #[test]

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -120,7 +120,7 @@ fn active_turn_cell_keeps_exploration_notes_inside_exploring_block() {
         "rendered_exploration_notes=\n{rendered}"
     );
     assert!(rendered.contains("Read src/main.rs"));
-    assert!(!rendered.contains(
+    assert!(rendered.contains(
         "I have inspected the repository structure and will now inspect the core modules."
     ));
     assert!(!rendered.contains("waiting for model response · 12s elapsed"));

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -5,14 +5,15 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Flex, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Tabs, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Tabs, Wrap},
 };
 
 use super::super::command::{
     command_detail_text, command_spec_by_index, current_turn_preview, download_status_text,
     general_help_text, help_text, matching_commands, model_help_text,
     palette_command_by_index, palette_commands, quick_actions_text, recent_transcript_preview,
-    status_prompt_sources_text, status_resources_text, status_runtime_text, status_workspace_text,
+    status_context_text, status_prompt_sources_text, status_resources_text, status_runtime_text,
+    status_workspace_text,
 };
 use super::super::custom_terminal::Frame;
 use super::super::interaction_text::status_active_pending_interaction_text;
@@ -42,6 +43,10 @@ pub(super) fn render_overlay(
         }
         Overlay::Status => {
             render_status_modal(f, app, popup);
+            None
+        }
+        Overlay::Context => {
+            render_context_modal(f, app, popup);
             None
         }
         Overlay::Setup => {
@@ -120,28 +125,27 @@ fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
             let query = app.input.trim_start().trim_start_matches('/');
             let items = matching_commands(query)
                 .into_iter()
-                .enumerate()
-                .map(|(idx, spec)| {
-                    let style = if idx == app.command_palette_idx {
-                        Style::default()
-                            .fg(Color::Cyan)
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default()
-                    };
-                    ListItem::new(format!("{}  {}", spec.usage, spec.summary)).style(style)
-                })
+                .map(command_palette_item)
                 .collect::<Vec<_>>();
             let detail = command_spec_by_index(query, app.command_palette_idx)
                 .map(command_detail_text)
                 .unwrap_or_else(help_text);
-            f.render_widget(
-                List::new(items).block(
-                    Block::default()
-                        .borders(Borders::LEFT | Borders::RIGHT)
-                        .title(" Commands "),
-                ),
+            let mut state = command_palette_list_state(app.command_palette_idx);
+            f.render_stateful_widget(
+                List::new(items)
+                    .highlight_style(
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .highlight_symbol("› ")
+                    .block(
+                        Block::default()
+                            .borders(Borders::LEFT | Borders::RIGHT)
+                            .title(" Commands "),
+                    ),
                 inner[0],
+                &mut state,
             );
             f.render_widget(
                 Paragraph::new(detail)
@@ -264,13 +268,22 @@ fn render_command_palette(f: &mut Frame, app: &TuiApp, area: Rect) {
         ),
         chunks[0],
     );
-    f.render_widget(
-        List::new(items).block(
-            Block::default()
-                .borders(Borders::LEFT | Borders::RIGHT)
-                .title(" Matches "),
-        ),
+    let mut state = command_palette_list_state(app.command_palette_idx);
+    f.render_stateful_widget(
+        List::new(items)
+            .highlight_style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("› ")
+            .block(
+                Block::default()
+                    .borders(Borders::LEFT | Borders::RIGHT)
+                    .title(" Matches "),
+            ),
         body[0],
+        &mut state,
     );
     let detail = palette_command_by_index(app, query, app.command_palette_idx)
         .map(command_preview_text)
@@ -288,60 +301,78 @@ fn render_command_palette(f: &mut Frame, app: &TuiApp, area: Rect) {
     );
 }
 
+fn command_palette_list_state(selected_index: usize) -> ListState {
+    let mut state = ListState::default();
+    state.select(Some(selected_index));
+    state
+}
+
 fn palette_items_for_empty_query(app: &TuiApp) -> Vec<ListItem<'static>> {
     palette_commands(app, "")
         .into_iter()
-        .enumerate()
-        .map(|(idx, spec)| command_palette_item(idx, app.command_palette_idx, spec))
+        .map(command_palette_item)
         .collect()
 }
 
-fn palette_items_for_matches(app: &TuiApp, query: &str) -> Vec<ListItem<'static>> {
+fn palette_items_for_matches(_app: &TuiApp, query: &str) -> Vec<ListItem<'static>> {
     matching_commands(query)
         .into_iter()
-        .enumerate()
-        .scan(None::<&'static str>, |last_category, (idx, spec)| {
-            let mut lines = Vec::new();
-            if *last_category != Some(spec.category) {
-                lines.push(Line::from(Span::styled(
-                    format!("{} commands", spec.category),
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::BOLD),
-                )));
-                *last_category = Some(spec.category);
-            }
-            let style = if idx == app.command_palette_idx {
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default()
-            };
-            lines.push(Line::from(format!("{}  {}", spec.usage, spec.summary)));
-            lines.push(Line::from(""));
-            Some(ListItem::new(lines).style(style))
-        })
+        .map(command_palette_item)
         .collect()
 }
 
-fn command_palette_item(
-    index: usize,
-    selected_index: usize,
-    spec: &CommandSpec,
-) -> ListItem<'static> {
-    let style = if index == selected_index {
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
-    };
-    ListItem::new(vec![
-        Line::from(format!("{}  {}", spec.usage, spec.summary)),
-        Line::from(""),
+fn command_palette_item(spec: &CommandSpec) -> ListItem<'static> {
+    ListItem::new(command_palette_line(spec))
+}
+
+fn command_palette_line(spec: &CommandSpec) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{:<12}", spec.usage),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!("{}  ", spec.summary)),
+        Span::styled(
+            format!("[{}]", spec.category),
+            Style::default().fg(Color::DarkGray),
+        ),
     ])
-    .style(style)
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::{buffer::Buffer, layout::Rect};
+    use ratatui::widgets::StatefulWidget;
+
+    use super::*;
+    use crate::tui::command::COMMAND_SPECS;
+
+    #[test]
+    fn command_palette_state_scrolls_to_selected_item() {
+        let items = (0..20)
+            .map(|idx| ListItem::new(format!("item {idx}")))
+            .collect::<Vec<_>>();
+        let area = Rect::new(0, 0, 20, 5);
+        let mut buffer = Buffer::empty(area);
+        let mut state = command_palette_list_state(10);
+
+        List::new(items).render(area, &mut buffer, &mut state);
+
+        assert!(state.offset() > 0);
+    }
+
+    #[test]
+    fn command_palette_line_is_compact_single_row() {
+        let spec = &COMMAND_SPECS[0];
+        let line = command_palette_line(spec).to_string();
+
+        assert!(line.contains(spec.usage));
+        assert!(line.contains(spec.summary));
+        assert!(line.contains(spec.category));
+        assert!(!line.contains('\n'));
+    }
 }
 
 fn render_status_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
@@ -468,6 +499,29 @@ fn render_status_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
         Paragraph::new("Esc close  Enter close  /help commands  /model switch runtime")
             .alignment(Alignment::Center),
         chunks[5],
+    );
+}
+
+fn render_context_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(8), Constraint::Length(2)])
+        .split(area);
+
+    f.render_widget(
+        Paragraph::new(status_context_text(app))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Context "),
+            )
+            .wrap(Wrap { trim: false }),
+        chunks[0],
+    );
+    f.render_widget(
+        Paragraph::new("Esc close  /context re-open  /status runtime details")
+            .alignment(Alignment::Center),
+        chunks[1],
     );
 }
 

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -13,57 +13,22 @@ pub(super) async fn execute_local_command(
     oauth_manager: &Arc<OAuthManager>,
 ) -> anyhow::Result<bool> {
     app.remember_command(match command.kind {
-        LocalCommandKind::Help => "help",
-        LocalCommandKind::Status => "status",
-        LocalCommandKind::Clear => "clear",
-        LocalCommandKind::Resume => "resume",
-        LocalCommandKind::Plan => "plan",
         LocalCommandKind::Approval => "approval",
-        LocalCommandKind::Compact => "compact",
-        LocalCommandKind::Setup => "setup",
-        LocalCommandKind::Model => "model",
         LocalCommandKind::BaseUrl => "base-url",
+        LocalCommandKind::Clear => "clear",
+        LocalCommandKind::Compact => "compact",
+        LocalCommandKind::Context => "context",
+        LocalCommandKind::Help => "help",
         LocalCommandKind::Login => "login",
         LocalCommandKind::Logout => "logout",
+        LocalCommandKind::Model => "model",
+        LocalCommandKind::Plan => "plan",
         LocalCommandKind::Quit => "quit",
+        LocalCommandKind::Resume => "resume",
+        LocalCommandKind::Setup => "setup",
+        LocalCommandKind::Status => "status",
     });
     match command.kind {
-        LocalCommandKind::Help => {
-            app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening help".into()));
-            app.open_overlay(Overlay::Help(HelpTab::General));
-        }
-        LocalCommandKind::Status => {
-            app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening status".into()));
-            app.open_overlay(Overlay::Status);
-        }
-        LocalCommandKind::Clear => {
-            app.set_runtime_phase(
-                RuntimePhase::LocalCommand,
-                Some("clearing transcript".into()),
-            );
-            app.reset_transcript();
-        }
-        LocalCommandKind::Resume => {
-            app.set_runtime_phase(
-                RuntimePhase::LocalCommand,
-                Some("opening resume picker".into()),
-            );
-            app.open_overlay(Overlay::ResumePicker);
-        }
-        LocalCommandKind::Plan => {
-            app.set_runtime_phase(
-                RuntimePhase::LocalCommand,
-                Some("entering planning mode".into()),
-            );
-            app.set_pending_plan_approval(false);
-            app.set_agent_execution_mode(AgentExecutionMode::Plan);
-            if let Some(agent) = agent_slot.as_mut() {
-                agent.set_execution_mode(AgentExecutionMode::Plan);
-            }
-            app.push_notice(
-                "Planning mode enabled. Use the next prompt to analyze, refine, or finalize a plan.",
-            );
-        }
         LocalCommandKind::Approval => {
             let next_mode = match app.bash_approval_mode {
                 BashApprovalMode::Suggestion => BashApprovalMode::Always,
@@ -85,6 +50,18 @@ pub(super) async fn execute_local_command(
             );
             app.push_notice(notice);
         }
+        LocalCommandKind::BaseUrl => handle_base_url_command(command.arg.as_deref(), app)?,
+        LocalCommandKind::Help => {
+            app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening help".into()));
+            app.open_overlay(Overlay::Help(HelpTab::General));
+        }
+        LocalCommandKind::Clear => {
+            app.set_runtime_phase(
+                RuntimePhase::LocalCommand,
+                Some("clearing transcript".into()),
+            );
+            app.reset_transcript();
+        }
         LocalCommandKind::Compact => {
             if let Some(agent) = agent_slot.take() {
                 start_compact_task(app, agent);
@@ -92,12 +69,10 @@ pub(super) async fn execute_local_command(
                 app.push_notice("No active agent available for compaction.");
             }
         }
-        LocalCommandKind::Setup => {
-            app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening setup".into()));
-            app.open_overlay(Overlay::Setup);
+        LocalCommandKind::Context => {
+            app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening context".into()));
+            app.open_overlay(Overlay::Context);
         }
-        LocalCommandKind::Model => handle_model_command(command.arg.as_deref(), app)?,
-        LocalCommandKind::BaseUrl => handle_base_url_command(command.arg.as_deref(), app)?,
         LocalCommandKind::Login => {
             if app.is_busy() {
                 app.push_notice("A task is already running. Wait for it to finish.");
@@ -122,9 +97,39 @@ pub(super) async fn execute_local_command(
                 }
             }
         }
+        LocalCommandKind::Model => handle_model_command(command.arg.as_deref(), app)?,
+        LocalCommandKind::Plan => {
+            app.set_runtime_phase(
+                RuntimePhase::LocalCommand,
+                Some("entering planning mode".into()),
+            );
+            app.set_pending_plan_approval(false);
+            app.set_agent_execution_mode(AgentExecutionMode::Plan);
+            if let Some(agent) = agent_slot.as_mut() {
+                agent.set_execution_mode(AgentExecutionMode::Plan);
+            }
+            app.push_notice(
+                "Planning mode enabled. Use the next prompt to analyze, refine, or finalize a plan.",
+            );
+        }
         LocalCommandKind::Quit => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("quitting".into()));
             return Ok(true);
+        }
+        LocalCommandKind::Resume => {
+            app.set_runtime_phase(
+                RuntimePhase::LocalCommand,
+                Some("opening resume picker".into()),
+            );
+            app.open_overlay(Overlay::ResumePicker);
+        }
+        LocalCommandKind::Setup => {
+            app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening setup".into()));
+            app.open_overlay(Overlay::Setup);
+        }
+        LocalCommandKind::Status => {
+            app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening status".into()));
+            app.open_overlay(Overlay::Status);
         }
     }
     if let Some(agent) = agent_slot.as_ref() {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -28,6 +28,7 @@ pub enum Overlay {
     Help(HelpTab),
     CommandPalette,
     Status,
+    Context,
     Setup,
     ProviderPicker,
     ModelPicker,
@@ -51,6 +52,7 @@ pub enum ProviderFamily {
 pub enum LocalCommandKind {
     Help,
     Status,
+    Context,
     Clear,
     Resume,
     Plan,


### PR DESCRIPTION
## Summary

- add a Claude-style `/context` command and overlay for inspecting active runtime context
- align slash-command surfaces toward Codex/Claude behavior with alphabetical display ordering
- tighten live transcript rendering for responding cards, exploration ordering, and resume hints

## What Changed

- add `/context` parsing, help text, command execution, and context modal rendering
- sort built-in command display surfaces alphabetically without changing implementation order
- make command palette and help command lists use stateful scrolling behavior
- render live responding output as a stable response card
- preserve `Exploring -> Agent -> Exploring` ordering instead of merging exploration blocks
- add `rara resume [session_id]` and print an exact resume hint when exiting TUI

## Validation

- `cargo test parses_context_command -- --nocapture`
- `cargo test palette_commands_are_sorted_alphabetically_for_empty_query -- --nocapture`
- `cargo test help_text_lists_built_in_commands_alphabetically -- --nocapture`
- `cargo test status_context_text_includes_prompt_sources_and_plan_state -- --nocapture`
- `cargo test active_turn_cell_preserves_exploration_agent_exploration_order -- --nocapture`
- `cargo test active_turn_cell_renders_live_response_as_card -- --nocapture`
- `cargo test resume_hint_includes_exact_command -- --nocapture`
- `cargo test clap_parses_resume_command_with_optional_session_id -- --nocapture`
- `cargo test command_palette_state_scrolls_to_selected_item -- --nocapture`
- `cargo check`
