### PR TITLE
feat: support long-running background tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3375,6 +3375,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "downcast-rs"
@@ -7749,6 +7755,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs 1.2.1",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8553,6 +8580,7 @@ dependencies = [
  "lancedb",
  "open",
  "owo-colors",
+ "portable-pty",
  "pulldown-cmark",
  "rand 0.9.2",
  "rara-config",
@@ -9699,6 +9727,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9739,6 +9778,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -10329,7 +10384,7 @@ dependencies = [
  "census",
  "crc32fast",
  "crossbeam-channel",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "fastdivide",
  "fnv",
  "fs4",
@@ -10381,7 +10436,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6300428e0c104c4f7db6f95b466a6f5c1b9aece094ec57cdd365337908dc7344"
 dependencies = [
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "fastdivide",
  "itertools 0.14.0",
  "serde",
@@ -12287,6 +12342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ pulldown-cmark = "0.13"
 textwrap = "0.16.2"
 unicode-width = "0.2"
 syntect = "5"
+portable-pty = "0.9"
 two-face = { version = "0.5", default-features = false, features = ["syntect-default-onig"] }
 agent-client-protocol = { version = "0.11", features = ["unstable"] }
 hf-hub = "0.5"

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -409,9 +409,17 @@ fn command_exists(program: &str) -> bool {
 fn command_search_path_dirs() -> Vec<PathBuf> {
     env::var_os("PATH")
         .map(|paths| {
-            env::split_paths(&paths)
-                .filter(|dir| dir.is_dir())
-                .collect::<Vec<_>>()
+            let mut dirs = Vec::new();
+            for dir in env::split_paths(&paths) {
+                if !dir.is_absolute() || !dir.is_dir() {
+                    continue;
+                }
+                let dir = fs::canonicalize(&dir).unwrap_or(dir);
+                if !dirs.iter().any(|existing| existing == &dir) {
+                    dirs.push(dir);
+                }
+            }
+            dirs
         })
         .unwrap_or_default()
 }
@@ -510,6 +518,7 @@ mod tests {
         shell_command_flag, shell_program, SandboxBackend, SandboxManager, DEFAULT_SHELL,
         MACOS_SANDBOX_EXEC,
     };
+    use std::env;
     use std::path::PathBuf;
     use std::time::Duration;
     use tempfile::tempdir;
@@ -861,8 +870,11 @@ mod tests {
         let tempdir = tempdir().expect("tempdir");
         let custom_bin = tempdir.path().join("custom-bin");
         std::fs::create_dir_all(&custom_bin).expect("custom bin dir");
+        let custom_bin = std::fs::canonicalize(&custom_bin).expect("canonical custom bin");
         let original_path = std::env::var_os("PATH");
-        std::env::set_var("PATH", custom_bin.display().to_string());
+        let test_path =
+            env::join_paths([PathBuf::from("."), custom_bin.clone()]).expect("build test PATH");
+        std::env::set_var("PATH", test_path);
 
         let manager = manager("linux", SandboxBackend::LinuxBubblewrap);
         let wrapped = manager
@@ -885,6 +897,17 @@ mod tests {
                     ]
             }),
             "linux sandbox should bind PATH command directories that are outside standard runtime roots"
+        );
+        assert!(
+            !wrapped.args.windows(3).any(|window| {
+                window
+                    == [
+                        String::from("--ro-bind"),
+                        String::from("."),
+                        String::from("."),
+                    ]
+            }),
+            "linux sandbox should not bind relative PATH entries"
         );
     }
 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -28,6 +27,7 @@ const LINUX_RUNTIME_READ_ROOTS: &[&str] = &[
     "/bin",
     "/sbin",
     "/usr",
+    "/opt",
     "/etc",
     "/lib",
     "/lib64",
@@ -80,20 +80,6 @@ impl SandboxManager {
         })
     }
 
-    fn get_proxy_hosts(&self) -> Vec<String> {
-        let mut proxies = HashSet::new();
-        for var in &["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] {
-            if let Ok(url_str) = env::var(var) {
-                if let Ok(url) = url::Url::parse(&url_str) {
-                    if let Some(host) = url.host_str() {
-                        proxies.insert(host.to_string());
-                    }
-                }
-            }
-        }
-        proxies.into_iter().collect()
-    }
-
     fn create_profile(&self, allow_net: bool) -> Result<PathBuf> {
         if self.os != "macos" {
             bail!("sandbox profile creation is only supported on macOS");
@@ -115,12 +101,6 @@ impl SandboxManager {
             net_rules.push_str("(allow network*)");
         } else {
             net_rules.push_str("(deny network*)\n(allow network-outbound (literal \"/private/var/run/mDNSResponder\"))\n");
-            for host in self.get_proxy_hosts() {
-                net_rules.push_str(&format!(
-                    "(allow network-outbound (remote ip \"{}:*\"))\n",
-                    host
-                ));
-            }
         }
 
         let profile = format!(
@@ -163,6 +143,28 @@ impl SandboxManager {
         }
     }
 
+    fn append_ro_bind(args: &mut Vec<String>, path: &Path) {
+        Self::append_mount_target_parent_dirs(args, path);
+        args.push("--ro-bind".to_string());
+        args.push(path.display().to_string());
+        args.push(path.display().to_string());
+    }
+
+    fn linux_runtime_read_roots() -> Vec<PathBuf> {
+        let mut roots = LINUX_RUNTIME_READ_ROOTS
+            .iter()
+            .map(PathBuf::from)
+            .filter(|path| path.exists())
+            .collect::<Vec<_>>();
+        for path_dir in command_search_path_dirs() {
+            if roots.iter().any(|root| path_dir.starts_with(root)) {
+                continue;
+            }
+            roots.push(path_dir);
+        }
+        roots
+    }
+
     fn linux_sandbox_args(&self, cwd: &str, allow_net: bool) -> Vec<String> {
         let cwd_path = Path::new(cwd);
         let mut args = vec![
@@ -176,17 +178,26 @@ impl SandboxManager {
             "/proc".to_string(),
             "--tmpfs".to_string(),
             "/tmp".to_string(),
+            "--dir".to_string(),
+            "/run".to_string(),
+            "--dir".to_string(),
+            "/var".to_string(),
+            "--symlink".to_string(),
+            "../run".to_string(),
+            "/var/run".to_string(),
         ];
         for dir in sandbox_home_dirs(&self.sandbox_home) {
             args.push("--dir".to_string());
             args.push(dir.display().to_string());
         }
 
-        for root in LINUX_RUNTIME_READ_ROOTS {
-            if Path::new(root).exists() {
-                args.push("--ro-bind".to_string());
-                args.push((*root).to_string());
-                args.push((*root).to_string());
+        for root in Self::linux_runtime_read_roots() {
+            Self::append_ro_bind(&mut args, &root);
+        }
+
+        if let Ok(resolv_conf) = fs::metadata("/etc/resolv.conf") {
+            if resolv_conf.is_file() {
+                Self::append_ro_bind(&mut args, Path::new("/etc/resolv.conf"));
             }
         }
 
@@ -252,6 +263,19 @@ impl SandboxManager {
                 "sandboxed command execution is unsupported on platform {}",
                 platform
             ),
+        }
+    }
+
+    pub fn wrap_pty_shell_command(
+        &self,
+        original_cmd: &str,
+        cwd: &str,
+        allow_net: bool,
+    ) -> Result<WrappedCommand> {
+        match &self.backend {
+            // macOS sandbox-exec does not preserve interactive PTY stdin reliably.
+            SandboxBackend::MacosSeatbelt => Ok(wrap_direct_shell_command(original_cmd)),
+            _ => self.wrap_shell_command(original_cmd, cwd, allow_net),
         }
     }
 
@@ -380,6 +404,16 @@ fn command_exists(program: &str) -> bool {
     env::var_os("PATH")
         .map(|paths| env::split_paths(&paths).any(|dir| dir.join(program).is_file()))
         .unwrap_or(false)
+}
+
+fn command_search_path_dirs() -> Vec<PathBuf> {
+    env::var_os("PATH")
+        .map(|paths| {
+            env::split_paths(&paths)
+                .filter(|dir| dir.is_dir())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
 }
 
 fn shell_program() -> String {
@@ -607,6 +641,18 @@ mod tests {
     }
 
     #[test]
+    fn wrap_pty_shell_command_uses_direct_backend_on_macos() {
+        let manager = manager("macos", SandboxBackend::MacosSeatbelt);
+
+        let wrapped = manager
+            .wrap_pty_shell_command("read line", "/workspace/project", false)
+            .expect("pty shell wrapper");
+
+        assert!(!wrapped.sandboxed);
+        assert_eq!(wrapped.sandbox_backend, "direct");
+    }
+
+    #[test]
     fn shell_command_flag_uses_login_shell_for_common_user_shells() {
         assert_eq!(shell_command_flag("/bin/zsh"), "-lc");
         assert_eq!(shell_command_flag("/usr/bin/bash"), "-lc");
@@ -807,6 +853,38 @@ mod tests {
                     ]
             }),
             "linux sandbox should still mount the workspace path itself"
+        );
+    }
+
+    #[test]
+    fn linux_sandbox_binds_command_search_path_dirs() {
+        let tempdir = tempdir().expect("tempdir");
+        let custom_bin = tempdir.path().join("custom-bin");
+        std::fs::create_dir_all(&custom_bin).expect("custom bin dir");
+        let original_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", custom_bin.display().to_string());
+
+        let manager = manager("linux", SandboxBackend::LinuxBubblewrap);
+        let wrapped = manager
+            .wrap_shell_command("custom-tool --version", "/workspace/project", false)
+            .expect("linux sandbox wrapper");
+
+        if let Some(path) = original_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+
+        assert!(
+            wrapped.args.windows(3).any(|window| {
+                window
+                    == [
+                        String::from("--ro-bind"),
+                        custom_bin.display().to_string(),
+                        custom_bin.display().to_string(),
+                    ]
+            }),
+            "linux sandbox should bind PATH command directories that are outside standard runtime roots"
         );
     }
 }

--- a/docs/features/planning-mode.md
+++ b/docs/features/planning-mode.md
@@ -28,6 +28,9 @@ If the model ends a planning turn with narration alone, runtime must continue th
 
 - `explore_agent` is a read-only exploration sidecar for repository inspection;
 - `plan_agent` is a read-only planning sidecar for delegated sub-planning;
+- sub-agents must not recursively create sub-agents;
+- general worker sub-agents do not receive tool access until RARA has an explicit
+  nested-agent depth and observability contract;
 - planning sub-agents follow the same completion contract:
   - `<plan>`
   - `<request_user_input>`

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -56,6 +56,16 @@ The transcript should move toward Codex/Claude-style tool visibility:
   - `Messages to be submitted after next tool call`
   - `Queued follow-up messages`
 
+### Running query cancellation
+
+- When no overlay is open and a model query is running, `Esc` requests
+  cancellation for the current query.
+- Cancellation is cooperative: provider streaming loops should check the query
+  cancellation token and return a local cancellation error instead of leaving the
+  TUI stuck in `streaming model output`.
+- Cancellation must preserve the current agent state so the user can continue
+  from the same thread after the task exits.
+
 ## Non-Goals
 
 - This does not yet implement the full Codex "interrupt and send immediately" steer path.

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -29,6 +29,22 @@ The transcript should move toward Codex/Claude-style tool visibility:
 
 - `bash` tool execution must emit live transcript updates while stdout/stderr are still being produced.
 - The final `bash` tool result should keep the exit code and avoid duplicating large output that was already streamed live.
+- background bash tasks must be inspectable without imposing a fixed task-count limit:
+  - `background_task_list` lists known background tasks;
+  - `background_task_status` reads status and recent output for one task;
+  - `background_task_stop` stops one task, or all running background bash tasks
+    when no task id is supplied.
+
+### PTY sessions
+
+- PTY sessions must be inspectable and stoppable without imposing a fixed
+  session-count limit:
+  - `pty_list` lists known PTY sessions;
+  - `pty_status` reads status and recent output for one session;
+  - `pty_stop` stops one session, or all running PTY sessions when no session id
+    is supplied.
+- `pty_read`, `pty_write`, and `pty_kill` remain supported for direct session
+  interaction and backward compatibility.
 
 ### Queued follow-up messages
 

--- a/docs/journal/2026-04-28-background-task-controls.md
+++ b/docs/journal/2026-04-28-background-task-controls.md
@@ -23,6 +23,10 @@ PTY sessions.
   - `pty_stop`
 - Background task and PTY management intentionally adds observability and stop
   controls without adding task-count or session-count caps.
+- Running TUI query tasks now carry a cooperative cancellation token. Pressing
+  `Esc` with no overlay open requests cancellation for the active model query,
+  and OpenAI-compatible, Codex Responses, and Ollama streaming loops check that
+  token while reading provider output.
 
 ## Why
 
@@ -37,6 +41,8 @@ stoppable so long-running tasks are manageable.
 - `cargo test tools::agent::tests -- --nocapture`
 - `cargo test background_tasks_can_be_listed_and_stopped_without_count_limit -- --nocapture`
 - `cargo test tools::pty::tests -- --nocapture`
+- `cargo test esc_cancels_busy_query_without_overlay -- --nocapture`
+- `cargo test query_cancellation_sets_running_task_token -- --nocapture`
 - `cargo check`
 
 ## Notes

--- a/docs/journal/2026-04-28-background-task-controls.md
+++ b/docs/journal/2026-04-28-background-task-controls.md
@@ -1,0 +1,48 @@
+# 2026-04-28 · Background Task Controls
+
+## Summary
+
+RARA now makes the Claude-style sub-agent recursion boundary explicit and adds
+Codex/Claude-style management tools for long-running background bash tasks and
+PTY sessions.
+
+## What Changed
+
+- Sub-agent prompts now explicitly say that sub-agents must complete work
+  directly instead of delegating to another agent.
+- Sub-agent tool managers keep recursive agent tools unavailable by contract:
+  read-only sub-agents receive only read-only repository inspection tools, and
+  general worker sub-agents still receive no tools.
+- Background bash tasks now have:
+  - `background_task_list`
+  - `background_task_status`
+  - `background_task_stop`
+- PTY sessions now have:
+  - `pty_list`
+  - `pty_status`
+  - `pty_stop`
+- Background task and PTY management intentionally adds observability and stop
+  controls without adding task-count or session-count caps.
+
+## Why
+
+Claude Code avoids ordinary sub-agent re-delegation, which keeps sidecar work
+bounded and understandable. Codex and Claude both expose ways to inspect and
+stop long-running terminal work. RARA now follows that split: keep recursive
+sub-agent creation disabled for now, but make terminal work observable and
+stoppable so long-running tasks are manageable.
+
+## Validation
+
+- `cargo test tools::agent::tests -- --nocapture`
+- `cargo test background_tasks_can_be_listed_and_stopped_without_count_limit -- --nocapture`
+- `cargo test tools::pty::tests -- --nocapture`
+- `cargo check`
+
+## Notes
+
+The existing full `tools::bash::tests` target still depends on macOS sandbox
+streaming behavior in `streaming_call_reports_stdout_and_stderr_chunks`; in the
+current local environment that test returned no streamed output under
+`macos-seatbelt`. The new background task list/stop regression test passed
+independently.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -82,6 +82,7 @@ Priority order for this phase:
   - persist after the user message is accepted, after each assistant message, after each tool-result batch, after runtime continuation messages, and before waiting for pending user approval;
   - make `SessionManager::save_session` crash-tolerant by writing through a temporary file and atomic rename instead of overwriting `history.json` directly;
   - separate resumable transcript history from transient TUI task state so interrupted turns can resume with a clear `in progress` / `interrupted` / `failed` boundary rather than only an end-of-turn save.
+- [ ] Define background task restart/reattach semantics before persisting background task metadata across process restarts; the durable index should make completed logs discoverable without pretending killed parent processes are still attachable.
 - [ ] Make compaction a first-class runtime lifecycle event with persisted summaries, token counters, and boundary metadata ownership aligned with the thread domain.
 - [ ] Define thread-scoped and workspace-scoped `MemoryRecord` storage plus promotion rules so durable findings are not mixed with transient turn context.
 - [ ] Replace the current placeholder retrieval path with real vector retrieval over Lance/LanceDB, including metadata-aware ranking for thread and workspace memory selection.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -30,9 +30,11 @@ pub use self::planning::{
     CompletedInteraction, PendingApproval, PendingUserInput, PlanStep, PlanStepStatus,
 };
 
-const MAX_TOOL_ROUNDS_PER_TURN: usize = 8;
-const MAX_PLAN_CONTINUATIONS_PER_TURN: usize = 2;
-const MAX_EXECUTE_CONTINUATIONS_PER_TURN: usize = 2;
+// Match Claude Code's long-running sub-agent budget scale: a RARA query can
+// span many model/tool continuations, but still needs a finite runaway guard.
+const MAX_AGENTIC_TURNS_PER_QUERY: usize = 200;
+const MAX_PLAN_CONTINUATIONS_PER_QUERY: usize = 10;
+const MAX_EXECUTE_CONTINUATIONS_PER_QUERY: usize = 10;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AgentExecutionMode {
@@ -183,7 +185,7 @@ impl Agent {
         F: FnMut(AgentEvent) + Send,
     {
         let turn_start_idx = self.history.len();
-        let mut tool_rounds = 0usize;
+        let mut agentic_turns = 0usize;
         let mut plan_continuations = 0usize;
         let mut execute_continuations = 0usize;
         self.inspection_progress = InspectionProgress::default();
@@ -192,6 +194,7 @@ impl Agent {
         let repaired_history = repair_tool_result_history(&self.history);
         if repaired_history != self.history {
             self.replace_history(repaired_history);
+            self.checkpoint_session()?;
         }
         self.clear_completed_interactions();
 
@@ -199,18 +202,18 @@ impl Agent {
             role: "user".to_string(),
             content: json!([{"type": "text", "text": prompt.clone()}]),
         });
+        self.checkpoint_session()?;
 
         self.run_agent_loop_with_limit(
             output_mode,
             &mut report,
-            &mut tool_rounds,
+            &mut agentic_turns,
             &mut plan_continuations,
             &mut execute_continuations,
         )
         .await?;
 
-        self.session_manager
-            .save_session(&self.session_id, &self.history)?;
+        self.checkpoint_session()?;
         let turn_text = format!(
             "User: {}\nAgent Response: {:?}",
             prompt,
@@ -231,6 +234,11 @@ impl Agent {
                 .await;
         }
         Ok(())
+    }
+
+    pub(super) fn checkpoint_session(&self) -> Result<()> {
+        self.session_manager
+            .save_session(&self.session_id, &self.history)
     }
 
     async fn run_model_turn<F>(
@@ -372,13 +380,13 @@ impl Agent {
     where
         F: FnMut(AgentEvent) + Send,
     {
-        let mut tool_rounds = 0usize;
+        let mut agentic_turns = 0usize;
         let mut plan_continuations = 0usize;
         let mut execute_continuations = 0usize;
         self.run_agent_loop_with_limit(
             output_mode,
             report,
-            &mut tool_rounds,
+            &mut agentic_turns,
             &mut plan_continuations,
             &mut execute_continuations,
         )
@@ -389,7 +397,7 @@ impl Agent {
         &mut self,
         output_mode: AgentOutputMode,
         report: &mut F,
-        tool_rounds: &mut usize,
+        agentic_turns: &mut usize,
         plan_continuations: &mut usize,
         execute_continuations: &mut usize,
     ) -> Result<()>
@@ -401,13 +409,14 @@ impl Agent {
             let turn_output = self.run_model_turn(output_mode, report).await?;
             self.last_query_plan_updated = turn_output.plan_updated;
             self.push_history_message(turn_output.assistant_message);
+            self.checkpoint_session()?;
 
             if turn_output.tool_calls.is_empty() {
                 if self.should_continue_plan_without_tools(
                     turn_output.plan_updated,
                     turn_output.continue_inspection,
                     turn_output.had_text_response,
-                    *tool_rounds,
+                    *agentic_turns,
                     *plan_continuations,
                 ) {
                     *plan_continuations += 1;
@@ -432,12 +441,13 @@ impl Agent {
                         RuntimeContinuationPhase::PlanContinuationRequired
                     };
                     self.push_history_message(
-                        self.runtime_continuation_message(phase, *tool_rounds),
+                        self.runtime_continuation_message(phase, *agentic_turns),
                     );
+                    self.checkpoint_session()?;
                     continue;
                 }
                 if self.should_continue_execute_without_tools(
-                    *tool_rounds,
+                    *agentic_turns,
                     *execute_continuations,
                     turn_output.continue_inspection,
                 ) {
@@ -448,42 +458,47 @@ impl Agent {
                     ));
                     self.push_history_message(self.runtime_continuation_message(
                         RuntimeContinuationPhase::ExecutionContinuationRequired,
-                        *tool_rounds,
+                        *agentic_turns,
                     ));
+                    self.checkpoint_session()?;
                     continue;
                 }
                 self.complete_active_plan_step();
                 break;
             }
-            *tool_rounds += 1;
-            if *tool_rounds > MAX_TOOL_ROUNDS_PER_TURN {
+            *agentic_turns += 1;
+            if *agentic_turns > MAX_AGENTIC_TURNS_PER_QUERY {
                 let skipped_results =
                     self.tool_loop_limit_result_messages(&turn_output.tool_calls, report);
                 self.extend_history_messages(skipped_results);
+                self.checkpoint_session()?;
                 report(AgentEvent::Status(
-                    "Tool loop reached the limit. Requesting a final answer without more tool calls."
+                    "Agentic turn budget reached. Requesting a final answer without more tool calls."
                         .to_string(),
                 ));
                 self.push_history_message(self.runtime_continuation_message(
                     RuntimeContinuationPhase::FinalAnswerRequired,
-                    *tool_rounds,
+                    *agentic_turns,
                 ));
+                self.checkpoint_session()?;
                 let final_turn = self
                     .run_model_turn_with_tools(output_mode, report, &[])
                     .await?;
                 self.last_query_plan_updated = final_turn.plan_updated;
                 if final_turn.tool_calls.is_empty() && final_turn.had_text_response {
                     self.push_history_message(final_turn.assistant_message);
+                    self.checkpoint_session()?;
                 } else {
                     if !final_turn.tool_calls.is_empty() {
                         self.push_history_message(final_turn.assistant_message);
                         let skipped_results =
                             self.tool_loop_limit_result_messages(&final_turn.tool_calls, report);
                         self.extend_history_messages(skipped_results);
+                        self.checkpoint_session()?;
                     }
                     let fallback_text = self.tool_loop_limit_fallback_text();
                     report(AgentEvent::Status(
-                        "Tool loop reached the limit. Returning a bounded final response without more tool calls."
+                        "Agentic turn budget reached. Returning a bounded final response without more tool calls."
                             .to_string(),
                     ));
                     report(AgentEvent::AssistantText(fallback_text.clone()));
@@ -491,6 +506,7 @@ impl Agent {
                         println!("Agent: {}", fallback_text);
                     }
                     self.push_history_message(assistant_text_message(fallback_text));
+                    self.checkpoint_session()?;
                 }
                 self.complete_active_plan_step();
                 break;
@@ -500,10 +516,11 @@ impl Agent {
                 .execute_tool_calls(turn_output.tool_calls, report)
                 .await?;
             if self.pending_approval.is_some() {
+                self.checkpoint_session()?;
                 break;
             }
             self.advance_plan_step();
-            self.extend_history_for_next_turn(tool_results, report, *tool_rounds);
+            self.extend_history_for_next_turn(tool_results, report, *agentic_turns)?;
         }
         Ok(())
     }
@@ -520,8 +537,8 @@ impl Agent {
             .iter()
             .map(|tool_call| {
                 let content = format!(
-                    "Error: tool call '{}' was not executed because this turn reached the {} tool-round limit.",
-                    tool_call.name, MAX_TOOL_ROUNDS_PER_TURN
+                    "Error: tool call '{}' was not executed because this query reached the {} agentic-turn budget.",
+                    tool_call.name, MAX_AGENTIC_TURNS_PER_QUERY
                 );
                 report(AgentEvent::ToolResult {
                     name: tool_call.name.clone(),
@@ -536,7 +553,7 @@ impl Agent {
     fn tool_loop_limit_fallback_text(&self) -> String {
         let mut lines = vec![
             format!(
-                "Tool loop reached the {MAX_TOOL_ROUNDS_PER_TURN}-round limit before a clean final answer was produced."
+                "Agentic turn budget reached after {MAX_AGENTIC_TURNS_PER_QUERY} agentic turns before a clean final answer was produced."
             ),
             "I stopped additional tool execution, recorded any skipped tool calls as error results, and preserved the transcript for the next turn.".to_string(),
         ];
@@ -591,6 +608,11 @@ impl Agent {
                             allow_net: tool_call
                                 .input
                                 .get("allow_net")
+                                .and_then(Value::as_bool)
+                                .unwrap_or(false),
+                            run_in_background: tool_call
+                                .input
+                                .get("run_in_background")
                                 .and_then(Value::as_bool)
                                 .unwrap_or(false),
                         }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -30,12 +30,6 @@ pub use self::planning::{
     CompletedInteraction, PendingApproval, PendingUserInput, PlanStep, PlanStepStatus,
 };
 
-// Match Claude Code's long-running sub-agent budget scale: a RARA query can
-// span many model/tool continuations, but still needs a finite runaway guard.
-const MAX_AGENTIC_TURNS_PER_QUERY: usize = 200;
-const MAX_PLAN_CONTINUATIONS_PER_QUERY: usize = 10;
-const MAX_EXECUTE_CONTINUATIONS_PER_QUERY: usize = 10;
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AgentExecutionMode {
     Execute,
@@ -186,8 +180,6 @@ impl Agent {
     {
         let turn_start_idx = self.history.len();
         let mut agentic_turns = 0usize;
-        let mut plan_continuations = 0usize;
-        let mut execute_continuations = 0usize;
         self.inspection_progress = InspectionProgress::default();
         self.last_query_plan_updated = false;
         self.compact_if_needed_with_reporter(&mut report).await?;
@@ -204,14 +196,8 @@ impl Agent {
         });
         self.checkpoint_session()?;
 
-        self.run_agent_loop_with_limit(
-            output_mode,
-            &mut report,
-            &mut agentic_turns,
-            &mut plan_continuations,
-            &mut execute_continuations,
-        )
-        .await?;
+        self.run_agent_loop_with_limit(output_mode, &mut report, &mut agentic_turns)
+            .await?;
 
         self.checkpoint_session()?;
         let turn_text = format!(
@@ -381,16 +367,8 @@ impl Agent {
         F: FnMut(AgentEvent) + Send,
     {
         let mut agentic_turns = 0usize;
-        let mut plan_continuations = 0usize;
-        let mut execute_continuations = 0usize;
-        self.run_agent_loop_with_limit(
-            output_mode,
-            report,
-            &mut agentic_turns,
-            &mut plan_continuations,
-            &mut execute_continuations,
-        )
-        .await
+        self.run_agent_loop_with_limit(output_mode, report, &mut agentic_turns)
+            .await
     }
 
     async fn run_agent_loop_with_limit<F>(
@@ -398,8 +376,6 @@ impl Agent {
         output_mode: AgentOutputMode,
         report: &mut F,
         agentic_turns: &mut usize,
-        plan_continuations: &mut usize,
-        execute_continuations: &mut usize,
     ) -> Result<()>
     where
         F: FnMut(AgentEvent) + Send,
@@ -417,9 +393,7 @@ impl Agent {
                     turn_output.continue_inspection,
                     turn_output.had_text_response,
                     *agentic_turns,
-                    *plan_continuations,
                 ) {
-                    *plan_continuations += 1;
                     let phase = if matches!(
                         self.planning_outcome_contract(
                             turn_output.plan_updated,
@@ -448,10 +422,8 @@ impl Agent {
                 }
                 if self.should_continue_execute_without_tools(
                     *agentic_turns,
-                    *execute_continuations,
                     turn_output.continue_inspection,
                 ) {
-                    *execute_continuations += 1;
                     report(AgentEvent::Status(
                         "Repository review needs more code inspection. Continuing the same turn."
                             .to_string(),
@@ -467,50 +439,6 @@ impl Agent {
                 break;
             }
             *agentic_turns += 1;
-            if *agentic_turns > MAX_AGENTIC_TURNS_PER_QUERY {
-                let skipped_results =
-                    self.tool_loop_limit_result_messages(&turn_output.tool_calls, report);
-                self.extend_history_messages(skipped_results);
-                self.checkpoint_session()?;
-                report(AgentEvent::Status(
-                    "Agentic turn budget reached. Requesting a final answer without more tool calls."
-                        .to_string(),
-                ));
-                self.push_history_message(self.runtime_continuation_message(
-                    RuntimeContinuationPhase::FinalAnswerRequired,
-                    *agentic_turns,
-                ));
-                self.checkpoint_session()?;
-                let final_turn = self
-                    .run_model_turn_with_tools(output_mode, report, &[])
-                    .await?;
-                self.last_query_plan_updated = final_turn.plan_updated;
-                if final_turn.tool_calls.is_empty() && final_turn.had_text_response {
-                    self.push_history_message(final_turn.assistant_message);
-                    self.checkpoint_session()?;
-                } else {
-                    if !final_turn.tool_calls.is_empty() {
-                        self.push_history_message(final_turn.assistant_message);
-                        let skipped_results =
-                            self.tool_loop_limit_result_messages(&final_turn.tool_calls, report);
-                        self.extend_history_messages(skipped_results);
-                        self.checkpoint_session()?;
-                    }
-                    let fallback_text = self.tool_loop_limit_fallback_text();
-                    report(AgentEvent::Status(
-                        "Agentic turn budget reached. Returning a bounded final response without more tool calls."
-                            .to_string(),
-                    ));
-                    report(AgentEvent::AssistantText(fallback_text.clone()));
-                    if matches!(output_mode, AgentOutputMode::Terminal) {
-                        println!("Agent: {}", fallback_text);
-                    }
-                    self.push_history_message(assistant_text_message(fallback_text));
-                    self.checkpoint_session()?;
-                }
-                self.complete_active_plan_step();
-                break;
-            }
 
             let tool_results = self
                 .execute_tool_calls(turn_output.tool_calls, report)
@@ -523,58 +451,6 @@ impl Agent {
             self.extend_history_for_next_turn(tool_results, report, *agentic_turns)?;
         }
         Ok(())
-    }
-
-    fn tool_loop_limit_result_messages<F>(
-        &self,
-        tool_calls: &[ToolCall],
-        report: &mut F,
-    ) -> Vec<Message>
-    where
-        F: FnMut(AgentEvent) + Send,
-    {
-        tool_calls
-            .iter()
-            .map(|tool_call| {
-                let content = format!(
-                    "Error: tool call '{}' was not executed because this query reached the {} agentic-turn budget.",
-                    tool_call.name, MAX_AGENTIC_TURNS_PER_QUERY
-                );
-                report(AgentEvent::ToolResult {
-                    name: tool_call.name.clone(),
-                    content: content.clone(),
-                    is_error: true,
-                });
-                tool_result_message(&tool_call.id, content, true)
-            })
-            .collect()
-    }
-
-    fn tool_loop_limit_fallback_text(&self) -> String {
-        let mut lines = vec![
-            format!(
-                "Agentic turn budget reached after {MAX_AGENTIC_TURNS_PER_QUERY} agentic turns before a clean final answer was produced."
-            ),
-            "I stopped additional tool execution, recorded any skipped tool calls as error results, and preserved the transcript for the next turn.".to_string(),
-        ];
-        if !self.current_plan.is_empty() {
-            lines.push(String::new());
-            lines.push("Current plan state:".to_string());
-            lines.extend(
-                self.current_plan.iter().map(|step| {
-                    format!("- [{}] {}", plan_step_status_label(&step.status), step.step)
-                }),
-            );
-        }
-        if let Some(explanation) = self
-            .plan_explanation
-            .as_deref()
-            .filter(|explanation| !explanation.trim().is_empty())
-        {
-            lines.push(String::new());
-            lines.push(explanation.trim().to_string());
-        }
-        lines.join("\n")
     }
 
     async fn execute_tool_calls<F>(
@@ -712,21 +588,6 @@ impl Agent {
             }
         }
         Ok(tool_results)
-    }
-}
-
-fn assistant_text_message(text: String) -> Message {
-    Message {
-        role: "assistant".to_string(),
-        content: json!([{"type": "text", "text": text}]),
-    }
-}
-
-fn plan_step_status_label(status: &PlanStepStatus) -> &'static str {
-    match status {
-        PlanStepStatus::Pending => "pending",
-        PlanStepStatus::InProgress => "in_progress",
-        PlanStepStatus::Completed => "completed",
     }
 }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -19,7 +19,7 @@ use crate::workspace::WorkspaceMemory;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 use uuid::Uuid;
 
 pub use self::compact::{latest_compact_boundary_metadata, CompactBoundaryMetadata, CompactState};
@@ -116,6 +116,7 @@ pub struct Agent {
     inspection_progress: InspectionProgress,
     last_query_plan_updated: bool,
     prompt_config: PromptRuntimeConfig,
+    cancellation_token: Option<Arc<AtomicBool>>,
 }
 
 impl Agent {
@@ -152,6 +153,7 @@ impl Agent {
             inspection_progress: InspectionProgress::default(),
             last_query_plan_updated: false,
             prompt_config: PromptRuntimeConfig::default(),
+            cancellation_token: None,
         }
     }
 
@@ -251,6 +253,7 @@ impl Agent {
     {
         report(AgentEvent::Status("Sending prompt to model.".to_string()));
         let turn_metadata = self.llm_turn_metadata();
+        turn_metadata.ensure_not_cancelled()?;
         let mut messages = self
             .history
             .iter()
@@ -352,9 +355,14 @@ impl Agent {
     }
 
     fn llm_turn_metadata(&self) -> LlmTurnMetadata {
-        match self.execution_mode {
+        let metadata = match self.execution_mode {
             AgentExecutionMode::Execute => LlmTurnMetadata::execute(),
             AgentExecutionMode::Plan => LlmTurnMetadata::plan(),
+        };
+        if let Some(token) = self.cancellation_token.as_ref() {
+            metadata.with_cancellation(token.clone())
+        } else {
+            metadata
         }
     }
 

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -46,7 +46,6 @@ pub(super) struct InspectionProgress {
 #[derive(Clone, Copy)]
 pub(super) enum RuntimeContinuationPhase {
     ToolResultsAvailable,
-    FinalAnswerRequired,
     PlanContinuationRequired,
     PlanStructuredOutcomeRequired,
     ExecutionContinuationRequired,
@@ -417,7 +416,6 @@ impl Agent {
         continue_inspection: bool,
         had_text_response: bool,
         agentic_turns: usize,
-        plan_continuations: usize,
     ) -> bool {
         let shallow_initial_plan =
             plan_updated && agentic_turns == 0 && self.current_plan.len() <= 1;
@@ -439,7 +437,6 @@ impl Agent {
                     && !plan_updated
                     && !continue_inspection
                     && self.pending_user_input.is_none()))
-            && plan_continuations < MAX_PLAN_CONTINUATIONS_PER_QUERY
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
             && (continue_inspection
@@ -472,13 +469,11 @@ impl Agent {
     pub(super) fn should_continue_execute_without_tools(
         &self,
         _agentic_turns: usize,
-        execute_continuations: usize,
         continue_inspection: bool,
     ) -> bool {
         let inspection_intent = continue_inspection || self.inspection_progress.has_any_evidence();
         matches!(self.execution_mode, AgentExecutionMode::Execute)
             && inspection_intent
-            && execute_continuations < MAX_EXECUTE_CONTINUATIONS_PER_QUERY
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
             && (continue_inspection || !self.inspection_progress.has_minimum_review_evidence())
@@ -675,7 +670,6 @@ impl RuntimeContinuationPhase {
     fn label(self) -> &'static str {
         match self {
             Self::ToolResultsAvailable => "tool_results_available",
-            Self::FinalAnswerRequired => "final_answer_required",
             Self::PlanContinuationRequired => "plan_continuation_required",
             Self::PlanStructuredOutcomeRequired => "plan_structured_outcome_required",
             Self::ExecutionContinuationRequired => "execution_continuation_required",
@@ -691,14 +685,6 @@ impl RuntimeContinuationPhase {
                 "Either call the next tool directly, or provide the final answer.",
                 "Do not ask the user to continue.",
                 "Do not repeat tool results verbatim.",
-            ],
-            Self::FinalAnswerRequired => vec![
-                "The tool loop reached the execution limit for this turn.",
-                "Do not call any more tools.",
-                "Synthesize the result from the repository context and tool results already in the conversation.",
-                "If another tool call would be useful, state the limitation in the final answer instead of emitting a tool call.",
-                "Provide the final answer now.",
-                "Do not ask the user to continue.",
             ],
             Self::PlanContinuationRequired => vec![
                 "Continue planning immediately.",

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -64,7 +64,7 @@ pub(super) enum PlanningOutcomeContract {
 struct RuntimeContinuation<'a> {
     phase: &'a str,
     mode: &'a str,
-    tool_rounds: usize,
+    agentic_turns: usize,
     inspection: RuntimeInspectionSnapshot,
     plan: RuntimePlanSnapshot,
     pending_interaction: &'a str,
@@ -231,12 +231,12 @@ impl Agent {
                     RuntimeContinuationPhase::ToolResultsAvailable,
                     0,
                 ));
+                self.checkpoint_session()?;
                 self.run_agent_loop(output_mode, &mut report).await?;
             }
         }
 
-        self.session_manager
-            .save_session(&self.session_id, &self.history)?;
+        self.checkpoint_session()?;
         Ok(())
     }
 
@@ -292,6 +292,7 @@ impl Agent {
                     result_text,
                     false,
                 ));
+                self.checkpoint_session()?;
             }
             Err(err) => {
                 let error_text = format!("Error: {}", err);
@@ -305,11 +306,13 @@ impl Agent {
                     error_text,
                     true,
                 ));
+                self.checkpoint_session()?;
             }
         }
         self.push_history_message(
             self.runtime_continuation_message(RuntimeContinuationPhase::ToolResultsAvailable, 1),
         );
+        self.checkpoint_session()?;
         if !keep_always {
             self.bash_approval_mode = BashApprovalMode::Suggestion;
         }
@@ -320,8 +323,9 @@ impl Agent {
         &mut self,
         tool_results: Vec<Message>,
         report: &mut F,
-        tool_rounds: usize,
-    ) where
+        agentic_turns: usize,
+    ) -> Result<()>
+    where
         F: FnMut(AgentEvent) + Send,
     {
         self.extend_history_messages(tool_results);
@@ -330,8 +334,9 @@ impl Agent {
         ));
         self.push_history_message(self.runtime_continuation_message(
             RuntimeContinuationPhase::ToolResultsAvailable,
-            tool_rounds,
+            agentic_turns,
         ));
+        self.checkpoint_session()
     }
 
     pub(super) fn visible_tool_schemas(&self) -> Vec<Value> {
@@ -378,6 +383,7 @@ impl Agent {
                 RuntimeContinuationPhase::PlanContinuationRequired,
                 0,
             ));
+            self.checkpoint_session()?;
         } else {
             self.execution_mode = AgentExecutionMode::Execute;
             report(AgentEvent::Status(
@@ -386,6 +392,7 @@ impl Agent {
             self.push_history_message(
                 self.runtime_continuation_message(RuntimeContinuationPhase::PlanApproved, 0),
             );
+            self.checkpoint_session()?;
         }
 
         self.run_agent_loop(output_mode, &mut report).await
@@ -409,16 +416,17 @@ impl Agent {
         plan_updated: bool,
         continue_inspection: bool,
         had_text_response: bool,
-        tool_rounds: usize,
+        agentic_turns: usize,
         plan_continuations: usize,
     ) -> bool {
-        let shallow_initial_plan = plan_updated && tool_rounds == 0 && self.current_plan.len() <= 1;
+        let shallow_initial_plan =
+            plan_updated && agentic_turns == 0 && self.current_plan.len() <= 1;
         let has_inspection_evidence = self.inspection_progress.has_any_evidence();
-        let still_missing_inspection_evidence = tool_rounds > 0
+        let still_missing_inspection_evidence = agentic_turns > 0
             && !plan_updated
             && has_inspection_evidence
             && !self.inspection_progress.has_minimum_review_evidence();
-        let needs_plan_synthesis = tool_rounds > 0 && has_inspection_evidence && !plan_updated;
+        let needs_plan_synthesis = agentic_turns > 0 && has_inspection_evidence && !plan_updated;
         !matches!(
             self.planning_outcome_contract(plan_updated, continue_inspection, had_text_response),
             PlanningOutcomeContract::Satisfied
@@ -431,7 +439,7 @@ impl Agent {
                     && !plan_updated
                     && !continue_inspection
                     && self.pending_user_input.is_none()))
-            && plan_continuations < MAX_PLAN_CONTINUATIONS_PER_TURN
+            && plan_continuations < MAX_PLAN_CONTINUATIONS_PER_QUERY
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
             && (continue_inspection
@@ -463,14 +471,14 @@ impl Agent {
 
     pub(super) fn should_continue_execute_without_tools(
         &self,
-        _tool_rounds: usize,
+        _agentic_turns: usize,
         execute_continuations: usize,
         continue_inspection: bool,
     ) -> bool {
         let inspection_intent = continue_inspection || self.inspection_progress.has_any_evidence();
         matches!(self.execution_mode, AgentExecutionMode::Execute)
             && inspection_intent
-            && execute_continuations < MAX_EXECUTE_CONTINUATIONS_PER_TURN
+            && execute_continuations < MAX_EXECUTE_CONTINUATIONS_PER_QUERY
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
             && (continue_inspection || !self.inspection_progress.has_minimum_review_evidence())
@@ -538,7 +546,7 @@ impl Agent {
     pub(super) fn runtime_continuation_message(
         &self,
         phase: RuntimeContinuationPhase,
-        tool_rounds: usize,
+        agentic_turns: usize,
     ) -> Message {
         let pending_interaction = if self.pending_approval.is_some() {
             "approval"
@@ -550,7 +558,7 @@ impl Agent {
         let payload = RuntimeContinuation {
             phase: phase.label(),
             mode: self.execution_mode_label(),
-            tool_rounds,
+            agentic_turns,
             inspection: RuntimeInspectionSnapshot {
                 list_calls: self.inspection_progress.list_calls,
                 source_reads: self.inspection_progress.source_reads,

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -70,6 +70,13 @@ impl Agent {
         self.prompt_config = prompt_config;
     }
 
+    pub fn set_cancellation_token(
+        &mut self,
+        cancellation_token: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    ) {
+        self.cancellation_token = cancellation_token;
+    }
+
     pub fn prompt_config(&self) -> &PromptRuntimeConfig {
         &self.prompt_config
     }

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -84,12 +84,13 @@ async fn appends_continuation_after_tool_result() {
 
     let mut tool_manager = ToolManager::new();
     tool_manager.register(Box::new(StubTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
     let mut agent = Agent::new(
         tool_manager,
         backend.clone(),
-        Arc::new(VectorDB::new("data/lancedb")),
-        Arc::new(SessionManager::new().expect("session manager")),
-        Arc::new(WorkspaceMemory::new().expect("workspace memory")),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
     );
 
     agent
@@ -225,8 +226,9 @@ async fn does_not_append_continuation_without_tools() {
 }
 
 #[tokio::test]
-async fn forces_final_answer_when_tool_loop_exceeds_limit() {
-    let mut responses = (0..=super::super::MAX_AGENTIC_TURNS_PER_QUERY)
+async fn continues_tool_loop_without_fixed_turn_cap() {
+    let tool_turns = 205;
+    let mut responses = (0..tool_turns)
         .map(|idx| LlmResponse {
             content: vec![ContentBlock::ToolUse {
                 id: format!("tool-{idx}"),
@@ -248,103 +250,35 @@ async fn forces_final_answer_when_tool_loop_exceeds_limit() {
 
     let mut tool_manager = ToolManager::new();
     tool_manager.register(Box::new(StubTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
     let mut agent = Agent::new(
         tool_manager,
         backend.clone(),
-        Arc::new(VectorDB::new("data/lancedb")),
-        Arc::new(SessionManager::new().expect("session manager")),
-        Arc::new(WorkspaceMemory::new().expect("workspace memory")),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
     );
 
     agent
         .query_with_mode("loop".to_string(), super::super::AgentOutputMode::Silent)
         .await
-        .expect("query should finish with a forced final answer");
+        .expect("query should continue until the model returns a final answer");
 
     let observed_tools = backend.observed_tools();
     assert_eq!(
         observed_tools.len(),
-        super::super::MAX_AGENTIC_TURNS_PER_QUERY + 2
+        tool_turns + 1,
+        "the agent should continue past the former fixed turn cap before the final answer"
     );
-    assert!(observed_tools.last().is_some_and(|tools| tools.is_empty()));
     assert!(agent.history.last().is_some_and(|message| message
         .content
         .to_string()
         .contains("Final answer after reviewing the tool results.")));
-}
-
-#[tokio::test]
-async fn returns_local_fallback_when_forced_final_answer_still_calls_tools() {
-    let mut responses = (0..=super::super::MAX_AGENTIC_TURNS_PER_QUERY)
-        .map(|idx| LlmResponse {
-            content: vec![ContentBlock::ToolUse {
-                id: format!("tool-{idx}"),
-                name: "stub_tool".to_string(),
-                input: json!({}),
-            }],
-            stop_reason: Some("tool_use".to_string()),
-            usage: Some(TokenUsage::default()),
-        })
-        .collect::<Vec<_>>();
-    responses.push(LlmResponse {
-        content: vec![
-            ContentBlock::Text {
-                text: "Partial text before requesting another tool.".to_string(),
-            },
-            ContentBlock::ToolUse {
-                id: "tool-final".to_string(),
-                name: "stub_tool".to_string(),
-                input: json!({}),
-            },
-        ],
-        stop_reason: Some("tool_use".to_string()),
-        usage: Some(TokenUsage::default()),
-    });
-    let backend = Arc::new(SequencedBackend::new(responses));
-
-    let mut tool_manager = ToolManager::new();
-    tool_manager.register(Box::new(StubTool));
-    let mut agent = Agent::new(
-        tool_manager,
-        backend.clone(),
-        Arc::new(VectorDB::new("data/lancedb")),
-        Arc::new(SessionManager::new().expect("session manager")),
-        Arc::new(WorkspaceMemory::new().expect("workspace memory")),
-    );
-
-    let mut events = Vec::new();
-    agent
-        .query_with_mode_and_events(
-            "loop".to_string(),
-            super::super::AgentOutputMode::Silent,
-            |event| events.push(event),
-        )
-        .await
-        .expect("query should finish with a local fallback answer");
-
-    let observed_tools = backend.observed_tools();
-    assert!(observed_tools.last().is_some_and(|tools| tools.is_empty()));
-    let fallback_message = agent
-        .history
-        .last()
-        .expect("fallback message should be appended")
-        .content
-        .to_string();
-    assert!(fallback_message.contains(&format!(
-        "Agentic turn budget reached after {} agentic turns",
-        super::super::MAX_AGENTIC_TURNS_PER_QUERY
-    )));
-    assert!(!fallback_message.contains("Partial text before requesting another tool."));
     assert!(agent
         .history
         .iter()
-        .any(|message| message.content.to_string().contains("tool-final")));
+        .any(|message| message.content.to_string().contains("tool-204")));
     assert_no_unresolved_tool_uses(&agent.history);
-    assert!(events.iter().any(|event| matches!(
-        event,
-        super::super::AgentEvent::AssistantText(text)
-            if text.contains("Agentic turn budget reached")
-    )));
 }
 
 #[test]

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use anyhow::Result;
+use async_trait::async_trait;
 use serde_json::json;
 
 use crate::agent::planning::{
@@ -9,7 +11,7 @@ use crate::agent::{
     Agent, AgentExecutionMode, ContentBlock, PendingUserInput, PlanStep, PlanStepStatus,
     RuntimeContinuationPhase,
 };
-use crate::llm::{LlmResponse, TokenUsage};
+use crate::llm::{LlmBackend, LlmResponse, TokenUsage};
 use crate::session::SessionManager;
 use crate::tool::ToolManager;
 use crate::tool_result::ToolResultStore;
@@ -17,6 +19,47 @@ use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
 
 use super::support::{test_runtime_storage, SequencedBackend, StubTool};
+
+struct CheckpointObserverBackend {
+    session_manager: Arc<SessionManager>,
+    session_id: String,
+}
+
+#[async_trait]
+impl LlmBackend for CheckpointObserverBackend {
+    async fn ask(
+        &self,
+        _messages: &[crate::agent::Message],
+        _tools: &[serde_json::Value],
+    ) -> Result<LlmResponse> {
+        let persisted = self
+            .session_manager
+            .load_thread_history(&self.session_id)
+            .expect("user message should be checkpointed before model call");
+        assert!(persisted.iter().any(|message| {
+            message.role == "user" && message.content.to_string().contains("checkpoint me")
+        }));
+        Ok(LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "checkpoint observed".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        })
+    }
+
+    async fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+        Ok(vec![0.0; 8])
+    }
+
+    async fn summarize(
+        &self,
+        _messages: &[crate::agent::Message],
+        _instruction: &str,
+    ) -> Result<String> {
+        Ok("summary".to_string())
+    }
+}
 
 #[tokio::test]
 async fn appends_continuation_after_tool_result() {
@@ -65,6 +108,36 @@ async fn appends_continuation_after_tool_result() {
     assert!(second_round
         .iter()
         .any(|message| { message.content.to_string().contains("tool_result") }));
+}
+
+#[tokio::test]
+async fn checkpoints_user_message_before_first_model_turn() {
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let session_id = "checkpoint-before-model".to_string();
+    let backend = Arc::new(CheckpointObserverBackend {
+        session_manager: session_manager.clone(),
+        session_id: session_id.clone(),
+    });
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new(
+            &rara_dir.join("lancedb").display().to_string(),
+        )),
+        session_manager,
+        workspace,
+    );
+    agent.session_id = session_id;
+    agent.tool_result_store =
+        ToolResultStore::new(rara_dir.join("tool-results")).expect("tool result store");
+
+    agent
+        .query_with_mode(
+            "checkpoint me".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("query should succeed");
 }
 
 #[tokio::test]
@@ -153,7 +226,7 @@ async fn does_not_append_continuation_without_tools() {
 
 #[tokio::test]
 async fn forces_final_answer_when_tool_loop_exceeds_limit() {
-    let mut responses = (0..=super::super::MAX_TOOL_ROUNDS_PER_TURN)
+    let mut responses = (0..=super::super::MAX_AGENTIC_TURNS_PER_QUERY)
         .map(|idx| LlmResponse {
             content: vec![ContentBlock::ToolUse {
                 id: format!("tool-{idx}"),
@@ -191,7 +264,7 @@ async fn forces_final_answer_when_tool_loop_exceeds_limit() {
     let observed_tools = backend.observed_tools();
     assert_eq!(
         observed_tools.len(),
-        super::super::MAX_TOOL_ROUNDS_PER_TURN + 2
+        super::super::MAX_AGENTIC_TURNS_PER_QUERY + 2
     );
     assert!(observed_tools.last().is_some_and(|tools| tools.is_empty()));
     assert!(agent.history.last().is_some_and(|message| message
@@ -202,7 +275,7 @@ async fn forces_final_answer_when_tool_loop_exceeds_limit() {
 
 #[tokio::test]
 async fn returns_local_fallback_when_forced_final_answer_still_calls_tools() {
-    let mut responses = (0..=super::super::MAX_TOOL_ROUNDS_PER_TURN)
+    let mut responses = (0..=super::super::MAX_AGENTIC_TURNS_PER_QUERY)
         .map(|idx| LlmResponse {
             content: vec![ContentBlock::ToolUse {
                 id: format!("tool-{idx}"),
@@ -258,8 +331,8 @@ async fn returns_local_fallback_when_forced_final_answer_still_calls_tools() {
         .content
         .to_string();
     assert!(fallback_message.contains(&format!(
-        "Tool loop reached the {}-round limit",
-        super::super::MAX_TOOL_ROUNDS_PER_TURN
+        "Agentic turn budget reached after {} agentic turns",
+        super::super::MAX_AGENTIC_TURNS_PER_QUERY
     )));
     assert!(!fallback_message.contains("Partial text before requesting another tool."));
     assert!(agent
@@ -270,7 +343,7 @@ async fn returns_local_fallback_when_forced_final_answer_still_calls_tools() {
     assert!(events.iter().any(|event| matches!(
         event,
         super::super::AgentEvent::AssistantText(text)
-            if text.contains("Tool loop reached the")
+            if text.contains("Agentic turn budget reached")
     )));
 }
 

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -128,6 +128,22 @@ impl LlmBackend for OllamaBackend {
         tools: &[Value],
         on_text_delta: &mut (dyn FnMut(String) + Send),
     ) -> Result<LlmResponse> {
+        self.ask_streaming_with_context(
+            messages,
+            tools,
+            crate::llm::LlmTurnMetadata::default(),
+            on_text_delta,
+        )
+        .await
+    }
+
+    async fn ask_streaming_with_context(
+        &self,
+        messages: &[Message],
+        tools: &[Value],
+        metadata: crate::llm::LlmTurnMetadata,
+        on_text_delta: &mut (dyn FnMut(String) + Send),
+    ) -> Result<LlmResponse> {
         let endpoint = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
         let mut body = json!({
             "model": self.model,
@@ -175,6 +191,7 @@ impl LlmBackend for OllamaBackend {
         let mut saw_done = false;
 
         while let Some(chunk) = stream.next().await {
+            metadata.ensure_not_cancelled()?;
             let chunk = chunk?;
             buffer.extend_from_slice(&chunk);
 

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -106,7 +106,7 @@ impl LlmBackend for OpenAiCompatibleBackend {
             self.endpoint_kind,
             self.reasoning_effort.as_deref(),
             self.thinking,
-            metadata,
+            metadata.clone(),
         );
 
         let completions_url = self.endpoint_url("chat/completions");
@@ -143,7 +143,7 @@ impl LlmBackend for OpenAiCompatibleBackend {
             self.endpoint_kind,
             self.reasoning_effort.as_deref(),
             self.thinking,
-            metadata,
+            metadata.clone(),
         );
         body["stream"] = json!(true);
 
@@ -172,6 +172,7 @@ impl LlmBackend for OpenAiCompatibleBackend {
         let mut usage = None;
 
         while let Some(event) = stream.next().await {
+            metadata.ensure_not_cancelled()?;
             let event = event.map_err(|error| anyhow!("Failed to decode SSE event: {error}"))?;
             let data = event.data.trim();
             if data.is_empty() {

--- a/src/llm/openai_compatible/codex.rs
+++ b/src/llm/openai_compatible/codex.rs
@@ -47,6 +47,7 @@ impl CodexBackend {
         &self,
         messages: &[Message],
         tools: &[Value],
+        metadata: crate::llm::LlmTurnMetadata,
         mut on_text_delta: Option<&mut (dyn FnMut(String) + Send)>,
     ) -> Result<LlmResponse> {
         let body = build_codex_responses_request(
@@ -82,6 +83,7 @@ impl CodexBackend {
         let mut streamed_text = String::new();
 
         while let Some(event) = stream.next().await {
+            metadata.ensure_not_cancelled()?;
             let event =
                 event.map_err(|error| anyhow!("Failed to decode Codex SSE event: {error}"))?;
             if event.data.trim().is_empty() {
@@ -116,7 +118,8 @@ impl CodexBackend {
 #[async_trait]
 impl LlmBackend for CodexBackend {
     async fn ask(&self, m: &[Message], t: &[Value]) -> Result<LlmResponse> {
-        self.ask_responses_streaming(m, t, None).await
+        self.ask_responses_streaming(m, t, crate::llm::LlmTurnMetadata::default(), None)
+            .await
     }
 
     async fn ask_streaming(
@@ -125,7 +128,23 @@ impl LlmBackend for CodexBackend {
         tools: &[Value],
         on_text_delta: &mut (dyn FnMut(String) + Send),
     ) -> Result<LlmResponse> {
-        self.ask_responses_streaming(messages, tools, Some(on_text_delta))
+        self.ask_responses_streaming(
+            messages,
+            tools,
+            crate::llm::LlmTurnMetadata::default(),
+            Some(on_text_delta),
+        )
+        .await
+    }
+
+    async fn ask_streaming_with_context(
+        &self,
+        messages: &[Message],
+        tools: &[Value],
+        metadata: crate::llm::LlmTurnMetadata,
+        on_text_delta: &mut (dyn FnMut(String) + Send),
+    ) -> Result<LlmResponse> {
+        self.ask_responses_streaming(messages, tools, metadata, Some(on_text_delta))
             .await
     }
 

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -1,6 +1,10 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use serde_json::{json, Value};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::Duration;
 use url::Url;
 
@@ -27,15 +31,17 @@ pub enum LlmExecutionMode {
     Plan,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct LlmTurnMetadata {
     execution_mode: LlmExecutionMode,
+    cancellation: Option<Arc<AtomicBool>>,
 }
 
 impl Default for LlmTurnMetadata {
     fn default() -> Self {
         Self {
             execution_mode: LlmExecutionMode::Execute,
+            cancellation: None,
         }
     }
 }
@@ -44,16 +50,36 @@ impl LlmTurnMetadata {
     pub fn execute() -> Self {
         Self {
             execution_mode: LlmExecutionMode::Execute,
+            cancellation: None,
         }
     }
 
     pub fn plan() -> Self {
         Self {
             execution_mode: LlmExecutionMode::Plan,
+            cancellation: None,
         }
     }
 
-    pub fn prefers_strong_reasoning(self) -> bool {
+    pub fn with_cancellation(mut self, cancellation: Arc<AtomicBool>) -> Self {
+        self.cancellation = Some(cancellation);
+        self
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancellation
+            .as_ref()
+            .is_some_and(|cancellation| cancellation.load(Ordering::SeqCst))
+    }
+
+    pub fn ensure_not_cancelled(&self) -> Result<()> {
+        if self.is_cancelled() {
+            return Err(anyhow!("LLM turn cancelled by user"));
+        }
+        Ok(())
+    }
+
+    pub fn prefers_strong_reasoning(&self) -> bool {
         matches!(self.execution_mode, LlmExecutionMode::Plan)
     }
 }

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -7,13 +7,19 @@ use crate::session::SessionManager;
 use crate::skill::SkillManager;
 use crate::tool::ToolManager;
 use crate::tools::agent::{AgentTool, ExploreAgentTool, PlanAgentTool, TeamCreateTool};
-use crate::tools::bash::{BackgroundTaskStatusTool, BackgroundTaskStore, BashTool};
+use crate::tools::bash::{
+    BackgroundTaskListTool, BackgroundTaskStatusTool, BackgroundTaskStopTool, BackgroundTaskStore,
+    BashTool,
+};
 use crate::tools::context::RetrieveSessionContextTool;
 use crate::tools::file::{
     ListFilesTool, ReadFileTool, ReplaceLinesTool, ReplaceTool, WriteFileTool,
 };
 use crate::tools::patch::ApplyPatchTool;
-use crate::tools::pty::{PtyKillTool, PtyReadTool, PtySessionStore, PtyStartTool, PtyWriteTool};
+use crate::tools::pty::{
+    PtyKillTool, PtyListTool, PtyReadTool, PtySessionStore, PtyStartTool, PtyStatusTool,
+    PtyStopTool, PtyWriteTool,
+};
 use crate::tools::search::{GlobTool, GrepTool};
 use crate::tools::skill::SkillTool;
 use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
@@ -45,7 +51,13 @@ pub(super) fn create_full_tool_manager(
         sandbox: sandbox.clone(),
         background_tasks: background_tasks.clone(),
     }));
-    tm.register(Box::new(BackgroundTaskStatusTool { background_tasks }));
+    tm.register(Box::new(BackgroundTaskListTool {
+        background_tasks: background_tasks.clone(),
+    }));
+    tm.register(Box::new(BackgroundTaskStatusTool {
+        background_tasks: background_tasks.clone(),
+    }));
+    tm.register(Box::new(BackgroundTaskStopTool { background_tasks }));
     tm.register(Box::new(PtyStartTool {
         sessions: pty_sessions.clone(),
         sandbox: sandbox.clone(),
@@ -53,10 +65,19 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(PtyReadTool {
         sessions: pty_sessions.clone(),
     }));
+    tm.register(Box::new(PtyListTool {
+        sessions: pty_sessions.clone(),
+    }));
+    tm.register(Box::new(PtyStatusTool {
+        sessions: pty_sessions.clone(),
+    }));
     tm.register(Box::new(PtyWriteTool {
         sessions: pty_sessions.clone(),
     }));
     tm.register(Box::new(PtyKillTool {
+        sessions: pty_sessions.clone(),
+    }));
+    tm.register(Box::new(PtyStopTool {
         sessions: pty_sessions,
     }));
     tm.register(Box::new(ReadFileTool));

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -7,12 +7,13 @@ use crate::session::SessionManager;
 use crate::skill::SkillManager;
 use crate::tool::ToolManager;
 use crate::tools::agent::{AgentTool, ExploreAgentTool, PlanAgentTool, TeamCreateTool};
-use crate::tools::bash::BashTool;
+use crate::tools::bash::{BackgroundTaskStatusTool, BackgroundTaskStore, BashTool};
 use crate::tools::context::RetrieveSessionContextTool;
 use crate::tools::file::{
     ListFilesTool, ReadFileTool, ReplaceLinesTool, ReplaceTool, WriteFileTool,
 };
 use crate::tools::patch::ApplyPatchTool;
+use crate::tools::pty::{PtyKillTool, PtyReadTool, PtySessionStore, PtyStartTool, PtyWriteTool};
 use crate::tools::search::{GlobTool, GrepTool};
 use crate::tools::skill::SkillTool;
 use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
@@ -32,9 +33,31 @@ pub(super) fn create_full_tool_manager(
 ) -> ToolManager {
     let mut tm = ToolManager::new();
     let vector_db_uri = vector_db_uri_for_workspace(&workspace);
+    let background_tasks = Arc::new(
+        BackgroundTaskStore::new(workspace.rara_dir.join("background-tasks"))
+            .expect("background task store"),
+    );
+    let pty_sessions = Arc::new(
+        PtySessionStore::new(workspace.rara_dir.join("pty-sessions")).expect("pty session store"),
+    );
 
     tm.register(Box::new(BashTool {
         sandbox: sandbox.clone(),
+        background_tasks: background_tasks.clone(),
+    }));
+    tm.register(Box::new(BackgroundTaskStatusTool { background_tasks }));
+    tm.register(Box::new(PtyStartTool {
+        sessions: pty_sessions.clone(),
+        sandbox: sandbox.clone(),
+    }));
+    tm.register(Box::new(PtyReadTool {
+        sessions: pty_sessions.clone(),
+    }));
+    tm.register(Box::new(PtyWriteTool {
+        sessions: pty_sessions.clone(),
+    }));
+    tm.register(Box::new(PtyKillTool {
+        sessions: pty_sessions,
     }));
     tm.register(Box::new(ReadFileTool));
     tm.register(Box::new(ApplyPatchTool));

--- a/src/session.rs
+++ b/src/session.rs
@@ -81,7 +81,9 @@ impl SessionManager {
             fs::create_dir_all(parent)?;
         }
         let content = serde_json::to_string(history)?;
-        fs::write(path, content)?;
+        let tmp_path = path.with_extension(format!("json.tmp-{}", uuid::Uuid::new_v4()));
+        fs::write(&tmp_path, content)?;
+        fs::rename(tmp_path, path)?;
         Ok(())
     }
 
@@ -364,6 +366,28 @@ mod tests {
         let canonical_messages: Vec<Message> = serde_json::from_str(&canonical_history)?;
         assert_eq!(canonical_messages.len(), 1);
         assert_eq!(canonical_messages[0].role, "user");
+        Ok(())
+    }
+
+    #[test]
+    fn save_session_writes_history_without_leaving_temp_files() -> Result<()> {
+        let temp = tempdir()?;
+        let session_manager = SessionManager::new_for_rara_dir(temp.path().join(".rara"))?;
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: serde_json::json!([{"type": "text", "text": "hello"}]),
+        }];
+
+        session_manager.save_session("thread-atomic-history", &history)?;
+
+        let path = session_manager.session_history_path("thread-atomic-history");
+        let persisted: Vec<Message> = serde_json::from_str(&fs::read_to_string(&path)?)?;
+        assert_eq!(persisted, history);
+        let leftovers = fs::read_dir(path.parent().expect("history parent"))?
+            .filter_map(std::result::Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp-"))
+            .count();
+        assert_eq!(leftovers, 0);
         Ok(())
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -4,7 +4,7 @@ use crate::thread_rollout_log;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -83,8 +83,30 @@ impl SessionManager {
         let content = serde_json::to_string(history)?;
         let tmp_path = path.with_extension(format!("json.tmp-{}", uuid::Uuid::new_v4()));
         fs::write(&tmp_path, content)?;
-        fs::rename(tmp_path, path)?;
+        if let Err(err) = Self::replace_file(&tmp_path, &path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(err);
+        }
         Ok(())
+    }
+
+    #[cfg(not(windows))]
+    fn replace_file(src: &Path, dst: &Path) -> Result<()> {
+        fs::rename(src, dst)?;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    fn replace_file(src: &Path, dst: &Path) -> Result<()> {
+        match fs::rename(src, dst) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists && dst.exists() => {
+                fs::remove_file(dst)?;
+                fs::rename(src, dst)?;
+                Ok(())
+            }
+            Err(err) => Err(err.into()),
+        }
     }
 
     pub fn load_thread_history(&self, thread_id: &str) -> Result<Vec<Message>> {

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -29,12 +29,32 @@ impl SubAgentKind {
 
     fn append_prompt(self) -> &'static str {
         match self {
-            SubAgentKind::General => "",
+            SubAgentKind::General => {
+                "## Sub-Agent Role\n- You are a direct worker sub-agent.\n- Do not delegate to another agent or spawn sub-agents; complete the assigned work directly."
+            }
             SubAgentKind::Explore => {
-                "## Sub-Agent Role\n- You are a read-only exploration sub-agent.\n- Inspect the repository and summarize concrete findings.\n- Do not propose edits you cannot justify from inspected code.\n- Do not narrate each next tool call; call the tool directly.\n- End with a concise findings summary."
+                concat!(
+                    "## Sub-Agent Role\n",
+                    "- You are a read-only exploration sub-agent.\n",
+                    "- Inspect the repository and summarize concrete findings.\n",
+                    "- Do not propose edits you cannot justify from inspected code.\n",
+                    "- Do not narrate each next tool call; call the tool directly.\n",
+                    "- Do not delegate to another agent or spawn sub-agents; inspect and answer directly.\n",
+                    "- End with a concise findings summary."
+                )
             }
             SubAgentKind::Plan => {
-                "## Sub-Agent Role\n- You are a read-only planning sub-agent.\n- Inspect the repository and refine an implementation approach.\n- Keep plans shallow and grouped by behavior.\n- Use <plan> only when the plan is decision-complete.\n- If the plan is not ready, summarize what additional inspection is still needed and end with <continue_inspection/>.\n- Do not stop with narration alone.\n- End with exactly one of: <plan>, <request_user_input>, or <continue_inspection/>."
+                concat!(
+                    "## Sub-Agent Role\n",
+                    "- You are a read-only planning sub-agent.\n",
+                    "- Inspect the repository and refine an implementation approach.\n",
+                    "- Keep plans shallow and grouped by behavior.\n",
+                    "- Use <plan> only when the plan is decision-complete.\n",
+                    "- If the plan is not ready, summarize what additional inspection is still needed and end with <continue_inspection/>.\n",
+                    "- Do not stop with narration alone.\n",
+                    "- Do not delegate to another agent or spawn sub-agents; inspect and answer directly.\n",
+                    "- End with exactly one of: <plan>, <request_user_input>, or <continue_inspection/>."
+                )
             }
         }
     }
@@ -273,11 +293,7 @@ async fn run_sub_agent(
     workspace: Arc<WorkspaceMemory>,
     prompt_config: PromptRuntimeConfig,
 ) -> Result<SubAgentResult, ToolError> {
-    let tool_manager = if kind.read_only() {
-        build_read_only_tool_manager()
-    } else {
-        ToolManager::new()
-    };
+    let tool_manager = build_subagent_tool_manager(kind);
     let mut sub = Agent::new(tool_manager, backend, vdb, session_manager, workspace);
     sub.set_execution_mode(kind.execution_mode());
     sub.set_prompt_config(append_subagent_prompt(prompt_config, kind.append_prompt()));
@@ -304,6 +320,14 @@ fn build_read_only_tool_manager() -> ToolManager {
     tool_manager.register(Box::new(GlobTool));
     tool_manager.register(Box::new(GrepTool));
     tool_manager
+}
+
+fn build_subagent_tool_manager(kind: SubAgentKind) -> ToolManager {
+    if kind.read_only() {
+        build_read_only_tool_manager()
+    } else {
+        ToolManager::new()
+    }
 }
 
 fn append_subagent_prompt(
@@ -381,14 +405,15 @@ fn serialize_pending_user_input(request: &PendingUserInput) -> Value {
 #[cfg(test)]
 mod tests {
     use super::{
-        append_subagent_prompt, build_read_only_tool_manager, latest_assistant_text_from_history,
+        append_subagent_prompt, build_read_only_tool_manager, build_subagent_tool_manager,
+        latest_assistant_text_from_history, SubAgentKind,
     };
     use crate::agent::Message;
     use crate::prompt::PromptRuntimeConfig;
     use serde_json::json;
 
     #[test]
-    fn read_only_subagent_manager_excludes_mutating_tools() {
+    fn read_only_subagent_manager_excludes_mutating_and_agent_tools() {
         let manager = build_read_only_tool_manager();
         assert!(manager.get_tool("read_file").is_some());
         assert!(manager.get_tool("list_files").is_some());
@@ -398,6 +423,28 @@ mod tests {
         assert!(manager.get_tool("write_file").is_none());
         assert!(manager.get_tool("apply_patch").is_none());
         assert!(manager.get_tool("bash").is_none());
+        assert!(manager.get_tool("background_task_list").is_none());
+        assert!(manager.get_tool("background_task_status").is_none());
+        assert!(manager.get_tool("background_task_stop").is_none());
+        assert!(manager.get_tool("pty_start").is_none());
+        assert!(manager.get_tool("pty_list").is_none());
+        assert!(manager.get_tool("pty_status").is_none());
+        assert!(manager.get_tool("pty_stop").is_none());
+        assert!(manager.get_tool("spawn_agent").is_none());
+        assert!(manager.get_tool("explore_agent").is_none());
+        assert!(manager.get_tool("plan_agent").is_none());
+        assert!(manager.get_tool("team_create").is_none());
+    }
+
+    #[test]
+    fn general_subagent_manager_does_not_expose_recursive_agent_tools() {
+        let manager = build_subagent_tool_manager(SubAgentKind::General);
+        assert!(manager.get_tool("spawn_agent").is_none());
+        assert!(manager.get_tool("explore_agent").is_none());
+        assert!(manager.get_tool("plan_agent").is_none());
+        assert!(manager.get_tool("team_create").is_none());
+        assert!(manager.get_tool("bash").is_none());
+        assert!(manager.get_tool("pty_start").is_none());
     }
 
     #[test]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -15,6 +15,7 @@ use tokio::fs;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use uuid::Uuid;
 
 pub struct BashTool {
@@ -26,10 +27,19 @@ pub struct BackgroundTaskStatusTool {
     pub background_tasks: Arc<BackgroundTaskStore>,
 }
 
+pub struct BackgroundTaskListTool {
+    pub background_tasks: Arc<BackgroundTaskStore>,
+}
+
+pub struct BackgroundTaskStopTool {
+    pub background_tasks: Arc<BackgroundTaskStore>,
+}
+
 #[derive(Debug, Clone)]
 pub struct BackgroundTaskStore {
     dir: PathBuf,
     tasks: Arc<Mutex<HashMap<String, BackgroundTaskRecord>>>,
+    stop_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -49,6 +59,7 @@ pub enum BackgroundTaskStatus {
     Running,
     Completed,
     Failed,
+    Killed,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -149,6 +160,7 @@ impl BackgroundTaskStore {
         Ok(Self {
             dir,
             tasks: Arc::new(Mutex::new(HashMap::new())),
+            stop_signals: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -157,7 +169,7 @@ impl BackgroundTaskStore {
         command: String,
         sandboxed: bool,
         sandbox_backend: String,
-    ) -> Result<BackgroundTaskRecord, ToolError> {
+    ) -> Result<(BackgroundTaskRecord, oneshot::Receiver<()>), ToolError> {
         let id = format!("bash-{}", Uuid::new_v4());
         let output_path = self.dir.join(format!("{id}.log"));
         let record = BackgroundTaskRecord {
@@ -169,11 +181,16 @@ impl BackgroundTaskStore {
             sandboxed,
             sandbox_backend,
         };
+        let (stop_tx, stop_rx) = oneshot::channel();
         self.tasks
             .lock()
             .expect("background task store lock")
-            .insert(id, record.clone());
-        Ok(record)
+            .insert(id.clone(), record.clone());
+        self.stop_signals
+            .lock()
+            .expect("background task stop signal lock")
+            .insert(id, stop_tx);
+        Ok((record, stop_rx))
     }
 
     fn finish(&self, id: &str, status: BackgroundTaskStatus, exit_code: Option<i32>) {
@@ -183,9 +200,15 @@ impl BackgroundTaskStore {
             .expect("background task store lock")
             .get_mut(id)
         {
-            record.status = status;
+            if !matches!(record.status, BackgroundTaskStatus::Killed) {
+                record.status = status;
+            }
             record.exit_code = exit_code;
         }
+        self.stop_signals
+            .lock()
+            .expect("background task stop signal lock")
+            .remove(id);
     }
 
     fn get(&self, id: &str) -> Option<BackgroundTaskRecord> {
@@ -194,6 +217,53 @@ impl BackgroundTaskStore {
             .expect("background task store lock")
             .get(id)
             .cloned()
+    }
+
+    fn list(&self) -> Vec<BackgroundTaskRecord> {
+        let mut records = self
+            .tasks
+            .lock()
+            .expect("background task store lock")
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by(|left, right| left.id.cmp(&right.id));
+        records
+    }
+
+    fn stop(&self, id: &str) -> Result<BackgroundTaskRecord, ToolError> {
+        let mut tasks = self.tasks.lock().expect("background task store lock");
+        let record = tasks
+            .get_mut(id)
+            .ok_or_else(|| ToolError::InvalidInput(format!("unknown task id: {id}")))?;
+        if !matches!(record.status, BackgroundTaskStatus::Running) {
+            return Ok(record.clone());
+        }
+        record.status = BackgroundTaskStatus::Killed;
+        let stopped = record.clone();
+        drop(tasks);
+
+        if let Some(stop) = self
+            .stop_signals
+            .lock()
+            .expect("background task stop signal lock")
+            .remove(id)
+        {
+            let _ = stop.send(());
+        }
+        Ok(stopped)
+    }
+
+    fn stop_all(&self) -> Vec<BackgroundTaskRecord> {
+        let ids = self
+            .list()
+            .into_iter()
+            .filter(|record| matches!(record.status, BackgroundTaskStatus::Running))
+            .map(|record| record.id)
+            .collect::<Vec<_>>();
+        ids.into_iter()
+            .filter_map(|id| self.stop(&id).ok())
+            .collect()
     }
 }
 
@@ -353,7 +423,7 @@ impl Tool for BashTool {
         })?;
 
         if request.run_in_background {
-            let record = self.background_tasks.start_record(
+            let (record, stop_rx) = self.background_tasks.start_record(
                 request.summary(),
                 wrapped.sandboxed,
                 wrapped.sandbox_backend.clone(),
@@ -363,6 +433,7 @@ impl Tool for BashTool {
                 wrapped,
                 record.clone(),
                 self.background_tasks.clone(),
+                stop_rx,
             );
             return Ok(json!({
                 "stdout": "",
@@ -449,6 +520,30 @@ impl Tool for BashTool {
 }
 
 #[async_trait]
+impl Tool for BackgroundTaskListTool {
+    fn name(&self) -> &str {
+        "background_task_list"
+    }
+
+    fn description(&self) -> &str {
+        "List background bash tasks"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {}
+        })
+    }
+
+    async fn call(&self, _input: Value) -> Result<Value, ToolError> {
+        Ok(json!({
+            "tasks": self.background_tasks.list(),
+        }))
+    }
+}
+
+#[async_trait]
 impl Tool for BackgroundTaskStatusTool {
     fn name(&self) -> &str {
         "background_task_status"
@@ -505,14 +600,46 @@ impl Tool for BackgroundTaskStatusTool {
     }
 }
 
+#[async_trait]
+impl Tool for BackgroundTaskStopTool {
+    fn name(&self) -> &str {
+        "background_task_stop"
+    }
+
+    fn description(&self) -> &str {
+        "Stop one background bash task, or all running background bash tasks when task_id is omitted"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Background task id returned by bash run_in_background. Omit to stop all running background bash tasks."
+                }
+            }
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        if let Some(task_id) = input.get("task_id").and_then(Value::as_str) {
+            let task = self.background_tasks.stop(task_id)?;
+            return Ok(json!({ "stopped": [task] }));
+        }
+        Ok(json!({ "stopped": self.background_tasks.stop_all() }))
+    }
+}
+
 fn spawn_background_bash_task(
     mut child: Child,
     wrapped: WrappedCommand,
     record: BackgroundTaskRecord,
     store: Arc<BackgroundTaskStore>,
+    stop_rx: oneshot::Receiver<()>,
 ) {
     tokio::spawn(async move {
-        let result = run_background_bash_task(&mut child, wrapped, &record).await;
+        let result = run_background_bash_task(&mut child, wrapped, &record, stop_rx).await;
         let (status, exit_code) = match result {
             Ok(code) => {
                 if code == Some(0) {
@@ -539,6 +666,7 @@ async fn run_background_bash_task(
     child: &mut Child,
     wrapped: WrappedCommand,
     record: &BackgroundTaskRecord,
+    mut stop_rx: oneshot::Receiver<()>,
 ) -> Result<Option<i32>, ToolError> {
     if let Some(parent) = record.output_path.parent() {
         fs::create_dir_all(parent).await?;
@@ -574,14 +702,28 @@ async fn run_background_bash_task(
         .append(true)
         .open(&record.output_path)
         .await?;
-    while let Some((stream, chunk)) = rx.recv().await {
-        if !chunk.is_empty() {
-            match stream {
-                BashStreamKind::Stdout => output_file.write_all(chunk.as_bytes()).await?,
-                BashStreamKind::Stderr => {
-                    output_file.write_all(b"[stderr] ").await?;
-                    output_file.write_all(chunk.as_bytes()).await?;
+    let mut stop_requested = false;
+    loop {
+        tokio::select! {
+            chunk = rx.recv() => {
+                let Some((stream, chunk)) = chunk else {
+                    break;
+                };
+                if !chunk.is_empty() {
+                    match stream {
+                        BashStreamKind::Stdout => output_file.write_all(chunk.as_bytes()).await?,
+                        BashStreamKind::Stderr => {
+                            output_file.write_all(b"[stderr] ").await?;
+                            output_file.write_all(chunk.as_bytes()).await?;
+                        }
+                    }
                 }
+            }
+            _ = &mut stop_rx, if !stop_requested => {
+                stop_requested = true;
+                child.start_kill()
+                    .map_err(|err| ToolError::ExecutionFailed(format!("stop background task: {err}")))?;
+                output_file.write_all(b"[stderr] background task stop requested\n").await?;
             }
         }
     }
@@ -693,8 +835,9 @@ async fn ensure_sandbox_home_dirs(sandbox_home: &Path) -> Result<(), ToolError> 
 mod tests {
     use super::{
         command_env_for_wrapped, read_output_tail, sandbox_command_env, sandbox_output_hint,
-        unsandboxed_execution_warning, BackgroundTaskStatus, BackgroundTaskStatusTool,
-        BackgroundTaskStore, BashCommandInput, BashTool,
+        unsandboxed_execution_warning, BackgroundTaskListTool, BackgroundTaskStatus,
+        BackgroundTaskStatusTool, BackgroundTaskStopTool, BackgroundTaskStore, BashCommandInput,
+        BashTool,
     };
     use crate::sandbox::{SandboxManager, WrappedCommand};
     use crate::tool::{Tool, ToolOutputStream, ToolProgressEvent};
@@ -991,6 +1134,67 @@ mod tests {
             Some(&json!(BackgroundTaskStatus::Running))
         );
         assert!(last.get("output_path").and_then(Value::as_str).is_some());
+    }
+
+    #[tokio::test]
+    async fn background_tasks_can_be_listed_and_stopped_without_count_limit() {
+        let temp = tempdir().expect("tempdir");
+        let sandbox = SandboxManager::new_for_rara_dir(temp.path().join(".rara")).expect("sandbox");
+        let Ok(wrapped) = sandbox.wrap_exec_command(
+            "sh",
+            &["-c".to_string(), "sleep 30".to_string()],
+            temp.path().to_string_lossy().as_ref(),
+            false,
+        ) else {
+            return;
+        };
+        if !binary_exists(&wrapped.program) {
+            return;
+        }
+
+        let background_tasks = Arc::new(
+            BackgroundTaskStore::new(temp.path().join(".rara/background-tasks"))
+                .expect("background task store"),
+        );
+        let tool = BashTool {
+            sandbox: Arc::new(sandbox),
+            background_tasks: background_tasks.clone(),
+        };
+        let list_tool = BackgroundTaskListTool {
+            background_tasks: background_tasks.clone(),
+        };
+        let stop_tool = BackgroundTaskStopTool {
+            background_tasks: background_tasks.clone(),
+        };
+
+        let started = tool
+            .call(json!({
+                "program": "sh",
+                "args": ["-c", "sleep 30"],
+                "run_in_background": true,
+            }))
+            .await
+            .expect("background start");
+        let task_id = started
+            .get("background_task_id")
+            .and_then(Value::as_str)
+            .expect("task id")
+            .to_string();
+
+        let listed = list_tool.call(json!({})).await.expect("list tasks");
+        assert_eq!(
+            listed.get("tasks").and_then(Value::as_array).map(Vec::len),
+            Some(1)
+        );
+
+        let stopped = stop_tool
+            .call(json!({ "task_id": task_id }))
+            .await
+            .expect("stop task");
+        assert_eq!(
+            stopped.pointer("/stopped/0/status"),
+            Some(&json!(BackgroundTaskStatus::Killed))
+        );
     }
 
     #[tokio::test]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -569,9 +569,20 @@ async fn run_background_bash_task(
     ));
     let stderr_task = tokio::spawn(read_stream_chunks(stderr, BashStreamKind::Stderr, tx));
 
+    let mut output_file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&record.output_path)
+        .await?;
     while let Some((stream, chunk)) = rx.recv().await {
         if !chunk.is_empty() {
-            append_background_output(&record.output_path, stream, &chunk).await?;
+            match stream {
+                BashStreamKind::Stdout => output_file.write_all(chunk.as_bytes()).await?,
+                BashStreamKind::Stderr => {
+                    output_file.write_all(b"[stderr] ").await?;
+                    output_file.write_all(chunk.as_bytes()).await?;
+                }
+            }
         }
     }
 

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -6,15 +6,48 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::env;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
+use std::sync::Mutex;
 use tokio::fs;
-use tokio::io::{AsyncRead, AsyncReadExt};
-use tokio::process::Command;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
+use uuid::Uuid;
 
 pub struct BashTool {
     pub sandbox: Arc<SandboxManager>,
+    pub background_tasks: Arc<BackgroundTaskStore>,
+}
+
+pub struct BackgroundTaskStatusTool {
+    pub background_tasks: Arc<BackgroundTaskStore>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BackgroundTaskStore {
+    dir: PathBuf,
+    tasks: Arc<Mutex<HashMap<String, BackgroundTaskRecord>>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BackgroundTaskRecord {
+    id: String,
+    command: String,
+    output_path: PathBuf,
+    status: BackgroundTaskStatus,
+    exit_code: Option<i32>,
+    sandboxed: bool,
+    sandbox_backend: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundTaskStatus {
+    Running,
+    Completed,
+    Failed,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -46,6 +79,8 @@ pub struct BashCommandInput {
     pub env: HashMap<String, String>,
     #[serde(default)]
     pub allow_net: bool,
+    #[serde(default)]
+    pub run_in_background: bool,
 }
 
 impl BashCommandInput {
@@ -107,6 +142,60 @@ impl BashCommandInput {
     }
 }
 
+impl BackgroundTaskStore {
+    pub fn new(dir: PathBuf) -> Result<Self, ToolError> {
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self {
+            dir,
+            tasks: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    fn start_record(
+        &self,
+        command: String,
+        sandboxed: bool,
+        sandbox_backend: String,
+    ) -> Result<BackgroundTaskRecord, ToolError> {
+        let id = format!("bash-{}", Uuid::new_v4());
+        let output_path = self.dir.join(format!("{id}.log"));
+        let record = BackgroundTaskRecord {
+            id: id.clone(),
+            command,
+            output_path,
+            status: BackgroundTaskStatus::Running,
+            exit_code: None,
+            sandboxed,
+            sandbox_backend,
+        };
+        self.tasks
+            .lock()
+            .expect("background task store lock")
+            .insert(id, record.clone());
+        Ok(record)
+    }
+
+    fn finish(&self, id: &str, status: BackgroundTaskStatus, exit_code: Option<i32>) {
+        if let Some(record) = self
+            .tasks
+            .lock()
+            .expect("background task store lock")
+            .get_mut(id)
+        {
+            record.status = status;
+            record.exit_code = exit_code;
+        }
+    }
+
+    fn get(&self, id: &str) -> Option<BackgroundTaskRecord> {
+        self.tasks
+            .lock()
+            .expect("background task store lock")
+            .get(id)
+            .cloned()
+    }
+}
+
 fn sandbox_command_env(
     sandbox_home: &Path,
     overrides: &HashMap<String, String>,
@@ -131,6 +220,9 @@ fn sandbox_command_env(
             format!("{sandbox_home}/.local/share"),
         ),
     ]);
+    if let Ok(path) = env::var("PATH") {
+        env_map.insert("PATH".to_string(), path);
+    }
     env_map.extend(overrides.clone());
     env_map
 }
@@ -183,7 +275,12 @@ impl Tool for BashTool {
                     "additionalProperties": { "type": "string" },
                     "description": "Optional environment overrides."
                 },
-                "allow_net": { "type": "boolean", "default": false }
+                "allow_net": { "type": "boolean", "default": false },
+                "run_in_background": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Run the command as a background task and return a task id immediately. Use background_task_status to inspect output later."
+                }
             },
             "anyOf": [
                 { "required": ["command"] },
@@ -230,6 +327,9 @@ impl Tool for BashTool {
         }
 
         let mut command = Command::new(&wrapped.program);
+        if wrapped.sandboxed {
+            command.env_clear();
+        }
         command
             .args(&wrapped.args)
             .current_dir(&cwd)
@@ -250,6 +350,31 @@ impl Tool for BashTool {
                 ))
             }
         })?;
+
+        if request.run_in_background {
+            let record = self.background_tasks.start_record(
+                request.summary(),
+                wrapped.sandboxed,
+                wrapped.sandbox_backend.clone(),
+            )?;
+            spawn_background_bash_task(
+                child,
+                wrapped,
+                record.clone(),
+                self.background_tasks.clone(),
+            );
+            return Ok(json!({
+                "stdout": "",
+                "stderr": "",
+                "exit_code": 0,
+                "live_streamed": false,
+                "sandboxed": record.sandboxed,
+                "sandbox_backend": record.sandbox_backend,
+                "background_task_id": record.id,
+                "output_path": record.output_path,
+                "status": record.status,
+            }));
+        }
 
         let stdout = child
             .stdout
@@ -322,6 +447,176 @@ impl Tool for BashTool {
     }
 }
 
+#[async_trait]
+impl Tool for BackgroundTaskStatusTool {
+    fn name(&self) -> &str {
+        "background_task_status"
+    }
+
+    fn description(&self) -> &str {
+        "Inspect a background bash task and read the tail of its output"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "string",
+                    "description": "Background task id returned by bash run_in_background."
+                },
+                "tail_bytes": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 12000,
+                    "description": "Maximum number of output bytes to return from the end of the task log."
+                }
+            },
+            "required": ["task_id"]
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let task_id = input["task_id"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("task_id".into()))?;
+        let tail_bytes = input
+            .get("tail_bytes")
+            .and_then(Value::as_u64)
+            .unwrap_or(12_000)
+            .min(1_000_000) as usize;
+        let record = self
+            .background_tasks
+            .get(task_id)
+            .ok_or_else(|| ToolError::InvalidInput(format!("unknown task id: {task_id}")))?;
+        let output = read_output_tail(&record.output_path, tail_bytes).await?;
+
+        Ok(json!({
+            "task_id": record.id,
+            "command": record.command,
+            "status": record.status,
+            "exit_code": record.exit_code,
+            "output_path": record.output_path,
+            "output": output,
+            "sandboxed": record.sandboxed,
+            "sandbox_backend": record.sandbox_backend,
+        }))
+    }
+}
+
+fn spawn_background_bash_task(
+    mut child: Child,
+    wrapped: WrappedCommand,
+    record: BackgroundTaskRecord,
+    store: Arc<BackgroundTaskStore>,
+) {
+    tokio::spawn(async move {
+        let result = run_background_bash_task(&mut child, wrapped, &record).await;
+        let (status, exit_code) = match result {
+            Ok(code) => {
+                if code == Some(0) {
+                    (BackgroundTaskStatus::Completed, code)
+                } else {
+                    (BackgroundTaskStatus::Failed, code)
+                }
+            }
+            Err(err) => {
+                let _ = append_background_output(
+                    &record.output_path,
+                    BashStreamKind::Stderr,
+                    &format!("background task failed: {err}\n"),
+                )
+                .await;
+                (BackgroundTaskStatus::Failed, None)
+            }
+        };
+        store.finish(&record.id, status, exit_code);
+    });
+}
+
+async fn run_background_bash_task(
+    child: &mut Child,
+    wrapped: WrappedCommand,
+    record: &BackgroundTaskRecord,
+) -> Result<Option<i32>, ToolError> {
+    if let Some(parent) = record.output_path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    fs::write(&record.output_path, "").await?;
+    if !wrapped.sandboxed {
+        append_background_output(
+            &record.output_path,
+            BashStreamKind::Stderr,
+            &unsandboxed_execution_warning(&wrapped),
+        )
+        .await?;
+    }
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| ToolError::ExecutionFailed("stdout pipe unavailable".into()))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| ToolError::ExecutionFailed("stderr pipe unavailable".into()))?;
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let stdout_task = tokio::spawn(read_stream_chunks(
+        stdout,
+        BashStreamKind::Stdout,
+        tx.clone(),
+    ));
+    let stderr_task = tokio::spawn(read_stream_chunks(stderr, BashStreamKind::Stderr, tx));
+
+    while let Some((stream, chunk)) = rx.recv().await {
+        if !chunk.is_empty() {
+            append_background_output(&record.output_path, stream, &chunk).await?;
+        }
+    }
+
+    let status = child.wait().await?;
+    stdout_task
+        .await
+        .map_err(|err| ToolError::ExecutionFailed(err.to_string()))??;
+    stderr_task
+        .await
+        .map_err(|err| ToolError::ExecutionFailed(err.to_string()))??;
+    if let Some(path) = wrapped.cleanup_path.as_ref() {
+        let _ = fs::remove_file(path).await;
+    }
+    Ok(status.code())
+}
+
+async fn append_background_output(
+    path: &Path,
+    stream: BashStreamKind,
+    chunk: &str,
+) -> Result<(), ToolError> {
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await?;
+    match stream {
+        BashStreamKind::Stdout => file.write_all(chunk.as_bytes()).await?,
+        BashStreamKind::Stderr => {
+            file.write_all(b"[stderr] ").await?;
+            file.write_all(chunk.as_bytes()).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolError> {
+    let bytes = match fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(err) => return Err(err.into()),
+    };
+    let start = bytes.len().saturating_sub(max_bytes);
+    Ok(String::from_utf8_lossy(&bytes[start..]).into_owned())
+}
+
 async fn read_stream_chunks<R>(
     reader: R,
     stream: BashStreamKind,
@@ -382,7 +677,8 @@ async fn ensure_sandbox_home_dirs(sandbox_home: &Path) -> Result<(), ToolError> 
 mod tests {
     use super::{
         command_env_for_wrapped, sandbox_command_env, sandbox_output_hint,
-        unsandboxed_execution_warning, BashCommandInput, BashTool,
+        unsandboxed_execution_warning, BackgroundTaskStatus, BackgroundTaskStatusTool,
+        BackgroundTaskStore, BashCommandInput, BashTool,
     };
     use crate::sandbox::{SandboxManager, WrappedCommand};
     use crate::tool::{Tool, ToolOutputStream, ToolProgressEvent};
@@ -403,6 +699,7 @@ mod tests {
 
         assert_eq!(input.command.as_deref(), Some("cargo test"));
         assert!(input.allow_net);
+        assert!(!input.run_in_background);
         assert_eq!(input.summary(), "cargo test");
     }
 
@@ -424,12 +721,28 @@ mod tests {
         );
         assert_eq!(input.cwd.as_deref(), Some("/tmp/workspace"));
         assert_eq!(input.env.get("RUST_LOG").map(String::as_str), Some("debug"));
+        assert!(!input.run_in_background);
         assert_eq!(input.summary(), "cargo check --workspace");
+    }
+
+    #[test]
+    fn parses_background_payload() {
+        let input = BashCommandInput::from_value(json!({
+            "program": "cargo",
+            "args": ["test"],
+            "run_in_background": true
+        }))
+        .expect("background payload");
+
+        assert!(input.run_in_background);
+        assert_eq!(input.summary(), "cargo test");
     }
 
     #[test]
     fn sandbox_command_env_defaults_home_and_xdg_roots() {
         let sandbox_home = Path::new("/tmp/rara-test-home");
+        let original_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", "/custom/bin:/usr/bin");
         let env_map = sandbox_command_env(sandbox_home, &HashMap::new());
 
         assert_eq!(
@@ -444,6 +757,15 @@ mod tests {
             env_map.get("XDG_CACHE_HOME").map(String::as_str),
             Some("/tmp/rara-test-home/.cache")
         );
+        assert_eq!(
+            env_map.get("PATH").map(String::as_str),
+            Some("/custom/bin:/usr/bin")
+        );
+        if let Some(path) = original_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
     }
 
     #[test]
@@ -457,6 +779,7 @@ mod tests {
                     "XDG_CACHE_HOME".to_string(),
                     "/custom/home/.cache".to_string(),
                 ),
+                ("PATH".to_string(), "/override/bin".to_string()),
             ]),
         );
 
@@ -471,6 +794,10 @@ mod tests {
         assert_eq!(
             env_map.get("XDG_CONFIG_HOME").map(String::as_str),
             Some("/tmp/rara-test-home/.config")
+        );
+        assert_eq!(
+            env_map.get("PATH").map(String::as_str),
+            Some("/override/bin")
         );
     }
 
@@ -528,7 +855,7 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let sandbox = SandboxManager::new_for_rara_dir(temp.path().join(".rara")).expect("sandbox");
         let Ok(wrapped) = sandbox.wrap_exec_command(
-            "sh",
+            "/bin/sh",
             &[
                 "-c".to_string(),
                 "printf 'out\\n'; printf 'err\\n' >&2".to_string(),
@@ -543,12 +870,16 @@ mod tests {
         }
         let tool = BashTool {
             sandbox: Arc::new(sandbox),
+            background_tasks: Arc::new(
+                BackgroundTaskStore::new(temp.path().join(".rara/background-tasks"))
+                    .expect("background task store"),
+            ),
         };
         let mut events = Vec::new();
         let result = tool
             .call_with_events(
                 json!({
-                    "program": "sh",
+                    "program": "/bin/sh",
                     "args": ["-c", "printf 'out\\n'; printf 'err\\n' >&2"],
                 }),
                 &mut |event| events.push(event),
@@ -556,7 +887,10 @@ mod tests {
             .await
             .expect("bash result");
 
-        assert!(!events.is_empty());
+        assert!(
+            !events.is_empty(),
+            "expected streamed events, got result: {result}"
+        );
         assert!(events.iter().any(|event| matches!(
             event,
             ToolProgressEvent::Output {
@@ -576,6 +910,70 @@ mod tests {
             result.get("sandbox_backend").and_then(Value::as_str),
             Some(wrapped.sandbox_backend.as_str())
         );
+    }
+
+    #[tokio::test]
+    async fn background_call_returns_task_and_status_reads_output() {
+        let temp = tempdir().expect("tempdir");
+        let sandbox = SandboxManager::new_for_rara_dir(temp.path().join(".rara")).expect("sandbox");
+        let Ok(wrapped) = sandbox.wrap_exec_command(
+            "sh",
+            &["-c".to_string(), "printf 'background-out\\n'".to_string()],
+            temp.path().to_string_lossy().as_ref(),
+            false,
+        ) else {
+            return;
+        };
+        if !binary_exists(&wrapped.program) {
+            return;
+        }
+
+        let background_tasks = Arc::new(
+            BackgroundTaskStore::new(temp.path().join(".rara/background-tasks"))
+                .expect("background task store"),
+        );
+        let tool = BashTool {
+            sandbox: Arc::new(sandbox),
+            background_tasks: background_tasks.clone(),
+        };
+        let status_tool = BackgroundTaskStatusTool {
+            background_tasks: background_tasks.clone(),
+        };
+
+        let started = tool
+            .call(json!({
+                "program": "sh",
+                "args": ["-c", "printf 'background-out\\n'"],
+                "run_in_background": true,
+            }))
+            .await
+            .expect("background start");
+        let task_id = started
+            .get("background_task_id")
+            .and_then(Value::as_str)
+            .expect("task id");
+        assert_eq!(
+            started.get("status"),
+            Some(&json!(BackgroundTaskStatus::Running))
+        );
+
+        let mut last = Value::Null;
+        for _ in 0..50 {
+            last = status_tool
+                .call(json!({ "task_id": task_id, "tail_bytes": 4096 }))
+                .await
+                .expect("background status");
+            if last.get("status") != Some(&json!(BackgroundTaskStatus::Running)) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        assert_ne!(
+            last.get("status"),
+            Some(&json!(BackgroundTaskStatus::Running))
+        );
+        assert!(last.get("output_path").and_then(Value::as_str).is_some());
     }
 
     fn binary_exists(program: &str) -> bool {

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -457,7 +457,7 @@ impl Tool for BashTool {
             .take()
             .ok_or_else(|| ToolError::ExecutionFailed("stderr pipe unavailable".into()))?;
 
-        let (tx, mut rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::channel(64);
         let stdout_task = tokio::spawn(read_stream_chunks(
             stdout,
             BashStreamKind::Stdout,
@@ -689,7 +689,7 @@ async fn run_background_bash_task(
         .stderr
         .take()
         .ok_or_else(|| ToolError::ExecutionFailed("stderr pipe unavailable".into()))?;
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (tx, mut rx) = mpsc::channel(64);
     let stdout_task = tokio::spawn(read_stream_chunks(
         stdout,
         BashStreamKind::Stdout,
@@ -778,7 +778,7 @@ async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolE
 async fn read_stream_chunks<R>(
     reader: R,
     stream: BashStreamKind,
-    tx: mpsc::UnboundedSender<(BashStreamKind, String)>,
+    tx: mpsc::Sender<(BashStreamKind, String)>,
 ) -> Result<(), ToolError>
 where
     R: AsyncRead + Unpin + Send + 'static,
@@ -791,7 +791,9 @@ where
             break;
         }
         let chunk = String::from_utf8_lossy(&buffer[..read]).into_owned();
-        let _ = tx.send((stream, chunk));
+        if tx.send((stream, chunk)).await.is_err() {
+            break;
+        }
     }
     Ok(())
 }

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -5,13 +5,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::env;
+use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::Mutex;
 use tokio::fs;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -366,7 +367,7 @@ impl Tool for BashTool {
             return Ok(json!({
                 "stdout": "",
                 "stderr": "",
-                "exit_code": 0,
+                "exit_code": null,
                 "live_streamed": false,
                 "sandboxed": record.sandboxed,
                 "sandbox_backend": record.sandbox_backend,
@@ -608,13 +609,17 @@ async fn append_background_output(
 }
 
 async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolError> {
-    let bytes = match fs::read(path).await {
-        Ok(bytes) => bytes,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+    let mut file = match fs::File::open(path).await {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
         Err(err) => return Err(err.into()),
     };
-    let start = bytes.len().saturating_sub(max_bytes);
-    Ok(String::from_utf8_lossy(&bytes[start..]).into_owned())
+    let file_len = file.metadata().await?.len();
+    let start = file_len.saturating_sub(max_bytes as u64);
+    file.seek(SeekFrom::Start(start)).await?;
+    let mut bytes = Vec::with_capacity(max_bytes.min(file_len as usize));
+    file.read_to_end(&mut bytes).await?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 async fn read_stream_chunks<R>(
@@ -676,7 +681,7 @@ async fn ensure_sandbox_home_dirs(sandbox_home: &Path) -> Result<(), ToolError> 
 #[cfg(test)]
 mod tests {
     use super::{
-        command_env_for_wrapped, sandbox_command_env, sandbox_output_hint,
+        command_env_for_wrapped, read_output_tail, sandbox_command_env, sandbox_output_hint,
         unsandboxed_execution_warning, BackgroundTaskStatus, BackgroundTaskStatusTool,
         BackgroundTaskStore, BashCommandInput, BashTool,
     };
@@ -952,6 +957,7 @@ mod tests {
             .get("background_task_id")
             .and_then(Value::as_str)
             .expect("task id");
+        assert_eq!(started.get("exit_code"), Some(&Value::Null));
         assert_eq!(
             started.get("status"),
             Some(&json!(BackgroundTaskStatus::Running))
@@ -974,6 +980,30 @@ mod tests {
             Some(&json!(BackgroundTaskStatus::Running))
         );
         assert!(last.get("output_path").and_then(Value::as_str).is_some());
+    }
+
+    #[tokio::test]
+    async fn read_output_tail_returns_only_requested_suffix() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("task.log");
+        tokio::fs::write(&path, b"0123456789tail")
+            .await
+            .expect("write log");
+
+        let output = read_output_tail(&path, 4).await.expect("tail");
+
+        assert_eq!(output, "tail");
+    }
+
+    #[tokio::test]
+    async fn read_output_tail_missing_file_is_empty() {
+        let temp = tempdir().expect("tempdir");
+
+        let output = read_output_tail(&temp.path().join("missing.log"), 4)
+            .await
+            .expect("missing tail");
+
+        assert_eq!(output, "");
     }
 
     fn binary_exists(program: &str) -> bool {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,6 +3,7 @@ pub mod bash;
 pub mod context;
 pub mod file;
 pub mod patch;
+pub mod pty;
 pub mod search;
 pub mod skill;
 pub mod vector;

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -22,11 +22,23 @@ pub struct PtyReadTool {
     pub sessions: Arc<PtySessionStore>,
 }
 
+pub struct PtyListTool {
+    pub sessions: Arc<PtySessionStore>,
+}
+
+pub struct PtyStatusTool {
+    pub sessions: Arc<PtySessionStore>,
+}
+
 pub struct PtyWriteTool {
     pub sessions: Arc<PtySessionStore>,
 }
 
 pub struct PtyKillTool {
+    pub sessions: Arc<PtySessionStore>,
+}
+
+pub struct PtyStopTool {
     pub sessions: Arc<PtySessionStore>,
 }
 
@@ -182,6 +194,18 @@ impl PtySessionStore {
             .map(PtySessionRecord::snapshot)
     }
 
+    fn list(&self) -> Vec<PtySessionSnapshot> {
+        let mut snapshots = self
+            .sessions
+            .lock()
+            .expect("pty session store lock")
+            .values()
+            .map(PtySessionRecord::snapshot)
+            .collect::<Vec<_>>();
+        snapshots.sort_by(|left, right| left.id.cmp(&right.id));
+        snapshots
+    }
+
     fn write(&self, id: &str, input: &str) -> Result<PtySessionSnapshot, ToolError> {
         let writer = {
             let sessions = self.sessions.lock().expect("pty session store lock");
@@ -219,6 +243,18 @@ impl PtySessionStore {
         snapshot.status = PtySessionStatus::Killed;
         Ok(snapshot)
     }
+
+    fn kill_all(&self) -> Vec<PtySessionSnapshot> {
+        let ids = self
+            .list()
+            .into_iter()
+            .filter(|snapshot| matches!(snapshot.status, PtySessionStatus::Running))
+            .map(|snapshot| snapshot.id)
+            .collect::<Vec<_>>();
+        ids.into_iter()
+            .filter_map(|id| self.kill(&id).ok())
+            .collect()
+    }
 }
 
 struct PtySessionSnapshot {
@@ -244,6 +280,17 @@ impl PtySessionRecord {
 }
 
 impl PtySessionSnapshot {
+    fn metadata_json(self) -> Value {
+        json!({
+            "session_id": self.id,
+            "command": self.command,
+            "status": self.status.as_str(),
+            "output_path": self.output_path,
+            "sandboxed": self.sandboxed,
+            "sandbox_backend": self.sandbox_backend,
+        })
+    }
+
     async fn into_json(self, tail_bytes: usize) -> Result<Value, ToolError> {
         let output = read_output_tail(&self.output_path, tail_bytes).await?;
         Ok(json!({
@@ -364,6 +411,64 @@ impl Tool for PtyReadTool {
 }
 
 #[async_trait]
+impl Tool for PtyListTool {
+    fn name(&self) -> &str {
+        "pty_list"
+    }
+
+    fn description(&self) -> &str {
+        "List PTY sessions"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {}
+        })
+    }
+
+    async fn call(&self, _input: Value) -> Result<Value, ToolError> {
+        let sessions = self
+            .sessions
+            .list()
+            .into_iter()
+            .map(PtySessionSnapshot::metadata_json)
+            .collect::<Vec<_>>();
+        Ok(json!({ "sessions": sessions }))
+    }
+}
+
+#[async_trait]
+impl Tool for PtyStatusTool {
+    fn name(&self) -> &str {
+        "pty_status"
+    }
+
+    fn description(&self) -> &str {
+        "Inspect a PTY session and read the tail of its output"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "session_id": { "type": "string" },
+                "tail_bytes": { "type": "integer", "default": 12000, "minimum": 1 }
+            },
+            "required": ["session_id"]
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        PtyReadTool {
+            sessions: self.sessions.clone(),
+        }
+        .call(input)
+        .await
+    }
+}
+
+#[async_trait]
 impl Tool for PtyWriteTool {
     fn name(&self) -> &str {
         "pty_write"
@@ -423,6 +528,43 @@ impl Tool for PtyKillTool {
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("session_id".into()))?;
         self.sessions.kill(session_id)?.into_json(12_000).await
+    }
+}
+
+#[async_trait]
+impl Tool for PtyStopTool {
+    fn name(&self) -> &str {
+        "pty_stop"
+    }
+
+    fn description(&self) -> &str {
+        "Stop one PTY session, or all running PTY sessions when session_id is omitted"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "PTY session id returned by pty_start. Omit to stop all running PTY sessions."
+                }
+            }
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        if let Some(session_id) = input.get("session_id").and_then(Value::as_str) {
+            let session = self.sessions.kill(session_id)?;
+            return Ok(json!({ "stopped": [session.metadata_json()] }));
+        }
+        let stopped = self
+            .sessions
+            .kill_all()
+            .into_iter()
+            .map(PtySessionSnapshot::metadata_json)
+            .collect::<Vec<_>>();
+        Ok(json!({ "stopped": stopped }))
     }
 }
 
@@ -580,6 +722,72 @@ mod tests {
         assert!(
             output.contains("got:hello from pty"),
             "last pty output did not contain expected marker: {last}"
+        );
+    }
+
+    #[tokio::test]
+    async fn pty_sessions_can_be_listed_statused_and_stopped() {
+        let temp = tempdir().expect("tempdir");
+        let sessions = Arc::new(PtySessionStore::new(temp.path().join("pty")).expect("pty store"));
+        let list = PtyListTool {
+            sessions: sessions.clone(),
+        };
+        let status = PtyStatusTool {
+            sessions: sessions.clone(),
+        };
+        let stop = PtyStopTool {
+            sessions: sessions.clone(),
+        };
+
+        let command = "sleep 30".to_string();
+        let started = sessions
+            .start(
+                command.clone(),
+                WrappedCommand {
+                    program: "/bin/sh".to_string(),
+                    args: vec!["-c".to_string(), command],
+                    cleanup_path: None,
+                    sandboxed: false,
+                    sandbox_backend: "direct".to_string(),
+                    sandbox_home: None,
+                },
+                temp.path().display().to_string(),
+                HashMap::new(),
+                24,
+                120,
+            )
+            .expect("start pty")
+            .into_json(12_000)
+            .await
+            .expect("pty json");
+        let session_id = started
+            .get("session_id")
+            .and_then(Value::as_str)
+            .expect("session id")
+            .to_string();
+
+        let listed = list.call(json!({})).await.expect("list ptys");
+        assert_eq!(
+            listed
+                .get("sessions")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            Some(1)
+        );
+
+        let inspected = status
+            .call(json!({ "session_id": session_id }))
+            .await
+            .expect("pty status");
+        assert_eq!(
+            inspected.get("status").and_then(Value::as_str),
+            Some("running")
+        );
+
+        let stopped = stop.call(json!({})).await.expect("stop all ptys");
+        assert_eq!(
+            stopped.pointer("/stopped/0/status").and_then(Value::as_str),
+            Some("killed")
         );
     }
 }

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -6,10 +6,11 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::env;
 use std::fs::OpenOptions;
-use std::io::{Read, Write};
+use std::io::{Read, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use uuid::Uuid;
 
 pub struct PtyStartTool {
@@ -104,6 +105,9 @@ impl PtySessionStore {
             cmd.arg(arg);
         }
         cmd.cwd(&cwd);
+        if wrapped.sandboxed {
+            cmd.env_clear();
+        }
         for (key, value) in command_env {
             cmd.env(key, value);
         }
@@ -463,13 +467,17 @@ fn ensure_sandbox_home_dirs(sandbox_home: &Path) -> Result<(), ToolError> {
 }
 
 async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolError> {
-    let bytes = match tokio::fs::read(path).await {
-        Ok(bytes) => bytes,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+    let mut file = match tokio::fs::File::open(path).await {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
         Err(err) => return Err(err.into()),
     };
-    let start = bytes.len().saturating_sub(max_bytes);
-    Ok(String::from_utf8_lossy(&bytes[start..]).into_owned())
+    let file_len = file.metadata().await?.len();
+    let start = file_len.saturating_sub(max_bytes as u64);
+    file.seek(SeekFrom::Start(start)).await?;
+    let mut bytes = Vec::with_capacity(max_bytes.min(file_len as usize));
+    file.read_to_end(&mut bytes).await?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 #[cfg(test)]
@@ -477,6 +485,19 @@ mod tests {
     use super::*;
     use crate::sandbox::WrappedCommand;
     use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn read_output_tail_returns_only_requested_suffix() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("pty.log");
+        tokio::fs::write(&path, b"0123456789tail")
+            .await
+            .expect("write log");
+
+        let output = read_output_tail(&path, 4).await.expect("tail");
+
+        assert_eq!(output, "tail");
+    }
 
     #[tokio::test]
     async fn pty_session_accepts_input_and_exposes_output() {

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -183,30 +183,41 @@ impl PtySessionStore {
     }
 
     fn write(&self, id: &str, input: &str) -> Result<PtySessionSnapshot, ToolError> {
-        let sessions = self.sessions.lock().expect("pty session store lock");
-        let record = sessions
-            .get(id)
-            .ok_or_else(|| ToolError::InvalidInput(format!("unknown pty session id: {id}")))?;
-        let mut writer = record.writer.lock().expect("pty writer lock");
+        let writer = {
+            let sessions = self.sessions.lock().expect("pty session store lock");
+            let record = sessions
+                .get(id)
+                .ok_or_else(|| ToolError::InvalidInput(format!("unknown pty session id: {id}")))?;
+            record.writer.clone()
+        };
+        let mut writer = writer.lock().expect("pty writer lock");
         writer.write_all(input.as_bytes())?;
         writer.flush()?;
         drop(writer);
-        Ok(record.snapshot())
+        self.get(id)
+            .ok_or_else(|| ToolError::InvalidInput(format!("unknown pty session id: {id}")))
     }
 
     fn kill(&self, id: &str) -> Result<PtySessionSnapshot, ToolError> {
-        let sessions = self.sessions.lock().expect("pty session store lock");
-        let record = sessions
-            .get(id)
-            .ok_or_else(|| ToolError::InvalidInput(format!("unknown pty session id: {id}")))?;
-        record
-            .child
+        let (child, status, mut snapshot) = {
+            let sessions = self.sessions.lock().expect("pty session store lock");
+            let record = sessions
+                .get(id)
+                .ok_or_else(|| ToolError::InvalidInput(format!("unknown pty session id: {id}")))?;
+            (
+                record.child.clone(),
+                record.status.clone(),
+                record.snapshot(),
+            )
+        };
+        child
             .lock()
             .expect("pty child lock")
             .kill()
             .map_err(|err| ToolError::ExecutionFailed(format!("kill pty session: {err}")))?;
-        *record.status.lock().expect("pty status lock") = PtySessionStatus::Killed;
-        Ok(record.snapshot())
+        *status.lock().expect("pty status lock") = PtySessionStatus::Killed;
+        snapshot.status = PtySessionStatus::Killed;
+        Ok(snapshot)
     }
 }
 

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -1,0 +1,545 @@
+use crate::sandbox::{sandbox_failure_hint, SandboxManager, WrappedCommand};
+use crate::tool::{Tool, ToolError};
+use async_trait::async_trait;
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::env;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use uuid::Uuid;
+
+pub struct PtyStartTool {
+    pub sessions: Arc<PtySessionStore>,
+    pub sandbox: Arc<SandboxManager>,
+}
+
+pub struct PtyReadTool {
+    pub sessions: Arc<PtySessionStore>,
+}
+
+pub struct PtyWriteTool {
+    pub sessions: Arc<PtySessionStore>,
+}
+
+pub struct PtyKillTool {
+    pub sessions: Arc<PtySessionStore>,
+}
+
+pub struct PtySessionStore {
+    dir: PathBuf,
+    sessions: Mutex<HashMap<String, PtySessionRecord>>,
+}
+
+struct PtySessionRecord {
+    id: String,
+    command: String,
+    output_path: PathBuf,
+    sandboxed: bool,
+    sandbox_backend: String,
+    writer: Arc<Mutex<Box<dyn Write + Send>>>,
+    child: Arc<Mutex<Box<dyn portable_pty::Child + Send + Sync>>>,
+    status: Arc<Mutex<PtySessionStatus>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PtySessionStatus {
+    Running,
+    Completed,
+    Killed,
+}
+
+impl PtySessionStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Killed => "killed",
+        }
+    }
+}
+
+impl PtySessionStore {
+    pub fn new(dir: PathBuf) -> Result<Self, ToolError> {
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self {
+            dir,
+            sessions: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn start(
+        &self,
+        command: String,
+        wrapped: WrappedCommand,
+        cwd: String,
+        env: HashMap<String, String>,
+        rows: u16,
+        cols: u16,
+    ) -> Result<PtySessionSnapshot, ToolError> {
+        let id = format!("pty-{}", Uuid::new_v4());
+        let output_path = self.dir.join(format!("{id}.log"));
+        let pty_system = NativePtySystem::default();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|err| ToolError::ExecutionFailed(format!("open pty: {err}")))?;
+        let command_env = command_env_for_wrapped(&wrapped, &env)?;
+        if wrapped.sandboxed && wrapped.sandbox_backend == "macos-seatbelt" {
+            let sandbox_home = wrapped.sandbox_home.as_deref().ok_or_else(|| {
+                ToolError::ExecutionFailed("sandboxed pty is missing sandbox home".into())
+            })?;
+            ensure_sandbox_home_dirs(sandbox_home)?;
+        }
+
+        let mut cmd = CommandBuilder::new(&wrapped.program);
+        for arg in &wrapped.args {
+            cmd.arg(arg);
+        }
+        cmd.cwd(&cwd);
+        for (key, value) in command_env {
+            cmd.env(key, value);
+        }
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|err| ToolError::ExecutionFailed(format!("spawn pty command: {err}")))?;
+        drop(pair.slave);
+        let mut reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(|err| ToolError::ExecutionFailed(format!("clone pty reader: {err}")))?;
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|err| ToolError::ExecutionFailed(format!("take pty writer: {err}")))?;
+        let child = Arc::new(Mutex::new(child));
+        let status = Arc::new(Mutex::new(PtySessionStatus::Running));
+        let reader_status = status.clone();
+        let reader_path = output_path.clone();
+
+        thread::spawn(move || {
+            let mut file = match OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&reader_path)
+            {
+                Ok(file) => file,
+                Err(_) => return,
+            };
+            let mut buffer = [0_u8; 4096];
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let _ = file.write_all(&buffer[..n]);
+                        let _ = file.flush();
+                    }
+                    Err(_) => break,
+                }
+            }
+            let mut status = reader_status.lock().expect("pty status lock");
+            if matches!(*status, PtySessionStatus::Running) {
+                *status = PtySessionStatus::Completed;
+            }
+        });
+
+        let record = PtySessionRecord {
+            id: id.clone(),
+            command,
+            output_path,
+            sandboxed: wrapped.sandboxed,
+            sandbox_backend: wrapped.sandbox_backend,
+            writer: Arc::new(Mutex::new(writer)),
+            child,
+            status,
+        };
+        let snapshot = record.snapshot();
+        self.sessions
+            .lock()
+            .expect("pty session store lock")
+            .insert(id, record);
+        Ok(snapshot)
+    }
+
+    fn get(&self, id: &str) -> Option<PtySessionSnapshot> {
+        self.sessions
+            .lock()
+            .expect("pty session store lock")
+            .get(id)
+            .map(PtySessionRecord::snapshot)
+    }
+
+    fn write(&self, id: &str, input: &str) -> Result<PtySessionSnapshot, ToolError> {
+        let sessions = self.sessions.lock().expect("pty session store lock");
+        let record = sessions
+            .get(id)
+            .ok_or_else(|| ToolError::InvalidInput(format!("unknown pty session id: {id}")))?;
+        let mut writer = record.writer.lock().expect("pty writer lock");
+        writer.write_all(input.as_bytes())?;
+        writer.flush()?;
+        drop(writer);
+        Ok(record.snapshot())
+    }
+
+    fn kill(&self, id: &str) -> Result<PtySessionSnapshot, ToolError> {
+        let sessions = self.sessions.lock().expect("pty session store lock");
+        let record = sessions
+            .get(id)
+            .ok_or_else(|| ToolError::InvalidInput(format!("unknown pty session id: {id}")))?;
+        record
+            .child
+            .lock()
+            .expect("pty child lock")
+            .kill()
+            .map_err(|err| ToolError::ExecutionFailed(format!("kill pty session: {err}")))?;
+        *record.status.lock().expect("pty status lock") = PtySessionStatus::Killed;
+        Ok(record.snapshot())
+    }
+}
+
+struct PtySessionSnapshot {
+    id: String,
+    command: String,
+    output_path: PathBuf,
+    sandboxed: bool,
+    sandbox_backend: String,
+    status: PtySessionStatus,
+}
+
+impl PtySessionRecord {
+    fn snapshot(&self) -> PtySessionSnapshot {
+        PtySessionSnapshot {
+            id: self.id.clone(),
+            command: self.command.clone(),
+            output_path: self.output_path.clone(),
+            sandboxed: self.sandboxed,
+            sandbox_backend: self.sandbox_backend.clone(),
+            status: *self.status.lock().expect("pty status lock"),
+        }
+    }
+}
+
+impl PtySessionSnapshot {
+    async fn into_json(self, tail_bytes: usize) -> Result<Value, ToolError> {
+        let output = read_output_tail(&self.output_path, tail_bytes).await?;
+        Ok(json!({
+            "session_id": self.id,
+            "command": self.command,
+            "status": self.status.as_str(),
+            "output_path": self.output_path,
+            "sandboxed": self.sandboxed,
+            "sandbox_backend": self.sandbox_backend,
+            "output": output,
+        }))
+    }
+}
+
+#[async_trait]
+impl Tool for PtyStartTool {
+    fn name(&self) -> &str {
+        "pty_start"
+    }
+
+    fn description(&self) -> &str {
+        "Start an interactive PTY session for commands that need terminal input"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string", "description": "Shell command to run inside a PTY." },
+                "cwd": { "type": "string", "description": "Optional working directory." },
+                "env": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" },
+                    "description": "Optional environment overrides."
+                },
+                "allow_net": { "type": "boolean", "default": false },
+                "rows": { "type": "integer", "default": 24, "minimum": 1 },
+                "cols": { "type": "integer", "default": 120, "minimum": 1 }
+            },
+            "required": ["command"]
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let command = input["command"]
+            .as_str()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| ToolError::InvalidInput("command".into()))?
+            .to_string();
+        let cwd = input
+            .get("cwd")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                env::current_dir()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|_| ".".to_string())
+            });
+        let env = parse_env(input.get("env"))?;
+        let allow_net = input
+            .get("allow_net")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let wrapped = self
+            .sandbox
+            .wrap_pty_shell_command(&command, &cwd, allow_net)
+            .map_err(|err| {
+                ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
+            })?;
+        let rows = input.get("rows").and_then(Value::as_u64).unwrap_or(24) as u16;
+        let cols = input.get("cols").and_then(Value::as_u64).unwrap_or(120) as u16;
+        self.sessions
+            .start(command, wrapped, cwd, env, rows.max(1), cols.max(1))?
+            .into_json(12_000)
+            .await
+    }
+}
+
+#[async_trait]
+impl Tool for PtyReadTool {
+    fn name(&self) -> &str {
+        "pty_read"
+    }
+
+    fn description(&self) -> &str {
+        "Read recent output from a PTY session"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "session_id": { "type": "string" },
+                "tail_bytes": { "type": "integer", "default": 12000, "minimum": 1 }
+            },
+            "required": ["session_id"]
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let session_id = input["session_id"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("session_id".into()))?;
+        let tail_bytes = input
+            .get("tail_bytes")
+            .and_then(Value::as_u64)
+            .unwrap_or(12_000)
+            .min(1_000_000) as usize;
+        self.sessions
+            .get(session_id)
+            .ok_or_else(|| {
+                ToolError::InvalidInput(format!("unknown pty session id: {session_id}"))
+            })?
+            .into_json(tail_bytes)
+            .await
+    }
+}
+
+#[async_trait]
+impl Tool for PtyWriteTool {
+    fn name(&self) -> &str {
+        "pty_write"
+    }
+
+    fn description(&self) -> &str {
+        "Write input to a running PTY session"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "session_id": { "type": "string" },
+                "input": { "type": "string", "description": "Text to write, including newlines or control characters when needed." }
+            },
+            "required": ["session_id", "input"]
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let session_id = input["session_id"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("session_id".into()))?;
+        let text = input["input"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("input".into()))?;
+        self.sessions
+            .write(session_id, text)?
+            .into_json(12_000)
+            .await
+    }
+}
+
+#[async_trait]
+impl Tool for PtyKillTool {
+    fn name(&self) -> &str {
+        "pty_kill"
+    }
+
+    fn description(&self) -> &str {
+        "Kill a PTY session"
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "session_id": { "type": "string" }
+            },
+            "required": ["session_id"]
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let session_id = input["session_id"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("session_id".into()))?;
+        self.sessions.kill(session_id)?.into_json(12_000).await
+    }
+}
+
+fn parse_env(value: Option<&Value>) -> Result<HashMap<String, String>, ToolError> {
+    let Some(value) = value else {
+        return Ok(HashMap::new());
+    };
+    serde_json::from_value(value.clone())
+        .map_err(|err| ToolError::InvalidInput(format!("env: {err}")))
+}
+
+fn command_env_for_wrapped(
+    wrapped: &WrappedCommand,
+    overrides: &HashMap<String, String>,
+) -> Result<HashMap<String, String>, ToolError> {
+    let mut env_map = HashMap::new();
+    if wrapped.sandboxed {
+        let sandbox_home = wrapped.sandbox_home.as_deref().ok_or_else(|| {
+            ToolError::ExecutionFailed("sandboxed pty is missing sandbox home".into())
+        })?;
+        env_map.insert("HOME".to_string(), sandbox_home.display().to_string());
+        env_map.insert(
+            "XDG_CACHE_HOME".to_string(),
+            sandbox_home.join(".cache").display().to_string(),
+        );
+        env_map.insert(
+            "XDG_CONFIG_HOME".to_string(),
+            sandbox_home.join(".config").display().to_string(),
+        );
+        env_map.insert(
+            "XDG_DATA_HOME".to_string(),
+            sandbox_home.join(".local/share").display().to_string(),
+        );
+    }
+    if let Ok(path) = env::var("PATH") {
+        env_map.insert("PATH".to_string(), path);
+    }
+    env_map.extend(overrides.clone());
+    Ok(env_map)
+}
+
+fn ensure_sandbox_home_dirs(sandbox_home: &Path) -> Result<(), ToolError> {
+    for dir in [
+        sandbox_home,
+        &sandbox_home.join(".cache"),
+        &sandbox_home.join(".config"),
+        &sandbox_home.join(".local"),
+        &sandbox_home.join(".local/share"),
+    ] {
+        std::fs::create_dir_all(dir)?;
+    }
+    Ok(())
+}
+
+async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolError> {
+    let bytes = match tokio::fs::read(path).await {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(err) => return Err(err.into()),
+    };
+    let start = bytes.len().saturating_sub(max_bytes);
+    Ok(String::from_utf8_lossy(&bytes[start..]).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn pty_session_accepts_input_and_exposes_output() {
+        let temp = tempdir().expect("tempdir");
+        let sessions = Arc::new(PtySessionStore::new(temp.path().join("pty")).expect("pty store"));
+        let sandbox = Arc::new(
+            SandboxManager::new_for_rara_dir(temp.path().join(".rara")).expect("sandbox manager"),
+        );
+        let start = PtyStartTool {
+            sessions: sessions.clone(),
+            sandbox,
+        };
+        let write = PtyWriteTool {
+            sessions: sessions.clone(),
+        };
+        let read = PtyReadTool {
+            sessions: sessions.clone(),
+        };
+
+        let started = start
+            .call(json!({
+                "command": "read line; printf \"got:%s\\n\" \"$line\"",
+                "cwd": temp.path(),
+            }))
+            .await
+            .expect("start pty");
+        let session_id = started
+            .get("session_id")
+            .and_then(Value::as_str)
+            .expect("session id")
+            .to_string();
+
+        write
+            .call(json!({
+                "session_id": session_id,
+                "input": "hello from pty\n",
+            }))
+            .await
+            .expect("write pty");
+
+        let mut last = Value::Null;
+        for _ in 0..50 {
+            last = read
+                .call(json!({ "session_id": session_id, "tail_bytes": 4096 }))
+                .await
+                .expect("read pty");
+            if last
+                .get("output")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .contains("got:hello from pty")
+            {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let output = last
+            .get("output")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        assert!(
+            output.contains("got:hello from pty"),
+            "last pty output did not contain expected marker: {last}"
+        );
+    }
+}

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -140,24 +140,20 @@ impl PtySessionStore {
         let child = Arc::new(Mutex::new(child));
         let status = Arc::new(Mutex::new(PtySessionStatus::Running));
         let reader_status = status.clone();
-        let reader_path = output_path.clone();
+        let mut output_file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&output_path)
+            .map_err(|err| ToolError::ExecutionFailed(format!("open pty session log: {err}")))?;
 
         thread::spawn(move || {
-            let mut file = match OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&reader_path)
-            {
-                Ok(file) => file,
-                Err(_) => return,
-            };
             let mut buffer = [0_u8; 4096];
             loop {
                 match reader.read(&mut buffer) {
                     Ok(0) => break,
                     Ok(n) => {
-                        let _ = file.write_all(&buffer[..n]);
-                        let _ = file.flush();
+                        let _ = output_file.write_all(&buffer[..n]);
+                        let _ = output_file.flush();
                     }
                     Err(_) => break,
                 }
@@ -327,8 +323,8 @@ impl Tool for PtyStartTool {
                     "description": "Optional environment overrides."
                 },
                 "allow_net": { "type": "boolean", "default": false },
-                "rows": { "type": "integer", "default": 24, "minimum": 1 },
-                "cols": { "type": "integer", "default": 120, "minimum": 1 }
+                "rows": { "type": "integer", "default": 24, "minimum": 1, "maximum": 65535 },
+                "cols": { "type": "integer", "default": 120, "minimum": 1, "maximum": 65535 }
             },
             "required": ["command"]
         })
@@ -361,10 +357,10 @@ impl Tool for PtyStartTool {
             .map_err(|err| {
                 ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
             })?;
-        let rows = input.get("rows").and_then(Value::as_u64).unwrap_or(24) as u16;
-        let cols = input.get("cols").and_then(Value::as_u64).unwrap_or(120) as u16;
+        let rows = parse_pty_dimension(input.get("rows"), 24, "rows")?;
+        let cols = parse_pty_dimension(input.get("cols"), 120, "cols")?;
         self.sessions
-            .start(command, wrapped, cwd, env, rows.max(1), cols.max(1))?
+            .start(command, wrapped, cwd, env, rows, cols)?
             .into_json(12_000)
             .await
     }
@@ -633,6 +629,24 @@ async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolE
     Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
+fn parse_pty_dimension(value: Option<&Value>, default: u16, name: &str) -> Result<u16, ToolError> {
+    let Some(value) = value else {
+        return Ok(default);
+    };
+    let Some(value) = value.as_u64() else {
+        return Err(ToolError::InvalidInput(format!(
+            "{name} must be an integer"
+        )));
+    };
+    if value == 0 || value > u16::MAX as u64 {
+        return Err(ToolError::InvalidInput(format!(
+            "{name} must be between 1 and {}",
+            u16::MAX
+        )));
+    }
+    Ok(value as u16)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -650,6 +664,15 @@ mod tests {
         let output = read_output_tail(&path, 4).await.expect("tail");
 
         assert_eq!(output, "tail");
+    }
+
+    #[test]
+    fn parse_pty_dimension_rejects_overflowing_values() {
+        let value = json!(u16::MAX as u64 + 1);
+
+        let err = parse_pty_dimension(Some(&value), 24, "rows").expect_err("overflow rejected");
+
+        assert!(matches!(err, ToolError::InvalidInput(_)));
     }
 
     #[tokio::test]

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -475,19 +475,13 @@ async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolE
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sandbox::WrappedCommand;
     use tempfile::tempdir;
 
     #[tokio::test]
     async fn pty_session_accepts_input_and_exposes_output() {
         let temp = tempdir().expect("tempdir");
         let sessions = Arc::new(PtySessionStore::new(temp.path().join("pty")).expect("pty store"));
-        let sandbox = Arc::new(
-            SandboxManager::new_for_rara_dir(temp.path().join(".rara")).expect("sandbox manager"),
-        );
-        let start = PtyStartTool {
-            sessions: sessions.clone(),
-            sandbox,
-        };
         let write = PtyWriteTool {
             sessions: sessions.clone(),
         };
@@ -495,13 +489,27 @@ mod tests {
             sessions: sessions.clone(),
         };
 
-        let started = start
-            .call(json!({
-                "command": "read line; printf \"got:%s\\n\" \"$line\"",
-                "cwd": temp.path(),
-            }))
+        let command = "read line; printf \"got:%s\\n\" \"$line\"".to_string();
+        let started = sessions
+            .start(
+                command.clone(),
+                WrappedCommand {
+                    program: "/bin/sh".to_string(),
+                    args: vec!["-c".to_string(), command],
+                    cleanup_path: None,
+                    sandboxed: false,
+                    sandbox_backend: "direct".to_string(),
+                    sandbox_home: None,
+                },
+                temp.path().display().to_string(),
+                HashMap::new(),
+                24,
+                120,
+            )
+            .expect("start pty")
+            .into_json(12_000)
             .await
-            .expect("start pty");
+            .expect("pty json");
         let session_id = started
             .get("session_id")
             .and_then(Value::as_str)

--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -42,4 +42,5 @@ pub enum AppEvent {
     RefreshDeepSeekModels,
     SelectHelpTab(HelpTab),
     ApplyOverlaySelection,
+    CancelRunningTask,
 }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -227,6 +227,7 @@ pub(super) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             _ => AppEvent::Noop,
         },
         None => match (code, modifiers) {
+            (KeyCode::Esc, _) if app.is_busy() => AppEvent::CancelRunningTask,
             (KeyCode::Esc, _) => AppEvent::Noop,
             (KeyCode::Enter, KeyModifiers::SHIFT) | (KeyCode::Char('j'), KeyModifiers::CONTROL) => {
                 AppEvent::InsertNewline

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -43,9 +43,10 @@ use self::provider_flow::{
 };
 use self::render::{desired_viewport_height, render};
 use self::runtime::{
-    execute_local_command, finish_running_task_if_ready, should_suggest_planning_mode,
-    start_deepseek_model_list_task, start_oauth_task, start_pending_approval_task,
-    start_plan_approval_resume_task, start_query_task, start_rebuild_task,
+    execute_local_command, finish_running_task_if_ready, request_running_task_cancellation,
+    should_suggest_planning_mode, start_deepseek_model_list_task, start_oauth_task,
+    start_pending_approval_task, start_plan_approval_resume_task, start_query_task,
+    start_rebuild_task,
 };
 use self::session_restore::{
     provider_requires_api_key, restore_latest_thread, restore_thread_by_id,
@@ -185,6 +186,7 @@ async fn dispatch_event(
         AppEvent::Noop => {}
         AppEvent::OpenOverlay(overlay) => app.open_overlay(overlay),
         AppEvent::CloseOverlay => app.close_overlay(),
+        AppEvent::CancelRunningTask => request_running_task_cancellation(app),
         AppEvent::SubmitComposer => {
             if handle_submit(app, agent_slot, oauth_manager).await? {
                 return Ok(true);

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -173,6 +173,7 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
                     cwd: Some("/repo".into()),
                     env: Default::default(),
                     allow_net: false,
+                    run_in_background: false,
                 },
             }),
             source: None,

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -22,6 +22,10 @@ pub fn start_query_task(app: &mut TuiApp, prompt: String, agent: Agent) {
     tasks::start_query_task(app, prompt, agent);
 }
 
+pub fn request_running_task_cancellation(app: &mut TuiApp) {
+    tasks::request_running_task_cancellation(app);
+}
+
 pub fn should_suggest_planning_mode(app: &TuiApp, prompt: &str) -> bool {
     tasks::should_suggest_planning_mode(app, prompt)
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -4,7 +4,10 @@ mod oauth;
 mod tests;
 
 use secrecy::ExposeSecret;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::Instant;
 
 use rara_provider_catalog::{
@@ -96,6 +99,7 @@ fn try_start_queued_follow_up(app: &mut TuiApp, agent_slot: &mut Option<Agent>) 
 
 pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agent) {
     let (sender, receiver) = mpsc::unbounded_channel();
+    let cancellation_token = Arc::new(AtomicBool::new(false));
     app.clear_pending_planning_suggestion();
     app.clear_active_live_sections();
     app.begin_running_turn();
@@ -104,6 +108,7 @@ pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agen
     app.notice = Some("Running prompt.".into());
     app.set_runtime_phase(RuntimePhase::SendingPrompt, Some("sending prompt".into()));
     app.push_entry("You", prompt.clone());
+    agent.set_cancellation_token(Some(cancellation_token.clone()));
 
     let handle = tokio::spawn(async move {
         let tx = sender.clone();
@@ -123,6 +128,8 @@ pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agen
         handle,
         started_at: Instant::now(),
         next_heartbeat_after_secs: 2,
+        cancellation_token: Some(cancellation_token),
+        cancellation_requested: false,
     });
 }
 
@@ -218,6 +225,8 @@ pub(super) fn start_compact_task(app: &mut TuiApp, mut agent: Agent) {
         handle,
         started_at: Instant::now(),
         next_heartbeat_after_secs: 2,
+        cancellation_token: None,
+        cancellation_requested: false,
     });
 }
 
@@ -227,6 +236,7 @@ pub(super) fn start_pending_approval_task(
     mut agent: Agent,
 ) {
     let (sender, receiver) = mpsc::unbounded_channel();
+    let cancellation_token = Arc::new(AtomicBool::new(false));
     let selection_label = match selection {
         BashApprovalMode::Once => "run once",
         BashApprovalMode::Always => "always allow bash",
@@ -237,6 +247,7 @@ pub(super) fn start_pending_approval_task(
         RuntimePhase::ProcessingResponse,
         Some("resuming after approval".into()),
     );
+    agent.set_cancellation_token(Some(cancellation_token.clone()));
 
     let handle = tokio::spawn(async move {
         let tx = sender.clone();
@@ -256,6 +267,8 @@ pub(super) fn start_pending_approval_task(
         handle,
         started_at: Instant::now(),
         next_heartbeat_after_secs: 2,
+        cancellation_token: Some(cancellation_token),
+        cancellation_requested: false,
     });
 }
 
@@ -265,6 +278,7 @@ pub(super) fn start_plan_approval_resume_task(
     mut agent: Agent,
 ) {
     let (sender, receiver) = mpsc::unbounded_channel();
+    let cancellation_token = Arc::new(AtomicBool::new(false));
     app.clear_active_live_sections();
     app.set_pending_plan_approval(false);
     app.record_completed_interaction(
@@ -297,6 +311,7 @@ pub(super) fn start_plan_approval_resume_task(
         crate::agent::AgentExecutionMode::Execute
     });
     app.set_agent_execution_mode(agent.execution_mode);
+    agent.set_cancellation_token(Some(cancellation_token.clone()));
 
     let handle = tokio::spawn(async move {
         let tx = sender.clone();
@@ -320,6 +335,8 @@ pub(super) fn start_plan_approval_resume_task(
         handle,
         started_at: Instant::now(),
         next_heartbeat_after_secs: 2,
+        cancellation_token: Some(cancellation_token),
+        cancellation_requested: false,
     });
 }
 
@@ -353,6 +370,8 @@ pub(super) fn start_rebuild_task(app: &mut TuiApp) {
         handle,
         started_at: Instant::now(),
         next_heartbeat_after_secs: u64::MAX,
+        cancellation_token: None,
+        cancellation_requested: false,
     });
 }
 
@@ -393,7 +412,36 @@ pub(super) fn start_deepseek_model_list_task(app: &mut TuiApp) {
         handle,
         started_at: Instant::now(),
         next_heartbeat_after_secs: u64::MAX,
+        cancellation_token: None,
+        cancellation_requested: false,
     });
+}
+
+pub(super) fn request_running_task_cancellation(app: &mut TuiApp) {
+    let Some(task) = app.running_task.as_mut() else {
+        return;
+    };
+    if !matches!(task.kind, TaskKind::Query) {
+        app.notice = Some("Only running model queries can be cancelled from the TUI.".into());
+        return;
+    }
+    if task.cancellation_requested {
+        app.notice =
+            Some("Cancellation already requested. Waiting for the provider stream to stop.".into());
+        return;
+    }
+    if let Some(token) = task.cancellation_token.as_ref() {
+        token.store(true, Ordering::SeqCst);
+        task.cancellation_requested = true;
+        task.next_heartbeat_after_secs = 0;
+        app.notice = Some("Cancellation requested.".into());
+        app.set_runtime_phase(
+            RuntimePhase::ProcessingResponse,
+            Some("cancelling query".into()),
+        );
+    } else {
+        app.notice = Some("This running task does not expose cancellation.".into());
+    }
 }
 
 pub(super) async fn finish_running_task_if_ready(
@@ -467,6 +515,8 @@ pub(super) async fn finish_running_task_if_ready(
                     }
                 }
                 Err(err) => {
+                    let error_message = format_error_chain(&err);
+                    let cancelled = error_message.contains("cancelled by user");
                     restore_execute_mode_after_plan_turn(app, &mut agent);
                     app.clear_active_live_sections();
                     app.set_pending_plan_approval(false);
@@ -476,8 +526,14 @@ pub(super) async fn finish_running_task_if_ready(
                     }
                     app.release_pending_follow_ups();
                     app.finalize_agent_stream(None);
+                    if cancelled {
+                        app.finalize_active_turn();
+                        app.notice = Some("Query cancelled.".into());
+                        app.set_runtime_phase(RuntimePhase::Idle, Some("query cancelled".into()));
+                        return Ok(());
+                    }
                     app.set_runtime_phase(RuntimePhase::Failed, Some("query failed".into()));
-                    let mut message = format!("Query failed:\n{}", format_error_chain(&err));
+                    let mut message = format!("Query failed:\n{error_message}");
                     if app.config.provider == "ollama" {
                         let base_url = app
                             .config

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -75,20 +75,22 @@ fn try_start_queued_follow_up(app: &mut TuiApp, agent_slot: &mut Option<Agent>) 
         return;
     }
 
-    let Some(prompt) = app.pop_queued_follow_up_message() else {
+    let mut prompts = Vec::new();
+    while let Some(p) = app.pop_queued_follow_up_message() {
+        prompts.push(p);
+    }
+    if prompts.is_empty() {
         return;
-    };
+    }
+    let prompt = prompts.join("\n\n");
+
     let Some(agent) = agent_slot.take() else {
+        // If the agent is missing, re-queue the merged prompt
         app.queue_follow_up_message(prompt);
         return;
     };
 
-    let remaining = app.queued_follow_up_count();
-    app.notice = Some(if remaining > 0 {
-        format!("Running queued follow-up. {remaining} more queued.")
-    } else {
-        "Running queued follow-up.".to_string()
-    });
+    app.notice = Some("Running queued follow-up.".to_string());
     start_query_task(app, prompt, agent);
 }
 
@@ -635,30 +637,68 @@ pub(super) async fn finish_running_task_if_ready(
 }
 
 fn emit_query_heartbeat(app: &mut TuiApp) {
-    let Some(task) = app.running_task.as_mut() else {
-        return;
-    };
-    if !matches!(task.kind, TaskKind::Query) {
-        return;
-    }
+    let elapsed = {
+        let Some(task) = app.running_task.as_mut() else {
+            return;
+        };
+        if !matches!(task.kind, TaskKind::Query) {
+            return;
+        }
 
-    let elapsed = task.started_at.elapsed().as_secs();
-    if elapsed < task.next_heartbeat_after_secs {
-        return;
-    }
+        let elapsed = task.started_at.elapsed().as_secs();
+        if elapsed < task.next_heartbeat_after_secs {
+            return;
+        }
+        task.next_heartbeat_after_secs = elapsed.saturating_add(1);
+        elapsed
+    };
 
     let is_local = super::super::command::is_local_provider(&app.config.provider);
-    let detail = if is_local {
-        format!("local model is still generating · {}s elapsed", elapsed)
-    } else {
-        format!("waiting for model response · {}s elapsed", elapsed)
+    let current_detail = app
+        .runtime_phase_detail
+        .as_deref()
+        .map(|detail| detail.split(" · ").next().unwrap_or(detail))
+        .filter(|detail| !detail.trim().is_empty());
+    let (phase, detail, notice) = match app.runtime_phase {
+        RuntimePhase::RunningTool => {
+            let detail = format!(
+                "{} · {}s elapsed",
+                current_detail.unwrap_or("running tool"),
+                elapsed
+            );
+            (
+                RuntimePhase::RunningTool,
+                detail.clone(),
+                format!("Running tool · {}s elapsed", elapsed),
+            )
+        }
+        RuntimePhase::ProcessingResponse => {
+            let detail = format!(
+                "{} · {}s elapsed",
+                current_detail.unwrap_or("processing response"),
+                elapsed
+            );
+            (
+                RuntimePhase::ProcessingResponse,
+                detail.clone(),
+                format!("Processing response · {}s elapsed", elapsed),
+            )
+        }
+        _ => {
+            let detail = if is_local {
+                format!("local model is still generating · {}s elapsed", elapsed)
+            } else {
+                format!("waiting for model response · {}s elapsed", elapsed)
+            };
+            let notice = if is_local {
+                format!("Working locally · {}s elapsed", elapsed)
+            } else {
+                format!("Waiting on {} · {}s elapsed", app.config.provider, elapsed)
+            };
+            (RuntimePhase::SendingPrompt, detail, notice)
+        }
     };
-    task.next_heartbeat_after_secs = elapsed.saturating_add(1);
 
-    app.set_runtime_phase(RuntimePhase::SendingPrompt, Some(detail.clone()));
-    app.notice = Some(if is_local {
-        format!("Working locally · {}s elapsed", elapsed)
-    } else {
-        format!("Waiting on {} · {}s elapsed", app.config.provider, elapsed)
-    });
+    app.set_runtime_phase(phase, Some(detail));
+    app.notice = Some(notice);
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -78,10 +78,7 @@ fn try_start_queued_follow_up(app: &mut TuiApp, agent_slot: &mut Option<Agent>) 
         return;
     }
 
-    let mut prompts = Vec::new();
-    while let Some(p) = app.pop_queued_follow_up_message() {
-        prompts.push(p);
-    }
+    let prompts = app.drain_queued_follow_up_messages();
     if prompts.is_empty() {
         return;
     }

--- a/src/tui/runtime/tasks/oauth.rs
+++ b/src/tui/runtime/tasks/oauth.rs
@@ -53,6 +53,8 @@ pub(crate) fn start_oauth_task(
         handle,
         started_at: std::time::Instant::now(),
         next_heartbeat_after_secs: u64::MAX,
+        cancellation_token: None,
+        cancellation_requested: false,
     });
 }
 

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::time::{Duration, Instant};
 
 use tempfile::tempdir;
@@ -20,8 +23,8 @@ use crate::workspace::WorkspaceMemory;
 use serde_json::json;
 
 use super::{
-    emit_query_heartbeat, merge_rebuilt_agent, should_suggest_planning_mode, start_oauth_task,
-    try_start_queued_follow_up,
+    emit_query_heartbeat, merge_rebuilt_agent, request_running_task_cancellation,
+    should_suggest_planning_mode, start_oauth_task, try_start_queued_follow_up,
 };
 
 #[test]
@@ -256,6 +259,8 @@ async fn query_heartbeat_preserves_running_tool_phase() {
         handle,
         started_at: Instant::now() - Duration::from_secs(3),
         next_heartbeat_after_secs: 0,
+        cancellation_token: None,
+        cancellation_requested: false,
     });
     app.set_runtime_phase(
         RuntimePhase::RunningTool,
@@ -269,6 +274,44 @@ async fn query_heartbeat_preserves_running_tool_phase() {
         app.runtime_phase_detail.as_deref(),
         Some("streaming bash output · 3s elapsed")
     );
+    if let Some(task) = app.running_task.take() {
+        task.handle.abort();
+    }
+}
+
+#[tokio::test]
+async fn query_cancellation_sets_running_task_token() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let (_sender, receiver) = mpsc::unbounded_channel();
+    let token = Arc::new(AtomicBool::new(false));
+    let handle = tokio::spawn(std::future::pending::<TaskCompletion>());
+    app.running_task = Some(RunningTask {
+        kind: TaskKind::Query,
+        receiver,
+        handle,
+        started_at: Instant::now(),
+        next_heartbeat_after_secs: 2,
+        cancellation_token: Some(token.clone()),
+        cancellation_requested: false,
+    });
+
+    request_running_task_cancellation(&mut app);
+
+    assert!(token.load(Ordering::SeqCst));
+    assert!(app
+        .running_task
+        .as_ref()
+        .is_some_and(|task| task.cancellation_requested));
+    assert_eq!(app.runtime_phase, RuntimePhase::ProcessingResponse);
+    assert_eq!(
+        app.runtime_phase_detail.as_deref(),
+        Some("cancelling query")
+    );
+
     if let Some(task) = app.running_task.take() {
         task.handle.abort();
     }

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -12,7 +12,9 @@ use crate::oauth::OAuthManager;
 use crate::prompt::PromptRuntimeConfig;
 use crate::session::SessionManager;
 use crate::tool::ToolManager;
-use crate::tui::state::{OAuthLoginMode, RunningTask, RuntimePhase, TaskKind, TuiApp};
+use crate::tui::state::{
+    OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp,
+};
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
 use serde_json::json;
@@ -247,7 +249,7 @@ async fn query_heartbeat_preserves_running_tool_phase() {
     })
     .expect("build tui app");
     let (_sender, receiver) = mpsc::unbounded_channel();
-    let handle = tokio::spawn(std::future::pending());
+    let handle = tokio::spawn(std::future::pending::<TaskCompletion>());
     app.running_task = Some(RunningTask {
         kind: TaskKind::Query,
         receiver,

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use tempfile::tempdir;
+use tokio::sync::mpsc;
 
 use crate::agent::{
     Agent, AgentExecutionMode, BashApprovalMode, Message, PlanStep, PlanStepStatus,
@@ -10,12 +12,15 @@ use crate::oauth::OAuthManager;
 use crate::prompt::PromptRuntimeConfig;
 use crate::session::SessionManager;
 use crate::tool::ToolManager;
-use crate::tui::state::{OAuthLoginMode, TuiApp};
+use crate::tui::state::{OAuthLoginMode, RunningTask, RuntimePhase, TaskKind, TuiApp};
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
 use serde_json::json;
 
-use super::{merge_rebuilt_agent, should_suggest_planning_mode, start_oauth_task};
+use super::{
+    emit_query_heartbeat, merge_rebuilt_agent, should_suggest_planning_mode, start_oauth_task,
+    try_start_queued_follow_up,
+};
 
 #[test]
 fn suggests_planning_for_repo_review_requests() {
@@ -181,4 +186,88 @@ fn merge_rebuilt_agent_preserves_session_and_turn_state() {
         merged.prompt_config().warnings,
         vec!["missing custom prompt".to_string()]
     );
+}
+
+#[tokio::test]
+async fn queued_follow_ups_start_as_one_multiline_turn() {
+    let temp = tempdir().unwrap();
+    let workspace_root = temp.path().join("workspace");
+    let rara_dir = workspace_root.join(".rara");
+    std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+    std::fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+    std::fs::create_dir_all(rara_dir.join("tool-results")).expect("tool results");
+
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.queue_follow_up_message("first line");
+    app.queue_follow_up_message("second line");
+
+    let workspace = Arc::new(WorkspaceMemory::from_paths(
+        workspace_root.clone(),
+        rara_dir.clone(),
+    ));
+    let session_manager = Arc::new(SessionManager {
+        storage_dir: rara_dir.join("rollouts"),
+        legacy_storage_dir: rara_dir.join("sessions"),
+    });
+    let agent = Agent::new(
+        ToolManager::new(),
+        Arc::new(crate::llm::MockLlm),
+        Arc::new(VectorDB::new(
+            &rara_dir.join("lancedb").display().to_string(),
+        )),
+        session_manager,
+        workspace,
+    );
+    let mut agent_slot = Some(agent);
+
+    try_start_queued_follow_up(&mut app, &mut agent_slot);
+
+    assert_eq!(app.queued_follow_up_count(), 0);
+    assert!(app.running_task.is_some());
+    assert_eq!(app.active_turn.entries.len(), 1);
+    assert_eq!(app.active_turn.entries[0].role, "You");
+    assert_eq!(
+        app.active_turn.entries[0].message,
+        "first line\n\nsecond line"
+    );
+
+    if let Some(task) = app.running_task.take() {
+        task.handle.abort();
+    }
+}
+
+#[tokio::test]
+async fn query_heartbeat_preserves_running_tool_phase() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let (_sender, receiver) = mpsc::unbounded_channel();
+    let handle = tokio::spawn(std::future::pending());
+    app.running_task = Some(RunningTask {
+        kind: TaskKind::Query,
+        receiver,
+        handle,
+        started_at: Instant::now() - Duration::from_secs(3),
+        next_heartbeat_after_secs: 0,
+    });
+    app.set_runtime_phase(
+        RuntimePhase::RunningTool,
+        Some("streaming bash output".into()),
+    );
+
+    emit_query_heartbeat(&mut app);
+
+    assert_eq!(app.runtime_phase, RuntimePhase::RunningTool);
+    assert_eq!(
+        app.runtime_phase_detail.as_deref(),
+        Some("streaming bash output · 3s elapsed")
+    );
+    if let Some(task) = app.running_task.take() {
+        task.handle.abort();
+    }
 }

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -148,6 +148,10 @@ pub(super) fn restore_thread_by_id(
                             .and_then(|payload| payload.get("allow_net"))
                             .and_then(|value| value.as_bool())
                             .unwrap_or(false),
+                        run_in_background: payload
+                            .and_then(|payload| payload.get("run_in_background"))
+                            .and_then(|value| value.as_bool())
+                            .unwrap_or(false),
                     });
                 agent.pending_approval = Some(PendingApproval {
                     tool_use_id: payload
@@ -527,6 +531,7 @@ mod tests {
                 cwd: Some(root.display().to_string()),
                 env: Default::default(),
                 allow_net: false,
+                run_in_background: false,
             },
         });
         original_agent.history.push(Message {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -174,6 +174,24 @@ fn queued_follow_up_messages_preserve_fifo_order() {
 }
 
 #[test]
+fn drain_queued_follow_up_messages_preserves_fifo_order() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+
+    app.queue_follow_up_message("first");
+    app.queue_follow_up_message("second");
+
+    assert_eq!(
+        app.drain_queued_follow_up_messages(),
+        vec!["first".to_string(), "second".to_string()]
+    );
+    assert_eq!(app.pop_queued_follow_up_message(), None);
+}
+
+#[test]
 fn pending_follow_up_messages_release_on_tool_boundary() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -392,6 +392,10 @@ impl TuiApp {
         }
     }
 
+    pub fn drain_queued_follow_up_messages(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.queued_follow_up_messages)
+    }
+
     pub fn begin_running_turn(&mut self) {
         self.running_tool_boundary_count = 0;
     }

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicBool, Arc};
 use std::time::Instant;
 
 use ratatui::text::Line;
@@ -265,6 +265,8 @@ pub struct RunningTask {
     pub handle: JoinHandle<TaskCompletion>,
     pub started_at: Instant,
     pub next_heartbeat_after_secs: u64,
+    pub cancellation_token: Option<Arc<AtomicBool>>,
+    pub cancellation_requested: bool,
 }
 
 pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 5] = [

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -79,6 +79,8 @@ async fn busy_submit_queues_follow_up_message() {
         }),
         started_at: Instant::now(),
         next_heartbeat_after_secs: 2,
+        cancellation_token: None,
+        cancellation_requested: false,
     });
 
     let mut agent_slot = None;
@@ -110,6 +112,38 @@ async fn busy_submit_queues_follow_up_message() {
 }
 
 #[tokio::test]
+async fn esc_cancels_busy_query_without_overlay() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+
+    let (_sender, receiver) = mpsc::unbounded_channel();
+    app.running_task = Some(RunningTask {
+        kind: TaskKind::Query,
+        receiver,
+        handle: tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            unreachable!()
+        }),
+        started_at: Instant::now(),
+        next_heartbeat_after_secs: 2,
+        cancellation_token: None,
+        cancellation_requested: false,
+    });
+
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Esc), &app),
+        AppEvent::CancelRunningTask
+    ));
+
+    if let Some(task) = app.running_task.take() {
+        task.handle.abort();
+    }
+}
+
+#[tokio::test]
 async fn busy_submit_allows_quit_command() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
@@ -128,6 +162,8 @@ async fn busy_submit_allows_quit_command() {
         }),
         started_at: Instant::now(),
         next_heartbeat_after_secs: u64::MAX,
+        cancellation_token: None,
+        cancellation_requested: false,
     });
 
     let mut agent_slot = None;


### PR DESCRIPTION
## Summary

- Add Claude-style background bash tasks via `run_in_background` and `background_task_status`
- Add Codex-style PTY sessions via `pty_start`, `pty_read`, `pty_write`, and `pty_kill`
- Improve long-running agent durability with larger per-query budgets, additional checkpoints, and batched queued follow-ups
- Fix sandbox command execution by binding standard Linux runtime roots and clearing inherited env for sandboxed commands

## Motivation

RARA should support long-running agent work without forcing every shell command to block the model loop. This change adds two complementary execution modes:

- background bash tasks for non-interactive long-running commands;
- PTY sessions for interactive commands that need terminal input.

It also aligns the agent loop with longer-running task expectations by increasing the agentic turn budget and checkpointing session history more often.

## Implementation Notes

- Background bash output is persisted under `.rara/background-tasks`.
- PTY session output is persisted under `.rara/pty-sessions`.
- Linux PTY commands continue to use the sandbox wrapper.
- macOS PTY commands use direct execution because `sandbox-exec` does not reliably preserve interactive PTY stdin; the tool result reports `sandboxed=false` and `sandbox_backend=direct`.
- Sandboxed bash now clears inherited environment variables before injecting the controlled sandbox environment, preventing host proxy variables from leaking into sandboxed commands.

## Tests

- `cargo test tools::bash::tests -- --nocapture`
- `cargo test tools::pty::tests -- --nocapture`
- `cargo test tui::runtime::tasks::tests -- --nocapture`
- `cargo test tui::session_restore -- --nocapture`
- `cargo test agent::tests::planning -- --nocapture`
- `cargo test session::tests::save_session_writes_history_without_leaving_temp_files -- --nocapture`
- `cargo test -p rara-sandbox -- --nocapture`
- `cargo check`
- `git diff --check`
