### PR TITLE
fix: enforce read-only subagent prompts

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -366,6 +366,23 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
             ),
         ),
         PromptSection::new(
+            "tool_workflow_discipline",
+            section(
+                "Tool Workflow Discipline",
+                &[
+                    "Use tools to make progress, not to perform ceremony. Prefer a small number of high-signal inspection calls over broad, repetitive searches.",
+                    "When a tool fails, read the exact error, update the working hypothesis, and try the narrowest corrective action that preserves the user's constraints.",
+                    "Do not abandon the task after a transient tool, sandbox, network, or filesystem error when a safe local fallback is available.",
+                    "When output is truncated, narrow the query, read a smaller range, or use a targeted search before asking the user for the missing content.",
+                    "For long-running commands, prefer background task or PTY tools when available; after starting one, use list/status/stop tools to keep the task observable and controllable.",
+                    "Do not start duplicate long-running commands when an existing background task or PTY session can be inspected.",
+                    "For GitHub work, inspect the real PR, review threads, checks, and branch state with GitHub tools before summarizing readiness or claiming that comments are resolved.",
+                    "For git work, inspect status before committing, keep commits scoped to the task, and never rewrite history unless the user explicitly asks for it.",
+                    "For code review or diagnosis tasks, produce an evidence-backed conclusion from inspected files and command output; do not stop with a description of what should be inspected next.",
+                ],
+            ),
+        ),
+        PromptSection::new(
             "implementation_policy",
             section(
                 "Implementation Policy",
@@ -744,6 +761,14 @@ mod tests {
         assert!(prompt.contains("assume the user wants you to solve the task"));
         assert!(prompt.contains("Do not stop at a proposed solution"));
         assert!(prompt.contains("Prefer local, reversible actions"));
+        assert!(prompt.contains("Tool Workflow Discipline"));
+        assert!(prompt.contains("read the exact error"));
+        assert!(prompt.contains("transient tool, sandbox, network, or filesystem error"));
+        assert!(prompt.contains("background task or PTY tools"));
+        assert!(prompt.contains("list/status/stop tools"));
+        assert!(prompt.contains("inspect the real PR, review threads, checks, and branch state"));
+        assert!(prompt.contains("never rewrite history"));
+        assert!(prompt.contains("evidence-backed conclusion"));
     }
 
     #[test]

--- a/docs/journal/2026-04-29-strict-read-only-subagents.md
+++ b/docs/journal/2026-04-29-strict-read-only-subagents.md
@@ -1,0 +1,35 @@
+# Strict Read-Only Subagents
+
+## Context
+
+RARA already restricts Explore and Plan subagents at the tool-manager layer: they only receive repository inspection tools and do not receive bash, PTY, editing, patching, or recursive agent tools.
+
+Claude Code's Explore and Plan prompts also make the read-only contract explicit. They forbid file creation, file mutation, temporary files, redirects, heredocs, and other shell-based write workarounds.
+
+## Change
+
+Explore and Plan subagent prompts now include a shared strict read-only contract:
+
+- no creating, modifying, deleting, moving, or copying files;
+- no temporary files, including under `/tmp`;
+- no shell commands, scripts, redirection, heredocs, or other state-changing workarounds;
+- only `read_file`, `list_files`, `glob`, and `grep` are valid inspection tools;
+- mutation requests must be answered with the limitation and an evidence-backed finding or plan.
+
+General worker subagents are unchanged, except they still do not receive recursive agent tools.
+
+## Validation
+
+Added prompt regression coverage for the strict read-only clauses and kept the existing tool-manager test that excludes mutating, PTY, bash, background task, and recursive agent tools from read-only subagents.
+
+## Follow-Up Tool Workflow Prompting
+
+The default system prompt now also includes a dedicated tool workflow discipline section. It makes the expected execution loop explicit:
+
+- use high-signal tool calls instead of broad repetitive searches;
+- diagnose exact tool errors and try narrow safe fallbacks before asking the user;
+- handle truncation by narrowing reads or searches;
+- keep long-running commands observable through background task or PTY list/status/stop tools;
+- inspect real GitHub review/check/branch state before summarizing PR readiness;
+- inspect git status before committing and do not rewrite history unless explicitly requested;
+- finish code review and diagnosis tasks with evidence-backed conclusions instead of stopping after describing the next inspection step.

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -8,7 +8,7 @@ use crate::tools::search::{GlobTool, GrepTool};
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 #[derive(Clone, Copy)]
@@ -16,6 +16,21 @@ enum SubAgentKind {
     General,
     Explore,
     Plan,
+}
+
+macro_rules! strict_read_only_subagent_prompt {
+    () => {
+        concat!(
+            "## Strict Read-Only Contract\n",
+            "- This is a STRICT READ-ONLY sub-agent task.\n",
+            "- You are prohibited from creating, modifying, deleting, moving, or copying files.\n",
+            "- Do not create temporary files anywhere, including /tmp.\n",
+            "- Do not run shell commands, scripts, redirection, heredocs, or any workaround that changes filesystem, process, network, git, or repository state.\n",
+            "- Bash, PTY, editing, patching, and agent-spawning tools are intentionally unavailable.\n",
+            "- Use only the read-only repository inspection tools available to you: read_file, list_files, glob, grep.\n",
+            "- If the assigned instruction requires mutation, report the limitation and provide the evidence-backed findings or plan instead of attempting a workaround."
+        )
+    };
 }
 
 impl SubAgentKind {
@@ -46,6 +61,9 @@ impl SubAgentKind {
                     "- Treat the assigned instruction as the complete task contract.\n",
                     "- Honor every constraint in the assigned instruction, including workspace, branch, network, and output limits.\n",
                     "- Stay inside the current workspace unless the assigned instruction explicitly allows another path.\n",
+                    "\n",
+                    strict_read_only_subagent_prompt!(),
+                    "\n",
                     "- Inspect the repository and summarize concrete findings.\n",
                     "- Do not propose edits you cannot justify from inspected code.\n",
                     "- Do not narrate each next tool call; call the tool directly.\n",
@@ -60,6 +78,9 @@ impl SubAgentKind {
                     "- Treat the assigned instruction as the complete task contract.\n",
                     "- Honor every constraint in the assigned instruction, including workspace, branch, network, and output limits.\n",
                     "- Stay inside the current workspace unless the assigned instruction explicitly allows another path.\n",
+                    "\n",
+                    strict_read_only_subagent_prompt!(),
+                    "\n",
                     "- Inspect the repository and refine an implementation approach.\n",
                     "- Keep plans shallow and grouped by behavior.\n",
                     "- Use <proposed_plan> only when the plan is decision-complete.\n",
@@ -418,8 +439,8 @@ fn serialize_pending_user_input(request: &PendingUserInput) -> Value {
 #[cfg(test)]
 mod tests {
     use super::{
-        append_subagent_prompt, build_read_only_tool_manager, build_subagent_tool_manager,
-        latest_assistant_text_from_history, SubAgentKind,
+        SubAgentKind, append_subagent_prompt, build_read_only_tool_manager,
+        build_subagent_tool_manager, latest_assistant_text_from_history,
     };
     use crate::agent::Message;
     use crate::prompt::PromptRuntimeConfig;
@@ -480,6 +501,27 @@ mod tests {
         assert!(prompt.contains("Treat the assigned instruction as the complete task contract."));
         assert!(prompt.contains("Honor every constraint in the assigned instruction"));
         assert!(prompt.contains("Stay inside the current workspace"));
+    }
+
+    #[test]
+    fn read_only_subagent_prompts_forbid_mutation_and_shell_workarounds() {
+        for kind in [SubAgentKind::Explore, SubAgentKind::Plan] {
+            let prompt = kind.append_prompt();
+
+            assert!(prompt.contains("STRICT READ-ONLY"));
+            assert!(prompt.contains("creating, modifying, deleting, moving, or copying files"));
+            assert!(prompt.contains("including /tmp"));
+            assert!(prompt.contains("redirection"));
+            assert!(prompt.contains("Bash, PTY, editing, patching"));
+            assert!(prompt.contains("read_file, list_files, glob, grep"));
+            assert!(prompt.contains("instead of attempting a workaround"));
+        }
+
+        assert!(
+            !SubAgentKind::General
+                .append_prompt()
+                .contains("STRICT READ-ONLY")
+        );
     }
 
     #[test]

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -27,6 +27,7 @@ macro_rules! strict_read_only_subagent_prompt {
             "- Do not create temporary files anywhere, including /tmp.\n",
             "- Do not run shell commands, scripts, redirection, heredocs, or any workaround that changes filesystem, process, network, git, or repository state.\n",
             "- Bash, PTY, editing, patching, and agent-spawning tools are intentionally unavailable.\n",
+            // Keep this prompt list synchronized with build_read_only_tool_manager().
             "- Use only the read-only repository inspection tools available to you: read_file, list_files, glob, grep.\n",
             "- If the assigned instruction requires mutation, report the limitation and provide the evidence-backed findings or plan instead of attempting a workaround."
         )
@@ -348,6 +349,7 @@ async fn run_sub_agent(
 }
 
 fn build_read_only_tool_manager() -> ToolManager {
+    // Keep this registration set synchronized with strict_read_only_subagent_prompt!().
     let mut tool_manager = ToolManager::new();
     tool_manager.register(Box::new(ReadFileTool));
     tool_manager.register(Box::new(ListFilesTool));


### PR DESCRIPTION
## Summary

- enforce a Claude-style strict read-only prompt contract for Explore and Plan subagents
- add default tool workflow guidance for error recovery, truncation, long-running tasks, GitHub review checks, and git safety
- document the prompt changes in a dated journal entry

## Testing

- `cargo test read_only_subagent -- --nocapture`
- `cargo test subagent_prompt -- --nocapture`
- `cargo test -p rara-instructions default_system_prompt_mentions_tool_safety_and_compaction -- --nocapture`
- `cargo check --message-format=short`
- `git diff --check`
