### PR TITLE
fix: align terminal tool schema prompts

### DIFF
--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -28,6 +28,14 @@ The transcript should move toward Codex/Claude-style tool visibility:
 ### Shell execution
 
 - `bash` tool execution must emit live transcript updates while stdout/stderr are still being produced.
+- `bash` tool descriptions and input schema must carry the command discipline
+  that the model sees at call time:
+  - prefer dedicated RARA tools for file search, reads, and edits;
+  - use `cwd` instead of prepending `cd`;
+  - avoid newline-separated shell chaining;
+  - keep commands sandboxed unless escalation is justified by user request or
+    clear sandbox failure evidence;
+  - use background task controls for long-running non-interactive commands.
 - The final `bash` tool result should keep the exit code and avoid duplicating large output that was already streamed live.
 - When shell execution pauses on a human approval request, the approval card should take visual priority over older live stdout/stderr progress from the same turn.
 - Approval choices should describe both the action and its scope, such as:
@@ -54,6 +62,10 @@ The transcript should move toward Codex/Claude-style tool visibility:
 
 ### PTY sessions
 
+- `pty_start` tool descriptions and input schema must frame PTY as an
+  interactive-command surface. Ordinary non-interactive commands should use
+  `bash`, while PTY sessions should preserve the same `cwd` and sandbox
+  guidance as shell execution.
 - PTY sessions must be inspectable and stoppable without imposing a fixed
   session-count limit:
   - `pty_list` lists known PTY sessions;

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -65,9 +65,9 @@ The transcript should move toward Codex/Claude-style tool visibility:
 - `pty_start` tool descriptions and input schema must frame PTY as an
   interactive-command surface. Ordinary non-interactive commands should use
   `bash`, while PTY sessions should preserve the same `cwd` guidance as shell
-  execution. Runtime sandboxing is platform-dependent: on macOS, PTY commands
-  currently run unsandboxed because `sandbox-exec` does not preserve
-  interactive PTY stdin reliably.
+  execution. Runtime sandboxing is platform-dependent: with the macOS seatbelt
+  backend, PTY commands currently run unsandboxed because `sandbox-exec` does
+  not preserve interactive PTY stdin reliably.
 - PTY sessions must be inspectable and stoppable without imposing a fixed
   session-count limit:
   - `pty_list` lists known PTY sessions;

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -64,8 +64,10 @@ The transcript should move toward Codex/Claude-style tool visibility:
 
 - `pty_start` tool descriptions and input schema must frame PTY as an
   interactive-command surface. Ordinary non-interactive commands should use
-  `bash`, while PTY sessions should preserve the same `cwd` and sandbox
-  guidance as shell execution.
+  `bash`, while PTY sessions should preserve the same `cwd` guidance as shell
+  execution. Runtime sandboxing is platform-dependent: on macOS, PTY commands
+  currently run unsandboxed because `sandbox-exec` does not preserve
+  interactive PTY stdin reliably.
 - PTY sessions must be inspectable and stoppable without imposing a fixed
   session-count limit:
   - `pty_list` lists known PTY sessions;

--- a/docs/journal/2026-05-01-terminal-tool-schema-prompts.md
+++ b/docs/journal/2026-05-01-terminal-tool-schema-prompts.md
@@ -1,0 +1,36 @@
+# Terminal Tool Schema Prompts
+
+## Context
+
+RARA already had global command guidance in the instruction prompt, but the
+terminal tool schemas still exposed only minimal descriptions. That left the
+model without the same call-site guidance that Codex and Claude Code provide for
+shell execution.
+
+## Upstream Alignment
+
+- Codex keeps shell workdir as an explicit tool parameter and resolves it
+  against the turn cwd. It also routes patch application through a dedicated
+  apply-patch path instead of encouraging shell-based patch execution.
+- Claude Code puts Bash-specific discipline directly in the Bash tool
+  description: keep the working directory stable, prefer dedicated tools, avoid
+  shell-based file edits, avoid newline-separated command chaining, and keep
+  commands sandboxed unless escalation is justified.
+
+## Implementation Checkpoint
+
+- Strengthened the `bash` tool description and input schema with command
+  discipline for dedicated tools, `cwd`, sandbox escalation, background tasks,
+  and shell-edit avoidance.
+- Strengthened background task tool descriptions so models know to inspect or
+  stop long-running work instead of starting duplicates.
+- Strengthened `pty_start` and PTY control descriptions so PTY is reserved for
+  interactive terminal sessions while ordinary commands stay on `bash`.
+- Added focused schema-description tests for Bash, background tasks, and PTY.
+
+## Validation
+
+- `cargo test bash_tool_schema_guides_command_discipline -- --nocapture`
+- `cargo test background_task_tool_descriptions_point_to_run_in_background -- --nocapture`
+- `cargo test pty_tool_schema_guides_interactive_command_discipline -- --nocapture`
+- `cargo check`

--- a/docs/journal/2026-05-01-terminal-tool-schema-prompts.md
+++ b/docs/journal/2026-05-01-terminal-tool-schema-prompts.md
@@ -11,7 +11,7 @@ shell execution.
 
 - Codex keeps shell workdir as an explicit tool parameter and resolves it
   against the turn cwd. It also routes patch application through a dedicated
-  apply-patch path instead of encouraging shell-based patch execution.
+  `apply_patch` path instead of encouraging shell-based patch execution.
 - Claude Code puts Bash-specific discipline directly in the Bash tool
   description: keep the working directory stable, prefer dedicated tools, avoid
   shell-based file edits, avoid newline-separated command chaining, and keep

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -740,7 +740,7 @@ impl Tool for BashTool {
         "bash"
     }
     fn description(&self) -> &str {
-        "Run a shell command in the sandbox. Use the cwd field for the working directory when needed, and avoid cd unless it is necessary for the command itself."
+        "Run a shell command in the sandbox for commands that need process execution. Prefer dedicated RARA tools for file search, file reads, and file edits; do not use shell redirection, sed, awk, perl, or ad-hoc scripts to edit files when apply_patch or direct file tools can do the job. Use the cwd field instead of prepending cd, avoid newline-separated command chaining, and keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop."
     }
     fn input_schema(&self) -> Value {
         json!({
@@ -748,11 +748,11 @@ impl Tool for BashTool {
             "properties": {
                 "command": {
                     "type": "string",
-                    "description": "Legacy shell command string. Prefer program+args for new calls."
+                    "description": "Legacy shell command string. Prefer program+args for new calls. Avoid newline-separated command chaining, and do not use this field for file edits when apply_patch or direct file tools can do the job."
                 },
                 "program": {
                     "type": "string",
-                    "description": "Executable to run directly without a shell."
+                    "description": "Executable to run directly without a shell. Prefer this with args for ordinary commands."
                 },
                 "args": {
                     "type": "array",
@@ -761,7 +761,7 @@ impl Tool for BashTool {
                 },
                 "cwd": {
                     "type": "string",
-                    "description": "Optional working directory override. Defaults to the current turn cwd."
+                    "description": "Optional working directory override. Defaults to the current turn cwd; prefer this over prepending cd to a command."
                 },
                 "env": {
                     "type": "object",
@@ -776,13 +776,13 @@ impl Tool for BashTool {
                 "run_in_background": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Run the command as a background task and return a task id immediately. Use background_task_status to inspect output later."
+                    "description": "Run a long-running non-interactive command as a background task and return a task id immediately. Use background_task_status to inspect output later, background_task_list to find tasks, and background_task_stop to stop them."
                 },
                 "sandbox_permissions": {
                     "type": "string",
                     "enum": ["use_default", "require_escalated"],
                     "default": "use_default",
-                    "description": "Sandbox permissions for the command. Set to require_escalated to request approval to run this command outside the sandbox; defaults to use_default."
+                    "description": "Sandbox permissions for the command. Defaults to use_default. Set to require_escalated only when the user asked for it or sandbox failure evidence shows the command cannot work inside the sandbox."
                 },
                 "justification": {
                     "type": "string",
@@ -791,7 +791,7 @@ impl Tool for BashTool {
                 "prefix_rule": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Only set if sandbox_permissions is require_escalated. Suggested command prefix to approve for similar future commands, for example [\"git\", \"push\"] or [\"cargo\", \"test\"]."
+                    "description": "Only set if sandbox_permissions is require_escalated. Suggested scoped command prefix to approve for similar future commands, for example [\"git\", \"push\"] or [\"cargo\", \"test\"]. Do not suggest broad prefixes."
                 }
             },
             "anyOf": [
@@ -979,7 +979,7 @@ impl Tool for BackgroundTaskListTool {
     }
 
     fn description(&self) -> &str {
-        "List background bash tasks"
+        "List background bash tasks started with bash run_in_background. Use this before starting duplicate long-running work when task state is unclear."
     }
 
     fn input_schema(&self) -> Value {
@@ -1003,7 +1003,7 @@ impl Tool for BackgroundTaskStatusTool {
     }
 
     fn description(&self) -> &str {
-        "Inspect a background bash task and read the tail of its output"
+        "Inspect a background bash task started with bash run_in_background and read the tail of its output."
     }
 
     fn input_schema(&self) -> Value {
@@ -1061,7 +1061,7 @@ impl Tool for BackgroundTaskStopTool {
     }
 
     fn description(&self) -> &str {
-        "Stop one background bash task, or all running background bash tasks when task_id is omitted"
+        "Stop one background bash task, or all running background bash tasks when task_id is omitted."
     }
 
     fn input_schema(&self) -> Value {
@@ -1376,6 +1376,58 @@ mod tests {
         );
         assert_eq!(input.approval_prefix().as_deref(), Some("cargo check"));
         assert!(!input.is_read_only());
+    }
+
+    #[test]
+    fn bash_tool_schema_guides_command_discipline() {
+        let temp = tempdir().expect("tempdir");
+        let tool = BashTool {
+            sandbox: Arc::new(
+                SandboxManager::new_for_rara_dir(temp.path().join(".rara")).expect("sandbox"),
+            ),
+            background_tasks: Arc::new(
+                BackgroundTaskStore::new(temp.path().join(".rara/background-tasks"))
+                    .expect("background task store"),
+            ),
+            base_env: Arc::new(HashMap::new()),
+            sandbox_network_access: false,
+        };
+
+        let description = tool.description();
+        assert!(description.contains("Prefer dedicated RARA tools"));
+        assert!(description.contains("apply_patch"));
+        assert!(description.contains("cwd field"));
+        assert!(description.contains("newline-separated command chaining"));
+        assert!(description.contains("require_escalated"));
+        assert!(description.contains("background_task_status"));
+
+        let schema = tool.input_schema().to_string();
+        assert!(schema.contains("Prefer program+args"));
+        assert!(schema.contains("direct file tools"));
+        assert!(schema.contains("prefer this over prepending cd"));
+        assert!(schema.contains("sandbox failure evidence"));
+        assert!(schema.contains("Do not suggest broad prefixes"));
+    }
+
+    #[test]
+    fn background_task_tool_descriptions_point_to_run_in_background() {
+        let temp = tempdir().expect("tempdir");
+        let background_tasks = Arc::new(
+            BackgroundTaskStore::new(temp.path().join(".rara/background-tasks"))
+                .expect("background task store"),
+        );
+        let list = BackgroundTaskListTool {
+            background_tasks: background_tasks.clone(),
+        };
+        let status = BackgroundTaskStatusTool {
+            background_tasks: background_tasks.clone(),
+        };
+        let stop = BackgroundTaskStopTool { background_tasks };
+
+        assert!(list.description().contains("run_in_background"));
+        assert!(list.description().contains("duplicate long-running work"));
+        assert!(status.description().contains("run_in_background"));
+        assert!(stop.description().contains("task_id is omitted"));
     }
 
     #[test]

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -317,7 +317,7 @@ impl Tool for PtyStartTool {
     }
 
     fn description(&self) -> &str {
-        "Start an interactive PTY session only for commands that need terminal input, terminal control, or an interactive program. For ordinary non-interactive commands, use bash instead. Prefer dedicated RARA tools for file search, file reads, and file edits. Use the cwd field instead of prepending cd, and keep the session sandboxed unless allow_net is needed and supported by config."
+        "Start an interactive PTY session only for commands that need terminal input, terminal control, or an interactive program. For ordinary non-interactive commands, use bash instead. Prefer dedicated RARA tools for file search, file reads, and file edits. Use the cwd field instead of prepending cd. PTY sandboxing is platform-dependent and best-effort; on macOS, PTY commands currently run directly because sandbox-exec does not preserve interactive PTY stdin reliably. Treat allow_net as a network-access toggle, not a sandbox guarantee. Inspect or stop sessions with pty_status, pty_list, and pty_stop."
     }
 
     fn input_schema(&self) -> Value {
@@ -744,7 +744,12 @@ mod tests {
         assert!(description.contains("use bash instead"));
         assert!(description.contains("Prefer dedicated RARA tools"));
         assert!(description.contains("cwd field"));
-        assert!(description.contains("sandboxed"));
+        assert!(description.contains("sandboxing is platform-dependent"));
+        assert!(description.contains("macOS"));
+        assert!(description.contains("allow_net as a network-access toggle"));
+        assert!(description.contains("pty_status"));
+        assert!(description.contains("pty_list"));
+        assert!(description.contains("pty_stop"));
 
         let schema = start.input_schema().to_string();
         assert!(schema.contains("Use PTY only for interactive commands"));

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -317,15 +317,21 @@ impl Tool for PtyStartTool {
     }
 
     fn description(&self) -> &str {
-        "Start an interactive PTY session for commands that need terminal input. Use the cwd field for the working directory when needed, and avoid cd unless it is necessary for the command itself."
+        "Start an interactive PTY session only for commands that need terminal input, terminal control, or an interactive program. For ordinary non-interactive commands, use bash instead. Prefer dedicated RARA tools for file search, file reads, and file edits. Use the cwd field instead of prepending cd, and keep the session sandboxed unless allow_net is needed and supported by config."
     }
 
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",
             "properties": {
-                "command": { "type": "string", "description": "Shell command to run inside a PTY." },
-                "cwd": { "type": "string", "description": "Optional working directory. Defaults to the current turn cwd." },
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to run inside a PTY. Use PTY only for interactive commands; use bash for ordinary non-interactive commands."
+                },
+                "cwd": {
+                    "type": "string",
+                    "description": "Optional working directory. Defaults to the current turn cwd; prefer this over prepending cd to a command."
+                },
                 "env": {
                     "type": "object",
                     "additionalProperties": { "type": "string" },
@@ -387,7 +393,7 @@ impl Tool for PtyReadTool {
     }
 
     fn description(&self) -> &str {
-        "Read recent output from a PTY session"
+        "Read recent output from a PTY session started with pty_start."
     }
 
     fn input_schema(&self) -> Value {
@@ -427,7 +433,7 @@ impl Tool for PtyListTool {
     }
 
     fn description(&self) -> &str {
-        "List PTY sessions"
+        "List PTY sessions started with pty_start. Use this before starting duplicate interactive work when session state is unclear."
     }
 
     fn input_schema(&self) -> Value {
@@ -455,7 +461,7 @@ impl Tool for PtyStatusTool {
     }
 
     fn description(&self) -> &str {
-        "Inspect a PTY session and read the tail of its output"
+        "Inspect a PTY session started with pty_start and read the tail of its output."
     }
 
     fn input_schema(&self) -> Value {
@@ -485,7 +491,7 @@ impl Tool for PtyWriteTool {
     }
 
     fn description(&self) -> &str {
-        "Write input to a running PTY session"
+        "Write input to a running PTY session started with pty_start."
     }
 
     fn input_schema(&self) -> Value {
@@ -520,7 +526,7 @@ impl Tool for PtyKillTool {
     }
 
     fn description(&self) -> &str {
-        "Kill a PTY session"
+        "Kill a PTY session started with pty_start."
     }
 
     fn input_schema(&self) -> Value {
@@ -548,7 +554,7 @@ impl Tool for PtyStopTool {
     }
 
     fn description(&self) -> &str {
-        "Stop one PTY session, or all running PTY sessions when session_id is omitted"
+        "Stop one PTY session, or all running PTY sessions when session_id is omitted."
     }
 
     fn input_schema(&self) -> Value {
@@ -711,6 +717,42 @@ mod tests {
         let err = parse_pty_dimension(Some(&value), 24, "rows").expect_err("overflow rejected");
 
         assert!(matches!(err, ToolError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn pty_tool_schema_guides_interactive_command_discipline() {
+        let temp = tempdir().expect("tempdir");
+        let sessions = Arc::new(PtySessionStore::new(temp.path().join("pty")).expect("pty store"));
+        let start = PtyStartTool {
+            sessions: sessions.clone(),
+            sandbox: Arc::new(
+                SandboxManager::new_for_rara_dir(temp.path().join(".rara")).expect("sandbox"),
+            ),
+            base_env: Arc::new(HashMap::new()),
+            sandbox_network_access: false,
+        };
+        let list = PtyListTool {
+            sessions: sessions.clone(),
+        };
+        let status = PtyStatusTool {
+            sessions: sessions.clone(),
+        };
+        let stop = PtyStopTool { sessions };
+
+        let description = start.description();
+        assert!(description.contains("interactive PTY session only"));
+        assert!(description.contains("use bash instead"));
+        assert!(description.contains("Prefer dedicated RARA tools"));
+        assert!(description.contains("cwd field"));
+        assert!(description.contains("sandboxed"));
+
+        let schema = start.input_schema().to_string();
+        assert!(schema.contains("Use PTY only for interactive commands"));
+        assert!(schema.contains("use bash for ordinary non-interactive commands"));
+        assert!(schema.contains("prefer this over prepending cd"));
+        assert!(list.description().contains("duplicate interactive work"));
+        assert!(status.description().contains("pty_start"));
+        assert!(stop.description().contains("session_id is omitted"));
     }
 
     #[test]

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -317,7 +317,7 @@ impl Tool for PtyStartTool {
     }
 
     fn description(&self) -> &str {
-        "Start an interactive PTY session only for commands that need terminal input, terminal control, or an interactive program. For ordinary non-interactive commands, use bash instead. Prefer dedicated RARA tools for file search, file reads, and file edits. Use the cwd field instead of prepending cd. PTY sandboxing is platform-dependent and best-effort; on macOS, PTY commands currently run directly because sandbox-exec does not preserve interactive PTY stdin reliably. Treat allow_net as a network-access toggle, not a sandbox guarantee. Inspect or stop sessions with pty_status, pty_list, and pty_stop."
+        "Start an interactive PTY session only for commands that need terminal input, terminal control, or an interactive program. For ordinary non-interactive commands, use bash instead. Prefer dedicated RARA tools for file search, file reads, and file edits. Use the cwd field instead of prepending cd. PTY sandboxing is platform-dependent and best-effort; with the macOS seatbelt backend, PTY commands currently run directly because sandbox-exec does not preserve interactive PTY stdin reliably. Treat allow_net as a network-access toggle, not a sandbox guarantee. Inspect or stop sessions with pty_status, pty_list, and pty_stop."
     }
 
     fn input_schema(&self) -> Value {
@@ -745,7 +745,7 @@ mod tests {
         assert!(description.contains("Prefer dedicated RARA tools"));
         assert!(description.contains("cwd field"));
         assert!(description.contains("sandboxing is platform-dependent"));
-        assert!(description.contains("macOS"));
+        assert!(description.contains("macOS seatbelt backend"));
         assert!(description.contains("allow_net as a network-access toggle"));
         assert!(description.contains("pty_status"));
         assert!(description.contains("pty_list"));


### PR DESCRIPTION
## Summary

- Align Bash tool descriptions and schema text with Codex/Claude command discipline.
- Clarify background task inspection/stop descriptions for long-running commands.
- Clarify PTY as the interactive command surface and document the contract.

## Motivation

RARA already had global command guidance, but the command tools themselves still exposed minimal schema text. Models decide tool calls from the schema surface, so the Bash and PTY descriptions should carry the same call-site guidance used by Codex and Claude Code: stable cwd handling, dedicated tools before shell, sandbox-first execution, and background/PTY lifecycle controls.

## Testing

- `cargo fmt --check`
- `cargo test bash_tool_schema_guides_command_discipline -- --nocapture`
- `cargo test background_task_tool_descriptions_point_to_run_in_background -- --nocapture`
- `cargo test pty_tool_schema_guides_interactive_command_discipline -- --nocapture`
- `cargo check`
