### PR TITLE
fix(llm): tolerate legacy DeepSeek thinking tool history

### DIFF
--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -330,6 +330,7 @@ pub(super) fn build_chat_completion_request_body(
         body["tools"] = json!(openai_tools);
     }
     let strong_reasoning = !openai_tools.is_empty() || metadata.prefers_strong_reasoning();
+    normalize_deepseek_thinking_tool_history(&mut body, model, endpoint_kind, thinking);
     apply_deepseek_thinking_options(
         &mut body,
         model,
@@ -339,6 +340,36 @@ pub(super) fn build_chat_completion_request_body(
         strong_reasoning,
     );
     body
+}
+
+fn normalize_deepseek_thinking_tool_history(
+    body: &mut Value,
+    model: &str,
+    endpoint_kind: OpenAiEndpointKind,
+    thinking: Option<bool>,
+) {
+    if endpoint_kind != OpenAiEndpointKind::Deepseek
+        || !deepseek_supports_thinking(model)
+        || matches!(thinking, Some(false))
+    {
+        return;
+    }
+
+    let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for message in messages {
+        if message.get("role").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+        let has_tool_calls = message
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .is_some_and(|tool_calls| !tool_calls.is_empty());
+        if has_tool_calls && message.get("reasoning_content").is_none() {
+            message["reasoning_content"] = Value::String(String::new());
+        }
+    }
 }
 
 fn apply_deepseek_thinking_options(

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -347,6 +347,69 @@ fn deepseek_reasoner_defaults_preserve_standard_body() {
 }
 
 #[test]
+fn deepseek_thinking_tool_history_backfills_missing_reasoning_content() {
+    let body = build_chat_completion_request_body(
+        "deepseek-reasoner",
+        &[
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"text","text":""},
+                    {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"Cargo.toml"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content":"[package]"}
+                ]),
+            },
+        ],
+        &[json!({
+            "name": "read_file",
+            "description": "Read a file",
+            "input_schema": {"type":"object"}
+        })],
+        OpenAiEndpointKind::Deepseek,
+        None,
+        Some(true),
+        LlmTurnMetadata::default(),
+    );
+
+    assert_eq!(body["messages"][0]["role"], "assistant");
+    assert_eq!(body["messages"][0]["reasoning_content"], "");
+    assert_eq!(body["messages"][0]["tool_calls"][0]["id"], "tool-1");
+}
+
+#[test]
+fn deepseek_thinking_tool_history_preserves_existing_reasoning_content() {
+    let body = build_chat_completion_request_body(
+        "deepseek-reasoner",
+        &[Message {
+            role: "assistant".to_string(),
+            content: json!([
+                {"type":"provider_metadata","provider":"deepseek","key":"reasoning_content","value":"keep this reasoning"},
+                {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"Cargo.toml"}}
+            ]),
+        }],
+        &[json!({
+            "name": "read_file",
+            "description": "Read a file",
+            "input_schema": {"type":"object"}
+        })],
+        OpenAiEndpointKind::Deepseek,
+        None,
+        Some(true),
+        LlmTurnMetadata::default(),
+    );
+
+    assert_eq!(
+        body["messages"][0]["reasoning_content"],
+        "keep this reasoning"
+    );
+}
+
+#[test]
 fn deepseek_reasoner_explicit_thinking_enables_controls_for_tools() {
     let body = build_chat_completion_request_body(
         "deepseek-reasoner",


### PR DESCRIPTION
## Summary

- Backfill missing `reasoning_content` on legacy DeepSeek thinking-mode assistant tool-call history.
- Preserve existing DeepSeek reasoning metadata when it is already present.
- Add focused request-body tests for both paths.

## Why

DeepSeek thinking mode requires assistant messages with tool calls to carry `reasoning_content` during the same tool-call reasoning loop. Older RARA history can contain assistant tool-call messages without that provider metadata, which makes DeepSeek reject the next request with:

`The reasoning_content in the thinking mode must be passed back to the API.`

## Testing

- `cargo test deepseek_thinking_tool_history -- --nocapture`
- `cargo check`
- `git diff --check`
