### PR TITLE
fix: expose command install roots in sandbox

### DIFF
--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
@@ -11,6 +12,7 @@ pub struct SandboxManager {
     profile_dir: PathBuf,
     sandbox_home: PathBuf,
     backend: SandboxBackend,
+    command_install_roots: Vec<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -59,7 +61,22 @@ impl SandboxManager {
         Self::new_with_rara_dir(os, rara_dir)
     }
 
+    pub fn new_with_command_path(command_path: Option<String>) -> Result<Self> {
+        let os = std::env::consts::OS.to_string();
+        let root = std::env::current_dir()?;
+        let rara_dir = rara_config::workspace_data_dir_for(&root)?;
+        Self::new_with_rara_dir_and_command_path(os, rara_dir, command_path.map(OsString::from))
+    }
+
     fn new_with_rara_dir(os: String, rara_dir: PathBuf) -> Result<Self> {
+        Self::new_with_rara_dir_and_command_path(os, rara_dir, env::var_os("PATH"))
+    }
+
+    fn new_with_rara_dir_and_command_path(
+        os: String,
+        rara_dir: PathBuf,
+        command_path: Option<OsString>,
+    ) -> Result<Self> {
         if !rara_dir.exists() {
             fs::create_dir_all(&rara_dir)?;
         }
@@ -71,12 +88,14 @@ impl SandboxManager {
         let sandbox_home = process_sandbox_home();
 
         let backend = SandboxBackend::detect(os.as_str());
+        let command_install_roots = command_search_install_roots(command_path.as_deref());
 
         Ok(Self {
             os,
             profile_dir,
             sandbox_home,
             backend,
+            command_install_roots,
         })
     }
 
@@ -91,9 +110,15 @@ impl SandboxManager {
                 let path = home.join(sensitive_dir);
                 file_rules.push_str(&format!(
                     "(deny file-read* (subpath \"{}\"))\n",
-                    path.display()
+                    sandbox_profile_string_literal(&path)
                 ));
             }
+        }
+        for root in &self.command_install_roots {
+            let root = sandbox_profile_string_literal(&root);
+            file_rules.push_str(&format!(
+                "(allow file-read* (subpath \"{root}\"))\n(allow file-map-executable (subpath \"{root}\"))\n"
+            ));
         }
 
         let mut net_rules = String::new();
@@ -150,17 +175,17 @@ impl SandboxManager {
         args.push(path.display().to_string());
     }
 
-    fn linux_runtime_read_roots() -> Vec<PathBuf> {
+    fn linux_runtime_read_roots(&self) -> Vec<PathBuf> {
         let mut roots = LINUX_RUNTIME_READ_ROOTS
             .iter()
             .map(PathBuf::from)
             .filter(|path| path.exists())
             .collect::<Vec<_>>();
-        for path_dir in command_search_path_dirs() {
+        for path_dir in &self.command_install_roots {
             if roots.iter().any(|root| path_dir.starts_with(root)) {
                 continue;
             }
-            roots.push(path_dir);
+            roots.push(path_dir.clone());
         }
         roots
     }
@@ -191,7 +216,7 @@ impl SandboxManager {
             args.push(dir.display().to_string());
         }
 
-        for root in Self::linux_runtime_read_roots() {
+        for root in self.linux_runtime_read_roots() {
             Self::append_ro_bind(&mut args, &root);
         }
 
@@ -406,15 +431,23 @@ fn command_exists(program: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn command_search_path_dirs() -> Vec<PathBuf> {
-    env::var_os("PATH")
+fn command_search_path_dirs(command_path: Option<&std::ffi::OsStr>) -> Vec<PathBuf> {
+    command_path
+        .map(OsString::from)
+        .or_else(|| env::var_os("PATH"))
         .map(|paths| {
             let mut dirs = Vec::new();
             for dir in env::split_paths(&paths) {
                 if !dir.is_absolute() || !dir.is_dir() {
                     continue;
                 }
+                if path_contains_control_chars(&dir) {
+                    continue;
+                }
                 let dir = fs::canonicalize(&dir).unwrap_or(dir);
+                if path_contains_control_chars(&dir) {
+                    continue;
+                }
                 if !dirs.iter().any(|existing| existing == &dir) {
                     dirs.push(dir);
                 }
@@ -422,6 +455,46 @@ fn command_search_path_dirs() -> Vec<PathBuf> {
             dirs
         })
         .unwrap_or_default()
+}
+
+fn command_search_install_roots(command_path: Option<&std::ffi::OsStr>) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let home_dir = env::var_os("HOME")
+        .map(PathBuf::from)
+        .and_then(|path| fs::canonicalize(&path).ok().or(Some(path)));
+    for dir in command_search_path_dirs(command_path) {
+        let root = if matches!(
+            dir.file_name().and_then(|name| name.to_str()),
+            Some("bin" | "sbin")
+        ) {
+            let parent = dir.parent().unwrap_or_else(|| dir.as_path());
+            if parent == Path::new("/") || home_dir.as_deref() == Some(parent) {
+                dir.clone()
+            } else {
+                parent.to_path_buf()
+            }
+        } else {
+            dir
+        };
+        if !roots.iter().any(|existing| existing == &root) {
+            roots.push(root);
+        }
+    }
+    roots
+}
+
+fn path_contains_control_chars(path: &Path) -> bool {
+    path.display().to_string().chars().any(char::is_control)
+}
+
+fn sandbox_profile_string_literal(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
 }
 
 fn shell_program() -> String {
@@ -515,8 +588,8 @@ fn cleanup_profiles_older_than(profile_dir: &Path, max_age: Duration) -> Result<
 mod tests {
     use super::{
         DEFAULT_SHELL, MACOS_SANDBOX_EXEC, SandboxBackend, SandboxManager,
-        cleanup_profiles_older_than, cleanup_stale_profiles, sanitize_shell_program,
-        shell_command_flag, shell_program,
+        cleanup_profiles_older_than, cleanup_stale_profiles, command_search_install_roots,
+        sandbox_profile_string_literal, sanitize_shell_program, shell_command_flag, shell_program,
     };
     use std::env;
     use std::path::PathBuf;
@@ -529,6 +602,9 @@ mod tests {
             profile_dir: PathBuf::from("/tmp/rara-test-sandbox"),
             sandbox_home: PathBuf::from("/tmp/rara-test-sandbox-home"),
             backend,
+            command_install_roots: command_search_install_roots(
+                std::env::var_os("PATH").as_deref(),
+            ),
         }
     }
 
@@ -607,6 +683,9 @@ mod tests {
             profile_dir: tempdir.path().to_path_buf(),
             sandbox_home: tempdir.path().join("home"),
             backend: SandboxBackend::MacosSeatbelt,
+            command_install_roots: command_search_install_roots(
+                std::env::var_os("PATH").as_deref(),
+            ),
         };
 
         let wrapped = manager
@@ -927,5 +1006,110 @@ mod tests {
             }),
             "linux sandbox should not bind relative PATH entries"
         );
+    }
+
+    #[test]
+    fn linux_sandbox_binds_command_install_roots_for_bin_dirs() {
+        let tempdir = tempdir().expect("tempdir");
+        let tool_root = tempdir.path().join("toolchain");
+        let tool_bin = tool_root.join("bin");
+        std::fs::create_dir_all(&tool_bin).expect("tool bin dir");
+        let tool_root = std::fs::canonicalize(&tool_root).expect("canonical tool root");
+        let tool_bin = tool_root.join("bin");
+        let original_path = std::env::var_os("PATH");
+        set_env_var("PATH", &tool_bin);
+
+        let manager = manager("linux", SandboxBackend::LinuxBubblewrap);
+        let wrapped = manager
+            .wrap_shell_command("custom-tool --version", "/workspace/project", false)
+            .expect("linux sandbox wrapper");
+
+        if let Some(path) = original_path {
+            set_env_var("PATH", path);
+        } else {
+            remove_env_var("PATH");
+        }
+
+        assert!(
+            wrapped.args.windows(3).any(|window| {
+                window
+                    == [
+                        String::from("--ro-bind"),
+                        tool_root.display().to_string(),
+                        tool_root.display().to_string(),
+                    ]
+            }),
+            "linux sandbox should bind the PATH install root so symlinked launchers and adjacent libraries remain readable"
+        );
+    }
+
+    #[test]
+    fn macos_profile_allows_command_install_roots() {
+        let tempdir = tempdir().expect("tempdir");
+        let tool_root = tempdir.path().join("toolchain");
+        let tool_bin = tool_root.join("bin");
+        std::fs::create_dir_all(&tool_bin).expect("tool bin dir");
+        let tool_root = std::fs::canonicalize(&tool_root).expect("canonical tool root");
+        let original_path = std::env::var_os("PATH");
+        set_env_var("PATH", tool_root.join("bin"));
+        let manager = SandboxManager {
+            os: "macos".to_string(),
+            profile_dir: tempdir.path().to_path_buf(),
+            sandbox_home: tempdir.path().join("home"),
+            backend: SandboxBackend::MacosSeatbelt,
+            command_install_roots: command_search_install_roots(Some(
+                tool_root.join("bin").as_os_str(),
+            )),
+        };
+
+        let profile_path = manager.create_profile(false).expect("macos profile");
+
+        if let Some(path) = original_path {
+            set_env_var("PATH", path);
+        } else {
+            remove_env_var("PATH");
+        }
+
+        let profile = std::fs::read_to_string(profile_path).expect("profile contents");
+        let expected = tool_root.display().to_string();
+        assert!(
+            profile.contains(&format!("(allow file-read* (subpath \"{expected}\"))")),
+            "macos profile should allow reading PATH install roots"
+        );
+        assert!(
+            profile.contains(&format!(
+                "(allow file-map-executable (subpath \"{expected}\"))"
+            )),
+            "macos profile should allow mapping executables from PATH install roots"
+        );
+    }
+
+    #[test]
+    fn home_bin_path_stays_narrow() {
+        let tempdir = tempdir().expect("tempdir");
+        let home = tempdir.path().join("home");
+        let home_bin = home.join("bin");
+        std::fs::create_dir_all(&home_bin).expect("home bin dir");
+        let home = std::fs::canonicalize(&home).expect("canonical home");
+        let home_bin = home.join("bin");
+        let original_home = std::env::var_os("HOME");
+        set_env_var("HOME", &home);
+
+        let roots = command_search_install_roots(Some(home_bin.as_os_str()));
+
+        if let Some(home) = original_home {
+            set_env_var("HOME", home);
+        } else {
+            remove_env_var("HOME");
+        }
+
+        assert_eq!(roots, vec![home_bin]);
+    }
+
+    #[test]
+    fn sandbox_profile_string_literal_escapes_control_characters() {
+        let escaped = sandbox_profile_string_literal(PathBuf::from("/tmp/a\nb\tc").as_path());
+
+        assert_eq!(escaped, "/tmp/a\\nb\\tc");
     }
 }

--- a/docs/journal/2026-04-29-sandbox-path-roots.md
+++ b/docs/journal/2026-04-29-sandbox-path-roots.md
@@ -1,0 +1,26 @@
+# 2026-04-29 Sandbox Command Path Roots
+
+## Summary
+
+- Aligned RARA sandbox command visibility with the Codex pattern of preserving a
+  controlled execution environment while keeping filesystem access scoped.
+- Linux bubblewrap now derives command install roots from `PATH` entries. For
+  `bin` and `sbin` directories, the sandbox binds the installation prefix
+  read-only instead of only binding the executable directory.
+- macOS seatbelt profiles now grant read and executable-map access to the same
+  `PATH` install roots.
+- Runtime startup now captures a lightweight shell environment snapshot and
+  shares the captured `PATH` with sandbox mount construction, bash commands, and
+  PTY sessions.
+
+## Notes
+
+- Root-level `/bin` and `/sbin` remain bound as themselves so the Linux sandbox
+  does not fall back to a read-only bind of `/`.
+- The change avoids binding the whole home directory while still allowing
+  common user-installed tool layouts such as `~/.cargo/bin`,
+  `~/.local/bin`, and Homebrew-style prefixes to resolve symlinks and adjacent
+  runtime files.
+- The first snapshot slice captures `PATH` only. This mirrors the Codex and
+  Claude direction of reusing user shell initialization while avoiding a full
+  shell-state import before RARA has a richer environment policy.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod redaction;
 mod runtime_context;
 mod sandbox;
 mod session;
+mod shell_env;
 mod skill;
 mod state_db;
 mod thread_cli;

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -17,6 +17,7 @@ use crate::local_backend::{LocalLlmBackend, LocalProgressReporter};
 use crate::prompt::{PromptRuntimeConfig, PromptSkillSummary};
 use crate::sandbox::SandboxManager;
 use crate::session::SessionManager;
+use crate::shell_env::capture_shell_environment_snapshot;
 use crate::tool::ToolManager;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
@@ -60,7 +61,10 @@ pub(crate) async fn initialize_rara_context(
     let workspace = Arc::new(WorkspaceMemory::new()?);
     let vdb = Arc::new(VectorDB::new(&vector_db_uri_for_workspace(&workspace)));
     let session_manager = Arc::new(SessionManager::new()?);
-    let sandbox_manager = Arc::new(SandboxManager::new()?);
+    let shell_env = capture_shell_environment_snapshot().await;
+    let sandbox_manager = Arc::new(SandboxManager::new_with_command_path(
+        shell_env.env.get("PATH").cloned(),
+    )?);
 
     let mut prompt_config = PromptRuntimeConfig::from_config(config);
     let skill_manager = load_skill_manager(&mut prompt_config.warnings);
@@ -82,6 +86,7 @@ pub(crate) async fn initialize_rara_context(
         sandbox_manager,
         skill_manager,
         prompt_config.clone(),
+        Arc::new(shell_env.env),
     );
     let warnings = prompt_config.warnings.clone();
 

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::llm::LlmBackend;
@@ -37,6 +38,7 @@ pub(super) fn create_full_tool_manager(
     sandbox: Arc<SandboxManager>,
     skill_manager: Arc<SkillManager>,
     prompt_config: PromptRuntimeConfig,
+    shell_env: Arc<HashMap<String, String>>,
 ) -> ToolManager {
     let mut tm = ToolManager::new();
     let vector_db_uri = vector_db_uri_for_workspace(&workspace);
@@ -51,6 +53,7 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(BashTool {
         sandbox: sandbox.clone(),
         background_tasks: background_tasks.clone(),
+        base_env: shell_env.clone(),
     }));
     tm.register(Box::new(BackgroundTaskListTool {
         background_tasks: background_tasks.clone(),
@@ -62,6 +65,7 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(PtyStartTool {
         sessions: pty_sessions.clone(),
         sandbox: sandbox.clone(),
+        base_env: shell_env.clone(),
     }));
     tm.register(Box::new(PtyReadTool {
         sessions: pty_sessions.clone(),

--- a/src/shell_env.rs
+++ b/src/shell_env.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::timeout;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ShellEnvironmentSnapshot {
+    pub env: HashMap<String, String>,
+    pub source: Option<String>,
+}
+
+const SHELL_SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(5);
+const PATH_START_MARKER: &str = "__RARA_PATH_START__";
+const PATH_END_MARKER: &str = "__RARA_PATH_END__";
+
+pub(crate) async fn capture_shell_environment_snapshot() -> ShellEnvironmentSnapshot {
+    let Some(shell) = std::env::var_os("SHELL").and_then(|value| {
+        let path = Path::new(&value);
+        (path.is_absolute() && path.is_file()).then(|| path.to_path_buf())
+    }) else {
+        return process_environment_snapshot();
+    };
+
+    let shell_name = shell
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    let script = if shell_name == "fish" {
+        "echo __RARA_PATH_START__; string join : $PATH; echo __RARA_PATH_END__"
+    } else {
+        "printf '__RARA_PATH_START__%s__RARA_PATH_END__' \"$PATH\""
+    };
+
+    let mut command = Command::new(&shell);
+    command
+        .arg("-lc")
+        .arg(script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+
+    let Ok(Ok(output)) = timeout(SHELL_SNAPSHOT_TIMEOUT, command.output()).await else {
+        eprintln!("Warning: failed to capture shell PATH snapshot; using process PATH");
+        return process_environment_snapshot();
+    };
+    if !output.status.success() {
+        eprintln!("Warning: shell PATH snapshot command failed; using process PATH");
+        return process_environment_snapshot();
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let Some(path) = extract_marked_path(&stdout) else {
+        eprintln!("Warning: shell PATH snapshot output was not marked; using process PATH");
+        return process_environment_snapshot();
+    };
+
+    ShellEnvironmentSnapshot {
+        env: HashMap::from([("PATH".to_string(), path)]),
+        source: Some(shell.display().to_string()),
+    }
+}
+
+fn extract_marked_path(output: &str) -> Option<String> {
+    let start = output.find(PATH_START_MARKER)? + PATH_START_MARKER.len();
+    let remainder = &output[start..];
+    let end = remainder.find(PATH_END_MARKER)?;
+    let path = remainder[..end].trim();
+    (!path.is_empty()).then(|| path.to_string())
+}
+
+fn process_environment_snapshot() -> ShellEnvironmentSnapshot {
+    process_environment_snapshot_from_path(std::env::var("PATH").ok())
+}
+
+fn process_environment_snapshot_from_path(path: Option<String>) -> ShellEnvironmentSnapshot {
+    let env = path
+        .map(|path| HashMap::from([("PATH".to_string(), path)]))
+        .unwrap_or_default();
+    ShellEnvironmentSnapshot { env, source: None }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        PATH_END_MARKER, PATH_START_MARKER, extract_marked_path,
+        process_environment_snapshot_from_path,
+    };
+
+    #[test]
+    fn extracts_marked_path_from_noisy_shell_output() {
+        let output = format!(
+            "welcome\n{PATH_START_MARKER}/snapshot/bin:/usr/bin{PATH_END_MARKER}\nnotice\n"
+        );
+
+        assert_eq!(
+            extract_marked_path(&output).as_deref(),
+            Some("/snapshot/bin:/usr/bin")
+        );
+    }
+
+    #[test]
+    fn rejects_unmarked_shell_output() {
+        assert_eq!(extract_marked_path("/snapshot/bin:/usr/bin"), None);
+    }
+
+    #[test]
+    fn process_snapshot_preserves_path_when_available() {
+        let snapshot =
+            process_environment_snapshot_from_path(Some("/snapshot/bin:/usr/bin".to_string()));
+
+        assert_eq!(
+            snapshot.env.get("PATH").map(String::as_str),
+            Some("/snapshot/bin:/usr/bin")
+        );
+        assert_eq!(snapshot.source, None);
+    }
+}

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 pub struct BashTool {
     pub sandbox: Arc<SandboxManager>,
     pub background_tasks: Arc<BackgroundTaskStore>,
+    pub base_env: Arc<HashMap<String, String>>,
 }
 
 pub struct BackgroundTaskStatusTool {
@@ -619,6 +620,7 @@ impl BackgroundTaskStore {
 
 fn sandbox_command_env(
     sandbox_home: &Path,
+    base_env: &HashMap<String, String>,
     overrides: &HashMap<String, String>,
 ) -> HashMap<String, String> {
     let sandbox_home = sandbox_home.to_string_lossy();
@@ -641,24 +643,42 @@ fn sandbox_command_env(
             format!("{sandbox_home}/.local/share"),
         ),
     ]);
-    if let Ok(path) = env::var("PATH") {
-        env_map.insert("PATH".to_string(), path);
-    }
-    env_map.extend(overrides.clone());
+    env_map.extend(
+        base_env
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
+    env_map.extend(
+        overrides
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
     env_map
 }
 
 fn command_env_for_wrapped(
     wrapped: &WrappedCommand,
+    base_env: &HashMap<String, String>,
     overrides: &HashMap<String, String>,
 ) -> Result<HashMap<String, String>, ToolError> {
     if wrapped.sandboxed {
         let sandbox_home = wrapped.sandbox_home.as_deref().ok_or_else(|| {
             ToolError::ExecutionFailed("sandboxed command is missing sandbox home".into())
         })?;
-        Ok(sandbox_command_env(sandbox_home, overrides))
+        Ok(sandbox_command_env(sandbox_home, base_env, overrides))
     } else {
-        Ok(overrides.clone())
+        let mut env_map = HashMap::with_capacity(base_env.len() + overrides.len());
+        env_map.extend(
+            base_env
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+        env_map.extend(
+            overrides
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone())),
+        );
+        Ok(env_map)
     }
 }
 
@@ -738,7 +758,7 @@ impl Tool for BashTool {
                     ToolError::ExecutionFailed(format!("{} {}", e, sandbox_failure_hint()))
                 })?
         };
-        let command_env = command_env_for_wrapped(&wrapped, &request.env)?;
+        let command_env = command_env_for_wrapped(&wrapped, &self.base_env, &request.env)?;
 
         if wrapped.sandboxed && wrapped.sandbox_backend == "macos-seatbelt" {
             let sandbox_home = wrapped.sandbox_home.as_deref().ok_or_else(|| {
@@ -1202,23 +1222,6 @@ mod tests {
     use std::sync::Arc;
     use tempfile::tempdir;
 
-    fn set_env_var<K, V>(key: K, value: V)
-    where
-        K: AsRef<std::ffi::OsStr>,
-        V: AsRef<std::ffi::OsStr>,
-    {
-        // This test restores PATH before returning.
-        unsafe { std::env::set_var(key, value) };
-    }
-
-    fn remove_env_var<K>(key: K)
-    where
-        K: AsRef<std::ffi::OsStr>,
-    {
-        // This test restores PATH before returning.
-        unsafe { std::env::remove_var(key) };
-    }
-
     #[test]
     fn parses_legacy_shell_payload() {
         let input = BashCommandInput::from_value(json!({
@@ -1366,9 +1369,8 @@ mod tests {
     #[test]
     fn sandbox_command_env_defaults_home_and_xdg_roots() {
         let sandbox_home = Path::new("/tmp/rara-test-home");
-        let original_path = std::env::var_os("PATH");
-        set_env_var("PATH", "/custom/bin:/usr/bin");
-        let env_map = sandbox_command_env(sandbox_home, &HashMap::new());
+        let base_env = HashMap::from([("PATH".to_string(), "/custom/bin:/usr/bin".to_string())]);
+        let env_map = sandbox_command_env(sandbox_home, &base_env, &HashMap::new());
 
         assert_eq!(
             env_map.get("HOME").map(String::as_str),
@@ -1386,11 +1388,6 @@ mod tests {
             env_map.get("PATH").map(String::as_str),
             Some("/custom/bin:/usr/bin")
         );
-        if let Some(path) = original_path {
-            set_env_var("PATH", path);
-        } else {
-            remove_env_var("PATH");
-        }
     }
 
     #[test]
@@ -1398,6 +1395,7 @@ mod tests {
         let sandbox_home = Path::new("/tmp/rara-test-home");
         let env_map = sandbox_command_env(
             sandbox_home,
+            &HashMap::from([("PATH".to_string(), "/snapshot/bin".to_string())]),
             &HashMap::from([
                 ("HOME".to_string(), "/custom/home".to_string()),
                 (
@@ -1447,11 +1445,16 @@ mod tests {
         };
         let env_map = command_env_for_wrapped(
             &wrapped,
+            &HashMap::from([("PATH".to_string(), "/snapshot/bin".to_string())]),
             &HashMap::from([("HOME".to_string(), "/real/home".to_string())]),
         )
         .expect("direct env");
 
         assert_eq!(env_map.get("HOME").map(String::as_str), Some("/real/home"));
+        assert_eq!(
+            env_map.get("PATH").map(String::as_str),
+            Some("/snapshot/bin")
+        );
         assert!(
             !env_map.contains_key("XDG_CONFIG_HOME"),
             "direct fallback should not apply sandbox-only XDG roots"
@@ -1499,6 +1502,7 @@ mod tests {
                 BackgroundTaskStore::new(temp.path().join(".rara/background-tasks"))
                     .expect("background task store"),
             ),
+            base_env: Arc::new(HashMap::new()),
         };
         let mut events = Vec::new();
         let result = tool
@@ -1560,6 +1564,7 @@ mod tests {
         let tool = BashTool {
             sandbox: Arc::new(sandbox),
             background_tasks: background_tasks.clone(),
+            base_env: Arc::new(HashMap::new()),
         };
         let status_tool = BackgroundTaskStatusTool {
             background_tasks: background_tasks.clone(),
@@ -1625,6 +1630,7 @@ mod tests {
         let tool = BashTool {
             sandbox: Arc::new(sandbox),
             background_tasks: background_tasks.clone(),
+            base_env: Arc::new(HashMap::new()),
         };
         let list_tool = BackgroundTaskListTool {
             background_tasks: background_tasks.clone(),

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -1,8 +1,8 @@
-use crate::sandbox::{sandbox_failure_hint, SandboxManager, WrappedCommand};
+use crate::sandbox::{SandboxManager, WrappedCommand, sandbox_failure_hint};
 use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::env;
 use std::fs::OpenOptions;
@@ -16,6 +16,7 @@ use uuid::Uuid;
 pub struct PtyStartTool {
     pub sessions: Arc<PtySessionStore>,
     pub sandbox: Arc<SandboxManager>,
+    pub base_env: Arc<HashMap<String, String>>,
 }
 
 pub struct PtyReadTool {
@@ -89,6 +90,7 @@ impl PtySessionStore {
         command: String,
         wrapped: WrappedCommand,
         cwd: String,
+        base_env: &HashMap<String, String>,
         env: HashMap<String, String>,
         rows: u16,
         cols: u16,
@@ -104,7 +106,7 @@ impl PtySessionStore {
                 pixel_height: 0,
             })
             .map_err(|err| ToolError::ExecutionFailed(format!("open pty: {err}")))?;
-        let command_env = command_env_for_wrapped(&wrapped, &env)?;
+        let command_env = command_env_for_wrapped(&wrapped, base_env, &env)?;
         if wrapped.sandboxed && wrapped.sandbox_backend == "macos-seatbelt" {
             let sandbox_home = wrapped.sandbox_home.as_deref().ok_or_else(|| {
                 ToolError::ExecutionFailed("sandboxed pty is missing sandbox home".into())
@@ -360,7 +362,7 @@ impl Tool for PtyStartTool {
         let rows = parse_pty_dimension(input.get("rows"), 24, "rows")?;
         let cols = parse_pty_dimension(input.get("cols"), 120, "cols")?;
         self.sessions
-            .start(command, wrapped, cwd, env, rows, cols)?
+            .start(command, wrapped, cwd, &self.base_env, env, rows, cols)?
             .into_json(12_000)
             .await
     }
@@ -574,9 +576,15 @@ fn parse_env(value: Option<&Value>) -> Result<HashMap<String, String>, ToolError
 
 fn command_env_for_wrapped(
     wrapped: &WrappedCommand,
+    base_env: &HashMap<String, String>,
     overrides: &HashMap<String, String>,
 ) -> Result<HashMap<String, String>, ToolError> {
-    let mut env_map = HashMap::new();
+    let mut env_map = HashMap::with_capacity(base_env.len() + overrides.len() + 4);
+    env_map.extend(
+        base_env
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
     if wrapped.sandboxed {
         let sandbox_home = wrapped.sandbox_home.as_deref().ok_or_else(|| {
             ToolError::ExecutionFailed("sandboxed pty is missing sandbox home".into())
@@ -595,10 +603,11 @@ fn command_env_for_wrapped(
             sandbox_home.join(".local/share").display().to_string(),
         );
     }
-    if let Ok(path) = env::var("PATH") {
-        env_map.insert("PATH".to_string(), path);
-    }
-    env_map.extend(overrides.clone());
+    env_map.extend(
+        overrides
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
     Ok(env_map)
 }
 
@@ -699,6 +708,7 @@ mod tests {
                     sandbox_home: None,
                 },
                 temp.path().display().to_string(),
+                &HashMap::new(),
                 HashMap::new(),
                 24,
                 120,
@@ -775,6 +785,7 @@ mod tests {
                     sandbox_home: None,
                 },
                 temp.path().display().to_string(),
+                &HashMap::new(),
                 HashMap::new(),
                 24,
                 120,


### PR DESCRIPTION
## Summary

- capture a lightweight shell PATH snapshot at runtime startup
- share the captured PATH with sandbox install-root discovery, bash commands, and PTY sessions
- allow Linux/macOS sandboxes to read command install roots derived from PATH entries

## Testing

- cargo test -p rara-sandbox -- --nocapture
- cargo test shell_env -- --nocapture
- cargo test tools::bash::tests::sandbox_command_env -- --nocapture
- cargo test tools::bash::tests::direct_wrapped_command -- --nocapture
- cargo test tools::pty::tests::pty_session_accepts_input_and_exposes_output -- --nocapture
- git diff --check

## Notes

- Full cargo check is currently blocked by local disk exhaustion: No space left on device while writing Cargo/rustc temporary artifacts.
