### PR TITLE
fix: skip empty assistant turns

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -433,9 +433,9 @@ impl Agent {
     {
         loop {
             self.ensure_active_plan_step();
-            let turn_output = self.run_model_turn(output_mode, report).await?;
+            let mut turn_output = self.run_model_turn(output_mode, report).await?;
             self.last_query_plan_updated = turn_output.plan_updated;
-            if let Some(message) = turn_output.assistant_message.clone() {
+            if let Some(message) = turn_output.assistant_message.take() {
                 self.push_history_message(message);
                 self.checkpoint_session()?;
             }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -96,7 +96,7 @@ struct ToolCall {
 
 #[derive(Debug)]
 struct TurnOutput {
-    assistant_message: Message,
+    assistant_message: Option<Message>,
     tool_calls: Vec<ToolCall>,
     plan_updated: bool,
     continue_inspection: bool,
@@ -389,10 +389,7 @@ impl Agent {
         }
 
         Ok(TurnOutput {
-            assistant_message: Message {
-                role: "assistant".to_string(),
-                content: serde_json::to_value(&sanitized_content)?,
-            },
+            assistant_message: assistant_turn_history_message(sanitized_content)?,
             tool_calls,
             plan_updated,
             continue_inspection,
@@ -438,8 +435,10 @@ impl Agent {
             self.ensure_active_plan_step();
             let turn_output = self.run_model_turn(output_mode, report).await?;
             self.last_query_plan_updated = turn_output.plan_updated;
-            self.push_history_message(turn_output.assistant_message);
-            self.checkpoint_session()?;
+            if let Some(message) = turn_output.assistant_message.clone() {
+                self.push_history_message(message);
+                self.checkpoint_session()?;
+            }
 
             if turn_output.tool_calls.is_empty() {
                 if self.should_continue_plan_without_tools(
@@ -739,6 +738,21 @@ impl Agent {
         }
         Ok(tool_results)
     }
+}
+
+fn assistant_turn_history_message(content: Vec<ContentBlock>) -> Result<Option<Message>> {
+    let has_visible_payload = content.iter().any(|block| match block {
+        ContentBlock::Text { text } => !text.trim().is_empty(),
+        ContentBlock::ToolUse { .. } => true,
+        ContentBlock::ProviderMetadata { .. } => false,
+    });
+    if !has_visible_payload {
+        return Ok(None);
+    }
+    Ok(Some(Message {
+        role: "assistant".to_string(),
+        content: serde_json::to_value(&content)?,
+    }))
 }
 
 fn is_compact_boundary_message(message: &Message) -> bool {

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -215,6 +215,42 @@ async fn recoverable_runtime_error_is_returned_to_model_once() {
 }
 
 #[tokio::test]
+async fn reasoning_only_turn_is_not_persisted_as_empty_assistant_message() {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::ProviderMetadata {
+            provider: "deepseek".to_string(),
+            key: "reasoning_content".to_string(),
+            value: json!("internal planning only"),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+
+    agent
+        .query_with_mode(
+            "list your todo".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("reasoning-only response should complete without empty history");
+
+    assert!(
+        !agent
+            .history
+            .iter()
+            .any(|message| message.role == "assistant")
+    );
+}
+
+#[tokio::test]
 async fn suggestion_mode_auto_allows_read_only_bash_commands() {
     let backend = Arc::new(SequencedBackend::new(vec![
         LlmResponse {

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -579,6 +579,9 @@ pub(super) fn to_openai_messages_for_endpoint(
                 flush_missing_tool_results(&mut openai_messages, &mut pending_tool_call_ids);
                 let assistant_message =
                     render_openai_assistant_message(&message.content, endpoint_kind);
+                if is_empty_openai_assistant_message(&assistant_message) {
+                    continue;
+                }
                 pending_tool_call_ids = assistant_tool_call_ids(&assistant_message);
                 openai_messages.push(assistant_message);
             }
@@ -650,6 +653,20 @@ fn render_openai_assistant_message(content: &Value, endpoint_kind: OpenAiEndpoin
         }
     }
     message
+}
+
+fn is_empty_openai_assistant_message(message: &Value) -> bool {
+    let content_empty = match message.get("content") {
+        None | Some(Value::Null) => true,
+        Some(Value::String(value)) => value.trim().is_empty(),
+        Some(Value::Array(values)) => values.is_empty(),
+        Some(_) => false,
+    };
+    let tool_calls_empty = message
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .is_none_or(Vec::is_empty);
+    content_empty && tool_calls_empty
 }
 
 fn provider_metadata_string<'a>(content: &'a Value, provider: &str, key: &str) -> Option<&'a str> {

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -241,6 +241,40 @@ fn deepseek_reasoning_content_roundtrips_as_provider_metadata() {
 }
 
 #[test]
+fn deepseek_skips_reasoning_only_assistant_history() {
+    let messages = vec![
+        Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"List your todo."}]),
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: json!([
+                {"type":"provider_metadata","provider":"deepseek","key":"reasoning_content","value":"internal planning only"}
+            ]),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"Continue."}]),
+        },
+    ];
+
+    let deepseek_messages =
+        to_openai_messages_for_endpoint(&messages, OpenAiEndpointKind::Deepseek);
+
+    assert_eq!(deepseek_messages.len(), 2);
+    assert!(deepseek_messages.iter().all(|message| {
+        !(message["role"] == "assistant"
+            && message.get("tool_calls").is_none()
+            && message
+                .get("content")
+                .is_none_or(|content| content.is_null()))
+    }));
+    assert_eq!(deepseek_messages[0]["role"], "user");
+    assert_eq!(deepseek_messages[1]["role"], "user");
+}
+
+#[test]
 fn deepseek_tool_call_reasoning_content_roundtrips_without_trimming() {
     let reasoning_content = "\n private chain summary \n";
     let response = parse_chat_completion_response(

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -175,7 +175,7 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
         return (
             "Planning",
             Color::Cyan,
-            "analyze, refine, or finalize a plan".to_string(),
+            "read-only planning; approve to execute".to_string(),
         );
     }
 
@@ -381,7 +381,7 @@ fn composer_hint(app: &TuiApp) -> &'static str {
     } else if let Some(pending) = app.active_pending_interaction() {
         pending_interaction_hint_text(pending.kind)
     } else if app.agent_execution_mode_label() == "plan" {
-        "planning mode  analyze, refine, or finalize a plan"
+        "planning mode  read-only planning; approve to execute"
     } else {
         "Enter submit  Shift+Enter newline  / open commands"
     }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -107,9 +107,7 @@ pub(super) async fn execute_local_command(
             if let Some(agent) = agent_slot.as_mut() {
                 agent.set_execution_mode(AgentExecutionMode::Plan);
             }
-            app.push_notice(
-                "Planning mode enabled. Use the next prompt to analyze, refine, or finalize a plan.",
-            );
+            app.push_notice("Planning mode enabled. Read-only planning; approve to execute.");
         }
         LocalCommandKind::Quit => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("quitting".into()));


### PR DESCRIPTION
## Summary

- Skip assistant history entries that contain only provider metadata and no visible text or tool calls.
- Drop already-persisted empty assistant messages when rendering OpenAI-compatible request history.
- Add regressions for DeepSeek reasoning-only history and agent-loop persistence.

## Purpose

DeepSeek rejects assistant messages that have neither `content` nor `tool_calls`. A reasoning-only response can be represented as provider metadata in RARA history, which rendered back to an invalid assistant message on the next request.

## Related Issues

- None

## Tests

- `cargo fmt --check`
- `cargo test reasoning_only_turn_is_not_persisted_as_empty_assistant_message -- --nocapture`
- `cargo test deepseek_skips_reasoning_only_assistant_history -- --nocapture`
- `cargo check`
