### PR TITLE
fix: preserve repeated active progress events

### DIFF
--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -628,9 +628,7 @@ fn ordered_exploration_agent_segments<'a>(
         match entry.role.as_str() {
             "Tool" => {
                 if let Some(action) = super::exploration_action_label(&entry.message) {
-                    if !exploration_items.iter().any(|existing| existing == &action) {
-                        exploration_items.push(action);
-                    }
+                    exploration_items.push(action);
                 }
             }
             "Exploring" => {
@@ -647,9 +645,7 @@ fn ordered_exploration_agent_segments<'a>(
                     })
                     .filter(|line| !line.is_empty())
                 {
-                    if !exploration_items.iter().any(|existing| existing == &item) {
-                        exploration_items.push(item);
-                    }
+                    exploration_items.push(item);
                 }
             }
             "Agent" => {

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -951,6 +951,40 @@ fn active_turn_cell_preserves_repeated_progress_events_when_interleaved() {
 }
 
 #[test]
+fn active_turn_cell_preserves_consecutive_duplicate_progress_events() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Run checks".into(),
+            payload: None,
+        }],
+    };
+
+    app.record_exploration_action("Read src/tui/render/cells.rs");
+    app.record_exploration_action("Read src/tui/render/cells.rs");
+    app.record_running_action("Run cargo check");
+    app.record_running_action("Run cargo check");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_eq!(rendered.matches("Read src/tui/render/cells.rs").count(), 2);
+    assert_eq!(rendered.matches("Run cargo check").count(), 2);
+    assert_eq!(rendered.matches(" Exploring ").count(), 2);
+    assert_eq!(rendered.matches(" Running ").count(), 2);
+}
+
+#[test]
 fn active_turn_cell_shows_live_thinking_tail_without_cloning_full_body() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -731,6 +731,61 @@ fn active_turn_cell_preserves_exploration_agent_exploration_order() {
 }
 
 #[test]
+fn active_turn_cell_preserves_duplicate_restored_exploration_segments() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Inspect the repository".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "read_file src/main.rs".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "read_file src/main.rs".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "The main entrypoint is thin.".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "read_file src/runtime_context.rs".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "read_file src/runtime_context.rs".into(),
+                payload: None,
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_eq!(rendered.matches("Read src/main.rs").count(), 2);
+    assert_eq!(rendered.matches("Read src/runtime_context.rs").count(), 2);
+    assert_eq!(rendered.matches(" Exploring ").count(), 2);
+}
+
+#[test]
 fn active_turn_cell_preserves_agent_then_exploration_order() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -329,31 +329,66 @@ impl TuiApp {
 
     pub fn record_exploration_action(&mut self, action: impl Into<String>) {
         let action = action.into();
-        self.active_live.exploration_actions.push(action.clone());
+        if !self
+            .active_live
+            .exploration_actions
+            .iter()
+            .any(|item| item == &action)
+        {
+            self.active_live.exploration_actions.push(action.clone());
+        }
         self.push_active_live_event(ActiveLiveEvent::ExplorationAction(action));
     }
 
     pub fn record_exploration_note(&mut self, note: impl Into<String>) {
         let note = note.into();
-        self.active_live.exploration_notes.push(note.clone());
+        if !self
+            .active_live
+            .exploration_notes
+            .iter()
+            .any(|item| item == &note)
+        {
+            self.active_live.exploration_notes.push(note.clone());
+        }
         self.push_active_live_event(ActiveLiveEvent::ExplorationNote(note));
     }
 
     pub fn record_running_action(&mut self, action: impl Into<String>) {
         let action = action.into();
-        self.active_live.running_actions.push(action.clone());
+        if !self
+            .active_live
+            .running_actions
+            .iter()
+            .any(|item| item == &action)
+        {
+            self.active_live.running_actions.push(action.clone());
+        }
         self.push_active_live_event(ActiveLiveEvent::RunningAction(action));
     }
 
     pub fn record_planning_action(&mut self, action: impl Into<String>) {
         let action = action.into();
-        self.active_live.planning_actions.push(action.clone());
+        if !self
+            .active_live
+            .planning_actions
+            .iter()
+            .any(|item| item == &action)
+        {
+            self.active_live.planning_actions.push(action.clone());
+        }
         self.push_active_live_event(ActiveLiveEvent::PlanningAction(action));
     }
 
     pub fn record_planning_note(&mut self, note: impl Into<String>) {
         let note = note.into();
-        self.active_live.planning_notes.push(note.clone());
+        if !self
+            .active_live
+            .planning_notes
+            .iter()
+            .any(|item| item == &note)
+        {
+            self.active_live.planning_notes.push(note.clone());
+        }
         self.push_active_live_event(ActiveLiveEvent::PlanningNote(note));
     }
 

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -324,79 +324,36 @@ impl TuiApp {
     }
 
     fn push_active_live_event(&mut self, event: ActiveLiveEvent) {
-        if self
-            .active_live
-            .events
-            .last()
-            .is_some_and(|last| last.role() == event.role() && last.message() == event.message())
-        {
-            return;
-        }
         self.active_live.events.push(event);
     }
 
     pub fn record_exploration_action(&mut self, action: impl Into<String>) {
         let action = action.into();
-        if !self
-            .active_live
-            .exploration_actions
-            .iter()
-            .any(|item| item == &action)
-        {
-            self.active_live.exploration_actions.push(action.clone());
-        }
+        self.active_live.exploration_actions.push(action.clone());
         self.push_active_live_event(ActiveLiveEvent::ExplorationAction(action));
     }
 
     pub fn record_exploration_note(&mut self, note: impl Into<String>) {
         let note = note.into();
-        if !self
-            .active_live
-            .exploration_notes
-            .iter()
-            .any(|item| item == &note)
-        {
-            self.active_live.exploration_notes.push(note.clone());
-        }
+        self.active_live.exploration_notes.push(note.clone());
         self.push_active_live_event(ActiveLiveEvent::ExplorationNote(note));
     }
 
     pub fn record_running_action(&mut self, action: impl Into<String>) {
         let action = action.into();
-        if !self
-            .active_live
-            .running_actions
-            .iter()
-            .any(|item| item == &action)
-        {
-            self.active_live.running_actions.push(action.clone());
-        }
+        self.active_live.running_actions.push(action.clone());
         self.push_active_live_event(ActiveLiveEvent::RunningAction(action));
     }
 
     pub fn record_planning_action(&mut self, action: impl Into<String>) {
         let action = action.into();
-        if !self
-            .active_live
-            .planning_actions
-            .iter()
-            .any(|item| item == &action)
-        {
-            self.active_live.planning_actions.push(action.clone());
-        }
+        self.active_live.planning_actions.push(action.clone());
         self.push_active_live_event(ActiveLiveEvent::PlanningAction(action));
     }
 
     pub fn record_planning_note(&mut self, note: impl Into<String>) {
         let note = note.into();
-        if !self
-            .active_live
-            .planning_notes
-            .iter()
-            .any(|item| item == &note)
-        {
-            self.active_live.planning_notes.push(note.clone());
-        }
+        self.active_live.planning_notes.push(note.clone());
         self.push_active_live_event(ActiveLiveEvent::PlanningNote(note));
     }
 


### PR DESCRIPTION
## Summary

- Preserve active TUI progress events as an ordered event stream instead of deduplicating repeated messages.
- Keep repeated `Exploring`, `Planning`, and `Running` entries visible so long-running turns render like Codex-style appended history cells.
- Add a focused regression test for consecutive duplicate progress events.

## Why

The current active progress state drops repeated adjacent events with the same role/message. In long turns this makes `Exploring` / `Thinking` / `Ran` style output look like it is updating the same area instead of appending the actual event sequence.

## Testing

- `cargo test active_turn_cell_preserves_consecutive_duplicate_progress_events -- --nocapture`
- `cargo test active_turn_cell -- --nocapture`
- `cargo check`
- `git diff --check`
