### PR TITLE
fix(tui): clarify approval UI and DeepSeek continuation

### DIFF
--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -41,6 +41,11 @@ The transcript should move toward Codex/Claude-style tool visibility:
   DeepSeek thinking mode is explicitly enabled; the default DeepSeek request body
   must preserve assistant tool calls and adjacent tool results so the model can
   continue after approval.
+- The default TUI terminal mode should preserve native terminal text selection.
+  Mouse capture may be added later only behind an explicit opt-in, because
+  terminal mouse reporting steals drag and wheel events from the host terminal.
+- Edit tool results should expose a diff-like preview in the transcript instead
+  of rendering only `old=` and `new=` summary lines.
 - background bash tasks must be inspectable without imposing a fixed task-count limit:
   - `background_task_list` lists known background tasks;
   - `background_task_status` reads status and recent output for one task;

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -29,6 +29,18 @@ The transcript should move toward Codex/Claude-style tool visibility:
 
 - `bash` tool execution must emit live transcript updates while stdout/stderr are still being produced.
 - The final `bash` tool result should keep the exit code and avoid duplicating large output that was already streamed live.
+- When shell execution pauses on a human approval request, the approval card should take visual priority over older live stdout/stderr progress from the same turn.
+- Approval choices should describe both the action and its scope, such as:
+  - allow only the current command;
+  - allow commands with the matching prefix for the current session;
+  - allow shell commands for the current session;
+  - deny the command.
+- OpenAI-compatible chat endpoints must keep approved shell command results as
+  protocol-level tool messages before the runtime continuation message. DeepSeek
+  v4/pro history folding for missing reasoning metadata is only valid when
+  DeepSeek thinking mode is explicitly enabled; the default DeepSeek request body
+  must preserve assistant tool calls and adjacent tool results so the model can
+  continue after approval.
 - background bash tasks must be inspectable without imposing a fixed task-count limit:
   - `background_task_list` lists known background tasks;
   - `background_task_status` reads status and recent output for one task;

--- a/docs/journal/2026-04-30-approval-ui-copy.md
+++ b/docs/journal/2026-04-30-approval-ui-copy.md
@@ -1,0 +1,32 @@
+# Approval UI Copy
+
+## Context
+
+Shell and plan approval cards used terse option labels such as `yes`, `prefix`,
+`on`, and `no`. Those labels exposed implementation shorthand instead of the
+decision scope, and active tool progress could compete with the approval card
+when a command paused for review.
+
+## Decision
+
+- Plan approval choices now use action-oriented labels:
+  - start implementation now;
+  - continue planning and refine the plan.
+- Shell approval choices now describe the scope:
+  - allow once;
+  - allow matching prefix for this session;
+  - allow shell commands for this session;
+  - deny the command.
+- Active turn rendering suppresses older explicit tool progress while a pending
+  interaction is active, keeping the approval request as the focused surface.
+- DeepSeek v4/pro default chat-completion requests keep approved shell results
+  as adjacent protocol tool messages before the runtime continuation. Legacy
+  reasoning-history folding now applies only when DeepSeek thinking mode is
+  explicitly enabled.
+
+## Validation
+
+- `cargo test interaction_text -- --nocapture`
+- `cargo test active_turn_cell_renders_shell_approval_as_interaction_card -- --nocapture`
+- `cargo test deepseek_v4_defaults_keep_tool_results_as_protocol_messages -- --nocapture`
+- `cargo check`

--- a/docs/journal/2026-04-30-approval-ui-copy.md
+++ b/docs/journal/2026-04-30-approval-ui-copy.md
@@ -23,10 +23,18 @@ when a command paused for review.
   as adjacent protocol tool messages before the runtime continuation. Legacy
   reasoning-history folding now applies only when DeepSeek thinking mode is
   explicitly enabled.
+- The TUI no longer enables terminal mouse capture by default, preserving native
+  drag selection and terminal scrollback behavior.
+- `replace` and `replace_lines` results now include a diff-like preview that the
+  transcript renderer can display with the existing patch preview path.
 
 ## Validation
 
 - `cargo test interaction_text -- --nocapture`
 - `cargo test active_turn_cell_renders_shell_approval_as_interaction_card -- --nocapture`
 - `cargo test deepseek_v4_defaults_keep_tool_results_as_protocol_messages -- --nocapture`
+- `cargo test replace_results_include_renderable_diff_preview -- --nocapture`
+- `cargo test replace_lines_replaces_inclusive_range_without_old_string -- --nocapture`
+- `cargo test sync_snapshot_reports_effective_network_access_for_pending_approval -- --nocapture`
+- `cargo test summary_cell_renders_indented_diff_block_as_patch_preview -- --nocapture`
 - `cargo check`

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -395,7 +395,7 @@ fn deepseek_history_requires_reasoning_content(
 ) -> bool {
     endpoint_kind == OpenAiEndpointKind::Deepseek
         && deepseek_supports_thinking(model)
-        && thinking != Some(false)
+        && thinking == Some(true)
 }
 
 fn deepseek_legacy_history_note(messages: &[Value]) -> String {

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -627,7 +627,7 @@ fn deepseek_folds_legacy_tool_calls_with_id_and_arguments() {
 }
 
 #[test]
-fn deepseek_default_thinking_folds_legacy_assistant_history_without_reasoning() {
+fn deepseek_default_thinking_preserves_legacy_assistant_history_without_reasoning() {
     let body = build_chat_completion_request_body(
         "deepseek-v4-pro",
         &[
@@ -653,12 +653,10 @@ fn deepseek_default_thinking_folds_legacy_assistant_history_without_reasoning() 
     assert!(body.get("thinking").is_none());
     let messages = body["messages"].as_array().expect("messages");
     assert_eq!(messages.len(), 2);
-    assert_eq!(messages[0]["role"], "user");
-    assert!(
-        messages[0]["content"]
-            .as_str()
-            .expect("folded note")
-            .contains("Legacy answer without provider metadata.")
+    assert_eq!(messages[0]["role"], "assistant");
+    assert_eq!(
+        messages[0]["content"],
+        "Legacy answer without provider metadata."
     );
     assert_eq!(messages[1]["role"], "user");
     assert_eq!(messages[1]["content"], "Continue.");

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -353,6 +353,56 @@ fn deepseek_reasoner_defaults_preserve_standard_body() {
 }
 
 #[test]
+fn deepseek_v4_defaults_keep_tool_results_as_protocol_messages() {
+    let body = build_chat_completion_request_body(
+        "deepseek-v4-pro",
+        &[
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"text","text":""},
+                    {"type":"tool_use","id":"tool-1","name":"bash","input":{"command":"cargo check"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content":"ok"}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([{
+                    "type": "text",
+                    "text": "<agent_runtime>\n{\"phase\":\"tool_results_available\"}\n</agent_runtime>"
+                }]),
+            },
+        ],
+        &[json!({
+            "name": "bash",
+            "description": "Run shell command",
+            "input_schema": {"type":"object"}
+        })],
+        OpenAiEndpointKind::Deepseek,
+        None,
+        None,
+        LlmTurnMetadata::default(),
+    );
+
+    let messages = body["messages"].as_array().expect("messages");
+    assert_eq!(messages[0]["role"], "assistant");
+    assert_eq!(messages[0]["tool_calls"][0]["id"], "tool-1");
+    assert_eq!(messages[1]["role"], "tool");
+    assert_eq!(messages[1]["tool_call_id"], "tool-1");
+    assert_eq!(messages[2]["role"], "user");
+    assert!(
+        messages[2]["content"]
+            .as_str()
+            .is_some_and(|content| content.contains("tool_results_available"))
+    );
+}
+
+#[test]
 fn deepseek_thinking_tool_history_folds_missing_reasoning_content() {
     let body = build_chat_completion_request_body(
         "deepseek-reasoner",

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -35,8 +35,8 @@ impl ToolResultStore {
         let inline = match tool_name {
             "apply_patch" => compact_apply_patch(result),
             "write_file" => compact_write_file(result),
-            "replace" => compact_replace(result),
-            "replace_lines" => compact_replace_lines(result),
+            "replace" => compact_replace(input, result),
+            "replace_lines" => compact_replace_lines(input, result),
             "spawn_agent" | "explore_agent" | "plan_agent" => {
                 compact_subagent_result(tool_name, result)
             }
@@ -368,10 +368,11 @@ fn compact_write_file(result: &Value) -> String {
     rendered
 }
 
-fn compact_replace(result: &Value) -> String {
+fn compact_replace(input: &Value, result: &Value) -> String {
     let path = result
         .get("path")
         .and_then(Value::as_str)
+        .or_else(|| input.get("path").and_then(Value::as_str))
         .unwrap_or("<unknown>");
     let replacements = result
         .get("replacements")
@@ -381,23 +382,25 @@ fn compact_replace(result: &Value) -> String {
         .get("line_delta")
         .and_then(Value::as_i64)
         .unwrap_or_default();
-    let old_preview = result
-        .get("old_preview")
+    let old_string = input
+        .get("old_string")
         .and_then(Value::as_str)
+        .or_else(|| result.get("old_preview").and_then(Value::as_str))
         .unwrap_or_default();
-    let new_preview = result
-        .get("new_preview")
+    let new_string = input
+        .get("new_string")
         .and_then(Value::as_str)
+        .or_else(|| result.get("new_preview").and_then(Value::as_str))
         .unwrap_or_default();
-    format!(
-        "replace {path}\nreplacements={replacements} line_delta={line_delta}\nold={old_preview}\nnew={new_preview}"
-    )
+    let diff = simple_patch_diff(path, old_string, new_string);
+    format!("replace {path}\nreplacements={replacements} line_delta={line_delta}\ndiff:\n{diff}")
 }
 
-fn compact_replace_lines(result: &Value) -> String {
+fn compact_replace_lines(input: &Value, result: &Value) -> String {
     let path = result
         .get("path")
         .and_then(Value::as_str)
+        .or_else(|| input.get("path").and_then(Value::as_str))
         .unwrap_or("<unknown>");
     let start_line = result
         .get("start_line")
@@ -419,9 +422,30 @@ fn compact_replace_lines(result: &Value) -> String {
         .get("line_delta")
         .and_then(Value::as_i64)
         .unwrap_or_default();
+    let old_string = result
+        .get("removed_string")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let new_string = input
+        .get("new_string")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let diff = simple_patch_diff(path, old_string, new_string);
     format!(
-        "replace_lines {path}:{start_line}-{end_line}\nremoved={removed_lines} inserted={inserted_lines} line_delta={line_delta}"
+        "replace_lines {path}:{start_line}-{end_line}\nremoved={removed_lines} inserted={inserted_lines} line_delta={line_delta}\ndiff:\n{diff}"
     )
+}
+
+fn simple_patch_diff(path: &str, old_string: &str, new_string: &str) -> String {
+    let mut lines = vec![
+        "*** Begin Patch".to_string(),
+        format!("*** Update File: {path}"),
+        "@@".to_string(),
+    ];
+    lines.extend(old_string.lines().map(|line| format!("-{line}")));
+    lines.extend(new_string.lines().map(|line| format!("+{line}")));
+    lines.push("*** End Patch".to_string());
+    lines.join("\n")
 }
 
 fn compact_subagent_result(tool_name: &str, result: &Value) -> String {
@@ -791,6 +815,34 @@ mod tests {
                 .expect("default tool result dir")
                 .ends_with(std::path::Path::new("tool-results"))
         );
+    }
+
+    #[test]
+    fn replace_results_include_renderable_diff_preview() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let store = ToolResultStore::new(tempdir.path()).expect("store");
+        let output = store
+            .compact_result(
+                "replace",
+                "tool-1",
+                &json!({
+                    "path": "src/main.rs",
+                    "old_string": "let old = true;",
+                    "new_string": "let new = true;"
+                }),
+                &json!({
+                    "status": "ok",
+                    "path": "src/main.rs",
+                    "replacements": 1,
+                    "line_delta": 0
+                }),
+            )
+            .expect("compact replace");
+
+        assert!(output.contains("diff:"));
+        assert!(output.contains("*** Update File: src/main.rs"));
+        assert!(output.contains("-let old = true;"));
+        assert!(output.contains("+let new = true;"));
     }
 
     #[test]

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -447,6 +447,7 @@ impl Tool for ReplaceLinesTool {
                 .collect::<Vec<_>>()
         };
         let removed_line_count = end_line - start_line + 1;
+        let removed_string = lines[start_line - 1..end_line].join("\n");
         lines.splice(start_line - 1..end_line, replacement_lines.iter().cloned());
 
         let mut updated = lines.join("\n");
@@ -461,6 +462,7 @@ impl Tool for ReplaceLinesTool {
             "start_line": start_line,
             "end_line": end_line,
             "removed_lines": removed_line_count,
+            "removed_string": removed_string,
             "inserted_lines": replacement_lines.len(),
             "line_delta": replacement_lines.len() as i64 - removed_line_count as i64,
         }))
@@ -809,6 +811,7 @@ mod tests {
             "one\nmiddle\nfour\n"
         );
         assert_eq!(result["removed_lines"], 2);
+        assert_eq!(result["removed_string"], "two\nthree");
         assert_eq!(result["inserted_lines"], 1);
         assert_eq!(result["line_delta"], -1);
     }

--- a/src/tui/interaction_text.rs
+++ b/src/tui/interaction_text.rs
@@ -24,8 +24,12 @@ pub fn pending_interaction_card_title(kind: ActivePendingInteractionKind) -> &'s
 
 pub fn pending_interaction_hint_text(kind: ActivePendingInteractionKind) -> &'static str {
     match kind {
-        ActivePendingInteractionKind::PlanApproval => "type reply  1 yes  2 plan",
-        ActivePendingInteractionKind::ShellApproval => "type reply  1 yes  2 prefix  3 on  4 no",
+        ActivePendingInteractionKind::PlanApproval => {
+            "plan ready  1 start implementation  2 continue planning"
+        }
+        ActivePendingInteractionKind::ShellApproval => {
+            "approval required  1 allow once  2 allow prefix  3 allow session  4 deny"
+        }
         ActivePendingInteractionKind::PlanningQuestion
         | ActivePendingInteractionKind::ExplorationQuestion
         | ActivePendingInteractionKind::SubAgentQuestion
@@ -35,13 +39,15 @@ pub fn pending_interaction_hint_text(kind: ActivePendingInteractionKind) -> &'st
 
 pub fn status_plan_approval_text(app: &TuiApp) -> String {
     let _ = app;
-    "Start implementation with this plan?\n\n1. yes\n2. keep planning".to_string()
+    "Plan ready for implementation.\n\n1. Start implementation now\n2. Continue planning and refine the plan".to_string()
 }
 
 pub fn pending_interaction_shortcut_text(kind: ActivePendingInteractionKind) -> &'static str {
     match kind {
-        ActivePendingInteractionKind::PlanApproval => "1 yes  2 plan",
-        ActivePendingInteractionKind::ShellApproval => "1 yes  2 prefix  3 on  4 no",
+        ActivePendingInteractionKind::PlanApproval => "1 start implementation  2 continue planning",
+        ActivePendingInteractionKind::ShellApproval => {
+            "1 allow once  2 allow prefix  3 allow session  4 deny"
+        }
         ActivePendingInteractionKind::PlanningQuestion
         | ActivePendingInteractionKind::ExplorationQuestion
         | ActivePendingInteractionKind::SubAgentQuestion
@@ -131,17 +137,15 @@ pub fn status_command_approval_text(app: &TuiApp) -> String {
         .approval_prefix()
         .unwrap_or_else(|| approval.command.clone());
 
+    let network = if approval.allow_net {
+        "enabled for this command"
+    } else {
+        "disabled unless already allowed by the sandbox"
+    };
+
     format!(
-        "command:\n{}\n\ncwd:\n{}\n\nnetwork:\n{}\n\nenv:\n{} override(s)\n\nmatching prefix:\n{}\n\n1. yes\n2. prefix\n3. on\n4. no",
-        approval.command,
-        cwd,
-        if approval.allow_net {
-            "allowed"
-        } else {
-            "disabled"
-        },
-        env_count,
-        prefix,
+        "Review this shell command before RARA runs it.\n\nCommand:\n  {}\n\nWorking directory:\n  {}\n\nNetwork access: {}\nEnvironment overrides: {}\nMatching prefix: {}\n\n1. Allow once - run only this command now\n2. Allow matching prefix - trust commands that start with `{}` for this session\n3. Allow for this session - stop asking for shell commands until the session changes\n4. Deny - do not run the command",
+        approval.command, cwd, network, env_count, prefix, prefix,
     )
 }
 
@@ -150,12 +154,17 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::config::ConfigManager;
-    use crate::tui::state::TuiApp;
+    use crate::tools::bash::BashCommandInput;
+    use crate::tui::state::{
+        InteractionKind, PendingApprovalSnapshot, PendingInteractionSnapshot, TuiApp,
+    };
 
-    use super::{pending_interaction_hint_text, status_plan_approval_text};
+    use super::{
+        pending_interaction_hint_text, status_command_approval_text, status_plan_approval_text,
+    };
 
     #[test]
-    fn plan_approval_text_uses_compact_choice_labels() {
+    fn plan_approval_text_uses_action_oriented_choice_labels() {
         let temp = tempdir().unwrap();
         let app = TuiApp::new(ConfigManager {
             path: temp.path().join("config.json"),
@@ -163,24 +172,64 @@ mod tests {
         .expect("app");
 
         let rendered = status_plan_approval_text(&app);
-        assert!(rendered.contains("1. yes"));
-        assert!(rendered.contains("2. keep planning"));
-        assert!(!rendered.contains("Start implementation now"));
+        assert!(rendered.contains("Plan ready for implementation."));
+        assert!(rendered.contains("1. Start implementation now"));
+        assert!(rendered.contains("2. Continue planning and refine the plan"));
+        assert!(!rendered.contains("1. yes"));
     }
 
     #[test]
-    fn pending_interaction_hint_text_is_compact_for_plan_and_shell_approval() {
+    fn pending_interaction_hint_text_describes_approval_scope() {
         assert_eq!(
             pending_interaction_hint_text(
                 crate::tui::state::ActivePendingInteractionKind::PlanApproval
             ),
-            "type reply  1 yes  2 plan"
+            "plan ready  1 start implementation  2 continue planning"
         );
         assert_eq!(
             pending_interaction_hint_text(
                 crate::tui::state::ActivePendingInteractionKind::ShellApproval
             ),
-            "type reply  1 yes  2 prefix  3 on  4 no"
+            "approval required  1 allow once  2 allow prefix  3 allow session  4 deny"
         );
+    }
+
+    #[test]
+    fn command_approval_text_uses_explicit_decision_labels() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.snapshot
+            .pending_interactions
+            .push(PendingInteractionSnapshot {
+                kind: InteractionKind::Approval,
+                title: "Pending Approval".into(),
+                summary: "cargo check".into(),
+                options: Vec::new(),
+                note: None,
+                approval: Some(PendingApprovalSnapshot {
+                    tool_use_id: "toolu_123".into(),
+                    command: "cargo check".into(),
+                    allow_net: false,
+                    payload: BashCommandInput {
+                        command: Some("cargo check".into()),
+                        cwd: Some("/repo".into()),
+                        ..Default::default()
+                    },
+                }),
+                source: None,
+            });
+
+        let rendered = status_command_approval_text(&app);
+        assert!(rendered.contains("Review this shell command before RARA runs it."));
+        assert!(rendered.contains("1. Allow once"));
+        assert!(rendered.contains("2. Allow matching prefix"));
+        assert!(rendered.contains("3. Allow for this session"));
+        assert!(rendered.contains("4. Deny"));
+        assert!(!rendered.contains("1. yes"));
+        assert!(!rendered.contains("3. on"));
+        assert!(!rendered.contains("4. no"));
     }
 }

--- a/src/tui/interaction_text.rs
+++ b/src/tui/interaction_text.rs
@@ -138,7 +138,7 @@ pub fn status_command_approval_text(app: &TuiApp) -> String {
         .unwrap_or_else(|| approval.command.clone());
 
     let network = if approval.allow_net {
-        "enabled for this command"
+        "enabled by sandbox config or command request"
     } else {
         "disabled unless already allowed by the sandbox"
     };

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -924,6 +924,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
         let has_live_running = !self.app.active_live.running_actions.is_empty();
         let live_events = self.app.active_live.events.as_slice();
         let has_live_events = !live_events.is_empty();
+        let has_active_pending_interaction = self.app.active_pending_interaction().is_some();
 
         if !user_message.is_empty() {
             cells.push(Box::new(UserCell::new(user_message)));
@@ -984,7 +985,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             }
         }
 
-        let explicit_progress_groups = (!has_live_events)
+        let explicit_progress_groups = (!has_live_events && !has_active_pending_interaction)
             .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
         if let Some(groups) = explicit_progress_groups.as_ref() {
             for (role, messages) in groups {
@@ -1249,7 +1250,9 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 14,
                 self.cwd,
             )));
-        } else if let Some((role, tool_result)) = latest_tool_result {
+        } else if !has_active_pending_interaction
+            && let Some((role, tool_result)) = latest_tool_result
+        {
             cells.push(Box::new(RespondingCell::from_tool_result(
                 role,
                 tool_result,

--- a/src/tui/render/cells_components.rs
+++ b/src/tui/render/cells_components.rs
@@ -59,7 +59,7 @@ impl HistoryCell for SummaryCell {
         let mut lines = vec![Line::from(section_span(self.title, self.color))];
         let mut summary_lines = self.summary.lines();
         while let Some(line) = summary_lines.next() {
-            if line == "diff:" {
+            if line.trim_start() == "diff:" {
                 lines.push(Line::from(vec![
                     Span::raw("  "),
                     Span::styled(
@@ -69,7 +69,10 @@ impl HistoryCell for SummaryCell {
                             .add_modifier(Modifier::BOLD),
                     ),
                 ]));
-                let diff = summary_lines.collect::<Vec<_>>().join("\n");
+                let diff = summary_lines
+                    .map(|line| line.trim_start())
+                    .collect::<Vec<_>>()
+                    .join("\n");
                 lines.extend(render_patch_preview(diff.as_str(), width));
                 break;
             }
@@ -771,4 +774,31 @@ impl HistoryCell for StartupCardCell {
 
 pub(super) fn planning_suggestion_text(app: &TuiApp) -> String {
     status_planning_suggestion_text(app)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HistoryCell, SummaryCell};
+    use ratatui::style::Color;
+
+    #[test]
+    fn summary_cell_renders_indented_diff_block_as_patch_preview() {
+        let cell = SummaryCell::new(
+            "Ran",
+            Color::LightYellow,
+            "  replace src/main.rs\n  diff:\n  *** Begin Patch\n  *** Update File: src/main.rs\n  @@\n  -old\n  +new\n  *** End Patch",
+        );
+
+        let rendered = cell
+            .display_lines(100)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("diff:"));
+        assert!(rendered.contains("Edited src/main.rs"));
+        assert!(rendered.contains("- old"));
+        assert!(rendered.contains("+ new"));
+    }
 }

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -36,8 +36,8 @@ fn active_turn_cell_renders_plan_approval_as_interaction_card() {
     assert_snapshot!("active_turn_cell_plan_approval", rendered);
     assert!(rendered.contains(" Awaiting Approval "));
     assert!(rendered.contains("Updated Plan"));
-    assert!(rendered.contains("1. yes"));
-    assert!(rendered.contains("2. keep planning"));
+    assert!(rendered.contains("1. Start implementation now"));
+    assert!(rendered.contains("2. Continue planning and refine the plan"));
     assert!(rendered.contains("Generalize instruction discovery"));
 }
 

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -154,11 +154,18 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
-        entries: vec![TranscriptEntry {
-            role: "You".into(),
-            message: "Run the migration helper".into(),
-            payload: None,
-        }],
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Run the migration helper".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool Progress".into(),
+                message: "background task stdout:\n    Checking nix v0.30.1".into(),
+                payload: None,
+            },
+        ],
     };
     app.snapshot
         .pending_interactions
@@ -194,9 +201,13 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
         .join("\n");
 
     assert!(rendered.contains(" Shell Approval "));
-    assert!(rendered.contains("command:"));
-    assert!(rendered.contains("cwd:"));
+    assert!(rendered.contains("Review this shell command before RARA runs it."));
+    assert!(rendered.contains("Command:"));
+    assert!(rendered.contains("Working directory:"));
     assert!(rendered.contains("bash ./scripts/migrate.sh"));
+    assert!(rendered.contains("1. Allow once"));
+    assert!(!rendered.contains("Tool Progress"));
+    assert!(!rendered.contains("background task stdout"));
 }
 
 #[test]

--- a/src/tui/render/cells_tests/snapshots/rara__tui__render__cells__tests__active_plan__active_turn_cell_plan_approval.snap
+++ b/src/tui/render/cells_tests/snapshots/rara__tui__render__cells__tests__active_plan__active_turn_cell_plan_approval.snap
@@ -11,8 +11,8 @@ expression: rendered
     □ Preserve cache and path resolution behavior
 
  Awaiting Approval 
-  Start implementation with this plan?
+  Plan ready for implementation.
   
-  1. yes
-  2. keep planning
-  1 yes  2 plan
+  1. Start implementation now
+  2. Continue planning and refine the plan
+  1 start implementation  2 continue planning

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1274,7 +1274,8 @@ impl TuiApp {
                 approval: Some(PendingApprovalSnapshot {
                     tool_use_id: pending.tool_use_id.clone(),
                     command: pending.request.summary(),
-                    allow_net: pending.request.allow_net,
+                    allow_net: self.config.sandbox_workspace_write.network_access
+                        || pending.request.allow_net,
                     payload: pending.request.clone(),
                 }),
                 source: None,

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -3,10 +3,17 @@ use super::{
     PendingInteractionSnapshot, ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn,
     TuiApp, input_requests_command_palette, parse_repo_slug, state_db_status_error,
 };
+use crate::agent::{Agent, PendingApproval};
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
 use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
 use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
+use crate::llm::MockLlm;
+use crate::session::SessionManager;
 use crate::state_db::{PersistedCompactState, PersistedPromptRuntimeState, StateDb};
+use crate::tool::ToolManager;
+use crate::tools::bash::BashCommandInput;
+use crate::vectordb::VectorDB;
+use crate::workspace::WorkspaceMemory;
 use tempfile::tempdir;
 
 fn provider_family_idx(family: ProviderFamily) -> usize {
@@ -84,6 +91,45 @@ fn prioritizes_active_pending_interaction_in_ui_order() {
         .expect("pending interaction");
     assert_eq!(active.kind, ActivePendingInteractionKind::PlanApproval);
     assert_eq!(active._snapshot.title, "Plan Ready");
+}
+
+#[test]
+fn sync_snapshot_reports_effective_network_access_for_pending_approval() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let rara_dir = root.join(".rara");
+    std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+    std::fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+    let mut app = TuiApp::new(ConfigManager {
+        path: root.join("config.json"),
+    })
+    .expect("app");
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        std::sync::Arc::new(MockLlm),
+        std::sync::Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        std::sync::Arc::new(SessionManager {
+            storage_dir: rara_dir.join("rollouts"),
+            legacy_storage_dir: rara_dir.join("sessions"),
+        }),
+        std::sync::Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+    );
+    agent.pending_approval = Some(PendingApproval {
+        tool_use_id: "tool-1".to_string(),
+        request: BashCommandInput {
+            command: Some("cargo check".to_string()),
+            allow_net: false,
+            ..Default::default()
+        },
+    });
+
+    app.sync_snapshot(&agent);
+
+    let approval = app
+        .pending_command_approval()
+        .and_then(|interaction| interaction.approval.as_ref())
+        .expect("pending approval");
+    assert!(approval.allow_net);
 }
 
 #[test]

--- a/src/tui/terminal_ui.rs
+++ b/src/tui/terminal_ui.rs
@@ -3,7 +3,7 @@ use std::io;
 use anyhow::Result;
 use crossterm::{
     cursor::Show,
-    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
+    event::{DisableBracketedPaste, EnableBracketedPaste},
     execute,
     terminal::disable_raw_mode,
 };
@@ -23,11 +23,7 @@ pub(super) fn build_terminal(
     viewport_height: u16,
 ) -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
-    execute!(
-        terminal.backend_mut(),
-        EnableMouseCapture,
-        EnableBracketedPaste
-    )?;
+    execute!(terminal.backend_mut(), EnableBracketedPaste)?;
 
     let result = (|| -> Result<()> {
         let size = terminal.size()?;
@@ -37,11 +33,7 @@ pub(super) fn build_terminal(
     })();
 
     if let Err(err) = result {
-        let _ = execute!(
-            terminal.backend_mut(),
-            DisableBracketedPaste,
-            DisableMouseCapture
-        );
+        let _ = execute!(terminal.backend_mut(), DisableBracketedPaste);
         return Err(err);
     }
 
@@ -64,11 +56,7 @@ pub(super) fn update_terminal_viewport(
 pub(super) fn teardown_terminal(
     mut terminal: Terminal<CrosstermBackend<std::io::Stdout>>,
 ) -> Result<()> {
-    execute!(
-        terminal.backend_mut(),
-        DisableBracketedPaste,
-        DisableMouseCapture
-    )?;
+    execute!(terminal.backend_mut(), DisableBracketedPaste)?;
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), Show)?;
     terminal.show_cursor()?;


### PR DESCRIPTION
## Summary

- Replace terse plan and shell approval labels with action-oriented choices that explain the scope of each decision.
- Keep pending approval cards focused by suppressing older live tool progress from the same active turn.
- Preserve DeepSeek v4/pro default tool-call history as assistant tool calls plus adjacent tool messages, so approved shell commands continue through the normal runtime continuation path.
- Preserve native terminal text selection and scrollback by avoiding default mouse capture in the TUI.
- Render `replace` and `replace_lines` tool results through the existing diff preview path.
- Report shell approval network state from effective sandbox access, not only the per-command request flag.
- Document the approval UI, DeepSeek continuation, terminal selection, and edit-diff transcript contracts.

## Purpose

The previous shell approval surface exposed implementation shorthand like `yes`, `prefix`, `on`, and `no`, and older live output could compete with the approval prompt. With DeepSeek v4/pro, approved shell command results could also be folded into plain quoted context by the legacy reasoning-history compatibility path, which made continuation after approval unreliable.

This also fixes two TUI usability gaps found while reviewing the approval flow: terminal mouse capture prevented normal drag selection/scrollback behavior, and edit summaries exposed `old=`/`new=` text instead of a readable diff preview. The network label now reflects the effective sandbox configuration, where workspace-write network access defaults to enabled.

## Related issue

No linked issue.

## Tests

- `cargo test interaction_text -- --nocapture`
- `cargo test active_turn_cell_renders_shell_approval_as_interaction_card -- --nocapture`
- `cargo test deepseek_v4_defaults_keep_tool_results_as_protocol_messages -- --nocapture`
- `cargo test deepseek_thinking_tool_history_folds_missing_reasoning_content -- --nocapture`
- `cargo test replace_results_include_renderable_diff_preview -- --nocapture`
- `cargo test replace_lines_replaces_inclusive_range_without_old_string -- --nocapture`
- `cargo test sync_snapshot_reports_effective_network_access_for_pending_approval -- --nocapture`
- `cargo test summary_cell_renders_indented_diff_block_as_patch_preview -- --nocapture`
- `cargo check`
