### PR TITLE
chore: add dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 8
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:30"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 8
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

- Add Dependabot configuration for Cargo workspace dependencies.
- Add Dependabot configuration for GitHub Actions workflows.
- Schedule both ecosystems daily with an open pull request limit of 8.

## Testing

- `git diff --check`

## Notes

- No Rust tests were run because this change only adds GitHub automation configuration.
