### PR TITLE
chore: run cargo fmt and add CI format check

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,23 @@
+name: fmt
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Run cargo fmt check
+        run: cargo fmt --all --check

--- a/crates/provider-catalog/src/deepseek.rs
+++ b/crates/provider-catalog/src/deepseek.rs
@@ -1,10 +1,10 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use rara_config::DEFAULT_DEEPSEEK_BASE_URL;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
-use crate::redaction::{redact_known_secret, sanitize_url_for_display};
 use crate::ModelCatalogRequest;
+use crate::redaction::{redact_known_secret, sanitize_url_for_display};
 
 const MODELS_TIMEOUT_SECS: u64 = 15;
 

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -176,7 +176,7 @@ fn skill_name_from_path(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{repo_skill_search_dirs, skill_search_dirs, SkillManager};
+    use super::{SkillManager, repo_skill_search_dirs, skill_search_dirs};
     use std::fs;
     use tempfile::tempdir;
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1,11 +1,11 @@
 use crate::llm::LlmBackend;
 use crate::tool::ToolManager;
+use agent_client_protocol::Error;
 use agent_client_protocol::schema::{
     AuthenticateRequest, AuthenticateResponse, CancelNotification, Implementation,
     InitializeRequest, InitializeResponse, NewSessionRequest, NewSessionResponse, PromptRequest,
     PromptResponse, ProtocolVersion, SessionId, StopReason,
 };
-use agent_client_protocol::Error;
 
 pub struct RaraAcpAgent {
     pub tool_manager: ToolManager,

--- a/src/agent/tests/context_view.rs
+++ b/src/agent/tests/context_view.rs
@@ -1,4 +1,4 @@
-use super::support::{test_runtime_storage, SequencedBackend};
+use super::support::{SequencedBackend, test_runtime_storage};
 use crate::agent::{Agent, AgentExecutionMode, Message, PlanStep, PlanStepStatus};
 use crate::llm::{ContentBlock, LlmResponse};
 use crate::prompt::PromptRuntimeConfig;
@@ -148,20 +148,24 @@ fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
     assert_eq!(runtime.total_input_tokens, 11);
     assert_eq!(runtime.total_output_tokens, 7);
     assert_eq!(runtime.prompt.base_prompt_kind, "default");
-    assert!(runtime
-        .prompt
-        .section_keys
-        .contains(&"append_system_prompt".to_string()));
+    assert!(
+        runtime
+            .prompt
+            .section_keys
+            .contains(&"append_system_prompt".to_string())
+    );
     assert_eq!(
         runtime.prompt.source_entries.len(),
         runtime.prompt.source_status_lines.len()
     );
     assert_eq!(runtime.prompt.source_entries[0].order, 1);
     assert!(!runtime.prompt.source_entries[0].inclusion_reason.is_empty());
-    assert!(runtime
-        .prompt
-        .warnings
-        .contains(&"missing prompt file".to_string()));
+    assert!(
+        runtime
+            .prompt
+            .warnings
+            .contains(&"missing prompt file".to_string())
+    );
     assert_eq!(runtime.plan.execution_mode, "plan");
     assert_eq!(
         runtime.plan.steps,
@@ -210,12 +214,16 @@ fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
         runtime.retrieval.memory_selection.selected_items[0].kind,
         "workspace_memory"
     );
-    assert!(runtime.retrieval.memory_selection.selected_items[0]
-        .detail
-        .contains(".rara/memory.md"));
-    assert!(runtime.retrieval.memory_selection.selected_items[0]
-        .detail
-        .contains("2 non-empty lines"));
+    assert!(
+        runtime.retrieval.memory_selection.selected_items[0]
+            .detail
+            .contains(".rara/memory.md")
+    );
+    assert!(
+        runtime.retrieval.memory_selection.selected_items[0]
+            .detail
+            .contains("2 non-empty lines")
+    );
     assert_eq!(
         runtime.retrieval.memory_selection.selected_items[1].kind,
         "compacted_summary"
@@ -252,22 +260,26 @@ fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
         runtime.retrieval.memory_selection.selected_items[9].kind,
         "retrieved_workspace_memory"
     );
-    assert!(runtime.retrieval.memory_selection.selected_items[9]
-        .detail
-        .contains("recalled=2 item(s)"));
+    assert!(
+        runtime.retrieval.memory_selection.selected_items[9]
+            .detail
+            .contains("recalled=2 item(s)")
+    );
     assert_eq!(
         runtime.retrieval.memory_selection.selected_items[10].kind,
         "retrieved_thread_context"
     );
-    assert!(runtime
-        .retrieval
-        .memory_selection
-        .selected_items
-        .iter()
-        .find(|item| item.kind == "retrieved_thread_context")
-        .is_some_and(|item| item
-            .detail
-            .contains("Auth picker already moved behind the shared runtime bootstrap.")));
+    assert!(
+        runtime
+            .retrieval
+            .memory_selection
+            .selected_items
+            .iter()
+            .find(|item| item.kind == "retrieved_thread_context")
+            .is_some_and(|item| item
+                .detail
+                .contains("Auth picker already moved behind the shared runtime bootstrap."))
+    );
     assert_eq!(runtime.retrieval.memory_selection.available_items.len(), 2);
     assert_eq!(
         runtime.retrieval.memory_selection.available_items[0].kind,
@@ -278,28 +290,36 @@ fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
         "vector_memory"
     );
     assert!(runtime.retrieval.memory_selection.dropped_items.is_empty());
-    assert!(runtime
-        .retrieval
-        .memory_selection
-        .selection_budget_tokens
-        .is_some());
+    assert!(
+        runtime
+            .retrieval
+            .memory_selection
+            .selection_budget_tokens
+            .is_some()
+    );
     assert!(runtime.budget.stable_instructions_budget > 0);
     assert!(runtime.budget.active_turn_budget > 0);
-    assert!(runtime
-        .assembly
-        .entries
-        .iter()
-        .any(|entry| entry.layer == "stable_instructions" && entry.injected));
-    assert!(runtime
-        .assembly
-        .entries
-        .iter()
-        .any(|entry| entry.layer == "compacted_history" && entry.injected));
-    assert!(runtime
-        .assembly
-        .entries
-        .iter()
-        .any(|entry| entry.layer == "retrieval_ready" && !entry.injected));
+    assert!(
+        runtime
+            .assembly
+            .entries
+            .iter()
+            .any(|entry| entry.layer == "stable_instructions" && entry.injected)
+    );
+    assert!(
+        runtime
+            .assembly
+            .entries
+            .iter()
+            .any(|entry| entry.layer == "compacted_history" && entry.injected)
+    );
+    assert!(
+        runtime
+            .assembly
+            .entries
+            .iter()
+            .any(|entry| entry.layer == "retrieval_ready" && !entry.injected)
+    );
 }
 
 #[test]

--- a/src/agent/tests/support.rs
+++ b/src/agent/tests/support.rs
@@ -7,7 +7,7 @@ use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
 use anyhow::Result;
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
 

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -1,6 +1,6 @@
-use crate::acp::{run_acp_stdio, RaraAcpAgent};
+use crate::acp::{RaraAcpAgent, run_acp_stdio};
 use crate::config::{
-    ConfigManager, RaraConfig, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL,
+    ConfigManager, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, RaraConfig,
 };
 use crate::llm::{LlmBackend, MockLlm};
 use crate::oauth::{OAuthManager, SavedCodexAuthMode};
@@ -8,7 +8,7 @@ use crate::redaction::redact_secrets;
 use crate::runtime_context;
 use crate::thread_cli;
 use crate::tui::StartupResumeTarget;
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
 use secrecy::ExposeSecret;
 

--- a/src/llm/codex_tools_compat.rs
+++ b/src/llm/codex_tools_compat.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::json;
 use serde_json::Value as JsonValue;
+use serde_json::json;
 use std::collections::BTreeMap;
 
 // Vendored from openai/codex codex-tools (rev 996aa23e4ce900468047ed3ec57d1e7271f8d6de),

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -1,18 +1,18 @@
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use futures::StreamExt;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::agent::Message;
 use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
 use super::shared::{
-    collect_assistant_content, context_budget_from_window, extract_single_tool_result,
-    hashed_embedding, http_client_for_target, parse_tool_arguments, render_openai_message_content,
-    ContextBudget, LlmBackend, LlmStreamEvent,
+    ContextBudget, LlmBackend, LlmStreamEvent, collect_assistant_content,
+    context_budget_from_window, extract_single_tool_result, hashed_embedding,
+    http_client_for_target, parse_tool_arguments, render_openai_message_content,
 };
 
 pub struct OllamaBackend {

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -1,10 +1,10 @@
 mod codex;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
 use secrecy::{ExposeSecret, SecretString};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::agent::Message;
 use crate::config::OpenAiEndpointKind;
@@ -12,9 +12,9 @@ use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
 use super::shared::{
-    collect_assistant_content, extract_message_text, http_client_for_target, model_context_budget,
+    ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata, collect_assistant_content,
+    extract_message_text, http_client_for_target, model_context_budget,
     next_stream_item_with_idle_timeout, parse_tool_arguments, render_openai_message_content,
-    ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata,
 };
 
 #[cfg(test)]

--- a/src/llm/openai_compatible/codex.rs
+++ b/src/llm/openai_compatible/codex.rs
@@ -1,22 +1,22 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use codex_login::default_client::default_headers as codex_default_headers;
 use eventsource_stream::Eventsource;
 use secrecy::{ExposeSecret, SecretString};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::agent::Message;
 use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
+use super::super::codex_tools_compat::ToolDefinition;
+use super::super::codex_tools_compat::ToolSpec;
 use super::super::codex_tools_compat::create_tools_json_for_responses_api;
 use super::super::codex_tools_compat::parse_tool_input_schema;
 use super::super::codex_tools_compat::tool_definition_to_responses_api_tool;
-use super::super::codex_tools_compat::ToolDefinition;
-use super::super::codex_tools_compat::ToolSpec;
 use super::super::shared::{
-    collect_assistant_content, model_context_budget, next_stream_item_with_idle_timeout,
-    parse_tool_arguments, render_openai_message_content, ContextBudget, LlmBackend, LlmStreamEvent,
+    ContextBudget, LlmBackend, LlmStreamEvent, collect_assistant_content, model_context_budget,
+    next_stream_item_with_idle_timeout, parse_tool_arguments, render_openai_message_content,
 };
 use super::{CodexBackend, OpenAiCompatibleBackend};
 

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -1,10 +1,10 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use futures::{Stream, StreamExt};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::{
-    atomic::{AtomicBool, Ordering},
     Arc,
+    atomic::{AtomicBool, Ordering},
 };
 use std::time::Duration;
 use url::Url;

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -110,9 +110,11 @@ fn fills_missing_openai_tool_results_before_follow_up_messages() {
     assert_eq!(openai_messages[1]["tool_call_id"], "tool-1");
     assert_eq!(openai_messages[2]["role"], "tool");
     assert_eq!(openai_messages[2]["tool_call_id"], "tool-2");
-    assert!(openai_messages[2]["content"]
-        .as_str()
-        .is_some_and(|content| content.contains("interrupted before a result was recorded")));
+    assert!(
+        openai_messages[2]["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("interrupted before a result was recorded"))
+    );
     assert_eq!(openai_messages[3]["role"], "user");
     assert_eq!(openai_messages[3]["content"], "continue");
 }
@@ -139,9 +141,11 @@ fn drops_orphan_openai_tool_results_without_context_prefix() {
     assert_eq!(openai_messages.len(), 1);
     assert_eq!(openai_messages[0]["role"], "user");
     assert_eq!(openai_messages[0]["content"], "continue");
-    assert!(!openai_messages.iter().any(|message| message["content"]
-        .as_str()
-        .is_some_and(|content| content.contains("tool_result orphan:"))));
+    assert!(!openai_messages.iter().any(|message| {
+        message["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("tool_result orphan:"))
+    }));
 }
 
 #[test]
@@ -341,9 +345,11 @@ fn deepseek_reasoner_defaults_preserve_standard_body() {
 
     assert!(body.get("thinking").is_none());
     assert!(body.get("reasoning_effort").is_none());
-    assert!(body["tools"]
-        .as_array()
-        .is_some_and(|tools| tools.len() == 1));
+    assert!(
+        body["tools"]
+            .as_array()
+            .is_some_and(|tools| tools.len() == 1)
+    );
 }
 
 #[test]
@@ -436,9 +442,11 @@ fn deepseek_reasoner_explicit_thinking_enables_controls_for_tools() {
 
     assert_eq!(body["thinking"]["type"], "enabled");
     assert_eq!(body["reasoning_effort"], "max");
-    assert!(body["tools"]
-        .as_array()
-        .is_some_and(|tools| tools.len() == 1));
+    assert!(
+        body["tools"]
+            .as_array()
+            .is_some_and(|tools| tools.len() == 1)
+    );
 }
 
 #[test]
@@ -462,9 +470,11 @@ fn deepseek_v4_explicit_thinking_enables_controls_for_tools() {
 
     assert_eq!(body["thinking"]["type"], "enabled");
     assert_eq!(body["reasoning_effort"], "max");
-    assert!(body["tools"]
-        .as_array()
-        .is_some_and(|tools| tools.len() == 1));
+    assert!(
+        body["tools"]
+            .as_array()
+            .is_some_and(|tools| tools.len() == 1)
+    );
 }
 
 #[test]
@@ -522,10 +532,12 @@ fn deepseek_explicit_thinking_folds_legacy_assistant_history_without_reasoning()
     let messages = body["messages"].as_array().expect("messages");
     assert_eq!(messages.len(), 2);
     assert_eq!(messages[0]["role"], "user");
-    assert!(messages[0]["content"]
-        .as_str()
-        .expect("folded note")
-        .contains("Legacy answer without provider metadata."));
+    assert!(
+        messages[0]["content"]
+            .as_str()
+            .expect("folded note")
+            .contains("Legacy answer without provider metadata.")
+    );
     assert_eq!(messages[1]["role"], "user");
     assert_eq!(messages[1]["content"], "Continue.");
 }
@@ -592,10 +604,12 @@ fn deepseek_default_thinking_folds_legacy_assistant_history_without_reasoning() 
     let messages = body["messages"].as_array().expect("messages");
     assert_eq!(messages.len(), 2);
     assert_eq!(messages[0]["role"], "user");
-    assert!(messages[0]["content"]
-        .as_str()
-        .expect("folded note")
-        .contains("Legacy answer without provider metadata."));
+    assert!(
+        messages[0]["content"]
+            .as_str()
+            .expect("folded note")
+            .contains("Legacy answer without provider metadata.")
+    );
     assert_eq!(messages[1]["role"], "user");
     assert_eq!(messages[1]["content"], "Continue.");
 }
@@ -683,10 +697,12 @@ fn deepseek_explicit_thinking_keeps_compatible_suffix_after_legacy_prefix() {
     assert_eq!(messages[0]["role"], "system");
     assert_eq!(messages[0]["content"], "System prompt.");
     assert_eq!(messages[1]["role"], "user");
-    assert!(messages[1]["content"]
-        .as_str()
-        .expect("folded note")
-        .contains("Legacy answer."));
+    assert!(
+        messages[1]["content"]
+            .as_str()
+            .expect("folded note")
+            .contains("Legacy answer.")
+    );
     assert_eq!(messages[2]["content"], "Fresh answer.");
     assert_eq!(messages[2]["reasoning_content"], "fresh reasoning");
     assert_eq!(messages[3]["content"], "Continue.");
@@ -1047,45 +1063,51 @@ fn codex_stream_events_collect_output_items_usage_and_text_deltas() {
 
     let mut on_delta = |event: LlmStreamEvent| deltas.push(event);
     let mut on_delta_option: Option<&mut (dyn FnMut(LlmStreamEvent) + Send)> = Some(&mut on_delta);
-    assert!(!apply_codex_stream_event(
-        &json!({"type":"response.output_text.delta","delta":"Hello"}),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut on_delta_option,
-    )
-    .unwrap());
+    assert!(
+        !apply_codex_stream_event(
+            &json!({"type":"response.output_text.delta","delta":"Hello"}),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut on_delta_option,
+        )
+        .unwrap()
+    );
 
     let mut no_delta_callback: Option<&mut (dyn FnMut(LlmStreamEvent) + Send)> = None;
-    assert!(!apply_codex_stream_event(
-        &json!({
-            "type":"response.output_item.done",
-            "item":{
-                "type":"message",
-                "content":[{"type":"output_text","text":"Hello"}]
-            }
-        }),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut no_delta_callback,
-    )
-    .unwrap());
+    assert!(
+        !apply_codex_stream_event(
+            &json!({
+                "type":"response.output_item.done",
+                "item":{
+                    "type":"message",
+                    "content":[{"type":"output_text","text":"Hello"}]
+                }
+            }),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut no_delta_callback,
+        )
+        .unwrap()
+    );
 
-    assert!(apply_codex_stream_event(
-        &json!({
-            "type":"response.completed",
-            "response":{
-                "id":"resp-1",
-                "usage":{"input_tokens":11,"output_tokens":7}
-            }
-        }),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut no_delta_callback,
-    )
-    .unwrap());
+    assert!(
+        apply_codex_stream_event(
+            &json!({
+                "type":"response.completed",
+                "response":{
+                    "id":"resp-1",
+                    "usage":{"input_tokens":11,"output_tokens":7}
+                }
+            }),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut no_delta_callback,
+        )
+        .unwrap()
+    );
 
     assert_eq!(deltas, vec![LlmStreamEvent::TextDelta("Hello".to_string())]);
     assert_eq!(streamed_text, "Hello");
@@ -1105,14 +1127,16 @@ fn codex_stream_reasoning_delta_is_reported_without_agent_text() {
     let mut on_event = |event: LlmStreamEvent| events.push(event);
     let mut on_event_option: Option<&mut (dyn FnMut(LlmStreamEvent) + Send)> = Some(&mut on_event);
 
-    assert!(!apply_codex_stream_event(
-        &json!({"type":"response.reasoning_summary_text.delta","delta":"checking files"}),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut on_event_option,
-    )
-    .unwrap());
+    assert!(
+        !apply_codex_stream_event(
+            &json!({"type":"response.reasoning_summary_text.delta","delta":"checking files"}),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut on_event_option,
+        )
+        .unwrap()
+    );
 
     assert_eq!(streamed_text, "");
     assert_eq!(
@@ -1128,21 +1152,23 @@ fn codex_stream_conversation_item_done_is_treated_as_output_item() {
     let mut streamed_text = String::new();
     let mut no_delta_callback: Option<&mut (dyn FnMut(LlmStreamEvent) + Send)> = None;
 
-    assert!(!apply_codex_stream_event(
-        &json!({
-            "type":"conversation.item.done",
-            "item":{
-                "type":"message",
-                "role":"assistant",
-                "content":[{"type":"output_text","text":"Hello from conversation item"}]
-            }
-        }),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut no_delta_callback,
-    )
-    .unwrap());
+    assert!(
+        !apply_codex_stream_event(
+            &json!({
+                "type":"conversation.item.done",
+                "item":{
+                    "type":"message",
+                    "role":"assistant",
+                    "content":[{"type":"output_text","text":"Hello from conversation item"}]
+                }
+            }),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut no_delta_callback,
+        )
+        .unwrap()
+    );
 
     let response = parse_codex_response(&super::openai_compatible::build_codex_stream_response(
         output_items,
@@ -1166,39 +1192,43 @@ fn codex_stream_output_item_added_is_upserted_by_done_item() {
     let mut streamed_text = String::new();
     let mut no_delta_callback: Option<&mut (dyn FnMut(LlmStreamEvent) + Send)> = None;
 
-    assert!(!apply_codex_stream_event(
-        &json!({
-            "type":"response.output_item.added",
-            "item":{
-                "id":"msg_1",
-                "type":"message",
-                "role":"assistant",
-                "content":[{"type":"output_text","text":"partial"}]
-            }
-        }),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut no_delta_callback,
-    )
-    .unwrap());
+    assert!(
+        !apply_codex_stream_event(
+            &json!({
+                "type":"response.output_item.added",
+                "item":{
+                    "id":"msg_1",
+                    "type":"message",
+                    "role":"assistant",
+                    "content":[{"type":"output_text","text":"partial"}]
+                }
+            }),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut no_delta_callback,
+        )
+        .unwrap()
+    );
 
-    assert!(!apply_codex_stream_event(
-        &json!({
-            "type":"response.output_item.done",
-            "item":{
-                "id":"msg_1",
-                "type":"message",
-                "role":"assistant",
-                "content":[{"type":"output_text","text":"final"}]
-            }
-        }),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut no_delta_callback,
-    )
-    .unwrap());
+    assert!(
+        !apply_codex_stream_event(
+            &json!({
+                "type":"response.output_item.done",
+                "item":{
+                    "id":"msg_1",
+                    "type":"message",
+                    "role":"assistant",
+                    "content":[{"type":"output_text","text":"final"}]
+                }
+            }),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut no_delta_callback,
+        )
+        .unwrap()
+    );
 
     let response = parse_codex_response(&super::openai_compatible::build_codex_stream_response(
         output_items,
@@ -1222,39 +1252,43 @@ fn codex_stream_output_item_matches_mixed_id_and_call_id() {
     let mut streamed_text = String::new();
     let mut no_delta_callback: Option<&mut (dyn FnMut(LlmStreamEvent) + Send)> = None;
 
-    assert!(!apply_codex_stream_event(
-        &json!({
-            "type":"response.output_item.added",
-            "item":{
-                "id":"tool_1",
-                "type":"function_call",
-                "name":"bash",
-                "arguments":"{}"
-            }
-        }),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut no_delta_callback,
-    )
-    .unwrap());
+    assert!(
+        !apply_codex_stream_event(
+            &json!({
+                "type":"response.output_item.added",
+                "item":{
+                    "id":"tool_1",
+                    "type":"function_call",
+                    "name":"bash",
+                    "arguments":"{}"
+                }
+            }),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut no_delta_callback,
+        )
+        .unwrap()
+    );
 
-    assert!(!apply_codex_stream_event(
-        &json!({
-            "type":"response.output_item.done",
-            "item":{
-                "call_id":"tool_1",
-                "type":"function_call",
-                "name":"bash",
-                "arguments":"{\"cmd\":\"pwd\"}"
-            }
-        }),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut no_delta_callback,
-    )
-    .unwrap());
+    assert!(
+        !apply_codex_stream_event(
+            &json!({
+                "type":"response.output_item.done",
+                "item":{
+                    "call_id":"tool_1",
+                    "type":"function_call",
+                    "name":"bash",
+                    "arguments":"{\"cmd\":\"pwd\"}"
+                }
+            }),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut no_delta_callback,
+        )
+        .unwrap()
+    );
 
     assert_eq!(output_items.len(), 1);
     assert_eq!(output_items[0]["call_id"], "tool_1");
@@ -1268,20 +1302,22 @@ fn codex_stream_response_done_marks_completion() {
     let mut streamed_text = String::new();
     let mut no_delta_callback: Option<&mut (dyn FnMut(LlmStreamEvent) + Send)> = None;
 
-    assert!(apply_codex_stream_event(
-        &json!({
-            "type":"response.done",
-            "response":{
-                "id":"resp-1",
-                "usage":{"input_tokens":5,"output_tokens":3}
-            }
-        }),
-        &mut output_items,
-        &mut usage,
-        &mut streamed_text,
-        &mut no_delta_callback,
-    )
-    .unwrap());
+    assert!(
+        apply_codex_stream_event(
+            &json!({
+                "type":"response.done",
+                "response":{
+                    "id":"resp-1",
+                    "usage":{"input_tokens":5,"output_tokens":3}
+                }
+            }),
+            &mut output_items,
+            &mut usage,
+            &mut streamed_text,
+            &mut no_delta_callback,
+        )
+        .unwrap()
+    );
 
     assert_eq!(usage.as_ref().unwrap()["input_tokens"], 5);
     assert_eq!(usage.as_ref().unwrap()["output_tokens"], 3);
@@ -1478,9 +1514,11 @@ fn applies_ollama_stream_event_deltas_and_tool_calls() {
 fn rejects_ollama_streams_without_final_done_event() {
     let error = ensure_ollama_stream_completed(false, "http://localhost:11434/api/chat")
         .expect_err("missing done event should fail");
-    assert!(error
-        .to_string()
-        .contains("ended before the final done event"));
+    assert!(
+        error
+            .to_string()
+            .contains("ended before the final done event")
+    );
 }
 
 #[test]

--- a/src/local_backend.rs
+++ b/src/local_backend.rs
@@ -7,7 +7,7 @@ mod tests;
 
 use std::sync::{Arc, Mutex};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use candle::{DType, Tensor};
 use candle_transformers::generation::{LogitsProcessor, Sampling};
@@ -15,11 +15,11 @@ use serde_json::Value;
 
 use crate::agent::Message;
 use crate::config::RaraConfig;
-use crate::llm::{hashed_embedding, ContentBlock, LlmBackend, LlmResponse, TokenUsage};
+use crate::llm::{ContentBlock, LlmBackend, LlmResponse, TokenUsage, hashed_embedding};
 
 use self::model::{
-    build_hf_api, default_local_model_cache_dir as model_cache_dir, load_safetensors,
-    preferred_dtype, select_device, LocalModelSpec, LocalTextModel,
+    LocalModelSpec, LocalTextModel, build_hf_api, default_local_model_cache_dir as model_cache_dir,
+    load_safetensors, preferred_dtype, select_device,
 };
 use self::parser::parse_tool_aware_reply;
 use self::prompt::{build_agent_prompt, render_messages, scenario_token_cap};

--- a/src/local_backend/model.rs
+++ b/src/local_backend/model.rs
@@ -1,12 +1,12 @@
 use std::path::PathBuf;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use candle::{DType, Device};
 use candle_nn::VarBuilder;
 use candle_transformers::models::gemma4::{
+    Model as Gemma4Model,
     config::{Gemma4Config, Gemma4TextConfig},
     text::TextModel as Gemma4TextModel,
-    Model as Gemma4Model,
 };
 use candle_transformers::models::qwen3::{Config as Qwen3Config, ModelForCausalLM as Qwen3Model};
 use hf_hub::api::sync::{ApiBuilder, ApiRepo};

--- a/src/local_backend/prompt.rs
+++ b/src/local_backend/prompt.rs
@@ -1,4 +1,4 @@
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::agent::Message;
 

--- a/src/local_backend/tests.rs
+++ b/src/local_backend/tests.rs
@@ -2,7 +2,7 @@ use serde_json::json;
 
 use crate::agent::Message;
 
-use super::model::{default_local_model_cache_dir, extract_context_window, LocalModelSpec};
+use super::model::{LocalModelSpec, default_local_model_cache_dir, extract_context_window};
 use super::parser::{extract_json_object, parse_tool_aware_reply};
 use super::prompt::{render_content, scenario_token_cap};
 
@@ -46,8 +46,7 @@ fn extracts_first_json_object_from_mixed_text() {
 
 #[test]
 fn parses_tool_reply() {
-    let raw =
-        "{\"kind\":\"tool\",\"calls\":[{\"name\":\"read_file\",\"input\":{\"path\":\"Cargo.toml\"}}]}";
+    let raw = "{\"kind\":\"tool\",\"calls\":[{\"name\":\"read_file\",\"input\":{\"path\":\"Cargo.toml\"}}]}";
     let reply = parse_tool_aware_reply(raw).unwrap();
     assert_eq!(reply.kind.as_deref(), Some("tool"));
     assert_eq!(reply.calls.unwrap()[0].name, "read_file");

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,10 +1,10 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use codex_login::{
+    AuthCredentialsStoreMode, AuthDotJson, CLIENT_ID, DeviceCode as CodexDeviceCode,
+    LoginServer as CodexLoginServer, ServerOptions,
     complete_device_code_login as codex_complete_device_code_login, load_auth_dot_json,
     login_with_api_key as codex_login_with_api_key, logout as codex_logout,
     request_device_code as codex_request_device_code, run_login_server as codex_run_login_server,
-    AuthCredentialsStoreMode, AuthDotJson, DeviceCode as CodexDeviceCode,
-    LoginServer as CodexLoginServer, ServerOptions, CLIENT_ID,
 };
 use secrecy::SecretString;
 use std::io::Read;
@@ -296,9 +296,11 @@ mod tests {
             .start_browser_login(false)
             .expect("browser login session");
 
-        assert!(session
-            .auth_url()
-            .starts_with("https://auth.openai.com/oauth/authorize?"));
+        assert!(
+            session
+                .auth_url()
+                .starts_with("https://auth.openai.com/oauth/authorize?")
+        );
         assert!(session.auth_url().contains(CLIENT_ID));
         session.inner.cancel();
     }
@@ -480,9 +482,10 @@ mod tests {
         let err = manager
             .load_saved_credential()
             .expect_err("blank credentials should be rejected");
-        assert!(err
-            .to_string()
-            .contains("did not contain an API key or access token"));
+        assert!(
+            err.to_string()
+                .contains("did not contain an API key or access token")
+        );
     }
 
     #[test]

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,1 +1,1 @@
-pub use rara_sandbox::{sandbox_failure_hint, SandboxManager, WrappedCommand};
+pub use rara_sandbox::{SandboxManager, WrappedCommand, sandbox_failure_hint};

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,7 +1,7 @@
 use crate::agent::Message;
 use crate::state_db::PersistedStructuredRolloutEvent;
 use crate::thread_rollout_log;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/src/state_db/tests.rs
+++ b/src/state_db/tests.rs
@@ -305,16 +305,18 @@ fn load_rollout_events_prefers_append_only_log_without_snapshot_rewrite() -> Res
         }],
     )?;
 
-    assert!(!db
-        .rollout_root()
-        .join("session-events")
-        .join("events.json")
-        .exists());
-    assert!(db
-        .rollout_root()
-        .join("session-events")
-        .join("events.jsonl")
-        .exists());
+    assert!(
+        !db.rollout_root()
+            .join("session-events")
+            .join("events.json")
+            .exists()
+    );
+    assert!(
+        db.rollout_root()
+            .join("session-events")
+            .join("events.jsonl")
+            .exists()
+    );
 
     let events = db.load_rollout_events("session-events")?;
     assert_eq!(events.len(), 2);

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -1739,7 +1739,9 @@ mod tests {
             Some(1)
         );
         assert_eq!(
-            listed.pointer("/tasks/0/network_access").and_then(Value::as_bool),
+            listed
+                .pointer("/tasks/0/network_access")
+                .and_then(Value::as_bool),
             Some(wrapped.network_access)
         );
 

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -3,7 +3,7 @@ use crate::session::SessionManager;
 use crate::tool::{Tool, ToolError};
 use crate::vectordb::VectorDB;
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 pub struct RetrieveSessionContextTool {

--- a/src/tools/planning.rs
+++ b/src/tools/planning.rs
@@ -1,6 +1,6 @@
 use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 pub struct EnterPlanModeTool;
 

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -783,7 +783,10 @@ mod tests {
             .and_then(Value::as_str)
             .expect("session id")
             .to_string();
-        assert_eq!(started.get("network_access").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            started.get("network_access").and_then(Value::as_bool),
+            Some(true)
+        );
 
         write
             .call(json!({
@@ -862,7 +865,10 @@ mod tests {
             .and_then(Value::as_str)
             .expect("session id")
             .to_string();
-        assert_eq!(started.get("network_access").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            started.get("network_access").and_then(Value::as_bool),
+            Some(true)
+        );
 
         let listed = list.call(json!({})).await.expect("list ptys");
         assert_eq!(

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -2,7 +2,7 @@ use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
 use glob::glob;
 use regex::Regex;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::fs;
 use std::path::Path;
 

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -1,7 +1,7 @@
 use crate::skill::SkillManager;
 use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 pub struct SkillTool {

--- a/src/tools/vector.rs
+++ b/src/tools/vector.rs
@@ -1,7 +1,7 @@
 use crate::llm::LlmBackend;
 use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 pub struct RememberExperienceTool {

--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -1,6 +1,6 @@
 use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 pub struct WebFetchTool;
 #[async_trait]

--- a/src/tools/workspace.rs
+++ b/src/tools/workspace.rs
@@ -1,7 +1,7 @@
 use crate::tool::{Tool, ToolError};
 use crate::workspace::WorkspaceMemory;
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::sync::Arc;
 
 pub struct UpdateProjectMemoryTool {

--- a/src/tui/insert_history.rs
+++ b/src/tui/insert_history.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io;
 use std::io::Write;
 
+use crossterm::Command;
 use crossterm::cursor::MoveDown;
 use crossterm::cursor::MoveTo;
 use crossterm::cursor::MoveToColumn;
@@ -17,7 +18,6 @@ use crossterm::style::SetColors;
 use crossterm::style::SetForegroundColor;
 use crossterm::terminal::Clear;
 use crossterm::terminal::ClearType;
-use crossterm::Command;
 use ratatui::layout::Size;
 use ratatui::prelude::Backend;
 use ratatui::style::Color;

--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -76,9 +76,11 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(rendered.iter().any(|line| line.contains("Risk")));
-        assert!(rendered
-            .iter()
-            .any(|line| line.contains("OpenAI embedding API cost")));
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("OpenAI embedding API cost"))
+        );
         assert!(!pipe_columns.is_empty());
         assert!(pipe_columns.iter().all(|column| *column == pipe_columns[0]));
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 
 use crossterm::{event::EventStream, terminal::enable_raw_mode, terminal::size as terminal_size};
 use futures::StreamExt;
-use tokio::time::{interval, Duration};
+use tokio::time::{Duration, interval};
 
 use crate::agent::Agent;
 use crate::oauth::OAuthManager;
@@ -36,7 +36,7 @@ use crate::state_db::StateDb;
 
 use self::app_event::AppEvent;
 use self::command::{palette_command_by_index, palette_commands, parse_local_command};
-use self::event_stream::{translate_event, UiEvent};
+use self::event_stream::{UiEvent, translate_event};
 use self::keymap::map_key_to_event;
 use self::provider_flow::{
     open_provider_family_overlay, should_open_codex_auth_guide,
@@ -52,7 +52,7 @@ use self::session_restore::{
     provider_requires_api_key, restore_latest_thread, restore_thread_by_id,
 };
 use self::state::{
-    LocalCommandKind, OpenAiModelPickerAction, Overlay, TaskKind, TuiApp, PROVIDER_FAMILIES,
+    LocalCommandKind, OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, TaskKind, TuiApp,
 };
 use self::terminal_ui::{
     build_terminal, flush_committed_history, handle_paste, is_ssh_session, teardown_terminal,

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -15,7 +15,7 @@ use crate::tui::command::api_key_status;
 use crate::tui::is_ssh_session;
 use crate::tui::render::bottom_pane::editor_cursor_position;
 use crate::tui::state::{
-    current_model_presets, openai_profile_setup_kinds, ProviderFamily, TuiApp, PROVIDER_FAMILIES,
+    PROVIDER_FAMILIES, ProviderFamily, TuiApp, current_model_presets, openai_profile_setup_kinds,
 };
 
 fn wrapped_text_height(text: &str, area_width: u16) -> u16 {
@@ -315,7 +315,10 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
     } else {
         &format!(
             "Provider: {provider_label}\nBase URL: {}\nSelect a concrete model preset. Enter applies immediately.",
-            app.config.base_url.as_deref().unwrap_or("http://localhost:11434"),
+            app.config
+                .base_url
+                .as_deref()
+                .unwrap_or("http://localhost:11434"),
         )
     };
     let help_height = wrapped_text_height(help, area.width);
@@ -797,8 +800,7 @@ pub(super) fn render_model_name_editor_modal(
     app: &TuiApp,
     area: Rect,
 ) -> Option<(u16, u16)> {
-    let intro_text =
-        "Set the model name for the selected OpenAI-compatible endpoint profile.\nExample: gpt-4o-mini, kimi-k2, deepseek-chat, or any server-specific model id.";
+    let intro_text = "Set the model name for the selected OpenAI-compatible endpoint profile.\nExample: gpt-4o-mini, kimi-k2, deepseek-chat, or any server-specific model id.";
     let intro_height = wrapped_text_height(intro_text, area.width);
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -971,9 +971,11 @@ fn formatted_agent_markdown_keeps_first_and_latest_lines() {
     .collect::<Vec<_>>();
 
     assert!(rendered.iter().any(|line| line.contains("first line")));
-    assert!(rendered
-        .iter()
-        .any(|line| line.contains("... 2 more line(s)")));
+    assert!(
+        rendered
+            .iter()
+            .any(|line| line.contains("... 2 more line(s)"))
+    );
     assert!(rendered.iter().any(|line| line.contains("latest 1")));
     assert!(rendered.iter().any(|line| line.contains("latest 2")));
     assert!(!rendered.iter().any(|line| line.contains("middle 1")));

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use serde_json::json;
 
-use super::{state_db_status_error, InteractionKind, StateDb, TranscriptTurn, TuiApp};
+use super::{InteractionKind, StateDb, TranscriptTurn, TuiApp, state_db_status_error};
 use crate::state_db::{
     PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
     PersistedStructuredRolloutEvent, PersistedTurnEntry,

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    input_requests_command_palette, parse_repo_slug, state_db_status_error,
-    ActivePendingInteractionKind, InteractionKind, Overlay, PendingInteractionSnapshot,
-    ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp, PROVIDER_FAMILIES,
+    ActivePendingInteractionKind, InteractionKind, Overlay, PROVIDER_FAMILIES,
+    PendingInteractionSnapshot, ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn,
+    TuiApp, input_requests_command_palette, parse_repo_slug, state_db_status_error,
 };
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
 use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
@@ -302,10 +302,11 @@ fn deepseek_catalog_options_keep_current_custom_model_selectable() {
 
     app.set_deepseek_model_options(vec!["deepseek-chat".to_string()]);
 
-    assert!(app
-        .deepseek_model_options
-        .iter()
-        .any(|model| model == "deepseek-v4-preview"));
+    assert!(
+        app.deepseek_model_options
+            .iter()
+            .any(|model| model == "deepseek-v4-preview")
+    );
     assert_eq!(app.model_picker_idx, app.selected_preset_idx());
     assert_eq!(
         app.deepseek_model_options

--- a/src/tui/terminal_event.rs
+++ b/src/tui/terminal_event.rs
@@ -487,7 +487,7 @@ fn strip_ansi_control_sequences(input: &str) -> String {
 mod tests {
     use serde_json::json;
 
-    use super::{output_tail_preview, TerminalEvent, TerminalTarget};
+    use super::{TerminalEvent, TerminalTarget, output_tail_preview};
 
     #[test]
     fn builds_background_start_event_from_bash_result() {


### PR DESCRIPTION
- Apply cargo fmt across all source files (38 files)
  - Add .github/workflows/fmt.yml to enforce formatting in CI