### PR TITLE
fix: append tui progress events

### DIFF
--- a/docs/journal/2026-04-30-codex-style-progress-append.md
+++ b/docs/journal/2026-04-30-codex-style-progress-append.md
@@ -1,0 +1,23 @@
+# Codex-Style Progress Append
+
+RARA's active TUI progress events were already stored in order, but rendering
+still grouped adjacent `Exploring`, `Planning`, and `Running` events into one
+summary cell. Long tasks therefore looked like one mutable block instead of a
+Codex-style appended transcript.
+
+This checkpoint changes the active and committed transcript path to preserve
+event boundaries:
+
+- active live events render one cell per event in original order;
+- active live events materialize into one transcript entry per event when the
+  turn commits;
+- committed progress rendering no longer merges adjacent entries with the same
+  role;
+- focused tests cover long active exploration/planning/running sequences and
+  committed adjacent progress entries.
+
+Validation:
+
+- `cargo test active_turn_cell -- --nocapture`
+- `cargo test committed_turn_cell -- --nocapture`
+- `cargo check --message-format=short`

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -79,23 +79,6 @@ fn progress_entry_role(role: &str) -> bool {
     matches!(role, "Thinking" | "Exploring" | "Planning" | "Running")
 }
 
-fn active_live_event_groups(
-    events: &[crate::tui::state::ActiveLiveEvent],
-) -> Vec<(&'static str, Vec<&crate::tui::state::ActiveLiveEvent>)> {
-    let mut groups: Vec<(&'static str, Vec<&crate::tui::state::ActiveLiveEvent>)> = Vec::new();
-    for event in events {
-        let role = event.role();
-        if let Some((last_role, messages)) = groups.last_mut()
-            && *last_role == role
-        {
-            messages.push(event);
-            continue;
-        }
-        groups.push((role, vec![event]));
-    }
-    groups
-}
-
 fn progress_entry_message_lines(role: &str, message: &str) -> Vec<String> {
     if role == "Thinking" {
         return message
@@ -129,12 +112,6 @@ fn explicit_progress_entry_groups<'a>(
         if messages.is_empty() {
             continue;
         }
-        if let Some((last_role, last_messages)) = groups.last_mut()
-            && *last_role == role
-        {
-            last_messages.extend(messages);
-            continue;
-        }
         groups.push((role, messages));
     }
     groups
@@ -166,36 +143,26 @@ fn push_progress_group<'a>(
     }
 }
 
-fn push_live_event_group<'a>(
+fn push_live_event<'a>(
     cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-    role: &str,
-    events: Vec<&crate::tui::state::ActiveLiveEvent>,
+    event: &crate::tui::state::ActiveLiveEvent,
     active: bool,
 ) {
-    let mut actions = Vec::new();
-    let mut notes = Vec::new();
-    for event in events {
-        if event.is_note() {
-            notes.push(event.message().to_string());
-        } else {
-            actions.push(event.message().to_string());
-        }
-    }
-    match role {
-        "Thinking" => {
-            let mut message = actions.join("\n");
-            if !notes.is_empty() {
-                if !message.is_empty() {
-                    message.push('\n');
-                }
-                message.push_str(&notes.join("\n"));
-            }
-            cells.push(Box::new(ThinkingTextCell::new(&message, 4)));
-        }
+    let message = event.message().to_string();
+    match event.role() {
+        "Thinking" => cells.push(Box::new(ThinkingTextCell::new(&message, 4))),
         "Exploring" => cells.push(Box::new(ExploringCell::new(
             compact_progress_summary_lines(
-                actions.as_slice(),
-                notes.as_slice(),
+                if event.is_note() {
+                    &[]
+                } else {
+                    std::slice::from_ref(&message)
+                },
+                if event.is_note() {
+                    std::slice::from_ref(&message)
+                } else {
+                    &[]
+                },
                 4,
                 "more exploration step(s)",
             ),
@@ -203,15 +170,27 @@ fn push_live_event_group<'a>(
         ))),
         "Planning" => cells.push(Box::new(PlanningCell::new(
             compact_progress_summary_lines(
-                actions.as_slice(),
-                notes.as_slice(),
+                if event.is_note() {
+                    &[]
+                } else {
+                    std::slice::from_ref(&message)
+                },
+                if event.is_note() {
+                    std::slice::from_ref(&message)
+                } else {
+                    &[]
+                },
                 4,
                 "more planning step(s)",
             ),
             active,
         ))),
         "Running" => cells.push(Box::new(RunningCell::new(
-            compact_recent_first_summary_lines(actions.as_slice(), 4, "more running step(s)"),
+            compact_recent_first_summary_lines(
+                std::slice::from_ref(&message),
+                4,
+                "more running step(s)",
+            ),
             active,
         ))),
         _ => {
@@ -947,8 +926,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
         let has_live_planning = !self.app.active_live.planning_actions.is_empty()
             || !self.app.active_live.planning_notes.is_empty();
         let has_live_running = !self.app.active_live.running_actions.is_empty();
-        let live_event_groups = active_live_event_groups(self.app.active_live.events.as_slice());
-        let has_live_event_groups = !live_event_groups.is_empty();
+        let live_events = self.app.active_live.events.as_slice();
+        let has_live_events = !live_events.is_empty();
 
         if !user_message.is_empty() {
             cells.push(Box::new(UserCell::new(user_message)));
@@ -965,15 +944,13 @@ impl ActiveCell for ActiveTurnCell<'_> {
             }
         }
 
-        let ordered_exploration_agent_segments = if !has_live_event_groups
-            && !has_live_exploration
-            && !has_live_planning
-            && !has_live_running
-        {
-            ordered_exploration_agent_segments(current_turn.as_slice())
-        } else {
-            None
-        };
+        let ordered_exploration_agent_segments =
+            if !has_live_events && !has_live_exploration && !has_live_planning && !has_live_running
+            {
+                ordered_exploration_agent_segments(current_turn.as_slice())
+            } else {
+                None
+            };
         let uses_ordered_exploration_agent_segments = ordered_exploration_agent_segments.is_some();
 
         if let Some(segments) = ordered_exploration_agent_segments.as_ref() {
@@ -999,19 +976,19 @@ impl ActiveCell for ActiveTurnCell<'_> {
         let mut has_event_exploration_summary = false;
         let mut has_event_planning_summary = false;
         let mut has_event_running_summary = false;
-        if has_live_event_groups {
-            for (role, messages) in live_event_groups {
-                match role {
+        if has_live_events {
+            for event in live_events {
+                match event.role() {
                     "Exploring" => has_event_exploration_summary = true,
                     "Planning" => has_event_planning_summary = true,
                     "Running" => has_event_running_summary = true,
                     _ => {}
                 }
-                push_live_event_group(&mut cells, role, messages, true);
+                push_live_event(&mut cells, event, true);
             }
         }
 
-        let explicit_progress_groups = (!has_live_event_groups)
+        let explicit_progress_groups = (!has_live_events)
             .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
         if let Some(groups) = explicit_progress_groups.as_ref() {
             for (role, messages) in groups {
@@ -1027,7 +1004,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Exploring")
             .map(|entry| entry.message.clone());
 
-        let exploration_summary = if has_live_event_groups
+        let exploration_summary = if has_live_events
             || has_explicit_progress_groups
             || uses_ordered_exploration_agent_segments
         {
@@ -1059,7 +1036,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Planning")
             .map(|entry| entry.message.clone());
 
-        let planning_summary = if has_live_event_groups || has_explicit_progress_groups {
+        let planning_summary = if has_live_events || has_explicit_progress_groups {
             None
         } else if has_live_planning {
             Some(compact_progress_summary_lines(
@@ -1082,7 +1059,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Running")
             .map(|entry| entry.message.clone());
 
-        let running_summary = if has_live_event_groups || has_explicit_progress_groups {
+        let running_summary = if has_live_events || has_explicit_progress_groups {
             None
         } else if has_live_running {
             Some(compact_recent_first_summary_lines(

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -324,7 +324,7 @@ fn active_turn_cell_compacts_live_response_when_process_sections_exist() {
 }
 
 #[test]
-fn active_turn_cell_compacts_long_live_exploration_sections() {
+fn active_turn_cell_appends_long_live_exploration_events() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -352,19 +352,18 @@ fn active_turn_cell_compacts_long_live_exploration_sections() {
 
     assert!(rendered.contains(" Exploring "));
     assert!(rendered.contains("Cross-check the auth entrypoint."));
-    assert!(rendered.contains("... 1 more exploration step(s)"));
-    assert!(!rendered.contains("module_1.rs"));
+    assert!(!rendered.contains("more exploration step(s)"));
+    assert!(rendered.contains("module_1.rs"));
     assert!(rendered.contains("module_2.rs"));
     assert!(rendered.contains("module_3.rs"));
     assert!(rendered.contains("module_5.rs"));
-    assert!(
-        rendered.find("Cross-check the auth entrypoint.")
-            < rendered.find("... 1 more exploration step(s)")
-    );
+    assert_eq!(rendered.matches(" Exploring ").count(), 6);
+    assert!(rendered.find("module_1.rs") < rendered.find("module_5.rs"));
+    assert!(rendered.find("module_5.rs") < rendered.find("Cross-check the auth entrypoint."));
 }
 
 #[test]
-fn active_turn_cell_compacts_long_live_planning_sections() {
+fn active_turn_cell_appends_long_live_planning_events() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -392,19 +391,18 @@ fn active_turn_cell_compacts_long_live_planning_sections() {
 
     assert!(rendered.contains(" Planning "));
     assert!(rendered.contains("Reuse the shared auth bridge."));
-    assert!(rendered.contains("... 1 more planning step(s)"));
-    assert!(!rendered.contains("planning module 1"));
+    assert!(!rendered.contains("more planning step(s)"));
+    assert!(rendered.contains("planning module 1"));
     assert!(rendered.contains("planning module 2"));
-    assert!(
-        rendered.find("Reuse the shared auth bridge.")
-            < rendered.find("... 1 more planning step(s)")
-    );
     assert!(rendered.contains("planning module 3"));
     assert!(rendered.contains("planning module 5"));
+    assert_eq!(rendered.matches(" Planning ").count(), 6);
+    assert!(rendered.find("planning module 1") < rendered.find("planning module 5"));
+    assert!(rendered.find("planning module 5") < rendered.find("Reuse the shared auth bridge."));
 }
 
 #[test]
-fn active_turn_cell_compacts_long_live_running_sections() {
+fn active_turn_cell_appends_long_live_running_events() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -430,12 +428,13 @@ fn active_turn_cell_compacts_long_live_running_sections() {
         .join("\n");
 
     assert!(rendered.contains(" Running "));
-    assert!(rendered.contains("Run task 6"));
-    assert!(rendered.contains("... 2 more running step(s)"));
-    assert!(!rendered.contains("Run task 1"));
-    assert!(!rendered.contains("Run task 2"));
+    assert!(rendered.contains("Run task 1"));
+    assert!(rendered.contains("Run task 2"));
     assert!(rendered.contains("Run task 3"));
-    assert!(rendered.find("Run task 6") < rendered.find("... 2 more running step(s)"));
+    assert!(rendered.contains("Run task 6"));
+    assert!(!rendered.contains("more running step(s)"));
+    assert_eq!(rendered.matches(" Running ").count(), 6);
+    assert!(rendered.find("Run task 1") < rendered.find("Run task 6"));
 }
 
 #[test]

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -190,6 +190,55 @@ fn committed_turn_cell_keeps_progress_segments_and_terminal_output() {
 }
 
 #[test]
+fn committed_turn_cell_appends_adjacent_progress_entries() {
+    let entries = vec![
+        TranscriptEntry {
+            role: "You".into(),
+            message: "Inspect the split".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Exploring".into(),
+            message: "Read src/context/assembler.rs".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Exploring".into(),
+            message: "Read src/context/mod.rs".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Running".into(),
+            message: "Run cargo test active_turn_cell".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Running".into(),
+            message: "Run cargo check".into(),
+            payload: None,
+        },
+    ];
+
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let first_explored = rendered.find("Read src/context/assembler.rs").unwrap();
+    let second_explored = rendered.find("Read src/context/mod.rs").unwrap();
+    let first_ran = rendered.find("Run cargo test active_turn_cell").unwrap();
+    let second_ran = rendered.find("Run cargo check").unwrap();
+
+    assert_eq!(rendered.matches(" Explored ").count(), 2);
+    assert_eq!(rendered.matches(" Ran ").count(), 2);
+    assert!(first_explored < second_explored);
+    assert!(second_explored < first_ran);
+    assert!(first_ran < second_ran);
+}
+
+#[test]
 fn committed_turn_cell_places_completion_records_before_final_agent_message() {
     let entries = vec![
         TranscriptEntry { role: "You".into(), message: "Inspect the repo and decide whether to run the migration".into(), payload: None },

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -9,21 +9,6 @@ use super::{
 use crate::redaction::redact_secrets;
 use crate::tui::terminal_event::TerminalEvent;
 
-fn grouped_active_live_events(events: &[ActiveLiveEvent]) -> Vec<(&'static str, Vec<String>)> {
-    let mut groups: Vec<(&'static str, Vec<String>)> = Vec::new();
-    for event in events {
-        let role = event.role();
-        if let Some((last_role, messages)) = groups.last_mut()
-            && *last_role == role
-        {
-            messages.push(event.message().to_string());
-            continue;
-        }
-        groups.push((role, vec![event.message().to_string()]));
-    }
-    groups
-}
-
 fn legacy_active_live_sections(live: &ActiveLiveSections) -> Vec<(&'static str, Vec<String>)> {
     vec![
         (
@@ -276,14 +261,11 @@ impl TuiApp {
 
     fn materialize_active_live_entries(&mut self) {
         if !self.active_live.events.is_empty() {
-            let sections = grouped_active_live_events(&self.active_live.events);
-            for (role, lines) in sections {
-                if lines.is_empty() {
-                    continue;
-                }
-                self.active_turn
-                    .entries
-                    .push(TranscriptEntry::new(role, lines.join("\n")));
+            for event in &self.active_live.events {
+                self.active_turn.entries.push(TranscriptEntry::new(
+                    event.role(),
+                    event.message().to_string(),
+                ));
             }
             return;
         }


### PR DESCRIPTION
## Summary

- Render active progress as ordered appended events instead of regrouping adjacent `Exploring`, `Planning`, and `Running` entries.
- Materialize active live progress into one transcript entry per event when a turn commits.
- Keep committed progress entries appended, so adjacent same-role entries are not folded back into one card.
- Add focused rendering tests for active long progress sequences and committed adjacent progress entries.

## Testing

- `cargo test active_turn_cell -- --nocapture`
- `cargo test committed_turn_cell -- --nocapture`
- `cargo check --message-format=short`

## Related Issues

- None.
