### PR TITLE
fix: load home AGENTS before project instructions

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -20,6 +20,7 @@ static PLAN_MODE_PROMPT: LazyLock<String> = LazyLock::new(|| {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptSourceKind {
+    UserInstruction,
     ProjectInstruction,
     LocalMemory,
     CustomSystemPrompt,
@@ -38,6 +39,7 @@ pub struct PromptSource {
 impl PromptSource {
     pub fn kind_label(&self) -> &'static str {
         match self.kind {
+            PromptSourceKind::UserInstruction => "user_instruction",
             PromptSourceKind::ProjectInstruction => "project_instruction",
             PromptSourceKind::LocalMemory => "local_memory",
             PromptSourceKind::CustomSystemPrompt => "custom_system_prompt",
@@ -48,6 +50,9 @@ impl PromptSource {
 
     pub fn status_line(&self) -> String {
         match self.kind {
+            PromptSourceKind::UserInstruction => {
+                format!("user instruction: {}", self.display_path)
+            }
             PromptSourceKind::ProjectInstruction => {
                 format!("project instruction: {}", self.display_path)
             }
@@ -64,6 +69,9 @@ impl PromptSource {
 
     pub fn inclusion_reason(&self) -> &'static str {
         match self.kind {
+            PromptSourceKind::UserInstruction => {
+                "included as a user-level instruction source loaded from the RARA home directory before workspace instructions"
+            }
             PromptSourceKind::ProjectInstruction => {
                 "included as a repository instruction discovered while walking from the workspace root toward the current focus directory"
             }
@@ -457,7 +465,12 @@ fn dynamic_system_prompt_sections(
     let (cwd, branch) = workspace.get_env_info();
     let instruction_sections = sources
         .iter()
-        .filter(|source| matches!(source.kind, PromptSourceKind::ProjectInstruction))
+        .filter(|source| {
+            matches!(
+                source.kind,
+                PromptSourceKind::UserInstruction | PromptSourceKind::ProjectInstruction
+            )
+        })
         .map(|source| format!("## {}\n{}", source.label, source.content))
         .collect::<Vec<_>>();
     let instruction_block = if instruction_sections.is_empty() {

--- a/crates/instructions/src/workspace.rs
+++ b/crates/instructions/src/workspace.rs
@@ -143,7 +143,7 @@ impl WorkspaceMemory {
         vec![PromptSource {
             kind: PromptSourceKind::UserInstruction,
             label: format!("User Instruction ({USER_INSTRUCTION_FILE})"),
-            display_path: format!("~/.rara/{USER_INSTRUCTION_FILE}"),
+            display_path: path.display().to_string(),
             content,
         }]
     }
@@ -351,6 +351,7 @@ mod tests {
         fs::write(rara_home.join("AGENTS.md"), "user rules").expect("write user agents");
         fs::write(root.join("AGENTS.md"), "root rules").expect("write root agents");
         fs::write(root.join("src").join("AGENTS.md"), "src rules").expect("write src agents");
+        let user_instruction_path = rara_home.join("AGENTS.md").display().to_string();
 
         let workspace = WorkspaceMemory::from_paths(root.clone(), rara_dir);
         let sources = workspace.discover_prompt_sources_from_dir(&nested);
@@ -370,7 +371,7 @@ mod tests {
             vec![
                 (
                     PromptSourceKind::UserInstruction,
-                    "~/.rara/AGENTS.md".to_string(),
+                    user_instruction_path,
                     "user rules".to_string()
                 ),
                 (

--- a/crates/instructions/src/workspace.rs
+++ b/crates/instructions/src/workspace.rs
@@ -7,6 +7,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::SystemTime;
 
+const PROJECT_INSTRUCTION_FILES: [&str; 3] = ["CLAUDE.md", "GEMINI.md", "AGENTS.md"];
+const USER_INSTRUCTION_FILE: &str = "AGENTS.md";
+
 pub struct WorkspaceMemory {
     pub root: PathBuf,
     pub rara_dir: PathBuf,
@@ -92,8 +95,9 @@ impl WorkspaceMemory {
 
     fn discover_prompt_sources_from_dir(&self, focus: &Path) -> Vec<PromptSource> {
         let mut sources = Vec::new();
+        sources.extend(self.user_instruction_sources());
         for dir in self.instruction_search_dirs(focus) {
-            for file in ["CLAUDE.md", "GEMINI.md", "AGENTS.md"] {
+            for file in PROJECT_INSTRUCTION_FILES {
                 let path = dir.join(file);
                 if let Some(content) = self.cached_file_content(&path) {
                     let display_path = path
@@ -120,6 +124,23 @@ impl WorkspaceMemory {
             });
         }
         sources
+    }
+
+    fn user_instruction_sources(&self) -> Vec<PromptSource> {
+        let Some(rara_home) = self.rara_home_dir() else {
+            return Vec::new();
+        };
+        let path = rara_home.join(USER_INSTRUCTION_FILE);
+        let Some(content) = self.cached_file_content(&path) else {
+            return Vec::new();
+        };
+
+        vec![PromptSource {
+            kind: PromptSourceKind::ProjectInstruction,
+            label: format!("User Instruction ({USER_INSTRUCTION_FILE})"),
+            display_path: format!("~/.rara/{USER_INSTRUCTION_FILE}"),
+            content,
+        }]
     }
 
     pub fn get_env_info(&self) -> (String, String) {
@@ -230,6 +251,14 @@ impl WorkspaceMemory {
         dirs
     }
 
+    fn rara_home_dir(&self) -> Option<PathBuf> {
+        let workspaces_dir = self.rara_dir.parent()?;
+        if workspaces_dir.file_name()? != "workspaces" {
+            return None;
+        }
+        workspaces_dir.parent().map(Path::to_path_buf)
+    }
+
     fn focus_dir(&self) -> PathBuf {
         let Ok(cwd) = std::env::current_dir() else {
             return self.root.clone();
@@ -303,6 +332,37 @@ mod tests {
         assert_eq!(project_sources[1].display_path, "src/AGENTS.md");
         assert_eq!(project_sources[0].content, "root rules");
         assert_eq!(project_sources[1].content, "src rules");
+    }
+
+    #[test]
+    fn discover_prompt_sources_keeps_user_instruction_as_stable_prefix() {
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().join("repo");
+        let rara_home = dir.path().join("home").join(".rara");
+        let rara_dir = rara_home.join("workspaces").join("repo-123");
+        let nested = root.join("src/tools");
+        fs::create_dir_all(&nested).expect("mkdir nested");
+        fs::create_dir_all(&rara_dir).expect("mkdir rara workspace");
+        fs::write(rara_home.join("AGENTS.md"), "user rules").expect("write user agents");
+        fs::write(root.join("AGENTS.md"), "root rules").expect("write root agents");
+        fs::write(root.join("src").join("AGENTS.md"), "src rules").expect("write src agents");
+
+        let workspace = WorkspaceMemory::from_paths(root.clone(), rara_dir);
+        let sources = workspace.discover_prompt_sources_from_dir(&nested);
+
+        let project_sources = sources
+            .into_iter()
+            .filter(|source| matches!(source.kind, PromptSourceKind::ProjectInstruction))
+            .map(|source| (source.display_path, source.content))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            project_sources,
+            vec![
+                ("~/.rara/AGENTS.md".to_string(), "user rules".to_string()),
+                ("AGENTS.md".to_string(), "root rules".to_string()),
+                ("src/AGENTS.md".to_string(), "src rules".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/instructions/src/workspace.rs
+++ b/crates/instructions/src/workspace.rs
@@ -83,7 +83,12 @@ impl WorkspaceMemory {
     pub fn discover_instructions(&self) -> Vec<String> {
         self.discover_prompt_sources()
             .into_iter()
-            .filter(|source| matches!(source.kind, PromptSourceKind::ProjectInstruction))
+            .filter(|source| {
+                matches!(
+                    source.kind,
+                    PromptSourceKind::UserInstruction | PromptSourceKind::ProjectInstruction
+                )
+            })
             .map(|source| format!("### {}:\n{}", source.label, source.content))
             .collect()
     }
@@ -136,7 +141,7 @@ impl WorkspaceMemory {
         };
 
         vec![PromptSource {
-            kind: PromptSourceKind::ProjectInstruction,
+            kind: PromptSourceKind::UserInstruction,
             label: format!("User Instruction ({USER_INSTRUCTION_FILE})"),
             display_path: format!("~/.rara/{USER_INSTRUCTION_FILE}"),
             content,
@@ -350,17 +355,34 @@ mod tests {
         let workspace = WorkspaceMemory::from_paths(root.clone(), rara_dir);
         let sources = workspace.discover_prompt_sources_from_dir(&nested);
 
-        let project_sources = sources
+        let instruction_sources = sources
             .into_iter()
-            .filter(|source| matches!(source.kind, PromptSourceKind::ProjectInstruction))
-            .map(|source| (source.display_path, source.content))
+            .filter(|source| {
+                matches!(
+                    source.kind,
+                    PromptSourceKind::UserInstruction | PromptSourceKind::ProjectInstruction
+                )
+            })
+            .map(|source| (source.kind, source.display_path, source.content))
             .collect::<Vec<_>>();
         assert_eq!(
-            project_sources,
+            instruction_sources,
             vec![
-                ("~/.rara/AGENTS.md".to_string(), "user rules".to_string()),
-                ("AGENTS.md".to_string(), "root rules".to_string()),
-                ("src/AGENTS.md".to_string(), "src rules".to_string()),
+                (
+                    PromptSourceKind::UserInstruction,
+                    "~/.rara/AGENTS.md".to_string(),
+                    "user rules".to_string()
+                ),
+                (
+                    PromptSourceKind::ProjectInstruction,
+                    "AGENTS.md".to_string(),
+                    "root rules".to_string()
+                ),
+                (
+                    PromptSourceKind::ProjectInstruction,
+                    "src/AGENTS.md".to_string(),
+                    "src rules".to_string()
+                ),
             ]
         );
     }

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -181,14 +181,14 @@ fn skill_name_from_path(path: &Path) -> String {
     }
 }
 
-fn skill_file_sort_key(path: &Path) -> (String, u8, String) {
+fn skill_file_sort_key(path: &Path) -> (String, u8, &Path) {
     let name = skill_name_from_path(path);
     let priority = if path.file_name().and_then(|value| value.to_str()) == Some("SKILL.md") {
         1
     } else {
         0
     };
-    (name, priority, path.display().to_string())
+    (name, priority, path)
 }
 
 #[cfg(test)]

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -42,20 +42,27 @@ impl SkillManager {
     }
 
     pub fn load_from_dir(&mut self, dir: &Path) -> Result<()> {
+        let mut skill_files = Vec::new();
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
             if path.is_dir() {
                 let skill_file = path.join("SKILL.md");
                 if skill_file.exists() {
-                    self.load_skill_file(&skill_file, dir)?;
+                    skill_files.push(skill_file);
                 }
                 continue;
             }
 
             if path.extension().and_then(|s| s.to_str()) == Some("md") {
-                self.load_skill_file(&path, dir)?;
+                skill_files.push(path);
             }
+        }
+
+        skill_files
+            .sort_by(|left, right| skill_file_sort_key(left).cmp(&skill_file_sort_key(right)));
+        for path in skill_files {
+            self.load_skill_file(&path, dir)?;
         }
         Ok(())
     }
@@ -174,6 +181,16 @@ fn skill_name_from_path(path: &Path) -> String {
     }
 }
 
+fn skill_file_sort_key(path: &Path) -> (String, u8, String) {
+    let name = skill_name_from_path(path);
+    let priority = if path.file_name().and_then(|value| value.to_str()) == Some("SKILL.md") {
+        1
+    } else {
+        0
+    };
+    (name, priority, path.display().to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{SkillManager, repo_skill_search_dirs, skill_search_dirs};
@@ -209,7 +226,23 @@ mod tests {
     }
 
     #[test]
-    fn search_dirs_include_codex_compatible_home_and_repo_roots() {
+    fn load_from_dir_prefers_directory_skill_over_legacy_markdown_with_same_name() {
+        let dir = tempdir().expect("tempdir");
+        let skill_dir = dir.path().join("reviewer");
+        fs::create_dir_all(&skill_dir).expect("mkdir");
+        fs::write(dir.path().join("reviewer.md"), "# Legacy Reviewer\nlegacy").expect("write");
+        fs::write(skill_dir.join("SKILL.md"), "# Directory Reviewer\nworkflow").expect("write");
+
+        let mut manager = SkillManager::new();
+        manager.load_from_dir(dir.path()).expect("load");
+
+        let skill = manager.get_skill("reviewer").expect("reviewer skill");
+        assert_eq!(skill.description, "Directory Reviewer");
+        assert_eq!(skill.display_path, "reviewer/SKILL.md");
+    }
+
+    #[test]
+    fn search_dirs_keep_codex_compatible_prefix_order() {
         let temp = tempdir().expect("tempdir");
         let home = temp.path().join("home");
         let repo = temp.path().join("repo");
@@ -219,12 +252,18 @@ mod tests {
         fs::create_dir_all(repo.join(".git")).expect("mkdir git");
 
         let dirs = skill_search_dirs(&home, &nested);
-        assert!(dirs.contains(&home.join(".rara/skills")));
-        assert!(dirs.contains(&home.join(".agents/skills")));
-        assert!(dirs.contains(&home.join(".codex/skills")));
-        assert!(dirs.contains(&repo.join(".agents/skills")));
-        assert!(dirs.contains(&repo.join("crates/.agents/skills")));
-        assert!(dirs.contains(&nested.join(".rara/skills")));
+        assert_eq!(
+            dirs,
+            vec![
+                home.join(".rara/skills"),
+                home.join(".agents/skills"),
+                home.join(".codex/skills"),
+                repo.join(".agents/skills"),
+                repo.join("crates/.agents/skills"),
+                nested.join(".agents/skills"),
+                nested.join(".rara/skills"),
+            ]
+        );
     }
 
     #[test]

--- a/docs/features/context-architecture.md
+++ b/docs/features/context-architecture.md
@@ -82,6 +82,7 @@ turn unless explicitly disabled.
 Examples:
 
 - base runtime/system instructions;
+- user instruction files such as `~/.rara/AGENTS.md`;
 - project instruction files such as `AGENTS.md`;
 - runtime policy fields such as plan mode or bash approval mode.
 
@@ -89,6 +90,9 @@ Properties:
 
 - low churn;
 - deterministic precedence;
+- deterministic ordering: user-level instruction sources come first, followed
+  by project instruction sources from workspace root toward the current focus
+  directory, so moving into a deeper directory preserves the existing prefix;
 - persisted separately from turn history;
 - never compacted into conversational summaries.
 

--- a/docs/features/repo-extension-surface.md
+++ b/docs/features/repo-extension-surface.md
@@ -209,9 +209,17 @@ Precedence should be explicit and source-aware.
 
 For skill name conflicts:
 
-1. workspace-local `.agents/skills`
-2. nested workspace skill roots, if applicable
-3. home/global skills
+RARA loads lower-precedence roots first and lets later roots override earlier
+skills with the same name. The current order is:
+
+1. home/global skills under `~/.rara/skills`, `~/.agents/skills`, and
+   `~/.codex/skills`
+2. repo-local `.agents/skills` from the repository root toward the current
+   working directory
+3. current-working-directory `.rara/skills`
+
+Within a single root, skill discovery is deterministic. If both `name.md` and
+`name/SKILL.md` exist, the directory skill is loaded last and wins.
 
 RARA should surface overridden skills in status/debug output instead of hiding
 them.

--- a/docs/journal/2026-04-30-home-agents-instruction-order.md
+++ b/docs/journal/2026-04-30-home-agents-instruction-order.md
@@ -1,0 +1,22 @@
+# Home AGENTS Instruction Order
+
+## Checkpoint
+
+RARA now includes a user-level `~/.rara/AGENTS.md` prompt source when the
+workspace runtime data directory is under the normal `~/.rara/workspaces/...`
+layout.
+
+The stable instruction source order is:
+
+1. `~/.rara/AGENTS.md`
+2. project instruction files discovered from the workspace root toward the
+   current focus directory
+3. local workspace memory and configured runtime prompt sources
+
+This keeps the user-level instruction set as a stable prefix while preserving
+the existing root-to-focus ordering for repository instructions.
+
+## Validation
+
+- Added a focused workspace discovery test that asserts user, root, and nested
+  instruction sources are returned in prefix-stable order.

--- a/docs/journal/2026-04-30-home-agents-instruction-order.md
+++ b/docs/journal/2026-04-30-home-agents-instruction-order.md
@@ -5,6 +5,8 @@
 RARA now includes a user-level `~/.rara/AGENTS.md` prompt source when the
 workspace runtime data directory is under the normal `~/.rara/workspaces/...`
 layout.
+The source uses a dedicated `user_instruction` kind so status and context
+surfaces do not describe it as repository-walk discovery.
 
 The stable instruction source order is:
 

--- a/docs/journal/2026-04-30-home-agents-instruction-order.md
+++ b/docs/journal/2026-04-30-home-agents-instruction-order.md
@@ -20,3 +20,8 @@ the existing root-to-focus ordering for repository instructions.
 
 - Added a focused workspace discovery test that asserts user, root, and nested
   instruction sources are returned in prefix-stable order.
+- Tightened skill discovery tests so global skill roots, repo-local roots, and
+  current-directory skill roots keep a deterministic low-to-high precedence
+  order.
+- Made same-root skill loading deterministic; `name/SKILL.md` overrides
+  `name.md` when both exist.

--- a/src/context/assembly_view.rs
+++ b/src/context/assembly_view.rs
@@ -43,6 +43,7 @@ pub(crate) fn assemble_context_view(
     for source in &effective_prompt.sources {
         let kind = source.kind_label().to_string();
         let layer = match kind.as_str() {
+            "user_instruction" => "stable_instructions",
             "project_instruction" => "stable_instructions",
             "local_memory" => "workspace_prompt_sources",
             _ => "workspace_prompt_sources",


### PR DESCRIPTION
## Summary

- Load `~/.rara/AGENTS.md` as a user-level stable instruction source when the workspace uses the normal `~/.rara/workspaces/...` runtime layout.
- Preserve deterministic instruction ordering: user-level `AGENTS.md` first, then project instruction files from workspace root toward the current focus directory.
- Stabilize skill discovery order across home, repo, nested, and cwd skill roots, with deterministic same-root conflict handling.
- Document the stable instruction and skill ordering contracts and add an implementation checkpoint.

## Purpose

This aligns RARA with Codex-style global-before-project instruction sources while keeping the existing root-to-focus prefix stable as the current directory moves deeper in a repository. Skill discovery now follows the same principle: lower-precedence roots load first, later roots override same-name skills, and `name/SKILL.md` wins over `name.md` within the same root.

## Related Issues

- None.

## Testing

- `cargo test -p rara-instructions discover_prompt_sources_keeps_user_instruction_as_stable_prefix -- --nocapture`
- `cargo test -p rara-instructions workspace::tests -- --nocapture`
- `cargo test -p rara-skills -- --nocapture`
- `cargo check`
