### PR TITLE
feat(tui): add DeepSeek model catalog flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8577,6 +8577,7 @@ dependencies = [
  "rand 0.8.5",
  "rara-config",
  "rara-instructions",
+ "rara-provider-catalog",
  "rara-skills",
  "ratatui",
  "regex",
@@ -8621,6 +8622,19 @@ dependencies = [
  "anyhow",
  "rara-config",
  "tempfile",
+]
+
+[[package]]
+name = "rara-provider-catalog"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "rara-config",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,11 @@
 [workspace]
-members = [".", "crates/config", "crates/instructions", "crates/skills"]
+members = [
+    ".",
+    "crates/config",
+    "crates/instructions",
+    "crates/provider-catalog",
+    "crates/skills",
+]
 resolver = "2"
 
 [workspace.package]
@@ -40,6 +46,7 @@ sha2 = "0.10"
 secrecy = { version = "0.10", features = ["serde"] }
 rara-config = { path = "crates/config" }
 rara-instructions = { path = "crates/instructions" }
+rara-provider-catalog = { path = "crates/provider-catalog" }
 rara-skills = { path = "crates/skills" }
 urlencoding = "2.1"
 url = "2.5"

--- a/crates/provider-catalog/Cargo.toml
+++ b/crates/provider-catalog/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rara-provider-catalog"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+rara-config = { path = "../config" }
+reqwest = { version = "0.12", features = ["json"] }
+secrecy.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+url = "2.5"

--- a/crates/provider-catalog/src/deepseek.rs
+++ b/crates/provider-catalog/src/deepseek.rs
@@ -1,0 +1,116 @@
+use anyhow::{anyhow, Result};
+use rara_config::DEFAULT_DEEPSEEK_BASE_URL;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+use crate::redaction::{redact_known_secret, sanitize_url_for_display};
+use crate::ModelCatalogRequest;
+
+const MODELS_TIMEOUT_SECS: u64 = 15;
+
+pub const FALLBACK_MODELS: [&str; 2] = ["deepseek-chat", "deepseek-reasoner"];
+
+#[derive(Deserialize)]
+struct ModelsResponse {
+    data: Vec<ModelEntry>,
+}
+
+#[derive(Deserialize)]
+struct ModelEntry {
+    id: String,
+}
+
+pub fn fallback_models() -> Vec<String> {
+    FALLBACK_MODELS
+        .iter()
+        .map(|model| (*model).to_string())
+        .collect()
+}
+
+pub fn models_url(base_url: Option<&str>) -> String {
+    let base_url = base_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_DEEPSEEK_BASE_URL)
+        .trim_end_matches('/');
+    let root = base_url.strip_suffix("/v1").unwrap_or(base_url);
+    format!("{root}/models")
+}
+
+pub fn parse_models(body: &str) -> Result<Vec<String>> {
+    let response: ModelsResponse = serde_json::from_str(body)?;
+    let mut models = response
+        .data
+        .into_iter()
+        .map(|model| model.id.trim().to_string())
+        .filter(|id| !id.is_empty())
+        .collect::<Vec<_>>();
+    models.sort();
+    models.dedup();
+    Ok(models)
+}
+
+pub async fn load_models(request: ModelCatalogRequest<'_>) -> Result<Vec<String>> {
+    let api_key = request
+        .api_key
+        .map(SecretString::expose_secret)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("DeepSeek API key is required to list models"))?;
+    let url = models_url(request.base_url);
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(MODELS_TIMEOUT_SECS))
+        .build()?;
+    let response = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .bearer_auth(api_key)
+        .send()
+        .await?;
+
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        return Err(anyhow!(
+            "DeepSeek model list request failed at {}: {}",
+            sanitize_url_for_display(&url),
+            redact_known_secret(&body, api_key)
+        ));
+    }
+    parse_models(&body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{models_url, parse_models};
+
+    #[test]
+    fn deepseek_models_url_uses_root_models_endpoint() {
+        assert_eq!(
+            models_url(Some("https://api.deepseek.com/v1")),
+            "https://api.deepseek.com/models"
+        );
+        assert_eq!(
+            models_url(Some("https://api.deepseek.com")),
+            "https://api.deepseek.com/models"
+        );
+    }
+
+    #[test]
+    fn parses_deepseek_models_and_deduplicates_ids() {
+        let models = parse_models(
+            r#"{
+                "object": "list",
+                "data": [
+                    {"id": "deepseek-reasoner", "object": "model"},
+                    {"id": "deepseek-chat", "object": "model"},
+                    {"id": "deepseek-chat", "object": "model"},
+                    {"id": " ", "object": "model"}
+                ]
+            }"#,
+        )
+        .expect("parse models");
+
+        assert_eq!(models, vec!["deepseek-chat", "deepseek-reasoner"]);
+    }
+}

--- a/crates/provider-catalog/src/deepseek.rs
+++ b/crates/provider-catalog/src/deepseek.rs
@@ -39,14 +39,12 @@ pub fn models_url(base_url: Option<&str>) -> String {
 
 pub fn parse_models(body: &str) -> Result<Vec<String>> {
     let response: ModelsResponse = serde_json::from_str(body)?;
-    let mut models = response
+    let models = response
         .data
         .into_iter()
         .map(|model| model.id.trim().to_string())
         .filter(|id| !id.is_empty())
         .collect::<Vec<_>>();
-    models.sort();
-    models.dedup();
     Ok(models)
 }
 
@@ -97,7 +95,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_deepseek_models_and_deduplicates_ids() {
+    fn parses_deepseek_models_in_provider_order() {
         let models = parse_models(
             r#"{
                 "object": "list",
@@ -111,6 +109,9 @@ mod tests {
         )
         .expect("parse models");
 
-        assert_eq!(models, vec!["deepseek-chat", "deepseek-reasoner"]);
+        assert_eq!(
+            models,
+            vec!["deepseek-reasoner", "deepseek-chat", "deepseek-chat"]
+        );
     }
 }

--- a/crates/provider-catalog/src/lib.rs
+++ b/crates/provider-catalog/src/lib.rs
@@ -1,0 +1,38 @@
+pub mod deepseek;
+mod redaction;
+
+use anyhow::Result;
+use secrecy::SecretString;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ModelCatalogProvider {
+    DeepSeek,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ModelCatalogRequest<'a> {
+    pub api_key: Option<&'a SecretString>,
+    pub base_url: Option<&'a str>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelCatalog {
+    pub provider: ModelCatalogProvider,
+    pub models: Vec<String>,
+}
+
+pub fn fallback_models(provider: ModelCatalogProvider) -> Vec<String> {
+    match provider {
+        ModelCatalogProvider::DeepSeek => deepseek::fallback_models(),
+    }
+}
+
+pub async fn load_model_catalog(
+    provider: ModelCatalogProvider,
+    request: ModelCatalogRequest<'_>,
+) -> Result<ModelCatalog> {
+    let models = match provider {
+        ModelCatalogProvider::DeepSeek => deepseek::load_models(request).await?,
+    };
+    Ok(ModelCatalog { provider, models })
+}

--- a/crates/provider-catalog/src/redaction.rs
+++ b/crates/provider-catalog/src/redaction.rs
@@ -1,0 +1,86 @@
+const REDACTED_SECRET: &str = "[REDACTED_SECRET]";
+const REDACTED_URL_VALUE: &str = "<redacted>";
+const SENSITIVE_URL_QUERY_KEYS: &[&str] = &[
+    "access_token",
+    "api_key",
+    "client_secret",
+    "id_token",
+    "key",
+    "refresh_token",
+    "token",
+];
+
+pub fn redact_known_secret(input: &str, secret: &str) -> String {
+    if secret.is_empty() {
+        return input.to_string();
+    }
+    input.replace(secret, REDACTED_SECRET)
+}
+
+pub fn sanitize_url_for_display(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(mut url) => {
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+            url.set_fragment(None);
+
+            let query_pairs = url
+                .query_pairs()
+                .map(|(key, value)| {
+                    let key = key.into_owned();
+                    let value = value.into_owned();
+                    if SENSITIVE_URL_QUERY_KEYS
+                        .iter()
+                        .any(|candidate| candidate.eq_ignore_ascii_case(&key))
+                    {
+                        (key, REDACTED_URL_VALUE.to_string())
+                    } else {
+                        (key, value)
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            if query_pairs.is_empty() {
+                url.set_query(None);
+            } else {
+                let redacted_query = query_pairs
+                    .into_iter()
+                    .fold(
+                        url::form_urlencoded::Serializer::new(String::new()),
+                        |mut serializer, (key, value)| {
+                            serializer.append_pair(&key, &value);
+                            serializer
+                        },
+                    )
+                    .finish();
+                url.set_query(Some(&redacted_query));
+            }
+
+            url.to_string()
+        }
+        Err(_) => "<invalid-url>".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{redact_known_secret, sanitize_url_for_display};
+
+    #[test]
+    fn redacts_known_secret_from_error_body() {
+        assert_eq!(
+            redact_known_secret("invalid token sk-secret-value", "sk-secret-value"),
+            "invalid token [REDACTED_SECRET]"
+        );
+    }
+
+    #[test]
+    fn sanitizes_sensitive_url_parts() {
+        let rendered =
+            sanitize_url_for_display("https://user:pass@example.com/models?api_key=abc&env=prod");
+        assert_eq!(
+            rendered,
+            "https://example.com/models?api_key=%3Credacted%3E&env=prod"
+        );
+    }
+}

--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -39,6 +39,7 @@ pub enum AppEvent {
     CreateOpenAiProfile,
     EditOpenAiProfile,
     DeleteOpenAiProfile,
+    RefreshDeepSeekModels,
     SelectHelpTab(HelpTab),
     ApplyOverlaySelection,
 }

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -947,6 +947,23 @@ pub fn model_help_text(app: &TuiApp) -> String {
                         .collect::<Vec<_>>()
                         .join("\n")
                 }
+            } else if matches!(family, ProviderFamily::DeepSeek) {
+                app.deepseek_model_options
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, model)| {
+                        let marker = if app.config.active_openai_profile_kind()
+                            == Some(rara_config::OpenAiEndpointKind::Deepseek)
+                            && app.config.model.as_deref() == Some(model.as_str())
+                        {
+                            "*"
+                        } else {
+                            " "
+                        };
+                        format!("{marker} {}. {model} (deepseek/{model})", idx + 1)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
             } else {
                 current_model_presets(provider_idx)
                     .iter()
@@ -961,6 +978,7 @@ pub fn model_help_text(app: &TuiApp) -> String {
                         };
                         let shortcut = match family {
                             ProviderFamily::Codex => (idx + 1).to_string(),
+                            ProviderFamily::DeepSeek => (idx + 1).to_string(),
                             ProviderFamily::OpenAiCompatible => (idx + 1).to_string(),
                             ProviderFamily::CandleLocal => (idx + 1).to_string(),
                             ProviderFamily::Ollama => model.to_string(),

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -960,7 +960,10 @@ pub fn model_help_text(app: &TuiApp) -> String {
                         } else {
                             " "
                         };
-                        format!("{marker} {}. {model} (deepseek/{model})", idx + 1)
+                        format!(
+                            "{marker} {}. {model} (openai-compatible:deepseek/{model})",
+                            idx + 1
+                        )
                     })
                     .collect::<Vec<_>>()
                     .join("\n")
@@ -1029,11 +1032,11 @@ pub fn normalize_command_token(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        help_text, matching_commands, normalize_command_token, palette_commands,
+        help_text, matching_commands, model_help_text, normalize_command_token, palette_commands,
         parse_local_command, status_context_text, status_prompt_sources_text,
         status_resources_text, status_runtime_text, LocalCommandKind, COMMAND_SPECS,
     };
-    use crate::config::ConfigManager;
+    use crate::config::{ConfigManager, OpenAiEndpointKind};
     use crate::context::PromptSourceContextEntry;
     use crate::tui::state::{RuntimeSnapshot, TuiApp};
     use tempfile::tempdir;
@@ -1043,6 +1046,27 @@ mod tests {
         let command = parse_local_command("/model anything").expect("command should parse");
         assert!(matches!(command.kind, LocalCommandKind::Model));
         assert_eq!(command.arg.as_deref(), Some("anything"));
+    }
+
+    #[test]
+    fn model_help_text_labels_deepseek_as_openai_compatible_endpoint() {
+        let dir = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app");
+        app.config.select_openai_profile(
+            "deepseek-default",
+            "DeepSeek",
+            OpenAiEndpointKind::Deepseek,
+        );
+        app.config.set_model(Some("deepseek-chat".to_string()));
+        app.set_deepseek_model_options(vec!["deepseek-chat".to_string()]);
+
+        let rendered = model_help_text(&app);
+
+        assert!(rendered.contains("* 1. deepseek-chat (openai-compatible:deepseek/deepseek-chat)"));
+        assert!(!rendered.contains("(deepseek/deepseek-chat)"));
     }
 
     #[test]

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -51,10 +51,9 @@ pub(super) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             KeyCode::Esc => AppEvent::CloseOverlay,
             KeyCode::Up | KeyCode::Char('k') => AppEvent::MoveProviderSelection(-1),
             KeyCode::Down | KeyCode::Char('j') => AppEvent::MoveProviderSelection(1),
-            KeyCode::Char('1') => AppEvent::SetProviderSelection(0),
-            KeyCode::Char('2') => AppEvent::SetProviderSelection(1),
-            KeyCode::Char('3') => AppEvent::SetProviderSelection(2),
-            KeyCode::Char('4') => AppEvent::SetProviderSelection(3),
+            KeyCode::Char(ch) if ('1'..='9').contains(&ch) => {
+                AppEvent::SetProviderSelection(ch as usize - '1' as usize)
+            }
             KeyCode::Enter => AppEvent::ApplyOverlaySelection,
             _ => AppEvent::Noop,
         },

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -92,6 +92,12 @@ pub(super) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             KeyCode::Char('b') if app.selected_provider_family() == ProviderFamily::Ollama => {
                 AppEvent::OpenOverlay(Overlay::BaseUrlEditor)
             }
+            KeyCode::Char('r') if app.selected_provider_family() == ProviderFamily::DeepSeek => {
+                AppEvent::RefreshDeepSeekModels
+            }
+            KeyCode::Char('a') if app.selected_provider_family() == ProviderFamily::DeepSeek => {
+                AppEvent::OpenOverlay(Overlay::ApiKeyEditor)
+            }
             KeyCode::Char('e')
                 if matches!(
                     app.selected_provider_family(),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -43,8 +43,8 @@ use self::provider_flow::{
 use self::render::{desired_viewport_height, render};
 use self::runtime::{
     execute_local_command, finish_running_task_if_ready, should_suggest_planning_mode,
-    start_oauth_task, start_pending_approval_task, start_plan_approval_resume_task,
-    start_query_task, start_rebuild_task,
+    start_deepseek_model_list_task, start_oauth_task, start_pending_approval_task,
+    start_plan_approval_resume_task, start_query_task, start_rebuild_task,
 };
 use self::session_restore::{
     provider_requires_api_key, restore_latest_thread, restore_thread_by_id,
@@ -320,6 +320,8 @@ async fn dispatch_event(
             {
                 if app.selected_provider_family() == self::state::ProviderFamily::OpenAiCompatible {
                     return Ok(false);
+                } else if app.selected_provider_family() == self::state::ProviderFamily::DeepSeek {
+                    return Ok(false);
                 } else if should_open_codex_auth_guide(app, oauth_manager.as_ref()) {
                     app.select_local_model(app.model_picker_idx);
                     app.open_overlay(Overlay::AuthModePicker);
@@ -453,6 +455,10 @@ async fn dispatch_event(
                 app.push_notice("Wait for the current task before saving the API key.");
             } else if value.is_empty() && app.config.provider == "codex" {
                 app.push_notice("Enter a Codex API key or press Esc to go back.");
+            } else if value.is_empty()
+                && app.selected_provider_family() == self::state::ProviderFamily::DeepSeek
+            {
+                app.push_notice("Enter a DeepSeek API key or press Esc to go back.");
             } else if value.is_empty() && app.openai_setup_keep_empty_api_key {
                 app.notice = Some("Kept existing API key for the current profile.".into());
                 app.advance_openai_profile_setup();
@@ -469,6 +475,8 @@ async fn dispatch_event(
                     app.advance_openai_profile_setup();
                 }
             } else {
+                let was_deepseek =
+                    app.selected_provider_family() == self::state::ProviderFamily::DeepSeek;
                 app.config.set_api_key(value.to_string());
                 if app.config.provider == "codex" {
                     app.codex_auth_mode = Some(crate::oauth::SavedCodexAuthMode::ApiKey);
@@ -480,6 +488,10 @@ async fn dispatch_event(
                     app.notice = Some("Saved Codex API key. Rebuilding backend.".into());
                     app.overlay = None;
                     start_rebuild_task(app);
+                } else if was_deepseek {
+                    app.notice = Some("Saved DeepSeek API key. Loading models.".into());
+                    app.overlay = None;
+                    start_deepseek_model_list_task(app);
                 } else {
                     app.notice = Some("Saved API key for the current provider.".into());
                     if app.openai_setup_steps.is_empty() {
@@ -563,6 +575,17 @@ async fn dispatch_event(
                 apply_openai_model_picker_action(app, OpenAiModelPickerAction::DeleteProfile)?;
             }
         }
+        AppEvent::RefreshDeepSeekModels => {
+            if app.is_busy() {
+                app.push_notice("Wait for the current task before refreshing DeepSeek models.");
+            } else if app.selected_provider_family() != self::state::ProviderFamily::DeepSeek {
+                app.push_notice("DeepSeek model refresh is only available in DeepSeek.");
+            } else if !app.config.has_api_key() {
+                app.open_overlay(Overlay::ApiKeyEditor);
+            } else {
+                start_deepseek_model_list_task(app);
+            }
+        }
         AppEvent::SelectHelpTab(tab) => {
             app.open_overlay(Overlay::Help(tab));
         }
@@ -582,15 +605,19 @@ async fn dispatch_event(
                     app.push_notice("A task is already running. Wait for it to finish.");
                 } else {
                     open_provider_family_overlay(app, oauth_manager.as_ref()).await?;
+                    if app.selected_provider_family() == self::state::ProviderFamily::DeepSeek
+                        && app.config.has_api_key()
+                        && matches!(app.overlay, Some(Overlay::ModelPicker))
+                    {
+                        start_deepseek_model_list_task(app);
+                    }
                 }
             }
             Some(Overlay::OpenAiEndpointKindPicker) => {
                 if app.is_busy() {
                     app.push_notice("A task is already running. Wait for it to finish.");
                 } else {
-                    let kind = crate::tui::state::openai_compatible_preset_kind(
-                        app.openai_endpoint_kind_picker_idx,
-                    );
+                    let kind = app.selected_openai_setup_kind();
                     app.set_openai_setup_kind(kind);
                     app.config_manager.save(&app.config)?;
                 }
@@ -665,6 +692,15 @@ async fn dispatch_event(
                     {
                         if let Some(action) = app.selected_openai_model_picker_action() {
                             apply_openai_model_picker_action(app, action)?;
+                        }
+                    } else if app.selected_provider_family()
+                        == self::state::ProviderFamily::DeepSeek
+                    {
+                        if app.config.has_api_key() {
+                            app.select_local_model(app.model_picker_idx);
+                            start_rebuild_task(app);
+                        } else {
+                            app.open_overlay(Overlay::ApiKeyEditor);
                         }
                     } else {
                         app.select_local_model(app.model_picker_idx);

--- a/src/tui/provider_flow.rs
+++ b/src/tui/provider_flow.rs
@@ -2,6 +2,7 @@ use secrecy::{ExposeSecret, SecretString};
 
 use crate::agent::Agent;
 use crate::codex_model_catalog::load_codex_model_catalog;
+use crate::config::OpenAiEndpointKind;
 use crate::oauth::OAuthManager;
 
 use super::state::{Overlay, ProviderFamily, TuiApp};
@@ -148,6 +149,19 @@ pub(super) async fn open_provider_family_overlay(
     let entering_codex_family = matches!(app.selected_provider_family(), ProviderFamily::Codex);
     if entering_codex_family {
         oauth_manager.invalidate_saved_auth_cache();
+    }
+    if matches!(app.selected_provider_family(), ProviderFamily::DeepSeek) {
+        app.config.select_openai_profile(
+            OpenAiEndpointKind::Deepseek.default_profile_id(),
+            OpenAiEndpointKind::Deepseek.label(),
+            OpenAiEndpointKind::Deepseek,
+        );
+        if !app.config.has_api_key() {
+            app.open_overlay(Overlay::ApiKeyEditor);
+        } else {
+            app.open_overlay(Overlay::ModelPicker);
+        }
+        return Ok(());
     }
     let has_synced_codex_auth = if entering_codex_family {
         sync_codex_credential_from_auth_store(app, oauth_manager)?

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -14,7 +14,9 @@ use crate::tui::auth_mode_picker::build_auth_mode_picker_view;
 use crate::tui::command::api_key_status;
 use crate::tui::is_ssh_session;
 use crate::tui::render::bottom_pane::editor_cursor_position;
-use crate::tui::state::{current_model_presets, ProviderFamily, TuiApp, PROVIDER_FAMILIES};
+use crate::tui::state::{
+    current_model_presets, openai_profile_setup_kinds, ProviderFamily, TuiApp, PROVIDER_FAMILIES,
+};
 
 fn wrapped_text_height(text: &str, area_width: u16) -> u16 {
     let width = area_width.saturating_sub(2).max(1) as usize;
@@ -83,7 +85,7 @@ pub(super) fn render_provider_picker_modal(f: &mut Frame, app: &TuiApp, area: Re
         chunks[1],
     );
     f.render_widget(
-        Paragraph::new("1/2/3/4 select  Up/Down move  Enter continue  Esc close")
+        Paragraph::new("number jump  up/down move  enter choose  esc close")
             .alignment(Alignment::Center),
         chunks[2],
     );
@@ -212,6 +214,29 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
                 .style(style)
             })
             .collect::<Vec<_>>()
+    } else if app.selected_provider_family() == ProviderFamily::DeepSeek {
+        app.deepseek_model_options
+            .iter()
+            .enumerate()
+            .map(|(idx, model)| {
+                let style = if idx == app.model_picker_idx {
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                let current = if app.config.active_openai_profile_kind()
+                    == Some(crate::config::OpenAiEndpointKind::Deepseek)
+                    && app.config.model.as_deref() == Some(model.as_str())
+                {
+                    " current"
+                } else {
+                    ""
+                };
+                ListItem::new(format!("[{}] {}{}", idx + 1, model, current)).style(style)
+            })
+            .collect::<Vec<_>>()
     } else {
         let presets = current_model_presets(app.provider_picker_idx);
         presets
@@ -261,6 +286,15 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
                 .unwrap_or("https://api.openai.com/v1"),
             app.current_reasoning_effort_label(),
         )
+    } else if provider_label == "DeepSeek" {
+        &format!(
+            "Provider: DeepSeek\nBase URL: {}\nAPI key: {}\nChoose a DeepSeek model. R refreshes /models.",
+            app.config
+                .base_url
+                .as_deref()
+                .unwrap_or(crate::config::DEFAULT_DEEPSEEK_BASE_URL),
+            api_key_status(&app.config),
+        )
     } else {
         &format!(
             "Provider: {provider_label}\nBase URL: {}\nSelect a concrete model preset. Enter applies immediately.",
@@ -291,6 +325,8 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
     f.render_widget(
         Paragraph::new(if provider_label == "Codex" {
             "1-9 jump  Up/Down move  Enter choose level  Esc close"
+        } else if provider_label == "DeepSeek" {
+            "1-9 jump  Up/Down move  Enter apply  A api key  R refresh  Esc close"
         } else {
             "1-9 apply directly  Up/Down move  B edit base URL  Enter apply  Esc close"
         })
@@ -494,14 +530,9 @@ pub(super) fn render_openai_profile_picker_modal(f: &mut Frame, app: &TuiApp, ar
 }
 
 pub(super) fn render_openai_endpoint_kind_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
-    let kinds = [
-        crate::config::OpenAiEndpointKind::Custom,
-        crate::config::OpenAiEndpointKind::Deepseek,
-        crate::config::OpenAiEndpointKind::Kimi,
-        crate::config::OpenAiEndpointKind::Openrouter,
-    ];
-    let items = kinds
-        .into_iter()
+    let items = openai_profile_setup_kinds()
+        .iter()
+        .copied()
         .enumerate()
         .map(|(idx, kind)| {
             let current = if app.config.active_openai_profile_kind() == Some(kind) {

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -8,11 +8,13 @@ expression: rendered
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
 │[1] Codex                                                                                         │
 │  Use Codex with browser login, device-code login, or a Codex API key.                            │
-│[2] OpenAI-compatible                                                                             │
-│  Use OpenAI-compatible endpoint profiles such as Custom, DeepSeek, Kimi, or OpenRouter.          │
-│[3] Candle Local                                                                                  │
+│[2] DeepSeek                                                                                      │
+│  Use DeepSeek with an API key and model list from api.deepseek.com.                              │
+│[3] OpenAI-compatible                                                                             │
+│  Use OpenAI-compatible endpoint profiles such as Custom, Kimi, or OpenRouter.                    │
+│[4] Candle Local                                                                                  │
 │  Run local Candle models directly in-process.                                                    │
-│[4] Ollama                                                                                        │
+│[5] Ollama                                                                                        │
 │  Use an external Ollama server and choose a local tag.                                           │
 │                                                                                                  │
 │                                                                                                  │
@@ -23,6 +25,4 @@ expression: rendered
 │                                                                                                  │
 │                                                                                                  │
 │                                                                                                  │
-│                                                                                                  │
-│                                                                                                  │
-                       1/2/3/4 select  Up/Down move  Enter continue  Esc close
+                         number jump  up/down move  enter choose  esc close

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -19,6 +19,13 @@ use super::{
     transcript_viewport, transcript_visual_row_count,
 };
 
+fn provider_family_idx(family: ProviderFamily) -> usize {
+    crate::tui::state::PROVIDER_FAMILIES
+        .iter()
+        .position(|(candidate, _, _)| *candidate == family)
+        .expect("provider family present")
+}
+
 #[test]
 fn committed_turn_does_not_truncate_agent_response() {
     let entries = vec![
@@ -622,10 +629,7 @@ fn openai_model_picker_renders_profile_manager_not_endpoint_presets() {
         path: temp.path().join("config.json"),
     })
     .expect("build tui app");
-    app.provider_picker_idx = crate::tui::state::PROVIDER_FAMILIES
-        .iter()
-        .position(|(family, _, _)| *family == ProviderFamily::OpenAiCompatible)
-        .expect("openai-compatible family present");
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.config.select_openai_profile(
         "openrouter-main",
         "OpenRouter Main",
@@ -649,16 +653,38 @@ fn openai_model_picker_renders_profile_manager_not_endpoint_presets() {
 }
 
 #[test]
+fn deepseek_model_picker_renders_catalog_models_and_refresh_hint() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::DeepSeek);
+    app.config
+        .select_openai_profile("deepseek-default", "DeepSeek", OpenAiEndpointKind::Deepseek);
+    app.config.set_api_key("sk-deepseek");
+    app.set_deepseek_model_options(vec![
+        "deepseek-chat".to_string(),
+        "deepseek-reasoner".to_string(),
+    ]);
+    app.open_overlay(Overlay::ModelPicker);
+
+    let rendered = render_screen_text(&app, 100, 24);
+    assert!(rendered.contains("Provider: DeepSeek"));
+    assert!(rendered.contains("deepseek-chat"));
+    assert!(rendered.contains("deepseek-reasoner"));
+    assert!(rendered.contains("R refreshes /models"));
+    assert!(rendered.contains("A api key"));
+}
+
+#[test]
 fn openai_model_picker_renders_profile_defaults_when_fields_are_empty() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
     })
     .expect("build tui app");
-    app.provider_picker_idx = crate::tui::state::PROVIDER_FAMILIES
-        .iter()
-        .position(|(family, _, _)| *family == ProviderFamily::OpenAiCompatible)
-        .expect("openai-compatible family present");
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.config.select_openai_profile(
         "custom-defaults",
         "Custom Defaults",
@@ -724,10 +750,7 @@ fn api_key_editor_renders_full_prompt_on_standard_terminal() {
     config.base_url = Some("https://api.deepseek.com".into());
     config.model = Some("deepseek-chat".into());
     app.config = config;
-    app.provider_picker_idx = crate::tui::state::PROVIDER_FAMILIES
-        .iter()
-        .position(|(family, _, _)| *family == ProviderFamily::OpenAiCompatible)
-        .expect("openai-compatible family present");
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.open_overlay(Overlay::ApiKeyEditor);
 
     let rendered = render_screen_text(&app, 100, 24);

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -578,9 +578,7 @@ fn compact_summary_text_keeps_tail_of_long_explicit_blocks() {
 #[test]
 fn ssh_startup_page_warns_without_opening_setup_window() {
     let temp = tempdir().expect("tempdir");
-    let old_ssh_connection = std::env::var_os("SSH_CONNECTION");
-    let old_ssh_tty = std::env::var_os("SSH_TTY");
-    std::env::set_var("SSH_CONNECTION", "test");
+    let _ssh_env = crate::tui::terminal_ui::test_env::set_ssh_session(true);
 
     let cm = ConfigManager {
         path: temp.path().join("config.json"),
@@ -596,17 +594,6 @@ fn ssh_startup_page_warns_without_opening_setup_window() {
 
     let rendered = render_screen_text(&app, 100, 24);
     assert_snapshot!("ssh_startup_warning_screen", rendered);
-
-    if let Some(value) = old_ssh_connection {
-        std::env::set_var("SSH_CONNECTION", value);
-    } else {
-        std::env::remove_var("SSH_CONNECTION");
-    }
-    if let Some(value) = old_ssh_tty {
-        std::env::set_var("SSH_TTY", value);
-    } else {
-        std::env::remove_var("SSH_TTY");
-    }
 }
 
 #[test]

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -42,6 +42,10 @@ pub fn start_oauth_task(app: &mut TuiApp, oauth_manager: Arc<OAuthManager>, mode
     tasks::start_oauth_task(app, oauth_manager, mode);
 }
 
+pub fn start_deepseek_model_list_task(app: &mut TuiApp) {
+    tasks::start_deepseek_model_list_task(app);
+}
+
 pub async fn finish_running_task_if_ready(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -7,6 +7,9 @@ use secrecy::ExposeSecret;
 use std::sync::Arc;
 use std::time::Instant;
 
+use rara_provider_catalog::{
+    fallback_models, load_model_catalog, ModelCatalogProvider, ModelCatalogRequest,
+};
 use tokio::sync::mpsc;
 
 use crate::agent::{Agent, AgentOutputMode, BashApprovalMode};
@@ -359,6 +362,38 @@ pub(super) fn start_oauth_task(
     oauth::start_oauth_task(app, oauth_manager, mode);
 }
 
+pub(super) fn start_deepseek_model_list_task(app: &mut TuiApp) {
+    let (_sender, receiver) = mpsc::unbounded_channel();
+    let api_key = app.config.api_key.clone();
+    let base_url = app.config.base_url.clone();
+    app.notice = Some("Loading DeepSeek models.".into());
+    app.set_runtime_phase(
+        RuntimePhase::RebuildingBackend,
+        Some("loading models".into()),
+    );
+
+    let handle = tokio::spawn(async move {
+        let result = load_model_catalog(
+            ModelCatalogProvider::DeepSeek,
+            ModelCatalogRequest {
+                api_key: api_key.as_ref(),
+                base_url: base_url.as_deref(),
+            },
+        )
+        .await
+        .map(|catalog| catalog.models);
+        TaskCompletion::DeepSeekModels { result }
+    });
+
+    app.running_task = Some(RunningTask {
+        kind: TaskKind::DeepSeekModels,
+        receiver,
+        handle,
+        started_at: Instant::now(),
+        next_heartbeat_after_secs: u64::MAX,
+    });
+}
+
 pub(super) async fn finish_running_task_if_ready(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
@@ -572,6 +607,26 @@ pub(super) async fn finish_running_task_if_ready(
                 let message = format!("OAuth failed:\n{}", format_error_chain(&err));
                 app.push_entry("System", message.clone());
                 app.push_notice(message);
+            }
+        },
+        TaskCompletion::DeepSeekModels { result } => match result {
+            Ok(models) => {
+                let count = models.len();
+                app.set_deepseek_model_options(models);
+                app.notice = Some(format!("Loaded {count} DeepSeek models."));
+                app.set_runtime_phase(RuntimePhase::Idle, Some("models loaded".into()));
+                app.open_overlay(super::super::state::Overlay::ModelPicker);
+            }
+            Err(err) => {
+                app.set_deepseek_model_options(fallback_models(ModelCatalogProvider::DeepSeek));
+                let message = format!(
+                    "Failed to load DeepSeek models. Showing fallback list.\n{}",
+                    format_error_chain(&err)
+                );
+                app.push_entry("System", message.clone());
+                app.push_notice(message);
+                app.set_runtime_phase(RuntimePhase::Idle, Some("model list fallback".into()));
+                app.open_overlay(super::super::state::Overlay::ModelPicker);
             }
         },
     }

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -54,8 +54,7 @@ fn skips_planning_for_simple_requests() {
 #[test]
 fn browser_oauth_is_rejected_before_task_start_in_ssh() {
     let temp = tempdir().unwrap();
-    let old_ssh = std::env::var_os("SSH_CONNECTION");
-    std::env::set_var("SSH_CONNECTION", "test");
+    let _ssh_env = crate::tui::terminal_ui::test_env::set_ssh_session(true);
 
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -72,12 +71,6 @@ fn browser_oauth_is_rejected_before_task_start_in_ssh() {
         .notice
         .as_deref()
         .is_some_and(|value| value.contains("Browser login is unavailable")));
-
-    if let Some(value) = old_ssh {
-        std::env::set_var("SSH_CONNECTION", value);
-    } else {
-        std::env::remove_var("SSH_CONNECTION");
-    }
 }
 
 #[test]

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -10,8 +10,8 @@ use std::process::Command;
 use unicode_width::UnicodeWidthChar;
 
 pub use self::state_presets::{
-    current_model_presets, openai_compatible_preset_index, openai_compatible_preset_kind,
-    selected_preset_idx_for_config, selected_provider_family_idx_for_config,
+    current_model_presets, openai_compatible_preset_kind, selected_preset_idx_for_config,
+    selected_provider_family_idx_for_config,
 };
 use self::types::CommittedTranscriptRenderCache;
 pub use self::types::{
@@ -22,6 +22,17 @@ pub use self::types::{
     RunningTask, RuntimePhase, RuntimeSnapshot, TaskCompletion, TaskKind, TranscriptEntry,
     TranscriptTurn, TuiApp, TuiEvent, PROVIDER_FAMILIES,
 };
+
+const OPENAI_PROFILE_SETUP_KINDS: [OpenAiEndpointKind; 3] = [
+    OpenAiEndpointKind::Custom,
+    OpenAiEndpointKind::Kimi,
+    OpenAiEndpointKind::Openrouter,
+];
+
+pub fn openai_profile_setup_kinds() -> &'static [OpenAiEndpointKind] {
+    &OPENAI_PROFILE_SETUP_KINDS
+}
+
 use super::queued_input::PendingFollowUpMessage;
 use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
@@ -29,6 +40,7 @@ use crate::config::{ConfigManager, OpenAiEndpointKind, DEFAULT_CODEX_BASE_URL};
 use crate::redaction::redact_secrets;
 use crate::state_db::StateDb;
 use crate::tui::is_ssh_session;
+use rara_provider_catalog::{fallback_models, ModelCatalogProvider};
 
 fn completed_interaction_role(kind: InteractionKind, source: Option<&str>) -> &'static str {
     match kind {
@@ -471,6 +483,7 @@ impl TuiApp {
             openai_setup_steps: Vec::new(),
             openai_setup_keep_empty_api_key: false,
             codex_model_options: Vec::new(),
+            deepseek_model_options: fallback_models(ModelCatalogProvider::DeepSeek),
             recent_commands: Vec::new(),
             recent_threads: Vec::new(),
             resume_picker_idx: 0,
@@ -578,6 +591,13 @@ impl TuiApp {
                 })
                 .unwrap_or(0);
         }
+        if self.selected_provider_family() == ProviderFamily::DeepSeek {
+            return self
+                .deepseek_model_options
+                .iter()
+                .position(|model| self.config.model.as_deref() == Some(model.as_str()))
+                .unwrap_or(0);
+        }
         selected_preset_idx_for_config(&self.config, self.provider_picker_idx)
     }
 
@@ -588,6 +608,8 @@ impl TuiApp {
     pub fn current_model_picker_len(&self) -> usize {
         if self.selected_provider_family() == ProviderFamily::Codex {
             self.codex_model_options.len()
+        } else if self.selected_provider_family() == ProviderFamily::DeepSeek {
+            self.deepseek_model_options.len()
         } else if self.selected_provider_family() == ProviderFamily::OpenAiCompatible {
             self.openai_model_picker_profiles().len()
         } else {
@@ -648,6 +670,29 @@ impl TuiApp {
         self.sync_reasoning_effort_picker();
     }
 
+    pub fn set_deepseek_model_options(&mut self, options: Vec<String>) {
+        let mut options = if options.is_empty() {
+            fallback_models(ModelCatalogProvider::DeepSeek)
+        } else {
+            options
+        };
+        if let Some(current_model) = self
+            .config
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+        {
+            if !options.iter().any(|model| model == current_model) {
+                options.insert(0, current_model.to_string());
+            }
+        }
+        options.sort();
+        options.dedup();
+        self.deepseek_model_options = options;
+        self.model_picker_idx = self.selected_preset_idx();
+    }
+
     fn selected_model_preset(&self) -> (&'static str, &'static str, &'static str) {
         let presets = current_model_presets(self.provider_picker_idx);
         presets[self.model_picker_idx.min(presets.len().saturating_sub(1))]
@@ -660,6 +705,7 @@ impl TuiApp {
         self.selected_openai_model_picker_profile()
             .map(|profile| profile.kind)
             .or_else(|| self.config.active_openai_profile_kind())
+            .filter(|kind| *kind != OpenAiEndpointKind::Deepseek)
             .or(Some(OpenAiEndpointKind::Custom))
     }
 
@@ -697,7 +743,17 @@ impl TuiApp {
     }
 
     pub fn openai_endpoint_kind_count(&self) -> usize {
-        current_model_presets(self.provider_picker_idx).len()
+        openai_profile_setup_kinds().len()
+    }
+
+    pub fn selected_openai_setup_kind(&self) -> OpenAiEndpointKind {
+        openai_profile_setup_kinds()
+            .get(
+                self.openai_endpoint_kind_picker_idx
+                    .min(openai_profile_setup_kinds().len().saturating_sub(1)),
+            )
+            .copied()
+            .unwrap_or(OpenAiEndpointKind::Custom)
     }
 
     fn openai_profile_setup_sequence(&self) -> Vec<Overlay> {
@@ -809,7 +865,12 @@ impl TuiApp {
 
     pub fn openai_model_picker_profiles(&self) -> Vec<&crate::config::OpenAiEndpointProfile> {
         let active_id = self.config.active_openai_profile_id();
-        let mut profiles = self.config.openai_profiles.values().collect::<Vec<_>>();
+        let mut profiles = self
+            .config
+            .openai_profiles
+            .values()
+            .filter(|profile| profile.kind != OpenAiEndpointKind::Deepseek)
+            .collect::<Vec<_>>();
         profiles.sort_by(|left, right| {
             let left_active = Some(left.id.as_str()) == active_id;
             let right_active = Some(right.id.as_str()) == active_id;
@@ -917,6 +978,9 @@ impl TuiApp {
         if self.selected_provider_family() == ProviderFamily::Codex {
             return Some("codex");
         }
+        if self.selected_provider_family() == ProviderFamily::DeepSeek {
+            return None;
+        }
         if self.selected_provider_family() == ProviderFamily::OpenAiCompatible {
             return None;
         }
@@ -946,6 +1010,23 @@ impl TuiApp {
                     .set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
             }
             self.sync_reasoning_effort_picker();
+            return;
+        }
+        if self.selected_provider_family() == ProviderFamily::DeepSeek {
+            let Some(model) = self
+                .deepseek_model_options
+                .get(idx.min(self.deepseek_model_options.len().saturating_sub(1)))
+                .cloned()
+            else {
+                return;
+            };
+            self.config.select_openai_profile(
+                OpenAiEndpointKind::Deepseek.default_profile_id(),
+                OpenAiEndpointKind::Deepseek.label(),
+                OpenAiEndpointKind::Deepseek,
+            );
+            self.config.set_model(Some(model));
+            self.config.set_revision(None);
             return;
         }
 
@@ -1201,8 +1282,20 @@ impl TuiApp {
         if matches!(overlay, Overlay::ModelPicker) {
             let selected_family = self.selected_provider_family();
             if matches!(selected_family, ProviderFamily::OpenAiCompatible) {
-                if !matches!(selected_provider_family_idx_for_config(&self.config), 1) {
+                if !matches!(
+                    PROVIDER_FAMILIES
+                        .get(selected_provider_family_idx_for_config(&self.config))
+                        .map(|(family, _, _)| *family),
+                    Some(ProviderFamily::OpenAiCompatible)
+                ) {
                     self.config.set_provider("openai-compatible");
+                }
+                if self.config.active_openai_profile_kind() == Some(OpenAiEndpointKind::Deepseek) {
+                    self.config.select_openai_profile(
+                        OpenAiEndpointKind::Custom.default_profile_id(),
+                        OpenAiEndpointKind::Custom.label(),
+                        OpenAiEndpointKind::Custom,
+                    );
                 }
                 self.model_picker_idx = 0;
             } else if let Some(provider) = self.single_provider_for_selected_family() {
@@ -1214,7 +1307,11 @@ impl TuiApp {
         if matches!(overlay, Overlay::OpenAiEndpointKindPicker) {
             self.openai_endpoint_kind_picker_idx = self
                 .selected_openai_profile_kind()
-                .map(openai_compatible_preset_index)
+                .and_then(|kind| {
+                    openai_profile_setup_kinds()
+                        .iter()
+                        .position(|candidate| *candidate == kind)
+                })
                 .unwrap_or(0);
         }
         if matches!(overlay, Overlay::OpenAiProfilePicker) {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -684,7 +684,7 @@ impl TuiApp {
             .filter(|model| !model.is_empty())
         {
             if !options.iter().any(|model| model == current_model) {
-                options.insert(0, current_model.to_string());
+                options.push(current_model.to_string());
             }
         }
         options.sort();

--- a/src/tui/state/state_presets.rs
+++ b/src/tui/state/state_presets.rs
@@ -24,21 +24,29 @@ pub const OLLAMA_MODEL_PRESETS: [(&str, &str, &str); 3] = [
 ];
 
 pub fn selected_provider_family_idx_for_config(config: &RaraConfig) -> usize {
-    match config.provider.as_str() {
-        "codex" => 0,
-        "deepseek" => 1,
+    let family = match config.provider.as_str() {
+        "codex" => ProviderFamily::Codex,
+        "deepseek" => ProviderFamily::DeepSeek,
         "openai-compatible" => {
             if config.active_openai_profile_kind() == Some(OpenAiEndpointKind::Deepseek) {
-                1
+                ProviderFamily::DeepSeek
             } else {
-                2
+                ProviderFamily::OpenAiCompatible
             }
         }
-        "kimi" | "openrouter" => 2,
-        "ollama" | "ollama-native" | "ollama-openai" => 4,
-        "gemma4" | "qwn3" | "qwen3" => 3,
-        _ => 0,
-    }
+        "kimi" | "openrouter" => ProviderFamily::OpenAiCompatible,
+        "ollama" | "ollama-native" | "ollama-openai" => ProviderFamily::Ollama,
+        "gemma4" | "qwn3" | "qwen3" => ProviderFamily::CandleLocal,
+        _ => ProviderFamily::Codex,
+    };
+    provider_family_index(family)
+}
+
+fn provider_family_index(family: ProviderFamily) -> usize {
+    super::PROVIDER_FAMILIES
+        .iter()
+        .position(|(candidate, _, _)| *candidate == family)
+        .unwrap_or(0)
 }
 
 pub fn current_model_presets(

--- a/src/tui/state/state_presets.rs
+++ b/src/tui/state/state_presets.rs
@@ -26,9 +26,17 @@ pub const OLLAMA_MODEL_PRESETS: [(&str, &str, &str); 3] = [
 pub fn selected_provider_family_idx_for_config(config: &RaraConfig) -> usize {
     match config.provider.as_str() {
         "codex" => 0,
-        "openai-compatible" | "deepseek" | "kimi" | "openrouter" => 1,
-        "ollama" | "ollama-native" | "ollama-openai" => 3,
-        "gemma4" | "qwn3" | "qwen3" => 2,
+        "deepseek" => 1,
+        "openai-compatible" => {
+            if config.active_openai_profile_kind() == Some(OpenAiEndpointKind::Deepseek) {
+                1
+            } else {
+                2
+            }
+        }
+        "kimi" | "openrouter" => 2,
+        "ollama" | "ollama-native" | "ollama-openai" => 4,
+        "gemma4" | "qwn3" | "qwen3" => 3,
         _ => 0,
     }
 }
@@ -38,6 +46,7 @@ pub fn current_model_presets(
 ) -> &'static [(&'static str, &'static str, &'static str)] {
     match super::PROVIDER_FAMILIES[provider_picker_idx].0 {
         ProviderFamily::Codex => &CODEX_MODEL_PRESETS,
+        ProviderFamily::DeepSeek => &[],
         ProviderFamily::OpenAiCompatible => &OPENAI_COMPATIBLE_MODEL_PRESETS,
         ProviderFamily::CandleLocal => &LOCAL_MODEL_PRESETS,
         ProviderFamily::Ollama => &OLLAMA_MODEL_PRESETS,
@@ -95,7 +104,7 @@ mod tests {
             ..RaraConfig::default()
         };
 
-        assert_eq!(selected_provider_family_idx_for_config(&config), 1);
+        assert_eq!(selected_provider_family_idx_for_config(&config), 2);
     }
 
     #[test]
@@ -117,21 +126,31 @@ mod tests {
             ..RaraConfig::default()
         };
 
-        assert_eq!(selected_provider_family_idx_for_config(&local), 2);
-        assert_eq!(selected_provider_family_idx_for_config(&ollama), 3);
-        assert_eq!(selected_provider_family_idx_for_config(&ollama_native), 3);
-        assert_eq!(selected_provider_family_idx_for_config(&ollama_openai), 3);
+        assert_eq!(selected_provider_family_idx_for_config(&local), 3);
+        assert_eq!(selected_provider_family_idx_for_config(&ollama), 4);
+        assert_eq!(selected_provider_family_idx_for_config(&ollama_native), 4);
+        assert_eq!(selected_provider_family_idx_for_config(&ollama_openai), 4);
     }
 
     #[test]
     fn keeps_legacy_openai_endpoint_providers_in_openai_compatible_family() {
-        for provider in ["deepseek", "kimi", "openrouter"] {
+        for provider in ["kimi", "openrouter"] {
             let config = RaraConfig {
                 provider: provider.to_string(),
                 ..RaraConfig::default()
             };
-            assert_eq!(selected_provider_family_idx_for_config(&config), 1);
+            assert_eq!(selected_provider_family_idx_for_config(&config), 2);
         }
+    }
+
+    #[test]
+    fn routes_deepseek_provider_to_dedicated_family() {
+        let config = RaraConfig {
+            provider: "deepseek".to_string(),
+            ..RaraConfig::default()
+        };
+
+        assert_eq!(selected_provider_family_idx_for_config(&config), 1);
     }
 
     #[test]

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1,13 +1,20 @@
 use super::{
     input_requests_command_palette, parse_repo_slug, state_db_status_error,
     ActivePendingInteractionKind, InteractionKind, Overlay, PendingInteractionSnapshot,
-    ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp,
+    ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp, PROVIDER_FAMILIES,
 };
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
 use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
 use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
 use crate::state_db::{PersistedCompactState, PersistedPromptRuntimeState, StateDb};
 use tempfile::tempdir;
+
+fn provider_family_idx(family: ProviderFamily) -> usize {
+    PROVIDER_FAMILIES
+        .iter()
+        .position(|(candidate, _, _)| *candidate == family)
+        .expect("provider family present")
+}
 
 #[test]
 fn detects_slash_command_input() {
@@ -200,7 +207,7 @@ fn openai_compatible_preset_sets_default_connection_fields() {
     };
     let mut app = TuiApp::new(cm).expect("app");
 
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     assert_eq!(
         app.selected_provider_family(),
         ProviderFamily::OpenAiCompatible
@@ -231,7 +238,7 @@ fn openai_compatible_preset_preserves_custom_model_name() {
 
     app.config.set_provider("openai-compatible");
     app.config.set_model(Some("custom-model".to_string()));
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
 
     app.select_local_model(0);
 
@@ -240,15 +247,15 @@ fn openai_compatible_preset_preserves_custom_model_name() {
 }
 
 #[test]
-fn openai_compatible_presets_switch_active_endpoint_kind() {
+fn deepseek_family_selects_deepseek_profile_and_model() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {
         path: dir.path().join("config.json"),
     };
     let mut app = TuiApp::new(cm).expect("app");
 
-    app.provider_picker_idx = 1;
-    app.select_local_model(1);
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::DeepSeek);
+    app.select_local_model(0);
     assert_eq!(
         app.config.active_openai_profile_kind(),
         Some(OpenAiEndpointKind::Deepseek)
@@ -258,15 +265,34 @@ fn openai_compatible_presets_switch_active_endpoint_kind() {
         Some("https://api.deepseek.com/v1")
     );
     assert_eq!(app.config.model.as_deref(), Some("deepseek-chat"));
+}
 
-    app.select_local_model(3);
+#[test]
+fn deepseek_catalog_options_keep_current_custom_model_selectable() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::DeepSeek);
+    app.config
+        .select_openai_profile("deepseek-default", "DeepSeek", OpenAiEndpointKind::Deepseek);
+    app.config
+        .set_model(Some("deepseek-v4-preview".to_string()));
+
+    app.set_deepseek_model_options(vec!["deepseek-chat".to_string()]);
+
+    assert!(app
+        .deepseek_model_options
+        .iter()
+        .any(|model| model == "deepseek-v4-preview"));
+    assert_eq!(app.model_picker_idx, app.selected_preset_idx());
     assert_eq!(
-        app.config.active_openai_profile_kind(),
-        Some(OpenAiEndpointKind::Openrouter)
-    );
-    assert_eq!(
-        app.config.base_url.as_deref(),
-        Some("https://openrouter.ai/api/v1")
+        app.deepseek_model_options
+            .get(app.model_picker_idx)
+            .map(String::as_str),
+        Some("deepseek-v4-preview")
     );
 }
 
@@ -315,7 +341,7 @@ fn opening_openai_compatible_model_picker_restores_provider_scoped_state() {
     app.config.set_provider("codex");
     app.config.set_model(Some("codex".to_string()));
 
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.open_overlay(Overlay::ModelPicker);
 
     assert_eq!(app.config.provider, "openai-compatible");
@@ -327,7 +353,7 @@ fn opening_openai_compatible_model_picker_restores_provider_scoped_state() {
 }
 
 #[test]
-fn opening_openai_compatible_model_picker_keeps_active_profile_kind() {
+fn opening_openai_compatible_model_picker_excludes_deepseek_profile_kind() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {
         path: dir.path().join("config.json"),
@@ -337,15 +363,15 @@ fn opening_openai_compatible_model_picker_keeps_active_profile_kind() {
     app.config
         .select_openai_profile("deepseek-default", "DeepSeek", OpenAiEndpointKind::Deepseek);
     app.config.set_model(Some("deepseek-reasoner".to_string()));
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
 
     app.open_overlay(Overlay::ModelPicker);
 
     assert_eq!(
         app.config.active_openai_profile_kind(),
-        Some(OpenAiEndpointKind::Deepseek)
+        Some(OpenAiEndpointKind::Custom)
     );
-    assert_eq!(app.config.model.as_deref(), Some("deepseek-reasoner"));
+    assert_eq!(app.config.model.as_deref(), Some("gpt-4o-mini"));
 }
 
 #[test]
@@ -356,7 +382,7 @@ fn openai_compatible_model_picker_selects_profile_rows() {
     };
     let mut app = TuiApp::new(cm).expect("app");
 
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.open_overlay(Overlay::ModelPicker);
 
     assert_eq!(app.current_model_picker_len(), 1);
@@ -390,7 +416,7 @@ fn openai_compatible_model_picker_deletes_active_profile_and_keeps_next() {
     };
     let mut app = TuiApp::new(cm).expect("app");
 
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.config.select_openai_profile(
         "custom-default",
         "Custom endpoint",
@@ -427,7 +453,7 @@ fn openai_profile_active_state_survives_switching_to_codex_and_ollama() {
     };
     let mut app = TuiApp::new(cm).expect("app");
 
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.config.select_openai_profile(
         "openrouter-main",
         "OpenRouter Main",
@@ -446,12 +472,12 @@ fn openai_profile_active_state_survives_switching_to_codex_and_ollama() {
     app.select_local_model(0);
     assert_eq!(app.config.provider, "codex");
 
-    app.provider_picker_idx = 3;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::Ollama);
     app.open_overlay(Overlay::ModelPicker);
     app.select_local_model(0);
     assert_eq!(app.config.provider, "ollama");
 
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.open_overlay(Overlay::ModelPicker);
 
     assert_eq!(
@@ -478,7 +504,7 @@ fn opening_openai_profile_picker_prefers_active_profile_of_selected_kind() {
         "OpenRouter Main",
         OpenAiEndpointKind::Openrouter,
     );
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.model_picker_idx = 3;
 
     app.open_overlay(Overlay::OpenAiProfilePicker);
@@ -498,7 +524,7 @@ fn openai_model_selection_keeps_non_default_profile_for_same_kind() {
     };
     let mut app = TuiApp::new(cm).expect("app");
 
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.config.select_openai_profile(
         "openrouter-main",
         "OpenRouter Main",
@@ -528,7 +554,7 @@ fn model_name_editor_seeds_from_selected_provider_state() {
     app.config.set_provider("openai-compatible");
     app.config.set_model(Some("custom-model".to_string()));
     app.config.set_provider("codex");
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
 
     app.open_overlay(Overlay::ModelPicker);
     app.open_overlay(Overlay::ModelNameEditor);

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -51,6 +51,7 @@ pub enum Overlay {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ProviderFamily {
     Codex,
+    DeepSeek,
     OpenAiCompatible,
     CandleLocal,
     Ollama,
@@ -211,6 +212,7 @@ pub enum TaskKind {
     Compact,
     Rebuild,
     OAuth,
+    DeepSeekModels,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -234,6 +236,9 @@ pub enum TaskCompletion {
     OAuth {
         mode: OAuthLoginMode,
         result: anyhow::Result<secrecy::SecretString>,
+    },
+    DeepSeekModels {
+        result: anyhow::Result<Vec<String>>,
     },
 }
 
@@ -262,16 +267,21 @@ pub struct RunningTask {
     pub next_heartbeat_after_secs: u64,
 }
 
-pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 4] = [
+pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 5] = [
     (
         ProviderFamily::Codex,
         "Codex",
         "Use Codex with browser login, device-code login, or a Codex API key.",
     ),
     (
+        ProviderFamily::DeepSeek,
+        "DeepSeek",
+        "Use DeepSeek with an API key and model list from api.deepseek.com.",
+    ),
+    (
         ProviderFamily::OpenAiCompatible,
         "OpenAI-compatible",
-        "Use OpenAI-compatible endpoint profiles such as Custom, DeepSeek, Kimi, or OpenRouter.",
+        "Use OpenAI-compatible endpoint profiles such as Custom, Kimi, or OpenRouter.",
     ),
     (
         ProviderFamily::CandleLocal,
@@ -374,6 +384,7 @@ pub struct TuiApp {
     pub openai_setup_steps: Vec<Overlay>,
     pub openai_setup_keep_empty_api_key: bool,
     pub codex_model_options: Vec<CodexModelOption>,
+    pub deepseek_model_options: Vec<String>,
     pub recent_commands: Vec<String>,
     pub recent_threads: Vec<ThreadSummary>,
     pub resume_picker_idx: usize,

--- a/src/tui/terminal_ui.rs
+++ b/src/tui/terminal_ui.rs
@@ -79,3 +79,54 @@ fn viewport_area(width: u16, height: u16, viewport_height: u16) -> Rect {
 pub(crate) fn is_ssh_session() -> bool {
     std::env::var_os("SSH_CONNECTION").is_some() || std::env::var_os("SSH_TTY").is_some()
 }
+
+#[cfg(test)]
+pub(crate) mod test_env {
+    use std::ffi::OsString;
+    use std::sync::{LazyLock, Mutex, MutexGuard};
+
+    static SSH_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    pub(crate) struct SshEnvGuard {
+        old_ssh_connection: Option<OsString>,
+        old_ssh_tty: Option<OsString>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    pub(crate) fn set_ssh_session(enabled: bool) -> SshEnvGuard {
+        let lock = SSH_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let old_ssh_connection = std::env::var_os("SSH_CONNECTION");
+        let old_ssh_tty = std::env::var_os("SSH_TTY");
+
+        if enabled {
+            std::env::set_var("SSH_CONNECTION", "test");
+            std::env::remove_var("SSH_TTY");
+        } else {
+            std::env::remove_var("SSH_CONNECTION");
+            std::env::remove_var("SSH_TTY");
+        }
+
+        SshEnvGuard {
+            old_ssh_connection,
+            old_ssh_tty,
+            _lock: lock,
+        }
+    }
+
+    impl Drop for SshEnvGuard {
+        fn drop(&mut self) {
+            if let Some(value) = self.old_ssh_connection.as_ref() {
+                std::env::set_var("SSH_CONNECTION", value);
+            } else {
+                std::env::remove_var("SSH_CONNECTION");
+            }
+            if let Some(value) = self.old_ssh_tty.as_ref() {
+                std::env::set_var("SSH_TTY", value);
+            } else {
+                std::env::remove_var("SSH_TTY");
+            }
+        }
+    }
+}

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -150,14 +150,7 @@ async fn busy_submit_allows_quit_command() {
 async fn slash_palette_model_selection_opens_provider_picker_in_local_and_ssh() {
     for ssh in [false, true] {
         let temp = tempdir().expect("tempdir");
-        let old_ssh_connection = std::env::var_os("SSH_CONNECTION");
-        let old_ssh_tty = std::env::var_os("SSH_TTY");
-        if ssh {
-            std::env::set_var("SSH_CONNECTION", "test");
-        } else {
-            std::env::remove_var("SSH_CONNECTION");
-            std::env::remove_var("SSH_TTY");
-        }
+        let _ssh_env = super::terminal_ui::test_env::set_ssh_session(ssh);
 
         let mut app = TuiApp::new(ConfigManager {
             path: temp.path().join("config.json"),
@@ -186,17 +179,6 @@ async fn slash_palette_model_selection_opens_provider_picker_in_local_and_ssh() 
 
         assert!(matches!(app.overlay, Some(Overlay::ProviderPicker)));
         assert_eq!(app.notice.as_deref(), Some("Opened provider picker."));
-
-        if let Some(value) = old_ssh_connection {
-            std::env::set_var("SSH_CONNECTION", value);
-        } else {
-            std::env::remove_var("SSH_CONNECTION");
-        }
-        if let Some(value) = old_ssh_tty {
-            std::env::set_var("SSH_TTY", value);
-        } else {
-            std::env::remove_var("SSH_TTY");
-        }
     }
 }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -29,6 +29,13 @@ use super::{
     PendingPlanApprovalAction,
 };
 
+fn provider_family_idx(family: ProviderFamily) -> usize {
+    super::state::PROVIDER_FAMILIES
+        .iter()
+        .position(|(candidate, _, _)| *candidate == family)
+        .expect("provider family present")
+}
+
 #[test]
 fn pending_plan_approval_treats_generic_continue_as_approval() {
     assert_eq!(
@@ -429,7 +436,7 @@ fn openai_compatible_model_picker_exposes_profile_table_shortcuts() {
     })
     .expect("app");
 
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.open_overlay(Overlay::ModelPicker);
 
     assert!(matches!(
@@ -457,7 +464,7 @@ async fn openai_model_picker_delete_row_removes_active_profile() {
         path: temp.path().join("config.json"),
     })
     .expect("app");
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.config.select_openai_profile(
         "custom-default",
         "Custom endpoint",
@@ -507,7 +514,7 @@ async fn openai_model_picker_space_activates_selected_profile_and_starts_setup_w
         path: temp.path().join("config.json"),
     })
     .expect("app");
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.open_overlay(Overlay::ModelPicker);
 
     let oauth_manager = Arc::new(
@@ -540,13 +547,105 @@ async fn openai_model_picker_space_activates_selected_profile_and_starts_setup_w
 }
 
 #[tokio::test]
+async fn deepseek_provider_family_prompts_for_api_key_before_model_list() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    let oauth_manager = crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+        .expect("oauth manager");
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::DeepSeek);
+
+    open_provider_family_overlay(&mut app, &oauth_manager)
+        .await
+        .expect("open overlay");
+
+    assert_eq!(
+        app.config.active_openai_profile_kind(),
+        Some(OpenAiEndpointKind::Deepseek)
+    );
+    assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
+}
+
+#[tokio::test]
+async fn deepseek_api_key_save_starts_model_catalog_task() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::DeepSeek);
+    app.config
+        .select_openai_profile("deepseek-default", "DeepSeek", OpenAiEndpointKind::Deepseek);
+    app.open_overlay(Overlay::ApiKeyEditor);
+    app.api_key_input = "sk-deepseek-test".to_string();
+
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = None;
+
+    dispatch_event(
+        AppEvent::SaveApiKeyInput,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("save api key");
+
+    assert_eq!(app.config.api_key(), Some("sk-deepseek-test"));
+    assert!(matches!(
+        app.running_task.as_ref(),
+        Some(task) if matches!(task.kind, TaskKind::DeepSeekModels)
+    ));
+    if let Some(task) = app.running_task.take() {
+        task.handle.abort();
+    }
+}
+
+#[tokio::test]
+async fn deepseek_model_picker_enter_without_api_key_opens_api_key_editor() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::DeepSeek);
+    app.config
+        .select_openai_profile("deepseek-default", "DeepSeek", OpenAiEndpointKind::Deepseek);
+    app.config.clear_api_key();
+    app.open_overlay(Overlay::ModelPicker);
+
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = None;
+
+    dispatch_event(
+        AppEvent::ApplyOverlaySelection,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("apply model selection");
+
+    assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
+    assert!(app.running_task.is_none());
+}
+
+#[tokio::test]
 async fn openai_model_picker_edit_shortcut_starts_wizard_for_selected_profile() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
     })
     .expect("app");
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.config.select_openai_profile(
         "custom-default",
         "Custom endpoint",
@@ -593,7 +692,7 @@ async fn openai_profile_edit_wizard_keeps_existing_api_key_when_blank() {
         path: temp.path().join("config.json"),
     })
     .expect("app");
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.config.select_openai_profile(
         "openrouter-default",
         "OpenRouter",
@@ -649,7 +748,7 @@ async fn openai_model_picker_create_shortcut_opens_endpoint_kind_picker() {
         path: temp.path().join("config.json"),
     })
     .expect("app");
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.open_overlay(Overlay::ModelPicker);
 
     let oauth_manager = Arc::new(
@@ -681,7 +780,7 @@ async fn selecting_custom_endpoint_kind_prompts_for_profile_label() {
         path: temp.path().join("config.json"),
     })
     .expect("app");
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.overlay = Some(Overlay::OpenAiEndpointKindPicker);
     app.openai_endpoint_kind_picker_idx = 0;
 
@@ -717,7 +816,7 @@ async fn selecting_openai_profile_from_picker_switches_active_profile() {
         path: temp.path().join("config.json"),
     })
     .expect("app");
-    app.provider_picker_idx = 1;
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
     app.config.select_openai_profile(
         "openrouter-main",
         "OpenRouter Main",
@@ -755,15 +854,18 @@ async fn selecting_openai_profile_from_picker_switches_active_profile() {
 }
 
 #[tokio::test]
-async fn saving_openai_profile_label_creates_new_profile_for_selected_kind() {
+async fn saving_openai_profile_label_creates_new_openrouter_profile() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
     })
     .expect("app");
-    app.provider_picker_idx = 1;
-    app.config
-        .select_openai_profile("deepseek-default", "DeepSeek", OpenAiEndpointKind::Deepseek);
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
+    app.config.select_openai_profile(
+        "openrouter-default",
+        "OpenRouter",
+        OpenAiEndpointKind::Openrouter,
+    );
     app.open_overlay(Overlay::OpenAiProfilePicker);
     app.openai_profile_picker_idx = 0;
 
@@ -782,7 +884,7 @@ async fn saving_openai_profile_label_creates_new_profile_for_selected_kind() {
     .await
     .expect("open profile label editor");
 
-    app.openai_profile_label_input = "DeepSeek backup".to_string();
+    app.openai_profile_label_input = "OpenRouter backup".to_string();
 
     dispatch_event(
         AppEvent::SaveOpenAiProfileLabelInput,
@@ -795,16 +897,16 @@ async fn saving_openai_profile_label_creates_new_profile_for_selected_kind() {
 
     assert_eq!(
         app.config.active_openai_profile_id(),
-        Some("deepseek-deepseek-backup")
+        Some("openrouter-openrouter-backup")
     );
     assert_eq!(
         app.config.active_openai_profile_kind(),
-        Some(OpenAiEndpointKind::Deepseek)
+        Some(OpenAiEndpointKind::Openrouter)
     );
     assert!(app
         .config
         .openai_profiles
-        .contains_key("deepseek-deepseek-backup"));
+        .contains_key("openrouter-openrouter-backup"));
     assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
     assert_eq!(app.openai_setup_steps, vec![Overlay::ModelNameEditor]);
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -201,6 +201,24 @@ async fn slash_palette_model_selection_opens_provider_picker_in_local_and_ssh() 
 }
 
 #[test]
+fn provider_picker_number_keys_cover_current_provider_families() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    app.open_overlay(Overlay::ProviderPicker);
+
+    let key_char =
+        char::from_digit(super::state::PROVIDER_FAMILIES.len() as u32, 10).expect("digit key");
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Char(key_char)), &app),
+        AppEvent::SetProviderSelection(idx)
+            if idx == super::state::PROVIDER_FAMILIES.len() - 1
+    ));
+}
+
+#[test]
 fn auth_mode_picker_prefers_selection_navigation() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {


### PR DESCRIPTION
## Summary

- Add a dedicated `rara-provider-catalog` crate for provider model catalog loading.
- Move DeepSeek model listing into the new catalog boundary and wire `/model` to a dedicated DeepSeek provider family.
- Keep OpenAI-compatible profile creation focused on Custom, Kimi, and OpenRouter while preserving DeepSeek endpoint-kind mapping internally.
- Add TUI state, event, and render coverage for DeepSeek API key entry, model list refresh, fallback models, and picker layout.

## Testing

- `cargo fmt --check`
- `cargo test -p rara-provider-catalog`
- `cargo test tui::state::tests -- --nocapture`
- `cargo test tui::tests -- --nocapture`
- `cargo test tui::render::tests -- --nocapture`
- `cargo check`
- `git diff --check`
