### PR TITLE
fix: align TUI paste handling with Codex

### DIFF
--- a/docs/journal/2026-04-30-codex-style-paste-input.md
+++ b/docs/journal/2026-04-30-codex-style-paste-input.md
@@ -1,0 +1,9 @@
+# Codex-Style Paste Input
+
+RARA now enables terminal bracketed paste mode for the TUI session and disables it during teardown. This mirrors Codex's primary input contract where pasted text is delivered through a dedicated paste event instead of being replayed as ordinary key presses.
+
+The paste handler normalizes CRLF and CR line endings to LF before inserting text into the active composer. This keeps copied multi-line text as one composer edit and avoids interpreting embedded newlines as submit key events.
+
+Focused tests cover the crossterm paste event path and newline normalization.
+
+One Codex fallback remains open: Codex also has a `PasteBurst` state machine for terminals that do not emit bracketed paste events and instead deliver paste as a fast stream of key events. RARA should add that separately because it touches key dispatch, tick flushing, and Enter handling.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -96,6 +96,7 @@ Priority order for this phase:
 ## TUI / UX Parity
 
 - [ ] Continue improving transcript rendering stability across long and streaming sessions: reduce scroll jumps and flicker, strengthen bottom anchoring, and prevent stale transient sections from reappearing after their live phase ends.
+- [ ] Add Codex-style non-bracketed paste-burst detection for terminals that deliver pasted text as fast `Char` / `Enter` key streams instead of `Event::Paste`, so embedded newlines are inserted into the composer instead of submitting partial turns.
 - [ ] Improve long-running task progress reporting so the TUI heartbeat reflects the active phase (`sending prompt`, `streaming response`, `running tool`, `waiting for approval`, `checkpointing`) instead of resetting to a generic prompt-sending notice during long tool execution.
 - [ ] Rework long `Exploring` / `Explored` handling to follow Codex more closely: keep live exploration compact and summarize committed exploration into a source-aware digest instead of dumping long raw traces.
 - [ ] Decouple setup/help/model overlays from transcript layout so overlays behave as a pure top layer and do not perturb history viewport sizing.

--- a/src/tui/terminal_ui.rs
+++ b/src/tui/terminal_ui.rs
@@ -3,7 +3,7 @@ use std::io;
 use anyhow::Result;
 use crossterm::{
     cursor::Show,
-    event::{DisableMouseCapture, EnableMouseCapture},
+    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
     execute,
     terminal::disable_raw_mode,
 };
@@ -15,14 +15,19 @@ use super::render::committed_turn_lines;
 use super::state::TuiApp;
 
 pub(super) fn handle_paste(text: String, app: &mut TuiApp) {
-    app.insert_active_input_text(text.as_str());
+    let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+    app.insert_active_input_text(normalized.as_str());
 }
 
 pub(super) fn build_terminal(
     viewport_height: u16,
 ) -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
-    execute!(terminal.backend_mut(), EnableMouseCapture)?;
+    execute!(
+        terminal.backend_mut(),
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )?;
 
     let result = (|| -> Result<()> {
         let size = terminal.size()?;
@@ -32,7 +37,11 @@ pub(super) fn build_terminal(
     })();
 
     if let Err(err) = result {
-        let _ = execute!(terminal.backend_mut(), DisableMouseCapture);
+        let _ = execute!(
+            terminal.backend_mut(),
+            DisableBracketedPaste,
+            DisableMouseCapture
+        );
         return Err(err);
     }
 
@@ -55,7 +64,11 @@ pub(super) fn update_terminal_viewport(
 pub(super) fn teardown_terminal(
     mut terminal: Terminal<CrosstermBackend<std::io::Stdout>>,
 ) -> Result<()> {
-    execute!(terminal.backend_mut(), DisableMouseCapture)?;
+    execute!(
+        terminal.backend_mut(),
+        DisableBracketedPaste,
+        DisableMouseCapture
+    )?;
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), Show)?;
     terminal.show_cursor()?;

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -569,6 +569,37 @@ async fn paste_inserts_at_current_cursor_offset() {
 }
 
 #[tokio::test]
+async fn paste_normalizes_crlf_and_cr_newlines() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+
+    super::terminal_ui::handle_paste("first\r\nsecond\rthird".to_string(), &mut app);
+
+    assert_eq!(app.input, "first\nsecond\nthird");
+    assert_eq!(
+        app.composer_cursor_offset(),
+        "first\nsecond\nthird".chars().count()
+    );
+}
+
+#[test]
+fn crossterm_paste_event_uses_paste_channel() {
+    let temp = tempdir().expect("tempdir");
+    let app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+
+    match translate_event(Event::Paste("first\nsecond".to_string()), &app) {
+        Some(UiEvent::Paste(text)) => assert_eq!(text, "first\nsecond"),
+        other => panic!("expected paste event, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn composer_supports_vertical_cursor_navigation_across_lines() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {


### PR DESCRIPTION
## Summary

- Enable bracketed paste for the TUI session and disable it during teardown.
- Normalize pasted CRLF/CR line endings to LF before inserting into the composer.
- Add focused paste regression tests and document the remaining Codex `PasteBurst` fallback as follow-up work.

## Testing

- `cargo fmt --check`
- `cargo test paste -- --nocapture`
- `cargo check`
