### PR TITLE
fix(tui): refine OpenAI-compatible profile management

### DIFF
--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -194,15 +194,17 @@ impl RaraConfig {
     pub fn set_provider(&mut self, provider: impl Into<String>) {
         self.sync_active_provider_state();
         let provider = provider.into();
-        if let Some(kind) = OpenAiEndpointKind::from_legacy_provider(provider.as_str()) {
-            self.provider = "openai-compatible".to_string();
-            self.reset_provider_scoped_fields();
-            let profile = self.profile_for_kind_or_default(kind);
-            self.active_openai_profile_id = Some(profile.id.clone());
-            self.openai_profiles
-                .insert(profile.id.clone(), profile.clone());
-            self.apply_openai_profile(profile);
-            return;
+        if provider != "openai-compatible" {
+            if let Some(kind) = OpenAiEndpointKind::from_legacy_provider(provider.as_str()) {
+                self.provider = "openai-compatible".to_string();
+                self.reset_provider_scoped_fields();
+                let profile = self.profile_for_kind_or_default(kind);
+                self.active_openai_profile_id = Some(profile.id.clone());
+                self.openai_profiles
+                    .insert(profile.id.clone(), profile.clone());
+                self.apply_openai_profile(profile);
+                return;
+            }
         }
         self.provider = provider;
         self.reset_provider_scoped_fields();
@@ -992,6 +994,29 @@ mod tests {
         );
 
         assert_eq!(config.provider, "openai-compatible");
+        assert_eq!(config.active_openai_profile_id(), Some("openrouter-main"));
+        assert_eq!(config.api_key(), Some("sk-openrouter-main"));
+        assert_eq!(config.model.as_deref(), Some("anthropic/claude-sonnet-4"));
+    }
+
+    #[test]
+    fn switching_away_and_back_to_openai_compatible_keeps_active_profile() {
+        let mut config = RaraConfig::default();
+
+        config.select_openai_profile(
+            "openrouter-main",
+            "OpenRouter main",
+            OpenAiEndpointKind::Openrouter,
+        );
+        config.set_api_key("sk-openrouter-main");
+        config.set_model(Some("anthropic/claude-sonnet-4".to_string()));
+
+        config.set_provider("codex");
+        config.set_model(Some("gpt-5.1-codex".to_string()));
+        config.set_provider("ollama");
+        config.set_model(Some("gemma4".to_string()));
+        config.set_provider("openai-compatible");
+
         assert_eq!(config.active_openai_profile_id(), Some("openrouter-main"));
         assert_eq!(config.api_key(), Some("sk-openrouter-main"));
         assert_eq!(config.model.as_deref(), Some("anthropic/claude-sonnet-4"));

--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -36,6 +36,8 @@ pub enum AppEvent {
     SaveApiKeyInput,
     SaveModelNameInput,
     SaveOpenAiProfileLabelInput,
+    CreateOpenAiProfile,
+    EditOpenAiProfile,
     DeleteOpenAiProfile,
     SelectHelpTab(HelpTab),
     ApplyOverlaySelection,

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -72,6 +72,14 @@ pub(super) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             KeyCode::Esc => AppEvent::CloseOverlay,
             KeyCode::Up | KeyCode::Char('k') => AppEvent::MoveModelSelection(-1),
             KeyCode::Down | KeyCode::Char('j') => AppEvent::MoveModelSelection(1),
+            KeyCode::Char(' ')
+                if matches!(
+                    app.selected_provider_family(),
+                    ProviderFamily::OpenAiCompatible
+                ) =>
+            {
+                AppEvent::ApplyOverlaySelection
+            }
             KeyCode::Char('1') => AppEvent::SetModelSelection(0),
             KeyCode::Char('2') => AppEvent::SetModelSelection(1),
             KeyCode::Char('3') => AppEvent::SetModelSelection(2),
@@ -81,29 +89,24 @@ pub(super) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             KeyCode::Char('7') => AppEvent::SetModelSelection(6),
             KeyCode::Char('8') => AppEvent::SetModelSelection(7),
             KeyCode::Char('9') => AppEvent::SetModelSelection(8),
-            KeyCode::Char('b')
-                if matches!(
-                    app.selected_provider_family(),
-                    ProviderFamily::OpenAiCompatible | ProviderFamily::Ollama
-                ) =>
-            {
+            KeyCode::Char('b') if app.selected_provider_family() == ProviderFamily::Ollama => {
                 AppEvent::OpenOverlay(Overlay::BaseUrlEditor)
             }
-            KeyCode::Char('a')
+            KeyCode::Char('e')
                 if matches!(
                     app.selected_provider_family(),
                     ProviderFamily::OpenAiCompatible
                 ) =>
             {
-                AppEvent::OpenOverlay(Overlay::ApiKeyEditor)
+                AppEvent::EditOpenAiProfile
             }
-            KeyCode::Char('n')
+            KeyCode::Char('c')
                 if matches!(
                     app.selected_provider_family(),
                     ProviderFamily::OpenAiCompatible
                 ) =>
             {
-                AppEvent::OpenOverlay(Overlay::ModelNameEditor)
+                AppEvent::CreateOpenAiProfile
             }
             KeyCode::Char('d')
                 if matches!(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -319,7 +319,7 @@ async fn dispatch_event(
                 && !app.is_busy()
             {
                 if app.selected_provider_family() == self::state::ProviderFamily::OpenAiCompatible {
-                    return Ok(true);
+                    return Ok(false);
                 } else if should_open_codex_auth_guide(app, oauth_manager.as_ref()) {
                     app.select_local_model(app.model_picker_idx);
                     app.open_overlay(Overlay::AuthModePicker);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -319,9 +319,7 @@ async fn dispatch_event(
                 && !app.is_busy()
             {
                 if app.selected_provider_family() == self::state::ProviderFamily::OpenAiCompatible {
-                    if let Some(action) = app.selected_openai_model_picker_action() {
-                        apply_openai_model_picker_action(app, action)?;
-                    }
+                    return Ok(true);
                 } else if should_open_codex_auth_guide(app, oauth_manager.as_ref()) {
                     app.select_local_model(app.model_picker_idx);
                     app.open_overlay(Overlay::AuthModePicker);
@@ -455,6 +453,9 @@ async fn dispatch_event(
                 app.push_notice("Wait for the current task before saving the API key.");
             } else if value.is_empty() && app.config.provider == "codex" {
                 app.push_notice("Enter a Codex API key or press Esc to go back.");
+            } else if value.is_empty() && app.openai_setup_keep_empty_api_key {
+                app.notice = Some("Kept existing API key for the current profile.".into());
+                app.advance_openai_profile_setup();
             } else if value.is_empty() {
                 app.config.clear_api_key();
                 if app.config.provider == "codex" {
@@ -530,7 +531,28 @@ async fn dispatch_event(
                     app.config_manager.save(&app.config)?;
                     app.notice = Some(format!("Created endpoint profile: {label}"));
                     app.openai_profile_label_kind = None;
-                    app.begin_active_openai_profile_setup();
+                    app.begin_created_openai_profile_setup();
+                }
+            }
+        }
+        AppEvent::CreateOpenAiProfile => {
+            if app.is_busy() {
+                app.push_notice("Wait for the current task before creating a profile.");
+            } else if app.selected_provider_family()
+                == self::state::ProviderFamily::OpenAiCompatible
+            {
+                app.begin_openai_profile_setup();
+            }
+        }
+        AppEvent::EditOpenAiProfile => {
+            if app.is_busy() {
+                app.push_notice("Wait for the current task before editing a profile.");
+            } else if app.selected_provider_family()
+                == self::state::ProviderFamily::OpenAiCompatible
+            {
+                if app.select_openai_model_picker_profile().is_some() {
+                    app.config_manager.save(&app.config)?;
+                    app.begin_edit_openai_profile_setup();
                 }
             }
         }
@@ -836,9 +858,6 @@ fn apply_openai_model_picker_action(
     action: OpenAiModelPickerAction,
 ) -> anyhow::Result<()> {
     match action {
-        OpenAiModelPickerAction::CreateProfile => {
-            app.begin_openai_profile_setup();
-        }
         OpenAiModelPickerAction::SelectProfile => {
             if let Some(label) = app.select_openai_model_picker_profile() {
                 app.config_manager.save(&app.config)?;

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -389,10 +389,28 @@ fn openai_profile_table_row<'a>(app: &TuiApp, profile: &'a OpenAiEndpointProfile
         Cell::from(active),
         Cell::from(profile.label.as_str()),
         Cell::from(profile.kind.label()),
-        Cell::from(profile.model.as_deref().unwrap_or("-")),
+        Cell::from(profile_model_label(profile)),
         Cell::from(profile_api_key_status(profile)),
-        Cell::from(profile.base_url.as_deref().unwrap_or("-")),
+        Cell::from(profile_base_url_label(profile)),
     ])
+}
+
+fn profile_model_label(profile: &OpenAiEndpointProfile) -> &str {
+    profile
+        .model
+        .as_deref()
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .unwrap_or_else(|| profile.kind.default_model())
+}
+
+fn profile_base_url_label(profile: &OpenAiEndpointProfile) -> &str {
+    profile
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|base_url| !base_url.is_empty())
+        .unwrap_or_else(|| profile.kind.default_base_url())
 }
 
 fn profile_api_key_status(profile: &OpenAiEndpointProfile) -> &'static str {

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -379,19 +379,19 @@ fn render_openai_profile_manager_modal(f: &mut Frame, app: &TuiApp, area: Rect) 
     );
 }
 
-fn openai_profile_table_row(app: &TuiApp, profile: &OpenAiEndpointProfile) -> Row<'static> {
+fn openai_profile_table_row<'a>(app: &TuiApp, profile: &'a OpenAiEndpointProfile) -> Row<'a> {
     let active = if app.config.active_openai_profile_id() == Some(profile.id.as_str()) {
         "active"
     } else {
         ""
     };
     Row::new(vec![
-        Cell::from(active.to_string()),
-        Cell::from(profile.label.clone()),
-        Cell::from(profile.kind.label().to_string()),
-        Cell::from(profile.model.clone().unwrap_or_else(|| "-".to_string())),
-        Cell::from(profile_api_key_status(profile).to_string()),
-        Cell::from(profile.base_url.clone().unwrap_or_else(|| "-".to_string())),
+        Cell::from(active),
+        Cell::from(profile.label.as_str()),
+        Cell::from(profile.kind.label()),
+        Cell::from(profile.model.as_deref().unwrap_or("-")),
+        Cell::from(profile_api_key_status(profile)),
+        Cell::from(profile.base_url.as_deref().unwrap_or("-")),
     ])
 }
 

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::Line,
-    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, Cell, List, ListItem, Paragraph, Row, Table, TableState, Wrap},
 };
 use secrecy::ExposeSecret;
 use std::path::Path;
@@ -174,6 +174,10 @@ pub(super) fn render_resume_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect
 
 pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     let provider_label = PROVIDER_FAMILIES[app.provider_picker_idx].1;
+    if app.selected_provider_family() == ProviderFamily::OpenAiCompatible {
+        render_openai_profile_manager_modal(f, app, area);
+        return;
+    }
     let items = if app.selected_provider_family() == ProviderFamily::Codex {
         app.codex_model_options
             .iter()
@@ -208,8 +212,6 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
                 .style(style)
             })
             .collect::<Vec<_>>()
-    } else if app.selected_provider_family() == ProviderFamily::OpenAiCompatible {
-        render_openai_profile_manager_items(app)
     } else {
         let presets = current_model_presets(app.provider_picker_idx);
         presets
@@ -259,21 +261,6 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
                 .unwrap_or("https://api.openai.com/v1"),
             app.current_reasoning_effort_label(),
         )
-    } else if provider_label == "OpenAI-compatible" {
-        &format!(
-            "OpenAI-compatible profiles\nActive: {} ({})\nModel: {}  Key: {}\nBase URL: {}\nCreate or select profiles here. A key  B URL  N model  D delete.",
-            app.config.active_openai_profile_label().unwrap_or("-"),
-            app.config
-                .active_openai_profile_kind()
-                .unwrap_or(crate::config::OpenAiEndpointKind::Custom)
-                .label(),
-            app.current_model_label(),
-            api_key_status(&app.config),
-            app.config
-                .base_url
-                .as_deref()
-                .unwrap_or("https://api.openai.com/v1"),
-        )
     } else {
         &format!(
             "Provider: {provider_label}\nBase URL: {}\nSelect a concrete model preset. Enter applies immediately.",
@@ -304,8 +291,6 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
     f.render_widget(
         Paragraph::new(if provider_label == "Codex" {
             "1-9 jump  Up/Down move  Enter choose level  Esc close"
-        } else if provider_label == "OpenAI-compatible" {
-            "1-9 jump  Up/Down move  Enter select/create  A/B/N edit  D delete  Esc close"
         } else {
             "1-9 apply directly  Up/Down move  B edit base URL  Enter apply  Esc close"
         })
@@ -314,87 +299,100 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
     );
 }
 
-fn render_openai_profile_manager_items(app: &TuiApp) -> Vec<ListItem<'static>> {
-    let profiles = app.openai_model_picker_profiles();
-    let mut items = Vec::with_capacity(profiles.len() + 2);
-    items.push(openai_profile_manager_action_item(
-        app,
-        0,
-        "Create endpoint profile",
-        "Start the endpoint setup wizard.",
-    ));
-    items.extend(
-        profiles
-            .iter()
-            .enumerate()
-            .map(|(idx, profile)| openai_profile_row_item(app, idx + 1, profile)),
+fn render_openai_profile_manager_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
+    let active_label = app.config.active_openai_profile_label().unwrap_or("-");
+    let active_kind = app
+        .config
+        .active_openai_profile_kind()
+        .unwrap_or(crate::config::OpenAiEndpointKind::Custom)
+        .label();
+    let help = format!(
+        "OpenAI-compatible profiles\nActive: {active_label} ({active_kind})  model={}  key={}",
+        app.current_model_label(),
+        api_key_status(&app.config),
     );
-    if profiles.len() > 1 {
-        items.push(openai_profile_manager_action_item(
-            app,
-            profiles.len() + 1,
-            "Delete active profile",
-            "Remove the active profile from local config.",
-        ));
-    }
-    items
-}
+    let help_height = wrapped_text_height(help.as_str(), area.width);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(help_height),
+            Constraint::Min(6),
+            Constraint::Length(2),
+        ])
+        .split(area);
+    f.render_widget(
+        Paragraph::new(help)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Model Profiles "),
+            )
+            .wrap(Wrap { trim: false }),
+        chunks[0],
+    );
 
-fn openai_profile_manager_action_item(
-    app: &TuiApp,
-    idx: usize,
-    label: &str,
-    detail: &str,
-) -> ListItem<'static> {
-    let style = if idx == app.model_picker_idx {
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default()
-    };
-    ListItem::new(vec![
-        Line::from(format!("[{}] {label}", idx + 1)),
-        Line::from(format!("  {detail}")),
+    let profiles = app.openai_model_picker_profiles();
+    let rows = profiles
+        .iter()
+        .map(|profile| openai_profile_table_row(app, profile))
+        .collect::<Vec<_>>();
+    let header = Row::new(vec![
+        Cell::from("Status"),
+        Cell::from("Name"),
+        Cell::from("Type"),
+        Cell::from("Model"),
+        Cell::from("Key"),
+        Cell::from("Base URL"),
     ])
-    .style(style)
-}
-
-fn openai_profile_row_item(
-    app: &TuiApp,
-    idx: usize,
-    profile: &OpenAiEndpointProfile,
-) -> ListItem<'static> {
-    let style = if idx == app.model_picker_idx {
+    .style(Style::default().fg(Color::DarkGray));
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(8),
+            Constraint::Length(20),
+            Constraint::Length(14),
+            Constraint::Length(24),
+            Constraint::Length(8),
+            Constraint::Min(18),
+        ],
+    )
+    .header(header)
+    .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
+    .column_spacing(1)
+    .highlight_symbol("› ")
+    .row_highlight_style(
         Style::default()
             .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD)
+            .add_modifier(Modifier::BOLD),
+    );
+    let selected = if profiles.is_empty() {
+        None
     } else {
-        Style::default()
+        Some(app.model_picker_idx.min(profiles.len() - 1))
     };
+    let mut table_state = TableState::default().with_selected(selected);
+    f.render_stateful_widget(table, chunks[1], &mut table_state);
+    f.render_widget(
+        Paragraph::new("Space/Enter activate  C create  E edit wizard  D delete active  Esc close")
+            .alignment(Alignment::Center),
+        chunks[2],
+    );
+}
+
+fn openai_profile_table_row(app: &TuiApp, profile: &OpenAiEndpointProfile) -> Row<'static> {
     let active = if app.config.active_openai_profile_id() == Some(profile.id.as_str()) {
-        " active"
+        "active"
     } else {
         ""
     };
-    let model = profile.model.as_deref().unwrap_or("-");
-    let base_url = profile.base_url.as_deref().unwrap_or("-");
-    ListItem::new(vec![
-        Line::from(format!(
-            "[{}] {} ({}){}",
-            idx + 1,
-            profile.label,
-            profile.kind.label(),
-            active
-        )),
-        Line::from(format!(
-            "  model={}  key={}  url={}",
-            model,
-            profile_api_key_status(profile),
-            base_url
-        )),
+    Row::new(vec![
+        Cell::from(active.to_string()),
+        Cell::from(profile.label.clone()),
+        Cell::from(profile.kind.label().to_string()),
+        Cell::from(profile.model.clone().unwrap_or_else(|| "-".to_string())),
+        Cell::from(profile_api_key_status(profile).to_string()),
+        Cell::from(profile.base_url.clone().unwrap_or_else(|| "-".to_string())),
     ])
-    .style(style)
 }
 
 fn profile_api_key_status(profile: &OpenAiEndpointProfile) -> &'static str {

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -5,7 +5,7 @@ use ratatui::text::Line;
 use ratatui::{buffer::Buffer, layout::Rect};
 use tempfile::tempdir;
 
-use crate::config::{ConfigManager, RaraConfig};
+use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::{Overlay, ProviderFamily, TranscriptEntry, TranscriptTurn, TuiApp};
 
@@ -626,12 +626,23 @@ fn openai_model_picker_renders_profile_manager_not_endpoint_presets() {
         .iter()
         .position(|(family, _, _)| *family == ProviderFamily::OpenAiCompatible)
         .expect("openai-compatible family present");
+    app.config.select_openai_profile(
+        "openrouter-main",
+        "OpenRouter Main",
+        OpenAiEndpointKind::Openrouter,
+    );
+    app.config
+        .set_model(Some("anthropic/claude-3.7-sonnet".to_string()));
+    app.config.set_api_key("sk-openrouter");
     app.open_overlay(Overlay::ModelPicker);
 
     let rendered = render_screen_text(&app, 100, 24);
     assert!(rendered.contains("OpenAI-compatible profiles"));
-    assert!(rendered.contains("Create endpoint profile"));
-    assert!(rendered.contains("Custom endpoint"));
+    assert!(rendered.contains("Status"));
+    assert!(rendered.contains("OpenRouter Main"));
+    assert!(rendered.contains("anthropic/claude-3.7-sonnet"));
+    assert!(rendered.contains("active"));
+    assert!(rendered.contains("C create"));
     assert!(!rendered.contains("DeepSeek (openai-compatible/deepseek-chat)"));
     assert!(!rendered.contains("Kimi (openai-compatible/moonshot-v1-8k)"));
     assert!(!rendered.contains("OpenRouter (openai-compatible/openai/gpt-4o-mini)"));

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -649,6 +649,37 @@ fn openai_model_picker_renders_profile_manager_not_endpoint_presets() {
 }
 
 #[test]
+fn openai_model_picker_renders_profile_defaults_when_fields_are_empty() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.provider_picker_idx = crate::tui::state::PROVIDER_FAMILIES
+        .iter()
+        .position(|(family, _, _)| *family == ProviderFamily::OpenAiCompatible)
+        .expect("openai-compatible family present");
+    app.config.select_openai_profile(
+        "custom-defaults",
+        "Custom Defaults",
+        OpenAiEndpointKind::Custom,
+    );
+    let profile = app
+        .config
+        .openai_profiles
+        .get_mut("custom-defaults")
+        .expect("custom profile present");
+    profile.model = None;
+    profile.base_url = None;
+    app.open_overlay(Overlay::ModelPicker);
+
+    let rendered = render_screen_text(&app, 100, 24);
+    assert!(rendered.contains("Custom Defaults"));
+    assert!(rendered.contains(OpenAiEndpointKind::Custom.default_model()));
+    assert!(rendered.contains("https://api.openai"));
+}
+
+#[test]
 fn command_palette_query_uses_full_width_without_leaking_bottom_status() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -469,6 +469,7 @@ impl TuiApp {
             openai_profile_label_cursor_offset: None,
             openai_profile_label_kind: None,
             openai_setup_steps: Vec::new(),
+            openai_setup_keep_empty_api_key: false,
             codex_model_options: Vec::new(),
             recent_commands: Vec::new(),
             recent_threads: Vec::new(),
@@ -588,8 +589,7 @@ impl TuiApp {
         if self.selected_provider_family() == ProviderFamily::Codex {
             self.codex_model_options.len()
         } else if self.selected_provider_family() == ProviderFamily::OpenAiCompatible {
-            let profile_count = self.openai_model_picker_profiles().len();
-            1 + profile_count + usize::from(profile_count > 1)
+            self.openai_model_picker_profiles().len()
         } else {
             current_model_presets(self.provider_picker_idx).len()
         }
@@ -667,14 +667,14 @@ impl TuiApp {
         if self.selected_provider_family() != ProviderFamily::OpenAiCompatible {
             return None;
         }
-        let profile_count = self.openai_model_picker_profiles().len();
-        match self.model_picker_idx {
-            0 => Some(OpenAiModelPickerAction::CreateProfile),
-            idx if idx <= profile_count => Some(OpenAiModelPickerAction::SelectProfile),
-            idx if profile_count > 1 && idx == profile_count + 1 => {
-                Some(OpenAiModelPickerAction::DeleteProfile)
-            }
-            _ => None,
+        if self
+            .openai_model_picker_profiles()
+            .get(self.model_picker_idx)
+            .is_some()
+        {
+            Some(OpenAiModelPickerAction::SelectProfile)
+        } else {
+            None
         }
     }
 
@@ -732,17 +732,40 @@ impl TuiApp {
 
     pub fn begin_openai_profile_setup(&mut self) {
         self.openai_setup_steps.clear();
+        self.openai_setup_keep_empty_api_key = false;
         self.openai_profile_label_kind = None;
         self.open_overlay(Overlay::OpenAiEndpointKindPicker);
     }
 
     pub fn begin_active_openai_profile_setup(&mut self) {
+        self.openai_setup_keep_empty_api_key = false;
         self.openai_setup_steps = self.openai_profile_setup_sequence();
+        self.advance_openai_profile_setup();
+    }
+
+    pub fn begin_created_openai_profile_setup(&mut self) {
+        self.openai_setup_keep_empty_api_key = false;
+        let mut steps = self.openai_profile_setup_sequence();
+        if !steps.contains(&Overlay::ModelNameEditor) {
+            steps.push(Overlay::ModelNameEditor);
+        }
+        self.openai_setup_steps = steps;
+        self.advance_openai_profile_setup();
+    }
+
+    pub fn begin_edit_openai_profile_setup(&mut self) {
+        self.openai_setup_keep_empty_api_key = true;
+        self.openai_setup_steps = vec![
+            Overlay::BaseUrlEditor,
+            Overlay::ApiKeyEditor,
+            Overlay::ModelNameEditor,
+        ];
         self.advance_openai_profile_setup();
     }
 
     pub fn advance_openai_profile_setup(&mut self) {
         if self.openai_setup_steps.is_empty() {
+            self.openai_setup_keep_empty_api_key = false;
             self.open_overlay(Overlay::ModelPicker);
             self.notice = Some(
                 "Endpoint setup complete. Review the active profile and press Enter to rebuild."
@@ -756,6 +779,7 @@ impl TuiApp {
 
     pub fn cancel_openai_profile_setup(&mut self) {
         self.openai_setup_steps.clear();
+        self.openai_setup_keep_empty_api_key = false;
     }
 
     pub fn set_openai_setup_kind(&mut self, kind: OpenAiEndpointKind) {
@@ -809,7 +833,7 @@ impl TuiApp {
             return None;
         }
         self.openai_model_picker_profiles()
-            .get(self.model_picker_idx.checked_sub(1)?)
+            .get(self.model_picker_idx)
             .map(|profile| (*profile).clone())
     }
 
@@ -837,7 +861,7 @@ impl TuiApp {
         self.config
             .select_openai_profile(next.id, next.label, next.kind);
         let deleted = self.config.openai_profiles.remove(active_id.as_str())?;
-        self.model_picker_idx = 1;
+        self.model_picker_idx = 0;
         Some(deleted.label)
     }
 
@@ -1180,11 +1204,7 @@ impl TuiApp {
                 if !matches!(selected_provider_family_idx_for_config(&self.config), 1) {
                     self.config.set_provider("openai-compatible");
                 }
-                self.model_picker_idx = if self.openai_model_picker_profiles().is_empty() {
-                    0
-                } else {
-                    1
-                };
+                self.model_picker_idx = 0;
             } else if let Some(provider) = self.single_provider_for_selected_family() {
                 self.config.set_provider(provider.to_string());
                 self.model_picker_idx = self.selected_preset_idx();

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -349,7 +349,7 @@ fn opening_openai_compatible_model_picker_keeps_active_profile_kind() {
 }
 
 #[test]
-fn openai_compatible_model_picker_includes_explicit_profile_actions() {
+fn openai_compatible_model_picker_selects_profile_rows() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {
         path: dir.path().join("config.json"),
@@ -359,16 +359,9 @@ fn openai_compatible_model_picker_includes_explicit_profile_actions() {
     app.provider_picker_idx = 1;
     app.open_overlay(Overlay::ModelPicker);
 
-    assert_eq!(app.current_model_picker_len(), 2);
-    assert_eq!(app.model_picker_idx, 1);
+    assert_eq!(app.current_model_picker_len(), 1);
+    assert_eq!(app.model_picker_idx, 0);
 
-    app.model_picker_idx = 0;
-    assert_eq!(
-        app.selected_openai_model_picker_action(),
-        Some(crate::tui::state::OpenAiModelPickerAction::CreateProfile)
-    );
-
-    app.model_picker_idx = 1;
     assert_eq!(
         app.selected_openai_model_picker_action(),
         Some(crate::tui::state::OpenAiModelPickerAction::SelectProfile)
@@ -380,18 +373,12 @@ fn openai_compatible_model_picker_includes_explicit_profile_actions() {
         OpenAiEndpointKind::Openrouter,
     );
     app.open_overlay(Overlay::ModelPicker);
-    assert_eq!(app.current_model_picker_len(), 4);
+    assert_eq!(app.current_model_picker_len(), 2);
 
-    app.model_picker_idx = 2;
+    app.model_picker_idx = 1;
     assert_eq!(
         app.selected_openai_model_picker_action(),
         Some(crate::tui::state::OpenAiModelPickerAction::SelectProfile)
-    );
-
-    app.model_picker_idx = 3;
-    assert_eq!(
-        app.selected_openai_model_picker_action(),
-        Some(crate::tui::state::OpenAiModelPickerAction::DeleteProfile)
     );
 }
 
@@ -428,8 +415,54 @@ fn openai_compatible_model_picker_deletes_active_profile_and_keeps_next() {
         app.config.active_openai_profile_id(),
         Some("custom-default")
     );
-    assert_eq!(app.model_picker_idx, 1);
-    assert_eq!(app.current_model_picker_len(), 2);
+    assert_eq!(app.model_picker_idx, 0);
+    assert_eq!(app.current_model_picker_len(), 1);
+}
+
+#[test]
+fn openai_profile_active_state_survives_switching_to_codex_and_ollama() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+
+    app.provider_picker_idx = 1;
+    app.config.select_openai_profile(
+        "openrouter-main",
+        "OpenRouter Main",
+        OpenAiEndpointKind::Openrouter,
+    );
+    app.config
+        .set_model(Some("anthropic/claude-3.7-sonnet".to_string()));
+    app.config.set_api_key("sk-openrouter");
+    assert_eq!(
+        app.config.active_openai_profile_id(),
+        Some("openrouter-main")
+    );
+
+    app.provider_picker_idx = 0;
+    app.open_overlay(Overlay::ModelPicker);
+    app.select_local_model(0);
+    assert_eq!(app.config.provider, "codex");
+
+    app.provider_picker_idx = 3;
+    app.open_overlay(Overlay::ModelPicker);
+    app.select_local_model(0);
+    assert_eq!(app.config.provider, "ollama");
+
+    app.provider_picker_idx = 1;
+    app.open_overlay(Overlay::ModelPicker);
+
+    assert_eq!(
+        app.config.active_openai_profile_id(),
+        Some("openrouter-main")
+    );
+    assert_eq!(
+        app.config.model.as_deref(),
+        Some("anthropic/claude-3.7-sonnet")
+    );
+    assert_eq!(app.model_picker_idx, 0);
 }
 
 #[test]

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -58,7 +58,6 @@ pub enum ProviderFamily {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum OpenAiModelPickerAction {
-    CreateProfile,
     SelectProfile,
     DeleteProfile,
 }
@@ -373,6 +372,7 @@ pub struct TuiApp {
     pub openai_profile_label_cursor_offset: Option<usize>,
     pub openai_profile_label_kind: Option<OpenAiEndpointKind>,
     pub openai_setup_steps: Vec<Overlay>,
+    pub openai_setup_keep_empty_api_key: bool,
     pub codex_model_options: Vec<CodexModelOption>,
     pub recent_commands: Vec<String>,
     pub recent_threads: Vec<ThreadSummary>,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -422,7 +422,7 @@ fn app_starts_with_warning_instead_of_api_key_editor_for_hosted_provider_without
 }
 
 #[test]
-fn openai_compatible_model_picker_exposes_connection_edit_shortcuts() {
+fn openai_compatible_model_picker_exposes_profile_table_shortcuts() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -433,16 +433,16 @@ fn openai_compatible_model_picker_exposes_connection_edit_shortcuts() {
     app.open_overlay(Overlay::ModelPicker);
 
     assert!(matches!(
-        map_key_to_event(key(KeyCode::Char('b')), &app),
-        AppEvent::OpenOverlay(Overlay::BaseUrlEditor)
+        map_key_to_event(key(KeyCode::Char('c')), &app),
+        AppEvent::CreateOpenAiProfile
     ));
     assert!(matches!(
-        map_key_to_event(key(KeyCode::Char('a')), &app),
-        AppEvent::OpenOverlay(Overlay::ApiKeyEditor)
+        map_key_to_event(key(KeyCode::Char('e')), &app),
+        AppEvent::EditOpenAiProfile
     ));
     assert!(matches!(
-        map_key_to_event(key(KeyCode::Char('n')), &app),
-        AppEvent::OpenOverlay(Overlay::ModelNameEditor)
+        map_key_to_event(key(KeyCode::Char(' ')), &app),
+        AppEvent::ApplyOverlaySelection
     ));
     assert!(matches!(
         map_key_to_event(key(KeyCode::Char('d')), &app),
@@ -470,7 +470,6 @@ async fn openai_model_picker_delete_row_removes_active_profile() {
         OpenAiEndpointKind::Openrouter,
     );
     app.open_overlay(Overlay::ModelPicker);
-    app.model_picker_idx = 3;
 
     let oauth_manager = Arc::new(
         crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
@@ -479,7 +478,7 @@ async fn openai_model_picker_delete_row_removes_active_profile() {
     let mut agent_slot = None;
 
     dispatch_event(
-        AppEvent::ApplyOverlaySelection,
+        AppEvent::DeleteOpenAiProfile,
         &mut app,
         &mut agent_slot,
         &oauth_manager,
@@ -502,7 +501,7 @@ async fn openai_model_picker_delete_row_removes_active_profile() {
 }
 
 #[tokio::test]
-async fn openai_model_picker_numeric_profile_row_starts_setup_when_incomplete() {
+async fn openai_model_picker_space_activates_selected_profile_and_starts_setup_when_incomplete() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -518,7 +517,7 @@ async fn openai_model_picker_numeric_profile_row_starts_setup_when_incomplete() 
     let mut agent_slot = None;
 
     dispatch_event(
-        AppEvent::SetModelSelection(1),
+        AppEvent::SetModelSelection(0),
         &mut app,
         &mut agent_slot,
         &oauth_manager,
@@ -526,19 +525,40 @@ async fn openai_model_picker_numeric_profile_row_starts_setup_when_incomplete() 
     .await
     .expect("set model selection");
 
+    assert!(matches!(app.overlay, Some(Overlay::ModelPicker)));
+
+    dispatch_event(
+        AppEvent::ApplyOverlaySelection,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("activate selected profile");
+
     assert!(matches!(app.overlay, Some(Overlay::BaseUrlEditor)));
 }
 
 #[tokio::test]
-async fn openai_model_picker_setup_row_opens_endpoint_kind_picker() {
+async fn openai_model_picker_edit_shortcut_starts_wizard_for_selected_profile() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
     })
     .expect("app");
     app.provider_picker_idx = 1;
+    app.config.select_openai_profile(
+        "custom-default",
+        "Custom endpoint",
+        OpenAiEndpointKind::Custom,
+    );
+    app.config.select_openai_profile(
+        "openrouter-default",
+        "OpenRouter",
+        OpenAiEndpointKind::Openrouter,
+    );
     app.open_overlay(Overlay::ModelPicker);
-    app.model_picker_idx = 0;
+    app.model_picker_idx = 1;
 
     let oauth_manager = Arc::new(
         crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
@@ -547,7 +567,99 @@ async fn openai_model_picker_setup_row_opens_endpoint_kind_picker() {
     let mut agent_slot = None;
 
     dispatch_event(
-        AppEvent::ApplyOverlaySelection,
+        AppEvent::EditOpenAiProfile,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("open selected profile model editor");
+
+    assert_eq!(
+        app.config.active_openai_profile_id(),
+        Some("custom-default")
+    );
+    assert!(matches!(app.overlay, Some(Overlay::BaseUrlEditor)));
+    assert_eq!(
+        app.openai_setup_steps,
+        vec![Overlay::ApiKeyEditor, Overlay::ModelNameEditor]
+    );
+}
+
+#[tokio::test]
+async fn openai_profile_edit_wizard_keeps_existing_api_key_when_blank() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    app.provider_picker_idx = 1;
+    app.config.select_openai_profile(
+        "openrouter-default",
+        "OpenRouter",
+        OpenAiEndpointKind::Openrouter,
+    );
+    app.config.set_api_key("sk-openrouter");
+    app.open_overlay(Overlay::ModelPicker);
+
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = None;
+
+    dispatch_event(
+        AppEvent::EditOpenAiProfile,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("start edit wizard");
+    assert!(matches!(app.overlay, Some(Overlay::BaseUrlEditor)));
+
+    dispatch_event(
+        AppEvent::SaveBaseUrlInput,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("save base url");
+    assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
+    assert!(app.api_key_input.is_empty());
+
+    dispatch_event(
+        AppEvent::SaveApiKeyInput,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("skip api key");
+
+    assert_eq!(app.config.api_key(), Some("sk-openrouter"));
+    assert!(matches!(app.overlay, Some(Overlay::ModelNameEditor)));
+}
+
+#[tokio::test]
+async fn openai_model_picker_create_shortcut_opens_endpoint_kind_picker() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    app.provider_picker_idx = 1;
+    app.open_overlay(Overlay::ModelPicker);
+
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = None;
+
+    dispatch_event(
+        AppEvent::CreateOpenAiProfile,
         &mut app,
         &mut agent_slot,
         &oauth_manager,
@@ -694,6 +806,7 @@ async fn saving_openai_profile_label_creates_new_profile_for_selected_kind() {
         .openai_profiles
         .contains_key("deepseek-deepseek-backup"));
     assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
+    assert_eq!(app.openai_setup_steps, vec![Overlay::ModelNameEditor]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Replace the OpenAI-compatible `/model` profile actions list with a profile table.
- Keep create and edit as guided flows: `C` creates a profile, `E` edits the selected profile through the full connection wizard.
- Preserve the active OpenAI-compatible profile when switching away to Codex/Ollama and back.

## Notes

- DeepSeek model discovery via `GET /models` is intentionally not included in this PR.
- Blank API key input during the edit wizard keeps the existing key instead of clearing it.

## Tests

- `cargo fmt --check`
- `cargo test openai_model_picker -- --nocapture`
- `cargo test openai_profile_edit_wizard_keeps_existing_api_key_when_blank -- --nocapture`
- `cargo test openai_compatible_model_picker -- --nocapture`
- `cargo test -p rara-config switching_away_and_back_to_openai_compatible_keeps_active_profile -- --nocapture`
- `cargo check`
