### PR TITLE
fix: return fallback on tool loop limit

### DIFF
--- a/docs/journal/2026-04-27-tool-loop-final-fallback.md
+++ b/docs/journal/2026-04-27-tool-loop-final-fallback.md
@@ -1,0 +1,36 @@
+# 2026-04-27 · Tool Loop Final Fallback
+
+## Summary
+
+RARA now treats the per-turn tool-round limit as a bounded stop condition
+instead of a hard query failure. When the model keeps requesting tools after the
+limit, the runtime closes the transcript with explicit skipped-tool results and
+returns a local final fallback message.
+
+## What Changed
+
+- A final-answer continuation now tells the model to state limitations instead
+  of emitting another tool call.
+- If the over-limit model turn contains tool calls, RARA records synthetic
+  error `tool_result` messages for those calls before asking for a final answer.
+- If the forced final-answer turn still emits tool calls or no text, RARA:
+  - records synthetic error `tool_result` messages for any skipped calls;
+  - emits a bounded assistant fallback instead of returning `Query failed`;
+  - preserves plan state and any partial model text in the fallback.
+- Agent tests now cover the case where the model keeps emitting tool calls even
+  after tools are disabled for the final-answer attempt.
+
+## Why
+
+Claude Code's loop design keeps the core model/tool cycle simple, but protects
+the surrounding transcript invariants: tool-use blocks that reach the transcript
+must be paired with tool-result blocks, even when execution is interrupted or
+blocked. Applying the same boundary in RARA prevents orphan tool calls from
+leaking into OpenAI-compatible follow-up requests and keeps the user-facing TUI
+from ending on a low-level loop-limit error.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo test agent::tests::planning -- --nocapture`
+- `cargo check`

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -473,10 +473,7 @@ impl Agent {
                             self.tool_loop_limit_result_messages(&final_turn.tool_calls, report);
                         self.extend_history_messages(skipped_results);
                     }
-                    let fallback_text = self.tool_loop_limit_fallback_text(
-                        *tool_rounds,
-                        final_turn.text_response.as_deref(),
-                    );
+                    let fallback_text = self.tool_loop_limit_fallback_text();
                     report(AgentEvent::Status(
                         "Tool loop reached the limit. Returning a bounded final response without more tool calls."
                             .to_string(),
@@ -528,25 +525,13 @@ impl Agent {
             .collect()
     }
 
-    fn tool_loop_limit_fallback_text(
-        &self,
-        tool_rounds: usize,
-        final_text: Option<&str>,
-    ) -> String {
+    fn tool_loop_limit_fallback_text(&self) -> String {
         let mut lines = vec![
             format!(
-                "Tool loop reached the {tool_rounds}-round limit before a clean final answer was produced."
+                "Tool loop reached the {MAX_TOOL_ROUNDS_PER_TURN}-round limit before a clean final answer was produced."
             ),
             "I stopped additional tool execution, recorded any skipped tool calls as error results, and preserved the transcript for the next turn.".to_string(),
         ];
-        if let Some(text) = final_text.filter(|text| !text.trim().is_empty()) {
-            lines.push(String::new());
-            lines.push(
-                "The model also emitted this partial text before requesting more tools:"
-                    .to_string(),
-            );
-            lines.push(text.trim().to_string());
-        }
         if !self.current_plan.is_empty() {
             lines.push(String::new());
             lines.push("Current plan state:".to_string());

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -94,6 +94,7 @@ struct TurnOutput {
     plan_updated: bool,
     continue_inspection: bool,
     had_text_response: bool,
+    text_response: Option<String>,
 }
 
 pub struct Agent {
@@ -287,6 +288,7 @@ impl Agent {
         let mut plan_updated = false;
         let mut continue_inspection = false;
         let mut had_text_response = false;
+        let mut text_parts = Vec::new();
         let mut sanitized_content = Vec::new();
         for block in &response.content {
             match block {
@@ -296,6 +298,7 @@ impl Agent {
                     continue_inspection |= block_requests_continue;
                     if !clean_text.trim().is_empty() {
                         had_text_response = true;
+                        text_parts.push(clean_text.clone());
                         sanitized_content.push(ContentBlock::Text {
                             text: clean_text.clone(),
                         });
@@ -349,6 +352,7 @@ impl Agent {
             plan_updated,
             continue_inspection,
             had_text_response,
+            text_response: (!text_parts.is_empty()).then(|| text_parts.join("\n\n")),
         })
     }
 
@@ -445,6 +449,9 @@ impl Agent {
             }
             *tool_rounds += 1;
             if *tool_rounds > MAX_TOOL_ROUNDS_PER_TURN {
+                let skipped_results =
+                    self.tool_loop_limit_result_messages(&turn_output.tool_calls, report);
+                self.extend_history_messages(skipped_results);
                 report(AgentEvent::Status(
                     "Tool loop reached the limit. Requesting a final answer without more tool calls."
                         .to_string(),
@@ -457,12 +464,28 @@ impl Agent {
                     .run_model_turn_with_tools(output_mode, report, &[])
                     .await?;
                 self.last_query_plan_updated = final_turn.plan_updated;
-                self.push_history_message(final_turn.assistant_message);
-                if !final_turn.tool_calls.is_empty() || !final_turn.had_text_response {
-                    return Err(anyhow::anyhow!(
-                        "Tool loop exceeded {} rounds and the model still did not provide a final answer",
-                        MAX_TOOL_ROUNDS_PER_TURN
+                if final_turn.tool_calls.is_empty() && final_turn.had_text_response {
+                    self.push_history_message(final_turn.assistant_message);
+                } else {
+                    if !final_turn.tool_calls.is_empty() {
+                        self.push_history_message(final_turn.assistant_message);
+                        let skipped_results =
+                            self.tool_loop_limit_result_messages(&final_turn.tool_calls, report);
+                        self.extend_history_messages(skipped_results);
+                    }
+                    let fallback_text = self.tool_loop_limit_fallback_text(
+                        *tool_rounds,
+                        final_turn.text_response.as_deref(),
+                    );
+                    report(AgentEvent::Status(
+                        "Tool loop reached the limit. Returning a bounded final response without more tool calls."
+                            .to_string(),
                     ));
+                    report(AgentEvent::AssistantText(fallback_text.clone()));
+                    if matches!(output_mode, AgentOutputMode::Terminal) {
+                        println!("Agent: {}", fallback_text);
+                    }
+                    self.push_history_message(assistant_text_message(fallback_text));
                 }
                 self.complete_active_plan_step();
                 break;
@@ -478,6 +501,70 @@ impl Agent {
             self.extend_history_for_next_turn(tool_results, report, *tool_rounds);
         }
         Ok(())
+    }
+
+    fn tool_loop_limit_result_messages<F>(
+        &self,
+        tool_calls: &[ToolCall],
+        report: &mut F,
+    ) -> Vec<Message>
+    where
+        F: FnMut(AgentEvent) + Send,
+    {
+        tool_calls
+            .iter()
+            .map(|tool_call| {
+                let content = format!(
+                    "Error: tool call '{}' was not executed because this turn reached the {} tool-round limit.",
+                    tool_call.name, MAX_TOOL_ROUNDS_PER_TURN
+                );
+                report(AgentEvent::ToolResult {
+                    name: tool_call.name.clone(),
+                    content: content.clone(),
+                    is_error: true,
+                });
+                tool_result_message(&tool_call.id, content, true)
+            })
+            .collect()
+    }
+
+    fn tool_loop_limit_fallback_text(
+        &self,
+        tool_rounds: usize,
+        final_text: Option<&str>,
+    ) -> String {
+        let mut lines = vec![
+            format!(
+                "Tool loop reached the {tool_rounds}-round limit before a clean final answer was produced."
+            ),
+            "I stopped additional tool execution, recorded any skipped tool calls as error results, and preserved the transcript for the next turn.".to_string(),
+        ];
+        if let Some(text) = final_text.filter(|text| !text.trim().is_empty()) {
+            lines.push(String::new());
+            lines.push(
+                "The model also emitted this partial text before requesting more tools:"
+                    .to_string(),
+            );
+            lines.push(text.trim().to_string());
+        }
+        if !self.current_plan.is_empty() {
+            lines.push(String::new());
+            lines.push("Current plan state:".to_string());
+            lines.extend(
+                self.current_plan.iter().map(|step| {
+                    format!("- [{}] {}", plan_step_status_label(&step.status), step.step)
+                }),
+            );
+        }
+        if let Some(explanation) = self
+            .plan_explanation
+            .as_deref()
+            .filter(|explanation| !explanation.trim().is_empty())
+        {
+            lines.push(String::new());
+            lines.push(explanation.trim().to_string());
+        }
+        lines.join("\n")
     }
 
     async fn execute_tool_calls<F>(
@@ -610,6 +697,21 @@ impl Agent {
             }
         }
         Ok(tool_results)
+    }
+}
+
+fn assistant_text_message(text: String) -> Message {
+    Message {
+        role: "assistant".to_string(),
+        content: json!([{"type": "text", "text": text}]),
+    }
+}
+
+fn plan_step_status_label(status: &PlanStepStatus) -> &'static str {
+    match status {
+        PlanStepStatus::Pending => "pending",
+        PlanStepStatus::InProgress => "in_progress",
+        PlanStepStatus::Completed => "completed",
     }
 }
 

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -688,6 +688,7 @@ impl RuntimeContinuationPhase {
                 "The tool loop reached the execution limit for this turn.",
                 "Do not call any more tools.",
                 "Synthesize the result from the repository context and tool results already in the conversation.",
+                "If another tool call would be useful, state the limitation in the final answer instead of emitting a tool call.",
                 "Provide the final answer now.",
                 "Do not ask the user to continue.",
             ],

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -200,6 +200,68 @@ async fn forces_final_answer_when_tool_loop_exceeds_limit() {
         .contains("Final answer after reviewing the tool results.")));
 }
 
+#[tokio::test]
+async fn returns_local_fallback_when_forced_final_answer_still_calls_tools() {
+    let mut responses = (0..=super::super::MAX_TOOL_ROUNDS_PER_TURN)
+        .map(|idx| LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: format!("tool-{idx}"),
+                name: "stub_tool".to_string(),
+                input: json!({}),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        })
+        .collect::<Vec<_>>();
+    responses.push(LlmResponse {
+        content: vec![ContentBlock::ToolUse {
+            id: "tool-final".to_string(),
+            name: "stub_tool".to_string(),
+            input: json!({}),
+        }],
+        stop_reason: Some("tool_use".to_string()),
+        usage: Some(TokenUsage::default()),
+    });
+    let backend = Arc::new(SequencedBackend::new(responses));
+
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubTool));
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new("data/lancedb")),
+        Arc::new(SessionManager::new().expect("session manager")),
+        Arc::new(WorkspaceMemory::new().expect("workspace memory")),
+    );
+
+    let mut events = Vec::new();
+    agent
+        .query_with_mode_and_events(
+            "loop".to_string(),
+            super::super::AgentOutputMode::Silent,
+            |event| events.push(event),
+        )
+        .await
+        .expect("query should finish with a local fallback answer");
+
+    let observed_tools = backend.observed_tools();
+    assert!(observed_tools.last().is_some_and(|tools| tools.is_empty()));
+    assert!(agent.history.last().is_some_and(|message| message
+        .content
+        .to_string()
+        .contains("Tool loop reached the")));
+    assert!(agent
+        .history
+        .iter()
+        .any(|message| message.content.to_string().contains("tool-final")));
+    assert_no_unresolved_tool_uses(&agent.history);
+    assert!(events.iter().any(|event| matches!(
+        event,
+        super::super::AgentEvent::AssistantText(text)
+            if text.contains("Tool loop reached the")
+    )));
+}
+
 #[test]
 fn strips_continue_inspection_control_tag() {
     let (cleaned, requested) =
@@ -322,4 +384,34 @@ fn completes_only_active_plan_step_on_finish() {
     assert_eq!(agent.current_plan[0].status, PlanStepStatus::Completed);
     assert_eq!(agent.current_plan[1].status, PlanStepStatus::Completed);
     assert_eq!(agent.current_plan[2].status, PlanStepStatus::Pending);
+}
+
+fn assert_no_unresolved_tool_uses(history: &[crate::agent::Message]) {
+    let mut pending = Vec::new();
+    for message in history {
+        if let Some(items) = message.content.as_array() {
+            for item in items {
+                match item.get("type").and_then(serde_json::Value::as_str) {
+                    Some("tool_use") if message.role == "assistant" => {
+                        if let Some(id) = item.get("id").and_then(serde_json::Value::as_str) {
+                            pending.push(id.to_string());
+                        }
+                    }
+                    Some("tool_result") if message.role == "user" => {
+                        if let Some(id) =
+                            item.get("tool_use_id").and_then(serde_json::Value::as_str)
+                        {
+                            if let Some(pos) =
+                                pending.iter().position(|pending_id| pending_id == id)
+                            {
+                                pending.remove(pos);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    assert!(pending.is_empty(), "unresolved tool uses: {pending:?}");
 }

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -214,11 +214,16 @@ async fn returns_local_fallback_when_forced_final_answer_still_calls_tools() {
         })
         .collect::<Vec<_>>();
     responses.push(LlmResponse {
-        content: vec![ContentBlock::ToolUse {
-            id: "tool-final".to_string(),
-            name: "stub_tool".to_string(),
-            input: json!({}),
-        }],
+        content: vec![
+            ContentBlock::Text {
+                text: "Partial text before requesting another tool.".to_string(),
+            },
+            ContentBlock::ToolUse {
+                id: "tool-final".to_string(),
+                name: "stub_tool".to_string(),
+                input: json!({}),
+            },
+        ],
         stop_reason: Some("tool_use".to_string()),
         usage: Some(TokenUsage::default()),
     });
@@ -246,10 +251,17 @@ async fn returns_local_fallback_when_forced_final_answer_still_calls_tools() {
 
     let observed_tools = backend.observed_tools();
     assert!(observed_tools.last().is_some_and(|tools| tools.is_empty()));
-    assert!(agent.history.last().is_some_and(|message| message
+    let fallback_message = agent
+        .history
+        .last()
+        .expect("fallback message should be appended")
         .content
-        .to_string()
-        .contains("Tool loop reached the")));
+        .to_string();
+    assert!(fallback_message.contains(&format!(
+        "Tool loop reached the {}-round limit",
+        super::super::MAX_TOOL_ROUNDS_PER_TURN
+    )));
+    assert!(!fallback_message.contains("Partial text before requesting another tool."));
     assert!(agent
         .history
         .iter()


### PR DESCRIPTION
## Summary

- close over-limit tool calls with synthetic error `tool_result` messages
- return a bounded local fallback when the forced final-answer turn still emits tool calls or no text
- tighten the final-answer continuation prompt and document the Claude Code-inspired invariant

## Why

The agent loop previously returned `Query failed` when the model kept calling tools after the per-turn limit. It could also leave assistant tool calls in history without matching tool results, which can break OpenAI-compatible follow-up requests.

## Tests

- `cargo fmt --check`
- `cargo test agent::tests::planning -- --nocapture`
- `cargo check`
