### PR TITLE
fix(tui): keep transcript tail when folding long messages

### DIFF
--- a/.tmp-pr-transcript-tail-folding.md
+++ b/.tmp-pr-transcript-tail-folding.md
@@ -1,0 +1,12 @@
+## Summary
+
+- preserve both the opening line and latest lines when long transcript messages are folded
+- apply the same head-tail folding rule to plain prefixed rows and markdown-rendered agent/system rows
+- add focused transcript rendering tests for the new folding behavior
+
+## Testing
+
+- cargo test prefixed_message_lines_keep_first_and_latest_lines -- --nocapture
+- cargo test formatted_agent_markdown_keeps_first_and_latest_lines -- --nocapture
+- cargo test compact_summary_text_keeps_tail_of_long_explicit_blocks -- --nocapture
+- cargo check

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -400,16 +400,14 @@ pub(crate) fn prefixed_message_lines(
     }
 
     let mut lines = Vec::new();
+    let hidden_count = truncated_line_count(message_lines.len(), max_lines);
     let (head, tail) = head_tail_line_window(message_lines.as_slice(), max_lines);
     if let Some(first) = head.first() {
         lines.push(Line::from(format!("{role}: {first}")));
     }
-    if !tail.is_empty() {
+    if hidden_count > 0 {
         lines.push(Line::from(Span::styled(
-            format!(
-                "  ... {} more line(s)",
-                truncated_line_count(message_lines.len(), max_lines)
-            ),
+            format!("  ... {} more line(s)", hidden_count),
             Style::default().fg(Color::DarkGray),
         )));
     }
@@ -427,16 +425,14 @@ fn user_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
     }
 
     let mut lines = Vec::new();
+    let hidden_count = truncated_line_count(message_lines.len(), max_lines);
     let (head, tail) = head_tail_line_window(message_lines.as_slice(), max_lines);
     if let Some(first) = head.first() {
         lines.push(Line::from(format!("› {first}")));
     }
-    if !tail.is_empty() {
+    if hidden_count > 0 {
         lines.push(Line::from(Span::styled(
-            format!(
-                "  ... {} more line(s)",
-                truncated_line_count(message_lines.len(), max_lines)
-            ),
+            format!("  ... {} more line(s)", hidden_count),
             Style::default().fg(Color::DarkGray),
         )));
     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -369,6 +369,22 @@ pub(crate) fn compact_summary_text(summary: &str, max_visible: usize, more_label
     compact_summary_lines(items.as_slice(), max_visible, more_label)
 }
 
+fn truncated_line_count(total: usize, max_lines: usize) -> usize {
+    total.saturating_sub(max_lines)
+}
+
+fn head_tail_line_window<T>(items: &[T], max_lines: usize) -> (&[T], &[T]) {
+    if max_lines == usize::MAX || items.len() <= max_lines {
+        return (items, &[]);
+    }
+    if max_lines <= 1 {
+        return (&items[..1], &[]);
+    }
+
+    let tail_len = max_lines - 1;
+    (&items[..1], &items[items.len() - tail_len..])
+}
+
 pub(crate) fn prefixed_message_lines(
     role: &str,
     message: &str,
@@ -383,25 +399,24 @@ pub(crate) fn prefixed_message_lines(
         return vec![Line::from(format!("{role}:"))];
     }
 
-    let capped = if max_lines == usize::MAX {
-        message_lines.len()
-    } else {
-        max_lines
-    };
-
     let mut lines = Vec::new();
-    if let Some(first) = message_lines.first() {
+    let (head, tail) = head_tail_line_window(message_lines.as_slice(), max_lines);
+    if let Some(first) = head.first() {
         lines.push(Line::from(format!("{role}: {first}")));
     }
-    for line in message_lines.iter().skip(1).take(capped.saturating_sub(1)) {
-        lines.push(Line::from(format!("  {line}")));
-    }
-    if message_lines.len() > capped {
+    if !tail.is_empty() {
         lines.push(Line::from(Span::styled(
-            format!("  ... {} more line(s)", message_lines.len() - capped),
+            format!(
+                "  ... {} more line(s)",
+                truncated_line_count(message_lines.len(), max_lines)
+            ),
             Style::default().fg(Color::DarkGray),
         )));
     }
+    lines.extend(
+        tail.iter()
+            .map(|line| Line::from(format!("  {line}"))),
+    );
     lines
 }
 
@@ -411,25 +426,24 @@ fn user_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
         return vec![Line::from("›")];
     }
 
-    let capped = if max_lines == usize::MAX {
-        message_lines.len()
-    } else {
-        max_lines
-    };
-
     let mut lines = Vec::new();
-    if let Some(first) = message_lines.first() {
+    let (head, tail) = head_tail_line_window(message_lines.as_slice(), max_lines);
+    if let Some(first) = head.first() {
         lines.push(Line::from(format!("› {first}")));
     }
-    for line in message_lines.iter().skip(1).take(capped.saturating_sub(1)) {
-        lines.push(Line::from(format!("  {line}")));
-    }
-    if message_lines.len() > capped {
+    if !tail.is_empty() {
         lines.push(Line::from(Span::styled(
-            format!("  ... {} more line(s)", message_lines.len() - capped),
+            format!(
+                "  ... {} more line(s)",
+                truncated_line_count(message_lines.len(), max_lines)
+            ),
             Style::default().fg(Color::DarkGray),
         )));
     }
+    lines.extend(
+        tail.iter()
+            .map(|line| Line::from(format!("  {line}"))),
+    );
     lines
 }
 
@@ -461,23 +475,25 @@ fn bulleted_markdown_message_lines(
         return vec![Line::from("•")];
     }
 
-    let capped = if max_lines == usize::MAX {
-        rendered.len()
-    } else {
-        max_lines.min(rendered.len())
-    };
+    let hidden_count = truncated_line_count(rendered_len, max_lines);
+    let (head, tail) = head_tail_line_window(rendered.as_slice(), max_lines);
 
     let mut lines = prefix_lines(
-        rendered.into_iter().take(capped).collect(),
+        head.iter().cloned().collect(),
         Span::styled("• ", Style::default().add_modifier(Modifier::DIM)),
         Span::raw("  "),
     );
-    if capped < rendered_len {
+    if hidden_count > 0 {
         lines.push(Line::from(Span::styled(
-            format!("  ... {} more line(s)", rendered_len - capped),
+            format!("  ... {} more line(s)", hidden_count),
             Style::default().fg(Color::DarkGray),
         )));
     }
+    lines.extend(prefix_lines(
+        tail.iter().cloned().collect(),
+        Span::raw("  "),
+        Span::raw("  "),
+    ));
     lines
 }
 
@@ -495,25 +511,26 @@ fn markdown_message_lines(
         return vec![Line::from(role.to_string())];
     }
 
-    let capped = if max_lines == usize::MAX {
-        rendered.len()
-    } else {
-        max_lines.min(rendered.len())
-    };
-
     let mut lines = vec![Line::from(role.to_string())];
+    let hidden_count = truncated_line_count(rendered_len, max_lines);
+    let (head, tail) = head_tail_line_window(rendered.as_slice(), max_lines);
     let prefixed = prefix_lines(
-        rendered.into_iter().take(capped).collect(),
+        head.iter().cloned().collect(),
         Span::raw("  "),
         Span::raw("  "),
     );
     lines.extend(prefixed);
-    if capped < rendered_len {
+    if hidden_count > 0 {
         lines.push(Line::from(Span::styled(
-            format!("  ... {} more line(s)", rendered_len - capped),
+            format!("  ... {} more line(s)", hidden_count),
             Style::default().fg(Color::DarkGray),
         )));
     }
+    lines.extend(prefix_lines(
+        tail.iter().cloned().collect(),
+        Span::raw("  "),
+        Span::raw("  "),
+    ));
     lines
 }
 

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -11,8 +11,9 @@ use super::viewport::TranscriptViewport;
 use super::{
     committed_turn_cell, compact_progress_summary_lines, compact_recent_first_summary_lines,
     compact_summary_text, current_turn_exploration_summary_from_entries, current_turn_tool_summary,
-    desired_bottom_pane_height, desired_viewport_height, renderable_transcript_lines,
-    transcript_scroll_offset, transcript_viewport, transcript_visual_row_count,
+    desired_bottom_pane_height, desired_viewport_height, formatted_message_lines,
+    prefixed_message_lines, renderable_transcript_lines, transcript_scroll_offset,
+    transcript_viewport, transcript_visual_row_count,
 };
 
 #[test]
@@ -518,4 +519,47 @@ fn compact_summary_text_keeps_tail_of_long_explicit_blocks() {
     assert!(!rendered.contains("src/a.rs"));
     assert!(rendered.contains("src/b.rs"));
     assert!(rendered.contains("src/e.rs"));
+}
+
+#[test]
+fn prefixed_message_lines_keep_first_and_latest_lines() {
+    let rendered = prefixed_message_lines(
+        "Agent",
+        &["intro", "middle 1", "middle 2", "latest 1", "latest 2"].join("\n"),
+        3,
+    )
+    .into_iter()
+    .map(|line| line.to_string())
+    .collect::<Vec<_>>();
+
+    assert_eq!(rendered[0], "Agent: intro");
+    assert_eq!(rendered[1], "  ... 2 more line(s)");
+    assert_eq!(rendered[2], "  latest 1");
+    assert_eq!(rendered[3], "  latest 2");
+}
+
+#[test]
+fn formatted_agent_markdown_keeps_first_and_latest_lines() {
+    let rendered = formatted_message_lines(
+        "Agent",
+        &[
+            "first line",
+            "middle 1",
+            "middle 2",
+            "latest 1",
+            "latest 2",
+        ]
+        .join("\n"),
+        3,
+        Some(Path::new(".")),
+    )
+    .into_iter()
+    .map(|line| line.to_string())
+    .collect::<Vec<_>>();
+
+    assert!(rendered.iter().any(|line| line.contains("first line")));
+    assert!(rendered.iter().any(|line| line.contains("... 2 more line(s)")));
+    assert!(rendered.iter().any(|line| line.contains("latest 1")));
+    assert!(rendered.iter().any(|line| line.contains("latest 2")));
+    assert!(!rendered.iter().any(|line| line.contains("middle 1")));
 }

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -539,6 +539,23 @@ fn prefixed_message_lines_keep_first_and_latest_lines() {
 }
 
 #[test]
+fn prefixed_message_lines_show_truncation_when_max_lines_is_one() {
+    let agent_rendered = prefixed_message_lines("Agent", &["intro", "latest 1"].join("\n"), 1)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(agent_rendered[0], "Agent: intro");
+    assert_eq!(agent_rendered[1], "  ... 1 more line(s)");
+
+    let user_rendered = prefixed_message_lines("You", &["intro", "latest 1"].join("\n"), 1)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(user_rendered[0], "› intro");
+    assert_eq!(user_rendered[1], "  ... 1 more line(s)");
+}
+
+#[test]
 fn formatted_agent_markdown_keeps_first_and_latest_lines() {
     let rendered = formatted_message_lines(
         "Agent",


### PR DESCRIPTION
## Summary

- preserve both the opening line and latest lines when long transcript messages are folded
- apply the same head-tail folding rule to plain prefixed rows and markdown-rendered agent/system rows
- add focused transcript rendering tests for the new folding behavior

## Testing

- cargo test prefixed_message_lines_keep_first_and_latest_lines -- --nocapture
- cargo test formatted_agent_markdown_keeps_first_and_latest_lines -- --nocapture
- cargo test compact_summary_text_keeps_tail_of_long_explicit_blocks -- --nocapture
- cargo check
