### PR TITLE
fix(tools): require fresh reads before edits

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -354,7 +354,11 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                 &[
                     "Before modifying an existing file, inspect the relevant current contents with 'read_file' or repository search unless you already read the exact target in this turn.",
                     "Prefer 'apply_patch' for editing existing files because it is diff-shaped and reviewable.",
+                    "When using 'apply_patch', send a single patch string that starts with '*** Begin Patch' and ends with '*** End Patch'. Use '*** Add File: path' with '+' lines for new files, '*** Delete File: path' for deletes, and '*** Update File: path' for edits.",
+                    "Inside an update patch, use '@@' hunks and prefix every content line with exactly one marker: space for unchanged context, '-' for removed text, or '+' for inserted text. Preserve indentation exactly after that marker.",
+                    "For update hunks, include enough exact context from the current file for the old lines to match uniquely; if a hunk does not match, re-read the file and make the smallest corrected patch rather than guessing.",
                     "Use 'replace' only for one exact, unique snippet that you have verified from the current file contents.",
+                    "For 'replace', copy 'old_string' exactly from the current file, including whitespace and indentation.",
                     "Use 'replace_lines' only for large deletions or replacements when you have verified exact line numbers from the current file contents; do not pass hundreds of lines through 'replace.old_string'.",
                     "Use 'write_file' only for new files or intentional full-file rewrites after reading the current file when it already exists.",
                     "Do not use shell redirection, sed, perl, or ad-hoc scripts to edit files when direct edit tools or 'apply_patch' can do the job.",
@@ -765,7 +769,14 @@ mod tests {
         assert!(prompt.contains("rg --files"));
         assert!(prompt.contains("Before modifying an existing file"));
         assert!(prompt.contains("Prefer 'apply_patch' for editing existing files"));
+        assert!(prompt.contains("starts with '*** Begin Patch'"));
+        assert!(prompt.contains("'*** Add File: path' with '+' lines"));
+        assert!(prompt.contains("'*** Update File: path' for edits"));
+        assert!(prompt.contains("prefix every content line with exactly one marker"));
+        assert!(prompt.contains("Preserve indentation exactly after that marker"));
+        assert!(prompt.contains("include enough exact context"));
         assert!(prompt.contains("Use 'replace' only for one exact, unique snippet"));
+        assert!(prompt.contains("copy 'old_string' exactly from the current file"));
         assert!(prompt.contains("Use 'write_file' only for new files"));
         assert!(prompt.contains("Do not use shell redirection"));
         assert!(prompt.contains("first inspect local usage"));

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -352,7 +352,9 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
             section(
                 "Tool Use And Safety",
                 &[
-                    "Before modifying an existing file, inspect the relevant current contents with 'read_file' or repository search unless you already read the exact target in this turn.",
+                    "Before modifying an existing file, read the full current file with 'read_file' in this turn unless the tool result proves that the target was already fully read and has not changed.",
+                    "If a file was only partially read, the edit target is stale, or an edit tool reports that the file changed since it was read, re-read the full file before attempting the edit again.",
+                    "Never write from memory, a search snippet, or a stale summary when the direct file contents can be read locally.",
                     "Prefer 'apply_patch' for editing existing files because it is diff-shaped and reviewable.",
                     "When using 'apply_patch', send a single patch string that starts with '*** Begin Patch' and ends with '*** End Patch'. Use '*** Add File: path' with '+' lines for new files, '*** Delete File: path' for deletes, and '*** Update File: path' for edits.",
                     "Inside an update patch, use '@@' hunks and prefix every content line with exactly one marker: space for unchanged context, '-' for removed text, or '+' for inserted text. Preserve indentation exactly after that marker.",
@@ -400,7 +402,14 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                 "Implementation Policy",
                 &[
                     "Read relevant code before proposing changes to it.",
+                    "Let the existing codebase shape the solution: follow local APIs, naming, error handling, module boundaries, and test patterns before introducing a new abstraction.",
+                    "Keep changes small and reviewable. Prefer one focused behavioral fix over broad rewrites, formatting churn, or opportunistic cleanup.",
+                    "For large changes, decompose the work into several smaller behavior-preserving or independently testable changes, then continue one slice at a time.",
                     "Do not add features, refactors, configurability, comments, or abstractions beyond what the task requires.",
+                    "Add an abstraction only when it removes real duplication, clarifies a repeated contract, or matches an established local pattern.",
+                    "Preserve public APIs, persisted formats, and cross-module contracts unless the user explicitly asked to change them or the inspected code proves the change is necessary.",
+                    "When touching non-trivial behavior, add or update focused tests that exercise the changed path and its main edge cases.",
+                    "Run the narrowest useful formatter, test, build, or check commands after making code changes, and report exactly what passed or failed.",
                     "Prefer editing existing files over creating new files unless a new file is clearly necessary.",
                     "When referencing code locations in user-facing text, include file paths and line references when practical.",
                 ],
@@ -768,6 +777,9 @@ mod tests {
         assert!(prompt.contains("prefer 'rg' for text search"));
         assert!(prompt.contains("rg --files"));
         assert!(prompt.contains("Before modifying an existing file"));
+        assert!(prompt.contains("read the full current file"));
+        assert!(prompt.contains("If a file was only partially read"));
+        assert!(prompt.contains("Never write from memory"));
         assert!(prompt.contains("Prefer 'apply_patch' for editing existing files"));
         assert!(prompt.contains("starts with '*** Begin Patch'"));
         assert!(prompt.contains("'*** Add File: path' with '+' lines"));
@@ -781,6 +793,13 @@ mod tests {
         assert!(prompt.contains("Do not use shell redirection"));
         assert!(prompt.contains("first inspect local usage"));
         assert!(prompt.contains("<cmd> --help"));
+        assert!(prompt.contains("Let the existing codebase shape the solution"));
+        assert!(prompt.contains("Keep changes small and reviewable"));
+        assert!(prompt.contains("decompose the work into several smaller"));
+        assert!(prompt.contains("Add an abstraction only when it removes real duplication"));
+        assert!(prompt.contains("Preserve public APIs, persisted formats"));
+        assert!(prompt.contains("add or update focused tests"));
+        assert!(prompt.contains("Run the narrowest useful formatter"));
         assert!(prompt.contains("Autonomy And Execution Bias"));
         assert!(prompt.contains("assume the user wants you to solve the task"));
         assert!(prompt.contains("Do not stop at a proposed solution"));

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -324,6 +324,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                 "Workspace Behavior",
                 &[
                     "You are already inside the user's workspace and can inspect local files yourself.",
+                    "The environment context's cwd is the current working directory for local tools; relative paths are resolved from that directory unless a tool says otherwise.",
                     "Do not ask the user to paste local file contents or name local files when tools can read them directly.",
                     "For repository review or architecture analysis, inspect the workspace proactively with tools before asking follow-up questions.",
                     "For repository review, avoid repeating the same discovery tool call with the same arguments unless the workspace changed.",
@@ -366,6 +367,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "Do not use shell redirection, sed, perl, or ad-hoc scripts to edit files when direct edit tools or 'apply_patch' can do the job.",
                     "If a 'read_file' result is truncated, continue with offset=next_offset and a narrower limit instead of asking the user to paste the file.",
                     "When a CLI command or its flags are unfamiliar or uncertain, first inspect local usage with a safe read-only command such as '<cmd> --help', '<cmd> help', '<cmd> -h', or '<cmd> --version' before relying on guessed flags.",
+                    "For shell commands, pass the working directory through the tool's cwd field when needed and avoid using 'cd' unless it is necessary for the command itself.",
                     "If sandboxed bash is unavailable or blocked, continue with direct file tools such as read_file, apply_patch, and replace_lines before asking the user for help.",
                     "Use 'remember_experience' for global vector memory.",
                     "Use 'update_project_memory' to record facts into memory.md.",
@@ -501,18 +503,46 @@ fn dynamic_system_prompt_sections(
         PromptSection::optional("instructions", instruction_block),
         PromptSection::optional("memory", memory_block),
         PromptSection::optional("skills", skills_block),
-        PromptSection::new(
-            "runtime_context",
-            format!(
-                "## Runtime Context\n- workspace: {}\n- git branch: {}",
-                cwd, branch
-            ),
-        ),
+        PromptSection::new("runtime_context", render_environment_context(&cwd, &branch)),
         PromptSection::optional(
             "plan_mode",
             matches!(mode, PromptMode::Plan).then(plan_mode_prompt),
         ),
     ]
+}
+
+fn render_environment_context(cwd: &str, branch: &str) -> String {
+    let shell = std::env::var("SHELL")
+        .ok()
+        .and_then(|value| {
+            Path::new(&value)
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    format!(
+        "<environment_context>\n  <cwd>{}</cwd>\n  <shell>{}</shell>\n  <git_branch>{}</git_branch>\n</environment_context>",
+        escape_xml_text(cwd),
+        escape_xml_text(&shell),
+        escape_xml_text(branch),
+    )
+}
+
+fn escape_xml_text(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 fn render_available_skills_section(skills: &[PromptSkillSummary]) -> Option<String> {
@@ -685,7 +715,10 @@ mod tests {
             PromptMode::Plan,
         );
         assert!(prompt.contains("Current Execution Mode"));
-        assert!(prompt.contains("Runtime Context"));
+        assert!(prompt.contains("<environment_context>"));
+        assert!(prompt.contains("<cwd>"));
+        assert!(prompt.contains("<shell>"));
+        assert!(prompt.contains("<git_branch>"));
     }
 
     #[test]
@@ -774,6 +807,7 @@ mod tests {
         let prompt = super::default_system_prompt();
         assert!(prompt.contains("prompt injection"));
         assert!(prompt.contains("Conversation history may be compacted"));
+        assert!(prompt.contains("environment context's cwd"));
         assert!(prompt.contains("prefer 'rg' for text search"));
         assert!(prompt.contains("rg --files"));
         assert!(prompt.contains("Before modifying an existing file"));
@@ -793,6 +827,7 @@ mod tests {
         assert!(prompt.contains("Do not use shell redirection"));
         assert!(prompt.contains("first inspect local usage"));
         assert!(prompt.contains("<cmd> --help"));
+        assert!(prompt.contains("avoid using 'cd'"));
         assert!(prompt.contains("Let the existing codebase shape the solution"));
         assert!(prompt.contains("Keep changes small and reviewable"));
         assert!(prompt.contains("decompose the work into several smaller"));
@@ -821,6 +856,14 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(build_compact_instruction(&runtime), "custom compact");
+    }
+
+    #[test]
+    fn environment_context_escapes_xml_values() {
+        let rendered = super::render_environment_context("/tmp/a&b", "feat/<tag>");
+
+        assert!(rendered.contains("<cwd>/tmp/a&amp;b</cwd>"));
+        assert!(rendered.contains("<git_branch>feat/&lt;tag&gt;</git_branch>"));
     }
 
     #[test]

--- a/crates/instructions/src/workspace.rs
+++ b/crates/instructions/src/workspace.rs
@@ -149,12 +149,7 @@ impl WorkspaceMemory {
     }
 
     pub fn get_env_info(&self) -> (String, String) {
-        let cwd = self
-            .root
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("unknown")
-            .to_string();
+        let cwd = self.root.display().to_string();
         let marker = self.git_head_marker();
         let mut cache = self.cache.lock().expect("workspace cache poisoned");
         if let Some(cached) = cache.env_info.as_ref() {

--- a/docs/journal/2026-04-30-codex-claude-prompt-guidance.md
+++ b/docs/journal/2026-04-30-codex-claude-prompt-guidance.md
@@ -6,3 +6,9 @@ RARA's default system prompt now carries two complementary development contracts
 - Claude-style edit safety for full-file reads before existing-file edits, stale-file recovery, and avoiding writes from snippets or summaries.
 
 This complements the runtime file-read state enforcement in the edit tools. The prompt explains the expected behavior to the model, while the tools reject unsafe existing-file edits when the file was not fully read or changed after reading.
+
+The runtime context now follows Codex's structured environment-context shape for local path awareness:
+
+- inject `cwd` as a full local path instead of only a workspace label;
+- include the active shell and git branch in the same block;
+- tell the model to use tool working-directory fields instead of changing directories with `cd` when possible.

--- a/docs/journal/2026-04-30-codex-claude-prompt-guidance.md
+++ b/docs/journal/2026-04-30-codex-claude-prompt-guidance.md
@@ -1,0 +1,8 @@
+# 2026-04-30 Codex And Claude Prompt Guidance
+
+RARA's default system prompt now carries two complementary development contracts:
+
+- Codex-style engineering discipline for small reviewable changes, large-change decomposition, local codebase alignment, focused abstractions, API stability, and narrow validation.
+- Claude-style edit safety for full-file reads before existing-file edits, stale-file recovery, and avoiding writes from snippets or summaries.
+
+This complements the runtime file-read state enforcement in the edit tools. The prompt explains the expected behavior to the model, while the tools reject unsafe existing-file edits when the file was not fully read or changed after reading.

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -14,7 +14,7 @@ use crate::tools::bash::{
 };
 use crate::tools::context::RetrieveSessionContextTool;
 use crate::tools::file::{
-    ListFilesTool, ReadFileTool, ReplaceLinesTool, ReplaceTool, WriteFileTool,
+    FileReadState, ListFilesTool, ReadFileTool, ReplaceLinesTool, ReplaceTool, WriteFileTool,
 };
 use crate::tools::patch::ApplyPatchTool;
 use crate::tools::planning::EnterPlanModeTool;
@@ -50,6 +50,7 @@ pub(super) fn create_full_tool_manager(
     let pty_sessions = Arc::new(
         PtySessionStore::new(workspace.rara_dir.join("pty-sessions")).expect("pty session store"),
     );
+    let file_read_state = Arc::new(FileReadState::default());
 
     tm.register(Box::new(BashTool {
         sandbox: sandbox.clone(),
@@ -88,12 +89,12 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(PtyStopTool {
         sessions: pty_sessions,
     }));
-    tm.register(Box::new(ReadFileTool));
-    tm.register(Box::new(ApplyPatchTool));
-    tm.register(Box::new(WriteFileTool));
+    tm.register(Box::new(ReadFileTool::new(file_read_state.clone())));
+    tm.register(Box::new(ApplyPatchTool::new(file_read_state.clone())));
+    tm.register(Box::new(WriteFileTool::new(file_read_state.clone())));
     tm.register(Box::new(ListFilesTool));
-    tm.register(Box::new(ReplaceTool));
-    tm.register(Box::new(ReplaceLinesTool));
+    tm.register(Box::new(ReplaceTool::new(file_read_state.clone())));
+    tm.register(Box::new(ReplaceLinesTool::new(file_read_state)));
     tm.register(Box::new(WebFetchTool));
     tm.register(Box::new(WebSearchTool::from_env()));
     tm.register(Box::new(GlobTool));

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -351,7 +351,7 @@ async fn run_sub_agent(
 fn build_read_only_tool_manager() -> ToolManager {
     // Keep this registration set synchronized with strict_read_only_subagent_prompt!().
     let mut tool_manager = ToolManager::new();
-    tool_manager.register(Box::new(ReadFileTool));
+    tool_manager.register(Box::new(ReadFileTool::default()));
     tool_manager.register(Box::new(ListFilesTool));
     tool_manager.register(Box::new(GlobTool));
     tool_manager.register(Box::new(GrepTool));

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -740,7 +740,7 @@ impl Tool for BashTool {
         "bash"
     }
     fn description(&self) -> &str {
-        "Run shell command in sandbox"
+        "Run a shell command in the sandbox. Use the cwd field for the working directory when needed, and avoid cd unless it is necessary for the command itself."
     }
     fn input_schema(&self) -> Value {
         json!({
@@ -761,7 +761,7 @@ impl Tool for BashTool {
                 },
                 "cwd": {
                     "type": "string",
-                    "description": "Optional working directory override."
+                    "description": "Optional working directory override. Defaults to the current turn cwd."
                 },
                 "env": {
                     "type": "object",

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -1,9 +1,12 @@
 use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
 use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader as AsyncBufReader};
 use walkdir::WalkDir;
 
@@ -11,7 +14,137 @@ const DEFAULT_READ_LINE_LIMIT: usize = 2_000;
 const MAX_READ_LINE_CHARS: usize = 4_000;
 const MAX_READ_LINE_BYTES: usize = MAX_READ_LINE_CHARS * 4;
 
-pub struct ReadFileTool;
+#[derive(Debug, Default)]
+pub struct FileReadState {
+    files: Mutex<HashMap<PathBuf, FileReadEntry>>,
+}
+
+#[derive(Debug)]
+struct FileReadEntry {
+    modified: SystemTime,
+    content: Option<String>,
+    is_partial: bool,
+}
+
+impl FileReadState {
+    pub(crate) fn record_read(
+        &self,
+        path: &str,
+        output: &ReadFileOutput,
+        content: Option<String>,
+    ) -> Result<(), ToolError> {
+        let key = canonical_existing_path(path)?;
+        let metadata = fs::metadata(&key)?;
+        let entry = FileReadEntry {
+            modified: metadata.modified()?,
+            content,
+            is_partial: output.truncated || output.start_line != 1 || !output.total_lines_exact,
+        };
+        self.files
+            .lock()
+            .expect("file read state lock")
+            .insert(key, entry);
+        Ok(())
+    }
+
+    pub(crate) fn validate_existing_edit(&self, path: &str) -> Result<(), ToolError> {
+        let key = canonical_existing_path(path)?;
+        let files = self.files.lock().expect("file read state lock");
+        let Some(entry) = files.get(&key) else {
+            return Err(ToolError::ExecutionFailed(
+                "File has not been read yet. Read it first before writing to it.".into(),
+            ));
+        };
+        if entry.is_partial {
+            return Err(ToolError::ExecutionFailed(
+                "File was only partially read. Read the full file before writing to it.".into(),
+            ));
+        }
+
+        let metadata = fs::metadata(&key)?;
+        let modified = metadata.modified()?;
+        if modified > entry.modified {
+            if let Some(content) = &entry.content {
+                if fs::read_to_string(&key)? == *content {
+                    return Ok(());
+                }
+            }
+            return Err(ToolError::ExecutionFailed(
+                "File has been modified since read, either by the user or by a formatter. Read it again before attempting to write it.".into(),
+            ));
+        }
+
+        if let Some(content) = &entry.content {
+            let current = fs::read_to_string(&key)?;
+            if current != *content {
+                return Err(ToolError::ExecutionFailed(
+                    "File has changed since read. Read it again before attempting to write it."
+                        .into(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn record_write(&self, path: &str, content: &str) -> Result<(), ToolError> {
+        let key = canonical_existing_path(path)?;
+        let metadata = fs::metadata(&key)?;
+        let entry = FileReadEntry {
+            modified: metadata.modified()?,
+            content: Some(content.to_string()),
+            is_partial: false,
+        };
+        self.files
+            .lock()
+            .expect("file read state lock")
+            .insert(key, entry);
+        Ok(())
+    }
+
+    pub(crate) fn forget(&self, path: &str) -> Result<(), ToolError> {
+        let key = absolute_path(path)?;
+        self.files
+            .lock()
+            .expect("file read state lock")
+            .remove(&key);
+        Ok(())
+    }
+}
+
+pub(crate) type SharedFileReadState = Arc<FileReadState>;
+
+fn canonical_existing_path(path: &str) -> Result<PathBuf, ToolError> {
+    Ok(fs::canonicalize(path)?)
+}
+
+fn absolute_path(path: &str) -> Result<PathBuf, ToolError> {
+    let path = Path::new(path);
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(path))
+    }
+}
+
+pub struct ReadFileTool {
+    read_state: Option<SharedFileReadState>,
+}
+
+impl ReadFileTool {
+    pub fn new(read_state: SharedFileReadState) -> Self {
+        Self {
+            read_state: Some(read_state),
+        }
+    }
+}
+
+impl Default for ReadFileTool {
+    fn default() -> Self {
+        Self { read_state: None }
+    }
+}
+
 #[async_trait]
 impl Tool for ReadFileTool {
     fn name(&self) -> &str {
@@ -39,6 +172,13 @@ impl Tool for ReadFileTool {
             .ok_or(ToolError::InvalidInput("path".into()))?;
         let window = read_file_window_from_input(&i)?;
         let output = read_file_window(p, window).await?;
+        if let Some(read_state) = &self.read_state {
+            let full_content =
+                (!output.truncated && output.start_line == 1 && output.total_lines_exact)
+                    .then(|| fs::read_to_string(p))
+                    .transpose()?;
+            read_state.record_read(p, &output, full_content)?;
+        }
 
         Ok(json!({
             "content": output.content,
@@ -65,7 +205,7 @@ struct ReadFileWindow {
     limit: usize,
 }
 
-struct ReadFileOutput {
+pub(crate) struct ReadFileOutput {
     content: String,
     total_lines: Option<usize>,
     total_lines_exact: bool,
@@ -278,14 +418,31 @@ fn truncate_read_line(line: &str) -> (String, bool) {
     (truncated, true)
 }
 
-pub struct WriteFileTool;
+pub struct WriteFileTool {
+    read_state: Option<SharedFileReadState>,
+}
+
+impl WriteFileTool {
+    pub fn new(read_state: SharedFileReadState) -> Self {
+        Self {
+            read_state: Some(read_state),
+        }
+    }
+}
+
+impl Default for WriteFileTool {
+    fn default() -> Self {
+        Self { read_state: None }
+    }
+}
+
 #[async_trait]
 impl Tool for WriteFileTool {
     fn name(&self) -> &str {
         "write_file"
     }
     fn description(&self) -> &str {
-        "Create a new file or intentionally rewrite a whole file. For existing files, read the file first and prefer apply_patch for partial edits."
+        "Create a new file or intentionally rewrite a whole file. For existing files, read the full file first and prefer apply_patch for partial edits."
     }
     fn input_schema(&self) -> Value {
         json!({
@@ -305,12 +462,20 @@ impl Tool for WriteFileTool {
             .as_str()
             .ok_or(ToolError::InvalidInput("content".into()))?;
         let existing = existing_file_summary(p)?;
+        if existing.is_some()
+            && let Some(read_state) = &self.read_state
+        {
+            read_state.validate_existing_edit(p)?;
+        }
         let operation = if existing.is_some() {
             "overwritten"
         } else {
             "created"
         };
         fs::write(p, c)?;
+        if let Some(read_state) = &self.read_state {
+            read_state.record_write(p, c)?;
+        }
         Ok(json!({
             "status": "ok",
             "path": p,
@@ -323,14 +488,31 @@ impl Tool for WriteFileTool {
     }
 }
 
-pub struct ReplaceTool;
+pub struct ReplaceTool {
+    read_state: Option<SharedFileReadState>,
+}
+
+impl ReplaceTool {
+    pub fn new(read_state: SharedFileReadState) -> Self {
+        Self {
+            read_state: Some(read_state),
+        }
+    }
+}
+
+impl Default for ReplaceTool {
+    fn default() -> Self {
+        Self { read_state: None }
+    }
+}
+
 #[async_trait]
 impl Tool for ReplaceTool {
     fn name(&self) -> &str {
         "replace"
     }
     fn description(&self) -> &str {
-        "Replace one exact, unique string in a file. Read the file first and prefer apply_patch for structured multi-line edits."
+        "Replace one exact, unique string in a file. Read the full file first and prefer apply_patch for structured multi-line edits."
     }
     fn input_schema(&self) -> Value {
         json!({
@@ -353,12 +535,18 @@ impl Tool for ReplaceTool {
         let n = i["new_string"]
             .as_str()
             .ok_or(ToolError::InvalidInput("new".into()))?;
+        if let Some(read_state) = &self.read_state {
+            read_state.validate_existing_edit(p)?;
+        }
         let c = fs::read_to_string(p)?;
         if c.matches(o).count() != 1 {
             return Err(ToolError::ExecutionFailed("String not unique".into()));
         }
         let updated = c.replace(o, n);
         fs::write(p, &updated)?;
+        if let Some(read_state) = &self.read_state {
+            read_state.record_write(p, &updated)?;
+        }
         Ok(json!({
             "status": "ok",
             "path": p,
@@ -372,14 +560,31 @@ impl Tool for ReplaceTool {
     }
 }
 
-pub struct ReplaceLinesTool;
+pub struct ReplaceLinesTool {
+    read_state: Option<SharedFileReadState>,
+}
+
+impl ReplaceLinesTool {
+    pub fn new(read_state: SharedFileReadState) -> Self {
+        Self {
+            read_state: Some(read_state),
+        }
+    }
+}
+
+impl Default for ReplaceLinesTool {
+    fn default() -> Self {
+        Self { read_state: None }
+    }
+}
+
 #[async_trait]
 impl Tool for ReplaceLinesTool {
     fn name(&self) -> &str {
         "replace_lines"
     }
     fn description(&self) -> &str {
-        "Replace an inclusive line range in a file. Use only after reading the target range and verifying the current line numbers."
+        "Replace an inclusive line range in a file. Use only after reading the full file and verifying the current line numbers."
     }
     fn input_schema(&self) -> Value {
         json!({
@@ -419,6 +624,9 @@ impl Tool for ReplaceLinesTool {
                 "start_line must be <= end_line".into(),
             ));
         }
+        if let Some(read_state) = &self.read_state {
+            read_state.validate_existing_edit(path)?;
+        }
 
         let original = fs::read_to_string(path)?;
         let had_trailing_newline = original.ends_with('\n');
@@ -455,6 +663,9 @@ impl Tool for ReplaceLinesTool {
             updated.push('\n');
         }
         fs::write(path, updated)?;
+        if let Some(read_state) = &self.read_state {
+            read_state.record_write(path, &std::fs::read_to_string(path)?)?;
+        }
 
         Ok(json!({
             "status": "ok",
@@ -554,282 +765,4 @@ fn existing_file_summary(path: &str) -> Result<Option<(u64, usize)>, ToolError> 
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{
-        ListFilesTool, MAX_READ_LINE_BYTES, MAX_READ_LINE_CHARS, ReadFileTool, ReplaceLinesTool,
-        ReplaceTool, WriteFileTool,
-    };
-    use crate::tool::Tool;
-    use serde_json::{Value, json};
-
-    #[tokio::test]
-    async fn read_file_supports_line_ranges() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("sample.txt");
-        std::fs::write(&path, "a\nb\nc\nd\n").expect("write sample");
-
-        let tool = ReadFileTool;
-        let result = tool
-            .call(json!({
-                "path": path.display().to_string(),
-                "start_line": 2,
-                "end_line": 3
-            }))
-            .await
-            .expect("read file");
-
-        assert_eq!(result["content"], "b\nc");
-        assert_eq!(result["total_lines"], Value::Null);
-        assert_eq!(result["total_lines_exact"], false);
-        assert_eq!(result["observed_lines"], 4);
-        assert_eq!(result["start_line"], 2);
-        assert_eq!(result["end_line"], 3);
-        assert_eq!(result["offset"], 2);
-        assert_eq!(result["limit"], 2);
-        assert_eq!(result["num_lines"], 2);
-        assert_eq!(result["truncated"], true);
-        assert_eq!(result["next_offset"], 4);
-    }
-
-    #[tokio::test]
-    async fn read_file_supports_offset_limit_windows() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("sample.txt");
-        std::fs::write(&path, "alpha\nbeta\ngamma\n").expect("write sample");
-
-        let tool = ReadFileTool;
-        let result = tool
-            .call(json!({
-                "path": path.display().to_string(),
-                "offset": 2,
-                "limit": 1
-            }))
-            .await
-            .expect("read file");
-
-        assert_eq!(result["content"], "beta");
-        assert_eq!(result["total_lines"], Value::Null);
-        assert_eq!(result["total_lines_exact"], false);
-        assert_eq!(result["observed_lines"], 3);
-        assert_eq!(result["start_line"], 2);
-        assert_eq!(result["end_line"], 2);
-        assert_eq!(result["num_lines"], 1);
-        assert_eq!(result["truncated"], true);
-        assert_eq!(result["next_offset"], 3);
-    }
-
-    #[tokio::test]
-    async fn read_file_defaults_to_limited_first_window() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("large.txt");
-        let content = (1..=2002)
-            .map(|line| format!("line {line}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        std::fs::write(&path, content).expect("write sample");
-
-        let tool = ReadFileTool;
-        let result = tool
-            .call(json!({ "path": path.display().to_string() }))
-            .await
-            .expect("read file");
-
-        assert!(result["content"].as_str().unwrap().contains("line 1"));
-        assert!(result["content"].as_str().unwrap().contains("line 2000"));
-        assert!(!result["content"].as_str().unwrap().contains("line 2001"));
-        assert_eq!(result["total_lines"], Value::Null);
-        assert_eq!(result["total_lines_exact"], false);
-        assert_eq!(result["observed_lines"], 2001);
-        assert_eq!(result["start_line"], 1);
-        assert_eq!(result["end_line"], 2000);
-        assert_eq!(result["limit"], 2000);
-        assert_eq!(result["num_lines"], 2000);
-        assert_eq!(result["truncated"], true);
-        assert_eq!(result["next_offset"], 2001);
-    }
-
-    #[tokio::test]
-    async fn read_file_errors_when_offset_exceeds_file_length() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("sample.txt");
-        std::fs::write(&path, "one\ntwo\n").expect("write sample");
-
-        let tool = ReadFileTool;
-        let error = tool
-            .call(json!({
-                "path": path.display().to_string(),
-                "offset": 3
-            }))
-            .await
-            .expect_err("offset should fail");
-
-        assert!(error.to_string().contains("offset 3 exceeds file length 2"));
-    }
-
-    #[tokio::test]
-    async fn read_file_marks_truncated_long_lines() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("sample.txt");
-        std::fs::write(&path, "x".repeat(MAX_READ_LINE_CHARS + 1)).expect("write sample");
-
-        let tool = ReadFileTool;
-        let result = tool
-            .call(json!({ "path": path.display().to_string() }))
-            .await
-            .expect("read file");
-
-        assert_eq!(result["total_lines"], 1);
-        assert_eq!(result["total_lines_exact"], true);
-        assert_eq!(result["line_truncated"], true);
-        assert_eq!(result["truncated"], true);
-        assert!(
-            result["content"]
-                .as_str()
-                .unwrap()
-                .ends_with("... [line truncated]")
-        );
-    }
-
-    #[tokio::test]
-    async fn read_file_bounds_memory_for_very_long_lines() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("sample.txt");
-        let content = format!("{}\nsecond\n", "x".repeat(MAX_READ_LINE_BYTES * 2));
-        std::fs::write(&path, content).expect("write sample");
-
-        let tool = ReadFileTool;
-        let result = tool
-            .call(json!({
-                "path": path.display().to_string(),
-                "offset": 1,
-                "limit": 1
-            }))
-            .await
-            .expect("read file");
-
-        let content = result["content"].as_str().expect("content");
-        assert!(content.ends_with("... [line truncated]"));
-        assert!(content.chars().count() < MAX_READ_LINE_BYTES);
-        assert_eq!(result["line_truncated"], true);
-        assert_eq!(result["truncated"], true);
-        assert_eq!(result["next_offset"], 2);
-    }
-
-    #[tokio::test]
-    async fn list_files_skips_build_artifacts_by_default() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let root = tempdir.path();
-        std::fs::create_dir_all(root.join("src")).expect("mkdir src");
-        std::fs::create_dir_all(root.join("target/debug")).expect("mkdir target");
-        std::fs::write(root.join("src/main.rs"), "fn main() {}\n").expect("write source");
-        std::fs::write(root.join("target/debug/app"), "bin").expect("write artifact");
-
-        let tool = ListFilesTool;
-        let result = tool
-            .call(json!({ "path": root.display().to_string() }))
-            .await
-            .expect("list files");
-        let files = result["files"].as_array().expect("files array");
-        let rendered = files
-            .iter()
-            .filter_map(|value| value.as_str())
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        assert!(rendered.contains("src/main.rs"));
-        assert!(!rendered.contains("target/debug/app"));
-    }
-
-    #[tokio::test]
-    async fn write_file_reports_created_or_overwritten() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("sample.txt");
-
-        let tool = WriteFileTool;
-        let created = tool
-            .call(json!({
-                "path": path.display().to_string(),
-                "content": "hello\nworld\n"
-            }))
-            .await
-            .expect("write created");
-        assert_eq!(created["operation"], "created");
-        assert_eq!(created["line_count"], 2);
-
-        let overwritten = tool
-            .call(json!({
-                "path": path.display().to_string(),
-                "content": "updated\n"
-            }))
-            .await
-            .expect("write overwritten");
-        assert_eq!(overwritten["operation"], "overwritten");
-        assert_eq!(overwritten["previous_line_count"], 2);
-    }
-
-    #[tokio::test]
-    async fn replace_reports_preview_and_line_delta() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("sample.txt");
-        std::fs::write(&path, "hello old value\n").expect("write sample");
-
-        let tool = ReplaceTool;
-        let result = tool
-            .call(json!({
-                "path": path.display().to_string(),
-                "old_string": "old value",
-                "new_string": "new\nvalue"
-            }))
-            .await
-            .expect("replace content");
-
-        assert_eq!(result["replacements"], 1);
-        assert_eq!(result["old_preview"], "old value");
-        assert_eq!(result["new_preview"], "new\\nvalue");
-        assert_eq!(result["line_delta"], 1);
-    }
-
-    #[tokio::test]
-    async fn replace_lines_replaces_inclusive_range_without_old_string() {
-        let tempdir = tempfile::tempdir().expect("tempdir");
-        let path = tempdir.path().join("sample.txt");
-        std::fs::write(&path, "one\ntwo\nthree\nfour\n").expect("write sample");
-
-        let tool = ReplaceLinesTool;
-        let result = tool
-            .call(json!({
-                "path": path.display().to_string(),
-                "start_line": 2,
-                "end_line": 3,
-                "new_string": "middle"
-            }))
-            .await
-            .expect("replace lines");
-
-        assert_eq!(
-            std::fs::read_to_string(&path).unwrap(),
-            "one\nmiddle\nfour\n"
-        );
-        assert_eq!(result["removed_lines"], 2);
-        assert_eq!(result["removed_string"], "two\nthree");
-        assert_eq!(result["inserted_lines"], 1);
-        assert_eq!(result["line_delta"], -1);
-    }
-
-    #[test]
-    fn file_tool_descriptions_encode_safe_edit_contract() {
-        let write_tool = WriteFileTool;
-        let replace_tool = ReplaceTool;
-        let replace_lines_tool = ReplaceLinesTool;
-
-        assert!(write_tool.description().contains("Create a new file"));
-        assert!(write_tool.description().contains("read the file first"));
-        assert!(replace_tool.description().contains("exact, unique string"));
-        assert!(replace_tool.description().contains("Read the file first"));
-        assert!(
-            replace_lines_tool
-                .description()
-                .contains("verifying the current line numbers")
-        );
-    }
-}
+mod tests;

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -103,7 +103,7 @@ impl FileReadState {
     }
 
     pub(crate) fn forget(&self, path: &str) -> Result<(), ToolError> {
-        let key = absolute_path(path)?;
+        let key = canonical_existing_path(path)?;
         self.files
             .lock()
             .expect("file read state lock")
@@ -118,12 +118,9 @@ fn canonical_existing_path(path: &str) -> Result<PathBuf, ToolError> {
     Ok(fs::canonicalize(path)?)
 }
 
-fn absolute_path(path: &str) -> Result<PathBuf, ToolError> {
-    let path = Path::new(path);
-    if path.is_absolute() {
-        Ok(path.to_path_buf())
-    } else {
-        Ok(std::env::current_dir()?.join(path))
+fn record_write_best_effort(read_state: &FileReadState, path: &str, content: &str) {
+    if let Err(err) = read_state.record_write(path, content) {
+        eprintln!("Failed to record file read state after write: {err}");
     }
 }
 
@@ -474,7 +471,7 @@ impl Tool for WriteFileTool {
         };
         fs::write(p, c)?;
         if let Some(read_state) = &self.read_state {
-            read_state.record_write(p, c)?;
+            record_write_best_effort(read_state, p, c);
         }
         Ok(json!({
             "status": "ok",
@@ -545,7 +542,7 @@ impl Tool for ReplaceTool {
         let updated = c.replace(o, n);
         fs::write(p, &updated)?;
         if let Some(read_state) = &self.read_state {
-            read_state.record_write(p, &updated)?;
+            record_write_best_effort(read_state, p, &updated);
         }
         Ok(json!({
             "status": "ok",
@@ -662,9 +659,9 @@ impl Tool for ReplaceLinesTool {
         if had_trailing_newline && !updated.is_empty() {
             updated.push('\n');
         }
-        fs::write(path, updated)?;
+        fs::write(path, &updated)?;
         if let Some(read_state) = &self.read_state {
-            read_state.record_write(path, &std::fs::read_to_string(path)?)?;
+            record_write_best_effort(read_state, path, &updated);
         }
 
         Ok(json!({

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -324,6 +324,32 @@ async fn replace_rejects_file_changed_since_read() {
     assert!(error.to_string().contains("since read"));
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn forget_removes_canonical_read_state_for_symlink_paths() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    let link = tempdir.path().join("linked.txt");
+    std::fs::write(&path, "one\ntwo\n").expect("write sample");
+    std::os::unix::fs::symlink(&path, &link).expect("create symlink");
+
+    let read_state = Arc::new(FileReadState::default());
+    let read_tool = ReadFileTool::new(read_state.clone());
+
+    read_tool
+        .call(json!({ "path": link.display().to_string() }))
+        .await
+        .expect("read file through symlink");
+    read_state
+        .forget(&link.display().to_string())
+        .expect("forget symlink path");
+
+    let error = read_state
+        .validate_existing_edit(&path.display().to_string())
+        .expect_err("forget should remove the canonical entry");
+    assert!(error.to_string().contains("File has not been read yet"));
+}
+
 #[tokio::test]
 async fn replace_lines_replaces_inclusive_range_without_old_string() {
     let tempdir = tempfile::tempdir().expect("tempdir");

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -1,0 +1,377 @@
+use super::{
+    FileReadState, ListFilesTool, MAX_READ_LINE_BYTES, MAX_READ_LINE_CHARS, ReadFileTool,
+    ReplaceLinesTool, ReplaceTool, WriteFileTool,
+};
+use crate::tool::Tool;
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn read_file_supports_line_ranges() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "a\nb\nc\nd\n").expect("write sample");
+
+    let tool = ReadFileTool::default();
+    let result = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "start_line": 2,
+            "end_line": 3
+        }))
+        .await
+        .expect("read file");
+
+    assert_eq!(result["content"], "b\nc");
+    assert_eq!(result["total_lines"], Value::Null);
+    assert_eq!(result["total_lines_exact"], false);
+    assert_eq!(result["observed_lines"], 4);
+    assert_eq!(result["start_line"], 2);
+    assert_eq!(result["end_line"], 3);
+    assert_eq!(result["offset"], 2);
+    assert_eq!(result["limit"], 2);
+    assert_eq!(result["num_lines"], 2);
+    assert_eq!(result["truncated"], true);
+    assert_eq!(result["next_offset"], 4);
+}
+
+#[tokio::test]
+async fn read_file_supports_offset_limit_windows() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "alpha\nbeta\ngamma\n").expect("write sample");
+
+    let tool = ReadFileTool::default();
+    let result = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "offset": 2,
+            "limit": 1
+        }))
+        .await
+        .expect("read file");
+
+    assert_eq!(result["content"], "beta");
+    assert_eq!(result["total_lines"], Value::Null);
+    assert_eq!(result["total_lines_exact"], false);
+    assert_eq!(result["observed_lines"], 3);
+    assert_eq!(result["start_line"], 2);
+    assert_eq!(result["end_line"], 2);
+    assert_eq!(result["num_lines"], 1);
+    assert_eq!(result["truncated"], true);
+    assert_eq!(result["next_offset"], 3);
+}
+
+#[tokio::test]
+async fn read_file_defaults_to_limited_first_window() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("large.txt");
+    let content = (1..=2002)
+        .map(|line| format!("line {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    std::fs::write(&path, content).expect("write sample");
+
+    let tool = ReadFileTool::default();
+    let result = tool
+        .call(json!({ "path": path.display().to_string() }))
+        .await
+        .expect("read file");
+
+    assert!(result["content"].as_str().unwrap().contains("line 1"));
+    assert!(result["content"].as_str().unwrap().contains("line 2000"));
+    assert!(!result["content"].as_str().unwrap().contains("line 2001"));
+    assert_eq!(result["total_lines"], Value::Null);
+    assert_eq!(result["total_lines_exact"], false);
+    assert_eq!(result["observed_lines"], 2001);
+    assert_eq!(result["start_line"], 1);
+    assert_eq!(result["end_line"], 2000);
+    assert_eq!(result["limit"], 2000);
+    assert_eq!(result["num_lines"], 2000);
+    assert_eq!(result["truncated"], true);
+    assert_eq!(result["next_offset"], 2001);
+}
+
+#[tokio::test]
+async fn read_file_errors_when_offset_exceeds_file_length() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "one\ntwo\n").expect("write sample");
+
+    let tool = ReadFileTool::default();
+    let error = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "offset": 3
+        }))
+        .await
+        .expect_err("offset should fail");
+
+    assert!(error.to_string().contains("offset 3 exceeds file length 2"));
+}
+
+#[tokio::test]
+async fn read_file_marks_truncated_long_lines() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "x".repeat(MAX_READ_LINE_CHARS + 1)).expect("write sample");
+
+    let tool = ReadFileTool::default();
+    let result = tool
+        .call(json!({ "path": path.display().to_string() }))
+        .await
+        .expect("read file");
+
+    assert_eq!(result["total_lines"], 1);
+    assert_eq!(result["total_lines_exact"], true);
+    assert_eq!(result["line_truncated"], true);
+    assert_eq!(result["truncated"], true);
+    assert!(
+        result["content"]
+            .as_str()
+            .unwrap()
+            .ends_with("... [line truncated]")
+    );
+}
+
+#[tokio::test]
+async fn read_file_bounds_memory_for_very_long_lines() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    let content = format!("{}\nsecond\n", "x".repeat(MAX_READ_LINE_BYTES * 2));
+    std::fs::write(&path, content).expect("write sample");
+
+    let tool = ReadFileTool::default();
+    let result = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "offset": 1,
+            "limit": 1
+        }))
+        .await
+        .expect("read file");
+
+    let content = result["content"].as_str().expect("content");
+    assert!(content.ends_with("... [line truncated]"));
+    assert!(content.chars().count() < MAX_READ_LINE_BYTES);
+    assert_eq!(result["line_truncated"], true);
+    assert_eq!(result["truncated"], true);
+    assert_eq!(result["next_offset"], 2);
+}
+
+#[tokio::test]
+async fn list_files_skips_build_artifacts_by_default() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let root = tempdir.path();
+    std::fs::create_dir_all(root.join("src")).expect("mkdir src");
+    std::fs::create_dir_all(root.join("target/debug")).expect("mkdir target");
+    std::fs::write(root.join("src/main.rs"), "fn main() {}\n").expect("write source");
+    std::fs::write(root.join("target/debug/app"), "bin").expect("write artifact");
+
+    let tool = ListFilesTool;
+    let result = tool
+        .call(json!({ "path": root.display().to_string() }))
+        .await
+        .expect("list files");
+    let files = result["files"].as_array().expect("files array");
+    let rendered = files
+        .iter()
+        .filter_map(|value| value.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("src/main.rs"));
+    assert!(!rendered.contains("target/debug/app"));
+}
+
+#[tokio::test]
+async fn write_file_reports_created_or_overwritten() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+
+    let tool = WriteFileTool::default();
+    let created = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "content": "hello\nworld\n"
+        }))
+        .await
+        .expect("write created");
+    assert_eq!(created["operation"], "created");
+    assert_eq!(created["line_count"], 2);
+
+    let overwritten = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "content": "updated\n"
+        }))
+        .await
+        .expect("write overwritten");
+    assert_eq!(overwritten["operation"], "overwritten");
+    assert_eq!(overwritten["previous_line_count"], 2);
+}
+
+#[tokio::test]
+async fn replace_reports_preview_and_line_delta() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "hello old value\n").expect("write sample");
+
+    let tool = ReplaceTool::default();
+    let result = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "old_string": "old value",
+            "new_string": "new\nvalue"
+        }))
+        .await
+        .expect("replace content");
+
+    assert_eq!(result["replacements"], 1);
+    assert_eq!(result["old_preview"], "old value");
+    assert_eq!(result["new_preview"], "new\\nvalue");
+    assert_eq!(result["line_delta"], 1);
+}
+
+#[tokio::test]
+async fn replace_requires_prior_full_read_when_state_is_enabled() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "hello old value\n").expect("write sample");
+    let read_state = Arc::new(FileReadState::default());
+    let replace_tool = ReplaceTool::new(read_state.clone());
+
+    let error = replace_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "old_string": "old value",
+            "new_string": "new value"
+        }))
+        .await
+        .expect_err("replace should require read");
+    assert!(error.to_string().contains("File has not been read yet"));
+
+    let read_tool = ReadFileTool::new(read_state);
+    read_tool
+        .call(json!({ "path": path.display().to_string() }))
+        .await
+        .expect("read file");
+    replace_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "old_string": "old value",
+            "new_string": "new value"
+        }))
+        .await
+        .expect("replace after read");
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read updated"),
+        "hello new value\n"
+    );
+}
+
+#[tokio::test]
+async fn replace_rejects_partial_read_state() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "one\ntwo\nthree\n").expect("write sample");
+    let read_state = Arc::new(FileReadState::default());
+    let read_tool = ReadFileTool::new(read_state.clone());
+    let replace_tool = ReplaceTool::new(read_state);
+
+    read_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "offset": 1,
+            "limit": 1
+        }))
+        .await
+        .expect("partial read");
+    let error = replace_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "old_string": "two",
+            "new_string": "second"
+        }))
+        .await
+        .expect_err("partial read should be rejected");
+    assert!(error.to_string().contains("only partially read"));
+}
+
+#[tokio::test]
+async fn replace_rejects_file_changed_since_read() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "one\ntwo\n").expect("write sample");
+    let read_state = Arc::new(FileReadState::default());
+    let read_tool = ReadFileTool::new(read_state.clone());
+    let replace_tool = ReplaceTool::new(read_state);
+
+    read_tool
+        .call(json!({ "path": path.display().to_string() }))
+        .await
+        .expect("read file");
+    std::fs::write(&path, "one\nexternal\n").expect("external write");
+
+    let error = replace_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "old_string": "external",
+            "new_string": "changed"
+        }))
+        .await
+        .expect_err("stale file should be rejected");
+    assert!(error.to_string().contains("since read"));
+}
+
+#[tokio::test]
+async fn replace_lines_replaces_inclusive_range_without_old_string() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "one\ntwo\nthree\nfour\n").expect("write sample");
+
+    let tool = ReplaceLinesTool::default();
+    let result = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "start_line": 2,
+            "end_line": 3,
+            "new_string": "middle"
+        }))
+        .await
+        .expect("replace lines");
+
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "one\nmiddle\nfour\n"
+    );
+    assert_eq!(result["removed_lines"], 2);
+    assert_eq!(result["removed_string"], "two\nthree");
+    assert_eq!(result["inserted_lines"], 1);
+    assert_eq!(result["line_delta"], -1);
+}
+
+#[test]
+fn file_tool_descriptions_encode_safe_edit_contract() {
+    let write_tool = WriteFileTool::default();
+    let replace_tool = ReplaceTool::default();
+    let replace_lines_tool = ReplaceLinesTool::default();
+
+    assert!(write_tool.description().contains("Create a new file"));
+    assert!(
+        write_tool
+            .description()
+            .contains("read the full file first")
+    );
+    assert!(replace_tool.description().contains("exact, unique string"));
+    assert!(
+        replace_tool
+            .description()
+            .contains("Read the full file first")
+    );
+    assert!(
+        replace_lines_tool
+            .description()
+            .contains("verifying the current line numbers")
+    );
+}

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -1,5 +1,5 @@
 use crate::tool::{Tool, ToolError};
-use crate::tools::file::SharedFileReadState;
+use crate::tools::file::{FileReadState, SharedFileReadState};
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use std::fs;
@@ -116,9 +116,10 @@ impl Tool for ApplyPatchTool {
                     stats.added_lines += lines.len();
                     previews.push(format!("Add file {path}"));
                     if !dry_run {
-                        write_text_file(&path, &join_lines(&lines))?;
+                        let content = join_lines(&lines);
+                        write_text_file(&path, &content)?;
                         if let Some(read_state) = &self.read_state {
-                            read_state.record_write(&path, &fs::read_to_string(&path)?)?;
+                            record_patch_write_best_effort(read_state, &path, &content);
                         }
                     }
                 }
@@ -178,7 +179,7 @@ impl Tool for ApplyPatchTool {
                         }
                         write_text_file(write_path, &updated)?;
                         if let Some(read_state) = &self.read_state {
-                            read_state.record_write(write_path, &updated)?;
+                            record_patch_write_best_effort(read_state, write_path, &updated);
                         }
                     }
                 }
@@ -219,6 +220,12 @@ fn validate_patch_read_state(
         }
     }
     Ok(())
+}
+
+fn record_patch_write_best_effort(read_state: &FileReadState, path: &str, content: &str) {
+    if let Err(err) = read_state.record_write(path, content) {
+        eprintln!("Failed to record file read state after patch write: {err}");
+    }
 }
 
 fn patch_preview(patch: &str) -> (String, bool) {

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -1,10 +1,22 @@
 use crate::tool::{Tool, ToolError};
+use crate::tools::file::SharedFileReadState;
 use async_trait::async_trait;
 use serde_json::{Value, json};
 use std::fs;
 use std::path::Path;
 
-pub struct ApplyPatchTool;
+#[derive(Default)]
+pub struct ApplyPatchTool {
+    read_state: Option<SharedFileReadState>,
+}
+
+impl ApplyPatchTool {
+    pub fn new(read_state: SharedFileReadState) -> Self {
+        Self {
+            read_state: Some(read_state),
+        }
+    }
+}
 
 const PATCH_PREVIEW_LINE_LIMIT: usize = 120;
 
@@ -54,7 +66,7 @@ impl Tool for ApplyPatchTool {
     }
 
     fn description(&self) -> &str {
-        "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files."
+        "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files. For update or delete operations, read the full target file first."
     }
 
     fn input_schema(&self) -> Value {
@@ -84,6 +96,9 @@ impl Tool for ApplyPatchTool {
             .and_then(Value::as_bool)
             .unwrap_or(false);
         let ops = parse_patch(patch)?;
+        if let Some(read_state) = &self.read_state {
+            validate_patch_read_state(read_state, &ops)?;
+        }
         let mut stats = PatchStats::default();
         let mut previews = Vec::new();
 
@@ -102,6 +117,9 @@ impl Tool for ApplyPatchTool {
                     previews.push(format!("Add file {path}"));
                     if !dry_run {
                         write_text_file(&path, &join_lines(&lines))?;
+                        if let Some(read_state) = &self.read_state {
+                            read_state.record_write(&path, &fs::read_to_string(&path)?)?;
+                        }
                     }
                 }
                 PatchOp::Delete { path } => {
@@ -117,6 +135,9 @@ impl Tool for ApplyPatchTool {
                     stats.removed_lines += removed_lines;
                     previews.push(format!("Delete file {path}"));
                     if !dry_run {
+                        if let Some(read_state) = &self.read_state {
+                            read_state.forget(&path)?;
+                        }
                         fs::remove_file(&path)?;
                     }
                 }
@@ -150,9 +171,15 @@ impl Tool for ApplyPatchTool {
                             if let Some(parent) = Path::new(target).parent() {
                                 fs::create_dir_all(parent)?;
                             }
+                            if let Some(read_state) = &self.read_state {
+                                read_state.forget(&path)?;
+                            }
                             fs::remove_file(&path)?;
                         }
                         write_text_file(write_path, &updated)?;
+                        if let Some(read_state) = &self.read_state {
+                            read_state.record_write(write_path, &updated)?;
+                        }
                     }
                 }
             }
@@ -177,6 +204,21 @@ impl Tool for ApplyPatchTool {
             "diff_truncated": diff_truncated,
         }))
     }
+}
+
+fn validate_patch_read_state(
+    read_state: &SharedFileReadState,
+    ops: &[PatchOp],
+) -> Result<(), ToolError> {
+    for op in ops {
+        match op {
+            PatchOp::Add { .. } => {}
+            PatchOp::Delete { path } | PatchOp::Update { path, .. } => {
+                read_state.validate_existing_edit(path)?;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn patch_preview(patch: &str) -> (String, bool) {
@@ -372,7 +414,9 @@ fn read_lines(path: &str) -> Result<Vec<String>, ToolError> {
 mod tests {
     use super::ApplyPatchTool;
     use crate::tool::Tool;
+    use crate::tools::file::{FileReadState, ReadFileTool};
     use serde_json::json;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn applies_update_patch() {
@@ -380,7 +424,7 @@ mod tests {
         let file = dir.path().join("sample.txt");
         std::fs::write(&file, "hello\nworld\n").expect("write");
 
-        let tool = ApplyPatchTool;
+        let tool = ApplyPatchTool::default();
         let result = tool
             .call(json!({
                 "patch": format!(
@@ -408,7 +452,7 @@ mod tests {
         let file = dir.path().join("sample.txt");
         std::fs::write(&file, "hello\nworld\n").expect("write");
 
-        let tool = ApplyPatchTool;
+        let tool = ApplyPatchTool::default();
         let result = tool
             .call(json!({
                 "patch": format!(
@@ -432,7 +476,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let file = dir.path().join("created.txt");
 
-        let tool = ApplyPatchTool;
+        let tool = ApplyPatchTool::default();
         let result = tool
             .call(json!({
                 "patch": format!(
@@ -449,5 +493,39 @@ mod tests {
         );
         assert_eq!(result["status"], "applied");
         assert_eq!(result["created_files"][0], file.display().to_string());
+    }
+
+    #[tokio::test]
+    async fn update_patch_requires_prior_full_read_when_state_is_enabled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sample.txt");
+        std::fs::write(&file, "hello\nworld\n").expect("write");
+        let read_state = Arc::new(FileReadState::default());
+        let patch_tool = ApplyPatchTool::new(read_state.clone());
+        let patch = format!(
+            "*** Begin Patch\n*** Update File: {}\n@@\n-hello\n+hi\n world\n*** End Patch",
+            file.display()
+        );
+
+        let error = patch_tool
+            .call(json!({ "patch": patch }))
+            .await
+            .expect_err("patch should require read");
+        assert!(error.to_string().contains("File has not been read yet"));
+
+        let read_tool = ReadFileTool::new(read_state);
+        read_tool
+            .call(json!({ "path": file.display().to_string() }))
+            .await
+            .expect("read file");
+        let patch = format!(
+            "*** Begin Patch\n*** Update File: {}\n@@\n-hello\n+hi\n world\n*** End Patch",
+            file.display()
+        );
+        patch_tool
+            .call(json!({ "patch": patch }))
+            .await
+            .expect("patch after read");
+        assert_eq!(std::fs::read_to_string(&file).expect("read"), "hi\nworld\n");
     }
 }

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -317,7 +317,7 @@ impl Tool for PtyStartTool {
     }
 
     fn description(&self) -> &str {
-        "Start an interactive PTY session for commands that need terminal input"
+        "Start an interactive PTY session for commands that need terminal input. Use the cwd field for the working directory when needed, and avoid cd unless it is necessary for the command itself."
     }
 
     fn input_schema(&self) -> Value {
@@ -325,7 +325,7 @@ impl Tool for PtyStartTool {
             "type": "object",
             "properties": {
                 "command": { "type": "string", "description": "Shell command to run inside a PTY." },
-                "cwd": { "type": "string", "description": "Optional working directory." },
+                "cwd": { "type": "string", "description": "Optional working directory. Defaults to the current turn cwd." },
                 "env": {
                     "type": "object",
                     "additionalProperties": { "type": "string" },


### PR DESCRIPTION
## Summary

- add Codex-style software engineering guidance and Claude-style edit safety rules to the default prompt
- require existing-file edits to have a fresh full-file read in the runtime tool manager
- share file read state across `read_file`, `apply_patch`, `write_file`, `replace`, and `replace_lines`
- move file tool tests into `src/tools/file/tests.rs` and add regression coverage for stale or partial reads

## Purpose

This keeps model guidance and tool behavior aligned: the prompt tells the agent to read files before editing, and the edit tools reject unsafe writes when a file was not fully read or changed after the read.

## Tests

- `cargo fmt --check`
- `cargo test tools::file::tests -- --nocapture`
- `cargo test tools::patch::tests -- --nocapture`
- `cargo test -p rara-instructions -- --nocapture`
- `cargo check`
