### PR TITLE
fix: clear approval card after decision

### DIFF
--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -858,10 +858,6 @@ impl InteractionCompletionKind {
     }
 }
 
-fn completion_role_color(role: &str) -> Option<Color> {
-    InteractionCompletionKind::from_role(role).map(|kind| kind.color())
-}
-
 fn completion_role_kind(role: &str) -> Option<InteractionCompletionKind> {
     InteractionCompletionKind::from_role(role)
 }
@@ -1049,10 +1045,12 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 )
             })
             .map(|entry| (entry.role.as_str(), entry.message.as_str()));
-        let latest_completion = current_turn
-            .iter()
-            .rev()
-            .find(|entry| completion_role_color(entry.role.as_str()).is_some());
+        let latest_completion = current_turn.iter().rev().find(|entry| {
+            let Some(kind) = completion_role_kind(entry.role.as_str()) else {
+                return false;
+            };
+            !(turn_live && matches!(kind, InteractionCompletionKind::ShellApprovalCompleted))
+        });
         let mut cells: Vec<Box<dyn HistoryCell + '_>> = Vec::new();
         let has_live_exploration = !self.app.active_live.exploration_actions.is_empty()
             || !self.app.active_live.exploration_notes.is_empty();

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -243,6 +243,100 @@ fn active_turn_cell_does_not_render_completed_plan_decision() {
 }
 
 #[test]
+fn active_turn_cell_does_not_render_completed_shell_approval_while_live() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Run the migration helper".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Shell Approval Completed".into(),
+                message: "Bash approval: Approved once for command: bash ./scripts/migrate.sh"
+                    .into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Running".into(),
+                message: "bash ./scripts/migrate.sh".into(),
+                payload: None,
+            },
+        ],
+    };
+    app.set_runtime_phase(
+        RuntimePhase::ProcessingResponse,
+        Some("resuming after approval".into()),
+    );
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(!rendered.contains(" Shell Approval Completed "));
+    assert!(!rendered.contains("Approved once for command"));
+    assert!(rendered.contains(" Running "));
+    assert!(rendered.contains("bash ./scripts/migrate.sh"));
+}
+
+#[test]
+fn active_turn_cell_falls_back_to_previous_completion_when_shell_approval_is_live() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Answer and run".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Question Answered".into(),
+                message: "User answered: yes".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Shell Approval Completed".into(),
+                message: "Bash approval: Approved once for command: cargo check".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Running".into(),
+                message: "cargo check".into(),
+                payload: None,
+            },
+        ],
+    };
+    app.set_runtime_phase(
+        RuntimePhase::ProcessingResponse,
+        Some("resuming after approval".into()),
+    );
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains(" Question Answered "));
+    assert!(rendered.contains("User answered: yes"));
+    assert!(!rendered.contains(" Shell Approval Completed "));
+    assert!(!rendered.contains("Approved once for command"));
+}
+
+#[test]
 fn active_turn_cell_keeps_streaming_response_without_responding_card() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -189,6 +189,7 @@ pub(super) fn start_pending_approval_task(
         BashApprovalDecision::Suggestion => "suggestion only",
     };
     app.notice = Some(format!("Answering approval request: {selection_label}."));
+    app.clear_pending_command_approval();
     app.set_runtime_phase(
         RuntimePhase::ProcessingResponse,
         Some("resuming after approval".into()),

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1557,6 +1557,13 @@ impl TuiApp {
             .find(|item| item.kind == InteractionKind::Approval)
     }
 
+    pub fn clear_pending_command_approval(&mut self) {
+        self.snapshot
+            .pending_interactions
+            .retain(|item| item.kind != InteractionKind::Approval);
+        self.persist_runtime_state();
+    }
+
     pub fn pending_plan_approval_interaction(&self) -> Option<&PendingInteractionSnapshot> {
         self.snapshot
             .pending_interactions

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -94,6 +94,67 @@ fn prioritizes_active_pending_interaction_in_ui_order() {
 }
 
 #[test]
+fn clear_pending_command_approval_removes_only_shell_approval() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.config = RaraConfig::default();
+    app.snapshot = RuntimeSnapshot {
+        pending_interactions: vec![
+            PendingInteractionSnapshot {
+                kind: InteractionKind::RequestInput,
+                title: "Question".to_string(),
+                summary: "Need a value".to_string(),
+                options: Vec::new(),
+                note: None,
+                approval: None,
+                source: Some("worker".to_string()),
+            },
+            PendingInteractionSnapshot {
+                kind: InteractionKind::Approval,
+                title: "Pending Approval".to_string(),
+                summary: "run cargo test".to_string(),
+                options: Vec::new(),
+                note: None,
+                approval: None,
+                source: None,
+            },
+            PendingInteractionSnapshot {
+                kind: InteractionKind::PlanApproval,
+                title: "Plan Ready".to_string(),
+                summary: "Review the plan.".to_string(),
+                options: Vec::new(),
+                note: None,
+                approval: None,
+                source: None,
+            },
+        ],
+        ..RuntimeSnapshot::default()
+    };
+
+    assert!(app.pending_command_approval().is_some());
+
+    app.clear_pending_command_approval();
+
+    assert!(app.pending_command_approval().is_none());
+    assert_eq!(app.snapshot.pending_interactions.len(), 2);
+    assert!(
+        app.snapshot
+            .pending_interactions
+            .iter()
+            .any(|item| item.kind == InteractionKind::RequestInput)
+    );
+    assert!(
+        app.snapshot
+            .pending_interactions
+            .iter()
+            .any(|item| item.kind == InteractionKind::PlanApproval)
+    );
+}
+
+#[test]
 fn sync_snapshot_reports_effective_network_access_for_pending_approval() {
     let dir = tempdir().expect("tempdir");
     let root = dir.path().to_path_buf();


### PR DESCRIPTION
## Summary

- clear pending shell approval state immediately after the user selects an approval option
- suppress live active-turn rendering of completed shell approval cards while the agent resumes work
- add focused state and render regression tests for the approval card lifecycle

## Motivation

Codex treats approval prompts as a transient bottom-pane overlay. Once the user makes a decision, the overlay is completed and popped immediately, while a compact decision record is kept in history. RARA previously kept the pending approval snapshot around until the resumed async task synchronized state, so the approved card could stay pinned at the bottom while the agent was already running.

## Tests

- `cargo fmt --check`
- `cargo test active_turn_cell_does_not_render_completed_shell_approval_while_live -- --nocapture`
- `cargo test clear_pending_command_approval_removes_only_shell_approval -- --nocapture`
- `cargo check`
