### PR TITLE
fix: keep plan decisions transient

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -362,6 +362,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "For update hunks, include enough exact context from the current file for the old lines to match uniquely; if a hunk does not match, re-read the file and make the smallest corrected patch rather than guessing.",
                     "Use 'replace' only for one exact, unique snippet that you have verified from the current file contents.",
                     "For 'replace', copy 'old_string' exactly from the current file, including whitespace and indentation.",
+                    "A 'partially read' or stale edit-tool error means you must re-read the file and retry a direct edit; it is not permission to bypass edit tools with sed, perl, shell redirection, or scripts.",
                     "Use 'replace_lines' only for large deletions or replacements when you have verified exact line numbers from the current file contents; do not pass hundreds of lines through 'replace.old_string'.",
                     "Use 'write_file' only for new files or intentional full-file rewrites after reading the current file when it already exists.",
                     "Do not use shell redirection, sed, perl, or ad-hoc scripts to edit files when direct edit tools or 'apply_patch' can do the job.",
@@ -823,6 +824,7 @@ mod tests {
         assert!(prompt.contains("include enough exact context"));
         assert!(prompt.contains("Use 'replace' only for one exact, unique snippet"));
         assert!(prompt.contains("copy 'old_string' exactly from the current file"));
+        assert!(prompt.contains("not permission to bypass edit tools"));
         assert!(prompt.contains("Use 'write_file' only for new files"));
         assert!(prompt.contains("Do not use shell redirection"));
         assert!(prompt.contains("first inspect local usage"));

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -35,15 +35,22 @@ impl FileReadState {
     ) -> Result<(), ToolError> {
         let key = canonical_existing_path(path)?;
         let metadata = fs::metadata(&key)?;
+        let modified = metadata.modified()?;
+        let is_partial = output.truncated || output.start_line != 1 || !output.total_lines_exact;
+        let mut files = self.files.lock().expect("file read state lock");
+        if is_partial {
+            if let Some(existing) = files.get(&key) {
+                if !existing.is_partial && existing.modified == modified {
+                    return Ok(());
+                }
+            }
+        }
         let entry = FileReadEntry {
-            modified: metadata.modified()?,
+            modified,
             content,
-            is_partial: output.truncated || output.start_line != 1 || !output.total_lines_exact,
+            is_partial,
         };
-        self.files
-            .lock()
-            .expect("file read state lock")
-            .insert(key, entry);
+        files.insert(key, entry);
         Ok(())
     }
 

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -36,7 +36,7 @@ impl FileReadState {
         let key = canonical_existing_path(path)?;
         let metadata = fs::metadata(&key)?;
         let modified = metadata.modified()?;
-        let is_partial = output.truncated || output.start_line != 1 || !output.total_lines_exact;
+        let is_partial = output.is_partial();
         let mut files = self.files.lock().expect("file read state lock");
         if is_partial {
             if let Some(existing) = files.get(&key) {
@@ -222,6 +222,12 @@ pub(crate) struct ReadFileOutput {
     next_offset: Option<usize>,
     line_truncated: bool,
     bytes_read: usize,
+}
+
+impl ReadFileOutput {
+    fn is_partial(&self) -> bool {
+        self.truncated || self.start_line != 1 || !self.total_lines_exact
+    }
 }
 
 struct BoundedLineRead {

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -299,6 +299,42 @@ async fn replace_rejects_partial_read_state() {
 }
 
 #[tokio::test]
+async fn partial_read_does_not_downgrade_existing_full_read_state() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "one\ntwo\nthree\n").expect("write sample");
+    let read_state = Arc::new(FileReadState::default());
+    let read_tool = ReadFileTool::new(read_state.clone());
+    let replace_tool = ReplaceTool::new(read_state);
+
+    read_tool
+        .call(json!({ "path": path.display().to_string() }))
+        .await
+        .expect("full read");
+    read_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "offset": 2,
+            "limit": 1
+        }))
+        .await
+        .expect("partial read");
+
+    replace_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "old_string": "two",
+            "new_string": "second"
+        }))
+        .await
+        .expect("replace after full read and later partial read");
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read updated"),
+        "one\nsecond\nthree\n"
+    );
+}
+
+#[tokio::test]
 async fn replace_rejects_file_changed_since_read() {
     let tempdir = tempfile::tempdir().expect("tempdir");
     let path = tempdir.path().join("sample.txt");

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -375,7 +375,15 @@ fn composer_hint(app: &TuiApp) -> &'static str {
     } else if app.has_queued_follow_up_messages() {
         queued_follow_up_hint()
     } else if app.is_busy() {
-        "Enter queue  Esc cancel"
+        if app
+            .running_task
+            .as_ref()
+            .is_some_and(|task| matches!(task.kind, TaskKind::Query))
+        {
+            "Enter queue  Esc cancel"
+        } else {
+            "Enter queue"
+        }
     } else if app.has_pending_planning_suggestion() {
         "planning suggested  1 enter planning mode  2 continue in execute mode"
     } else if let Some(pending) = app.active_pending_interaction() {
@@ -817,6 +825,32 @@ mod tests {
         });
 
         assert_eq!(composer_hint(&app), "Enter queue  Esc cancel");
+
+        if let Some(task) = app.running_task.take() {
+            task.handle.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn busy_composer_hint_hides_cancel_for_non_query_tasks() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.runtime_phase = RuntimePhase::ProcessingResponse;
+        let (_sender, receiver) = mpsc::unbounded_channel();
+        app.running_task = Some(RunningTask {
+            kind: TaskKind::Compact,
+            receiver,
+            handle: tokio::spawn(std::future::pending::<TaskCompletion>()),
+            started_at: Instant::now(),
+            next_heartbeat_after_secs: 2,
+            cancellation_token: None,
+            cancellation_requested: false,
+        });
+
+        assert_eq!(composer_hint(&app), "Enter queue");
 
         if let Some(task) = app.running_task.take() {
             task.handle.abort();

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -375,7 +375,7 @@ fn composer_hint(app: &TuiApp) -> &'static str {
     } else if app.has_queued_follow_up_messages() {
         queued_follow_up_hint()
     } else if app.is_busy() {
-        "busy  wait for the current task to finish"
+        "Enter queue  Esc cancel"
     } else if app.has_pending_planning_suggestion() {
         "planning suggested  1 enter planning mode  2 continue in execute mode"
     } else if let Some(pending) = app.active_pending_interaction() {
@@ -635,12 +635,16 @@ fn display_char_width(ch: char) -> usize {
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
+    use std::time::Instant;
+
     use ratatui::{layout::Rect, style::Color};
     use tempfile::tempdir;
+    use tokio::sync::mpsc;
 
     use crate::config::ConfigManager;
     use crate::tui::state::{
-        InteractionKind, PendingInteractionSnapshot, RuntimePhase, RuntimeSnapshot, TuiApp,
+        InteractionKind, PendingInteractionSnapshot, RunningTask, RuntimePhase, RuntimeSnapshot,
+        TaskCompletion, TaskKind, TuiApp,
     };
 
     use super::{
@@ -791,6 +795,32 @@ mod tests {
             composer_hint(&app),
             "pending follow-up  will submit after next tool call"
         );
+    }
+
+    #[tokio::test]
+    async fn busy_composer_hint_keeps_only_action_keys() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.runtime_phase = RuntimePhase::ProcessingResponse;
+        let (_sender, receiver) = mpsc::unbounded_channel();
+        app.running_task = Some(RunningTask {
+            kind: TaskKind::Query,
+            receiver,
+            handle: tokio::spawn(std::future::pending::<TaskCompletion>()),
+            started_at: Instant::now(),
+            next_heartbeat_after_secs: 2,
+            cancellation_token: None,
+            cancellation_requested: false,
+        });
+
+        assert_eq!(composer_hint(&app), "Enter queue  Esc cancel");
+
+        if let Some(task) = app.running_task.take() {
+            task.handle.abort();
+        }
     }
 
     #[test]

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -819,7 +819,6 @@ fn ordered_exploration_agent_segments<'a>(
 #[derive(Clone, Copy)]
 pub(super) enum InteractionCompletionKind {
     ShellApprovalCompleted,
-    PlanDecision,
     QuestionAnswered,
     PlanningQuestionAnswered,
     ExplorationQuestionAnswered,
@@ -830,7 +829,6 @@ impl InteractionCompletionKind {
     fn from_role(role: &str) -> Option<Self> {
         match role {
             "Shell Approval Completed" => Some(Self::ShellApprovalCompleted),
-            "Plan Decision" => Some(Self::PlanDecision),
             "Question Answered" => Some(Self::QuestionAnswered),
             "Planning Question Answered" => Some(Self::PlanningQuestionAnswered),
             "Exploration Question Answered" => Some(Self::ExplorationQuestionAnswered),
@@ -842,7 +840,6 @@ impl InteractionCompletionKind {
     fn title(self) -> &'static str {
         match self {
             Self::ShellApprovalCompleted => "Shell Approval Completed",
-            Self::PlanDecision => "Plan Decision",
             Self::QuestionAnswered => "Question Answered",
             Self::PlanningQuestionAnswered => "Planning Question Answered",
             Self::ExplorationQuestionAnswered => "Exploration Question Answered",
@@ -852,7 +849,6 @@ impl InteractionCompletionKind {
 
     fn color(self) -> Color {
         match self {
-            Self::PlanDecision => Color::Cyan,
             Self::ShellApprovalCompleted
             | Self::QuestionAnswered
             | Self::PlanningQuestionAnswered
@@ -930,9 +926,6 @@ impl HistoryCell for CommittedTurnCell<'_> {
             let kind = match entry.kind {
                 super::history_pipeline::CommittedCompletionKind::ShellApprovalCompleted => {
                     InteractionCompletionKind::ShellApprovalCompleted
-                }
-                super::history_pipeline::CommittedCompletionKind::PlanDecision => {
-                    InteractionCompletionKind::PlanDecision
                 }
                 super::history_pipeline::CommittedCompletionKind::PlanningQuestionAnswered => {
                     InteractionCompletionKind::PlanningQuestionAnswered

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -211,7 +211,7 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
 }
 
 #[test]
-fn active_turn_cell_renders_completed_plan_decision() {
+fn active_turn_cell_does_not_render_completed_plan_decision() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -238,8 +238,8 @@ fn active_turn_cell_renders_completed_plan_decision() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains(" Plan Decision "));
-    assert!(rendered.contains("Approved and started implementation"));
+    assert!(!rendered.contains(" Plan Decision "));
+    assert!(!rendered.contains("Approved and started implementation"));
 }
 
 #[test]

--- a/src/tui/render/cells_tests/committed.rs
+++ b/src/tui/render/cells_tests/committed.rs
@@ -300,11 +300,6 @@ fn committed_turn_cell_orders_completion_records_by_interaction_kind() {
             payload: None,
         },
         TranscriptEntry {
-            role: "Plan Decision".into(),
-            message: "Approved the proposed implementation plan.".into(),
-            payload: None,
-        },
-        TranscriptEntry {
             role: "Shell Approval Completed".into(),
             message: "Approved the one-off shell command.".into(),
             payload: None,
@@ -329,17 +324,16 @@ fn committed_turn_cell_orders_completion_records_by_interaction_kind() {
         .join("\n");
 
     let shell_idx = rendered.find(" Shell Approval Completed ").unwrap();
-    let plan_idx = rendered.find(" Plan Decision ").unwrap();
     let planning_question_idx = rendered.find(" Planning Question Answered ").unwrap();
     let generic_question_idx = rendered.find(" Question Answered ").unwrap();
     let agent_idx = rendered
         .find("• Here is the final narrative summary.")
         .unwrap();
 
-    assert!(shell_idx < plan_idx);
-    assert!(plan_idx < planning_question_idx);
+    assert!(shell_idx < planning_question_idx);
     assert!(planning_question_idx < generic_question_idx);
     assert!(generic_question_idx < agent_idx);
+    assert!(!rendered.contains(" Plan Decision "));
 }
 
 #[test]

--- a/src/tui/render/history_pipeline.rs
+++ b/src/tui/render/history_pipeline.rs
@@ -3,7 +3,6 @@ use crate::tui::state::TranscriptEntry;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(super) enum CommittedCompletionKind {
     ShellApprovalCompleted,
-    PlanDecision,
     PlanningQuestionAnswered,
     ExplorationQuestionAnswered,
     SubAgentQuestionAnswered,
@@ -48,7 +47,6 @@ pub(super) fn narrative_entries<'a>(
 pub(super) fn completion_role_kind(role: &str) -> Option<CommittedCompletionKind> {
     match role {
         "Shell Approval Completed" => Some(CommittedCompletionKind::ShellApprovalCompleted),
-        "Plan Decision" => Some(CommittedCompletionKind::PlanDecision),
         "Planning Question Answered" => Some(CommittedCompletionKind::PlanningQuestionAnswered),
         "Exploration Question Answered" => {
             Some(CommittedCompletionKind::ExplorationQuestionAnswered)

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -224,22 +224,13 @@ pub(super) fn start_plan_approval_resume_task(
     continue_planning: bool,
     agent: Agent,
 ) {
-    let (decision_summary, notice) = if continue_planning {
-        ("Continued planning", "Continuing plan refinement.")
+    let notice = if continue_planning {
+        "Continuing plan refinement."
     } else {
-        (
-            "Approved and started implementation",
-            "Plan approved. Continuing with implementation.",
-        )
+        "Plan approved. Continuing with implementation."
     };
 
-    start_plan_resume_task(
-        app,
-        continue_planning,
-        agent,
-        decision_summary,
-        notice.to_string(),
-    );
+    start_plan_resume_task(app, continue_planning, agent, notice.to_string());
 }
 
 fn start_automatic_plan_implementation_task(app: &mut TuiApp, agent: Agent) {
@@ -247,7 +238,6 @@ fn start_automatic_plan_implementation_task(app: &mut TuiApp, agent: Agent) {
         app,
         false,
         agent,
-        "Auto-approved agent-generated plan",
         "Plan generated automatically. Continuing with implementation.".into(),
     );
 }
@@ -256,19 +246,12 @@ fn start_plan_resume_task(
     app: &mut TuiApp,
     continue_planning: bool,
     mut agent: Agent,
-    decision_summary: &'static str,
     notice: String,
 ) {
     let (sender, receiver) = mpsc::unbounded_channel();
     let cancellation_token = Arc::new(AtomicBool::new(false));
     app.clear_active_live_sections();
     app.set_pending_plan_approval(false);
-    app.record_completed_interaction(
-        crate::tui::state::InteractionKind::PlanApproval,
-        "Plan Decision",
-        decision_summary,
-        None,
-    );
     app.notice = Some(notice);
     app.set_runtime_phase(
         RuntimePhase::ProcessingResponse,
@@ -535,6 +518,7 @@ pub(super) async fn finish_running_task_if_ready(
                         app.finalize_active_turn();
                         app.notice = Some("Query cancelled.".into());
                         app.set_runtime_phase(RuntimePhase::Idle, Some("query cancelled".into()));
+                        try_start_queued_follow_up(app, agent_slot);
                         return Ok(());
                     }
                     app.set_runtime_phase(RuntimePhase::Failed, Some("query failed".into()));
@@ -552,6 +536,7 @@ pub(super) async fn finish_running_task_if_ready(
                     }
                     app.push_entry("System", message.clone());
                     app.push_notice(message);
+                    try_start_queued_follow_up(app, agent_slot);
                 }
             }
         }

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -152,6 +152,63 @@ impl LlmBackend for ExitPlanModeBackend {
     }
 }
 
+fn create_test_agent(temp: &tempfile::TempDir) -> Agent {
+    let workspace_root = temp.path().join("workspace");
+    let rara_dir = workspace_root.join(".rara");
+    std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+    std::fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+    std::fs::create_dir_all(rara_dir.join("tool-results")).expect("tool results");
+
+    let workspace = Arc::new(WorkspaceMemory::from_paths(
+        workspace_root.clone(),
+        rara_dir.clone(),
+    ));
+    let session_manager = Arc::new(SessionManager {
+        storage_dir: rara_dir.join("rollouts"),
+        legacy_storage_dir: rara_dir.join("sessions"),
+    });
+    Agent::new(
+        ToolManager::new(),
+        Arc::new(crate::llm::MockLlm),
+        Arc::new(VectorDB::new(
+            &rara_dir.join("lancedb").display().to_string(),
+        )),
+        session_manager,
+        workspace,
+    )
+}
+
+fn install_completed_query_task(app: &mut TuiApp, agent: Agent, result: anyhow::Result<()>) {
+    let (_sender, receiver) = mpsc::unbounded_channel();
+    let handle = tokio::spawn(async move { TaskCompletion::Query { agent, result } });
+    app.running_task = Some(RunningTask {
+        kind: TaskKind::Query,
+        receiver,
+        handle,
+        started_at: Instant::now(),
+        next_heartbeat_after_secs: 2,
+        cancellation_token: None,
+        cancellation_requested: false,
+    });
+}
+
+async fn finish_ready_query_task(app: &mut TuiApp, agent_slot: &mut Option<Agent>) {
+    for _ in 0..20 {
+        finish_running_task_if_ready(app, agent_slot)
+            .await
+            .expect("finish task");
+        if app
+            .running_task
+            .as_ref()
+            .is_some_and(|task| matches!(task.kind, TaskKind::Query))
+            && !app.has_queued_follow_up_messages()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 #[test]
 fn browser_oauth_is_rejected_before_task_start_in_ssh() {
     let temp = tempdir().unwrap();
@@ -332,6 +389,56 @@ async fn queued_follow_ups_start_as_one_multiline_turn() {
         app.active_turn.entries[0].message,
         "first line\n\nsecond line"
     );
+
+    if let Some(task) = app.running_task.take() {
+        task.handle.abort();
+    }
+}
+
+#[tokio::test]
+async fn queued_follow_up_starts_after_query_failure() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let agent = create_test_agent(&temp);
+    app.queue_follow_up_message("inspect the failure");
+    install_completed_query_task(&mut app, agent, Err(anyhow::anyhow!("backend failed")));
+
+    let mut agent_slot = None;
+    finish_ready_query_task(&mut app, &mut agent_slot).await;
+
+    assert_eq!(app.queued_follow_up_count(), 0);
+    assert!(app.running_task.is_some());
+    assert_eq!(app.active_turn.entries.len(), 1);
+    assert_eq!(app.active_turn.entries[0].role, "You");
+    assert_eq!(app.active_turn.entries[0].message, "inspect the failure");
+
+    if let Some(task) = app.running_task.take() {
+        task.handle.abort();
+    }
+}
+
+#[tokio::test]
+async fn queued_follow_up_starts_after_query_cancellation() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let agent = create_test_agent(&temp);
+    app.queue_follow_up_message("continue after cancel");
+    install_completed_query_task(&mut app, agent, Err(anyhow::anyhow!("cancelled by user")));
+
+    let mut agent_slot = None;
+    finish_ready_query_task(&mut app, &mut agent_slot).await;
+
+    assert_eq!(app.queued_follow_up_count(), 0);
+    assert!(app.running_task.is_some());
+    assert_eq!(app.active_turn.entries.len(), 1);
+    assert_eq!(app.active_turn.entries[0].role, "You");
+    assert_eq!(app.active_turn.entries[0].message, "continue after cancel");
 
     if let Some(task) = app.running_task.take() {
         task.handle.abort();


### PR DESCRIPTION
## Summary

- keep plan approval completion transient instead of rendering a persistent Plan Decision history card
- shorten the busy composer hint to the actionable keys for queueing or cancelling
- start queued follow-up messages after query failure or Esc cancellation
- preserve full-read edit state when a later partial read inspects the same unchanged file
- clarify prompt guidance so stale or partial edit-tool errors do not justify bypassing direct edit tools

## Testing

- `cargo fmt --check`
- `cargo test busy_composer_hint_keeps_only_action_keys -- --nocapture`
- `cargo test active_turn_cell_does_not_render_completed_plan_decision -- --nocapture`
- `cargo test committed_turn_cell_orders_completion_records_by_interaction_kind -- --nocapture`
- `cargo test queued_follow_up_starts_after_query -- --nocapture`
- `cargo test partial_read_does_not_downgrade_existing_full_read_state -- --nocapture`
- `cargo test -p rara-instructions default_system_prompt_mentions_tool_safety_and_compaction -- --nocapture`
- `cargo check`
