### PR TITLE
fix: allow apply patch after partial reads

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -369,16 +369,17 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
             section(
                 "Tool Use And Safety",
                 &[
-                    "Before modifying an existing file, read the full current file with 'read_file' in this turn unless the tool result proves that the target was already fully read and has not changed.",
-                    "If a file was only partially read, the edit target is stale, or an edit tool reports that the file changed since it was read, re-read the full file before attempting the edit again.",
+                    "Before modifying an existing file, inspect the relevant current file contents with 'read_file' in this turn unless the tool result proves that the target was already read and has not changed.",
+                    "If a file was only partially read, the edit target is stale, or an edit tool reports that the file changed since it was read, re-read the current relevant content before attempting the edit again.",
                     "Never write from memory, a search snippet, or a stale summary when the direct file contents can be read locally.",
                     "Prefer 'apply_patch' for editing existing files because it is diff-shaped and reviewable.",
                     "When using 'apply_patch', send a single patch string that starts with '*** Begin Patch' and ends with '*** End Patch'. Use '*** Add File: path' with '+' lines for new files, '*** Delete File: path' for deletes, and '*** Update File: path' for edits.",
                     "Inside an update patch, use '@@' hunks and prefix every content line with exactly one marker: space for unchanged context, '-' for removed text, or '+' for inserted text. Preserve indentation exactly after that marker.",
-                    "For update hunks, include enough exact context from the current file for the old lines to match uniquely; if a hunk does not match, re-read the file and make the smallest corrected patch rather than guessing.",
+                    "For update hunks, include enough exact context from the current file for the old lines to match uniquely. If a full read is unavailable because the file or line is too large, use 'apply_patch' with exact context from the current partial read rather than shell text-editing commands.",
+                    "If an 'apply_patch' hunk does not match, re-read the file and make the smallest corrected patch rather than guessing.",
                     "Use 'replace' only for one exact, unique snippet that you have verified from the current file contents.",
                     "For 'replace', copy 'old_string' exactly from the current file, including whitespace and indentation.",
-                    "A 'partially read' or stale edit-tool error means you must re-read the file and retry a direct edit; it is not permission to bypass edit tools with sed, perl, shell redirection, or scripts.",
+                    "A 'partially read' or stale edit-tool error means you must re-read the relevant current content and retry a direct edit tool; it is not permission to bypass edit tools with sed, perl, shell redirection, or scripts.",
                     "Use 'replace_lines' only for large deletions or replacements when you have verified exact line numbers from the current file contents; do not pass hundreds of lines through 'replace.old_string'.",
                     "Use 'write_file' only for new files or intentional full-file rewrites after reading the current file when it already exists.",
                     "Do not use shell redirection, sed, perl, or ad-hoc scripts to edit files when direct edit tools or 'apply_patch' can do the job.",
@@ -861,7 +862,7 @@ mod tests {
         assert!(prompt.contains("prefer 'rg' for text search"));
         assert!(prompt.contains("rg --files"));
         assert!(prompt.contains("Before modifying an existing file"));
-        assert!(prompt.contains("read the full current file"));
+        assert!(prompt.contains("inspect the relevant current file contents"));
         assert!(prompt.contains("If a file was only partially read"));
         assert!(prompt.contains("Never write from memory"));
         assert!(prompt.contains("Prefer 'apply_patch' for editing existing files"));
@@ -871,6 +872,8 @@ mod tests {
         assert!(prompt.contains("prefix every content line with exactly one marker"));
         assert!(prompt.contains("Preserve indentation exactly after that marker"));
         assert!(prompt.contains("include enough exact context"));
+        assert!(prompt.contains("If a full read is unavailable"));
+        assert!(prompt.contains("use 'apply_patch' with exact context"));
         assert!(prompt.contains("Use 'replace' only for one exact, unique snippet"));
         assert!(prompt.contains("copy 'old_string' exactly from the current file"));
         assert!(prompt.contains("not permission to bypass edit tools"));

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -377,6 +377,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "For whole-file deletes, use '*** Delete File: path' by itself; do not include removed file contents under that header.",
                     "Inside an update patch, use '@@' hunks and prefix every content line with exactly one marker: space for unchanged context, '-' for removed text, or '+' for inserted text. Preserve indentation exactly after that marker.",
                     "For update hunks, include enough exact context from the current file for the old lines to match uniquely. If a full read is unavailable because the file or line is too large, use 'apply_patch' with exact context from the current partial read rather than shell text-editing commands.",
+                    "Partial reads are sufficient only for context-backed 'apply_patch' updates whose old/context lines match the current file. Other edit tools may still require a full read as reported by their tool errors.",
                     "If an 'apply_patch' hunk does not match, re-read the file and make the smallest corrected patch rather than guessing.",
                     "Use 'replace' only for one exact, unique snippet that you have verified from the current file contents.",
                     "For 'replace', copy 'old_string' exactly from the current file, including whitespace and indentation.",
@@ -877,6 +878,8 @@ mod tests {
         assert!(prompt.contains("include enough exact context"));
         assert!(prompt.contains("If a full read is unavailable"));
         assert!(prompt.contains("use 'apply_patch' with exact context"));
+        assert!(prompt.contains("Partial reads are sufficient only"));
+        assert!(prompt.contains("Other edit tools may still require a full read"));
         assert!(prompt.contains("Use 'replace' only for one exact, unique snippet"));
         assert!(prompt.contains("copy 'old_string' exactly from the current file"));
         assert!(prompt.contains("not permission to bypass edit tools"));

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -374,6 +374,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "Never write from memory, a search snippet, or a stale summary when the direct file contents can be read locally.",
                     "Prefer 'apply_patch' for editing existing files because it is diff-shaped and reviewable.",
                     "When using 'apply_patch', send a single patch string that starts with '*** Begin Patch' and ends with '*** End Patch'. Use '*** Add File: path' with '+' lines for new files, '*** Delete File: path' for deletes, and '*** Update File: path' for edits.",
+                    "For whole-file deletes, use '*** Delete File: path' by itself; do not include removed file contents under that header.",
                     "Inside an update patch, use '@@' hunks and prefix every content line with exactly one marker: space for unchanged context, '-' for removed text, or '+' for inserted text. Preserve indentation exactly after that marker.",
                     "For update hunks, include enough exact context from the current file for the old lines to match uniquely. If a full read is unavailable because the file or line is too large, use 'apply_patch' with exact context from the current partial read rather than shell text-editing commands.",
                     "If an 'apply_patch' hunk does not match, re-read the file and make the smallest corrected patch rather than guessing.",
@@ -868,6 +869,8 @@ mod tests {
         assert!(prompt.contains("Prefer 'apply_patch' for editing existing files"));
         assert!(prompt.contains("starts with '*** Begin Patch'"));
         assert!(prompt.contains("'*** Add File: path' with '+' lines"));
+        assert!(prompt.contains("'*** Delete File: path' for deletes"));
+        assert!(prompt.contains("do not include removed file contents"));
         assert!(prompt.contains("'*** Update File: path' for edits"));
         assert!(prompt.contains("prefix every content line with exactly one marker"));
         assert!(prompt.contains("Preserve indentation exactly after that marker"));

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -66,7 +66,7 @@ impl Tool for ApplyPatchTool {
     }
 
     fn description(&self) -> &str {
-        "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files. For update or delete operations, read the full target file first."
+        "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files. Update operations verify hunks against current file contents; delete operations require reading the full target file first."
     }
 
     fn input_schema(&self) -> Value {
@@ -96,8 +96,9 @@ impl Tool for ApplyPatchTool {
             .and_then(Value::as_bool)
             .unwrap_or(false);
         let ops = parse_patch(patch)?;
+        validate_patch_update_context(&ops)?;
         if let Some(read_state) = &self.read_state {
-            validate_patch_read_state(read_state, &ops)?;
+            validate_patch_delete_read_state(read_state, &ops)?;
         }
         let mut stats = PatchStats::default();
         let mut previews = Vec::new();
@@ -207,15 +208,27 @@ impl Tool for ApplyPatchTool {
     }
 }
 
-fn validate_patch_read_state(
+fn validate_patch_delete_read_state(
     read_state: &SharedFileReadState,
     ops: &[PatchOp],
 ) -> Result<(), ToolError> {
     for op in ops {
-        match op {
-            PatchOp::Add { .. } => {}
-            PatchOp::Delete { path } | PatchOp::Update { path, .. } => {
-                read_state.validate_existing_edit(path)?;
+        if let PatchOp::Delete { path } = op {
+            read_state.validate_existing_edit(path)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_patch_update_context(ops: &[PatchOp]) -> Result<(), ToolError> {
+    for op in ops {
+        if let PatchOp::Update { path, chunks, .. } = op {
+            for chunk in chunks {
+                if !chunk.lines.iter().any(|line| line.kind != '+') {
+                    return Err(ToolError::ExecutionFailed(format!(
+                        "Patch hunk for {path} must include at least one context or removed line"
+                    )));
+                }
             }
         }
     }
@@ -503,28 +516,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_patch_requires_prior_full_read_when_state_is_enabled() {
+    async fn update_patch_allows_partial_read_when_hunk_matches_current_file() {
         let dir = tempfile::tempdir().expect("tempdir");
         let file = dir.path().join("sample.txt");
         std::fs::write(&file, "hello\nworld\n").expect("write");
         let read_state = Arc::new(FileReadState::default());
+        let read_tool = ReadFileTool::new(read_state.clone());
         let patch_tool = ApplyPatchTool::new(read_state.clone());
-        let patch = format!(
-            "*** Begin Patch\n*** Update File: {}\n@@\n-hello\n+hi\n world\n*** End Patch",
-            file.display()
-        );
 
-        let error = patch_tool
-            .call(json!({ "patch": patch }))
-            .await
-            .expect_err("patch should require read");
-        assert!(error.to_string().contains("File has not been read yet"));
-
-        let read_tool = ReadFileTool::new(read_state);
         read_tool
-            .call(json!({ "path": file.display().to_string() }))
+            .call(json!({
+                "path": file.display().to_string(),
+                "offset": 1,
+                "limit": 1
+            }))
             .await
-            .expect("read file");
+            .expect("partial read");
         let patch = format!(
             "*** Begin Patch\n*** Update File: {}\n@@\n-hello\n+hi\n world\n*** End Patch",
             file.display()
@@ -532,7 +539,61 @@ mod tests {
         patch_tool
             .call(json!({ "patch": patch }))
             .await
-            .expect("patch after read");
+            .expect("patch after partial read");
         assert_eq!(std::fs::read_to_string(&file).expect("read"), "hi\nworld\n");
+    }
+
+    #[tokio::test]
+    async fn update_patch_rejects_add_only_hunk_without_current_context() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sample.txt");
+        std::fs::write(&file, "hello\n").expect("write");
+        let tool = ApplyPatchTool::default();
+
+        let error = tool
+            .call(json!({
+                "patch": format!(
+                    "*** Begin Patch\n*** Update File: {}\n@@\n+inserted\n*** End Patch",
+                    file.display()
+                )
+            }))
+            .await
+            .expect_err("add-only update hunk should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("must include at least one context or removed line")
+        );
+        assert_eq!(std::fs::read_to_string(&file).expect("read"), "hello\n");
+    }
+
+    #[tokio::test]
+    async fn delete_patch_still_requires_prior_full_read_when_state_is_enabled() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sample.txt");
+        std::fs::write(&file, "hello\nworld\n").expect("write");
+        let read_state = Arc::new(FileReadState::default());
+        let read_tool = ReadFileTool::new(read_state.clone());
+        let patch_tool = ApplyPatchTool::new(read_state);
+
+        read_tool
+            .call(json!({
+                "path": file.display().to_string(),
+                "offset": 1,
+                "limit": 1
+            }))
+            .await
+            .expect("partial read");
+
+        let error = patch_tool
+            .call(json!({
+                "patch": format!("*** Begin Patch\n*** Delete File: {}\n*** End Patch", file.display())
+            }))
+            .await
+            .expect_err("delete should require full read");
+
+        assert!(error.to_string().contains("only partially read"));
+        assert!(file.exists());
     }
 }

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -208,6 +208,11 @@ impl Tool for ApplyPatchTool {
 fn validate_patch_update_context(ops: &[PatchOp]) -> Result<(), ToolError> {
     for op in ops {
         if let PatchOp::Update { path, chunks, .. } = op {
+            if chunks.is_empty() {
+                return Err(ToolError::ExecutionFailed(format!(
+                    "Update patch for {path} must include at least one hunk"
+                )));
+            }
             for chunk in chunks {
                 if !chunk.lines.iter().any(|line| line.kind != '+') {
                     return Err(ToolError::ExecutionFailed(format!(
@@ -551,6 +556,30 @@ mod tests {
                 .contains("must include at least one context or removed line")
         );
         assert_eq!(std::fs::read_to_string(&file).expect("read"), "hello\n");
+    }
+
+    #[tokio::test]
+    async fn update_patch_rejects_empty_hunks() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sample.txt");
+        let moved = dir.path().join("moved.txt");
+        std::fs::write(&file, "hello\n").expect("write");
+        let tool = ApplyPatchTool::default();
+
+        let error = tool
+            .call(json!({
+                "patch": format!(
+                    "*** Begin Patch\n*** Update File: {}\n*** Move to: {}\n*** End Patch",
+                    file.display(),
+                    moved.display()
+                )
+            }))
+            .await
+            .expect_err("empty update hunk should be rejected");
+
+        assert!(error.to_string().contains("must include at least one hunk"));
+        assert!(file.exists());
+        assert!(!moved.exists());
     }
 
     #[tokio::test]

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -66,7 +66,7 @@ impl Tool for ApplyPatchTool {
     }
 
     fn description(&self) -> &str {
-        "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files. Update operations verify hunks against current file contents; delete operations require reading the full target file first."
+        "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files. Update operations verify hunks against current file contents."
     }
 
     fn input_schema(&self) -> Value {
@@ -97,9 +97,6 @@ impl Tool for ApplyPatchTool {
             .unwrap_or(false);
         let ops = parse_patch(patch)?;
         validate_patch_update_context(&ops)?;
-        if let Some(read_state) = &self.read_state {
-            validate_patch_delete_read_state(read_state, &ops)?;
-        }
         let mut stats = PatchStats::default();
         let mut previews = Vec::new();
 
@@ -206,18 +203,6 @@ impl Tool for ApplyPatchTool {
             "diff_truncated": diff_truncated,
         }))
     }
-}
-
-fn validate_patch_delete_read_state(
-    read_state: &SharedFileReadState,
-    ops: &[PatchOp],
-) -> Result<(), ToolError> {
-    for op in ops {
-        if let PatchOp::Delete { path } = op {
-            read_state.validate_existing_edit(path)?;
-        }
-    }
-    Ok(())
 }
 
 fn validate_patch_update_context(ops: &[PatchOp]) -> Result<(), ToolError> {
@@ -569,7 +554,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_patch_still_requires_prior_full_read_when_state_is_enabled() {
+    async fn delete_patch_allows_partial_read_when_state_is_enabled() {
         let dir = tempfile::tempdir().expect("tempdir");
         let file = dir.path().join("sample.txt");
         std::fs::write(&file, "hello\nworld\n").expect("write");
@@ -586,14 +571,16 @@ mod tests {
             .await
             .expect("partial read");
 
-        let error = patch_tool
+        let result = patch_tool
             .call(json!({
                 "patch": format!("*** Begin Patch\n*** Delete File: {}\n*** End Patch", file.display())
             }))
             .await
-            .expect_err("delete should require full read");
+            .expect("delete after partial read");
 
-        assert!(error.to_string().contains("only partially read"));
-        assert!(file.exists());
+        assert_eq!(result["status"], "applied");
+        assert_eq!(result["files_changed"], 1);
+        assert_eq!(result["deleted_files"][0], file.display().to_string());
+        assert!(!file.exists());
     }
 }


### PR DESCRIPTION
## Summary

- Allow `apply_patch` update operations to proceed after a partial `read_file` when their hunks match the current file contents.
- Keep full-read protection for delete patches, where there is no hunk context to validate against.
- Reject add-only update hunks that provide no current file context, and update prompt guidance to prefer context-backed `apply_patch` over shell text editing when full reads are unavailable.

## Testing

- cargo fmt --check
- cargo test tools::patch::tests -- --nocapture
- cargo test -p rara-instructions
- cargo check
