### PR TITLE
fix: address apply patch review followups

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -377,7 +377,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "For whole-file deletes, use '*** Delete File: path' by itself; do not include removed file contents under that header.",
                     "Inside an update patch, use '@@' hunks and prefix every content line with exactly one marker: space for unchanged context, '-' for removed text, or '+' for inserted text. Preserve indentation exactly after that marker.",
                     "For update hunks, include enough exact context from the current file for the old lines to match uniquely. If a full read is unavailable because the file or line is too large, use 'apply_patch' with exact context from the current partial read rather than shell text-editing commands.",
-                    "Partial reads are sufficient only for context-backed 'apply_patch' updates whose old/context lines match the current file. Other edit tools may still require a full read as reported by their tool errors.",
+                    "Partial reads are sufficient for context-backed 'apply_patch' updates whose old/context lines match the current file, and for whole-file deletes via '*** Delete File: path'. Other edit tools may still require a full read as reported by their tool errors.",
                     "If an 'apply_patch' hunk does not match, re-read the file and make the smallest corrected patch rather than guessing.",
                     "Use 'replace' only for one exact, unique snippet that you have verified from the current file contents.",
                     "For 'replace', copy 'old_string' exactly from the current file, including whitespace and indentation.",
@@ -878,7 +878,8 @@ mod tests {
         assert!(prompt.contains("include enough exact context"));
         assert!(prompt.contains("If a full read is unavailable"));
         assert!(prompt.contains("use 'apply_patch' with exact context"));
-        assert!(prompt.contains("Partial reads are sufficient only"));
+        assert!(prompt.contains("Partial reads are sufficient for context-backed"));
+        assert!(prompt.contains("whole-file deletes via '*** Delete File: path'"));
         assert!(prompt.contains("Other edit tools may still require a full read"));
         assert!(prompt.contains("Use 'replace' only for one exact, unique snippet"));
         assert!(prompt.contains("copy 'old_string' exactly from the current file"));

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -378,18 +378,26 @@ fn apply_update_chunks(
     let mut cursor = 0usize;
 
     for chunk in chunks {
-        let old_lines: Vec<String> = chunk
-            .lines
-            .iter()
-            .filter(|line| line.kind != DiffLineKind::Addition)
-            .map(|line| line.text.clone())
-            .collect();
-        let new_lines: Vec<String> = chunk
-            .lines
-            .iter()
-            .filter(|line| line.kind != DiffLineKind::Removal)
-            .map(|line| line.text.clone())
-            .collect();
+        let mut old_lines = Vec::new();
+        let mut new_lines = Vec::new();
+        let mut added_in_chunk = 0usize;
+        let mut removed_in_chunk = 0usize;
+        for line in &chunk.lines {
+            match line.kind {
+                DiffLineKind::Context => {
+                    old_lines.push(line.text.clone());
+                    new_lines.push(line.text.clone());
+                }
+                DiffLineKind::Addition => {
+                    new_lines.push(line.text.clone());
+                    added_in_chunk += 1;
+                }
+                DiffLineKind::Removal => {
+                    old_lines.push(line.text.clone());
+                    removed_in_chunk += 1;
+                }
+            }
+        }
 
         let Some(relative_start) = find_subsequence(&original_lines[cursor..], &old_lines) else {
             return Err(ToolError::ExecutionFailed(format!(
@@ -401,16 +409,8 @@ fn apply_update_chunks(
         output.extend(new_lines.clone());
         cursor = start + old_lines.len();
         stats.hunks_applied += 1;
-        stats.added_lines += chunk
-            .lines
-            .iter()
-            .filter(|line| line.kind == DiffLineKind::Addition)
-            .count();
-        stats.removed_lines += chunk
-            .lines
-            .iter()
-            .filter(|line| line.kind == DiffLineKind::Removal)
-            .count();
+        stats.added_lines += added_in_chunk;
+        stats.removed_lines += removed_in_chunk;
     }
 
     output.extend_from_slice(&original_lines[cursor..]);

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -43,8 +43,26 @@ struct Chunk {
 
 #[derive(Debug)]
 struct DiffLine {
-    kind: char,
+    kind: DiffLineKind,
     text: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DiffLineKind {
+    Context,
+    Addition,
+    Removal,
+}
+
+impl DiffLineKind {
+    fn from_marker(marker: char) -> Option<Self> {
+        match marker {
+            ' ' => Some(Self::Context),
+            '+' => Some(Self::Addition),
+            '-' => Some(Self::Removal),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -214,7 +232,11 @@ fn validate_patch_update_context(ops: &[PatchOp]) -> Result<(), ToolError> {
                 )));
             }
             for chunk in chunks {
-                if !chunk.lines.iter().any(|line| line.kind != '+') {
+                if chunk
+                    .lines
+                    .iter()
+                    .all(|line| line.kind == DiffLineKind::Addition)
+                {
                     return Err(ToolError::ExecutionFailed(format!(
                         "Patch hunk for {path} must include at least one context or removed line"
                     )));
@@ -313,11 +335,11 @@ fn parse_patch(patch: &str) -> Result<Vec<PatchOp>, ToolError> {
                     let kind = current.chars().next().ok_or_else(|| {
                         ToolError::InvalidInput("Unexpected empty patch line".into())
                     })?;
-                    if !matches!(kind, ' ' | '+' | '-') {
+                    let Some(kind) = DiffLineKind::from_marker(kind) else {
                         return Err(ToolError::InvalidInput(format!(
                             "Unexpected patch line: {current}"
                         )));
-                    }
+                    };
                     let chunk = current_chunk.get_or_insert_with(|| Chunk { lines: Vec::new() });
                     chunk.lines.push(DiffLine {
                         kind,
@@ -359,13 +381,13 @@ fn apply_update_chunks(
         let old_lines: Vec<String> = chunk
             .lines
             .iter()
-            .filter(|line| line.kind != '+')
+            .filter(|line| line.kind != DiffLineKind::Addition)
             .map(|line| line.text.clone())
             .collect();
         let new_lines: Vec<String> = chunk
             .lines
             .iter()
-            .filter(|line| line.kind != '-')
+            .filter(|line| line.kind != DiffLineKind::Removal)
             .map(|line| line.text.clone())
             .collect();
 
@@ -379,8 +401,16 @@ fn apply_update_chunks(
         output.extend(new_lines.clone());
         cursor = start + old_lines.len();
         stats.hunks_applied += 1;
-        stats.added_lines += chunk.lines.iter().filter(|line| line.kind == '+').count();
-        stats.removed_lines += chunk.lines.iter().filter(|line| line.kind == '-').count();
+        stats.added_lines += chunk
+            .lines
+            .iter()
+            .filter(|line| line.kind == DiffLineKind::Addition)
+            .count();
+        stats.removed_lines += chunk
+            .lines
+            .iter()
+            .filter(|line| line.kind == DiffLineKind::Removal)
+            .count();
     }
 
     output.extend_from_slice(&original_lines[cursor..]);


### PR DESCRIPTION
## Summary

- Replace raw diff marker chars in `apply_patch` update handling with a structured `DiffLineKind`.
- Use idiomatic `all(Addition)` validation for add-only hunks.
- Clarify prompt guidance that partial reads are also sufficient for `*** Delete File: path`.

## Why

This follows up on post-merge review feedback from PR #117.

## Testing

- `cargo fmt --check`
- `cargo test tools::patch::tests -- --nocapture`
- `cargo test -p rara-instructions`
- `cargo check`
