### PR TITLE
feat: add codex-style bash approval rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8617,6 +8617,7 @@ name = "rara-config"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "codex-execpolicy",
  "dirs",
  "secrecy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.17"
+codex-execpolicy = { git = "https://github.com/openai/codex", package = "codex-execpolicy", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
 
 [package]
 name = "rara"

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+codex-execpolicy.workspace = true
 dirs.workspace = true
 secrecy.workspace = true
 serde.workspace = true

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use codex_execpolicy::{blocking_append_allow_prefix_rule, PolicyParser};
 use dirs::home_dir;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
@@ -654,6 +655,48 @@ impl ConfigManager {
         Ok(())
     }
 
+    pub fn rules_path(&self) -> PathBuf {
+        self.path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("rules")
+            .join("default.rules")
+    }
+
+    pub fn load_allowed_command_prefixes(&self) -> Result<Vec<String>> {
+        let path = self.rules_path();
+        let content = match fs::read_to_string(&path) {
+            Ok(content) => content,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(err.into()),
+        };
+        let mut parser = PolicyParser::new();
+        parser.parse(&path.display().to_string(), &content)?;
+        let policy = parser.build();
+        Ok(policy
+            .get_allowed_prefixes()
+            .into_iter()
+            .map(|prefix| prefix.join(" "))
+            .collect())
+    }
+
+    pub fn save_allowed_command_prefixes(&self, prefixes: &[String]) -> Result<()> {
+        let path = self.rules_path();
+        let mut requested = Vec::new();
+        for prefix in prefixes {
+            if requested.contains(prefix) {
+                continue;
+            }
+            let tokens: Vec<String> = prefix.split_whitespace().map(str::to_string).collect();
+            if tokens.is_empty() {
+                continue;
+            }
+            blocking_append_allow_prefix_rule(&path, &tokens)?;
+            requested.push(prefix.clone());
+        }
+        Ok(())
+    }
+
     fn default_config() -> RaraConfig {
         RaraConfig {
             provider: "mock".to_string(),
@@ -1050,6 +1093,56 @@ mod tests {
         assert_eq!(
             config.provider_states["codex"].reasoning_summary.as_deref(),
             Some(DEFAULT_REASONING_SUMMARY)
+        );
+    }
+
+    #[test]
+    fn saves_and_loads_allowed_command_prefix_rules() {
+        let dir = tempdir().expect("tempdir");
+        let manager =
+            ConfigManager::new_for_rara_home(dir.path().join(".rara")).expect("config manager");
+
+        manager
+            .save_allowed_command_prefixes(&[
+                "git push".to_string(),
+                "cargo test".to_string(),
+                "git push".to_string(),
+            ])
+            .expect("save rules");
+        let loaded = manager.load_allowed_command_prefixes().expect("load rules");
+
+        assert_eq!(
+            loaded,
+            vec!["cargo test".to_string(), "git push".to_string()]
+        );
+        assert_eq!(
+            fs::read_to_string(manager.rules_path()).expect("read rules"),
+            "prefix_rule(pattern=[\"git\", \"push\"], decision=\"allow\")\n\
+prefix_rule(pattern=[\"cargo\", \"test\"], decision=\"allow\")\n"
+        );
+    }
+
+    #[test]
+    fn loads_codex_style_allowed_command_prefix_rules() {
+        let dir = tempdir().expect("tempdir");
+        let manager =
+            ConfigManager::new_for_rara_home(dir.path().join(".rara")).expect("config manager");
+        fs::create_dir_all(manager.rules_path().parent().unwrap()).expect("create rules dir");
+        fs::write(
+            manager.rules_path(),
+            r#"
+prefix_rule(
+    pattern=["git", "push"],
+)
+prefix_rule(pattern=["cargo","test"], decision="allow")
+prefix_rule(pattern=["rm", "-rf"], decision="prompt")
+"#,
+        )
+        .expect("write rules");
+
+        assert_eq!(
+            manager.load_allowed_command_prefixes().expect("load rules"),
+            vec!["cargo test".to_string(), "git push".to_string()]
         );
     }
 

--- a/docs/journal/2026-04-28-read-only-bash-policy.md
+++ b/docs/journal/2026-04-28-read-only-bash-policy.md
@@ -1,0 +1,19 @@
+# Read-Only Bash Approval Policy
+
+## Context
+
+RARA already supports a `bash_approval=suggestion` mode, but every bash call paused for user approval. Claude Code treats clearly read-only shell commands as concurrency-safe and permission-safe, while keeping write, network, background, and complex shell commands under the normal permission flow.
+
+## Implementation Checkpoint
+
+- Added a conservative read-only classifier on `BashCommandInput`.
+- Auto-allows read-only bash commands in suggestion mode.
+- Added rules-file-backed command-prefix approvals, mirroring Codex-style exec policy amendments without opening all bash commands.
+- Persists accepted prefixes in `rules/default.rules` under the user RARA config directory.
+- Keeps commands with network access, background execution, environment overrides, output redirection, unparseable shell syntax, or known write-capable subcommands under approval.
+- Covered the policy with focused bash classifier tests and agent-loop approval tests.
+
+## Follow-Up
+
+- The classifier intentionally covers the common Claude-style read-only surface first: `git`, `rg`, `grep`, `find`, `fd`, `sed`, basic file inspection commands, `docker` read-only inspection, and `pyright`.
+- A future hardening pass can replace the small local tokenizer with a stricter shell parser if RARA needs broader compound-shell support.

--- a/docs/journal/2026-04-28-terminal-event-cells.md
+++ b/docs/journal/2026-04-28-terminal-event-cells.md
@@ -14,9 +14,8 @@ results.
   before rendering them into the existing transcript representation.
 - Added `TerminalCell` so committed and active history can render terminal
   activity as a command/result block instead of a generic tool-result row.
-- Added an internal `Terminal Event` transcript role that stores serialized
-  terminal events for the TUI renderer while preserving the existing transcript
-  storage shape.
+- Added an internal transcript payload for terminal events so the TUI renderer
+  can consume typed data directly instead of JSON-encoding internal events.
 - Moved terminal output tailing and ANSI/control-sequence cleanup into the
   terminal event layer so runtime event formatting and TUI rendering share the
   same behavior.
@@ -32,8 +31,8 @@ requiring them to parse UI text.
 ## Current Boundary
 
 - The typed terminal event exists inside the TUI runtime event path.
-- Persistence remains transcript-compatible, but terminal entries now keep the
-  typed event payload in an internal transcript role.
+- Persistence remains transcript-compatible, but live terminal entries now keep
+  the typed event payload alongside the transcript-compatible summary.
 - `TerminalCell` renders typed terminal events first and keeps text-summary
   parsing only as a restore/backward-compatibility fallback. A later
   thread-domain migration can persist typed terminal rollout items directly.

--- a/docs/journal/2026-04-28-terminal-event-cells.md
+++ b/docs/journal/2026-04-28-terminal-event-cells.md
@@ -1,0 +1,44 @@
+# 2026-04-28 · Terminal Event Cells
+
+## Summary
+
+RARA now has a Codex-style typed terminal event layer for PTY sessions and
+background bash tasks, plus a dedicated TUI history cell for terminal command
+results.
+
+## What Changed
+
+- Added `TerminalEvent` with typed begin, output-delta, end, list, and stop
+  variants for PTY sessions and background tasks.
+- Routed terminal tool uses, progress, and results through typed TUI events
+  before rendering them into the existing transcript representation.
+- Added `TerminalCell` so committed and active history can render terminal
+  activity as a command/result block instead of a generic tool-result row.
+- Moved terminal output tailing and ANSI/control-sequence cleanup into the
+  terminal event layer so runtime event formatting and TUI rendering share the
+  same behavior.
+
+## Why
+
+Codex keeps command execution as structured lifecycle events and lets the TUI
+render those events through dedicated history cells. RARA still persists plain
+transcript entries today, but introducing a typed terminal event boundary gives
+future app-server and third-party consumers a stable event shape without
+requiring them to parse UI text.
+
+## Current Boundary
+
+- The typed terminal event exists inside the TUI runtime event path.
+- Persistence remains transcript-compatible; terminal events are currently
+  downgraded to transcript entries for restore compatibility.
+- `TerminalCell` still reconstructs display state from transcript-compatible
+  terminal summaries. A later thread-domain migration can persist typed
+  terminal rollout items directly.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo test terminal_event -- --nocapture`
+- `cargo test terminal_result_as_terminal_cell -- --nocapture`
+- `cargo test tui::runtime::events::tests -- --nocapture`
+- `cargo check`

--- a/docs/journal/2026-04-28-terminal-event-cells.md
+++ b/docs/journal/2026-04-28-terminal-event-cells.md
@@ -14,6 +14,9 @@ results.
   before rendering them into the existing transcript representation.
 - Added `TerminalCell` so committed and active history can render terminal
   activity as a command/result block instead of a generic tool-result row.
+- Added an internal `Terminal Event` transcript role that stores serialized
+  terminal events for the TUI renderer while preserving the existing transcript
+  storage shape.
 - Moved terminal output tailing and ANSI/control-sequence cleanup into the
   terminal event layer so runtime event formatting and TUI rendering share the
   same behavior.
@@ -29,11 +32,11 @@ requiring them to parse UI text.
 ## Current Boundary
 
 - The typed terminal event exists inside the TUI runtime event path.
-- Persistence remains transcript-compatible; terminal events are currently
-  downgraded to transcript entries for restore compatibility.
-- `TerminalCell` still reconstructs display state from transcript-compatible
-  terminal summaries. A later thread-domain migration can persist typed
-  terminal rollout items directly.
+- Persistence remains transcript-compatible, but terminal entries now keep the
+  typed event payload in an internal transcript role.
+- `TerminalCell` renders typed terminal events first and keeps text-summary
+  parsing only as a restore/backward-compatibility fallback. A later
+  thread-domain migration can persist typed terminal rollout items directly.
 
 ## Validation
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -43,6 +43,14 @@ pub enum BashApprovalMode {
     Suggestion,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BashApprovalDecision {
+    Once,
+    Prefix,
+    Always,
+    Suggestion,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Message {
     pub role: String,
@@ -112,6 +120,7 @@ pub struct Agent {
     pub pending_approval: Option<PendingApproval>,
     pub completed_user_input: Option<CompletedInteraction>,
     pub completed_approval: Option<CompletedInteraction>,
+    pub approved_bash_prefixes: Vec<String>,
     pub compact_state: CompactState,
     inspection_progress: InspectionProgress,
     last_query_plan_updated: bool,
@@ -149,6 +158,7 @@ impl Agent {
             pending_approval: None,
             completed_user_input: None,
             completed_approval: None,
+            approved_bash_prefixes: Vec::new(),
             compact_state: CompactState::default(),
             inspection_progress: InspectionProgress::default(),
             last_query_plan_updated: false,
@@ -501,36 +511,53 @@ impl Agent {
                                 .unwrap_or(false),
                         }
                     });
-                let summary = request.summary();
-                self.pending_approval = Some(PendingApproval {
-                    tool_use_id: tool_id.clone(),
-                    request: request.clone(),
-                });
-                self.pending_user_input = Some(PendingUserInput {
-                    question: "Bash command needs approval. What should RARA do?".to_string(),
-                    options: vec![
-                        (
-                            "Run once".to_string(),
-                            "Execute this command now and then return to suggestion mode."
-                                .to_string(),
-                        ),
-                        (
-                            "Always allow bash".to_string(),
-                            "Execute now and keep bash approval open for later commands."
-                                .to_string(),
-                        ),
-                        (
-                            "Suggestion only".to_string(),
-                            "Do not run the command automatically. Continue with a safer path."
-                                .to_string(),
-                        ),
-                    ],
-                    note: Some(format!("command: {}", summary)),
-                });
-                report(AgentEvent::Status(
-                    "Bash approval required. Waiting for a structured user decision.".to_string(),
-                ));
-                break;
+                if request.is_read_only() || self.is_bash_prefix_approved(&request) {
+                    report(AgentEvent::Status(format!(
+                        "Shell command allowed by policy: {}",
+                        request.summary()
+                    )));
+                } else {
+                    let summary = request.summary();
+                    self.pending_approval = Some(PendingApproval {
+                        tool_use_id: tool_id.clone(),
+                        request: request.clone(),
+                    });
+                    self.pending_user_input = Some(PendingUserInput {
+                        question: "Bash command needs approval. What should RARA do?".to_string(),
+                        options: vec![
+                            (
+                                "Run once".to_string(),
+                                "Execute this command now and then return to suggestion mode."
+                                    .to_string(),
+                            ),
+                            (
+                                "Allow matching prefix".to_string(),
+                                format!(
+                                    "Execute now and auto-allow later commands that start with '{}'.",
+                                    request
+                                        .approval_prefix()
+                                        .unwrap_or_else(|| request.summary())
+                                ),
+                            ),
+                            (
+                                "Always allow bash".to_string(),
+                                "Execute now and keep bash approval open for later commands."
+                                    .to_string(),
+                            ),
+                            (
+                                "Suggestion only".to_string(),
+                                "Do not run the command automatically. Continue with a safer path."
+                                    .to_string(),
+                            ),
+                        ],
+                        note: Some(format!("command: {}", summary)),
+                    });
+                    report(AgentEvent::Status(
+                        "Bash approval required. Waiting for a structured user decision."
+                            .to_string(),
+                    ));
+                    break;
+                }
             }
             if !self.is_tool_allowed_in_current_mode(&tool_name) {
                 let error_text = format!(

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -208,23 +208,17 @@ impl Agent {
                     .await?;
             }
             BashApprovalDecision::Prefix => {
-                if let Some(prefix) = pending.request.approval_prefix() {
-                    if !self.approved_bash_prefixes.contains(&prefix) {
-                        self.approved_bash_prefixes.push(prefix.clone());
-                    }
-                    self.completed_approval = Some(CompletedInteraction {
-                        title: "Bash approval".to_string(),
-                        summary: format!("Approved prefix for session: {}", prefix),
-                    });
-                } else {
-                    self.completed_approval = Some(CompletedInteraction {
-                        title: "Bash approval".to_string(),
-                        summary: format!(
-                            "Approved once for command: {}",
-                            pending.request.summary()
-                        ),
-                    });
+                let prefix = pending
+                    .request
+                    .approval_prefix()
+                    .unwrap_or_else(|| pending.request.summary());
+                if !self.approved_bash_prefixes.contains(&prefix) {
+                    self.approved_bash_prefixes.push(prefix.clone());
                 }
+                self.completed_approval = Some(CompletedInteraction {
+                    title: "Bash approval".to_string(),
+                    summary: format!("Approved prefix for session: {}", prefix),
+                });
                 self.execute_pending_bash(pending, false, output_mode, &mut report)
                     .await?;
             }

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -160,6 +160,12 @@ impl Agent {
         self.bash_approval_mode = mode;
     }
 
+    pub fn is_bash_prefix_approved(&self, request: &BashCommandInput) -> bool {
+        self.approved_bash_prefixes
+            .iter()
+            .any(|prefix| request.matches_approval_prefix(prefix))
+    }
+
     pub fn clear_completed_interactions(&mut self) {
         self.completed_user_input = None;
         self.completed_approval = None;
@@ -176,7 +182,7 @@ impl Agent {
 
     pub async fn answer_pending_approval_with_events<F>(
         &mut self,
-        selection: BashApprovalMode,
+        selection: BashApprovalDecision,
         output_mode: AgentOutputMode,
         mut report: F,
     ) -> Result<()>
@@ -193,7 +199,7 @@ impl Agent {
         self.completed_approval = None;
 
         match selection {
-            BashApprovalMode::Once => {
+            BashApprovalDecision::Once => {
                 self.completed_approval = Some(CompletedInteraction {
                     title: "Bash approval".to_string(),
                     summary: format!("Approved once for command: {}", pending.request.summary()),
@@ -201,7 +207,28 @@ impl Agent {
                 self.execute_pending_bash(pending, false, output_mode, &mut report)
                     .await?;
             }
-            BashApprovalMode::Always => {
+            BashApprovalDecision::Prefix => {
+                if let Some(prefix) = pending.request.approval_prefix() {
+                    if !self.approved_bash_prefixes.contains(&prefix) {
+                        self.approved_bash_prefixes.push(prefix.clone());
+                    }
+                    self.completed_approval = Some(CompletedInteraction {
+                        title: "Bash approval".to_string(),
+                        summary: format!("Approved prefix for session: {}", prefix),
+                    });
+                } else {
+                    self.completed_approval = Some(CompletedInteraction {
+                        title: "Bash approval".to_string(),
+                        summary: format!(
+                            "Approved once for command: {}",
+                            pending.request.summary()
+                        ),
+                    });
+                }
+                self.execute_pending_bash(pending, false, output_mode, &mut report)
+                    .await?;
+            }
+            BashApprovalDecision::Always => {
                 self.bash_approval_mode = BashApprovalMode::Always;
                 self.completed_approval = Some(CompletedInteraction {
                     title: "Bash approval".to_string(),
@@ -210,7 +237,7 @@ impl Agent {
                 self.execute_pending_bash(pending, true, output_mode, &mut report)
                     .await?;
             }
-            BashApprovalMode::Suggestion => {
+            BashApprovalDecision::Suggestion => {
                 self.completed_approval = Some(CompletedInteraction {
                     title: "Bash approval".to_string(),
                     summary: format!("Kept as suggestion only: {}", pending.request.summary()),

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -8,8 +8,8 @@ use crate::agent::planning::{
     parse_plan_block, parse_request_user_input_block, strip_continue_inspection_control,
 };
 use crate::agent::{
-    Agent, AgentExecutionMode, ContentBlock, PendingUserInput, PlanStep, PlanStepStatus,
-    RuntimeContinuationPhase,
+    Agent, AgentExecutionMode, BashApprovalDecision, ContentBlock, PendingUserInput, PlanStep,
+    PlanStepStatus, RuntimeContinuationPhase,
 };
 use crate::llm::{LlmBackend, LlmResponse, TokenUsage};
 use crate::session::SessionManager;
@@ -18,7 +18,7 @@ use crate::tool_result::ToolResultStore;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
 
-use super::support::{test_runtime_storage, SequencedBackend, StubTool};
+use super::support::{test_runtime_storage, SequencedBackend, StubBashTool, StubTool};
 
 struct CheckpointObserverBackend {
     session_manager: Arc<SessionManager>,
@@ -109,6 +109,164 @@ async fn appends_continuation_after_tool_result() {
     assert!(second_round
         .iter()
         .any(|message| { message.content.to_string().contains("tool_result") }));
+}
+
+#[tokio::test]
+async fn suggestion_mode_auto_allows_read_only_bash_commands() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "tool-readonly-bash".to_string(),
+                name: "bash".to_string(),
+                input: json!({ "command": "git status --short" }),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "done".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubBashTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.bash_approval_mode = crate::agent::BashApprovalMode::Suggestion;
+
+    agent
+        .query_with_mode(
+            "inspect git state".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("query should auto-allow read-only bash");
+
+    assert!(agent.pending_approval.is_none());
+    assert_eq!(backend.observed_messages().len(), 2);
+}
+
+#[tokio::test]
+async fn suggestion_mode_keeps_write_bash_commands_pending_approval() {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::ToolUse {
+            id: "tool-write-bash".to_string(),
+            name: "bash".to_string(),
+            input: json!({ "command": "git push origin main" }),
+        }],
+        stop_reason: Some("tool_use".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubBashTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.bash_approval_mode = crate::agent::BashApprovalMode::Suggestion;
+
+    agent
+        .query_with_mode(
+            "push changes".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("query should pause on write bash approval");
+
+    assert!(agent.pending_approval.is_some());
+    assert_eq!(backend.observed_messages().len(), 1);
+}
+
+#[tokio::test]
+async fn approved_bash_prefix_auto_allows_later_matching_commands() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "tool-first-push".to_string(),
+                name: "bash".to_string(),
+                input: json!({ "command": "git push origin main" }),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "first push done".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "tool-second-push".to_string(),
+                name: "bash".to_string(),
+                input: json!({ "command": "git push origin feature" }),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "second push done".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubBashTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.bash_approval_mode = crate::agent::BashApprovalMode::Suggestion;
+
+    agent
+        .query_with_mode(
+            "push once".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("first query should pause on approval");
+    assert!(agent.pending_approval.is_some());
+
+    agent
+        .answer_pending_approval_with_events(
+            BashApprovalDecision::Prefix,
+            super::super::AgentOutputMode::Silent,
+            |_| {},
+        )
+        .await
+        .expect("prefix approval should execute pending command");
+    assert_eq!(agent.approved_bash_prefixes, vec!["git push".to_string()]);
+
+    agent
+        .query_with_mode(
+            "push matching prefix".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("matching prefix should auto-allow bash");
+
+    assert!(agent.pending_approval.is_none());
+    assert_eq!(backend.observed_messages().len(), 4);
 }
 
 #[tokio::test]

--- a/src/agent/tests/support.rs
+++ b/src/agent/tests/support.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 
 pub(super) struct StubTool;
+pub(super) struct StubBashTool;
 
 #[async_trait]
 impl Tool for StubTool {
@@ -26,6 +27,22 @@ impl Tool for StubTool {
     }
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({ "status": "ok", "value": 42 }))
+    }
+}
+
+#[async_trait]
+impl Tool for StubBashTool {
+    fn name(&self) -> &str {
+        "bash"
+    }
+    fn description(&self) -> &str {
+        "Return a simple bash result"
+    }
+    fn input_schema(&self) -> Value {
+        json!({"type":"object"})
+    }
+    async fn call(&self, _input: Value) -> Result<Value, ToolError> {
+        Ok(json!({ "stdout": "ok\n", "stderr": "", "exit_code": 0 }))
     }
 }
 

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -152,6 +152,259 @@ impl BashCommandInput {
     pub fn to_value(&self) -> Value {
         serde_json::to_value(self).expect("bash command input should serialize")
     }
+
+    pub fn is_read_only(&self) -> bool {
+        if self.allow_net || self.run_in_background || !self.env.is_empty() {
+            return false;
+        }
+        if let Some(command) = self
+            .command
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+        {
+            return shell_command_is_read_only(command);
+        }
+        self.program
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .is_some_and(|program| argv_is_read_only(program, &self.args))
+    }
+
+    pub fn approval_prefix(&self) -> Option<String> {
+        if let Some(command) = self
+            .command
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+        {
+            let segments = split_shell_segments(command)?;
+            if segments.len() != 1 {
+                return None;
+            }
+            let tokens = tokenize_shell_segment(&segments[0])?;
+            return prefix_from_tokens(&tokens);
+        }
+
+        let program = self
+            .program
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())?;
+        let mut tokens = Vec::with_capacity(self.args.len() + 1);
+        tokens.push(program.to_string());
+        tokens.extend(self.args.iter().cloned());
+        prefix_from_tokens(&tokens)
+    }
+
+    pub fn matches_approval_prefix(&self, prefix: &str) -> bool {
+        let summary = self.summary();
+        summary == prefix
+            || summary
+                .strip_prefix(prefix)
+                .is_some_and(|suffix| suffix.starts_with(char::is_whitespace))
+    }
+}
+
+fn prefix_from_tokens(tokens: &[String]) -> Option<String> {
+    let program = tokens.first()?;
+    let program = Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program);
+    if let Some(subcommand) = tokens.get(1) {
+        Some(format!("{program} {subcommand}"))
+    } else {
+        Some(program.to_string())
+    }
+}
+
+fn shell_command_is_read_only(command: &str) -> bool {
+    if command.contains('\n')
+        || command.contains('`')
+        || command.contains("$(")
+        || command.contains('>')
+    {
+        return false;
+    }
+    split_shell_segments(command)
+        .filter(|segments| !segments.is_empty())
+        .is_some_and(|segments| {
+            segments.into_iter().all(|segment| {
+                tokenize_shell_segment(&segment).is_some_and(|tokens| {
+                    if tokens.is_empty() {
+                        return false;
+                    }
+                    argv_is_read_only(&tokens[0], &tokens[1..])
+                })
+            })
+        })
+}
+
+fn argv_is_read_only(program: &str, args: &[String]) -> bool {
+    let program = Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program);
+    match program {
+        "pwd" | "ls" | "tree" | "cat" | "head" | "tail" | "wc" | "stat" | "file" | "du" | "df"
+        | "which" | "type" | "whereis" | "uname" => true,
+        "rg" | "grep" => !args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "--files-with-matches=")),
+        "sed" => !args.iter().any(|arg| {
+            arg == "-i"
+                || arg.starts_with("-i.")
+                || arg == "--in-place"
+                || arg.starts_with("--in-place=")
+        }),
+        "find" => !args.iter().any(|arg| {
+            matches!(
+                arg.as_str(),
+                "-delete" | "-exec" | "-execdir" | "-ok" | "-okdir"
+            )
+        }),
+        "fd" | "fdfind" => !args.iter().any(|arg| {
+            matches!(
+                arg.as_str(),
+                "-x" | "--exec" | "-X" | "--exec-batch" | "--list-details"
+            )
+        }),
+        "git" => git_args_are_read_only(args),
+        "docker" => docker_args_are_read_only(args),
+        "pyright" => !args
+            .iter()
+            .any(|arg| matches!(arg.as_str(), "--watch" | "-w")),
+        _ => false,
+    }
+}
+
+fn git_args_are_read_only(args: &[String]) -> bool {
+    let mut index = 0;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--no-pager" | "--no-optional-locks" => index += 1,
+            "-C" | "-c" | "--git-dir" | "--work-tree" => return false,
+            value if value.starts_with('-') => return false,
+            _ => break,
+        }
+    }
+    let Some(subcommand) = args.get(index).map(String::as_str) else {
+        return false;
+    };
+    let rest = &args[index + 1..];
+    match subcommand {
+        "diff" | "log" | "show" | "shortlog" | "status" | "blame" | "ls-files" | "merge-base"
+        | "rev-parse" | "rev-list" | "describe" | "cat-file" | "for-each-ref" | "grep" => true,
+        "stash" => rest.first().is_some_and(|value| value == "list"),
+        "remote" => rest.is_empty() || rest == ["-v"] || rest == ["--verbose"],
+        "config" => rest.first().is_some_and(|value| value == "--get"),
+        "reflog" => !rest
+            .iter()
+            .any(|value| matches!(value.as_str(), "expire" | "delete" | "exists")),
+        "branch" => {
+            rest.is_empty()
+                || rest.iter().all(|value| {
+                    matches!(
+                        value.as_str(),
+                        "--list" | "-l" | "-a" | "--all" | "-r" | "--remotes" | "-v" | "-vv"
+                    )
+                })
+        }
+        _ => false,
+    }
+}
+
+fn docker_args_are_read_only(args: &[String]) -> bool {
+    args.first()
+        .is_some_and(|value| matches!(value.as_str(), "ps" | "images" | "logs" | "inspect"))
+}
+
+fn split_shell_segments(command: &str) -> Option<Vec<String>> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut chars = command.chars().peekable();
+    let mut quote: Option<char> = None;
+    while let Some(ch) = chars.next() {
+        if let Some(active_quote) = quote {
+            if ch == active_quote {
+                quote = None;
+            }
+            current.push(ch);
+            continue;
+        }
+        match ch {
+            '\'' | '"' => {
+                quote = Some(ch);
+                current.push(ch);
+            }
+            ';' | '|' => {
+                push_shell_segment(&mut segments, &mut current);
+            }
+            '&' if chars.peek() == Some(&'&') => {
+                chars.next();
+                push_shell_segment(&mut segments, &mut current);
+            }
+            '&' => return None,
+            _ => current.push(ch),
+        }
+    }
+    if quote.is_some() {
+        return None;
+    }
+    push_shell_segment(&mut segments, &mut current);
+    Some(segments)
+}
+
+fn push_shell_segment(segments: &mut Vec<String>, current: &mut String) {
+    let segment = current.trim();
+    if !segment.is_empty() {
+        segments.push(segment.to_string());
+    }
+    current.clear();
+}
+
+fn tokenize_shell_segment(segment: &str) -> Option<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut chars = segment.chars().peekable();
+    let mut quote: Option<char> = None;
+    while let Some(ch) = chars.next() {
+        match quote {
+            Some(active_quote) => {
+                if ch == active_quote {
+                    quote = None;
+                } else if ch == '\\' && active_quote == '"' {
+                    if let Some(next) = chars.next() {
+                        current.push(next);
+                    }
+                } else {
+                    current.push(ch);
+                }
+            }
+            None => match ch {
+                '\'' | '"' => quote = Some(ch),
+                '\\' => {
+                    if let Some(next) = chars.next() {
+                        current.push(next);
+                    }
+                }
+                '<' => return None,
+                value if value.is_whitespace() => {
+                    if !current.is_empty() {
+                        tokens.push(std::mem::take(&mut current));
+                    }
+                }
+                _ => current.push(ch),
+            },
+        }
+    }
+    if quote.is_some() {
+        return None;
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    Some(tokens)
 }
 
 impl BackgroundTaskStore {
@@ -897,6 +1150,69 @@ mod tests {
 
         assert!(input.run_in_background);
         assert_eq!(input.summary(), "cargo test");
+    }
+
+    #[test]
+    fn classifies_read_only_commands_for_approval_policy() {
+        for command in [
+            "git status --short",
+            "git diff -- src/tools/bash.rs",
+            "git log --oneline -n 5",
+            "rg -n read_only src",
+            "find src -name '*.rs'",
+            "sed -n '1,20p' src/tools/bash.rs",
+            "cat Cargo.toml | grep '^name'",
+            "docker inspect rara-dev",
+            "pyright --outputjson",
+        ] {
+            let input =
+                BashCommandInput::from_value(json!({ "command": command })).expect("bash payload");
+            assert!(input.is_read_only(), "{command} should be read-only");
+        }
+    }
+
+    #[test]
+    fn keeps_write_network_background_and_complex_commands_under_approval() {
+        for payload in [
+            json!({ "command": "git push origin main" }),
+            json!({ "command": "rm -rf target" }),
+            json!({ "command": "sed -i '' 's/a/b/' Cargo.toml" }),
+            json!({ "command": "find . -name '*.tmp' -delete" }),
+            json!({ "command": "cat Cargo.toml > /tmp/out" }),
+            json!({ "command": "git status", "allow_net": true }),
+            json!({ "command": "rg TODO", "run_in_background": true }),
+            json!({ "program": "rg", "args": ["TODO"], "env": { "PATH": "/tmp/bin" } }),
+        ] {
+            let input = BashCommandInput::from_value(payload).expect("bash payload");
+            assert!(
+                !input.is_read_only(),
+                "{} should require approval",
+                input.summary()
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_structured_read_only_programs() {
+        let input = BashCommandInput::from_value(json!({
+            "program": "/usr/bin/git",
+            "args": ["status", "--short"]
+        }))
+        .expect("structured payload");
+
+        assert!(input.is_read_only());
+    }
+
+    #[test]
+    fn derives_and_matches_codex_style_approval_prefix() {
+        let input = BashCommandInput::from_value(json!({
+            "command": "git push origin main"
+        }))
+        .expect("bash payload");
+
+        assert_eq!(input.approval_prefix().as_deref(), Some("git push"));
+        assert!(input.matches_approval_prefix("git push"));
+        assert!(!input.matches_approval_prefix("git pull"));
     }
 
     #[test]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -239,11 +239,8 @@ impl BashCommandInput {
 
 fn prefix_from_tokens(tokens: &[String]) -> Option<String> {
     let program = tokens.first()?;
-    let program = Path::new(program)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(program);
-    if let Some(subcommand) = tokens.get(1) {
+    let program = command_basename(program);
+    if let Some(subcommand) = approval_subcommand_token(program, &tokens[1..]) {
         Some(format!("{program} {subcommand}"))
     } else {
         Some(program.to_string())
@@ -254,14 +251,68 @@ fn normalized_tokens_summary(tokens: &[String]) -> String {
     let Some(program) = tokens.first() else {
         return String::new();
     };
-    let program = Path::new(program)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(program);
+    let program = command_basename(program);
+    let rest = &tokens[1..];
+    let args = approval_subcommand_index(program, rest)
+        .map(|index| rest[index..].iter().cloned().collect::<Vec<_>>())
+        .unwrap_or_else(|| rest.to_vec());
     std::iter::once(program.to_string())
-        .chain(tokens.iter().skip(1).cloned())
+        .chain(args)
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn command_basename(command: &str) -> &str {
+    Path::new(command)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(command)
+}
+
+fn approval_subcommand_token<'a>(program: &str, args: &'a [String]) -> Option<&'a str> {
+    approval_subcommand_index(program, args).and_then(|index| args.get(index).map(String::as_str))
+}
+
+fn approval_subcommand_index(program: &str, args: &[String]) -> Option<usize> {
+    match program {
+        "git" => skip_known_global_options(
+            args,
+            &["--no-pager", "--no-optional-locks"],
+            &["-C", "-c", "--git-dir", "--work-tree"],
+        ),
+        "docker" => skip_known_global_options(
+            args,
+            &["--debug", "--tls", "--tlsverify"],
+            &["--config", "--context", "--host", "-H", "--log-level"],
+        ),
+        _ => args.first().map(|_| 0),
+    }
+}
+
+fn skip_known_global_options(
+    args: &[String],
+    valueless_options: &[&str],
+    value_options: &[&str],
+) -> Option<usize> {
+    let mut index = 0;
+    while index < args.len() {
+        let arg = args[index].as_str();
+        if valueless_options.contains(&arg) {
+            index += 1;
+        } else if value_options.contains(&arg) {
+            index += 2;
+        } else if value_options
+            .iter()
+            .any(|option| arg.starts_with(&format!("{option}=")))
+        {
+            index += 1;
+        } else if arg.starts_with('-') {
+            index += 1;
+        } else {
+            return Some(index);
+        }
+    }
+    None
 }
 
 fn shell_command_is_read_only(command: &str) -> bool {
@@ -1280,6 +1331,17 @@ mod tests {
             Some("git push")
         );
         assert!(structured_input.matches_approval_prefix("git push"));
+    }
+
+    #[test]
+    fn approval_prefix_skips_known_global_options() {
+        let input = BashCommandInput::from_value(json!({
+            "command": "git --no-pager push origin main"
+        }))
+        .expect("shell payload");
+
+        assert_eq!(input.approval_prefix().as_deref(), Some("git push"));
+        assert!(input.matches_approval_prefix("git push"));
     }
 
     #[test]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -197,11 +197,43 @@ impl BashCommandInput {
     }
 
     pub fn matches_approval_prefix(&self, prefix: &str) -> bool {
-        let summary = self.summary();
-        summary == prefix
-            || summary
+        let normalized = self.normalized_approval_summary();
+        normalized == prefix
+            || normalized
                 .strip_prefix(prefix)
                 .is_some_and(|suffix| suffix.starts_with(char::is_whitespace))
+    }
+
+    fn normalized_approval_summary(&self) -> String {
+        if let Some(command) = self
+            .command
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+        {
+            if let Some(tokens) = split_shell_segments(command).and_then(|segments| {
+                if segments.len() == 1 {
+                    tokenize_shell_segment(&segments[0])
+                } else {
+                    None
+                }
+            }) {
+                return normalized_tokens_summary(&tokens);
+            }
+            return command.to_string();
+        }
+
+        let Some(program) = self
+            .program
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        else {
+            return self.summary();
+        };
+        let mut tokens = Vec::with_capacity(self.args.len() + 1);
+        tokens.push(program.to_string());
+        tokens.extend(self.args.iter().cloned());
+        normalized_tokens_summary(&tokens)
     }
 }
 
@@ -216,6 +248,20 @@ fn prefix_from_tokens(tokens: &[String]) -> Option<String> {
     } else {
         Some(program.to_string())
     }
+}
+
+fn normalized_tokens_summary(tokens: &[String]) -> String {
+    let Some(program) = tokens.first() else {
+        return String::new();
+    };
+    let program = Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program);
+    std::iter::once(program.to_string())
+        .chain(tokens.iter().skip(1).cloned())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn shell_command_is_read_only(command: &str) -> bool {
@@ -1213,6 +1259,27 @@ mod tests {
         assert_eq!(input.approval_prefix().as_deref(), Some("git push"));
         assert!(input.matches_approval_prefix("git push"));
         assert!(!input.matches_approval_prefix("git pull"));
+    }
+
+    #[test]
+    fn approval_prefix_matching_normalizes_program_paths() {
+        let shell_input = BashCommandInput::from_value(json!({
+            "command": "/usr/bin/git push origin main"
+        }))
+        .expect("shell payload");
+        assert_eq!(shell_input.approval_prefix().as_deref(), Some("git push"));
+        assert!(shell_input.matches_approval_prefix("git push"));
+
+        let structured_input = BashCommandInput::from_value(json!({
+            "program": "/usr/bin/git",
+            "args": ["push", "origin", "main"]
+        }))
+        .expect("structured payload");
+        assert_eq!(
+            structured_input.approval_prefix().as_deref(),
+            Some("git push")
+        );
+        assert!(structured_input.matches_approval_prefix("git push"));
     }
 
     #[test]

--- a/src/tui/interaction_text.rs
+++ b/src/tui/interaction_text.rs
@@ -25,7 +25,7 @@ pub fn pending_interaction_card_title(kind: ActivePendingInteractionKind) -> &'s
 pub fn pending_interaction_hint_text(kind: ActivePendingInteractionKind) -> &'static str {
     match kind {
         ActivePendingInteractionKind::PlanApproval => "type reply  1 yes  2 plan",
-        ActivePendingInteractionKind::ShellApproval => "type reply  1 yes  2 on  3 no",
+        ActivePendingInteractionKind::ShellApproval => "type reply  1 yes  2 prefix  3 on  4 no",
         ActivePendingInteractionKind::PlanningQuestion
         | ActivePendingInteractionKind::ExplorationQuestion
         | ActivePendingInteractionKind::SubAgentQuestion
@@ -41,7 +41,7 @@ pub fn status_plan_approval_text(app: &TuiApp) -> String {
 pub fn pending_interaction_shortcut_text(kind: ActivePendingInteractionKind) -> &'static str {
     match kind {
         ActivePendingInteractionKind::PlanApproval => "1 yes  2 plan",
-        ActivePendingInteractionKind::ShellApproval => "1 yes  2 on  3 no",
+        ActivePendingInteractionKind::ShellApproval => "1 yes  2 prefix  3 on  4 no",
         ActivePendingInteractionKind::PlanningQuestion
         | ActivePendingInteractionKind::ExplorationQuestion
         | ActivePendingInteractionKind::SubAgentQuestion
@@ -180,7 +180,7 @@ mod tests {
             pending_interaction_hint_text(
                 crate::tui::state::ActivePendingInteractionKind::ShellApproval
             ),
-            "type reply  1 yes  2 on  3 no"
+            "type reply  1 yes  2 prefix  3 on  4 no"
         );
     }
 }

--- a/src/tui/interaction_text.rs
+++ b/src/tui/interaction_text.rs
@@ -126,9 +126,13 @@ pub fn status_command_approval_text(app: &TuiApp) -> String {
         .filter(|value| !value.trim().is_empty())
         .unwrap_or(".");
     let env_count = approval.payload.env.len();
+    let prefix = approval
+        .payload
+        .approval_prefix()
+        .unwrap_or_else(|| approval.command.clone());
 
     format!(
-        "command:\n{}\n\ncwd:\n{}\n\nnetwork:\n{}\n\nenv:\n{} override(s)\n\n1. yes\n2. on\n3. no",
+        "command:\n{}\n\ncwd:\n{}\n\nnetwork:\n{}\n\nenv:\n{} override(s)\n\nmatching prefix:\n{}\n\n1. yes\n2. prefix\n3. on\n4. no",
         approval.command,
         cwd,
         if approval.allow_net {
@@ -137,6 +141,7 @@ pub fn status_command_approval_text(app: &TuiApp) -> String {
             "disabled"
         },
         env_count,
+        prefix,
     )
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -59,7 +59,7 @@ use self::terminal_ui::{
     update_terminal_viewport,
 };
 use crate::agent::AgentExecutionMode;
-use crate::agent::BashApprovalMode;
+use crate::agent::BashApprovalDecision;
 
 #[derive(Debug, Clone)]
 pub enum StartupResumeTarget {
@@ -399,9 +399,10 @@ async fn dispatch_event(
                     self::state::ActivePendingInteractionKind::ShellApproval => {
                         if let Some(agent) = agent_slot.take() {
                             let selection = match idx {
-                                0 => BashApprovalMode::Once,
-                                1 => BashApprovalMode::Always,
-                                _ => BashApprovalMode::Suggestion,
+                                0 => BashApprovalDecision::Once,
+                                1 => BashApprovalDecision::Prefix,
+                                2 => BashApprovalDecision::Always,
+                                _ => BashApprovalDecision::Suggestion,
                             };
                             start_pending_approval_task(app, selection, agent);
                         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -18,6 +18,7 @@ mod render;
 mod runtime;
 mod session_restore;
 mod state;
+mod terminal_event;
 mod terminal_ui;
 #[cfg(test)]
 mod tests;

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -9,6 +9,10 @@ use crate::tui::plan_display::should_show_updated_plan;
 use crate::tui::state::{
     contains_structured_planning_output, RuntimePhase, TranscriptEntry, TuiApp,
 };
+use crate::tui::terminal_event::{
+    TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
+    TERMINAL_EVENT_ROLE,
+};
 
 #[path = "cells_components.rs"]
 mod components;
@@ -263,8 +267,7 @@ fn terminal_cell_from_entries<'a>(
     entries: impl DoubleEndedIterator<Item = &'a TranscriptEntry>,
 ) -> Option<TerminalCell> {
     let data = entries
-        .filter(|entry| matches!(entry.role.as_str(), "Tool Result" | "Tool Error"))
-        .filter_map(|entry| parse_terminal_tool_result(&entry.message))
+        .filter_map(terminal_cell_data_from_entry)
         .next_back()?;
     Some(TerminalCell::new(
         data.command,
@@ -274,6 +277,95 @@ fn terminal_cell_from_entries<'a>(
     ))
 }
 
+fn terminal_cell_data_from_entry(entry: &TranscriptEntry) -> Option<TerminalCellData> {
+    if entry.role == TERMINAL_EVENT_ROLE {
+        let event = serde_json::from_str::<TerminalEvent>(&entry.message).ok()?;
+        return terminal_cell_data_from_event(&event);
+    }
+
+    if matches!(entry.role.as_str(), "Tool Result" | "Tool Error") {
+        return parse_terminal_tool_result(&entry.message);
+    }
+
+    None
+}
+
+fn terminal_cell_data_from_event(event: &TerminalEvent) -> Option<TerminalCellData> {
+    match event {
+        TerminalEvent::Begin(command) => Some(terminal_cell_data_from_command(command, true)),
+        TerminalEvent::End(command) => Some(terminal_cell_data_from_command(command, false)),
+        TerminalEvent::List(collection) => {
+            Some(terminal_cell_data_from_collection(collection, "list"))
+        }
+        TerminalEvent::Stop(collection) => {
+            Some(terminal_cell_data_from_collection(collection, "stop"))
+        }
+        TerminalEvent::OutputDelta(_) => None,
+    }
+}
+
+fn terminal_cell_data_from_command(
+    command: &TerminalCommandEvent,
+    force_active: bool,
+) -> TerminalCellData {
+    let target = match command.target {
+        TerminalTarget::Pty => "pty",
+        TerminalTarget::BackgroundTask => "background",
+    };
+    let command_label = command
+        .command
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .or(command.id.as_deref())
+        .unwrap_or("command");
+    let mut output = command.output.clone();
+    if let Some(output_path) = command.output_path.as_deref() {
+        if !output_path.trim().is_empty() {
+            output.push(output_path.to_string());
+        }
+    }
+    TerminalCellData {
+        command: format!("{target} {command_label}"),
+        output,
+        active: force_active || command.status == "running",
+        success: if force_active {
+            None
+        } else {
+            terminal_status_success(&command.status)
+        },
+    }
+}
+
+fn terminal_cell_data_from_collection(
+    collection: &TerminalCollectionEvent,
+    action: &str,
+) -> TerminalCellData {
+    let target = match collection.target {
+        TerminalTarget::Pty => "pty",
+        TerminalTarget::BackgroundTask => "background",
+    };
+    let output = collection
+        .items
+        .iter()
+        .take(6)
+        .map(|item| {
+            let id = item.id.as_deref().unwrap_or("<unknown>");
+            let command = item
+                .command
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("command unavailable");
+            format!("{id} {}: {command}", item.status)
+        })
+        .collect::<Vec<_>>();
+    TerminalCellData {
+        command: format!("{target} {action}"),
+        output,
+        active: false,
+        success: Some(!collection.items.iter().any(|item| item.is_error)),
+    }
+}
+
 fn parse_terminal_tool_result(message: &str) -> Option<TerminalCellData> {
     let mut lines = message.lines();
     let first = lines.next()?.trim();
@@ -281,7 +373,16 @@ fn parse_terminal_tool_result(message: &str) -> Option<TerminalCellData> {
     let mut output = Vec::new();
     let mut in_output = false;
     for line in lines {
-        if line.trim() == "output:" {
+        let trimmed = line.trim();
+        if trimmed == "output:" {
+            in_output = true;
+            continue;
+        }
+        if let Some(inline_output) = trimmed.strip_prefix("output:") {
+            let inline_output = inline_output.trim();
+            if !inline_output.is_empty() {
+                output.push(inline_output.to_string());
+            }
             in_output = true;
             continue;
         }
@@ -291,10 +392,7 @@ fn parse_terminal_tool_result(message: &str) -> Option<TerminalCellData> {
     }
 
     if let Some(rest) = first.strip_prefix("pty ") {
-        let (head, command) = rest
-            .split_once(": ")
-            .map(|(head, command)| (head, command.to_string()))
-            .unwrap_or((rest, rest.to_string()));
+        let (head, command) = parse_terminal_result_head(rest);
         let status = head.split_whitespace().nth(1).unwrap_or("unknown");
         return Some(TerminalCellData {
             command: format!("pty {command}"),
@@ -305,10 +403,7 @@ fn parse_terminal_tool_result(message: &str) -> Option<TerminalCellData> {
     }
 
     if let Some(rest) = first.strip_prefix("background task ") {
-        let (head, command) = rest
-            .split_once(": ")
-            .map(|(head, command)| (head, command.to_string()))
-            .unwrap_or((rest, rest.to_string()));
+        let (head, command) = parse_terminal_result_head(rest);
         let status = head.split_whitespace().nth(1).unwrap_or("unknown");
         return Some(TerminalCellData {
             command: format!("background {command}"),
@@ -319,6 +414,18 @@ fn parse_terminal_tool_result(message: &str) -> Option<TerminalCellData> {
     }
 
     None
+}
+
+fn parse_terminal_result_head(rest: &str) -> (&str, String) {
+    if let Some((head, command)) = rest.split_once(": ") {
+        return (head, command.to_string());
+    }
+    let fallback = rest
+        .split_whitespace()
+        .next()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(rest);
+    (rest, fallback.to_string())
 }
 
 fn terminal_status_success(status: &str) -> Option<bool> {
@@ -488,7 +595,7 @@ impl HistoryCell for CommittedTurnCell<'_> {
             matches!(
                 entry.role.as_str(),
                 "Tool" | "Tool Result" | "Tool Error" | "Tool Progress"
-            )
+            ) || entry.role == TERMINAL_EVENT_ROLE
         });
         if let Some(summary) = explicit_exploration
             .map(|summary| compact_summary_text(&summary, 4, "more exploration step(s)"))
@@ -615,7 +722,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             matches!(
                 entry.role.as_str(),
                 "Tool" | "Tool Result" | "Tool Error" | "Tool Progress"
-            )
+            ) || entry.role == TERMINAL_EVENT_ROLE
         });
         let user_message = current_turn
             .iter()

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -17,7 +17,7 @@ pub(crate) use self::components::StartupCardCell;
 use self::components::{
     planning_suggestion_text, CommittedInteractionCell, ExploredCell, ExploringCell, MessageCell,
     PendingInteractionCell, PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell,
-    RanCell, RespondingCell, RunningCell, UserCell,
+    RanCell, RespondingCell, RunningCell, TerminalCell, UserCell,
 };
 use super::{
     compact_progress_summary_lines, compact_recent_first_summary_lines, compact_summary_lines,
@@ -42,6 +42,13 @@ pub(crate) trait ActiveCell {
 enum OrderedActiveSegment<'a> {
     Exploration(Vec<String>),
     Agent(&'a str),
+}
+
+struct TerminalCellData {
+    command: String,
+    output: Vec<String>,
+    active: bool,
+    success: Option<bool>,
 }
 
 fn trim_trailing_empty_lines(lines: &mut Vec<Line<'static>>) {
@@ -252,6 +259,77 @@ fn parse_render_plan_block(message: &str) -> Option<(Vec<(String, String)>, Opti
     ))
 }
 
+fn terminal_cell_from_entries<'a>(
+    entries: impl DoubleEndedIterator<Item = &'a TranscriptEntry>,
+) -> Option<TerminalCell> {
+    let data = entries
+        .filter(|entry| matches!(entry.role.as_str(), "Tool Result" | "Tool Error"))
+        .filter_map(|entry| parse_terminal_tool_result(&entry.message))
+        .next_back()?;
+    Some(TerminalCell::new(
+        data.command,
+        data.output,
+        data.active,
+        data.success,
+    ))
+}
+
+fn parse_terminal_tool_result(message: &str) -> Option<TerminalCellData> {
+    let mut lines = message.lines();
+    let first = lines.next()?.trim();
+
+    let mut output = Vec::new();
+    let mut in_output = false;
+    for line in lines {
+        if line.trim() == "output:" {
+            in_output = true;
+            continue;
+        }
+        if in_output {
+            output.push(line.trim_end().to_string());
+        }
+    }
+
+    if let Some(rest) = first.strip_prefix("pty ") {
+        let (head, command) = rest
+            .split_once(": ")
+            .map(|(head, command)| (head, command.to_string()))
+            .unwrap_or((rest, rest.to_string()));
+        let status = head.split_whitespace().nth(1).unwrap_or("unknown");
+        return Some(TerminalCellData {
+            command: format!("pty {command}"),
+            output,
+            active: status == "running",
+            success: terminal_status_success(status),
+        });
+    }
+
+    if let Some(rest) = first.strip_prefix("background task ") {
+        let (head, command) = rest
+            .split_once(": ")
+            .map(|(head, command)| (head, command.to_string()))
+            .unwrap_or((rest, rest.to_string()));
+        let status = head.split_whitespace().nth(1).unwrap_or("unknown");
+        return Some(TerminalCellData {
+            command: format!("background {command}"),
+            output,
+            active: status == "running",
+            success: terminal_status_success(status),
+        });
+    }
+
+    None
+}
+
+fn terminal_status_success(status: &str) -> Option<bool> {
+    match status {
+        "running" => None,
+        "completed" | "stopped" => Some(true),
+        "failed" | "killed" => Some(false),
+        _ => None,
+    }
+}
+
 fn ordered_exploration_agent_segments<'a>(
     current_turn: &[&'a TranscriptEntry],
 ) -> Option<Vec<OrderedActiveSegment<'a>>> {
@@ -425,7 +503,9 @@ impl HistoryCell for CommittedTurnCell<'_> {
             cells.push(Box::new(PlanningCell::new(summary, false)));
         }
 
-        if let Some(summary) = explicit_running
+        if let Some(cell) = terminal_cell_from_entries(self.entries.iter()) {
+            cells.push(Box::new(cell));
+        } else if let Some(summary) = explicit_running
             .or_else(|| current_turn_tool_summary(entry_refs.as_slice(), false, None))
         {
             cells.push(Box::new(RanCell::new(summary)));
@@ -688,7 +768,9 @@ impl ActiveCell for ActiveTurnCell<'_> {
         };
         let has_running_summary = running_summary.is_some();
         let running_active = turn_live && has_running_summary;
-        if let Some(summary) = running_summary {
+        if let Some(cell) = terminal_cell_from_entries(current_turn.iter().copied()) {
+            cells.push(Box::new(cell));
+        } else if let Some(summary) = running_summary {
             cells.push(Box::new(RunningCell::new(summary, running_active)));
         }
         let compact_live_response =

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -7,11 +7,11 @@ use crate::tui::interaction_text::{
 };
 use crate::tui::plan_display::should_show_updated_plan;
 use crate::tui::state::{
-    contains_structured_planning_output, RuntimePhase, TranscriptEntry, TuiApp,
+    contains_structured_planning_output, RuntimePhase, TranscriptEntry, TranscriptEntryPayload,
+    TuiApp,
 };
 use crate::tui::terminal_event::{
     TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
-    TERMINAL_EVENT_ROLE,
 };
 
 #[path = "cells_components.rs"]
@@ -278,8 +278,7 @@ fn terminal_cell_from_entries<'a>(
 }
 
 fn terminal_cell_data_from_entry(entry: &TranscriptEntry) -> Option<TerminalCellData> {
-    if entry.role == TERMINAL_EVENT_ROLE {
-        let event = serde_json::from_str::<TerminalEvent>(&entry.message).ok()?;
+    if let Some(TranscriptEntryPayload::Terminal(event)) = entry.payload.as_ref() {
         return terminal_cell_data_from_event(&event);
     }
 
@@ -595,7 +594,7 @@ impl HistoryCell for CommittedTurnCell<'_> {
             matches!(
                 entry.role.as_str(),
                 "Tool" | "Tool Result" | "Tool Error" | "Tool Progress"
-            ) || entry.role == TERMINAL_EVENT_ROLE
+            ) || matches!(entry.payload, Some(TranscriptEntryPayload::Terminal(_)))
         });
         if let Some(summary) = explicit_exploration
             .map(|summary| compact_summary_text(&summary, 4, "more exploration step(s)"))
@@ -722,7 +721,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             matches!(
                 entry.role.as_str(),
                 "Tool" | "Tool Result" | "Tool Error" | "Tool Progress"
-            ) || entry.role == TERMINAL_EVENT_ROLE
+            ) || matches!(entry.payload, Some(TranscriptEntryPayload::Terminal(_)))
         });
         let user_message = current_turn
             .iter()

--- a/src/tui/render/cells_components.rs
+++ b/src/tui/render/cells_components.rs
@@ -186,6 +186,92 @@ impl HistoryCell for RunningCell {
     }
 }
 
+pub(super) struct TerminalCell {
+    command: String,
+    output: Vec<String>,
+    active: bool,
+    success: Option<bool>,
+}
+
+impl TerminalCell {
+    pub(super) fn new(
+        command: impl Into<String>,
+        output: Vec<String>,
+        active: bool,
+        success: Option<bool>,
+    ) -> Self {
+        Self {
+            command: command.into(),
+            output,
+            active,
+            success,
+        }
+    }
+
+    fn bullet(&self) -> Span<'static> {
+        let color = match (self.active, self.success) {
+            (true, _) => Color::Yellow,
+            (false, Some(true)) => Color::LightGreen,
+            (false, Some(false)) => Color::Red,
+            (false, None) => Color::LightYellow,
+        };
+        Span::styled("•", Style::default().fg(color).add_modifier(Modifier::BOLD))
+    }
+
+    fn title(&self) -> &'static str {
+        if self.active {
+            "Running"
+        } else {
+            "Ran"
+        }
+    }
+
+    fn output_lines(&self) -> Vec<String> {
+        const EDGE_LIMIT: usize = 3;
+        if self.output.len() <= EDGE_LIMIT * 2 + 1 {
+            return self.output.clone();
+        }
+
+        let omitted = self.output.len() - EDGE_LIMIT * 2;
+        let mut lines = self
+            .output
+            .iter()
+            .take(EDGE_LIMIT)
+            .cloned()
+            .collect::<Vec<_>>();
+        lines.push(format!("... {omitted} more line(s)"));
+        lines.extend(
+            self.output
+                .iter()
+                .skip(self.output.len() - EDGE_LIMIT)
+                .cloned(),
+        );
+        lines
+    }
+}
+
+impl HistoryCell for TerminalCell {
+    fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
+        let mut lines = vec![Line::from(vec![
+            self.bullet(),
+            Span::raw(" "),
+            Span::styled(self.title(), Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" "),
+            Span::raw(self.command.clone()),
+        ])];
+
+        for (idx, output) in self.output_lines().into_iter().enumerate() {
+            let prefix = if idx == 0 { "  └ " } else { "    " };
+            lines.push(Line::from(vec![
+                Span::styled(prefix, Style::default().fg(Color::DarkGray)),
+                Span::styled(output, Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+
+        lines
+    }
+}
+
 struct ApprovalCell {
     title: &'static str,
     color: Color,

--- a/src/tui/render/cells_tests.rs
+++ b/src/tui/render/cells_tests.rs
@@ -4,9 +4,7 @@ use std::path::Path;
 
 use crate::config::ConfigManager;
 use crate::tui::state::{RuntimePhase, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp};
-use crate::tui::terminal_event::{
-    TerminalCommandEvent, TerminalEvent, TerminalTarget, TERMINAL_EVENT_ROLE,
-};
+use crate::tui::terminal_event::{TerminalCommandEvent, TerminalEvent, TerminalTarget};
 use insta::assert_snapshot;
 use tempfile::tempdir;
 

--- a/src/tui/render/cells_tests.rs
+++ b/src/tui/render/cells_tests.rs
@@ -4,6 +4,9 @@ use std::path::Path;
 
 use crate::config::ConfigManager;
 use crate::tui::state::{RuntimePhase, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp};
+use crate::tui::terminal_event::{
+    TerminalCommandEvent, TerminalEvent, TerminalTarget, TERMINAL_EVENT_ROLE,
+};
 use insta::assert_snapshot;
 use tempfile::tempdir;
 

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -145,6 +145,50 @@ fn active_turn_cell_renders_terminal_result_as_terminal_cell() {
 }
 
 #[test]
+fn active_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Start the dev server".into(),
+            },
+            TranscriptEntry {
+                role: TERMINAL_EVENT_ROLE.into(),
+                message: serde_json::to_string(&TerminalEvent::End(TerminalCommandEvent {
+                    target: TerminalTarget::Pty,
+                    id: Some("pty-123".into()),
+                    status: "running".into(),
+                    command: Some("npm run dev".into()),
+                    exit_code: None,
+                    output: vec!["ready".into(), "listening on 3000".into()],
+                    output_path: None,
+                    is_error: false,
+                }))
+                .expect("terminal event json"),
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Running pty npm run dev"));
+    assert!(rendered.contains("└ ready"));
+    assert!(rendered.contains("listening on 3000"));
+    assert!(!rendered.contains(TERMINAL_EVENT_ROLE));
+}
+
+#[test]
 fn active_turn_cell_renders_planning_suggestion_without_active_turn_entries() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -15,14 +15,17 @@ fn active_turn_cell_keeps_sections_in_stable_order() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Inspect the codebase".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Tool".into(),
                 message: "list_files src".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Tool".into(),
                 message: "bash cargo check".into(),
+                payload: None,
             },
         ],
     };
@@ -71,6 +74,7 @@ fn active_turn_cell_renders_progress_sections_as_compact_stack() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect the codebase".into(),
+            payload: None,
         }],
     };
     app.record_exploration_note("Inspect the auth bridge.");
@@ -118,15 +122,18 @@ fn active_turn_cell_renders_terminal_result_as_terminal_cell() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Start the dev server".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Tool".into(),
                 message: "pty_start npm run dev".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Tool Result".into(),
                 message: "pty pty-123 running: npm run dev\noutput:\nready\nlistening on 3000"
                     .into(),
+                payload: None,
             },
         ],
     };
@@ -157,21 +164,18 @@ fn active_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Start the dev server".into(),
+                payload: None,
             },
-            TranscriptEntry {
-                role: TERMINAL_EVENT_ROLE.into(),
-                message: serde_json::to_string(&TerminalEvent::End(TerminalCommandEvent {
-                    target: TerminalTarget::Pty,
-                    id: Some("pty-123".into()),
-                    status: "running".into(),
-                    command: Some("npm run dev".into()),
-                    exit_code: None,
-                    output: vec!["ready".into(), "listening on 3000".into()],
-                    output_path: None,
-                    is_error: false,
-                }))
-                .expect("terminal event json"),
-            },
+            TranscriptEntry::terminal_event(TerminalEvent::End(TerminalCommandEvent {
+                target: TerminalTarget::Pty,
+                id: Some("pty-123".into()),
+                status: "running".into(),
+                command: Some("npm run dev".into()),
+                exit_code: None,
+                output: vec!["ready".into(), "listening on 3000".into()],
+                output_path: None,
+                is_error: false,
+            })),
         ],
     };
 
@@ -185,7 +189,7 @@ fn active_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
     assert!(rendered.contains("Running pty npm run dev"));
     assert!(rendered.contains("└ ready"));
     assert!(rendered.contains("listening on 3000"));
-    assert!(!rendered.contains(TERMINAL_EVENT_ROLE));
+    assert!(!rendered.contains("Terminal Event"));
 }
 
 #[test]
@@ -221,19 +225,14 @@ fn active_turn_cell_keeps_exploration_notes_inside_exploring_block() {
     app.runtime_phase_detail = Some("waiting for model response · 12s elapsed".into());
     app.active_turn = TranscriptTurn {
         entries: vec![
-            TranscriptEntry {
-                role: "You".into(),
-                message: "Review this repository".into(),
-            },
-            TranscriptEntry {
-                role: "Tool".into(),
-                message: "read_file src/main.rs".into(),
-            },
+            TranscriptEntry { role: "You".into(), message: "Review this repository".into(), payload: None },
+            TranscriptEntry { role: "Tool".into(), message: "read_file src/main.rs".into(), payload: None },
             TranscriptEntry {
                 role: "Agent".into(),
                 message:
                     "I have inspected the repository structure and will now inspect the core modules."
                         .into(),
+                payload: None,
             },
         ],
     };
@@ -269,6 +268,7 @@ fn active_turn_cell_uses_stateful_live_exploration_sections() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect the repository".into(),
+            payload: None,
         }],
     };
     app.record_exploration_action("Read src/tools/vector.rs");
@@ -301,15 +301,9 @@ fn active_turn_cell_compacts_live_response_when_process_sections_exist() {
     app.runtime_phase_detail = Some("waiting for model response".into());
     app.active_turn = TranscriptTurn {
         entries: vec![
-            TranscriptEntry {
-                role: "You".into(),
-                message: "Inspect the repository".into(),
-            },
-            TranscriptEntry {
-                role: "Agent".into(),
-                message: "I have inspected the repository structure.\nI checked the runtime boundary.\nI checked the prompt assembly path.\nNext I will inspect the persistence layer.\nThen I will verify the restore contract."
-                    .into(),
-            },
+            TranscriptEntry { role: "You".into(), message: "Inspect the repository".into(), payload: None },
+            TranscriptEntry { role: "Agent".into(), message: "I have inspected the repository structure.\nI checked the runtime boundary.\nI checked the prompt assembly path.\nNext I will inspect the persistence layer.\nThen I will verify the restore contract."
+                    .into(), payload: None },
         ],
     };
     app.record_exploration_action("Read src/runtime_context.rs");
@@ -341,6 +335,7 @@ fn active_turn_cell_compacts_long_live_exploration_sections() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect the repository".into(),
+            payload: None,
         }],
     };
     for idx in 1..=5 {
@@ -380,6 +375,7 @@ fn active_turn_cell_compacts_long_live_planning_sections() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Refine the plan".into(),
+            payload: None,
         }],
     };
     for idx in 1..=5 {
@@ -419,6 +415,7 @@ fn active_turn_cell_compacts_long_live_running_sections() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run the checks".into(),
+            payload: None,
         }],
     };
     for idx in 1..=6 {
@@ -455,6 +452,7 @@ fn active_turn_cell_updated_plan_snapshot() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Read the local codebase and propose the next refactor".into(),
+            payload: None,
         }],
     };
     app.record_planning_note("The auth flow should reuse codex_login instead of mirroring it.");
@@ -498,14 +496,8 @@ fn active_turn_cell_hides_structured_plan_response_once_plan_card_exists() {
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
         entries: vec![
-            TranscriptEntry {
-                role: "You".into(),
-                message: "Plan the next refactor".into(),
-            },
-            TranscriptEntry {
-                role: "Agent".into(),
-                message: "<plan>\n- [completed] Inspect the auth flow\n- [in_progress] Reuse codex_login\n- [pending] Add auth picker snapshots\n</plan>\nPrefer direct auth reuse before expanding more TUI flows.".into(),
-            },
+            TranscriptEntry { role: "You".into(), message: "Plan the next refactor".into(), payload: None },
+            TranscriptEntry { role: "Agent".into(), message: "<plan>\n- [completed] Inspect the auth flow\n- [in_progress] Reuse codex_login\n- [pending] Add auth picker snapshots\n</plan>\nPrefer direct auth reuse before expanding more TUI flows.".into(), payload: None },
         ],
     };
     app.snapshot.plan_steps = vec![
@@ -539,14 +531,8 @@ fn active_turn_cell_prefers_inline_plan_artifact_over_preamble_before_snapshot_s
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
         entries: vec![
-            TranscriptEntry {
-                role: "You".into(),
-                message: "Review the codebase and propose changes".into(),
-            },
-            TranscriptEntry {
-                role: "Agent".into(),
-                message: "我基于当前代码的建议如下。\n这里先给一个简短前言。\n<plan>\n- [completed] Inspect the runtime entrypoint\n- [pending] Tighten the render path\n</plan>\nKeep the diff narrow and reviewable.".into(),
-            },
+            TranscriptEntry { role: "You".into(), message: "Review the codebase and propose changes".into(), payload: None },
+            TranscriptEntry { role: "Agent".into(), message: "我基于当前代码的建议如下。\n这里先给一个简短前言。\n<plan>\n- [completed] Inspect the runtime entrypoint\n- [pending] Tighten the render path\n</plan>\nKeep the diff narrow and reviewable.".into(), payload: None },
         ],
     };
 
@@ -579,12 +565,14 @@ fn active_turn_cell_suppresses_planning_chatter_when_exploring() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Review this repository".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message:
                     "I will now read crates/instructions/src/prompt.rs to continue the review."
                         .into(),
+                payload: None,
             },
         ],
     };
@@ -617,10 +605,12 @@ fn active_turn_cell_uses_planning_sidecar_for_non_structured_plan_output() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Read the local codebase and suggest improvements".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Planning".into(),
                 message: "The current discovery is hardcoded to root-level markdown files.".into(),
+                payload: None,
             },
         ],
     };
@@ -650,18 +640,22 @@ fn active_turn_cell_uses_explicit_sidecar_entries_when_live_state_is_empty() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Inspect and summarize the repository".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Exploring".into(),
                 message: "└ Read crates/instructions/src/workspace.rs".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Planning".into(),
                 message: "The instruction discovery is still root-name based.".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Running".into(),
                 message: "└ waiting for model response".into(),
+                payload: None,
             },
         ],
     };
@@ -694,19 +688,23 @@ fn active_turn_cell_preserves_exploration_agent_exploration_order() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Inspect the repository".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Tool".into(),
                 message: "read_file src/main.rs".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "The main entrypoint is thin; I will inspect the runtime bootstrap next."
                     .into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Tool".into(),
                 message: "read_file src/runtime_context.rs".into(),
+                payload: None,
             },
         ],
     };
@@ -746,14 +744,17 @@ fn active_turn_cell_preserves_agent_then_exploration_order() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Inspect the bootstrap path".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "I have narrowed this down to the runtime bootstrap path.".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Tool".into(),
                 message: "read_file src/runtime_context.rs".into(),
+                payload: None,
             },
         ],
     };
@@ -788,11 +789,13 @@ fn active_turn_cell_uses_lightweight_busy_response_when_not_streaming() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Review this repository".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "I have inspected the main module and will continue with the tool layer."
                     .into(),
+                payload: None,
             },
         ],
     };
@@ -825,11 +828,13 @@ fn active_turn_cell_renders_live_response_as_lightweight_message() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Review this repository".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "I have inspected the main module and will continue with the tool layer."
                     .into(),
+                payload: None,
             },
         ],
     };
@@ -861,10 +866,12 @@ fn active_turn_cell_prefers_responding_over_tool_result_while_processing_respons
             TranscriptEntry {
                 role: "You".into(),
                 message: "Review the repository".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Tool Result".into(),
                 message: "bash stdout: partial output".into(),
+                payload: None,
             },
         ],
     };
@@ -895,10 +902,12 @@ fn active_turn_cell_prefers_responding_over_system_notice_while_sending_prompt()
             TranscriptEntry {
                 role: "You".into(),
                 message: "Review the repository".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "System".into(),
                 message: "temporary setup notice".into(),
+                payload: None,
             },
         ],
     };
@@ -927,6 +936,7 @@ fn active_turn_cell_shows_planning_section_for_plan_agent() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Plan the refactor".into(),
+            payload: None,
         }],
     };
     app.record_planning_action("Delegate plan refinement: refine the plan");
@@ -955,14 +965,8 @@ fn active_turn_cell_renders_device_code_prompt_system_message() {
     app.runtime_phase_detail = Some("Waiting for device-code confirmation.".into());
     app.active_turn = TranscriptTurn {
         entries: vec![
-            TranscriptEntry {
-                role: "Runtime".into(),
-                message: "Starting Codex device-code login flow.".into(),
-            },
-            TranscriptEntry {
-                role: "System".into(),
-                message: "Open this URL in a browser and enter the one-time code:\nhttps://example.test\n\nCode: ABCD".into(),
-            },
+            TranscriptEntry { role: "Runtime".into(), message: "Starting Codex device-code login flow.".into(), payload: None },
+            TranscriptEntry { role: "System".into(), message: "Open this URL in a browser and enter the one-time code:\nhttps://example.test\n\nCode: ABCD".into(), payload: None },
         ],
     };
 

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -106,6 +106,45 @@ fn active_turn_cell_renders_progress_sections_as_compact_stack() {
 }
 
 #[test]
+fn active_turn_cell_renders_terminal_result_as_terminal_cell() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Start the dev server".into(),
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "pty_start npm run dev".into(),
+            },
+            TranscriptEntry {
+                role: "Tool Result".into(),
+                message: "pty pty-123 running: npm run dev\noutput:\nready\nlistening on 3000"
+                    .into(),
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Running pty npm run dev"));
+    assert!(rendered.contains("└ ready"));
+    assert!(rendered.contains("listening on 3000"));
+    assert!(!rendered.contains("Run pty_start"));
+}
+
+#[test]
 fn active_turn_cell_renders_planning_suggestion_without_active_turn_entries() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -12,6 +12,7 @@ fn active_turn_cell_renders_plan_approval_as_interaction_card() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
+            payload: None,
         }],
     };
     app.snapshot.plan_steps = vec![
@@ -52,6 +53,7 @@ fn active_turn_cell_renders_updated_plan_checklist() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Improve the plan rendering".into(),
+            payload: None,
         }],
     };
     app.snapshot.plan_steps = vec![
@@ -93,6 +95,7 @@ fn active_turn_cell_hides_stale_updated_plan_after_plan_turn_finishes() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Implement the approved fix".into(),
+            payload: None,
         }],
     };
     app.snapshot.plan_steps = vec![("pending".into(), "Inspect the config loading flow".into())];
@@ -122,10 +125,12 @@ fn active_turn_cell_hides_stale_exploring_after_live_phase_finishes() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Inspect the repository".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Exploring".into(),
                 message: "└ Read src/main.rs".into(),
+                payload: None,
             },
         ],
     };
@@ -152,6 +157,7 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run the migration helper".into(),
+            payload: None,
         }],
     };
     app.snapshot
@@ -203,6 +209,7 @@ fn active_turn_cell_renders_completed_plan_decision() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
+            payload: None,
         }],
     };
     app.record_completed_interaction(
@@ -235,10 +242,12 @@ fn active_turn_cell_keeps_streaming_response_without_responding_card() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "你好".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Tool Result".into(),
                 message: "bash stdout: partial".into(),
+                payload: None,
             },
         ],
     };
@@ -273,6 +282,7 @@ fn active_turn_cell_does_not_repeat_stale_plan_decision_from_snapshot() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Approve the plan".into(),
+            payload: None,
         }],
     };
     app.record_completed_interaction(
@@ -286,6 +296,7 @@ fn active_turn_cell_does_not_repeat_stale_plan_decision_from_snapshot() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Continue with the next task".into(),
+            payload: None,
         }],
     };
 
@@ -310,6 +321,7 @@ fn active_turn_cell_labels_delegated_plan_questions() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
+            payload: None,
         }],
     };
     app.record_local_request_input(
@@ -349,6 +361,7 @@ fn active_turn_cell_labels_delegated_completed_questions() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
+            payload: None,
         }],
     };
     app.record_completed_interaction(

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -240,6 +240,75 @@ fn committed_turn_cell_renders_terminal_result_as_terminal_cell() {
 }
 
 #[test]
+fn committed_turn_cell_renders_terminal_result_with_inline_output_path() {
+    let entries = vec![
+        TranscriptEntry {
+            role: "You".into(),
+            message: "Run tests in the background".into(),
+        },
+        TranscriptEntry {
+            role: "Tool Result".into(),
+            message:
+                "background task bash-123 running\noutput: /tmp/rara/background-tasks/bash-123.log"
+                    .into(),
+        },
+    ];
+
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Running background bash-123"));
+    assert!(rendered.contains("/tmp/rara/background-tasks/bash-123.log"));
+    assert!(!rendered.contains("background bash-123 running"));
+}
+
+#[test]
+fn committed_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
+    let entries = vec![
+        TranscriptEntry {
+            role: "You".into(),
+            message: "Run tests in the background".into(),
+        },
+        TranscriptEntry {
+            role: TERMINAL_EVENT_ROLE.into(),
+            message: serde_json::to_string(&TerminalEvent::End(TerminalCommandEvent {
+                target: TerminalTarget::BackgroundTask,
+                id: Some("bash-123".into()),
+                status: "completed".into(),
+                command: Some("cargo test".into()),
+                exit_code: Some(0),
+                output: vec!["compile".into(), "running tests".into(), "ok".into()],
+                output_path: None,
+                is_error: false,
+            }))
+            .expect("terminal event json"),
+        },
+        TranscriptEntry {
+            role: "Agent".into(),
+            message: "The background test task completed.".into(),
+        },
+    ];
+
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Ran background cargo test"));
+    assert!(rendered.contains("└ compile"));
+    assert!(rendered.contains("running tests"));
+    assert!(rendered.contains("ok"));
+    assert!(rendered.contains("• The background test task completed."));
+    assert!(!rendered.contains(TERMINAL_EVENT_ROLE));
+}
+
+#[test]
 fn committed_turn_cell_keeps_final_agent_response_when_system_notice_arrives_after_tool_turn() {
     let entries = vec![
         TranscriptEntry {

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -6,18 +6,22 @@ fn committed_turn_cell_keeps_user_summary_and_agent_sections_in_order() {
         TranscriptEntry {
             role: "You".into(),
             message: "Review this repo".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Tool".into(),
             message: "list_files .".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Tool".into(),
             message: "bash cargo check".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Agent".into(),
             message: "Final recommendation".into(),
+            payload: None,
         },
     ];
 
@@ -43,14 +47,17 @@ fn committed_turn_cell_ignores_routine_system_notices() {
         TranscriptEntry {
             role: "You".into(),
             message: "Review this repo".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Agent".into(),
             message: "Final recommendation".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "System".into(),
             message: "prompt finished".into(),
+            payload: None,
         },
     ];
 
@@ -69,26 +76,22 @@ fn committed_turn_cell_ignores_routine_system_notices() {
 #[test]
 fn committed_turn_cell_renders_materialized_sidecar_sections() {
     let entries = vec![
-        TranscriptEntry {
-            role: "You".into(),
-            message: "Review the workspace logic".into(),
-        },
+        TranscriptEntry { role: "You".into(), message: "Review the workspace logic".into(), payload: None },
         TranscriptEntry {
             role: "Exploring".into(),
             message:
                 "Delegate repository exploration: inspect instruction discovery\nSub-agent summary: current discovery is hardcoded"
                     .into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Planning".into(),
             message:
                 "Delegate plan refinement: generalize instruction discovery\nSub-agent summary: reuse the workspace traversal helper"
                     .into(),
+            payload: None,
         },
-        TranscriptEntry {
-            role: "Agent".into(),
-            message: "Here is the final recommendation.".into(),
-        },
+        TranscriptEntry { role: "Agent".into(), message: "Here is the final recommendation.".into(), payload: None },
     ];
 
     let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
@@ -115,24 +118,16 @@ fn committed_turn_cell_renders_materialized_sidecar_sections() {
 #[test]
 fn committed_turn_cell_places_completion_records_before_final_agent_message() {
     let entries = vec![
-        TranscriptEntry {
-            role: "You".into(),
-            message: "Inspect the repo and decide whether to run the migration".into(),
-        },
-        TranscriptEntry {
-            role: "Exploring".into(),
-            message: "└ Read crates/instructions/src/workspace.rs".into(),
-        },
-        TranscriptEntry {
-            role: "Shell Approval Completed".into(),
-            message: "Bash approval: Approved once for command: bash ./scripts/migrate.sh"
-                .into(),
-        },
+        TranscriptEntry { role: "You".into(), message: "Inspect the repo and decide whether to run the migration".into(), payload: None },
+        TranscriptEntry { role: "Exploring".into(), message: "└ Read crates/instructions/src/workspace.rs".into(), payload: None },
+        TranscriptEntry { role: "Shell Approval Completed".into(), message: "Bash approval: Approved once for command: bash ./scripts/migrate.sh"
+                .into(), payload: None },
         TranscriptEntry {
             role: "Agent".into(),
             message:
                 "I approved the one-off shell step and can now continue with the final recommendation."
                     .into(),
+            payload: None,
         },
     ];
 
@@ -159,26 +154,32 @@ fn committed_turn_cell_orders_completion_records_by_interaction_kind() {
         TranscriptEntry {
             role: "You".into(),
             message: "Inspect the workflow and capture the decision trail".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Question Answered".into(),
             message: "Captured the generic answer.".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Plan Decision".into(),
             message: "Approved the proposed implementation plan.".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Shell Approval Completed".into(),
             message: "Approved the one-off shell command.".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Planning Question Answered".into(),
             message: "Chose the plan_agent option.".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Agent".into(),
             message: "Here is the final narrative summary.".into(),
+            payload: None,
         },
     ];
 
@@ -206,22 +207,10 @@ fn committed_turn_cell_orders_completion_records_by_interaction_kind() {
 #[test]
 fn committed_turn_cell_renders_terminal_result_as_terminal_cell() {
     let entries = vec![
-        TranscriptEntry {
-            role: "You".into(),
-            message: "Run tests in the background".into(),
-        },
-        TranscriptEntry {
-            role: "Tool".into(),
-            message: "background_task_status bash-123".into(),
-        },
-        TranscriptEntry {
-            role: "Tool Result".into(),
-            message: "background task bash-123 completed: cargo test\nexit_code: 0\noutput:\ncompile\nrunning tests\nok".into(),
-        },
-        TranscriptEntry {
-            role: "Agent".into(),
-            message: "The background test task completed.".into(),
-        },
+        TranscriptEntry { role: "You".into(), message: "Run tests in the background".into(), payload: None },
+        TranscriptEntry { role: "Tool".into(), message: "background_task_status bash-123".into(), payload: None },
+        TranscriptEntry { role: "Tool Result".into(), message: "background task bash-123 completed: cargo test\nexit_code: 0\noutput:\ncompile\nrunning tests\nok".into(), payload: None },
+        TranscriptEntry { role: "Agent".into(), message: "The background test task completed.".into(), payload: None },
     ];
 
     let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
@@ -245,12 +234,14 @@ fn committed_turn_cell_renders_terminal_result_with_inline_output_path() {
         TranscriptEntry {
             role: "You".into(),
             message: "Run tests in the background".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Tool Result".into(),
             message:
                 "background task bash-123 running\noutput: /tmp/rara/background-tasks/bash-123.log"
                     .into(),
+            payload: None,
         },
     ];
 
@@ -272,24 +263,22 @@ fn committed_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
         TranscriptEntry {
             role: "You".into(),
             message: "Run tests in the background".into(),
+            payload: None,
         },
-        TranscriptEntry {
-            role: TERMINAL_EVENT_ROLE.into(),
-            message: serde_json::to_string(&TerminalEvent::End(TerminalCommandEvent {
-                target: TerminalTarget::BackgroundTask,
-                id: Some("bash-123".into()),
-                status: "completed".into(),
-                command: Some("cargo test".into()),
-                exit_code: Some(0),
-                output: vec!["compile".into(), "running tests".into(), "ok".into()],
-                output_path: None,
-                is_error: false,
-            }))
-            .expect("terminal event json"),
-        },
+        TranscriptEntry::terminal_event(TerminalEvent::End(TerminalCommandEvent {
+            target: TerminalTarget::BackgroundTask,
+            id: Some("bash-123".into()),
+            status: "completed".into(),
+            command: Some("cargo test".into()),
+            exit_code: Some(0),
+            output: vec!["compile".into(), "running tests".into(), "ok".into()],
+            output_path: None,
+            is_error: false,
+        })),
         TranscriptEntry {
             role: "Agent".into(),
             message: "The background test task completed.".into(),
+            payload: None,
         },
     ];
 
@@ -305,7 +294,7 @@ fn committed_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
     assert!(rendered.contains("running tests"));
     assert!(rendered.contains("ok"));
     assert!(rendered.contains("• The background test task completed."));
-    assert!(!rendered.contains(TERMINAL_EVENT_ROLE));
+    assert!(!rendered.contains("Terminal Event"));
 }
 
 #[test]
@@ -314,18 +303,22 @@ fn committed_turn_cell_keeps_final_agent_response_when_system_notice_arrives_aft
         TranscriptEntry {
             role: "You".into(),
             message: "Inspect the repository and summarize the result".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Tool".into(),
             message: "bash cargo check".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Agent".into(),
             message: "The repository is healthy and the check passed.".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "System".into(),
             message: "Waiting for device-code confirmation.".into(),
+            payload: None,
         },
     ];
 

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -204,6 +204,42 @@ fn committed_turn_cell_orders_completion_records_by_interaction_kind() {
 }
 
 #[test]
+fn committed_turn_cell_renders_terminal_result_as_terminal_cell() {
+    let entries = vec![
+        TranscriptEntry {
+            role: "You".into(),
+            message: "Run tests in the background".into(),
+        },
+        TranscriptEntry {
+            role: "Tool".into(),
+            message: "background_task_status bash-123".into(),
+        },
+        TranscriptEntry {
+            role: "Tool Result".into(),
+            message: "background task bash-123 completed: cargo test\nexit_code: 0\noutput:\ncompile\nrunning tests\nok".into(),
+        },
+        TranscriptEntry {
+            role: "Agent".into(),
+            message: "The background test task completed.".into(),
+        },
+    ];
+
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Ran background cargo test"));
+    assert!(rendered.contains("└ compile"));
+    assert!(rendered.contains("running tests"));
+    assert!(rendered.contains("ok"));
+    assert!(rendered.contains("• The background test task completed."));
+    assert!(!rendered.contains("background_task_status bash-123"));
+}
+
+#[test]
 fn committed_turn_cell_keeps_final_agent_response_when_system_notice_arrives_after_tool_turn() {
     let entries = vec![
         TranscriptEntry {

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -34,6 +34,7 @@ fn committed_turn_does_not_truncate_agent_response() {
         TranscriptEntry {
             role: "You".into(),
             message: "Review the code".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Agent".into(),
@@ -41,6 +42,7 @@ fn committed_turn_does_not_truncate_agent_response() {
                 .map(|idx| format!("Line {idx}"))
                 .collect::<Vec<_>>()
                 .join("\n"),
+            payload: None,
         },
     ];
 
@@ -66,6 +68,7 @@ fn keeps_history_reserve_once_transcript_exists() {
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Earlier prompt".into(),
+            payload: None,
         }],
     });
 
@@ -110,10 +113,12 @@ fn transcript_render_stays_above_bottom_pane() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Show output".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "TRANSCRIPT_SENTINEL".into(),
+                payload: None,
             },
         ],
     });
@@ -167,6 +172,7 @@ fn tool_summary_includes_apply_patch_target_files() {
     let entries = vec![TranscriptEntry {
         role: "Tool".into(),
         message: "apply_patch src/tui/render.rs, src/tui/runtime/events.rs".into(),
+        payload: None,
     }];
     let refs = entries.iter().collect::<Vec<_>>();
 
@@ -177,14 +183,8 @@ fn tool_summary_includes_apply_patch_target_files() {
 #[test]
 fn tool_summary_includes_bash_result_status_and_output_tail() {
     let entries = vec![
-        TranscriptEntry {
-            role: "Tool".into(),
-            message: "bash cd /Users/vl/Code/rara && cargo build 2>&1".into(),
-        },
-        TranscriptEntry {
-            role: "Tool Result".into(),
-            message: "bash failed with exit code 101\nstdout:\n   Compiling rara v0.1.0\nstderr:\nerror[E0425]: cannot find value `foo` in this scope".into(),
-        },
+        TranscriptEntry { role: "Tool".into(), message: "bash cd /Users/vl/Code/rara && cargo build 2>&1".into(), payload: None },
+        TranscriptEntry { role: "Tool Result".into(), message: "bash failed with exit code 101\nstdout:\n   Compiling rara v0.1.0\nstderr:\nerror[E0425]: cannot find value `foo` in this scope".into(), payload: None },
     ];
     let refs = entries.iter().collect::<Vec<_>>();
 
@@ -207,6 +207,7 @@ fn tool_summary_compacts_spawn_agent_instruction_json() {
                 "instruction": "Fix the file src/context/assembler.rs by removing the orphaned code block between the two cfg(test) markers. Read in small chunks and avoid one giant replacement payload."
             })
         ),
+        payload: None,
     }];
     let refs = entries.iter().collect::<Vec<_>>();
 
@@ -229,16 +230,19 @@ fn renderable_transcript_lines_include_committed_and_active_turns() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Earlier prompt".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "Committed answer".into(),
+                payload: None,
             },
         ],
     });
     app.active_turn.entries.push(TranscriptEntry {
         role: "You".into(),
         message: "Current prompt".into(),
+        payload: None,
     });
 
     let rendered = renderable_transcript_lines(&app, 100)
@@ -264,18 +268,21 @@ fn renderable_transcript_lines_insert_turn_dividers_between_rounds() {
             entries: vec![TranscriptEntry {
                 role: "You".into(),
                 message: "First prompt".into(),
+                payload: None,
             }],
         },
         TranscriptTurn {
             entries: vec![TranscriptEntry {
                 role: "Agent".into(),
                 message: "Second reply".into(),
+                payload: None,
             }],
         },
     ];
     app.active_turn.entries.push(TranscriptEntry {
         role: "You".into(),
         message: "Current prompt".into(),
+        payload: None,
     });
 
     let rendered = renderable_transcript_lines(&app, 24)
@@ -359,6 +366,7 @@ fn renderable_transcript_lines_cache_is_invalidated_when_committed_turns_change(
         entries: vec![TranscriptEntry {
             role: "Agent".into(),
             message: "First answer".into(),
+            payload: None,
         }],
     }]);
 
@@ -373,6 +381,7 @@ fn renderable_transcript_lines_cache_is_invalidated_when_committed_turns_change(
         entries: vec![TranscriptEntry {
             role: "Agent".into(),
             message: "Second answer".into(),
+            payload: None,
         }],
     }]);
 
@@ -397,16 +406,19 @@ fn transcript_viewport_is_independent_from_overlay_state() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Earlier prompt".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "Committed answer".into(),
+                payload: None,
             },
         ],
     });
     app.active_turn.entries.push(TranscriptEntry {
         role: "You".into(),
         message: "Current prompt".into(),
+        payload: None,
     });
 
     let base = transcript_viewport(&app, 80, 18);
@@ -440,6 +452,7 @@ fn transcript_viewport_keeps_manual_scroll_when_overlay_opens() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "Earlier prompt".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
@@ -447,6 +460,7 @@ fn transcript_viewport_keeps_manual_scroll_when_overlay_opens() {
                     .map(|idx| format!("Line {idx}"))
                     .collect::<Vec<_>>()
                     .join("\n"),
+                payload: None,
             },
         ],
     });
@@ -572,22 +586,27 @@ fn exploration_summary_only_keeps_read_actions() {
         TranscriptEntry {
             role: "Tool".into(),
             message: "list_files .".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Tool".into(),
             message: "glob src/**/*.rs".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Tool".into(),
             message: "grep planning mode src".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Tool".into(),
             message: "read_file src/main.rs".into(),
+            payload: None,
         },
         TranscriptEntry {
             role: "Agent".into(),
             message: "I will start by listing files and then inspect the main entrypoint.".into(),
+            payload: None,
         },
     ];
     let refs = entries.iter().collect::<Vec<_>>();
@@ -653,6 +672,7 @@ fn exploration_summary_compacts_long_read_lists() {
         .map(|idx| TranscriptEntry {
             role: "Tool".into(),
             message: format!("read_file src/module_{idx}.rs"),
+            payload: None,
         })
         .collect::<Vec<_>>();
     let refs = entries.iter().collect::<Vec<_>>();

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -4,7 +4,7 @@ mod tasks;
 
 use std::sync::Arc;
 
-use crate::agent::{Agent, BashApprovalMode};
+use crate::agent::{Agent, BashApprovalDecision};
 use crate::oauth::OAuthManager;
 
 use super::state::{LocalCommand, OAuthLoginMode, TuiApp};
@@ -30,7 +30,11 @@ pub fn should_suggest_planning_mode(app: &TuiApp, prompt: &str) -> bool {
     tasks::should_suggest_planning_mode(app, prompt)
 }
 
-pub fn start_pending_approval_task(app: &mut TuiApp, selection: BashApprovalMode, agent: Agent) {
+pub fn start_pending_approval_task(
+    app: &mut TuiApp,
+    selection: BashApprovalDecision,
+    agent: Agent,
+) {
     tasks::start_pending_approval_task(app, selection, agent);
 }
 

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -10,7 +10,7 @@ use self::helpers::{
 };
 use super::super::state::{contains_structured_planning_output, RuntimePhase, TuiApp, TuiEvent};
 use crate::agent::AgentEvent;
-use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
+use crate::tui::terminal_event::{TerminalEvent, TerminalTarget, TERMINAL_EVENT_ROLE};
 
 const TOOL_PROGRESS_LINE_LIMIT: usize = 16;
 
@@ -219,7 +219,8 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                 RuntimePhase::RunningTool,
                 Some(message.lines().next().unwrap_or(role).trim().to_string()),
             );
-            app.push_entry(role, message);
+            let payload = serde_json::to_string(&event).unwrap_or(message);
+            app.push_entry(TERMINAL_EVENT_ROLE, payload);
         }
         TuiEvent::ToolProgress {
             name,

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -10,7 +10,7 @@ use self::helpers::{
 };
 use super::super::state::{contains_structured_planning_output, RuntimePhase, TuiApp, TuiEvent};
 use crate::agent::AgentEvent;
-use crate::tui::terminal_event::{TerminalEvent, TerminalTarget, TERMINAL_EVENT_ROLE};
+use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
 const TOOL_PROGRESS_LINE_LIMIT: usize = 16;
 
@@ -219,8 +219,7 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                 RuntimePhase::RunningTool,
                 Some(message.lines().next().unwrap_or(role).trim().to_string()),
             );
-            let payload = serde_json::to_string(&event).unwrap_or(message);
-            app.push_entry(TERMINAL_EVENT_ROLE, payload);
+            app.push_terminal_event(event);
         }
         TuiEvent::ToolProgress {
             name,

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -10,6 +10,7 @@ use self::helpers::{
 };
 use super::super::state::{contains_structured_planning_output, RuntimePhase, TuiApp, TuiEvent};
 use crate::agent::AgentEvent;
+use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
 const TOOL_PROGRESS_LINE_LIMIT: usize = 16;
 
@@ -190,6 +191,36 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
             }
             app.push_entry(role, message)
         }
+        TuiEvent::Terminal(TerminalEvent::OutputDelta(event)) => {
+            let name = match event.target {
+                TerminalTarget::Pty => "pty",
+                TerminalTarget::BackgroundTask => "background task",
+            };
+            if !append_tool_progress(app, name, event.stream.into(), &event.chunk) {
+                return;
+            }
+            app.set_runtime_phase(
+                RuntimePhase::RunningTool,
+                Some(format!("streaming {name} output")),
+            );
+        }
+        TuiEvent::Terminal(event) => {
+            let role = event.transcript_role();
+            let message = event.to_transcript_message();
+            if role == "Tool" {
+                if let Some(action) = tool_action_label(&message) {
+                    app.record_running_action(action);
+                }
+            }
+            if matches!(role, "Tool Result" | "Tool Error") {
+                app.advance_running_tool_boundary();
+            }
+            app.set_runtime_phase(
+                RuntimePhase::RunningTool,
+                Some(message.lines().next().unwrap_or(role).trim().to_string()),
+            );
+            app.push_entry(role, message);
+        }
         TuiEvent::ToolProgress {
             name,
             stream,
@@ -220,10 +251,15 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
             role: "Agent Delta",
             message: text,
         }),
-        AgentEvent::ToolUse { name, input } => Some(TuiEvent::Transcript {
-            role: "Tool",
-            message: format_tool_use(&name, &input),
-        }),
+        AgentEvent::ToolUse { name, input } => {
+            if let Some(event) = TerminalEvent::from_tool_use(&name, &input) {
+                return Some(TuiEvent::Terminal(event));
+            }
+            Some(TuiEvent::Transcript {
+                role: "Tool",
+                message: format_tool_use(&name, &input),
+            })
+        }
         AgentEvent::ToolResult {
             name,
             content,
@@ -231,6 +267,9 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
         } => {
             if is_exploration_tool_name(&name) {
                 return None;
+            }
+            if let Some(event) = TerminalEvent::from_tool_result(&name, &content, is_error) {
+                return Some(TuiEvent::Terminal(event));
             }
             Some(TuiEvent::Transcript {
                 role: if is_error {
@@ -245,11 +284,15 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
             name,
             stream,
             chunk,
-        } => Some(TuiEvent::ToolProgress {
-            name,
-            stream,
-            chunk,
-        }),
+        } => TerminalEvent::from_tool_progress(&name, stream, &chunk)
+            .map(TuiEvent::Terminal)
+            .or_else(|| {
+                Some(TuiEvent::ToolProgress {
+                    name,
+                    stream,
+                    chunk,
+                })
+            }),
     }
 }
 

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -3,6 +3,9 @@ use std::borrow::Cow;
 use crate::tool::ToolOutputStream;
 use crate::tools::bash::BashCommandInput;
 use crate::tui::state::TuiApp;
+use crate::tui::terminal_event::{
+    output_tail_preview as terminal_output_tail_preview, TerminalEvent,
+};
 use crate::tui::tool_text::{compact_delegate_rest, compact_instruction};
 
 pub(super) fn is_oauth_prompt_message(message: &str) -> bool {
@@ -414,8 +417,55 @@ pub(super) fn format_tool_use(name: &str, input: &serde_json::Value) -> String {
         "plan_agent" => format_instruction_tool_use("plan_agent", input),
         "spawn_agent" => format_spawn_agent_use(input),
         "apply_patch" => format_apply_patch_use(input),
+        "pty_start" => input
+            .get("command")
+            .and_then(serde_json::Value::as_str)
+            .map(|command| format!("pty_start {}", compact_instruction(command)))
+            .unwrap_or_else(|| format!("{name} {input}")),
+        "pty_read" | "pty_status" | "pty_write" | "pty_kill" | "pty_stop" => {
+            format_session_tool_use(name, input, "session_id")
+        }
+        "background_task_status" | "background_task_stop" => {
+            format_session_tool_use(name, input, "task_id")
+        }
+        "background_task_list" | "pty_list" => name.to_string(),
         _ => format!("{name} {input}"),
     }
+}
+
+fn format_session_tool_use(name: &str, input: &serde_json::Value, id_key: &str) -> String {
+    let id = input
+        .get(id_key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if name == "pty_write" {
+        let preview = input
+            .get("input")
+            .and_then(serde_json::Value::as_str)
+            .map(summarize_terminal_input);
+        return match (id, preview) {
+            (Some(id), Some(preview)) => format!("{name} {id}: {preview}"),
+            (Some(id), None) => format!("{name} {id}"),
+            _ => format!("{name} {input}"),
+        };
+    }
+    match id {
+        Some(id) => format!("{name} {id}"),
+        None if name == "pty_stop" || name == "background_task_stop" => name.to_string(),
+        None => format!("{name} {input}"),
+    }
+}
+
+fn summarize_terminal_input(input: &str) -> String {
+    const MAX_CHARS: usize = 80;
+    let normalized = input.replace('\n', "\\n").replace('\r', "\\r");
+    if normalized.chars().count() <= MAX_CHARS {
+        return normalized;
+    }
+    let mut truncated = normalized.chars().take(MAX_CHARS).collect::<String>();
+    truncated.push('…');
+    truncated
 }
 
 fn format_replace_lines_use(input: &serde_json::Value) -> String {
@@ -544,6 +594,9 @@ pub(super) fn format_tool_result(name: &str, content: &str) -> String {
             return content.trim().to_string();
         }
         return format!("{name} {}", first_non_empty_line(content));
+    }
+    if let Some(event) = TerminalEvent::from_tool_result(name, content, false) {
+        return event.to_transcript_message();
     }
     if name == "bash" {
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
@@ -809,25 +862,7 @@ fn append_path_group(lines: &mut Vec<String>, label: &str, value: Option<&serde_
 }
 
 fn output_tail_preview(output: &str) -> Option<String> {
-    let lines = output
-        .lines()
-        .map(str::trim_end)
-        .filter(|line| !line.trim().is_empty())
-        .collect::<Vec<_>>();
-    if lines.is_empty() {
-        return None;
-    }
-
-    let preview = lines
-        .iter()
-        .rev()
-        .take(6)
-        .copied()
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .collect::<Vec<_>>();
-    Some(preview.join("\n"))
+    terminal_output_tail_preview(output).map(|lines| lines.join("\n"))
 }
 
 fn format_write_file_result(value: &serde_json::Value) -> String {

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -10,8 +10,9 @@ use super::{apply_tui_event, convert_agent_event};
 use crate::agent::{AgentEvent, AgentExecutionMode};
 use crate::config::ConfigManager;
 use crate::tool::ToolOutputStream;
+use crate::tui::state::TranscriptEntryPayload;
 use crate::tui::state::{RuntimePhase, TuiApp, TuiEvent};
-use crate::tui::terminal_event::{TerminalEvent, TerminalTarget, TERMINAL_EVENT_ROLE};
+use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
 #[test]
 fn parses_delegated_request_input_from_subagent_result() {
@@ -467,11 +468,9 @@ fn applies_terminal_begin_event_as_running_action() {
         vec!["Run cargo test".to_string()]
     );
     assert_eq!(app.active_turn.entries.len(), 1);
-    assert_eq!(app.active_turn.entries[0].role, TERMINAL_EVENT_ROLE);
-    let event = serde_json::from_str::<TerminalEvent>(&app.active_turn.entries[0].message)
-        .expect("terminal event payload");
-    match event {
-        TerminalEvent::Begin(command) => {
+    assert_eq!(app.active_turn.entries[0].role, "Terminal Event");
+    match app.active_turn.entries[0].payload.as_ref() {
+        Some(TranscriptEntryPayload::Terminal(TerminalEvent::Begin(command))) => {
             assert_eq!(command.target, TerminalTarget::BackgroundTask);
             assert_eq!(command.command.as_deref(), Some("cargo test"));
         }

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -1,16 +1,17 @@
 use serde_json::json;
 use tempfile::tempdir;
 
-use super::apply_tui_event;
 use super::helpers::{
     format_apply_patch_result, format_apply_patch_use, format_tool_progress, format_tool_result,
     format_tool_use, is_oauth_prompt_message, planning_note_lines, scrub_internal_control_tokens,
     subagent_request_input,
 };
-use crate::agent::AgentExecutionMode;
+use super::{apply_tui_event, convert_agent_event};
+use crate::agent::{AgentEvent, AgentExecutionMode};
 use crate::config::ConfigManager;
 use crate::tool::ToolOutputStream;
 use crate::tui::state::{RuntimePhase, TuiApp, TuiEvent};
+use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
 #[test]
 fn parses_delegated_request_input_from_subagent_result() {
@@ -300,6 +301,174 @@ fn formats_live_bash_tool_result_without_duplicate_tail() {
     assert!(rendered.contains("bash finished with exit code 0"));
     assert!(rendered.contains("output streamed above"));
     assert!(!rendered.contains("stdout:"));
+}
+
+#[test]
+fn formats_background_bash_start_as_task_summary() {
+    let rendered = format_tool_result(
+        "bash",
+        &json!({
+            "exit_code": null,
+            "live_streamed": false,
+            "background_task_id": "bash-123",
+            "output_path": "/tmp/rara/background-tasks/bash-123.log",
+            "status": "running"
+        })
+        .to_string(),
+    );
+
+    assert_eq!(
+        rendered,
+        "background task bash-123 running\noutput: /tmp/rara/background-tasks/bash-123.log"
+    );
+}
+
+#[test]
+fn formats_pty_result_with_sanitized_output_tail() {
+    let rendered = format_tool_result(
+        "pty_status",
+        &json!({
+            "session_id": "pty-123",
+            "command": "npm run dev",
+            "status": "running",
+            "output": "\u{1b}[32mready\u{1b}[0m\r\nline 2\nline 3\nline 4\nline 5\nline 6\nline 7\n"
+        })
+        .to_string(),
+    );
+
+    assert!(rendered.starts_with("pty pty-123 running: npm run dev"));
+    assert!(rendered.contains("output:"));
+    assert!(rendered.contains("line 7"));
+    assert!(rendered.contains("line 2"));
+    assert!(!rendered.contains("ready"));
+    assert!(!rendered.contains('\u{1b}'));
+}
+
+#[test]
+fn formats_background_task_status_with_output_tail() {
+    let rendered = format_tool_result(
+        "background_task_status",
+        &json!({
+            "task_id": "bash-123",
+            "command": "cargo test",
+            "status": "completed",
+            "exit_code": 0,
+            "output": "build\nrunning\nok\n"
+        })
+        .to_string(),
+    );
+
+    assert_eq!(
+        rendered,
+        "background task bash-123 completed: cargo test\nexit_code: 0\noutput:\nbuild\nrunning\nok"
+    );
+}
+
+#[test]
+fn formats_terminal_list_and_stop_results() {
+    let listed = format_tool_result(
+        "pty_list",
+        &json!({
+            "sessions": [
+                {
+                    "session_id": "pty-1",
+                    "command": "python repl.py",
+                    "status": "running"
+                }
+            ]
+        })
+        .to_string(),
+    );
+    assert_eq!(
+        listed,
+        "pty sessions: 1\n  pty pty-1 running: python repl.py"
+    );
+
+    let stopped = format_tool_result(
+        "background_task_stop",
+        &json!({
+            "stopped": [
+                {
+                    "id": "bash-1",
+                    "command": "sleep 10",
+                    "status": "killed"
+                }
+            ]
+        })
+        .to_string(),
+    );
+    assert_eq!(
+        stopped,
+        "background task stopped: 1\n  background task bash-1 killed: sleep 10"
+    );
+}
+
+#[test]
+fn formats_terminal_tool_use_without_dumping_json() {
+    let rendered = format_tool_use(
+        "pty_write",
+        &json!({
+            "session_id": "pty-123",
+            "input": "hello\n"
+        }),
+    );
+
+    assert_eq!(rendered, "pty_write pty-123: hello\\n");
+}
+
+#[test]
+fn converts_terminal_tool_result_to_typed_event() {
+    let event = convert_agent_event(AgentEvent::ToolResult {
+        name: "pty_status".to_string(),
+        content: json!({
+            "session_id": "pty-123",
+            "command": "cargo test",
+            "status": "completed",
+            "output": "ok\n"
+        })
+        .to_string(),
+        is_error: false,
+    })
+    .expect("tui event");
+
+    match event {
+        TuiEvent::Terminal(TerminalEvent::End(command)) => {
+            assert_eq!(command.target, TerminalTarget::Pty);
+            assert_eq!(command.id.as_deref(), Some("pty-123"));
+            assert_eq!(command.status, "completed");
+            assert_eq!(command.command.as_deref(), Some("cargo test"));
+            assert_eq!(command.output, vec!["ok".to_string()]);
+        }
+        _ => panic!("unexpected event"),
+    }
+}
+
+#[test]
+fn applies_terminal_begin_event_as_running_action() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+
+    let event = convert_agent_event(AgentEvent::ToolUse {
+        name: "bash".to_string(),
+        input: json!({
+            "command": "cargo test",
+            "run_in_background": true
+        }),
+    })
+    .expect("tui event");
+
+    apply_tui_event(&mut app, event);
+
+    assert_eq!(
+        app.active_live.running_actions,
+        vec!["Run cargo test".to_string()]
+    );
+    assert_eq!(app.active_turn.entries.len(), 1);
+    assert_eq!(app.active_turn.entries[0].role, "Tool");
+    assert_eq!(app.active_turn.entries[0].message, "bash cargo test");
 }
 
 #[test]

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -11,7 +11,7 @@ use crate::agent::{AgentEvent, AgentExecutionMode};
 use crate::config::ConfigManager;
 use crate::tool::ToolOutputStream;
 use crate::tui::state::{RuntimePhase, TuiApp, TuiEvent};
-use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
+use crate::tui::terminal_event::{TerminalEvent, TerminalTarget, TERMINAL_EVENT_ROLE};
 
 #[test]
 fn parses_delegated_request_input_from_subagent_result() {
@@ -467,8 +467,16 @@ fn applies_terminal_begin_event_as_running_action() {
         vec!["Run cargo test".to_string()]
     );
     assert_eq!(app.active_turn.entries.len(), 1);
-    assert_eq!(app.active_turn.entries[0].role, "Tool");
-    assert_eq!(app.active_turn.entries[0].message, "bash cargo test");
+    assert_eq!(app.active_turn.entries[0].role, TERMINAL_EVENT_ROLE);
+    let event = serde_json::from_str::<TerminalEvent>(&app.active_turn.entries[0].message)
+        .expect("terminal event payload");
+    match event {
+        TerminalEvent::Begin(command) => {
+            assert_eq!(command.target, TerminalTarget::BackgroundTask);
+            assert_eq!(command.command.as_deref(), Some("cargo test"));
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
 }
 
 #[test]

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -15,7 +15,7 @@ use rara_provider_catalog::{
 };
 use tokio::sync::mpsc;
 
-use crate::agent::{Agent, AgentOutputMode, BashApprovalMode};
+use crate::agent::{Agent, AgentOutputMode, BashApprovalDecision};
 use crate::redaction::sanitize_url_for_display;
 
 use super::super::state::{
@@ -43,6 +43,7 @@ fn merge_rebuilt_agent(mut rebuilt: Agent, previous: Agent) -> Agent {
     rebuilt.tool_result_store = previous.tool_result_store;
     rebuilt.execution_mode = previous.execution_mode;
     rebuilt.bash_approval_mode = previous.bash_approval_mode;
+    rebuilt.approved_bash_prefixes = previous.approved_bash_prefixes;
     rebuilt.current_plan = previous.current_plan;
     rebuilt.plan_explanation = previous.plan_explanation;
     rebuilt.pending_user_input = previous.pending_user_input;
@@ -94,6 +95,25 @@ fn try_start_queued_follow_up(app: &mut TuiApp, agent_slot: &mut Option<Agent>) 
     start_query_task(app, prompt, agent);
 }
 
+fn sync_bash_prefixes_from_config(app: &TuiApp, agent: &mut Agent) {
+    let Ok(prefixes) = app.config_manager.load_allowed_command_prefixes() else {
+        return;
+    };
+    for prefix in prefixes {
+        if !agent.approved_bash_prefixes.contains(&prefix) {
+            agent.approved_bash_prefixes.push(prefix);
+        }
+    }
+}
+
+fn sync_bash_prefixes_to_config(app: &mut TuiApp, agent: &Agent) -> anyhow::Result<()> {
+    if !agent.approved_bash_prefixes.is_empty() {
+        app.config_manager
+            .save_allowed_command_prefixes(&agent.approved_bash_prefixes)?;
+    }
+    Ok(())
+}
+
 pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agent) {
     let (sender, receiver) = mpsc::unbounded_channel();
     let cancellation_token = Arc::new(AtomicBool::new(false));
@@ -102,6 +122,7 @@ pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agen
     app.begin_running_turn();
     agent.set_execution_mode(app.agent_execution_mode);
     agent.set_bash_approval_mode(app.bash_approval_mode);
+    sync_bash_prefixes_from_config(app, &mut agent);
     app.notice = Some("Running prompt.".into());
     app.set_runtime_phase(RuntimePhase::SendingPrompt, Some("sending prompt".into()));
     app.push_entry("You", prompt.clone());
@@ -229,21 +250,23 @@ pub(super) fn start_compact_task(app: &mut TuiApp, mut agent: Agent) {
 
 pub(super) fn start_pending_approval_task(
     app: &mut TuiApp,
-    selection: BashApprovalMode,
+    selection: BashApprovalDecision,
     mut agent: Agent,
 ) {
     let (sender, receiver) = mpsc::unbounded_channel();
     let cancellation_token = Arc::new(AtomicBool::new(false));
     let selection_label = match selection {
-        BashApprovalMode::Once => "run once",
-        BashApprovalMode::Always => "always allow bash",
-        BashApprovalMode::Suggestion => "suggestion only",
+        BashApprovalDecision::Once => "run once",
+        BashApprovalDecision::Prefix => "allow matching prefix",
+        BashApprovalDecision::Always => "always allow bash",
+        BashApprovalDecision::Suggestion => "suggestion only",
     };
     app.notice = Some(format!("Answering approval request: {selection_label}."));
     app.set_runtime_phase(
         RuntimePhase::ProcessingResponse,
         Some("resuming after approval".into()),
     );
+    sync_bash_prefixes_from_config(app, &mut agent);
     agent.set_cancellation_token(Some(cancellation_token.clone()));
 
     let handle = tokio::spawn(async move {
@@ -476,6 +499,12 @@ pub(super) async fn finish_running_task_if_ready(
     match completion {
         TaskCompletion::Query { agent, result } => {
             let mut agent = agent;
+            if let Err(err) = sync_bash_prefixes_to_config(app, &agent) {
+                app.push_notice(format!(
+                    "Failed to persist bash approval rules: {}",
+                    format_error_chain(&err)
+                ));
+            }
             match result {
                 Ok(_) => {
                     let finished_plan_turn = matches!(

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -120,6 +120,7 @@ fn merge_rebuilt_agent_preserves_session_and_turn_state() {
     previous.total_output_tokens = 45;
     previous.execution_mode = AgentExecutionMode::Plan;
     previous.bash_approval_mode = BashApprovalMode::Suggestion;
+    previous.approved_bash_prefixes = vec!["git push".to_string()];
     previous.current_plan = vec![PlanStep {
         step: "Keep session continuity".into(),
         status: PlanStepStatus::InProgress,
@@ -165,6 +166,7 @@ fn merge_rebuilt_agent_preserves_session_and_turn_state() {
     assert_eq!(merged.total_output_tokens, 45);
     assert_eq!(merged.execution_mode, AgentExecutionMode::Plan);
     assert_eq!(merged.bash_approval_mode, BashApprovalMode::Suggestion);
+    assert_eq!(merged.approved_bash_prefixes, vec!["git push".to_string()]);
     assert_eq!(merged.current_plan.len(), 1);
     assert_eq!(merged.compact_state.estimated_history_tokens, 1_200);
     assert_eq!(merged.compact_state.compaction_count, 2);

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -184,10 +184,7 @@ pub(super) fn restore_thread_by_id(
                 let entries = turn
                     .entries
                     .into_iter()
-                    .map(|entry| TranscriptEntry {
-                        role: entry.role,
-                        message: entry.message,
-                    })
+                    .map(|entry| TranscriptEntry::new(entry.role, entry.message))
                     .collect::<Vec<_>>();
                 turns.push(TranscriptTurn { entries });
             }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -20,7 +20,7 @@ pub use self::types::{
     LocalCommand, LocalCommandKind, OAuthLoginMode, OpenAiModelPickerAction, Overlay,
     PendingApprovalSnapshot, PendingInteractionSnapshot, ProviderFamily, RebuildSuccess,
     RunningTask, RuntimePhase, RuntimeSnapshot, TaskCompletion, TaskKind, TranscriptEntry,
-    TranscriptTurn, TuiApp, TuiEvent, PROVIDER_FAMILIES,
+    TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent, PROVIDER_FAMILIES,
 };
 
 const OPENAI_PROFILE_SETUP_KINDS: [OpenAiEndpointKind; 3] = [
@@ -411,7 +411,7 @@ impl TuiApp {
         if !exists {
             self.active_turn
                 .entries
-                .push(TranscriptEntry { role, message });
+                .push(TranscriptEntry::new(role, message));
         }
     }
 

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -140,6 +140,7 @@ fn finalize_agent_stream_keeps_manual_transcript_scroll_position() {
     app.active_turn.entries.push(TranscriptEntry {
         role: "Agent".into(),
         message: "draft".into(),
+        payload: None,
     });
 
     app.finalize_agent_stream(Some("final answer".into()));
@@ -645,10 +646,12 @@ fn finalize_agent_stream_updates_latest_committed_turn_when_final_text_arrives_l
             TranscriptEntry {
                 role: "You".into(),
                 message: "你好".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "你好！".into(),
+                payload: None,
             },
         ],
     });
@@ -685,18 +688,22 @@ fn finalize_agent_stream_replaces_earlier_agent_entries_in_active_turn() {
             TranscriptEntry {
                 role: "You".into(),
                 message: "你好".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "你好".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "System".into(),
                 message: "temporary runtime detail".into(),
+                payload: None,
             },
             TranscriptEntry {
                 role: "Agent".into(),
                 message: "你好！".into(),
+                payload: None,
             },
         ],
     };

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -4,6 +4,7 @@ use ratatui::text::Line;
 
 use super::{PendingFollowUpMessage, RuntimePhase, TranscriptEntry, TranscriptTurn, TuiApp};
 use crate::redaction::redact_secrets;
+use crate::tui::terminal_event::TerminalEvent;
 
 impl TuiApp {
     fn replace_turn_agent_message(turn: &mut TranscriptTurn, message: String) -> bool {
@@ -42,10 +43,16 @@ impl TuiApp {
         if role == "You" && !self.active_turn.entries.is_empty() {
             self.commit_active_turn();
         }
-        self.active_turn.entries.push(TranscriptEntry {
-            role: role.to_string(),
-            message,
-        });
+        self.active_turn
+            .entries
+            .push(TranscriptEntry::new(role, message));
+        self.reset_transcript_scroll_if_following_tail();
+    }
+
+    pub fn push_terminal_event(&mut self, event: TerminalEvent) {
+        self.active_turn
+            .entries
+            .push(TranscriptEntry::terminal_event(event));
         self.reset_transcript_scroll_if_following_tail();
     }
 
@@ -217,10 +224,9 @@ impl TuiApp {
             if lines.is_empty() {
                 continue;
             }
-            self.active_turn.entries.push(TranscriptEntry {
-                role: role.to_string(),
-                message: lines.join("\n"),
-            });
+            self.active_turn
+                .entries
+                .push(TranscriptEntry::new(role, lines.join("\n")));
         }
     }
 

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -303,6 +303,30 @@ pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 5] = [
 pub struct TranscriptEntry {
     pub role: String,
     pub message: String,
+    pub payload: Option<TranscriptEntryPayload>,
+}
+
+#[derive(Clone, Debug)]
+pub enum TranscriptEntryPayload {
+    Terminal(TerminalEvent),
+}
+
+impl TranscriptEntry {
+    pub fn new(role: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            role: role.into(),
+            message: message.into(),
+            payload: None,
+        }
+    }
+
+    pub fn terminal_event(event: TerminalEvent) -> Self {
+        Self {
+            role: "Terminal Event".to_string(),
+            message: event.to_transcript_message(),
+            payload: Some(TranscriptEntryPayload::Terminal(event)),
+        }
+    }
 }
 
 #[derive(Clone, Default)]

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -21,6 +21,7 @@ use crate::state_db::StateDb;
 use crate::thread_store::ThreadSummary;
 use crate::tool::ToolOutputStream;
 use crate::tools::bash::BashCommandInput;
+use crate::tui::terminal_event::TerminalEvent;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum HelpTab {
@@ -252,6 +253,7 @@ pub enum TuiEvent {
         role: &'static str,
         message: String,
     },
+    Terminal(TerminalEvent),
     ToolProgress {
         name: String,
         stream: ToolOutputStream,

--- a/src/tui/terminal_event.rs
+++ b/src/tui/terminal_event.rs
@@ -1,0 +1,552 @@
+use serde::{Deserialize, Serialize};
+
+use crate::tool::ToolOutputStream;
+use crate::tools::bash::BashCommandInput;
+use crate::tui::tool_text::compact_instruction;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TerminalTarget {
+    Pty,
+    BackgroundTask,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TerminalStream {
+    Stdout,
+    Stderr,
+}
+
+impl From<ToolOutputStream> for TerminalStream {
+    fn from(stream: ToolOutputStream) -> Self {
+        match stream {
+            ToolOutputStream::Stdout => Self::Stdout,
+            ToolOutputStream::Stderr => Self::Stderr,
+        }
+    }
+}
+
+impl From<TerminalStream> for ToolOutputStream {
+    fn from(stream: TerminalStream) -> Self {
+        match stream {
+            TerminalStream::Stdout => Self::Stdout,
+            TerminalStream::Stderr => Self::Stderr,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum TerminalEvent {
+    Begin(TerminalCommandEvent),
+    OutputDelta(TerminalOutputDeltaEvent),
+    End(TerminalCommandEvent),
+    List(TerminalCollectionEvent),
+    Stop(TerminalCollectionEvent),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TerminalCommandEvent {
+    pub target: TerminalTarget,
+    pub id: Option<String>,
+    pub status: String,
+    pub command: Option<String>,
+    pub exit_code: Option<i64>,
+    pub output: Vec<String>,
+    pub output_path: Option<String>,
+    pub is_error: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TerminalOutputDeltaEvent {
+    pub target: TerminalTarget,
+    pub id: Option<String>,
+    pub stream: TerminalStream,
+    pub chunk: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TerminalCollectionEvent {
+    pub target: TerminalTarget,
+    pub items: Vec<TerminalCommandEvent>,
+}
+
+impl TerminalEvent {
+    pub(crate) fn from_tool_use(name: &str, input: &serde_json::Value) -> Option<Self> {
+        match name {
+            "pty_start" => {
+                let command = input
+                    .get("command")
+                    .and_then(serde_json::Value::as_str)
+                    .map(compact_instruction);
+                Some(Self::Begin(TerminalCommandEvent::new(
+                    TerminalTarget::Pty,
+                    None,
+                    "starting",
+                    command,
+                )))
+            }
+            "bash" => {
+                let request = BashCommandInput::from_value(input.clone()).ok()?;
+                if !request.run_in_background {
+                    return None;
+                }
+                Some(Self::Begin(TerminalCommandEvent::new(
+                    TerminalTarget::BackgroundTask,
+                    None,
+                    "starting",
+                    Some(request.summary()),
+                )))
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn from_tool_progress(
+        name: &str,
+        stream: ToolOutputStream,
+        chunk: &str,
+    ) -> Option<Self> {
+        let target = match name {
+            "pty_start" | "pty_read" | "pty_status" | "pty_write" | "pty_kill" => {
+                TerminalTarget::Pty
+            }
+            "bash" | "background_task_status" => TerminalTarget::BackgroundTask,
+            _ => return None,
+        };
+        if chunk.trim().is_empty() {
+            return None;
+        }
+        Some(Self::OutputDelta(TerminalOutputDeltaEvent {
+            target,
+            id: None,
+            stream: stream.into(),
+            chunk: chunk.to_string(),
+        }))
+    }
+
+    pub(crate) fn from_tool_result(name: &str, content: &str, is_error: bool) -> Option<Self> {
+        let value = serde_json::from_str::<serde_json::Value>(content).ok()?;
+        match name {
+            "bash" => background_bash_start_event(&value, is_error).map(Self::End),
+            "pty_start" | "pty_read" | "pty_status" | "pty_kill" => {
+                Some(Self::End(pty_command_event(&value, is_error)))
+            }
+            "pty_list" => Some(Self::List(collection_event(
+                TerminalTarget::Pty,
+                value.get("sessions"),
+                is_error,
+            ))),
+            "pty_stop" => Some(Self::Stop(collection_event(
+                TerminalTarget::Pty,
+                value.get("stopped"),
+                is_error,
+            ))),
+            "background_task_status" => Some(Self::End(background_task_event(&value, is_error))),
+            "background_task_list" => Some(Self::List(collection_event(
+                TerminalTarget::BackgroundTask,
+                value.get("tasks"),
+                is_error,
+            ))),
+            "background_task_stop" => Some(Self::Stop(collection_event(
+                TerminalTarget::BackgroundTask,
+                value.get("stopped"),
+                is_error,
+            ))),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn transcript_role(&self) -> &'static str {
+        match self {
+            Self::Begin(_) | Self::OutputDelta(_) => "Tool",
+            Self::End(event) if event.is_error => "Tool Error",
+            Self::List(event) | Self::Stop(event)
+                if event.items.iter().any(|item| item.is_error) =>
+            {
+                "Tool Error"
+            }
+            Self::End(_) | Self::List(_) | Self::Stop(_) => "Tool Result",
+        }
+    }
+
+    pub(crate) fn to_transcript_message(&self) -> String {
+        match self {
+            Self::Begin(event) => {
+                let command = event
+                    .command
+                    .as_deref()
+                    .filter(|command| !command.is_empty())
+                    .unwrap_or("command");
+                format!("{} {}", event.tool_name(), command)
+            }
+            Self::OutputDelta(event) => {
+                let stream = match event.stream {
+                    TerminalStream::Stdout => "stdout",
+                    TerminalStream::Stderr => "stderr",
+                };
+                format!(
+                    "{} {stream}:\n{}",
+                    event.tool_name(),
+                    event.chunk.trim_end()
+                )
+            }
+            Self::End(event) => event.to_result_message(),
+            Self::List(event) => event.to_collection_message("list"),
+            Self::Stop(event) => event.to_collection_message("stop"),
+        }
+    }
+}
+
+impl TerminalCommandEvent {
+    fn new(
+        target: TerminalTarget,
+        id: Option<String>,
+        status: impl Into<String>,
+        command: Option<String>,
+    ) -> Self {
+        Self {
+            target,
+            id,
+            status: status.into(),
+            command,
+            exit_code: None,
+            output: Vec::new(),
+            output_path: None,
+            is_error: false,
+        }
+    }
+
+    fn tool_name(&self) -> &'static str {
+        match self.target {
+            TerminalTarget::Pty => "pty_start",
+            TerminalTarget::BackgroundTask => "bash",
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self.target {
+            TerminalTarget::Pty => "pty",
+            TerminalTarget::BackgroundTask => "background task",
+        }
+    }
+
+    fn to_result_message(&self) -> String {
+        let id = self.id.as_deref().unwrap_or("<unknown>");
+        let mut rendered = match self.command.as_deref() {
+            Some(command) if !command.is_empty() => {
+                format!("{} {id} {}: {command}", self.label(), self.status)
+            }
+            _ => format!("{} {id} {}", self.label(), self.status),
+        };
+        if let Some(exit_code) = self.exit_code {
+            rendered.push_str(&format!("\nexit_code: {exit_code}"));
+        }
+        if let Some(output_path) = self.output_path.as_deref() {
+            rendered.push_str(&format!("\noutput: {output_path}"));
+        } else if !self.output.is_empty() {
+            rendered.push_str("\noutput:\n");
+            rendered.push_str(&self.output.join("\n"));
+        }
+        rendered
+    }
+}
+
+impl TerminalOutputDeltaEvent {
+    fn tool_name(&self) -> &'static str {
+        match self.target {
+            TerminalTarget::Pty => "pty",
+            TerminalTarget::BackgroundTask => "background task",
+        }
+    }
+}
+
+impl TerminalCollectionEvent {
+    fn to_collection_message(&self, action: &str) -> String {
+        let label = match self.target {
+            TerminalTarget::Pty => "pty",
+            TerminalTarget::BackgroundTask => "background task",
+        };
+        let collection_label = match (self.target, action) {
+            (TerminalTarget::Pty, "list") => "pty sessions",
+            (TerminalTarget::BackgroundTask, "list") => "background tasks",
+            _ => label,
+        };
+        if self.items.is_empty() {
+            return match action {
+                "stop" => format!("{label} stopped: none"),
+                _ => format!("{collection_label}: none"),
+            };
+        }
+
+        let mut lines = match action {
+            "stop" => vec![format!("{label} stopped: {}", self.items.len())],
+            _ => vec![format!("{collection_label}: {}", self.items.len())],
+        };
+        for item in self.items.iter().take(6) {
+            let id = item.id.as_deref().unwrap_or("<unknown>");
+            let command = item.command.as_deref().unwrap_or("command unavailable");
+            lines.push(format!("  {label} {id} {}: {command}", item.status));
+        }
+        let remaining = self.items.len().saturating_sub(6);
+        if remaining > 0 {
+            lines.push(format!("... {remaining} more"));
+        }
+        lines.join("\n")
+    }
+}
+
+fn background_bash_start_event(
+    value: &serde_json::Value,
+    is_error: bool,
+) -> Option<TerminalCommandEvent> {
+    let task_id = value
+        .get("background_task_id")
+        .and_then(serde_json::Value::as_str)?;
+    let status = value
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+    let output_path = value
+        .get("output_path")
+        .and_then(serde_json::Value::as_str)
+        .map(ToString::to_string);
+    let mut event = TerminalCommandEvent::new(
+        TerminalTarget::BackgroundTask,
+        Some(task_id.to_string()),
+        status,
+        None,
+    );
+    event.output_path = output_path;
+    event.is_error = is_error;
+    Some(event)
+}
+
+fn pty_command_event(value: &serde_json::Value, is_error: bool) -> TerminalCommandEvent {
+    let mut event = TerminalCommandEvent::new(
+        TerminalTarget::Pty,
+        value
+            .get("session_id")
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string),
+        value
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown"),
+        value
+            .get("command")
+            .and_then(serde_json::Value::as_str)
+            .map(compact_instruction),
+    );
+    event.output = value
+        .get("output")
+        .and_then(serde_json::Value::as_str)
+        .and_then(output_tail_preview)
+        .unwrap_or_default();
+    event.is_error = is_error;
+    event
+}
+
+fn background_task_event(value: &serde_json::Value, is_error: bool) -> TerminalCommandEvent {
+    let mut event = TerminalCommandEvent::new(
+        TerminalTarget::BackgroundTask,
+        value
+            .get("task_id")
+            .or_else(|| value.get("id"))
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string),
+        value
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown"),
+        value
+            .get("command")
+            .and_then(serde_json::Value::as_str)
+            .map(compact_instruction),
+    );
+    event.exit_code = value.get("exit_code").and_then(serde_json::Value::as_i64);
+    event.output = value
+        .get("output")
+        .and_then(serde_json::Value::as_str)
+        .and_then(output_tail_preview)
+        .unwrap_or_default();
+    event.is_error = is_error;
+    event
+}
+
+fn collection_event(
+    target: TerminalTarget,
+    value: Option<&serde_json::Value>,
+    is_error: bool,
+) -> TerminalCollectionEvent {
+    let items = value
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+        .iter()
+        .map(|item| collection_item_event(target, item, is_error))
+        .collect::<Vec<_>>();
+    TerminalCollectionEvent { target, items }
+}
+
+fn collection_item_event(
+    target: TerminalTarget,
+    value: &serde_json::Value,
+    is_error: bool,
+) -> TerminalCommandEvent {
+    let mut event = TerminalCommandEvent::new(
+        target,
+        value
+            .get("session_id")
+            .or_else(|| value.get("task_id"))
+            .or_else(|| value.get("id"))
+            .and_then(serde_json::Value::as_str)
+            .map(ToString::to_string),
+        value
+            .get("status")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("unknown"),
+        value
+            .get("command")
+            .and_then(serde_json::Value::as_str)
+            .map(compact_instruction),
+    );
+    event.is_error = is_error;
+    event
+}
+
+pub(crate) fn output_tail_preview(output: &str) -> Option<Vec<String>> {
+    let lines = output
+        .lines()
+        .map(sanitize_terminal_output_line)
+        .filter(|line| !line.trim().is_empty())
+        .collect::<Vec<_>>();
+    if lines.is_empty() {
+        return None;
+    }
+
+    Some(
+        lines
+            .iter()
+            .rev()
+            .take(6)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>(),
+    )
+}
+
+pub(crate) fn sanitize_terminal_output_line(line: &str) -> String {
+    strip_ansi_control_sequences(line).trim_end().to_string()
+}
+
+fn strip_ansi_control_sequences(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            if ch != '\r' {
+                output.push(ch);
+            }
+            continue;
+        }
+
+        match chars.peek().copied() {
+            Some('[') => {
+                chars.next();
+                for next in chars.by_ref() {
+                    if ('@'..='~').contains(&next) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                chars.next();
+                let mut previous_escape = false;
+                for next in chars.by_ref() {
+                    if next == '\u{7}' || (previous_escape && next == '\\') {
+                        break;
+                    }
+                    previous_escape = next == '\u{1b}';
+                }
+            }
+            Some(_) => {
+                chars.next();
+            }
+            None => {}
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{TerminalEvent, TerminalTarget};
+
+    #[test]
+    fn builds_background_start_event_from_bash_result() {
+        let event = TerminalEvent::from_tool_result(
+            "bash",
+            &json!({
+                "background_task_id": "task-1",
+                "status": "running",
+                "output_path": "/tmp/rara.log"
+            })
+            .to_string(),
+            false,
+        )
+        .expect("terminal event");
+
+        assert_eq!(event.transcript_role(), "Tool Result");
+        assert_eq!(
+            event.to_transcript_message(),
+            "background task task-1 running\noutput: /tmp/rara.log"
+        );
+    }
+
+    #[test]
+    fn sanitizes_pty_output_event_tail() {
+        let event = TerminalEvent::from_tool_result(
+            "pty_status",
+            &json!({
+                "session_id": "pty-1",
+                "status": "completed",
+                "command": "cargo test",
+                "output": "\u{1b}[31mred\u{1b}[0m\r\nok\n"
+            })
+            .to_string(),
+            false,
+        )
+        .expect("terminal event");
+
+        assert_eq!(
+            event.to_transcript_message(),
+            "pty pty-1 completed: cargo test\noutput:\nred\nok"
+        );
+    }
+
+    #[test]
+    fn builds_background_use_event_only_for_background_bash() {
+        let event = TerminalEvent::from_tool_use(
+            "bash",
+            &json!({
+                "command": "sleep 10",
+                "run_in_background": true
+            }),
+        )
+        .expect("terminal event");
+
+        match event {
+            TerminalEvent::Begin(command) => {
+                assert_eq!(command.target, TerminalTarget::BackgroundTask);
+                assert_eq!(command.command.as_deref(), Some("sleep 10"));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+}

--- a/src/tui/terminal_event.rs
+++ b/src/tui/terminal_event.rs
@@ -4,6 +4,8 @@ use crate::tool::ToolOutputStream;
 use crate::tools::bash::BashCommandInput;
 use crate::tui::tool_text::compact_instruction;
 
+pub(crate) const TERMINAL_EVENT_ROLE: &str = "Terminal Event";
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum TerminalTarget {

--- a/src/tui/terminal_event.rs
+++ b/src/tui/terminal_event.rs
@@ -6,8 +6,6 @@ use crate::tool::ToolOutputStream;
 use crate::tools::bash::BashCommandInput;
 use crate::tui::tool_text::compact_instruction;
 
-pub(crate) const TERMINAL_EVENT_ROLE: &str = "Terminal Event";
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum TerminalTarget {

--- a/src/tui/terminal_event.rs
+++ b/src/tui/terminal_event.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use serde::{Deserialize, Serialize};
 
 use crate::tool::ToolOutputStream;
@@ -132,7 +134,7 @@ impl TerminalEvent {
         let value = serde_json::from_str::<serde_json::Value>(content).ok()?;
         match name {
             "bash" => background_bash_start_event(&value, is_error).map(Self::End),
-            "pty_start" | "pty_read" | "pty_status" | "pty_kill" => {
+            "pty_start" | "pty_read" | "pty_status" | "pty_write" | "pty_kill" => {
                 Some(Self::End(pty_command_event(&value, is_error)))
             }
             "pty_list" => Some(Self::List(collection_event(
@@ -419,26 +421,25 @@ fn collection_item_event(
 }
 
 pub(crate) fn output_tail_preview(output: &str) -> Option<Vec<String>> {
-    let lines = output
-        .lines()
-        .map(sanitize_terminal_output_line)
-        .filter(|line| !line.trim().is_empty())
-        .collect::<Vec<_>>();
+    const TAIL_LIMIT: usize = 6;
+
+    let mut lines = VecDeque::with_capacity(TAIL_LIMIT);
+    for line in output.lines() {
+        let sanitized = sanitize_terminal_output_line(line);
+        if sanitized.trim().is_empty() {
+            continue;
+        }
+        if lines.len() == TAIL_LIMIT {
+            lines.pop_front();
+        }
+        lines.push_back(sanitized);
+    }
+
     if lines.is_empty() {
         return None;
     }
 
-    Some(
-        lines
-            .iter()
-            .rev()
-            .take(6)
-            .cloned()
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .collect::<Vec<_>>(),
-    )
+    Some(lines.into_iter().collect())
 }
 
 pub(crate) fn sanitize_terminal_output_line(line: &str) -> String {
@@ -488,7 +489,7 @@ fn strip_ansi_control_sequences(input: &str) -> String {
 mod tests {
     use serde_json::json;
 
-    use super::{TerminalEvent, TerminalTarget};
+    use super::{output_tail_preview, TerminalEvent, TerminalTarget};
 
     #[test]
     fn builds_background_start_event_from_bash_result() {
@@ -529,6 +530,55 @@ mod tests {
         assert_eq!(
             event.to_transcript_message(),
             "pty pty-1 completed: cargo test\noutput:\nred\nok"
+        );
+    }
+
+    #[test]
+    fn builds_pty_write_result_as_terminal_event() {
+        let event = TerminalEvent::from_tool_result(
+            "pty_write",
+            &json!({
+                "session_id": "pty-1",
+                "status": "running",
+                "command": "cargo test",
+                "output": "line 1\nline 2\n"
+            })
+            .to_string(),
+            false,
+        )
+        .expect("terminal event");
+
+        match event {
+            TerminalEvent::End(command) => {
+                assert_eq!(command.target, TerminalTarget::Pty);
+                assert_eq!(command.id.as_deref(), Some("pty-1"));
+                assert_eq!(command.status, "running");
+                assert_eq!(
+                    command.output,
+                    vec!["line 1".to_string(), "line 2".to_string()]
+                );
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn output_tail_preview_keeps_only_last_non_empty_lines() {
+        let output = (1..=10)
+            .map(|index| format!("line {index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(
+            output_tail_preview(&output),
+            Some(vec![
+                "line 5".to_string(),
+                "line 6".to_string(),
+                "line 7".to_string(),
+                "line 8".to_string(),
+                "line 9".to_string(),
+                "line 10".to_string(),
+            ])
         );
     }
 


### PR DESCRIPTION
## Summary

- auto-allow conservative read-only bash commands in suggestion mode
- add Codex-style prefix approvals backed by `~/.rara/rules/default.rules`
- reuse Codex `codex-execpolicy` for rules parsing and append behavior
- preserve approved prefixes across rebuilt agents and sync them through the TUI runtime

## Testing

- `cargo fmt --check`
- `cargo check`
- `cargo test -p rara-config allowed_command_prefix_rules -- --nocapture`
- `cargo test approved_bash_prefix_auto_allows_later_matching_commands -- --nocapture`
- `cargo test tui::runtime::tasks::tests::merge_rebuilt_agent_preserves_session_and_turn_state -- --nocapture`
