### PR TITLE
fix: add sandbox network config

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -6,18 +6,19 @@ mod secrets;
 mod serde_helpers;
 
 pub use self::defaults::{
-    should_apply_codex_base_url, should_reset_codex_base_url, should_reset_codex_model,
     DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL,
     DEFAULT_DEEPSEEK_BASE_URL, DEFAULT_DEEPSEEK_MODEL, DEFAULT_KIMI_BASE_URL, DEFAULT_KIMI_MODEL,
     DEFAULT_OPENAI_COMPATIBLE_BASE_URL, DEFAULT_OPENAI_COMPATIBLE_MODEL,
     DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OPENROUTER_MODEL, DEFAULT_REASONING_SUMMARY,
     LEGACY_CODEX_BASE_URL, LEGACY_CODEX_MODEL, LEGACY_CODEX_MODEL_V1, LEGACY_CODEX_MODEL_V1_MINI,
-    REASONING_SUMMARY_DETAILED, REASONING_SUMMARY_NONE,
+    REASONING_SUMMARY_DETAILED, REASONING_SUMMARY_NONE, should_apply_codex_base_url,
+    should_reset_codex_base_url, should_reset_codex_model,
 };
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{
-    ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for, workspace_data_dir_for_home,
     ConfigManager, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState, RaraConfig,
+    SandboxWorkspaceWriteConfig, ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for,
+    workspace_data_dir_for_home,
 };
 pub use self::provider_surface::{
     ConfigValueSource, EffectiveProviderSurface, ResolvedProviderValue,

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -1,18 +1,18 @@
 use anyhow::Result;
-use codex_execpolicy::{blocking_append_allow_prefix_rule, PolicyParser};
+use codex_execpolicy::{PolicyParser, blocking_append_allow_prefix_rule};
 use dirs::home_dir;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use std::collections::{hash_map::DefaultHasher, BTreeMap};
+use std::collections::{BTreeMap, hash_map::DefaultHasher};
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 use crate::defaults::{
-    should_apply_codex_base_url, should_reset_codex_model, DEFAULT_CODEX_BASE_URL,
-    DEFAULT_CODEX_MODEL, DEFAULT_DEEPSEEK_BASE_URL, DEFAULT_DEEPSEEK_MODEL, DEFAULT_KIMI_BASE_URL,
-    DEFAULT_KIMI_MODEL, DEFAULT_OPENAI_COMPATIBLE_BASE_URL, DEFAULT_OPENAI_COMPATIBLE_MODEL,
-    DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OPENROUTER_MODEL, DEFAULT_REASONING_SUMMARY,
+    DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, DEFAULT_DEEPSEEK_BASE_URL, DEFAULT_DEEPSEEK_MODEL,
+    DEFAULT_KIMI_BASE_URL, DEFAULT_KIMI_MODEL, DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+    DEFAULT_OPENAI_COMPATIBLE_MODEL, DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_REASONING_SUMMARY, should_apply_codex_base_url, should_reset_codex_model,
 };
 use crate::migration::migrate_reasoning_summary;
 use crate::provider_surface::{ConfigValueSource, EffectiveProviderSurface, ResolvedProviderValue};
@@ -117,6 +117,30 @@ pub struct OpenAiEndpointProfile {
     pub revision: Option<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub struct SandboxWorkspaceWriteConfig {
+    #[serde(default = "default_true")]
+    pub network_access: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for SandboxWorkspaceWriteConfig {
+    fn default() -> Self {
+        Self {
+            network_access: true,
+        }
+    }
+}
+
+impl SandboxWorkspaceWriteConfig {
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct RaraConfig {
     pub provider: String,
@@ -145,6 +169,11 @@ pub struct RaraConfig {
     pub active_openai_profile_id: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub openai_profiles: BTreeMap<String, OpenAiEndpointProfile>,
+    #[serde(
+        default,
+        skip_serializing_if = "SandboxWorkspaceWriteConfig::is_default"
+    )]
+    pub sandbox_workspace_write: SandboxWorkspaceWriteConfig,
 }
 
 impl RaraConfig {
@@ -798,8 +827,8 @@ fn stable_path_hash(root: &Path) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        workspace_data_dir_for_home, ConfigManager, OpenAiEndpointKind, OpenAiEndpointProfile,
-        ProviderConfigState, RaraConfig,
+        ConfigManager, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState, RaraConfig,
+        workspace_data_dir_for_home,
     };
     use crate::defaults::{
         DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL,
@@ -831,6 +860,63 @@ mod tests {
         let mut config = RaraConfig::default();
         config.set_api_key("");
         assert!(!config.has_api_key());
+    }
+
+    #[test]
+    fn loads_codex_style_sandbox_workspace_network_access() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "codex",
+                "sandbox_workspace_write": {
+                    "network_access": true
+                }
+            }"#,
+        )
+        .expect("deserialize config");
+
+        assert!(config.sandbox_workspace_write.network_access);
+    }
+
+    #[test]
+    fn sandbox_workspace_network_access_defaults_on() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "codex"
+            }"#,
+        )
+        .expect("deserialize config");
+
+        assert!(config.sandbox_workspace_write.network_access);
+    }
+
+    #[test]
+    fn sandbox_workspace_network_access_empty_object_defaults_on() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "codex",
+                "sandbox_workspace_write": {}
+            }"#,
+        )
+        .expect("deserialize config");
+
+        assert!(config.sandbox_workspace_write.network_access);
+    }
+
+    #[test]
+    fn sandbox_workspace_network_access_can_be_disabled() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "codex",
+                "sandbox_workspace_write": {
+                    "network_access": false
+                }
+            }"#,
+        )
+        .expect("deserialize config");
+
+        assert!(!config.sandbox_workspace_write.network_access);
+        let json = serde_json::to_string(&config).expect("serialize config");
+        assert!(json.contains("sandbox_workspace_write"));
     }
 
     #[test]

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -23,6 +23,7 @@ pub struct WrappedCommand {
     pub sandboxed: bool,
     pub sandbox_backend: String,
     pub sandbox_home: Option<PathBuf>,
+    pub network_access: bool,
 }
 
 const LINUX_RUNTIME_READ_ROOTS: &[&str] = &[
@@ -266,6 +267,7 @@ impl SandboxManager {
                     sandboxed: true,
                     sandbox_backend: self.backend.name().to_string(),
                     sandbox_home: Some(self.sandbox_home.clone()),
+                    network_access: allow_net,
                 })
             }
             SandboxBackend::LinuxBubblewrap => {
@@ -281,6 +283,7 @@ impl SandboxManager {
                     sandboxed: true,
                     sandbox_backend: self.backend.name().to_string(),
                     sandbox_home: Some(self.sandbox_home.clone()),
+                    network_access: allow_net,
                 })
             }
             SandboxBackend::Direct => Ok(wrap_direct_shell_command(original_cmd)),
@@ -329,6 +332,7 @@ impl SandboxManager {
                     sandboxed: true,
                     sandbox_backend: self.backend.name().to_string(),
                     sandbox_home: Some(self.sandbox_home.clone()),
+                    network_access: allow_net,
                 })
             }
             SandboxBackend::LinuxBubblewrap => {
@@ -343,6 +347,7 @@ impl SandboxManager {
                     sandboxed: true,
                     sandbox_backend: self.backend.name().to_string(),
                     sandbox_home: Some(self.sandbox_home.clone()),
+                    network_access: allow_net,
                 })
             }
             SandboxBackend::Direct => Ok(wrap_direct_exec_command(program, args)),
@@ -406,6 +411,7 @@ fn wrap_direct_shell_command(original_cmd: &str) -> WrappedCommand {
         sandboxed: false,
         sandbox_backend: SandboxBackend::Direct.name().to_string(),
         sandbox_home: None,
+        network_access: true,
     }
 }
 
@@ -417,6 +423,7 @@ fn wrap_direct_exec_command(program: &str, args: &[String]) -> WrappedCommand {
         sandboxed: false,
         sandbox_backend: SandboxBackend::Direct.name().to_string(),
         sandbox_home: None,
+        network_access: true,
     }
 }
 
@@ -905,6 +912,21 @@ mod tests {
             wrapped.sandbox_home.as_deref(),
             Some(manager.sandbox_home.as_path())
         );
+    }
+
+    #[test]
+    fn linux_sandbox_keeps_network_when_allowed() {
+        let manager = manager("linux", SandboxBackend::LinuxBubblewrap);
+
+        let wrapped = manager
+            .wrap_shell_command("curl https://example.com", "/workspace/project", true)
+            .expect("linux sandbox wrapper");
+
+        assert!(
+            !wrapped.args.contains(&"--unshare-net".to_string()),
+            "linux sandbox should not isolate networking when allow_net is true"
+        );
+        assert!(wrapped.network_access);
     }
 
     #[test]

--- a/docs/journal/2026-04-30-sandbox-network-config.md
+++ b/docs/journal/2026-04-30-sandbox-network-config.md
@@ -1,0 +1,29 @@
+# Sandbox Network Config
+
+RARA now mirrors Codex-style workspace-write sandbox network configuration with
+`sandbox_workspace_write.network_access`.
+
+The default is enabled. This keeps ordinary sandboxed shell and PTY commands
+able to use the network without requiring every tool call to set `allow_net`.
+Users can still disable network access explicitly with:
+
+```json
+{
+  "sandbox_workspace_write": {
+    "network_access": false
+  }
+}
+```
+
+Tool-level `allow_net` remains supported as an explicit per-call opt-in when the
+global config is disabled. Wrapped commands now carry the effective network
+state so bash and PTY session environments can expose
+`RARA_SANDBOX_NETWORK_DISABLED=1` when sandbox networking is disabled.
+
+Validated with:
+
+- `cargo test -p rara-config sandbox_workspace -- --nocapture`
+- `cargo test -p rara-sandbox linux_sandbox -- --nocapture`
+- `cargo test sandbox_command_env -- --nocapture`
+- `cargo test sandboxed_pty_env_falls_back_to_process_path_when_snapshot_path_is_missing -- --nocapture`
+- `cargo check --message-format=short`

--- a/docs/journal/2026-04-30-sandbox-network-config.md
+++ b/docs/journal/2026-04-30-sandbox-network-config.md
@@ -19,11 +19,17 @@ Tool-level `allow_net` remains supported as an explicit per-call opt-in when the
 global config is disabled. Wrapped commands now carry the effective network
 state so bash and PTY session environments can expose
 `RARA_SANDBOX_NETWORK_DISABLED=1` when sandbox networking is disabled.
+Background task records and PTY session snapshots also expose `network_access`
+so list/status/stop surfaces show the effective policy that was used when the
+process started.
 
 Validated with:
 
 - `cargo test -p rara-config sandbox_workspace -- --nocapture`
 - `cargo test -p rara-sandbox linux_sandbox -- --nocapture`
 - `cargo test sandbox_command_env -- --nocapture`
+- `cargo test background_call_returns_task_and_status_reads_output -- --nocapture`
+- `cargo test background_tasks_can_be_listed_and_stopped_without_count_limit -- --nocapture`
 - `cargo test sandboxed_pty_env_falls_back_to_process_path_when_snapshot_path_is_missing -- --nocapture`
+- `cargo test pty_sessions_can_be_listed_statused_and_stopped -- --nocapture`
 - `cargo check --message-format=short`

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -87,6 +87,7 @@ pub(crate) async fn initialize_rara_context(
         skill_manager,
         prompt_config.clone(),
         Arc::new(shell_env.env),
+        config.sandbox_workspace_write.network_access,
     );
     let warnings = prompt_config.warnings.clone();
 

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -39,6 +39,7 @@ pub(super) fn create_full_tool_manager(
     skill_manager: Arc<SkillManager>,
     prompt_config: PromptRuntimeConfig,
     shell_env: Arc<HashMap<String, String>>,
+    sandbox_network_access: bool,
 ) -> ToolManager {
     let mut tm = ToolManager::new();
     let vector_db_uri = vector_db_uri_for_workspace(&workspace);
@@ -54,6 +55,7 @@ pub(super) fn create_full_tool_manager(
         sandbox: sandbox.clone(),
         background_tasks: background_tasks.clone(),
         base_env: shell_env.clone(),
+        sandbox_network_access,
     }));
     tm.register(Box::new(BackgroundTaskListTool {
         background_tasks: background_tasks.clone(),
@@ -66,6 +68,7 @@ pub(super) fn create_full_tool_manager(
         sessions: pty_sessions.clone(),
         sandbox: sandbox.clone(),
         base_env: shell_env.clone(),
+        sandbox_network_access,
     }));
     tm.register(Box::new(PtyReadTool {
         sessions: pty_sessions.clone(),

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -22,6 +22,7 @@ pub struct BashTool {
     pub sandbox: Arc<SandboxManager>,
     pub background_tasks: Arc<BackgroundTaskStore>,
     pub base_env: Arc<HashMap<String, String>>,
+    pub sandbox_network_access: bool,
 }
 
 pub struct BackgroundTaskStatusTool {
@@ -622,6 +623,7 @@ fn sandbox_command_env(
     sandbox_home: &Path,
     base_env: &HashMap<String, String>,
     overrides: &HashMap<String, String>,
+    network_access: bool,
 ) -> HashMap<String, String> {
     let sandbox_home = sandbox_home.to_string_lossy();
     let mut env_map = HashMap::from([
@@ -654,6 +656,9 @@ fn sandbox_command_env(
             .map(|(key, value)| (key.clone(), value.clone())),
     );
     ensure_usable_path(&mut env_map);
+    if !network_access {
+        env_map.insert("RARA_SANDBOX_NETWORK_DISABLED".to_string(), "1".to_string());
+    }
     env_map
 }
 
@@ -677,7 +682,12 @@ fn command_env_for_wrapped(
         let sandbox_home = wrapped.sandbox_home.as_deref().ok_or_else(|| {
             ToolError::ExecutionFailed("sandboxed command is missing sandbox home".into())
         })?;
-        Ok(sandbox_command_env(sandbox_home, base_env, overrides))
+        Ok(sandbox_command_env(
+            sandbox_home,
+            base_env,
+            overrides,
+            wrapped.network_access,
+        ))
     } else {
         let mut env_map = HashMap::with_capacity(base_env.len() + overrides.len());
         env_map.extend(
@@ -728,7 +738,11 @@ impl Tool for BashTool {
                     "additionalProperties": { "type": "string" },
                     "description": "Optional environment overrides."
                 },
-                "allow_net": { "type": "boolean", "default": false },
+                "allow_net": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Request network access for this command. Commands already have network access when sandbox_workspace_write.network_access is enabled in config."
+                },
                 "run_in_background": {
                     "type": "boolean",
                     "default": false,
@@ -752,9 +766,10 @@ impl Tool for BashTool {
     ) -> Result<Value, ToolError> {
         let request = BashCommandInput::from_value(i)?;
         let cwd = request.working_dir()?;
+        let allow_net = self.sandbox_network_access || request.allow_net;
         let wrapped = if let Some(command) = request.command.as_deref() {
             self.sandbox
-                .wrap_shell_command(command, &cwd, request.allow_net)
+                .wrap_shell_command(command, &cwd, allow_net)
                 .map_err(|e| {
                     ToolError::ExecutionFailed(format!("{} {}", e, sandbox_failure_hint()))
                 })?
@@ -765,7 +780,7 @@ impl Tool for BashTool {
                 .filter(|value| !value.trim().is_empty())
                 .ok_or_else(|| ToolError::InvalidInput("program".into()))?;
             self.sandbox
-                .wrap_exec_command(program, &request.args, &cwd, request.allow_net)
+                .wrap_exec_command(program, &request.args, &cwd, allow_net)
                 .map_err(|e| {
                     ToolError::ExecutionFailed(format!("{} {}", e, sandbox_failure_hint()))
                 })?
@@ -1382,7 +1397,7 @@ mod tests {
     fn sandbox_command_env_defaults_home_and_xdg_roots() {
         let sandbox_home = Path::new("/tmp/rara-test-home");
         let base_env = HashMap::from([("PATH".to_string(), "/custom/bin:/usr/bin".to_string())]);
-        let env_map = sandbox_command_env(sandbox_home, &base_env, &HashMap::new());
+        let env_map = sandbox_command_env(sandbox_home, &base_env, &HashMap::new(), true);
 
         assert_eq!(
             env_map.get("HOME").map(String::as_str),
@@ -1416,6 +1431,7 @@ mod tests {
                 ),
                 ("PATH".to_string(), "/override/bin".to_string()),
             ]),
+            true,
         );
 
         assert_eq!(
@@ -1443,11 +1459,29 @@ mod tests {
             sandbox_home,
             &HashMap::from([("PATH".to_string(), String::new())]),
             &HashMap::new(),
+            true,
         );
 
         assert!(
             env_map.get("PATH").is_some_and(|path| !path.is_empty()),
             "sandbox env must keep a usable PATH after env_clear"
+        );
+    }
+
+    #[test]
+    fn sandbox_command_env_marks_disabled_network() {
+        let env_map = sandbox_command_env(
+            Path::new("/tmp/rara-test-home"),
+            &HashMap::new(),
+            &HashMap::new(),
+            false,
+        );
+
+        assert_eq!(
+            env_map
+                .get("RARA_SANDBOX_NETWORK_DISABLED")
+                .map(String::as_str),
+            Some("1")
         );
     }
 
@@ -1469,6 +1503,7 @@ mod tests {
             sandboxed: false,
             sandbox_backend: "direct".to_string(),
             sandbox_home: None,
+            network_access: true,
         };
         let env_map = command_env_for_wrapped(
             &wrapped,
@@ -1497,6 +1532,7 @@ mod tests {
             sandboxed: false,
             sandbox_backend: "direct".to_string(),
             sandbox_home: None,
+            network_access: true,
         };
 
         let warning = unsandboxed_execution_warning(&wrapped);
@@ -1530,6 +1566,7 @@ mod tests {
                     .expect("background task store"),
             ),
             base_env: Arc::new(HashMap::new()),
+            sandbox_network_access: false,
         };
         let mut events = Vec::new();
         let result = tool
@@ -1592,6 +1629,7 @@ mod tests {
             sandbox: Arc::new(sandbox),
             background_tasks: background_tasks.clone(),
             base_env: Arc::new(HashMap::new()),
+            sandbox_network_access: false,
         };
         let status_tool = BackgroundTaskStatusTool {
             background_tasks: background_tasks.clone(),
@@ -1658,6 +1696,7 @@ mod tests {
             sandbox: Arc::new(sandbox),
             background_tasks: background_tasks.clone(),
             base_env: Arc::new(HashMap::new()),
+            sandbox_network_access: false,
         };
         let list_tool = BackgroundTaskListTool {
             background_tasks: background_tasks.clone(),

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -53,6 +53,7 @@ pub struct BackgroundTaskRecord {
     exit_code: Option<i32>,
     sandboxed: bool,
     sandbox_backend: String,
+    network_access: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -521,6 +522,7 @@ impl BackgroundTaskStore {
         command: String,
         sandboxed: bool,
         sandbox_backend: String,
+        network_access: bool,
     ) -> Result<(BackgroundTaskRecord, oneshot::Receiver<()>), ToolError> {
         let id = format!("bash-{}", Uuid::new_v4());
         let output_path = self.dir.join(format!("{id}.log"));
@@ -532,6 +534,7 @@ impl BackgroundTaskStore {
             exit_code: None,
             sandboxed,
             sandbox_backend,
+            network_access,
         };
         let (stop_tx, stop_rx) = oneshot::channel();
         self.tasks
@@ -824,6 +827,7 @@ impl Tool for BashTool {
                 request.summary(),
                 wrapped.sandboxed,
                 wrapped.sandbox_backend.clone(),
+                wrapped.network_access,
             )?;
             spawn_background_bash_task(
                 child,
@@ -842,6 +846,7 @@ impl Tool for BashTool {
                 "background_task_id": record.id,
                 "output_path": record.output_path,
                 "status": record.status,
+                "network_access": record.network_access,
             }));
         }
 
@@ -993,6 +998,7 @@ impl Tool for BackgroundTaskStatusTool {
             "output": output,
             "sandboxed": record.sandboxed,
             "sandbox_backend": record.sandbox_backend,
+            "network_access": record.network_access,
         }))
     }
 }
@@ -1652,6 +1658,10 @@ mod tests {
             started.get("status"),
             Some(&json!(BackgroundTaskStatus::Running))
         );
+        assert_eq!(
+            started.get("network_access").and_then(Value::as_bool),
+            Some(wrapped.network_access)
+        );
 
         let mut last = Value::Null;
         for _ in 0..50 {
@@ -1670,6 +1680,10 @@ mod tests {
             Some(&json!(BackgroundTaskStatus::Running))
         );
         assert!(last.get("output_path").and_then(Value::as_str).is_some());
+        assert_eq!(
+            last.get("network_access").and_then(Value::as_bool),
+            Some(wrapped.network_access)
+        );
     }
 
     #[tokio::test]
@@ -1724,6 +1738,10 @@ mod tests {
             listed.get("tasks").and_then(Value::as_array).map(Vec::len),
             Some(1)
         );
+        assert_eq!(
+            listed.pointer("/tasks/0/network_access").and_then(Value::as_bool),
+            Some(wrapped.network_access)
+        );
 
         let stopped = stop_tool
             .call(json!({ "task_id": task_id }))
@@ -1732,6 +1750,12 @@ mod tests {
         assert_eq!(
             stopped.pointer("/stopped/0/status"),
             Some(&json!(BackgroundTaskStatus::Killed))
+        );
+        assert_eq!(
+            stopped
+                .pointer("/stopped/0/network_access")
+                .and_then(Value::as_bool),
+            Some(wrapped.network_access)
         );
     }
 

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -55,6 +55,7 @@ struct PtySessionRecord {
     output_path: PathBuf,
     sandboxed: bool,
     sandbox_backend: String,
+    network_access: bool,
     writer: Arc<Mutex<Box<dyn Write + Send>>>,
     child: Arc<Mutex<Box<dyn portable_pty::Child + Send + Sync>>>,
     status: Arc<Mutex<PtySessionStatus>>,
@@ -173,6 +174,7 @@ impl PtySessionStore {
             output_path,
             sandboxed: wrapped.sandboxed,
             sandbox_backend: wrapped.sandbox_backend,
+            network_access: wrapped.network_access,
             writer: Arc::new(Mutex::new(writer)),
             child,
             status,
@@ -262,6 +264,7 @@ struct PtySessionSnapshot {
     output_path: PathBuf,
     sandboxed: bool,
     sandbox_backend: String,
+    network_access: bool,
     status: PtySessionStatus,
 }
 
@@ -273,6 +276,7 @@ impl PtySessionRecord {
             output_path: self.output_path.clone(),
             sandboxed: self.sandboxed,
             sandbox_backend: self.sandbox_backend.clone(),
+            network_access: self.network_access,
             status: *self.status.lock().expect("pty status lock"),
         }
     }
@@ -287,6 +291,7 @@ impl PtySessionSnapshot {
             "output_path": self.output_path,
             "sandboxed": self.sandboxed,
             "sandbox_backend": self.sandbox_backend,
+            "network_access": self.network_access,
         })
     }
 
@@ -299,6 +304,7 @@ impl PtySessionSnapshot {
             "output_path": self.output_path,
             "sandboxed": self.sandboxed,
             "sandbox_backend": self.sandbox_backend,
+            "network_access": self.network_access,
             "output": output,
         }))
     }
@@ -777,6 +783,7 @@ mod tests {
             .and_then(Value::as_str)
             .expect("session id")
             .to_string();
+        assert_eq!(started.get("network_access").and_then(Value::as_bool), Some(true));
 
         write
             .call(json!({
@@ -855,6 +862,7 @@ mod tests {
             .and_then(Value::as_str)
             .expect("session id")
             .to_string();
+        assert_eq!(started.get("network_access").and_then(Value::as_bool), Some(true));
 
         let listed = list.call(json!({})).await.expect("list ptys");
         assert_eq!(
@@ -863,6 +871,12 @@ mod tests {
                 .and_then(Value::as_array)
                 .map(Vec::len),
             Some(1)
+        );
+        assert_eq!(
+            listed
+                .pointer("/sessions/0/network_access")
+                .and_then(Value::as_bool),
+            Some(true)
         );
 
         let inspected = status
@@ -873,11 +887,21 @@ mod tests {
             inspected.get("status").and_then(Value::as_str),
             Some("running")
         );
+        assert_eq!(
+            inspected.get("network_access").and_then(Value::as_bool),
+            Some(true)
+        );
 
         let stopped = stop.call(json!({})).await.expect("stop all ptys");
         assert_eq!(
             stopped.pointer("/stopped/0/status").and_then(Value::as_str),
             Some("killed")
+        );
+        assert_eq!(
+            stopped
+                .pointer("/stopped/0/network_access")
+                .and_then(Value::as_bool),
+            Some(true)
         );
     }
 }

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -17,6 +17,7 @@ pub struct PtyStartTool {
     pub sessions: Arc<PtySessionStore>,
     pub sandbox: Arc<SandboxManager>,
     pub base_env: Arc<HashMap<String, String>>,
+    pub sandbox_network_access: bool,
 }
 
 pub struct PtyReadTool {
@@ -324,7 +325,11 @@ impl Tool for PtyStartTool {
                     "additionalProperties": { "type": "string" },
                     "description": "Optional environment overrides."
                 },
-                "allow_net": { "type": "boolean", "default": false },
+                "allow_net": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Request network access for this PTY session. PTY sessions already have network access when sandbox_workspace_write.network_access is enabled in config."
+                },
                 "rows": { "type": "integer", "default": 24, "minimum": 1, "maximum": 65535 },
                 "cols": { "type": "integer", "default": 120, "minimum": 1, "maximum": 65535 }
             },
@@ -353,6 +358,7 @@ impl Tool for PtyStartTool {
             .get("allow_net")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let allow_net = self.sandbox_network_access || allow_net;
         let wrapped = self
             .sandbox
             .wrap_pty_shell_command(&command, &cwd, allow_net)
@@ -610,6 +616,9 @@ fn command_env_for_wrapped(
     );
     if wrapped.sandboxed {
         ensure_usable_path(&mut env_map);
+        if !wrapped.network_access {
+            env_map.insert("RARA_SANDBOX_NETWORK_DISABLED".to_string(), "1".to_string());
+        }
     }
     Ok(env_map)
 }
@@ -708,6 +717,7 @@ mod tests {
             sandboxed: true,
             sandbox_backend: "linux-bubblewrap".to_string(),
             sandbox_home: Some(temp.path().join("home")),
+            network_access: false,
         };
         let env_map = command_env_for_wrapped(
             &wrapped,
@@ -719,6 +729,12 @@ mod tests {
         assert!(
             env_map.get("PATH").is_some_and(|path| !path.is_empty()),
             "sandboxed PTY env must keep a usable PATH after env_clear"
+        );
+        assert_eq!(
+            env_map
+                .get("RARA_SANDBOX_NETWORK_DISABLED")
+                .map(String::as_str),
+            Some("1")
         );
     }
 
@@ -744,6 +760,7 @@ mod tests {
                     sandboxed: false,
                     sandbox_backend: "direct".to_string(),
                     sandbox_home: None,
+                    network_access: true,
                 },
                 temp.path().display().to_string(),
                 &HashMap::new(),
@@ -821,6 +838,7 @@ mod tests {
                     sandboxed: false,
                     sandbox_backend: "direct".to_string(),
                     sandbox_home: None,
+                    network_access: true,
                 },
                 temp.path().display().to_string(),
                 &HashMap::new(),


### PR DESCRIPTION
## Summary

- Add Codex-style `sandbox_workspace_write.network_access` config for sandboxed commands.
- Default sandbox network access to enabled while preserving explicit opt-out.
- Thread the effective network policy through bash, background commands, and PTY sessions.
- Mark sandboxed child environments with `RARA_SANDBOX_NETWORK_DISABLED=1` when network access is disabled.

## Validation

- `cargo test -p rara-config sandbox_workspace -- --nocapture`
- `cargo test -p rara-sandbox linux_sandbox -- --nocapture`
- `cargo test sandbox_command_env -- --nocapture`
- `cargo test sandboxed_pty_env_falls_back_to_process_path_when_snapshot_path_is_missing -- --nocapture`
- `cargo check --message-format=short`
