### PR TITLE
feat: add codex-style shell escalation

### DIFF
--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -294,6 +294,10 @@ impl SandboxManager {
         }
     }
 
+    pub fn wrap_unsandboxed_shell_command(&self, original_cmd: &str) -> WrappedCommand {
+        wrap_direct_shell_command(original_cmd)
+    }
+
     pub fn wrap_pty_shell_command(
         &self,
         original_cmd: &str,
@@ -305,6 +309,10 @@ impl SandboxManager {
             SandboxBackend::MacosSeatbelt => Ok(wrap_direct_shell_command(original_cmd)),
             _ => self.wrap_shell_command(original_cmd, cwd, allow_net),
         }
+    }
+
+    pub fn wrap_unsandboxed_exec_command(&self, program: &str, args: &[String]) -> WrappedCommand {
+        wrap_direct_exec_command(program, args)
     }
 
     pub fn wrap_exec_command(

--- a/docs/journal/2026-04-30-codex-style-shell-escalation.md
+++ b/docs/journal/2026-04-30-codex-style-shell-escalation.md
@@ -1,0 +1,25 @@
+# 2026-04-30 Codex-Style Shell Escalation
+
+RARA now accepts a Codex-style explicit sandbox bypass request on the `bash`
+tool:
+
+- `sandbox_permissions = "use_default"` keeps the existing sandbox behavior.
+- `sandbox_permissions = "require_escalated"` requests approval to run outside
+  the sandbox and can include a `justification` string.
+- `prefix_rule` can suggest the reusable approval prefix for equivalent future
+  commands.
+
+When an escalated command is approved and executed, the bash tool uses the
+direct command wrapper and reports `sandboxed = false` with the existing
+unsandboxed execution warning. This keeps the bypass visible in the transcript
+and separates command approval from the sandbox policy.
+
+This implements the model-requested escalation path from Codex. The next step
+for full Codex parity is a structured sandbox-denial error path that can power
+`on-failure` approval and retry without relying on stderr keyword matching.
+
+Validation:
+
+- `cargo test escalated_sandbox_request -- --nocapture`
+- `cargo test suggestion_mode_uses_escalated_sandbox_justification_for_approval -- --nocapture`
+- `cargo check`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -118,6 +118,7 @@ Priority order for this phase:
   - make deny rules take precedence over allow / bypass rules;
   - support explicit command-prefix or command-pattern rules for trusted commands;
   - allow unsandboxed execution only when policy permits it and the transcript/status surface makes the bypass visible;
+  - add a structured sandbox-denial error path for Codex-style `on-failure` approval and retry without stderr keyword matching;
   - document that convenience exclusions are not a security boundary.
 - [ ] Add a structured auto-permission classifier side query after deterministic deny rules, with compact transcript projection that includes user intent and tool actions but excludes assistant prose.
 - [ ] Add a background-task state classifier for long-running agents that reports `working` / `blocked` / `done` / `failed` as derived status while keeping persisted task transcript as source of truth.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -553,32 +553,26 @@ impl Agent {
                 tool_results.push(tool_result_message(&tool_id, result_text, false));
                 continue;
             }
-            if tool_call.name == "bash" && matches!(self.execution_mode, AgentExecutionMode::Plan) {
-                let request =
-                    BashCommandInput::from_value(tool_call.input.clone()).unwrap_or_else(|_| {
-                        BashCommandInput {
-                            command: tool_call
-                                .input
-                                .get("command")
-                                .and_then(Value::as_str)
-                                .map(str::to_string),
-                            program: None,
-                            args: Vec::new(),
-                            cwd: None,
-                            env: Default::default(),
-                            allow_net: tool_call
-                                .input
-                                .get("allow_net")
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false),
-                            run_in_background: tool_call
-                                .input
-                                .get("run_in_background")
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false),
-                            ..Default::default()
-                        }
-                    });
+            let bash_request = if tool_call.name == "bash" {
+                match BashCommandInput::from_value(tool_call.input.clone()) {
+                    Ok(request) => Some(request),
+                    Err(err) => {
+                        let error_text = format!("Error: invalid bash payload: {err}");
+                        report(AgentEvent::ToolResult {
+                            name: tool_name.clone(),
+                            content: error_text.clone(),
+                            is_error: true,
+                        });
+                        tool_results.push(tool_result_message(&tool_id, error_text, true));
+                        continue;
+                    }
+                }
+            } else {
+                None
+            };
+            if let Some(request) = bash_request.as_ref()
+                && matches!(self.execution_mode, AgentExecutionMode::Plan)
+            {
                 if !request.is_read_only() {
                     let error_text = format!(
                         "Error: bash is read-only in plan mode. Refuse command '{}' and inspect with read-only commands or return a plan.",
@@ -593,35 +587,13 @@ impl Agent {
                     continue;
                 }
             }
-            if tool_call.name == "bash"
-                && matches!(self.bash_approval_mode, BashApprovalMode::Suggestion)
+            if let Some(request) = bash_request.as_ref()
+                && (request.requires_escalated_permissions()
+                    || matches!(self.bash_approval_mode, BashApprovalMode::Suggestion))
             {
-                let request =
-                    BashCommandInput::from_value(tool_call.input.clone()).unwrap_or_else(|_| {
-                        BashCommandInput {
-                            command: tool_call
-                                .input
-                                .get("command")
-                                .and_then(Value::as_str)
-                                .map(str::to_string),
-                            program: None,
-                            args: Vec::new(),
-                            cwd: None,
-                            env: Default::default(),
-                            allow_net: tool_call
-                                .input
-                                .get("allow_net")
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false),
-                            run_in_background: tool_call
-                                .input
-                                .get("run_in_background")
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false),
-                            ..Default::default()
-                        }
-                    });
-                if request.is_read_only() || self.is_bash_prefix_approved(&request) {
+                if !request.requires_escalated_permissions()
+                    && (request.is_read_only() || self.is_bash_prefix_approved(request))
+                {
                     report(AgentEvent::Status(format!(
                         "Shell command allowed by policy: {}",
                         request.summary()
@@ -630,7 +602,7 @@ impl Agent {
                     let summary = request.summary();
                     self.pending_approval = Some(PendingApproval {
                         tool_use_id: tool_id.clone(),
-                        request: request.clone(),
+                        request: request.to_owned(),
                     });
                     let question = request
                         .justification

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -576,6 +576,7 @@ impl Agent {
                                 .get("run_in_background")
                                 .and_then(Value::as_bool)
                                 .unwrap_or(false),
+                            ..Default::default()
                         }
                     });
                 if !request.is_read_only() {
@@ -617,6 +618,7 @@ impl Agent {
                                 .get("run_in_background")
                                 .and_then(Value::as_bool)
                                 .unwrap_or(false),
+                            ..Default::default()
                         }
                     });
                 if request.is_read_only() || self.is_bash_prefix_approved(&request) {
@@ -630,8 +632,16 @@ impl Agent {
                         tool_use_id: tool_id.clone(),
                         request: request.clone(),
                     });
+                    let question = request
+                        .justification
+                        .as_ref()
+                        .filter(|value| !value.trim().is_empty())
+                        .cloned()
+                        .unwrap_or_else(|| {
+                            "Bash command needs approval. What should RARA do?".to_string()
+                        });
                     self.pending_user_input = Some(PendingUserInput {
-                        question: "Bash command needs approval. What should RARA do?".to_string(),
+                        question,
                         options: vec![
                             (
                                 "Run once".to_string(),

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -152,6 +152,9 @@ impl Agent {
     }
 
     pub fn is_bash_prefix_approved(&self, request: &BashCommandInput) -> bool {
+        if request.requires_escalated_permissions() {
+            return false;
+        }
         self.approved_bash_prefixes
             .iter()
             .any(|prefix| request.matches_approval_prefix(prefix))

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -349,6 +349,86 @@ async fn suggestion_mode_uses_escalated_sandbox_justification_for_approval() {
 }
 
 #[tokio::test]
+async fn always_mode_still_requires_approval_for_escalated_sandbox_request() {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::ToolUse {
+            id: "tool-escalated-bash".to_string(),
+            name: "bash".to_string(),
+            input: json!({
+                "program": "cargo",
+                "args": ["check"],
+                "sandbox_permissions": "require_escalated"
+            }),
+        }],
+        stop_reason: Some("tool_use".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubBashTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.bash_approval_mode = crate::agent::BashApprovalMode::Always;
+
+    agent
+        .query_with_mode(
+            "run check outside sandbox".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("query should pause on escalated bash approval");
+
+    assert!(agent.pending_approval.is_some());
+    assert_eq!(backend.observed_messages().len(), 1);
+}
+
+#[tokio::test]
+async fn approved_sandboxed_prefix_does_not_auto_allow_escalated_request() {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::ToolUse {
+            id: "tool-escalated-bash".to_string(),
+            name: "bash".to_string(),
+            input: json!({
+                "program": "cargo",
+                "args": ["check"],
+                "sandbox_permissions": "require_escalated",
+                "prefix_rule": ["cargo", "check"]
+            }),
+        }],
+        stop_reason: Some("tool_use".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubBashTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.bash_approval_mode = crate::agent::BashApprovalMode::Suggestion;
+    agent.approved_bash_prefixes.push("cargo check".to_string());
+
+    agent
+        .query_with_mode(
+            "run check outside sandbox".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("query should pause on escalated bash approval");
+
+    assert!(agent.pending_approval.is_some());
+    assert_eq!(backend.observed_messages().len(), 1);
+}
+
+#[tokio::test]
 async fn plan_mode_allows_read_only_bash_commands() {
     let backend = Arc::new(SequencedBackend::new(vec![
         LlmResponse {

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -294,6 +294,61 @@ async fn suggestion_mode_keeps_write_bash_commands_pending_approval() {
 }
 
 #[tokio::test]
+async fn suggestion_mode_uses_escalated_sandbox_justification_for_approval() {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::ToolUse {
+            id: "tool-escalated-bash".to_string(),
+            name: "bash".to_string(),
+            input: json!({
+                "program": "cargo",
+                "args": ["check"],
+                "sandbox_permissions": "require_escalated",
+                "justification": "Do you want to run cargo check outside the sandbox?",
+                "prefix_rule": ["cargo", "check"]
+            }),
+        }],
+        stop_reason: Some("tool_use".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubBashTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.bash_approval_mode = crate::agent::BashApprovalMode::Suggestion;
+
+    agent
+        .query_with_mode(
+            "run check outside sandbox".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("query should pause on escalated bash approval");
+
+    assert!(agent.pending_approval.is_some());
+    let pending = agent
+        .pending_user_input
+        .as_ref()
+        .expect("pending user input");
+    assert_eq!(
+        pending.question,
+        "Do you want to run cargo check outside the sandbox?"
+    );
+    assert_eq!(
+        agent
+            .pending_approval
+            .as_ref()
+            .and_then(|approval| approval.request.approval_prefix()),
+        Some("cargo check".to_string())
+    );
+}
+
+#[tokio::test]
 async fn plan_mode_allows_read_only_bash_commands() {
     let backend = Arc::new(SequencedBackend::new(vec![
         LlmResponse {

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -194,6 +194,10 @@ impl BashCommandInput {
             .is_some_and(|program| argv_is_read_only(program, &self.args))
     }
 
+    pub fn requires_escalated_permissions(&self) -> bool {
+        self.sandbox_permissions == BashSandboxPermissions::RequireEscalated
+    }
+
     pub fn approval_prefix(&self) -> Option<String> {
         if !self.prefix_rule.is_empty() {
             return Some(self.prefix_rule.join(" "));

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -96,6 +96,20 @@ pub struct BashCommandInput {
     pub allow_net: bool,
     #[serde(default)]
     pub run_in_background: bool,
+    #[serde(default)]
+    pub sandbox_permissions: BashSandboxPermissions,
+    #[serde(default)]
+    pub justification: Option<String>,
+    #[serde(default)]
+    pub prefix_rule: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BashSandboxPermissions {
+    #[default]
+    UseDefault,
+    RequireEscalated,
 }
 
 impl BashCommandInput {
@@ -157,7 +171,13 @@ impl BashCommandInput {
     }
 
     pub fn is_read_only(&self) -> bool {
-        if self.allow_net || self.run_in_background || !self.env.is_empty() {
+        if self.allow_net
+            || self.run_in_background
+            || !self.env.is_empty()
+            || self.sandbox_permissions != BashSandboxPermissions::UseDefault
+            || self.justification.is_some()
+            || !self.prefix_rule.is_empty()
+        {
             return false;
         }
         if let Some(command) = self
@@ -175,6 +195,9 @@ impl BashCommandInput {
     }
 
     pub fn approval_prefix(&self) -> Option<String> {
+        if !self.prefix_rule.is_empty() {
+            return Some(self.prefix_rule.join(" "));
+        }
         if let Some(command) = self
             .command
             .as_ref()
@@ -750,6 +773,21 @@ impl Tool for BashTool {
                     "type": "boolean",
                     "default": false,
                     "description": "Run the command as a background task and return a task id immediately. Use background_task_status to inspect output later."
+                },
+                "sandbox_permissions": {
+                    "type": "string",
+                    "enum": ["use_default", "require_escalated"],
+                    "default": "use_default",
+                    "description": "Sandbox permissions for the command. Set to require_escalated to request approval to run this command outside the sandbox; defaults to use_default."
+                },
+                "justification": {
+                    "type": "string",
+                    "description": "Only set if sandbox_permissions is require_escalated. Ask the user a short question explaining why this command needs to run outside the sandbox."
+                },
+                "prefix_rule": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Only set if sandbox_permissions is require_escalated. Suggested command prefix to approve for similar future commands, for example [\"git\", \"push\"] or [\"cargo\", \"test\"]."
                 }
             },
             "anyOf": [
@@ -771,22 +809,31 @@ impl Tool for BashTool {
         let cwd = request.working_dir()?;
         let allow_net = self.sandbox_network_access || request.allow_net;
         let wrapped = if let Some(command) = request.command.as_deref() {
-            self.sandbox
-                .wrap_shell_command(command, &cwd, allow_net)
-                .map_err(|e| {
-                    ToolError::ExecutionFailed(format!("{} {}", e, sandbox_failure_hint()))
-                })?
+            if request.sandbox_permissions == BashSandboxPermissions::RequireEscalated {
+                self.sandbox.wrap_unsandboxed_shell_command(command)
+            } else {
+                self.sandbox
+                    .wrap_shell_command(command, &cwd, allow_net)
+                    .map_err(|e| {
+                        ToolError::ExecutionFailed(format!("{} {}", e, sandbox_failure_hint()))
+                    })?
+            }
         } else {
             let program = request
                 .program
                 .as_deref()
                 .filter(|value| !value.trim().is_empty())
                 .ok_or_else(|| ToolError::InvalidInput("program".into()))?;
-            self.sandbox
-                .wrap_exec_command(program, &request.args, &cwd, allow_net)
-                .map_err(|e| {
-                    ToolError::ExecutionFailed(format!("{} {}", e, sandbox_failure_hint()))
-                })?
+            if request.sandbox_permissions == BashSandboxPermissions::RequireEscalated {
+                self.sandbox
+                    .wrap_unsandboxed_exec_command(program, &request.args)
+            } else {
+                self.sandbox
+                    .wrap_exec_command(program, &request.args, &cwd, allow_net)
+                    .map_err(|e| {
+                        ToolError::ExecutionFailed(format!("{} {}", e, sandbox_failure_hint()))
+                    })?
+            }
         };
         let command_env = command_env_for_wrapped(&wrapped, &self.base_env, &request.env)?;
 
@@ -1242,9 +1289,9 @@ async fn ensure_sandbox_home_dirs(sandbox_home: &Path) -> Result<(), ToolError> 
 mod tests {
     use super::{
         BackgroundTaskListTool, BackgroundTaskStatus, BackgroundTaskStatusTool,
-        BackgroundTaskStopTool, BackgroundTaskStore, BashCommandInput, BashTool,
-        command_env_for_wrapped, read_output_tail, sandbox_command_env, sandbox_output_hint,
-        unsandboxed_execution_warning,
+        BackgroundTaskStopTool, BackgroundTaskStore, BashCommandInput, BashSandboxPermissions,
+        BashTool, command_env_for_wrapped, read_output_tail, sandbox_command_env,
+        sandbox_output_hint, unsandboxed_execution_warning,
     };
     use crate::sandbox::{SandboxManager, WrappedCommand};
     use crate::tool::{Tool, ToolOutputStream, ToolProgressEvent};
@@ -1302,6 +1349,46 @@ mod tests {
 
         assert!(input.run_in_background);
         assert_eq!(input.summary(), "cargo test");
+    }
+
+    #[test]
+    fn parses_codex_style_escalated_sandbox_request() {
+        let input = BashCommandInput::from_value(json!({
+            "program": "cargo",
+            "args": ["check"],
+            "sandbox_permissions": "require_escalated",
+            "justification": "Do you want to run cargo check outside the sandbox?",
+            "prefix_rule": ["cargo", "check"]
+        }))
+        .expect("escalated payload");
+
+        assert_eq!(
+            input.sandbox_permissions,
+            BashSandboxPermissions::RequireEscalated
+        );
+        assert_eq!(
+            input.justification.as_deref(),
+            Some("Do you want to run cargo check outside the sandbox?")
+        );
+        assert_eq!(input.approval_prefix().as_deref(), Some("cargo check"));
+        assert!(!input.is_read_only());
+    }
+
+    #[test]
+    fn escalated_sandbox_request_allows_missing_justification() {
+        let input = BashCommandInput::from_value(json!({
+            "program": "cargo",
+            "args": ["check"],
+            "sandbox_permissions": "require_escalated"
+        }))
+        .expect("escalated payload");
+
+        assert_eq!(
+            input.sandbox_permissions,
+            BashSandboxPermissions::RequireEscalated
+        );
+        assert!(input.justification.is_none());
+        assert!(!input.is_read_only());
     }
 
     #[test]
@@ -1545,6 +1632,47 @@ mod tests {
 
         assert!(warning.contains("without sandbox isolation"));
         assert!(warning.contains("direct"));
+    }
+
+    #[tokio::test]
+    async fn escalated_sandbox_request_runs_directly_after_approval() {
+        let temp = tempdir().expect("tempdir");
+        let sandbox = SandboxManager::new_for_rara_dir(temp.path().join(".rara")).expect("sandbox");
+        let tool = BashTool {
+            sandbox: Arc::new(sandbox),
+            background_tasks: Arc::new(
+                BackgroundTaskStore::new(temp.path().join(".rara/background-tasks"))
+                    .expect("background task store"),
+            ),
+            base_env: Arc::new(HashMap::new()),
+            sandbox_network_access: false,
+        };
+
+        let result = tool
+            .call(json!({
+                "program": "sh",
+                "args": ["-c", "printf direct"],
+                "sandbox_permissions": "require_escalated",
+                "justification": "Do you want to run this shell outside the sandbox?"
+            }))
+            .await
+            .expect("bash result");
+
+        assert_eq!(
+            result.get("sandboxed").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            result.get("sandbox_backend").and_then(Value::as_str),
+            Some("direct")
+        );
+        assert_eq!(result.get("stdout").and_then(Value::as_str), Some("direct"));
+        assert!(
+            result
+                .get("stderr")
+                .and_then(Value::as_str)
+                .is_some_and(|stderr| stderr.contains("without sandbox isolation"))
+        );
     }
 
     #[tokio::test]

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -180,6 +180,7 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
                     env: Default::default(),
                     allow_net: false,
                     run_in_background: false,
+                    ..Default::default()
                 },
             }),
             source: None,

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -150,6 +150,7 @@ pub(super) fn restore_thread_by_id(
                             .and_then(|payload| payload.get("run_in_background"))
                             .and_then(|value| value.as_bool())
                             .unwrap_or(false),
+                        ..Default::default()
                     });
                 agent.pending_approval = Some(PendingApproval {
                     tool_use_id: payload
@@ -521,6 +522,7 @@ mod tests {
                 env: Default::default(),
                 allow_net: false,
                 run_in_background: false,
+                ..Default::default()
             },
         });
         original_agent.history.push(Message {


### PR DESCRIPTION
## Summary

- Add Codex-style `sandbox_permissions` support to the `bash` tool.
- Let `require_escalated` route approved commands through explicit unsandboxed wrappers.
- Surface `justification` in shell approval prompts and preserve prefix-rule approval behavior.
- Document the implemented escalation path and leave structured sandbox-denial retry as follow-up.

## Testing

- `cargo test escalated_sandbox_request -- --nocapture`
- `cargo test suggestion_mode_uses_escalated_sandbox_justification_for_approval -- --nocapture`
- `cargo check`
- `git diff --check`

## Notes

This implements the model-requested escalation path from Codex. It intentionally does not implement stderr keyword-based on-failure retry; full parity needs a structured sandbox-denial error path first.
