### PR TITLE
fix(tui): group consecutive exploration cells

### DIFF
--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -112,6 +112,13 @@ fn explicit_progress_entry_groups<'a>(
         if messages.is_empty() {
             continue;
         }
+        if role == "Exploring"
+            && let Some((last_role, last_messages)) = groups.last_mut()
+            && *last_role == "Exploring"
+        {
+            last_messages.extend(messages);
+            continue;
+        }
         groups.push((role, messages));
     }
     groups
@@ -197,6 +204,50 @@ fn push_live_event<'a>(
             // Active live events currently produce only known progress roles.
         }
     }
+}
+
+fn push_live_events<'a>(
+    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+    events: &[crate::tui::state::ActiveLiveEvent],
+    active: bool,
+) {
+    let mut exploration_actions = Vec::new();
+    let mut exploration_notes = Vec::new();
+
+    let flush_exploration = |cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+                             actions: &mut Vec<String>,
+                             notes: &mut Vec<String>| {
+        if actions.is_empty() && notes.is_empty() {
+            return;
+        }
+        cells.push(Box::new(ExploringCell::new(
+            compact_progress_summary_lines(
+                actions.as_slice(),
+                notes.as_slice(),
+                4,
+                "more exploration step(s)",
+            ),
+            active,
+        )));
+        actions.clear();
+        notes.clear();
+    };
+
+    for event in events {
+        if event.role() == "Exploring" {
+            if event.is_note() {
+                exploration_notes.push(event.message().to_string());
+            } else {
+                exploration_actions.push(event.message().to_string());
+            }
+            continue;
+        }
+
+        flush_exploration(cells, &mut exploration_actions, &mut exploration_notes);
+        push_live_event(cells, event, active);
+    }
+
+    flush_exploration(cells, &mut exploration_actions, &mut exploration_notes);
 }
 
 fn split_progress_sentences(message: &str) -> Vec<String> {
@@ -655,6 +706,17 @@ fn ordered_exploration_agent_segments<'a>(
                 }
                 segments.push(OrderedActiveSegment::Agent(entry.message.as_str()));
             }
+            role if progress_entry_role(role)
+                || matches!(
+                    role,
+                    "Tool Result" | "Tool Error" | "Tool Progress" | "System"
+                ) =>
+            {
+                if !exploration_items.is_empty() {
+                    saw_interleaving = true;
+                    flush_exploration(&mut segments, &mut exploration_items);
+                }
+            }
             _ => {}
         }
     }
@@ -981,8 +1043,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
                     "Running" => has_event_running_summary = true,
                     _ => {}
                 }
-                push_live_event(&mut cells, event, true);
             }
+            push_live_events(&mut cells, live_events, true);
         }
 
         let explicit_progress_groups = (!has_live_events && !has_active_pending_interaction)

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -214,25 +214,6 @@ fn push_live_events<'a>(
     let mut exploration_actions = Vec::new();
     let mut exploration_notes = Vec::new();
 
-    let flush_exploration = |cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-                             actions: &mut Vec<String>,
-                             notes: &mut Vec<String>| {
-        if actions.is_empty() && notes.is_empty() {
-            return;
-        }
-        cells.push(Box::new(ExploringCell::new(
-            compact_progress_summary_lines(
-                actions.as_slice(),
-                notes.as_slice(),
-                4,
-                "more exploration step(s)",
-            ),
-            active,
-        )));
-        actions.clear();
-        notes.clear();
-    };
-
     for event in events {
         if event.role() == "Exploring" {
             if event.is_note() {
@@ -243,11 +224,43 @@ fn push_live_events<'a>(
             continue;
         }
 
-        flush_exploration(cells, &mut exploration_actions, &mut exploration_notes);
+        push_live_exploration_group(
+            cells,
+            &mut exploration_actions,
+            &mut exploration_notes,
+            active,
+        );
         push_live_event(cells, event, active);
     }
 
-    flush_exploration(cells, &mut exploration_actions, &mut exploration_notes);
+    push_live_exploration_group(
+        cells,
+        &mut exploration_actions,
+        &mut exploration_notes,
+        active,
+    );
+}
+
+fn push_live_exploration_group<'a>(
+    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+    actions: &mut Vec<String>,
+    notes: &mut Vec<String>,
+    active: bool,
+) {
+    if actions.is_empty() && notes.is_empty() {
+        return;
+    }
+    cells.push(Box::new(ExploringCell::new(
+        compact_progress_summary_lines(
+            actions.as_slice(),
+            notes.as_slice(),
+            4,
+            "more exploration step(s)",
+        ),
+        active,
+    )));
+    actions.clear();
+    notes.clear();
 }
 
 fn split_progress_sentences(message: &str) -> Vec<String> {

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -352,14 +352,14 @@ fn active_turn_cell_appends_long_live_exploration_events() {
 
     assert!(rendered.contains(" Exploring "));
     assert!(rendered.contains("Cross-check the auth entrypoint."));
-    assert!(!rendered.contains("more exploration step(s)"));
-    assert!(rendered.contains("module_1.rs"));
+    assert!(rendered.contains("1 more exploration step(s)"));
+    assert!(!rendered.contains("module_1.rs"));
     assert!(rendered.contains("module_2.rs"));
     assert!(rendered.contains("module_3.rs"));
+    assert!(rendered.contains("module_4.rs"));
     assert!(rendered.contains("module_5.rs"));
-    assert_eq!(rendered.matches(" Exploring ").count(), 6);
-    assert!(rendered.find("module_1.rs") < rendered.find("module_5.rs"));
-    assert!(rendered.find("module_5.rs") < rendered.find("Cross-check the auth entrypoint."));
+    assert_eq!(rendered.matches(" Exploring ").count(), 1);
+    assert!(rendered.find("module_2.rs") < rendered.find("module_5.rs"));
 }
 
 #[test]
@@ -1006,6 +1006,54 @@ fn active_turn_cell_preserves_repeated_progress_events_when_interleaved() {
 }
 
 #[test]
+fn active_turn_cell_groups_consecutive_exploration_events_only() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Inspect and run checks".into(),
+            payload: None,
+        }],
+    };
+
+    app.record_exploration_action("Read src/tui/render/cells.rs");
+    app.record_exploration_action("Read src/tui/render/cells_tests/active_general.rs");
+    app.record_running_action("Run cargo check");
+    app.record_exploration_action("Read src/tui/render/cells_components.rs");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_eq!(rendered.matches(" Exploring ").count(), 2);
+
+    let first_exploring_idx = rendered.find(" Exploring ").unwrap();
+    let first_read_idx = rendered.find("Read src/tui/render/cells.rs").unwrap();
+    let second_read_idx = rendered
+        .find("Read src/tui/render/cells_tests/active_general.rs")
+        .unwrap();
+    let running_idx = rendered.find(" Running ").unwrap();
+    let second_exploring_idx = rendered.rfind(" Exploring ").unwrap();
+    let third_read_idx = rendered
+        .find("Read src/tui/render/cells_components.rs")
+        .unwrap();
+
+    assert!(first_exploring_idx < first_read_idx);
+    assert!(first_read_idx < second_read_idx);
+    assert!(second_read_idx < running_idx);
+    assert!(running_idx < second_exploring_idx);
+    assert!(second_exploring_idx < third_read_idx);
+}
+
+#[test]
 fn active_turn_cell_preserves_consecutive_duplicate_progress_events() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
@@ -1035,7 +1083,7 @@ fn active_turn_cell_preserves_consecutive_duplicate_progress_events() {
 
     assert_eq!(rendered.matches("Read src/tui/render/cells.rs").count(), 2);
     assert_eq!(rendered.matches("Run cargo check").count(), 2);
-    assert_eq!(rendered.matches(" Exploring ").count(), 2);
+    assert_eq!(rendered.matches(" Exploring ").count(), 1);
     assert_eq!(rendered.matches(" Running ").count(), 2);
 }
 

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -231,7 +231,7 @@ fn committed_turn_cell_appends_adjacent_progress_entries() {
     let first_ran = rendered.find("Run cargo test active_turn_cell").unwrap();
     let second_ran = rendered.find("Run cargo check").unwrap();
 
-    assert_eq!(rendered.matches(" Explored ").count(), 2);
+    assert_eq!(rendered.matches(" Explored ").count(), 1);
     assert_eq!(rendered.matches(" Ran ").count(), 2);
     assert!(first_explored < second_explored);
     assert!(second_explored < first_ran);


### PR DESCRIPTION
## Summary

- Group consecutive active `Exploring` events into a single exploring cell.
- Start a new exploring cell when a non-exploration event appears between exploration events.
- Update focused active-cell render tests for the new grouping behavior.

## Purpose

This keeps consecutive repository inspection steps visually compact while preserving event boundaries when execution switches to another progress type and later returns to exploration.

## Related Issue

None.

## Testing

- `cargo test active_turn_cell_groups_consecutive_exploration_events_only -- --nocapture`
- `cargo test active_turn_cell_preserves_consecutive_duplicate_progress_events -- --nocapture`
- `cargo test tui::render::cells::tests::active_general -- --nocapture`
- `cargo check`
