### PR TITLE
fix(tui): group consecutive thinking cells

### DIFF
--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -263,12 +263,12 @@ fn push_live_thinking_group<'a>(
     messages: &mut Vec<String>,
     stream_lines: Option<&'a [Line<'static>]>,
 ) {
-    if messages.is_empty() && stream_lines.is_none_or(|lines| lines.is_empty()) {
+    if messages.is_empty() && stream_lines.map_or(true, |lines| lines.is_empty()) {
         return;
     }
     if stream_lines.is_some() {
         cells.push(Box::new(ThinkingGroupCell::new(
-            std::mem::take(messages),
+            std::mem::take(messages).join("\n"),
             stream_lines,
             4,
         )));

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -21,7 +21,8 @@ pub(crate) use self::components::StartupCardCell;
 use self::components::{
     CommittedInteractionCell, ExploredCell, ExploringCell, MessageCell, PendingInteractionCell,
     PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell, RanCell, RespondingCell,
-    RunningCell, TerminalCell, ThinkingCell, ThinkingTextCell, UserCell, planning_suggestion_text,
+    RunningCell, TerminalCell, ThinkingGroupCell, ThinkingTextCell, UserCell,
+    planning_suggestion_text,
 };
 use super::{
     compact_progress_summary_lines, compact_recent_first_summary_lines, compact_summary_lines,
@@ -209,13 +210,27 @@ fn push_live_event<'a>(
 fn push_live_events<'a>(
     cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
     events: &[crate::tui::state::ActiveLiveEvent],
+    streaming_thinking_lines: Option<&'a [Line<'static>]>,
     active: bool,
 ) {
+    let mut thinking_messages = Vec::new();
     let mut exploration_actions = Vec::new();
     let mut exploration_notes = Vec::new();
 
     for event in events {
+        if event.role() == "Thinking" {
+            push_live_exploration_group(
+                cells,
+                &mut exploration_actions,
+                &mut exploration_notes,
+                active,
+            );
+            thinking_messages.push(event.message().to_string());
+            continue;
+        }
+
         if event.role() == "Exploring" {
+            push_live_thinking_group(cells, &mut thinking_messages, None);
             if event.is_note() {
                 exploration_notes.push(event.message().to_string());
             } else {
@@ -224,6 +239,7 @@ fn push_live_events<'a>(
             continue;
         }
 
+        push_live_thinking_group(cells, &mut thinking_messages, None);
         push_live_exploration_group(
             cells,
             &mut exploration_actions,
@@ -233,12 +249,33 @@ fn push_live_events<'a>(
         push_live_event(cells, event, active);
     }
 
+    push_live_thinking_group(cells, &mut thinking_messages, streaming_thinking_lines);
     push_live_exploration_group(
         cells,
         &mut exploration_actions,
         &mut exploration_notes,
         active,
     );
+}
+
+fn push_live_thinking_group<'a>(
+    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+    messages: &mut Vec<String>,
+    stream_lines: Option<&'a [Line<'static>]>,
+) {
+    if messages.is_empty() && stream_lines.is_none_or(|lines| lines.is_empty()) {
+        return;
+    }
+    if stream_lines.is_some() {
+        cells.push(Box::new(ThinkingGroupCell::new(
+            std::mem::take(messages),
+            stream_lines,
+            4,
+        )));
+        return;
+    }
+    cells.push(Box::new(ThinkingTextCell::new(&messages.join("\n"), 4)));
+    messages.clear();
 }
 
 fn push_live_exploration_group<'a>(
@@ -1010,12 +1047,6 @@ impl ActiveCell for ActiveTurnCell<'_> {
             cells.push(Box::new(PlanModeCell));
         }
 
-        if turn_live && has_thinking_stream {
-            if let Some(lines) = streaming_thinking_lines {
-                cells.push(Box::new(ThinkingCell::new(lines, 4)));
-            }
-        }
-
         let ordered_exploration_agent_segments =
             if !has_live_events && !has_live_exploration && !has_live_planning && !has_live_running
             {
@@ -1048,7 +1079,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
         let mut has_event_exploration_summary = false;
         let mut has_event_planning_summary = false;
         let mut has_event_running_summary = false;
-        if has_live_events {
+        let has_live_thinking = turn_live && has_thinking_stream;
+        if has_live_events || has_live_thinking {
             for event in live_events {
                 match event.role() {
                     "Exploring" => has_event_exploration_summary = true,
@@ -1057,11 +1089,17 @@ impl ActiveCell for ActiveTurnCell<'_> {
                     _ => {}
                 }
             }
-            push_live_events(&mut cells, live_events, true);
+            push_live_events(
+                &mut cells,
+                live_events,
+                streaming_thinking_lines.filter(|_| has_live_thinking),
+                true,
+            );
         }
 
-        let explicit_progress_groups = (!has_live_events && !has_active_pending_interaction)
-            .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
+        let explicit_progress_groups =
+            (!has_live_events && !has_live_thinking && !has_active_pending_interaction)
+                .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
         if let Some(groups) = explicit_progress_groups.as_ref() {
             for (role, messages) in groups {
                 push_progress_group(&mut cells, role, messages.clone(), turn_live);

--- a/src/tui/render/cells_components.rs
+++ b/src/tui/render/cells_components.rs
@@ -241,19 +241,19 @@ impl HistoryCell for ThinkingTextCell {
 }
 
 pub(super) struct ThinkingGroupCell<'a> {
-    messages: Vec<String>,
+    message: String,
     stream_lines: Option<&'a [Line<'static>]>,
     max_lines: usize,
 }
 
 impl<'a> ThinkingGroupCell<'a> {
     pub(super) fn new(
-        messages: Vec<String>,
+        message: String,
         stream_lines: Option<&'a [Line<'static>]>,
         max_lines: usize,
     ) -> Self {
         Self {
-            messages,
+            message,
             stream_lines,
             max_lines,
         }
@@ -264,9 +264,8 @@ impl HistoryCell for ThinkingGroupCell<'_> {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
         let render_width = usize::from(width.saturating_sub(2));
         let mut rendered_lines = Vec::new();
-        if !self.messages.is_empty() {
-            let rendered =
-                render_markdown_text_with_width(&self.messages.join("\n"), Some(render_width));
+        if !self.message.is_empty() {
+            let rendered = render_markdown_text_with_width(&self.message, Some(render_width));
             rendered_lines.extend(rendered.lines);
         }
         if let Some(stream_lines) = self.stream_lines {

--- a/src/tui/render/cells_components.rs
+++ b/src/tui/render/cells_components.rs
@@ -204,36 +204,6 @@ impl HistoryCell for RunningCell {
     }
 }
 
-pub(super) struct ThinkingCell<'a> {
-    lines: &'a [Line<'static>],
-    max_lines: usize,
-}
-
-impl<'a> ThinkingCell<'a> {
-    pub(super) fn new(lines: &'a [Line<'static>], max_lines: usize) -> Self {
-        Self { lines, max_lines }
-    }
-}
-
-impl HistoryCell for ThinkingCell<'_> {
-    fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
-        let start = self.lines.len().saturating_sub(self.max_lines);
-        let body = markdown_body_lines(&self.lines[start..], self.max_lines);
-        let mut lines = vec![Line::from(section_span("Thinking", Color::LightBlue))];
-        if start > 0 {
-            lines.push(Line::from(Span::styled(
-                format!("  ... {start} more line(s)"),
-                Style::default().fg(Color::DarkGray),
-            )));
-        }
-        lines.extend(body.into_iter().map(|mut line| {
-            line.spans.insert(0, Span::raw("  "));
-            line
-        }));
-        lines
-    }
-}
-
 pub(super) struct ThinkingTextCell {
     message: String,
     max_lines: usize,
@@ -253,6 +223,56 @@ impl HistoryCell for ThinkingTextCell {
         let render_width = usize::from(width.saturating_sub(2));
         let rendered = render_markdown_text_with_width(&self.message, Some(render_width));
         let rendered_lines = rendered.lines;
+        let start = rendered_lines.len().saturating_sub(self.max_lines);
+        let body = markdown_body_lines(&rendered_lines[start..], self.max_lines);
+        let mut lines = vec![Line::from(section_span("Thinking", Color::LightBlue))];
+        if start > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("  ... {start} more line(s)"),
+                Style::default().fg(Color::DarkGray),
+            )));
+        }
+        lines.extend(body.into_iter().map(|mut line| {
+            line.spans.insert(0, Span::raw("  "));
+            line
+        }));
+        lines
+    }
+}
+
+pub(super) struct ThinkingGroupCell<'a> {
+    messages: Vec<String>,
+    stream_lines: Option<&'a [Line<'static>]>,
+    max_lines: usize,
+}
+
+impl<'a> ThinkingGroupCell<'a> {
+    pub(super) fn new(
+        messages: Vec<String>,
+        stream_lines: Option<&'a [Line<'static>]>,
+        max_lines: usize,
+    ) -> Self {
+        Self {
+            messages,
+            stream_lines,
+            max_lines,
+        }
+    }
+}
+
+impl HistoryCell for ThinkingGroupCell<'_> {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
+        let render_width = usize::from(width.saturating_sub(2));
+        let mut rendered_lines = Vec::new();
+        if !self.messages.is_empty() {
+            let rendered =
+                render_markdown_text_with_width(&self.messages.join("\n"), Some(render_width));
+            rendered_lines.extend(rendered.lines);
+        }
+        if let Some(stream_lines) = self.stream_lines {
+            rendered_lines.extend(stream_lines.iter().cloned());
+        }
+
         let start = rendered_lines.len().saturating_sub(self.max_lines);
         let body = markdown_body_lines(&rendered_lines[start..], self.max_lines);
         let mut lines = vec![Line::from(section_span("Thinking", Color::LightBlue))];

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -940,6 +940,78 @@ fn active_turn_cell_flattens_thinking_and_running_events_in_order() {
 }
 
 #[test]
+fn active_turn_cell_places_streaming_thinking_after_latest_progress_event() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::ProcessingResponse;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Run a long task".into(),
+            payload: None,
+        }],
+    };
+
+    app.append_agent_thinking_delta("first reasoning block\n");
+    app.flush_agent_thinking_stream_to_live_event();
+    app.record_running_action("Run cargo check");
+    app.append_agent_thinking_delta("second reasoning block\n");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let first_thinking = rendered.find("first reasoning block").unwrap();
+    let running = rendered.find("Run cargo check").unwrap();
+    let second_thinking = rendered.find("second reasoning block").unwrap();
+
+    assert!(first_thinking < running);
+    assert!(running < second_thinking);
+    assert_eq!(rendered.matches(" Thinking ").count(), 2);
+    assert_eq!(rendered.matches(" Running ").count(), 1);
+}
+
+#[test]
+fn active_turn_cell_groups_consecutive_thinking_events_with_stream() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::ProcessingResponse;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Reason about a task".into(),
+            payload: None,
+        }],
+    };
+
+    app.append_agent_thinking_delta("first reasoning block\n");
+    app.flush_agent_thinking_stream_to_live_event();
+    app.append_agent_thinking_delta("second reasoning block\n");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let first_thinking = rendered.find("first reasoning block").unwrap();
+    let second_thinking = rendered.find("second reasoning block").unwrap();
+
+    assert!(first_thinking < second_thinking);
+    assert_eq!(rendered.matches(" Thinking ").count(), 1);
+}
+
+#[test]
 fn active_turn_cell_preserves_flushed_thinking_leading_indentation() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {


### PR DESCRIPTION
## Summary

- render the active thinking stream in live-event order instead of pinning it above older progress cells
- group consecutive Thinking live events, including the current stream, into one Thinking cell
- add focused render regressions for interrupted and consecutive thinking streams

## Tests

- cargo fmt
- cargo test active_turn_cell_places_streaming_thinking_after_latest_progress_event -- --nocapture
- cargo test active_turn_cell_groups_consecutive_thinking_events_with_stream -- --nocapture
- cargo test tui::render::cells::tests::active_general -- --nocapture
- cargo check
