### PR TITLE
fix(tui): preserve progress cell append order

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -60,6 +60,7 @@ Priority order for this phase:
 
 - [ ] Complete `reasoning_summary` rollout across backend requests, switching flows, and status surfaces; retire remaining `thinking`-only behavior outside migration fallback.
 - [ ] Surface provider-scoped reasoning configuration in `/status` and provider/model switching flows, including where the effective value came from.
+- [ ] Study Gemini/Codex-style multi-model routing and add first-class support for using a top-tier model and a flash/fast model together, with `/status` showing the effective routing policy, assigned model roles, and provider/model provenance.
 - [ ] Deepen provider-surface continuity after hot-swap landed: tighten auth-mode/endpoint alignment, provenance reporting, and remaining runtime continuity edge cases.
 - [ ] Align Codex endpoint selection with auth mode so ChatGPT/Codex login and OpenAI API key sessions do not blindly share the same provider URL.
 - [ ] Split Codex-specific persisted auth/config back out to `~/.codex` while keeping provider-agnostic RARA config and runtime/session state under `~/.rara`.
@@ -105,6 +106,8 @@ Priority order for this phase:
 - [ ] Add Codex/Claude-style transcript role cards for `You` / `Agent` / `System` without mixing status chrome into committed transcript history.
 - [ ] Bring the main response UI closer to Codex / Claude Code: stabilize active response blocks while streaming and avoid falling back to generic transcript rows for states that should stay in dedicated response cards.
 - [ ] Rework the built-in command TUI (`/help`, `/model`, `/status`, command palette, setup overlays) to more closely match Codex / Claude Code.
+- [ ] Strengthen the `/context` display with a Claude Code-inspired source breakdown: show active context categories, source paths, ordering, token or budget contribution, cache hit rate, and dropped/omitted sources in a denser inspectable UI.
+- [ ] Refine `/status` into a more detailed runtime status surface that separates provider/model state, reasoning settings, sandbox/network policy, context injection state, tool availability, and pending interaction state.
 - [ ] Continue making tool-action transcript summaries more source-aware and file-aware so edit tools (`write_file`, `replace`, `apply_patch`) consistently show what they touched.
 - [ ] Continue refining the live `bash` transcript path so command execution behaves more like Codex: clearer lifecycle framing, streamed stdout/stderr handling, and better long-output folding.
 - [ ] Add a high-fidelity Claude Code / Codex transcript rendering pass for `write/update`, inline diff display, approval cards, and message-card hierarchy.

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -113,9 +113,9 @@ fn explicit_progress_entry_groups<'a>(
         if messages.is_empty() {
             continue;
         }
-        if role == "Exploring"
+        if matches!(role, "Exploring" | "Running")
             && let Some((last_role, last_messages)) = groups.last_mut()
-            && *last_role == "Exploring"
+            && *last_role == role
         {
             last_messages.extend(messages);
             continue;
@@ -216,6 +216,7 @@ fn push_live_events<'a>(
     let mut thinking_messages = Vec::new();
     let mut exploration_actions = Vec::new();
     let mut exploration_notes = Vec::new();
+    let mut running_actions = Vec::new();
 
     for event in events {
         if event.role() == "Thinking" {
@@ -225,17 +226,31 @@ fn push_live_events<'a>(
                 &mut exploration_notes,
                 active,
             );
+            push_live_running_group(cells, &mut running_actions, active);
             thinking_messages.push(event.message().to_string());
             continue;
         }
 
         if event.role() == "Exploring" {
             push_live_thinking_group(cells, &mut thinking_messages, None);
+            push_live_running_group(cells, &mut running_actions, active);
             if event.is_note() {
                 exploration_notes.push(event.message().to_string());
             } else {
                 exploration_actions.push(event.message().to_string());
             }
+            continue;
+        }
+
+        if event.role() == "Running" {
+            push_live_thinking_group(cells, &mut thinking_messages, None);
+            push_live_exploration_group(
+                cells,
+                &mut exploration_actions,
+                &mut exploration_notes,
+                active,
+            );
+            running_actions.push(event.message().to_string());
             continue;
         }
 
@@ -246,16 +261,18 @@ fn push_live_events<'a>(
             &mut exploration_notes,
             active,
         );
+        push_live_running_group(cells, &mut running_actions, active);
         push_live_event(cells, event, active);
     }
 
-    push_live_thinking_group(cells, &mut thinking_messages, streaming_thinking_lines);
     push_live_exploration_group(
         cells,
         &mut exploration_actions,
         &mut exploration_notes,
         active,
     );
+    push_live_running_group(cells, &mut running_actions, active);
+    push_live_thinking_group(cells, &mut thinking_messages, streaming_thinking_lines);
 }
 
 fn push_live_thinking_group<'a>(
@@ -298,6 +315,21 @@ fn push_live_exploration_group<'a>(
     )));
     actions.clear();
     notes.clear();
+}
+
+fn push_live_running_group<'a>(
+    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+    actions: &mut Vec<String>,
+    active: bool,
+) {
+    if actions.is_empty() {
+        return;
+    }
+    cells.push(Box::new(RunningCell::new(
+        compact_recent_first_summary_lines(actions.as_slice(), 4, "more running step(s)"),
+        active,
+    )));
+    actions.clear();
 }
 
 fn split_progress_sentences(message: &str) -> Vec<String> {

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -7,7 +7,7 @@ use crate::tui::interaction_text::{
 };
 use crate::tui::plan_display::should_show_updated_plan;
 use crate::tui::state::{
-    RuntimePhase, TranscriptEntry, TranscriptEntryPayload, TuiApp,
+    ActiveLiveEvent, RuntimePhase, TranscriptEntry, TranscriptEntryPayload, TuiApp,
     contains_structured_planning_output,
 };
 use crate::tui::terminal_event::{
@@ -76,45 +76,72 @@ fn is_progress_stack_title(line: &Line<'static>) -> bool {
     )
 }
 
-fn progress_entry_role(role: &str) -> bool {
-    matches!(role, "Thinking" | "Exploring" | "Planning" | "Running")
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ProgressRole {
+    Thinking,
+    Exploring,
+    Planning,
+    Running,
 }
 
-fn progress_entry_message_lines(role: &str, message: &str) -> Vec<String> {
-    if role == "Thinking" {
-        return message
+impl ProgressRole {
+    fn from_entry_role(role: &str) -> Option<Self> {
+        match role {
+            "Thinking" => Some(Self::Thinking),
+            "Exploring" => Some(Self::Exploring),
+            "Planning" => Some(Self::Planning),
+            "Running" => Some(Self::Running),
+            _ => None,
+        }
+    }
+
+    fn from_live_event(event: &ActiveLiveEvent) -> Self {
+        match event {
+            ActiveLiveEvent::Thinking(_) => Self::Thinking,
+            ActiveLiveEvent::ExplorationAction(_) | ActiveLiveEvent::ExplorationNote(_) => {
+                Self::Exploring
+            }
+            ActiveLiveEvent::PlanningAction(_) | ActiveLiveEvent::PlanningNote(_) => Self::Planning,
+            ActiveLiveEvent::RunningAction(_) => Self::Running,
+        }
+    }
+}
+
+fn progress_entry_message_lines(role: ProgressRole, message: &str) -> Vec<String> {
+    match role {
+        ProgressRole::Thinking => message
             .lines()
             .filter(|line| !line.trim().is_empty())
             .map(ToString::to_string)
-            .collect();
+            .collect(),
+        ProgressRole::Exploring | ProgressRole::Planning | ProgressRole::Running => message
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(|line| {
+                line.trim_start_matches("└")
+                    .trim_start_matches('•')
+                    .trim()
+                    .to_string()
+            })
+            .filter(|line| !line.is_empty())
+            .collect(),
     }
-
-    message
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(|line| {
-            line.trim_start_matches("└")
-                .trim_start_matches('•')
-                .trim()
-                .to_string()
-        })
-        .filter(|line| !line.is_empty())
-        .collect()
 }
 
 fn explicit_progress_entry_groups<'a>(
     entries: impl Iterator<Item = &'a TranscriptEntry>,
-) -> Vec<(&'a str, Vec<String>)> {
-    let mut groups: Vec<(&str, Vec<String>)> = Vec::new();
-    for entry in entries.filter(|entry| progress_entry_role(entry.role.as_str())) {
-        let role = entry.role.as_str();
+) -> Vec<(ProgressRole, Vec<String>)> {
+    let mut groups: Vec<(ProgressRole, Vec<String>)> = Vec::new();
+    for entry in entries {
+        let Some(role) = ProgressRole::from_entry_role(entry.role.as_str()) else {
+            continue;
+        };
         let messages = progress_entry_message_lines(role, &entry.message);
         if messages.is_empty() {
             continue;
         }
-        if matches!(role, "Exploring" | "Running")
-            && let Some((last_role, last_messages)) = groups.last_mut()
+        if let Some((last_role, last_messages)) = groups.last_mut()
             && *last_role == role
         {
             last_messages.extend(messages);
@@ -127,83 +154,26 @@ fn explicit_progress_entry_groups<'a>(
 
 fn push_progress_group<'a>(
     cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-    role: &str,
+    role: ProgressRole,
     messages: Vec<String>,
     active: bool,
 ) {
     match role {
-        "Thinking" => cells.push(Box::new(ThinkingTextCell::new(&messages.join("\n"), 4))),
-        "Exploring" => cells.push(Box::new(ExploringCell::new(
+        ProgressRole::Thinking => {
+            cells.push(Box::new(ThinkingTextCell::new(&messages.join("\n"), 4)))
+        }
+        ProgressRole::Exploring => cells.push(Box::new(ExploringCell::new(
             compact_summary_lines(messages.as_slice(), 4, "more exploration step(s)"),
             active,
         ))),
-        "Planning" => cells.push(Box::new(PlanningCell::new(
+        ProgressRole::Planning => cells.push(Box::new(PlanningCell::new(
             compact_summary_lines(messages.as_slice(), 4, "more planning step(s)"),
             active,
         ))),
-        "Running" => cells.push(Box::new(RunningCell::new(
+        ProgressRole::Running => cells.push(Box::new(RunningCell::new(
             compact_summary_lines(messages.as_slice(), 4, "more running step(s)"),
             active,
         ))),
-        _ => {
-            // Callers filter to known progress roles; ignore unknown roles defensively.
-        }
-    }
-}
-
-fn push_live_event<'a>(
-    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-    event: &crate::tui::state::ActiveLiveEvent,
-    active: bool,
-) {
-    let message = event.message().to_string();
-    match event.role() {
-        "Thinking" => cells.push(Box::new(ThinkingTextCell::new(&message, 4))),
-        "Exploring" => cells.push(Box::new(ExploringCell::new(
-            compact_progress_summary_lines(
-                if event.is_note() {
-                    &[]
-                } else {
-                    std::slice::from_ref(&message)
-                },
-                if event.is_note() {
-                    std::slice::from_ref(&message)
-                } else {
-                    &[]
-                },
-                4,
-                "more exploration step(s)",
-            ),
-            active,
-        ))),
-        "Planning" => cells.push(Box::new(PlanningCell::new(
-            compact_progress_summary_lines(
-                if event.is_note() {
-                    &[]
-                } else {
-                    std::slice::from_ref(&message)
-                },
-                if event.is_note() {
-                    std::slice::from_ref(&message)
-                } else {
-                    &[]
-                },
-                4,
-                "more planning step(s)",
-            ),
-            active,
-        ))),
-        "Running" => cells.push(Box::new(RunningCell::new(
-            compact_recent_first_summary_lines(
-                std::slice::from_ref(&message),
-                4,
-                "more running step(s)",
-            ),
-            active,
-        ))),
-        _ => {
-            // Active live events currently produce only known progress roles.
-        }
     }
 }
 
@@ -216,53 +186,60 @@ fn push_live_events<'a>(
     let mut thinking_messages = Vec::new();
     let mut exploration_actions = Vec::new();
     let mut exploration_notes = Vec::new();
+    let mut planning_actions = Vec::new();
+    let mut planning_notes = Vec::new();
     let mut running_actions = Vec::new();
 
     for event in events {
-        if event.role() == "Thinking" {
-            push_live_exploration_group(
-                cells,
-                &mut exploration_actions,
-                &mut exploration_notes,
-                active,
-            );
-            push_live_running_group(cells, &mut running_actions, active);
-            thinking_messages.push(event.message().to_string());
-            continue;
-        }
-
-        if event.role() == "Exploring" {
-            push_live_thinking_group(cells, &mut thinking_messages, None);
-            push_live_running_group(cells, &mut running_actions, active);
-            if event.is_note() {
-                exploration_notes.push(event.message().to_string());
-            } else {
-                exploration_actions.push(event.message().to_string());
+        match ProgressRole::from_live_event(event) {
+            ProgressRole::Thinking => {
+                push_live_exploration_group(
+                    cells,
+                    &mut exploration_actions,
+                    &mut exploration_notes,
+                    active,
+                );
+                push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
+                push_live_running_group(cells, &mut running_actions, active);
+                thinking_messages.push(event.message().to_string());
             }
-            continue;
+            ProgressRole::Exploring => {
+                push_live_thinking_group(cells, &mut thinking_messages, None);
+                push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
+                push_live_running_group(cells, &mut running_actions, active);
+                if event.is_note() {
+                    exploration_notes.push(event.message().to_string());
+                } else {
+                    exploration_actions.push(event.message().to_string());
+                }
+            }
+            ProgressRole::Planning => {
+                push_live_thinking_group(cells, &mut thinking_messages, None);
+                push_live_exploration_group(
+                    cells,
+                    &mut exploration_actions,
+                    &mut exploration_notes,
+                    active,
+                );
+                push_live_running_group(cells, &mut running_actions, active);
+                if event.is_note() {
+                    planning_notes.push(event.message().to_string());
+                } else {
+                    planning_actions.push(event.message().to_string());
+                }
+            }
+            ProgressRole::Running => {
+                push_live_thinking_group(cells, &mut thinking_messages, None);
+                push_live_exploration_group(
+                    cells,
+                    &mut exploration_actions,
+                    &mut exploration_notes,
+                    active,
+                );
+                push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
+                running_actions.push(event.message().to_string());
+            }
         }
-
-        if event.role() == "Running" {
-            push_live_thinking_group(cells, &mut thinking_messages, None);
-            push_live_exploration_group(
-                cells,
-                &mut exploration_actions,
-                &mut exploration_notes,
-                active,
-            );
-            running_actions.push(event.message().to_string());
-            continue;
-        }
-
-        push_live_thinking_group(cells, &mut thinking_messages, None);
-        push_live_exploration_group(
-            cells,
-            &mut exploration_actions,
-            &mut exploration_notes,
-            active,
-        );
-        push_live_running_group(cells, &mut running_actions, active);
-        push_live_event(cells, event, active);
     }
 
     push_live_exploration_group(
@@ -271,6 +248,7 @@ fn push_live_events<'a>(
         &mut exploration_notes,
         active,
     );
+    push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
     push_live_running_group(cells, &mut running_actions, active);
     push_live_thinking_group(cells, &mut thinking_messages, streaming_thinking_lines);
 }
@@ -310,6 +288,28 @@ fn push_live_exploration_group<'a>(
             notes.as_slice(),
             4,
             "more exploration step(s)",
+        ),
+        active,
+    )));
+    actions.clear();
+    notes.clear();
+}
+
+fn push_live_planning_group<'a>(
+    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+    actions: &mut Vec<String>,
+    notes: &mut Vec<String>,
+    active: bool,
+) {
+    if actions.is_empty() && notes.is_empty() {
+        return;
+    }
+    cells.push(Box::new(PlanningCell::new(
+        compact_progress_summary_lines(
+            actions.as_slice(),
+            notes.as_slice(),
+            4,
+            "more planning step(s)",
         ),
         active,
     )));
@@ -788,7 +788,7 @@ fn ordered_exploration_agent_segments<'a>(
                 }
                 segments.push(OrderedActiveSegment::Agent(entry.message.as_str()));
             }
-            role if progress_entry_role(role)
+            role if ProgressRole::from_entry_role(role).is_some()
                 || matches!(
                     role,
                     "Tool Result" | "Tool Error" | "Tool Progress" | "System"
@@ -1114,11 +1114,11 @@ impl ActiveCell for ActiveTurnCell<'_> {
         let has_live_thinking = turn_live && has_thinking_stream;
         if has_live_events || has_live_thinking {
             for event in live_events {
-                match event.role() {
-                    "Exploring" => has_event_exploration_summary = true,
-                    "Planning" => has_event_planning_summary = true,
-                    "Running" => has_event_running_summary = true,
-                    _ => {}
+                match ProgressRole::from_live_event(event) {
+                    ProgressRole::Exploring => has_event_exploration_summary = true,
+                    ProgressRole::Planning => has_event_planning_summary = true,
+                    ProgressRole::Running => has_event_running_summary = true,
+                    ProgressRole::Thinking => {}
                 }
             }
             push_live_events(
@@ -1134,7 +1134,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
         if let Some(groups) = explicit_progress_groups.as_ref() {
             for (role, messages) in groups {
-                push_progress_group(&mut cells, role, messages.clone(), turn_live);
+                push_progress_group(&mut cells, *role, messages.clone(), turn_live);
             }
         }
         let has_explicit_progress_groups = explicit_progress_groups

--- a/src/tui/render/cells_tests.rs
+++ b/src/tui/render/cells_tests.rs
@@ -9,7 +9,8 @@ use insta::assert_snapshot;
 use tempfile::tempdir;
 
 use super::{
-    ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell, explicit_progress_entry_groups,
+    ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell, ProgressRole,
+    explicit_progress_entry_groups,
 };
 
 #[path = "cells_tests/active_general.rs"]

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -391,14 +391,14 @@ fn active_turn_cell_appends_long_live_planning_events() {
 
     assert!(rendered.contains(" Planning "));
     assert!(rendered.contains("Reuse the shared auth bridge."));
-    assert!(!rendered.contains("more planning step(s)"));
-    assert!(rendered.contains("planning module 1"));
+    assert!(rendered.contains("1 more planning step(s)"));
+    assert!(!rendered.contains("planning module 1"));
     assert!(rendered.contains("planning module 2"));
     assert!(rendered.contains("planning module 3"));
+    assert!(rendered.contains("planning module 4"));
     assert!(rendered.contains("planning module 5"));
-    assert_eq!(rendered.matches(" Planning ").count(), 6);
-    assert!(rendered.find("planning module 1") < rendered.find("planning module 5"));
-    assert!(rendered.find("planning module 5") < rendered.find("Reuse the shared auth bridge."));
+    assert_eq!(rendered.matches(" Planning ").count(), 1);
+    assert!(rendered.find("planning module 2") < rendered.find("planning module 5"));
 }
 
 #[test]

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -428,13 +428,13 @@ fn active_turn_cell_appends_long_live_running_events() {
         .join("\n");
 
     assert!(rendered.contains(" Running "));
-    assert!(rendered.contains("Run task 1"));
-    assert!(rendered.contains("Run task 2"));
+    assert!(!rendered.contains("Run task 1"));
+    assert!(!rendered.contains("Run task 2"));
     assert!(rendered.contains("Run task 3"));
     assert!(rendered.contains("Run task 6"));
-    assert!(!rendered.contains("more running step(s)"));
-    assert_eq!(rendered.matches(" Running ").count(), 6);
-    assert!(rendered.find("Run task 1") < rendered.find("Run task 6"));
+    assert!(rendered.contains("more running step(s)"));
+    assert_eq!(rendered.matches(" Running ").count(), 1);
+    assert!(rendered.find("Run task 6") < rendered.find("Run task 3"));
 }
 
 #[test]
@@ -978,6 +978,44 @@ fn active_turn_cell_places_streaming_thinking_after_latest_progress_event() {
 }
 
 #[test]
+fn active_turn_cell_places_streaming_thinking_after_latest_exploration_event() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::ProcessingResponse;
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Inspect before reasoning again".into(),
+            payload: None,
+        }],
+    };
+
+    app.append_agent_thinking_delta("first reasoning block\n");
+    app.flush_agent_thinking_stream_to_live_event();
+    app.record_exploration_action("Read src/tui/render/cells.rs");
+    app.append_agent_thinking_delta("second reasoning block\n");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let first_thinking = rendered.find("first reasoning block").unwrap();
+    let exploring = rendered.find("Read src/tui/render/cells.rs").unwrap();
+    let second_thinking = rendered.find("second reasoning block").unwrap();
+
+    assert!(first_thinking < exploring);
+    assert!(exploring < second_thinking);
+    assert_eq!(rendered.matches(" Thinking ").count(), 2);
+    assert_eq!(rendered.matches(" Exploring ").count(), 1);
+}
+
+#[test]
 fn active_turn_cell_groups_consecutive_thinking_events_with_stream() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
@@ -1156,7 +1194,7 @@ fn active_turn_cell_preserves_consecutive_duplicate_progress_events() {
     assert_eq!(rendered.matches("Read src/tui/render/cells.rs").count(), 2);
     assert_eq!(rendered.matches("Run cargo check").count(), 2);
     assert_eq!(rendered.matches(" Exploring ").count(), 1);
-    assert_eq!(rendered.matches(" Running ").count(), 2);
+    assert_eq!(rendered.matches(" Running ").count(), 1);
 }
 
 #[test]

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -232,7 +232,7 @@ fn committed_turn_cell_appends_adjacent_progress_entries() {
     let second_ran = rendered.find("Run cargo check").unwrap();
 
     assert_eq!(rendered.matches(" Explored ").count(), 1);
-    assert_eq!(rendered.matches(" Ran ").count(), 2);
+    assert_eq!(rendered.matches(" Ran ").count(), 1);
     assert!(first_explored < second_explored);
     assert!(second_explored < first_ran);
     assert!(first_ran < second_ran);

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -11,7 +11,7 @@ fn explicit_progress_entry_groups_preserves_thinking_indentation() {
     let groups = explicit_progress_entry_groups(entries.iter());
 
     assert_eq!(groups.len(), 1);
-    assert_eq!(groups[0].0, "Thinking");
+    assert_eq!(groups[0].0, ProgressRole::Thinking);
     assert_eq!(
         groups[0].1,
         vec![
@@ -217,6 +217,16 @@ fn committed_turn_cell_appends_adjacent_progress_entries() {
             message: "Run cargo check".into(),
             payload: None,
         },
+        TranscriptEntry {
+            role: "Planning".into(),
+            message: "Refine the follow-up plan".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Planning".into(),
+            message: "Split the UI status work".into(),
+            payload: None,
+        },
     ];
 
     let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
@@ -230,12 +240,17 @@ fn committed_turn_cell_appends_adjacent_progress_entries() {
     let second_explored = rendered.find("Read src/context/mod.rs").unwrap();
     let first_ran = rendered.find("Run cargo test active_turn_cell").unwrap();
     let second_ran = rendered.find("Run cargo check").unwrap();
+    let first_planned = rendered.find("Refine the follow-up plan").unwrap();
+    let second_planned = rendered.find("Split the UI status work").unwrap();
 
     assert_eq!(rendered.matches(" Explored ").count(), 1);
     assert_eq!(rendered.matches(" Ran ").count(), 1);
+    assert_eq!(rendered.matches(" Planned ").count(), 1);
     assert!(first_explored < second_explored);
     assert!(second_explored < first_ran);
     assert!(first_ran < second_ran);
+    assert!(second_ran < first_planned);
+    assert!(first_planned < second_planned);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Preserve live progress cell ordering when streaming thinking follows exploration.
- Group consecutive live Running events into one Running cell while keeping interleaved progress types split.
- Group consecutive committed Running entries into one Ran cell.

## Purpose

Progress cells should follow append-order semantics: each update appears after the latest cell, and only consecutive events of the same progress type are merged. This prevents sequences like thinking -> exploring -> thinking from rendering as thinking -> thinking -> exploring.

## Related Issues

- None.

## Testing

- `cargo fmt --check`
- `cargo test active_turn_cell_places_streaming_thinking_after_latest_exploration_event -- --nocapture`
- `cargo test active_turn_cell_ -- --nocapture`
- `cargo test committed_turn_cell_appends_adjacent_progress_entries -- --nocapture`
- `cargo test explicit_progress_entry_groups_preserves_thinking_indentation -- --nocapture`
- `cargo check`
