### PR TITLE
docs: define context extension prefix contract

### DIFF
--- a/docs/features/context-architecture.md
+++ b/docs/features/context-architecture.md
@@ -225,6 +225,13 @@ RARA should therefore avoid:
 - treating the full transcript as memory;
 - storing every transient turn detail as long-lived memory.
 
+Memory and extension sources should also preserve the stable top-level context
+prefixes. New repository context, skill, hook, agent, or memory inputs should
+attach labels and provenance to structured source objects, not invent ad hoc
+model-facing prefixes. In particular, transient runtime artifacts such as
+orphan tool results should not be serialized back into ordinary user text with
+synthetic labels.
+
 ### Memory Scopes
 
 RARA should distinguish at least two memory scopes.

--- a/docs/features/repo-extension-surface.md
+++ b/docs/features/repo-extension-surface.md
@@ -7,6 +7,8 @@ ecosystems without immediately coupling discovery to execution.
 
 The initial target is compatibility with:
 
+- repo context files that describe local project rules, conventions, and active
+  workspace facts;
 - native RARA skills under `.agents/skills/`;
 - Claude-style agent definitions under `.claude/agents/`;
 - Claude-style lifecycle hooks under `.claude/hooks/`.
@@ -52,6 +54,58 @@ Later follow-up phases may include:
 
 - `SubagentStop`
 - `PreCompact`
+
+## Related Codex Capabilities
+
+Codex has a different extension shape, but the same compatibility pressure:
+repository guidance, local skills, runtime memory, and tool/result context must
+compose without making the model-facing prompt unstable across releases.
+
+RARA should therefore treat Codex-style inputs as additional normalized context
+sources instead of as a reason to rename or reshuffle the primary prompt
+sections.
+
+The Codex-related behaviors to preserve are:
+
+- repository instructions and repo-local skills participate in the same source
+  discovery pipeline as other workspace prompt sources;
+- durable memory and recalled thread/workspace facts enter through
+  `MemorySelection`;
+- tool results and runtime state stay structured runtime inputs instead of
+  being converted into ad hoc user-text prefixes;
+- visible `/context` and `/status` surfaces explain the same source objects that
+  were used for model assembly.
+
+## Prefix Stability Contract
+
+Repository context, skills, hooks, imported agents, and memory are expected
+long-term inputs for RARA, but their addition must not churn the stable
+model-facing prompt/context prefix layout.
+
+The main prefix names and top-level assembly order should stay stable unless a
+breaking context-format migration is explicitly planned.
+
+New capabilities should normally enter through one of these owned extension
+points:
+
+- a new source object under existing workspace prompt-source discovery;
+- a normalized extension object surfaced by this repository extension contract;
+- a memory or retrieval candidate produced for `MemorySelection`;
+- a lifecycle event handled behind the hook runtime boundary;
+- a child-thread or imported-agent profile executed through the thread domain.
+
+They should not:
+
+- inject raw repo files directly into the system prompt with new top-level
+  prefixes;
+- rename existing stable prompt sections just to match an external ecosystem;
+- serialize hook, skill, or agent metadata as ordinary user text;
+- add synthetic context prefixes for transient runtime artifacts such as orphan
+  tool results.
+
+If a new source needs a label for explainability, that label should be attached
+to the structured source object and rendered by `/context` or `/status`, not
+invented as an unowned prompt prefix.
 
 ## Non-Goals
 
@@ -266,6 +320,8 @@ That means:
 
 - imported Claude agents still run through RARA sub-agent/thread contracts;
 - imported hooks still operate through RARA lifecycle events;
+- repo context and repo-local skills still enter through source discovery and
+  context assembly instead of bypassing prompt ownership;
 - context injection still flows through `ContextAssembler` and
   `MemorySelection`;
 - thread persistence still flows through `ThreadStore` / `ThreadRecorder`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -68,6 +68,7 @@ Priority order for this phase:
 - [ ] Expand focused tests around workspace prompt-source discovery and cache invalidation across cwd changes, git branch changes, nested workspaces, and outside-workspace fallback.
 - [ ] Define and document `WorkspaceMemory` cache invalidation rules for prompt files and environment info instead of relying on implicit behavior.
 - [ ] Unify `discover_prompt_sources()` and TUI `/status` source reporting so displayed prompt sources match the actual injected sources.
+- [ ] Preserve stable top-level prompt/context prefixes while adding repo context, skills, hooks, imported agents, and memory sources; new inputs should enter through structured source objects, `MemorySelection`, lifecycle events, or thread-owned agent profiles instead of ad hoc prompt text.
 - [ ] Design a project-scoped extension surface that can ingest Claude/Codex-style repo customizations from `.claude/agents/`, `.claude/hooks/`, and `.agents/skills/`, with explicit precedence and compatibility rules before adding runtime execution.
 - [ ] Define and surface skill precedence/override behavior across home, repo, nested repo roots, and workspace-local skill roots.
 - [ ] Extend `SkillManager::list_summaries()` (or equivalent status output) with source precedence and overridden-skill visibility so conflicts are debuggable.


### PR DESCRIPTION
## Summary

- Document Codex-related repository context, skill, memory, and tool-result compatibility expectations beside the existing Claude-oriented extension surface.
- Add a prefix stability contract so future repo context, skills, hooks, imported agents, and memory sources enter through structured objects instead of changing top-level prompt prefixes.
- Record the corresponding TODO item for implementation follow-up.

## Testing

- Not run; documentation-only change.
