### PR TITLE
feat(tui): simplify openai-compatible profile management

### DIFF
--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -36,6 +36,7 @@ pub enum AppEvent {
     SaveApiKeyInput,
     SaveModelNameInput,
     SaveOpenAiProfileLabelInput,
+    DeleteOpenAiProfile,
     SelectHelpTab(HelpTab),
     ApplyOverlaySelection,
 }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -105,13 +105,13 @@ pub(super) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             {
                 AppEvent::OpenOverlay(Overlay::ModelNameEditor)
             }
-            KeyCode::Char('p')
+            KeyCode::Char('d')
                 if matches!(
                     app.selected_provider_family(),
                     ProviderFamily::OpenAiCompatible
                 ) =>
             {
-                AppEvent::OpenOverlay(Overlay::OpenAiProfilePicker)
+                AppEvent::DeleteOpenAiProfile
             }
             KeyCode::Enter => AppEvent::ApplyOverlaySelection,
             _ => AppEvent::Noop,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -320,25 +320,30 @@ async fn dispatch_event(
             {
                 if app.selected_provider_family() == self::state::ProviderFamily::OpenAiCompatible {
                     match app.selected_openai_model_picker_action() {
-                        Some(OpenAiModelPickerAction::Setup) => {
+                        Some(OpenAiModelPickerAction::CreateProfile) => {
                             app.begin_openai_profile_setup();
                         }
-                        Some(OpenAiModelPickerAction::Profiles) => {
-                            app.open_overlay(Overlay::OpenAiProfilePicker);
+                        Some(OpenAiModelPickerAction::SelectProfile) => {
+                            if let Some(label) = app.select_openai_model_picker_profile() {
+                                app.config_manager.save(&app.config)?;
+                                if app.openai_profile_needs_setup() {
+                                    app.notice =
+                                        Some(format!("Selected endpoint profile: {label}"));
+                                    app.begin_active_openai_profile_setup();
+                                } else {
+                                    start_rebuild_task(app);
+                                }
+                            }
                         }
-                        Some(OpenAiModelPickerAction::ApiKey) => {
-                            app.open_overlay(Overlay::ApiKeyEditor);
+                        Some(OpenAiModelPickerAction::DeleteProfile) => {
+                            if let Some(label) = app.delete_active_openai_profile() {
+                                app.config_manager.save(&app.config)?;
+                                app.notice = Some(format!("Deleted endpoint profile: {label}"));
+                            } else {
+                                app.push_notice("Cannot delete the only endpoint profile.");
+                            }
                         }
-                        Some(OpenAiModelPickerAction::BaseUrl) => {
-                            app.open_overlay(Overlay::BaseUrlEditor);
-                        }
-                        Some(OpenAiModelPickerAction::ModelName) => {
-                            app.open_overlay(Overlay::ModelNameEditor);
-                        }
-                        None => {
-                            app.select_local_model(app.model_picker_idx);
-                            start_rebuild_task(app);
-                        }
+                        None => {}
                     }
                 } else if should_open_codex_auth_guide(app, oauth_manager.as_ref()) {
                     app.select_local_model(app.model_picker_idx);
@@ -548,8 +553,18 @@ async fn dispatch_event(
                     app.config_manager.save(&app.config)?;
                     app.notice = Some(format!("Created endpoint profile: {label}"));
                     app.openai_profile_label_kind = None;
-                    app.overlay = Some(Overlay::ModelPicker);
+                    app.begin_active_openai_profile_setup();
                 }
+            }
+        }
+        AppEvent::DeleteOpenAiProfile => {
+            if app.is_busy() {
+                app.push_notice("Wait for the current task before deleting a profile.");
+            } else if let Some(label) = app.delete_active_openai_profile() {
+                app.config_manager.save(&app.config)?;
+                app.notice = Some(format!("Deleted endpoint profile: {label}"));
+            } else {
+                app.push_notice("Cannot delete the only endpoint profile.");
             }
         }
         AppEvent::SelectHelpTab(tab) => {
@@ -653,25 +668,30 @@ async fn dispatch_event(
                         == self::state::ProviderFamily::OpenAiCompatible
                     {
                         match app.selected_openai_model_picker_action() {
-                            Some(OpenAiModelPickerAction::Setup) => {
+                            Some(OpenAiModelPickerAction::CreateProfile) => {
                                 app.begin_openai_profile_setup();
                             }
-                            Some(OpenAiModelPickerAction::Profiles) => {
-                                app.open_overlay(Overlay::OpenAiProfilePicker);
+                            Some(OpenAiModelPickerAction::SelectProfile) => {
+                                if let Some(label) = app.select_openai_model_picker_profile() {
+                                    app.config_manager.save(&app.config)?;
+                                    if app.openai_profile_needs_setup() {
+                                        app.notice =
+                                            Some(format!("Selected endpoint profile: {label}"));
+                                        app.begin_active_openai_profile_setup();
+                                    } else {
+                                        start_rebuild_task(app);
+                                    }
+                                }
                             }
-                            Some(OpenAiModelPickerAction::ApiKey) => {
-                                app.open_overlay(Overlay::ApiKeyEditor);
+                            Some(OpenAiModelPickerAction::DeleteProfile) => {
+                                if let Some(label) = app.delete_active_openai_profile() {
+                                    app.config_manager.save(&app.config)?;
+                                    app.notice = Some(format!("Deleted endpoint profile: {label}"));
+                                } else {
+                                    app.push_notice("Cannot delete the only endpoint profile.");
+                                }
                             }
-                            Some(OpenAiModelPickerAction::BaseUrl) => {
-                                app.open_overlay(Overlay::BaseUrlEditor);
-                            }
-                            Some(OpenAiModelPickerAction::ModelName) => {
-                                app.open_overlay(Overlay::ModelNameEditor);
-                            }
-                            None => {
-                                app.select_local_model(app.model_picker_idx);
-                                start_rebuild_task(app);
-                            }
+                            None => {}
                         }
                     } else {
                         app.select_local_model(app.model_picker_idx);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -319,31 +319,8 @@ async fn dispatch_event(
                 && !app.is_busy()
             {
                 if app.selected_provider_family() == self::state::ProviderFamily::OpenAiCompatible {
-                    match app.selected_openai_model_picker_action() {
-                        Some(OpenAiModelPickerAction::CreateProfile) => {
-                            app.begin_openai_profile_setup();
-                        }
-                        Some(OpenAiModelPickerAction::SelectProfile) => {
-                            if let Some(label) = app.select_openai_model_picker_profile() {
-                                app.config_manager.save(&app.config)?;
-                                if app.openai_profile_needs_setup() {
-                                    app.notice =
-                                        Some(format!("Selected endpoint profile: {label}"));
-                                    app.begin_active_openai_profile_setup();
-                                } else {
-                                    start_rebuild_task(app);
-                                }
-                            }
-                        }
-                        Some(OpenAiModelPickerAction::DeleteProfile) => {
-                            if let Some(label) = app.delete_active_openai_profile() {
-                                app.config_manager.save(&app.config)?;
-                                app.notice = Some(format!("Deleted endpoint profile: {label}"));
-                            } else {
-                                app.push_notice("Cannot delete the only endpoint profile.");
-                            }
-                        }
-                        None => {}
+                    if let Some(action) = app.selected_openai_model_picker_action() {
+                        apply_openai_model_picker_action(app, action)?;
                     }
                 } else if should_open_codex_auth_guide(app, oauth_manager.as_ref()) {
                     app.select_local_model(app.model_picker_idx);
@@ -560,11 +537,8 @@ async fn dispatch_event(
         AppEvent::DeleteOpenAiProfile => {
             if app.is_busy() {
                 app.push_notice("Wait for the current task before deleting a profile.");
-            } else if let Some(label) = app.delete_active_openai_profile() {
-                app.config_manager.save(&app.config)?;
-                app.notice = Some(format!("Deleted endpoint profile: {label}"));
             } else {
-                app.push_notice("Cannot delete the only endpoint profile.");
+                apply_openai_model_picker_action(app, OpenAiModelPickerAction::DeleteProfile)?;
             }
         }
         AppEvent::SelectHelpTab(tab) => {
@@ -667,31 +641,8 @@ async fn dispatch_event(
                     } else if app.selected_provider_family()
                         == self::state::ProviderFamily::OpenAiCompatible
                     {
-                        match app.selected_openai_model_picker_action() {
-                            Some(OpenAiModelPickerAction::CreateProfile) => {
-                                app.begin_openai_profile_setup();
-                            }
-                            Some(OpenAiModelPickerAction::SelectProfile) => {
-                                if let Some(label) = app.select_openai_model_picker_profile() {
-                                    app.config_manager.save(&app.config)?;
-                                    if app.openai_profile_needs_setup() {
-                                        app.notice =
-                                            Some(format!("Selected endpoint profile: {label}"));
-                                        app.begin_active_openai_profile_setup();
-                                    } else {
-                                        start_rebuild_task(app);
-                                    }
-                                }
-                            }
-                            Some(OpenAiModelPickerAction::DeleteProfile) => {
-                                if let Some(label) = app.delete_active_openai_profile() {
-                                    app.config_manager.save(&app.config)?;
-                                    app.notice = Some(format!("Deleted endpoint profile: {label}"));
-                                } else {
-                                    app.push_notice("Cannot delete the only endpoint profile.");
-                                }
-                            }
-                            None => {}
+                        if let Some(action) = app.selected_openai_model_picker_action() {
+                            apply_openai_model_picker_action(app, action)?;
                         }
                     } else {
                         app.select_local_model(app.model_picker_idx);
@@ -878,6 +829,43 @@ async fn handle_submit(
         }
     }
     Ok(false)
+}
+
+fn apply_openai_model_picker_action(
+    app: &mut TuiApp,
+    action: OpenAiModelPickerAction,
+) -> anyhow::Result<()> {
+    match action {
+        OpenAiModelPickerAction::CreateProfile => {
+            app.begin_openai_profile_setup();
+        }
+        OpenAiModelPickerAction::SelectProfile => {
+            if let Some(label) = app.select_openai_model_picker_profile() {
+                app.config_manager.save(&app.config)?;
+                if app.openai_profile_needs_setup() {
+                    app.notice = Some(format!("Selected endpoint profile: {label}"));
+                    app.begin_active_openai_profile_setup();
+                } else {
+                    start_rebuild_task(app);
+                }
+            }
+        }
+        OpenAiModelPickerAction::DeleteProfile => {
+            if let Some(label) = app.delete_active_openai_profile() {
+                app.config_manager.save(&app.config)?;
+                if app.openai_profile_needs_setup() {
+                    app.notice = Some(format!("Deleted endpoint profile: {label}"));
+                    app.begin_active_openai_profile_setup();
+                } else {
+                    app.notice = Some(format!("Deleted endpoint profile: {label}"));
+                    start_rebuild_task(app);
+                }
+            } else {
+                app.push_notice("Cannot delete the only endpoint profile.");
+            }
+        }
+    }
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -4,10 +4,12 @@ use ratatui::{
     text::Line,
     widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
 };
+use secrecy::ExposeSecret;
 use std::path::Path;
 use unicode_width::UnicodeWidthChar;
 
 use super::Frame;
+use crate::config::OpenAiEndpointProfile;
 use crate::tui::auth_mode_picker::build_auth_mode_picker_view;
 use crate::tui::command::api_key_status;
 use crate::tui::is_ssh_session;
@@ -206,12 +208,12 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
                 .style(style)
             })
             .collect::<Vec<_>>()
+    } else if app.selected_provider_family() == ProviderFamily::OpenAiCompatible {
+        render_openai_profile_manager_items(app)
     } else {
         let presets = current_model_presets(app.provider_picker_idx);
-        let displayed_preset_count = app.openai_model_picker_preset_count();
-        let mut items = presets
+        presets
             .iter()
-            .take(displayed_preset_count)
             .enumerate()
             .map(|(idx, (label, provider, model))| {
                 let style = if idx == app.model_picker_idx {
@@ -221,15 +223,7 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
                 } else {
                     Style::default()
                 };
-                let current = if provider_label == "OpenAI-compatible" {
-                    if app.config.active_openai_profile_kind()
-                        == Some(crate::tui::state::openai_compatible_preset_kind(idx))
-                    {
-                        " current"
-                    } else {
-                        ""
-                    }
-                } else if app.config.provider == *provider
+                let current = if app.config.provider == *provider
                     && app.config.model.as_deref() == Some(*model)
                 {
                     " current"
@@ -252,44 +246,7 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
                 ))
                 .style(style)
             })
-            .collect::<Vec<_>>();
-        if provider_label == "OpenAI-compatible" {
-            let mut actions = Vec::new();
-            if app.openai_profile_needs_setup() {
-                actions.push((
-                    "Setup endpoint",
-                    "Guided setup for endpoint URL, API key, and model name.",
-                ));
-            }
-            actions.extend([
-                ("Profiles", "Switch or create endpoint profiles"),
-                ("API key", "Edit the API key for the active profile"),
-                ("Base URL", "Edit the base URL for the active profile"),
-                ("Model name", "Edit the model id for the active profile"),
-            ]);
-            let offset = displayed_preset_count;
-            items.extend(
-                actions
-                    .into_iter()
-                    .enumerate()
-                    .map(|(idx, (label, detail))| {
-                        let absolute_idx = offset + idx;
-                        let style = if absolute_idx == app.model_picker_idx {
-                            Style::default()
-                                .fg(Color::Cyan)
-                                .add_modifier(Modifier::BOLD)
-                        } else {
-                            Style::default()
-                        };
-                        ListItem::new(vec![
-                            Line::from(format!("[{}] {label}", absolute_idx + 1)),
-                            Line::from(format!("  {detail}")),
-                        ])
-                        .style(style)
-                    }),
-            );
-        }
-        items
+            .collect::<Vec<_>>()
     };
     let help = if provider_label == "Codex" && api_key_status(&app.config) == "missing" {
         "Provider: Codex\nAuthentication is required before this preset can be used.\nEnter opens the Codex login guide."
@@ -304,22 +261,18 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
         )
     } else if provider_label == "OpenAI-compatible" {
         &format!(
-            "Provider: {provider_label}\nEndpoint kind: {}\nEndpoint profile: {}\nBase URL: {}\nModel name: {}\nAPI key: {}\n{}",
-            app.selected_openai_profile_kind()
+            "OpenAI-compatible profiles\nActive: {} ({})\nModel: {}  Key: {}\nBase URL: {}\nCreate or select profiles here. A key  B URL  N model  D delete.",
+            app.config.active_openai_profile_label().unwrap_or("-"),
+            app.config
+                .active_openai_profile_kind()
                 .unwrap_or(crate::config::OpenAiEndpointKind::Custom)
                 .label(),
-            app.config.active_openai_profile_label().unwrap_or("-"),
+            app.current_model_label(),
+            api_key_status(&app.config),
             app.config
                 .base_url
                 .as_deref()
                 .unwrap_or("https://api.openai.com/v1"),
-            app.current_model_label(),
-            api_key_status(&app.config),
-            if app.openai_profile_needs_setup() {
-                "Active profile still needs setup. Press Enter on `Setup endpoint` to choose an endpoint family and walk through the required fields."
-            } else {
-                "The active profile is ready. Choose a preset to rebuild, or use the action rows below to edit the active profile."
-            },
         )
     } else {
         &format!(
@@ -352,17 +305,108 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
         Paragraph::new(if provider_label == "Codex" {
             "1-9 jump  Up/Down move  Enter choose level  Esc close"
         } else if provider_label == "OpenAI-compatible" {
-            if app.openai_profile_needs_setup() {
-                "1-5 jump  Up/Down move  Enter continue  Esc close"
-            } else {
-                "1-9 jump  Up/Down move  Enter choose  Esc close"
-            }
+            "1-9 jump  Up/Down move  Enter select/create  A/B/N edit  D delete  Esc close"
         } else {
             "1-9 apply directly  Up/Down move  B edit base URL  Enter apply  Esc close"
         })
         .alignment(Alignment::Center),
         chunks[2],
     );
+}
+
+fn render_openai_profile_manager_items(app: &TuiApp) -> Vec<ListItem<'static>> {
+    let profiles = app.openai_model_picker_profiles();
+    let mut items = Vec::with_capacity(profiles.len() + 2);
+    items.push(openai_profile_manager_action_item(
+        app,
+        0,
+        "Create endpoint profile",
+        "Start the endpoint setup wizard.",
+    ));
+    items.extend(
+        profiles
+            .iter()
+            .enumerate()
+            .map(|(idx, profile)| openai_profile_row_item(app, idx + 1, profile)),
+    );
+    if profiles.len() > 1 {
+        items.push(openai_profile_manager_action_item(
+            app,
+            profiles.len() + 1,
+            "Delete active profile",
+            "Remove the active profile from local config.",
+        ));
+    }
+    items
+}
+
+fn openai_profile_manager_action_item(
+    app: &TuiApp,
+    idx: usize,
+    label: &str,
+    detail: &str,
+) -> ListItem<'static> {
+    let style = if idx == app.model_picker_idx {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    ListItem::new(vec![
+        Line::from(format!("[{}] {label}", idx + 1)),
+        Line::from(format!("  {detail}")),
+    ])
+    .style(style)
+}
+
+fn openai_profile_row_item(
+    app: &TuiApp,
+    idx: usize,
+    profile: &OpenAiEndpointProfile,
+) -> ListItem<'static> {
+    let style = if idx == app.model_picker_idx {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+    let active = if app.config.active_openai_profile_id() == Some(profile.id.as_str()) {
+        " active"
+    } else {
+        ""
+    };
+    let model = profile.model.as_deref().unwrap_or("-");
+    let base_url = profile.base_url.as_deref().unwrap_or("-");
+    ListItem::new(vec![
+        Line::from(format!(
+            "[{}] {} ({}){}",
+            idx + 1,
+            profile.label,
+            profile.kind.label(),
+            active
+        )),
+        Line::from(format!(
+            "  model={}  key={}  url={}",
+            model,
+            profile_api_key_status(profile),
+            base_url
+        )),
+    ])
+    .style(style)
+}
+
+fn profile_api_key_status(profile: &OpenAiEndpointProfile) -> &'static str {
+    if profile
+        .api_key
+        .as_ref()
+        .is_some_and(|key| !key.expose_secret().trim().is_empty())
+    {
+        "set"
+    } else {
+        "missing"
+    }
 }
 
 pub(super) fn render_openai_profile_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -616,6 +616,28 @@ fn provider_picker_renders_as_full_overlay_on_standard_terminal() {
 }
 
 #[test]
+fn openai_model_picker_renders_profile_manager_not_endpoint_presets() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.provider_picker_idx = crate::tui::state::PROVIDER_FAMILIES
+        .iter()
+        .position(|(family, _, _)| *family == ProviderFamily::OpenAiCompatible)
+        .expect("openai-compatible family present");
+    app.open_overlay(Overlay::ModelPicker);
+
+    let rendered = render_screen_text(&app, 100, 24);
+    assert!(rendered.contains("OpenAI-compatible profiles"));
+    assert!(rendered.contains("Create endpoint profile"));
+    assert!(rendered.contains("Custom endpoint"));
+    assert!(!rendered.contains("DeepSeek (openai-compatible/deepseek-chat)"));
+    assert!(!rendered.contains("Kimi (openai-compatible/moonshot-v1-8k)"));
+    assert!(!rendered.contains("OpenRouter (openai-compatible/openai/gpt-4o-mini)"));
+}
+
+#[test]
 fn command_palette_query_uses_full_width_without_leaking_bottom_status() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -588,9 +588,8 @@ impl TuiApp {
         if self.selected_provider_family() == ProviderFamily::Codex {
             self.codex_model_options.len()
         } else if self.selected_provider_family() == ProviderFamily::OpenAiCompatible {
-            self.openai_model_picker_preset_count()
-                + 4
-                + usize::from(self.openai_profile_needs_setup())
+            let profile_count = self.openai_model_picker_profiles().len();
+            1 + profile_count + usize::from(profile_count > 1)
         } else {
             current_model_presets(self.provider_picker_idx).len()
         }
@@ -658,30 +657,23 @@ impl TuiApp {
         if self.selected_provider_family() != ProviderFamily::OpenAiCompatible {
             return None;
         }
-        let preset_count = self.openai_model_picker_preset_count();
-        if self.model_picker_idx < preset_count {
-            Some(openai_compatible_preset_kind(self.model_picker_idx))
-        } else {
-            Some(
-                self.config
-                    .active_openai_profile_kind()
-                    .unwrap_or(OpenAiEndpointKind::Custom),
-            )
-        }
+        self.selected_openai_model_picker_profile()
+            .map(|profile| profile.kind)
+            .or_else(|| self.config.active_openai_profile_kind())
+            .or(Some(OpenAiEndpointKind::Custom))
     }
 
     pub fn selected_openai_model_picker_action(&self) -> Option<OpenAiModelPickerAction> {
         if self.selected_provider_family() != ProviderFamily::OpenAiCompatible {
             return None;
         }
-        let preset_count = self.openai_model_picker_preset_count();
-        let setup_offset = usize::from(self.openai_profile_needs_setup());
-        match self.model_picker_idx.checked_sub(preset_count) {
-            Some(0) if self.openai_profile_needs_setup() => Some(OpenAiModelPickerAction::Setup),
-            Some(idx) if idx == setup_offset => Some(OpenAiModelPickerAction::Profiles),
-            Some(idx) if idx == setup_offset + 1 => Some(OpenAiModelPickerAction::ApiKey),
-            Some(idx) if idx == setup_offset + 2 => Some(OpenAiModelPickerAction::BaseUrl),
-            Some(idx) if idx == setup_offset + 3 => Some(OpenAiModelPickerAction::ModelName),
+        let profile_count = self.openai_model_picker_profiles().len();
+        match self.model_picker_idx {
+            0 => Some(OpenAiModelPickerAction::CreateProfile),
+            idx if idx <= profile_count => Some(OpenAiModelPickerAction::SelectProfile),
+            idx if profile_count > 1 && idx == profile_count + 1 => {
+                Some(OpenAiModelPickerAction::DeleteProfile)
+            }
             _ => None,
         }
     }
@@ -702,17 +694,6 @@ impl TuiApp {
             .as_deref()
             .is_none_or(|value| value.trim().is_empty());
         missing_api || missing_base_url || missing_model
-    }
-
-    pub fn openai_model_picker_preset_count(&self) -> usize {
-        if self.selected_provider_family() != ProviderFamily::OpenAiCompatible {
-            return current_model_presets(self.provider_picker_idx).len();
-        }
-        if self.openai_profile_needs_setup() {
-            0
-        } else {
-            current_model_presets(self.provider_picker_idx).len()
-        }
     }
 
     pub fn openai_endpoint_kind_count(&self) -> usize {
@@ -755,6 +736,11 @@ impl TuiApp {
         self.open_overlay(Overlay::OpenAiEndpointKindPicker);
     }
 
+    pub fn begin_active_openai_profile_setup(&mut self) {
+        self.openai_setup_steps = self.openai_profile_setup_sequence();
+        self.advance_openai_profile_setup();
+    }
+
     pub fn advance_openai_profile_setup(&mut self) {
         if self.openai_setup_steps.is_empty() {
             self.open_overlay(Overlay::ModelPicker);
@@ -773,10 +759,8 @@ impl TuiApp {
     }
 
     pub fn set_openai_setup_kind(&mut self, kind: OpenAiEndpointKind) {
-        self.config
-            .select_openai_profile(kind.default_profile_id(), kind.label(), kind);
-        self.openai_setup_steps = self.openai_profile_setup_sequence();
-        self.advance_openai_profile_setup();
+        self.openai_profile_label_kind = Some(kind);
+        self.open_overlay(Overlay::OpenAiProfileLabelEditor);
     }
 
     pub fn selected_openai_profiles(&self) -> Vec<(String, String)> {
@@ -797,6 +781,65 @@ impl TuiApp {
                 .then_with(|| left.0.cmp(&right.0))
         });
         profiles
+    }
+
+    pub fn openai_model_picker_profiles(&self) -> Vec<crate::config::OpenAiEndpointProfile> {
+        let active_id = self.config.active_openai_profile_id();
+        let mut profiles = self
+            .config
+            .openai_profiles
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        profiles.sort_by(|left, right| {
+            let left_active = Some(left.id.as_str()) == active_id;
+            let right_active = Some(right.id.as_str()) == active_id;
+            right_active
+                .cmp(&left_active)
+                .then_with(|| left.kind.label().cmp(right.kind.label()))
+                .then_with(|| {
+                    left.label
+                        .to_ascii_lowercase()
+                        .cmp(&right.label.to_ascii_lowercase())
+                })
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        profiles
+    }
+
+    pub fn selected_openai_model_picker_profile(
+        &self,
+    ) -> Option<crate::config::OpenAiEndpointProfile> {
+        if self.selected_provider_family() != ProviderFamily::OpenAiCompatible {
+            return None;
+        }
+        self.openai_model_picker_profiles()
+            .get(self.model_picker_idx.checked_sub(1)?)
+            .cloned()
+    }
+
+    pub fn select_openai_model_picker_profile(&mut self) -> Option<String> {
+        let profile = self.selected_openai_model_picker_profile()?;
+        let label = profile.label.clone();
+        self.config
+            .select_openai_profile(profile.id, profile.label, profile.kind);
+        Some(label)
+    }
+
+    pub fn delete_active_openai_profile(&mut self) -> Option<String> {
+        if self.selected_provider_family() != ProviderFamily::OpenAiCompatible {
+            return None;
+        }
+        if self.config.openai_profiles.len() <= 1 {
+            return None;
+        }
+        let active_id = self.config.active_openai_profile_id()?.to_string();
+        let deleted = self.config.openai_profiles.remove(active_id.as_str())?;
+        let next = self.openai_model_picker_profiles().into_iter().next()?;
+        self.config
+            .select_openai_profile(next.id, next.label, next.kind);
+        self.model_picker_idx = 1;
+        Some(deleted.label)
     }
 
     fn sync_openai_profile_picker(&mut self) {
@@ -1138,14 +1181,14 @@ impl TuiApp {
                 if !matches!(selected_provider_family_idx_for_config(&self.config), 1) {
                     self.config.set_provider("openai-compatible");
                 }
+                self.model_picker_idx = if self.openai_model_picker_profiles().is_empty() {
+                    0
+                } else {
+                    1
+                };
             } else if let Some(provider) = self.single_provider_for_selected_family() {
                 self.config.set_provider(provider.to_string());
-            }
-            self.model_picker_idx = self.selected_preset_idx();
-            if matches!(selected_family, ProviderFamily::OpenAiCompatible)
-                && self.openai_profile_needs_setup()
-            {
-                self.model_picker_idx = 0;
+                self.model_picker_idx = self.selected_preset_idx();
             }
             self.sync_reasoning_effort_picker();
         }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -783,14 +783,9 @@ impl TuiApp {
         profiles
     }
 
-    pub fn openai_model_picker_profiles(&self) -> Vec<crate::config::OpenAiEndpointProfile> {
+    pub fn openai_model_picker_profiles(&self) -> Vec<&crate::config::OpenAiEndpointProfile> {
         let active_id = self.config.active_openai_profile_id();
-        let mut profiles = self
-            .config
-            .openai_profiles
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
+        let mut profiles = self.config.openai_profiles.values().collect::<Vec<_>>();
         profiles.sort_by(|left, right| {
             let left_active = Some(left.id.as_str()) == active_id;
             let right_active = Some(right.id.as_str()) == active_id;
@@ -815,7 +810,7 @@ impl TuiApp {
         }
         self.openai_model_picker_profiles()
             .get(self.model_picker_idx.checked_sub(1)?)
-            .cloned()
+            .map(|profile| (*profile).clone())
     }
 
     pub fn select_openai_model_picker_profile(&mut self) -> Option<String> {
@@ -834,10 +829,14 @@ impl TuiApp {
             return None;
         }
         let active_id = self.config.active_openai_profile_id()?.to_string();
-        let deleted = self.config.openai_profiles.remove(active_id.as_str())?;
-        let next = self.openai_model_picker_profiles().into_iter().next()?;
+        let next = self
+            .openai_model_picker_profiles()
+            .into_iter()
+            .find(|profile| profile.id != active_id)?
+            .clone();
         self.config
             .select_openai_profile(next.id, next.label, next.kind);
+        let deleted = self.config.openai_profiles.remove(active_id.as_str())?;
         self.model_picker_idx = 1;
         Some(deleted.label)
     }

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -359,25 +359,77 @@ fn openai_compatible_model_picker_includes_explicit_profile_actions() {
     app.provider_picker_idx = 1;
     app.open_overlay(Overlay::ModelPicker);
 
-    assert_eq!(app.current_model_picker_len(), 5);
+    assert_eq!(app.current_model_picker_len(), 2);
+    assert_eq!(app.model_picker_idx, 1);
 
     app.model_picker_idx = 0;
     assert_eq!(
         app.selected_openai_model_picker_action(),
-        Some(crate::tui::state::OpenAiModelPickerAction::Setup)
+        Some(crate::tui::state::OpenAiModelPickerAction::CreateProfile)
     );
 
     app.model_picker_idx = 1;
     assert_eq!(
         app.selected_openai_model_picker_action(),
-        Some(crate::tui::state::OpenAiModelPickerAction::Profiles)
+        Some(crate::tui::state::OpenAiModelPickerAction::SelectProfile)
     );
+
+    app.config.select_openai_profile(
+        "openrouter-default",
+        "OpenRouter",
+        OpenAiEndpointKind::Openrouter,
+    );
+    app.open_overlay(Overlay::ModelPicker);
+    assert_eq!(app.current_model_picker_len(), 4);
 
     app.model_picker_idx = 2;
     assert_eq!(
         app.selected_openai_model_picker_action(),
-        Some(crate::tui::state::OpenAiModelPickerAction::ApiKey)
+        Some(crate::tui::state::OpenAiModelPickerAction::SelectProfile)
     );
+
+    app.model_picker_idx = 3;
+    assert_eq!(
+        app.selected_openai_model_picker_action(),
+        Some(crate::tui::state::OpenAiModelPickerAction::DeleteProfile)
+    );
+}
+
+#[test]
+fn openai_compatible_model_picker_deletes_active_profile_and_keeps_next() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+
+    app.provider_picker_idx = 1;
+    app.config.select_openai_profile(
+        "custom-default",
+        "Custom endpoint",
+        OpenAiEndpointKind::Custom,
+    );
+    app.config.select_openai_profile(
+        "openrouter-default",
+        "OpenRouter",
+        OpenAiEndpointKind::Openrouter,
+    );
+    app.open_overlay(Overlay::ModelPicker);
+
+    assert_eq!(
+        app.config.active_openai_profile_id(),
+        Some("openrouter-default")
+    );
+    assert_eq!(
+        app.delete_active_openai_profile().as_deref(),
+        Some("OpenRouter")
+    );
+    assert_eq!(
+        app.config.active_openai_profile_id(),
+        Some("custom-default")
+    );
+    assert_eq!(app.model_picker_idx, 1);
+    assert_eq!(app.current_model_picker_len(), 2);
 }
 
 #[test]

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -58,11 +58,9 @@ pub enum ProviderFamily {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum OpenAiModelPickerAction {
-    Setup,
-    Profiles,
-    ApiKey,
-    BaseUrl,
-    ModelName,
+    CreateProfile,
+    SelectProfile,
+    DeleteProfile,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -463,6 +463,7 @@ async fn openai_model_picker_delete_row_removes_active_profile() {
         "Custom endpoint",
         OpenAiEndpointKind::Custom,
     );
+    app.config.set_api_key("sk-custom");
     app.config.select_openai_profile(
         "openrouter-default",
         "OpenRouter",
@@ -491,6 +492,13 @@ async fn openai_model_picker_delete_row_removes_active_profile() {
         Some("custom-default")
     );
     assert!(matches!(app.overlay, Some(Overlay::ModelPicker)));
+    assert!(matches!(
+        app.running_task.as_ref(),
+        Some(task) if matches!(task.kind, TaskKind::Rebuild)
+    ));
+    if let Some(task) = app.running_task.take() {
+        task.handle.abort();
+    }
 }
 
 #[tokio::test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -445,21 +445,31 @@ fn openai_compatible_model_picker_exposes_connection_edit_shortcuts() {
         AppEvent::OpenOverlay(Overlay::ModelNameEditor)
     ));
     assert!(matches!(
-        map_key_to_event(key(KeyCode::Char('p')), &app),
-        AppEvent::OpenOverlay(Overlay::OpenAiProfilePicker)
+        map_key_to_event(key(KeyCode::Char('d')), &app),
+        AppEvent::DeleteOpenAiProfile
     ));
 }
 
 #[tokio::test]
-async fn openai_model_picker_action_row_opens_api_key_editor() {
+async fn openai_model_picker_delete_row_removes_active_profile() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
     })
     .expect("app");
     app.provider_picker_idx = 1;
+    app.config.select_openai_profile(
+        "custom-default",
+        "Custom endpoint",
+        OpenAiEndpointKind::Custom,
+    );
+    app.config.select_openai_profile(
+        "openrouter-default",
+        "OpenRouter",
+        OpenAiEndpointKind::Openrouter,
+    );
     app.open_overlay(Overlay::ModelPicker);
-    app.model_picker_idx = 2;
+    app.model_picker_idx = 3;
 
     let oauth_manager = Arc::new(
         crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
@@ -474,13 +484,17 @@ async fn openai_model_picker_action_row_opens_api_key_editor() {
         &oauth_manager,
     )
     .await
-    .expect("apply model selection");
+    .expect("delete profile");
 
-    assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
+    assert_eq!(
+        app.config.active_openai_profile_id(),
+        Some("custom-default")
+    );
+    assert!(matches!(app.overlay, Some(Overlay::ModelPicker)));
 }
 
 #[tokio::test]
-async fn openai_model_picker_numeric_action_row_opens_profile_picker() {
+async fn openai_model_picker_numeric_profile_row_starts_setup_when_incomplete() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -504,7 +518,7 @@ async fn openai_model_picker_numeric_action_row_opens_profile_picker() {
     .await
     .expect("set model selection");
 
-    assert!(matches!(app.overlay, Some(Overlay::OpenAiProfilePicker)));
+    assert!(matches!(app.overlay, Some(Overlay::BaseUrlEditor)));
 }
 
 #[tokio::test]
@@ -541,7 +555,7 @@ async fn openai_model_picker_setup_row_opens_endpoint_kind_picker() {
 }
 
 #[tokio::test]
-async fn selecting_custom_endpoint_kind_advances_into_guided_setup() {
+async fn selecting_custom_endpoint_kind_prompts_for_profile_label() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -566,10 +580,13 @@ async fn selecting_custom_endpoint_kind_advances_into_guided_setup() {
     .await
     .expect("select endpoint kind");
 
-    assert!(matches!(app.overlay, Some(Overlay::BaseUrlEditor)));
+    assert!(matches!(
+        app.overlay,
+        Some(Overlay::OpenAiProfileLabelEditor)
+    ));
     assert_eq!(
-        app.openai_setup_steps,
-        vec![Overlay::ApiKeyEditor, Overlay::ModelNameEditor]
+        app.openai_profile_label_kind,
+        Some(OpenAiEndpointKind::Custom)
     );
 }
 
@@ -668,7 +685,7 @@ async fn saving_openai_profile_label_creates_new_profile_for_selected_kind() {
         .config
         .openai_profiles
         .contains_key("deepseek-deepseek-backup"));
-    assert!(matches!(app.overlay, Some(Overlay::ModelPicker)));
+    assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Simplify the OpenAI-compatible `/model` surface into an endpoint profile manager.
- Move endpoint kind choices into the create-profile wizard instead of listing them as first-level model rows.
- Add profile selection/delete flows plus focused TUI state/render tests.

## Testing

- `cargo fmt --check`
- `cargo test openai_model_picker -- --nocapture`
- `cargo test saving_openai_profile_label -- --nocapture`
- `cargo test openai_compatible_model_picker -- --nocapture`
- `cargo check`
