### PR TITLE
fix: flatten active tui progress segments

### DIFF
--- a/docs/journal/2026-04-29-codex-style-active-progress.md
+++ b/docs/journal/2026-04-29-codex-style-active-progress.md
@@ -1,0 +1,16 @@
+# Codex-Style Active Progress Segments
+
+## Context
+
+Codex keeps reasoning and execution progress as transcript history cells instead of continuously overwriting one shared status area. Reasoning deltas are accumulated for the current block, finalized into a reasoning summary cell, and command execution is shown through separate execution cells.
+
+## Change
+
+RARA now keeps an ordered live event log for active TUI progress updates across Thinking, Exploring, Planning, and Running. Adjacent events with the same role are grouped and compacted, while interleaved events stay flat in their original order.
+
+This makes long turns render progress like `Thinking -> Running -> Thinking -> Running` as separate transcript segments instead of merging all updates into one Thinking or Running area.
+
+## Validation
+
+- Added a focused active turn rendering test for interleaved Thinking and Running events.
+- Updated the existing active plan snapshot to preserve progress event order.

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -172,26 +172,26 @@ fn push_live_event_group<'a>(
     events: Vec<&crate::tui::state::ActiveLiveEvent>,
     active: bool,
 ) {
-    let actions = events
-        .iter()
-        .filter(|event| !event.is_note())
-        .map(|event| event.message().to_string())
-        .collect::<Vec<_>>();
-    let notes = events
-        .iter()
-        .filter(|event| event.is_note())
-        .map(|event| event.message().to_string())
-        .collect::<Vec<_>>();
+    let mut actions = Vec::new();
+    let mut notes = Vec::new();
+    for event in events {
+        if event.is_note() {
+            notes.push(event.message().to_string());
+        } else {
+            actions.push(event.message().to_string());
+        }
+    }
     match role {
-        "Thinking" => cells.push(Box::new(ThinkingTextCell::new(
-            &actions
-                .iter()
-                .chain(notes.iter())
-                .cloned()
-                .collect::<Vec<_>>()
-                .join("\n"),
-            4,
-        ))),
+        "Thinking" => {
+            let mut message = actions.join("\n");
+            if !notes.is_empty() {
+                if !message.is_empty() {
+                    message.push('\n');
+                }
+                message.push_str(&notes.join("\n"));
+            }
+            cells.push(Box::new(ThinkingTextCell::new(&message, 4)));
+        }
         "Exploring" => cells.push(Box::new(ExploringCell::new(
             compact_progress_summary_lines(
                 actions.as_slice(),

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -7,8 +7,8 @@ use crate::tui::interaction_text::{
 };
 use crate::tui::plan_display::should_show_updated_plan;
 use crate::tui::state::{
-    contains_structured_planning_output, RuntimePhase, TranscriptEntry, TranscriptEntryPayload,
-    TuiApp,
+    RuntimePhase, TranscriptEntry, TranscriptEntryPayload, TuiApp,
+    contains_structured_planning_output,
 };
 use crate::tui::terminal_event::{
     TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
@@ -19,9 +19,9 @@ mod components;
 
 pub(crate) use self::components::StartupCardCell;
 use self::components::{
-    planning_suggestion_text, CommittedInteractionCell, ExploredCell, ExploringCell, MessageCell,
-    PendingInteractionCell, PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell,
-    RanCell, RespondingCell, RunningCell, TerminalCell, ThinkingCell, UserCell,
+    CommittedInteractionCell, ExploredCell, ExploringCell, MessageCell, PendingInteractionCell,
+    PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell, RanCell, RespondingCell,
+    RunningCell, TerminalCell, ThinkingCell, ThinkingTextCell, UserCell, planning_suggestion_text,
 };
 use super::{
     compact_progress_summary_lines, compact_recent_first_summary_lines, compact_summary_lines,
@@ -71,8 +71,138 @@ fn line_plain_text(line: &Line<'static>) -> String {
 fn is_progress_stack_title(line: &Line<'static>) -> bool {
     matches!(
         line_plain_text(line).trim(),
-        "Plan Mode" | "Exploring" | "Planning" | "Running"
+        "Plan Mode" | "Thinking" | "Exploring" | "Planning" | "Running"
     )
+}
+
+fn progress_entry_role(role: &str) -> bool {
+    matches!(role, "Thinking" | "Exploring" | "Planning" | "Running")
+}
+
+fn active_live_event_groups(
+    events: &[crate::tui::state::ActiveLiveEvent],
+) -> Vec<(&'static str, Vec<crate::tui::state::ActiveLiveEvent>)> {
+    let mut groups: Vec<(&'static str, Vec<crate::tui::state::ActiveLiveEvent>)> = Vec::new();
+    for event in events {
+        let role = event.role();
+        if let Some((last_role, messages)) = groups.last_mut()
+            && *last_role == role
+        {
+            messages.push(event.clone());
+            continue;
+        }
+        groups.push((role, vec![event.clone()]));
+    }
+    groups
+}
+
+fn explicit_progress_entry_groups<'a>(
+    entries: impl Iterator<Item = &'a TranscriptEntry>,
+) -> Vec<(&'a str, Vec<String>)> {
+    let mut groups: Vec<(&str, Vec<String>)> = Vec::new();
+    for entry in entries.filter(|entry| progress_entry_role(entry.role.as_str())) {
+        let role = entry.role.as_str();
+        let messages = entry
+            .message
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(|line| {
+                line.trim_start_matches("└")
+                    .trim_start_matches('•')
+                    .trim()
+                    .to_string()
+            })
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>();
+        if messages.is_empty() {
+            continue;
+        }
+        if let Some((last_role, last_messages)) = groups.last_mut()
+            && *last_role == role
+        {
+            last_messages.extend(messages);
+            continue;
+        }
+        groups.push((role, messages));
+    }
+    groups
+}
+
+fn push_progress_group<'a>(
+    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+    role: &str,
+    messages: Vec<String>,
+    active: bool,
+) {
+    match role {
+        "Thinking" => cells.push(Box::new(ThinkingTextCell::new(&messages.join("\n"), 4))),
+        "Exploring" => cells.push(Box::new(ExploringCell::new(
+            compact_summary_lines(messages.as_slice(), 4, "more exploration step(s)"),
+            active,
+        ))),
+        "Planning" => cells.push(Box::new(PlanningCell::new(
+            compact_summary_lines(messages.as_slice(), 4, "more planning step(s)"),
+            active,
+        ))),
+        "Running" => cells.push(Box::new(RunningCell::new(
+            compact_summary_lines(messages.as_slice(), 4, "more running step(s)"),
+            active,
+        ))),
+        _ => {}
+    }
+}
+
+fn push_live_event_group<'a>(
+    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+    role: &str,
+    events: Vec<crate::tui::state::ActiveLiveEvent>,
+    active: bool,
+) {
+    let actions = events
+        .iter()
+        .filter(|event| !event.is_note())
+        .map(|event| event.message().to_string())
+        .collect::<Vec<_>>();
+    let notes = events
+        .iter()
+        .filter(|event| event.is_note())
+        .map(|event| event.message().to_string())
+        .collect::<Vec<_>>();
+    match role {
+        "Thinking" => cells.push(Box::new(ThinkingTextCell::new(
+            &actions
+                .iter()
+                .chain(notes.iter())
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n"),
+            4,
+        ))),
+        "Exploring" => cells.push(Box::new(ExploringCell::new(
+            compact_progress_summary_lines(
+                actions.as_slice(),
+                notes.as_slice(),
+                4,
+                "more exploration step(s)",
+            ),
+            active,
+        ))),
+        "Planning" => cells.push(Box::new(PlanningCell::new(
+            compact_progress_summary_lines(
+                actions.as_slice(),
+                notes.as_slice(),
+                4,
+                "more planning step(s)",
+            ),
+            active,
+        ))),
+        "Running" => cells.push(Box::new(RunningCell::new(
+            compact_recent_first_summary_lines(actions.as_slice(), 4, "more running step(s)"),
+            active,
+        ))),
+        _ => {}
+    }
 }
 
 fn split_progress_sentences(message: &str) -> Vec<String> {
@@ -625,46 +755,34 @@ impl HistoryCell for CommittedTurnCell<'_> {
         }
 
         let entry_refs = self.entries.iter().collect::<Vec<_>>();
-        let explicit_exploration = self
-            .entries
-            .iter()
-            .find(|entry| entry.role == "Exploring")
-            .map(|entry| entry.message.clone());
-        let explicit_planning = self
-            .entries
-            .iter()
-            .find(|entry| entry.role == "Planning")
-            .map(|entry| entry.message.clone());
-        let explicit_running = self
-            .entries
-            .iter()
-            .find(|entry| entry.role == "Running")
-            .map(|entry| entry.message.clone());
+        let explicit_progress_groups = explicit_progress_entry_groups(self.entries.iter());
         let has_tool_activity = entry_refs.iter().any(|entry| {
             matches!(
                 entry.role.as_str(),
                 "Tool" | "Tool Result" | "Tool Error" | "Tool Progress"
             ) || matches!(entry.payload, Some(TranscriptEntryPayload::Terminal(_)))
         });
-        if let Some(summary) = explicit_exploration
-            .map(|summary| compact_summary_text(&summary, 4, "more exploration step(s)"))
-            .or_else(|| {
+        if explicit_progress_groups.is_empty() {
+            if let Some(summary) =
                 current_turn_exploration_summary_from_entries(entry_refs.as_slice(), false, None)
-            })
-        {
-            cells.push(Box::new(ExploredCell::new(summary)));
-        }
+            {
+                cells.push(Box::new(ExploredCell::new(summary)));
+            }
 
-        if let Some(summary) = explicit_planning {
-            cells.push(Box::new(PlanningCell::new(summary, false)));
-        }
-
-        if let Some(cell) = terminal_cell_from_entries(self.entries.iter()) {
-            cells.push(Box::new(cell));
-        } else if let Some(summary) = explicit_running
-            .or_else(|| current_turn_tool_summary(entry_refs.as_slice(), false, None))
-        {
-            cells.push(Box::new(RanCell::new(summary)));
+            if let Some(cell) = terminal_cell_from_entries(self.entries.iter()) {
+                cells.push(Box::new(cell));
+            } else if let Some(summary) =
+                current_turn_tool_summary(entry_refs.as_slice(), false, None)
+            {
+                cells.push(Box::new(RanCell::new(summary)));
+            }
+        } else {
+            for (role, messages) in explicit_progress_groups {
+                push_progress_group(&mut cells, role, messages, false);
+            }
+            if let Some(cell) = terminal_cell_from_entries(self.entries.iter()) {
+                cells.push(Box::new(cell));
+            }
         }
 
         let completion_entries = ordered_completion_entries(self.entries);
@@ -814,6 +932,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
         let has_live_planning = !self.app.active_live.planning_actions.is_empty()
             || !self.app.active_live.planning_notes.is_empty();
         let has_live_running = !self.app.active_live.running_actions.is_empty();
+        let live_event_groups = active_live_event_groups(self.app.active_live.events.as_slice());
+        let has_live_event_groups = !live_event_groups.is_empty();
 
         if !user_message.is_empty() {
             cells.push(Box::new(UserCell::new(user_message)));
@@ -830,12 +950,15 @@ impl ActiveCell for ActiveTurnCell<'_> {
             }
         }
 
-        let ordered_exploration_agent_segments =
-            if !has_live_exploration && !has_live_planning && !has_live_running {
-                ordered_exploration_agent_segments(current_turn.as_slice())
-            } else {
-                None
-            };
+        let ordered_exploration_agent_segments = if !has_live_event_groups
+            && !has_live_exploration
+            && !has_live_planning
+            && !has_live_running
+        {
+            ordered_exploration_agent_segments(current_turn.as_slice())
+        } else {
+            None
+        };
         let uses_ordered_exploration_agent_segments = ordered_exploration_agent_segments.is_some();
 
         if let Some(segments) = ordered_exploration_agent_segments.as_ref() {
@@ -858,12 +981,41 @@ impl ActiveCell for ActiveTurnCell<'_> {
             }
         }
 
+        let mut has_event_exploration_summary = false;
+        let mut has_event_planning_summary = false;
+        let mut has_event_running_summary = false;
+        if has_live_event_groups {
+            for (role, messages) in live_event_groups {
+                match role {
+                    "Exploring" => has_event_exploration_summary = true,
+                    "Planning" => has_event_planning_summary = true,
+                    "Running" => has_event_running_summary = true,
+                    _ => {}
+                }
+                push_live_event_group(&mut cells, role, messages, true);
+            }
+        }
+
+        let explicit_progress_groups = (!has_live_event_groups)
+            .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
+        if let Some(groups) = explicit_progress_groups.as_ref() {
+            for (role, messages) in groups {
+                push_progress_group(&mut cells, role, messages.clone(), turn_live);
+            }
+        }
+        let has_explicit_progress_groups = explicit_progress_groups
+            .as_ref()
+            .is_some_and(|groups| !groups.is_empty());
+
         let explicit_exploration = current_turn
             .iter()
             .find(|entry| entry.role == "Exploring")
             .map(|entry| entry.message.clone());
 
-        let exploration_summary = if uses_ordered_exploration_agent_segments {
+        let exploration_summary = if has_live_event_groups
+            || has_explicit_progress_groups
+            || uses_ordered_exploration_agent_segments
+        {
             None
         } else if has_live_exploration {
             Some(compact_progress_summary_lines(
@@ -892,7 +1044,9 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Planning")
             .map(|entry| entry.message.clone());
 
-        let planning_summary = if has_live_planning {
+        let planning_summary = if has_live_event_groups || has_explicit_progress_groups {
+            None
+        } else if has_live_planning {
             Some(compact_progress_summary_lines(
                 self.app.active_live.planning_actions.as_slice(),
                 self.app.active_live.planning_notes.as_slice(),
@@ -913,7 +1067,9 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Running")
             .map(|entry| entry.message.clone());
 
-        let running_summary = if has_live_running {
+        let running_summary = if has_live_event_groups || has_explicit_progress_groups {
+            None
+        } else if has_live_running {
             Some(compact_recent_first_summary_lines(
                 self.app.active_live.running_actions.as_slice(),
                 4,
@@ -937,8 +1093,13 @@ impl ActiveCell for ActiveTurnCell<'_> {
         } else if let Some(summary) = running_summary {
             cells.push(Box::new(RunningCell::new(summary, running_active)));
         }
-        let compact_live_response =
-            turn_live && (has_exploration_summary || has_planning_summary || has_running_summary);
+        let compact_live_response = turn_live
+            && (has_exploration_summary
+                || has_planning_summary
+                || has_running_summary
+                || has_event_exploration_summary
+                || has_event_planning_summary
+                || has_event_running_summary);
 
         let inline_plan_summary = latest_agent
             .and_then(|message| parse_render_plan_block(message))
@@ -1014,6 +1175,9 @@ impl ActiveCell for ActiveTurnCell<'_> {
             && !has_exploration_summary
             && !has_planning_summary
             && !has_running_summary
+            && !has_event_exploration_summary
+            && !has_event_planning_summary
+            && !has_event_running_summary
             && self.app.snapshot.plan_steps.is_empty()
             && !suppress_planning_chatter
             && !suppress_structured_plan_response
@@ -1107,6 +1271,9 @@ impl ActiveCell for ActiveTurnCell<'_> {
             && !has_exploration_summary
             && !has_planning_summary
             && !has_running_summary
+            && !has_event_exploration_summary
+            && !has_event_planning_summary
+            && !has_event_running_summary
             && self.app.pending_request_input().is_none()
             && !self.app.has_pending_plan_approval()
             && self.app.pending_command_approval().is_none()

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -149,7 +149,9 @@ fn push_progress_group<'a>(
             compact_summary_lines(messages.as_slice(), 4, "more running step(s)"),
             active,
         ))),
-        _ => {}
+        _ => {
+            // Callers filter to known progress roles; ignore unknown roles defensively.
+        }
     }
 }
 
@@ -201,7 +203,9 @@ fn push_live_event_group<'a>(
             compact_recent_first_summary_lines(actions.as_slice(), 4, "more running step(s)"),
             active,
         ))),
-        _ => {}
+        _ => {
+            // Active live events currently produce only known progress roles.
+        }
     }
 }
 

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -81,19 +81,42 @@ fn progress_entry_role(role: &str) -> bool {
 
 fn active_live_event_groups(
     events: &[crate::tui::state::ActiveLiveEvent],
-) -> Vec<(&'static str, Vec<crate::tui::state::ActiveLiveEvent>)> {
-    let mut groups: Vec<(&'static str, Vec<crate::tui::state::ActiveLiveEvent>)> = Vec::new();
+) -> Vec<(&'static str, Vec<&crate::tui::state::ActiveLiveEvent>)> {
+    let mut groups: Vec<(&'static str, Vec<&crate::tui::state::ActiveLiveEvent>)> = Vec::new();
     for event in events {
         let role = event.role();
         if let Some((last_role, messages)) = groups.last_mut()
             && *last_role == role
         {
-            messages.push(event.clone());
+            messages.push(event);
             continue;
         }
-        groups.push((role, vec![event.clone()]));
+        groups.push((role, vec![event]));
     }
     groups
+}
+
+fn progress_entry_message_lines(role: &str, message: &str) -> Vec<String> {
+    if role == "Thinking" {
+        return message
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(ToString::to_string)
+            .collect();
+    }
+
+    message
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            line.trim_start_matches("└")
+                .trim_start_matches('•')
+                .trim()
+                .to_string()
+        })
+        .filter(|line| !line.is_empty())
+        .collect()
 }
 
 fn explicit_progress_entry_groups<'a>(
@@ -102,19 +125,7 @@ fn explicit_progress_entry_groups<'a>(
     let mut groups: Vec<(&str, Vec<String>)> = Vec::new();
     for entry in entries.filter(|entry| progress_entry_role(entry.role.as_str())) {
         let role = entry.role.as_str();
-        let messages = entry
-            .message
-            .lines()
-            .map(str::trim)
-            .filter(|line| !line.is_empty())
-            .map(|line| {
-                line.trim_start_matches("└")
-                    .trim_start_matches('•')
-                    .trim()
-                    .to_string()
-            })
-            .filter(|line| !line.is_empty())
-            .collect::<Vec<_>>();
+        let messages = progress_entry_message_lines(role, &entry.message);
         if messages.is_empty() {
             continue;
         }
@@ -158,7 +169,7 @@ fn push_progress_group<'a>(
 fn push_live_event_group<'a>(
     cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
     role: &str,
-    events: Vec<crate::tui::state::ActiveLiveEvent>,
+    events: Vec<&crate::tui::state::ActiveLiveEvent>,
     active: bool,
 ) {
     let actions = events

--- a/src/tui/render/cells_components.rs
+++ b/src/tui/render/cells_components.rs
@@ -8,6 +8,7 @@ use ratatui::{
 use crate::tui::interaction_text::{
     pending_interaction_card_title, status_planning_suggestion_text,
 };
+use crate::tui::markdown_render::render_markdown_text_with_width;
 use crate::tui::plan_display::updated_plan_lines;
 use crate::tui::render::diff::render_patch_preview;
 use crate::tui::render::{
@@ -231,24 +232,26 @@ impl HistoryCell for ThinkingCell<'_> {
 }
 
 pub(super) struct ThinkingTextCell {
-    lines: Vec<Line<'static>>,
+    message: String,
     max_lines: usize,
 }
 
 impl ThinkingTextCell {
     pub(super) fn new(message: &str, max_lines: usize) -> Self {
-        let lines = message
-            .lines()
-            .map(|line| Line::from(line.to_string()))
-            .collect::<Vec<_>>();
-        Self { lines, max_lines }
+        Self {
+            message: message.to_string(),
+            max_lines,
+        }
     }
 }
 
 impl HistoryCell for ThinkingTextCell {
-    fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
-        let start = self.lines.len().saturating_sub(self.max_lines);
-        let body = markdown_body_lines(&self.lines[start..], self.max_lines);
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
+        let render_width = usize::from(width.saturating_sub(2));
+        let rendered = render_markdown_text_with_width(&self.message, Some(render_width));
+        let rendered_lines = rendered.lines;
+        let start = rendered_lines.len().saturating_sub(self.max_lines);
+        let body = markdown_body_lines(&rendered_lines[start..], self.max_lines);
         let mut lines = vec![Line::from(section_span("Thinking", Color::LightBlue))];
         if start > 0 {
             lines.push(Line::from(Span::styled(

--- a/src/tui/render/cells_components.rs
+++ b/src/tui/render/cells_components.rs
@@ -230,6 +230,40 @@ impl HistoryCell for ThinkingCell<'_> {
     }
 }
 
+pub(super) struct ThinkingTextCell {
+    lines: Vec<Line<'static>>,
+    max_lines: usize,
+}
+
+impl ThinkingTextCell {
+    pub(super) fn new(message: &str, max_lines: usize) -> Self {
+        let lines = message
+            .lines()
+            .map(|line| Line::from(line.to_string()))
+            .collect::<Vec<_>>();
+        Self { lines, max_lines }
+    }
+}
+
+impl HistoryCell for ThinkingTextCell {
+    fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
+        let start = self.lines.len().saturating_sub(self.max_lines);
+        let body = markdown_body_lines(&self.lines[start..], self.max_lines);
+        let mut lines = vec![Line::from(section_span("Thinking", Color::LightBlue))];
+        if start > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("  ... {start} more line(s)"),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+        lines.extend(body.into_iter().map(|mut line| {
+            line.spans.insert(0, Span::raw("  "));
+            line
+        }));
+        lines
+    }
+}
+
 pub(super) struct TerminalCell {
     command: String,
     output: Vec<String>,
@@ -263,11 +297,7 @@ impl TerminalCell {
     }
 
     fn title(&self) -> &'static str {
-        if self.active {
-            "Running"
-        } else {
-            "Ran"
-        }
+        if self.active { "Running" } else { "Ran" }
     }
 
     fn output_lines(&self) -> Vec<String> {

--- a/src/tui/render/cells_tests.rs
+++ b/src/tui/render/cells_tests.rs
@@ -8,7 +8,9 @@ use crate::tui::terminal_event::{TerminalCommandEvent, TerminalEvent, TerminalTa
 use insta::assert_snapshot;
 use tempfile::tempdir;
 
-use super::{ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell};
+use super::{
+    ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell, explicit_progress_entry_groups,
+};
 
 #[path = "cells_tests/active_general.rs"]
 mod active_general;

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -886,6 +886,43 @@ fn active_turn_cell_flattens_thinking_and_running_events_in_order() {
 }
 
 #[test]
+fn active_turn_cell_preserves_repeated_progress_events_when_interleaved() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Run checks".into(),
+            payload: None,
+        }],
+    };
+
+    app.record_running_action("Run cargo check");
+    app.record_planning_note("Inspect the next failure before retrying.");
+    app.record_running_action("Run cargo check");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let first_running_idx = rendered.find("Run cargo check").unwrap();
+    let planning_idx = rendered
+        .find("Inspect the next failure before retrying.")
+        .unwrap();
+    let second_running_idx = rendered.rfind("Run cargo check").unwrap();
+
+    assert!(first_running_idx < planning_idx);
+    assert!(planning_idx < second_running_idx);
+}
+
+#[test]
 fn active_turn_cell_shows_live_thinking_tail_without_cloning_full_body() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -844,6 +844,48 @@ fn active_turn_cell_shows_live_thinking_stream() {
 }
 
 #[test]
+fn active_turn_cell_flattens_thinking_and_running_events_in_order() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Run a long task".into(),
+            payload: None,
+        }],
+    };
+
+    app.append_agent_thinking_delta("first reasoning block\n");
+    app.flush_agent_thinking_stream_to_live_event();
+    app.record_running_action("Run cargo check");
+    app.append_agent_thinking_delta("second reasoning block\n");
+    app.flush_agent_thinking_stream_to_live_event();
+    app.record_running_action("Run cargo test");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let first_thinking = rendered.find("first reasoning block").unwrap();
+    let first_running = rendered.find("Run cargo check").unwrap();
+    let second_thinking = rendered.find("second reasoning block").unwrap();
+    let second_running = rendered.find("Run cargo test").unwrap();
+
+    assert!(first_thinking < first_running);
+    assert!(first_running < second_thinking);
+    assert!(second_thinking < second_running);
+    assert_eq!(rendered.matches(" Thinking ").count(), 2);
+    assert_eq!(rendered.matches(" Running ").count(), 2);
+}
+
+#[test]
 fn active_turn_cell_shows_live_thinking_tail_without_cloning_full_body() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -886,6 +886,35 @@ fn active_turn_cell_flattens_thinking_and_running_events_in_order() {
 }
 
 #[test]
+fn active_turn_cell_preserves_flushed_thinking_leading_indentation() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Inspect thinking formatting".into(),
+            payload: None,
+        }],
+    };
+
+    app.append_agent_thinking_delta("    let value = 1;\n");
+    app.flush_agent_thinking_stream_to_live_event();
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("      let value = 1;"));
+}
+
+#[test]
 fn active_turn_cell_preserves_repeated_progress_events_when_interleaved() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -116,6 +116,59 @@ fn committed_turn_cell_renders_materialized_sidecar_sections() {
 }
 
 #[test]
+fn committed_turn_cell_keeps_progress_segments_and_terminal_output() {
+    let entries = vec![
+        TranscriptEntry {
+            role: "You".into(),
+            message: "Run the checks".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Thinking".into(),
+            message: "I should run the focused test first.".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Running".into(),
+            message: "Run cargo test active_turn_cell".into(),
+            payload: None,
+        },
+        TranscriptEntry::terminal_event(TerminalEvent::End(TerminalCommandEvent {
+            target: TerminalTarget::BackgroundTask,
+            id: Some("bash-123".into()),
+            status: "completed".into(),
+            command: Some("cargo test active_turn_cell".into()),
+            exit_code: Some(0),
+            output: vec!["running 38 tests".into(), "ok".into()],
+            output_path: None,
+            is_error: false,
+        })),
+        TranscriptEntry {
+            role: "Agent".into(),
+            message: "The focused tests passed.".into(),
+            payload: None,
+        },
+    ];
+
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let thinking_idx = rendered.find(" Thinking ").unwrap();
+    let progress_idx = rendered.find("Run cargo test active_turn_cell").unwrap();
+    let terminal_idx = rendered.find("running 38 tests").unwrap();
+    let agent_idx = rendered.find("• The focused tests passed.").unwrap();
+
+    assert!(thinking_idx < progress_idx);
+    assert!(progress_idx < terminal_idx);
+    assert!(terminal_idx < agent_idx);
+    assert!(rendered.contains("ok"));
+}
+
+#[test]
 fn committed_turn_cell_places_completion_records_before_final_agent_message() {
     let entries = vec![
         TranscriptEntry { role: "You".into(), message: "Inspect the repo and decide whether to run the migration".into(), payload: None },

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -1,6 +1,27 @@
 use super::*;
 
 #[test]
+fn explicit_progress_entry_groups_preserves_thinking_indentation() {
+    let entries = vec![TranscriptEntry {
+        role: "Thinking".into(),
+        message: "    let value = 1;\n  aligned note\n\n".into(),
+        payload: None,
+    }];
+
+    let groups = explicit_progress_entry_groups(entries.iter());
+
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].0, "Thinking");
+    assert_eq!(
+        groups[0].1,
+        vec![
+            "    let value = 1;".to_string(),
+            "  aligned note".to_string()
+        ]
+    );
+}
+
+#[test]
 fn committed_turn_cell_keeps_user_summary_and_agent_sections_in_order() {
     let entries = vec![
         TranscriptEntry {

--- a/src/tui/render/cells_tests/snapshots/rara__tui__render__cells__tests__active_general__active_turn_cell_updated_plan.snap
+++ b/src/tui/render/cells_tests/snapshots/rara__tui__render__cells__tests__active_general__active_turn_cell_updated_plan.snap
@@ -5,10 +5,10 @@ expression: rendered
 › Read the local codebase and propose the next refactor
 
  Plan Mode 
- Exploring 
-  └ Read src/oauth.rs
  Planning 
   └ The auth flow should reuse codex_login instead of mirroring it.
+ Exploring 
+  └ Read src/oauth.rs
 
 • Updated Plan
   └ Prefer direct Codex auth reuse before extending more TUI flows.

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -8,7 +8,7 @@ use self::helpers::{
     is_oauth_prompt_message, planning_action_label, planning_note_lines, planning_result_note,
     scrub_internal_control_tokens, subagent_request_input, tool_action_label,
 };
-use super::super::state::{contains_structured_planning_output, RuntimePhase, TuiApp, TuiEvent};
+use super::super::state::{RuntimePhase, TuiApp, TuiEvent, contains_structured_planning_output};
 use crate::agent::AgentEvent;
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
@@ -35,6 +35,7 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                 app.append_agent_thinking_delta(&message);
                 return;
             } else if role == "Tool" || role == "Tool Result" || role == "Tool Error" {
+                app.flush_agent_thinking_stream_to_live_event();
                 if role == "Tool" {
                     if let Some(action) = exploration_action_label(&message) {
                         app.record_exploration_action(action);
@@ -209,6 +210,7 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
             );
         }
         TuiEvent::Terminal(event) => {
+            app.flush_agent_thinking_stream_to_live_event();
             let role = event.transcript_role();
             let message = event.to_transcript_message();
             if role == "Tool" {
@@ -230,6 +232,7 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
             stream,
             chunk,
         } => {
+            app.flush_agent_thinking_stream_to_live_event();
             if !append_tool_progress(app, &name, stream, &chunk) {
                 return;
             }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -15,7 +15,7 @@ pub use self::state_presets::{
 };
 use self::types::CommittedTranscriptRenderCache;
 pub use self::types::{
-    ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
+    ActiveLiveEvent, ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
     AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, HelpTab, InteractionKind,
     LocalCommand, LocalCommandKind, OAuthLoginMode, OpenAiModelPickerAction, Overlay,
     PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot, ProviderFamily,

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -141,9 +141,7 @@ impl TuiApp {
         if message.is_empty() {
             return;
         }
-        self.active_live
-            .events
-            .push(ActiveLiveEvent::Thinking(message));
+        self.push_active_live_event(ActiveLiveEvent::Thinking(message));
         self.reset_transcript_scroll_if_following_tail();
     }
 
@@ -343,6 +341,18 @@ impl TuiApp {
         self.active_live = super::ActiveLiveSections::default();
     }
 
+    fn push_active_live_event(&mut self, event: ActiveLiveEvent) {
+        if self
+            .active_live
+            .events
+            .last()
+            .is_some_and(|last| last.role() == event.role() && last.message() == event.message())
+        {
+            return;
+        }
+        self.active_live.events.push(event);
+    }
+
     pub fn record_exploration_action(&mut self, action: impl Into<String>) {
         let action = action.into();
         if !self
@@ -352,10 +362,8 @@ impl TuiApp {
             .any(|item| item == &action)
         {
             self.active_live.exploration_actions.push(action.clone());
-            self.active_live
-                .events
-                .push(ActiveLiveEvent::ExplorationAction(action));
         }
+        self.push_active_live_event(ActiveLiveEvent::ExplorationAction(action));
     }
 
     pub fn record_exploration_note(&mut self, note: impl Into<String>) {
@@ -367,10 +375,8 @@ impl TuiApp {
             .any(|item| item == &note)
         {
             self.active_live.exploration_notes.push(note.clone());
-            self.active_live
-                .events
-                .push(ActiveLiveEvent::ExplorationNote(note));
         }
+        self.push_active_live_event(ActiveLiveEvent::ExplorationNote(note));
     }
 
     pub fn record_running_action(&mut self, action: impl Into<String>) {
@@ -382,10 +388,8 @@ impl TuiApp {
             .any(|item| item == &action)
         {
             self.active_live.running_actions.push(action.clone());
-            self.active_live
-                .events
-                .push(ActiveLiveEvent::RunningAction(action));
         }
+        self.push_active_live_event(ActiveLiveEvent::RunningAction(action));
     }
 
     pub fn record_planning_action(&mut self, action: impl Into<String>) {
@@ -397,10 +401,8 @@ impl TuiApp {
             .any(|item| item == &action)
         {
             self.active_live.planning_actions.push(action.clone());
-            self.active_live
-                .events
-                .push(ActiveLiveEvent::PlanningAction(action));
         }
+        self.push_active_live_event(ActiveLiveEvent::PlanningAction(action));
     }
 
     pub fn record_planning_note(&mut self, note: impl Into<String>) {
@@ -412,10 +414,8 @@ impl TuiApp {
             .any(|item| item == &note)
         {
             self.active_live.planning_notes.push(note.clone());
-            self.active_live
-                .events
-                .push(ActiveLiveEvent::PlanningNote(note));
         }
+        self.push_active_live_event(ActiveLiveEvent::PlanningNote(note));
     }
 
     pub fn has_pending_planning_suggestion(&self) -> bool {

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -2,9 +2,49 @@ use std::path::PathBuf;
 
 use ratatui::text::Line;
 
-use super::{PendingFollowUpMessage, RuntimePhase, TranscriptEntry, TranscriptTurn, TuiApp};
+use super::{
+    ActiveLiveEvent, ActiveLiveSections, PendingFollowUpMessage, RuntimePhase, TranscriptEntry,
+    TranscriptTurn, TuiApp,
+};
 use crate::redaction::redact_secrets;
 use crate::tui::terminal_event::TerminalEvent;
+
+fn grouped_active_live_events(events: &[ActiveLiveEvent]) -> Vec<(&'static str, Vec<String>)> {
+    let mut groups: Vec<(&'static str, Vec<String>)> = Vec::new();
+    for event in events {
+        let role = event.role();
+        if let Some((last_role, messages)) = groups.last_mut()
+            && *last_role == role
+        {
+            messages.push(event.message().to_string());
+            continue;
+        }
+        groups.push((role, vec![event.message().to_string()]));
+    }
+    groups
+}
+
+fn legacy_active_live_sections(live: &ActiveLiveSections) -> Vec<(&'static str, Vec<String>)> {
+    vec![
+        (
+            "Exploring",
+            live.exploration_actions
+                .iter()
+                .chain(live.exploration_notes.iter())
+                .cloned()
+                .collect::<Vec<_>>(),
+        ),
+        (
+            "Planning",
+            live.planning_actions
+                .iter()
+                .chain(live.planning_notes.iter())
+                .cloned()
+                .collect::<Vec<_>>(),
+        ),
+        ("Running", live.running_actions.to_vec()),
+    ]
+}
 
 impl TuiApp {
     fn replace_turn_agent_message(turn: &mut TranscriptTurn, message: String) -> bool {
@@ -93,6 +133,20 @@ impl TuiApp {
         self.reset_transcript_scroll_if_following_tail();
     }
 
+    pub fn flush_agent_thinking_stream_to_live_event(&mut self) {
+        let Some(stream) = self.agent_thinking_stream.take() else {
+            return;
+        };
+        let message = stream.raw_text.trim().to_string();
+        if message.is_empty() {
+            return;
+        }
+        self.active_live
+            .events
+            .push(ActiveLiveEvent::Thinking(message));
+        self.reset_transcript_scroll_if_following_tail();
+    }
+
     pub fn agent_stream_lines(&self) -> Option<&[Line<'static>]> {
         self.agent_markdown_stream
             .as_ref()
@@ -114,7 +168,7 @@ impl TuiApp {
     }
 
     pub fn finalize_agent_stream(&mut self, final_message: Option<String>) {
-        self.agent_thinking_stream = None;
+        self.flush_agent_thinking_stream_to_live_event();
         let fallback = self
             .agent_markdown_stream
             .take()
@@ -223,27 +277,20 @@ impl TuiApp {
     }
 
     fn materialize_active_live_entries(&mut self) {
-        let sections = [
-            (
-                "Exploring",
-                self.active_live
-                    .exploration_actions
-                    .iter()
-                    .chain(self.active_live.exploration_notes.iter())
-                    .cloned()
-                    .collect::<Vec<_>>(),
-            ),
-            (
-                "Planning",
-                self.active_live
-                    .planning_actions
-                    .iter()
-                    .chain(self.active_live.planning_notes.iter())
-                    .cloned()
-                    .collect::<Vec<_>>(),
-            ),
-            ("Running", self.active_live.running_actions.to_vec()),
-        ];
+        if !self.active_live.events.is_empty() {
+            let sections = grouped_active_live_events(&self.active_live.events);
+            for (role, lines) in sections {
+                if lines.is_empty() {
+                    continue;
+                }
+                self.active_turn
+                    .entries
+                    .push(TranscriptEntry::new(role, lines.join("\n")));
+            }
+            return;
+        }
+
+        let sections = legacy_active_live_sections(&self.active_live);
 
         for (role, lines) in sections {
             if lines.is_empty() {
@@ -304,7 +351,10 @@ impl TuiApp {
             .iter()
             .any(|item| item == &action)
         {
-            self.active_live.exploration_actions.push(action);
+            self.active_live.exploration_actions.push(action.clone());
+            self.active_live
+                .events
+                .push(ActiveLiveEvent::ExplorationAction(action));
         }
     }
 
@@ -316,7 +366,10 @@ impl TuiApp {
             .iter()
             .any(|item| item == &note)
         {
-            self.active_live.exploration_notes.push(note);
+            self.active_live.exploration_notes.push(note.clone());
+            self.active_live
+                .events
+                .push(ActiveLiveEvent::ExplorationNote(note));
         }
     }
 
@@ -328,7 +381,10 @@ impl TuiApp {
             .iter()
             .any(|item| item == &action)
         {
-            self.active_live.running_actions.push(action);
+            self.active_live.running_actions.push(action.clone());
+            self.active_live
+                .events
+                .push(ActiveLiveEvent::RunningAction(action));
         }
     }
 
@@ -340,7 +396,10 @@ impl TuiApp {
             .iter()
             .any(|item| item == &action)
         {
-            self.active_live.planning_actions.push(action);
+            self.active_live.planning_actions.push(action.clone());
+            self.active_live
+                .events
+                .push(ActiveLiveEvent::PlanningAction(action));
         }
     }
 
@@ -352,7 +411,10 @@ impl TuiApp {
             .iter()
             .any(|item| item == &note)
         {
-            self.active_live.planning_notes.push(note);
+            self.active_live.planning_notes.push(note.clone());
+            self.active_live
+                .events
+                .push(ActiveLiveEvent::PlanningNote(note));
         }
     }
 

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -137,10 +137,10 @@ impl TuiApp {
         let Some(stream) = self.agent_thinking_stream.take() else {
             return;
         };
-        let message = stream.raw_text.trim().to_string();
-        if message.is_empty() {
+        if stream.raw_text.trim().is_empty() {
             return;
         }
+        let message = stream.raw_text.trim_end().to_string();
         self.push_active_live_event(ActiveLiveEvent::Thinking(message));
         self.reset_transcript_scroll_if_following_tail();
     }

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::path::PathBuf;
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::{Arc, atomic::AtomicBool};
 use std::time::Instant;
 
 use ratatui::text::Line;
@@ -368,8 +368,45 @@ impl AgentMarkdownStreamState {
     }
 }
 
+#[derive(Clone)]
+pub enum ActiveLiveEvent {
+    Thinking(String),
+    ExplorationAction(String),
+    ExplorationNote(String),
+    PlanningAction(String),
+    PlanningNote(String),
+    RunningAction(String),
+}
+
+impl ActiveLiveEvent {
+    pub fn role(&self) -> &'static str {
+        match self {
+            Self::Thinking(_) => "Thinking",
+            Self::ExplorationAction(_) | Self::ExplorationNote(_) => "Exploring",
+            Self::PlanningAction(_) | Self::PlanningNote(_) => "Planning",
+            Self::RunningAction(_) => "Running",
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        match self {
+            Self::Thinking(message)
+            | Self::ExplorationAction(message)
+            | Self::ExplorationNote(message)
+            | Self::PlanningAction(message)
+            | Self::PlanningNote(message)
+            | Self::RunningAction(message) => message,
+        }
+    }
+
+    pub fn is_note(&self) -> bool {
+        matches!(self, Self::ExplorationNote(_) | Self::PlanningNote(_))
+    }
+}
+
 #[derive(Default)]
 pub struct ActiveLiveSections {
+    pub events: Vec<ActiveLiveEvent>,
     pub exploration_actions: Vec<String>,
     pub exploration_notes: Vec<String>,
     pub planning_actions: Vec<String>,


### PR DESCRIPTION
## Summary

- Keep active TUI progress as an ordered live event log for Thinking, Exploring, Planning, and Running.
- Flush in-flight thinking into a separate progress segment before tool, terminal, or tool-progress events.
- Render interleaved progress segments in transcript order, while still compacting adjacent segments of the same role.
- Preserve terminal output cells when committed turns contain materialized progress segments.

## Testing

- `cargo test active_turn_cell -- --nocapture`
- `cargo test committed_turn_cell_keeps_progress_segments_and_terminal_output -- --nocapture`
- `cargo check --message-format=short`
