### PR TITLE
fix: keep shell approval shortcuts responsive

### DIFF
--- a/docs/journal/2026-05-01-shell-approval-shortcuts.md
+++ b/docs/journal/2026-05-01-shell-approval-shortcuts.md
@@ -1,0 +1,27 @@
+# Shell Approval Shortcuts
+
+## Context
+
+Shell command approval was being represented through both `pending_approval`
+and `pending_user_input`. That made the TUI vulnerable to rendering a bash
+approval as a generic request-input card, which exposed the wrong shortcut hint
+and could make numeric approval shortcuts appear unresponsive.
+
+## Implementation Checkpoint
+
+- Kept bash command approval on the structured `ShellApproval` path instead of
+  also creating a generic pending user-input question.
+- Centralized pending-option counts so key handling knows the real number of
+  valid options for plan approval, shell approval, and request-input cards.
+- Added the missing `4` shortcut for shell approval denial.
+- Added exact numeric submit handling as a fallback for terminals where a digit
+  lands in the composer before submission.
+- Covered both local and SSH shortcut mapping in tests.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo test pending_shell_approval_number_shortcuts_work_in_local_and_ssh -- --nocapture`
+- `cargo test pending_shell_approval_does_not_render_as_request_input -- --nocapture`
+- `cargo test suggestion_mode_uses_escalated_sandbox_justification_for_approval -- --nocapture`
+- `cargo check`

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -647,48 +647,9 @@ impl Agent {
                         request.summary()
                     )));
                 } else {
-                    let summary = request.summary();
                     self.pending_approval = Some(PendingApproval {
                         tool_use_id: tool_id.clone(),
                         request: request.to_owned(),
-                    });
-                    let question = request
-                        .justification
-                        .as_ref()
-                        .filter(|value| !value.trim().is_empty())
-                        .cloned()
-                        .unwrap_or_else(|| {
-                            "Bash command needs approval. What should RARA do?".to_string()
-                        });
-                    self.pending_user_input = Some(PendingUserInput {
-                        question,
-                        options: vec![
-                            (
-                                "Run once".to_string(),
-                                "Execute this command now and then return to suggestion mode."
-                                    .to_string(),
-                            ),
-                            (
-                                "Allow matching prefix".to_string(),
-                                format!(
-                                    "Execute now and auto-allow later commands that start with '{}'.",
-                                    request
-                                        .approval_prefix()
-                                        .unwrap_or_else(|| request.summary())
-                                ),
-                            ),
-                            (
-                                "Always allow bash".to_string(),
-                                "Execute now and keep bash approval open for later commands."
-                                    .to_string(),
-                            ),
-                            (
-                                "Suggestion only".to_string(),
-                                "Do not run the command automatically. Continue with a safer path."
-                                    .to_string(),
-                            ),
-                        ],
-                        note: Some(format!("command: {}", summary)),
                     });
                     report(AgentEvent::Status(
                         "Bash approval required. Waiting for a structured user decision."

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -368,13 +368,9 @@ async fn suggestion_mode_uses_escalated_sandbox_justification_for_approval() {
         .expect("query should pause on escalated bash approval");
 
     assert!(agent.pending_approval.is_some());
-    let pending = agent
-        .pending_user_input
-        .as_ref()
-        .expect("pending user input");
-    assert_eq!(
-        pending.question,
-        "Do you want to run cargo check outside the sandbox?"
+    assert!(
+        agent.pending_user_input.is_none(),
+        "bash approval should stay on the structured approval path"
     );
     assert_eq!(
         agent

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -226,61 +226,69 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             KeyCode::Enter => AppEvent::ApplyOverlaySelection,
             _ => AppEvent::Noop,
         },
-        None => match (code, modifiers) {
-            (KeyCode::Esc, _) if app.is_busy() => AppEvent::CancelRunningTask,
-            (KeyCode::Esc, _) => AppEvent::Noop,
-            (KeyCode::Enter, KeyModifiers::SHIFT) | (KeyCode::Char('j'), KeyModifiers::CONTROL) => {
-                AppEvent::InsertNewline
-            }
-            (KeyCode::Enter, _) => AppEvent::SubmitComposer,
-            (KeyCode::Left, _) => AppEvent::MoveCursorLeft,
-            (KeyCode::Right, _) => AppEvent::MoveCursorRight,
-            (KeyCode::Home, _) | (KeyCode::Char('a'), KeyModifiers::CONTROL) => {
-                AppEvent::MoveCursorHome
-            }
-            (KeyCode::End, _) | (KeyCode::Char('e'), KeyModifiers::CONTROL) => {
-                AppEvent::MoveCursorEnd
-            }
-            (KeyCode::Up, _) if app.should_handle_input_history_navigation(-1) => {
-                AppEvent::NavigateInputHistory(-1)
-            }
-            (KeyCode::Up, _) => AppEvent::MoveCursorUp,
-            (KeyCode::Down, _) if app.should_handle_input_history_navigation(1) => {
-                AppEvent::NavigateInputHistory(1)
-            }
-            (KeyCode::Down, _) => AppEvent::MoveCursorDown,
-            (KeyCode::Char('k'), _) if app.input.is_empty() => AppEvent::ScrollTranscript(-1),
-            (KeyCode::Char('j'), _) if app.input.is_empty() => AppEvent::ScrollTranscript(1),
-            (KeyCode::PageUp, _) if app.input.is_empty() => AppEvent::ScrollTranscript(-8),
-            (KeyCode::PageDown, _) if app.input.is_empty() => AppEvent::ScrollTranscript(8),
-            (KeyCode::Char('1'), _)
-                if app.input.is_empty()
-                    && (app.active_pending_interaction().is_some()
-                        || app.has_pending_planning_suggestion()) =>
+        None => {
+            if app.input.is_empty()
+                && let Some(index) = pending_shortcut_index(code, app)
             {
-                AppEvent::SelectPendingOption(0)
+                return AppEvent::SelectPendingOption(index);
             }
-            (KeyCode::Char('2'), _)
-                if app.input.is_empty()
-                    && (app.active_pending_interaction().is_some()
-                        || app.has_pending_planning_suggestion()) =>
-            {
-                AppEvent::SelectPendingOption(1)
+
+            match (code, modifiers) {
+                (KeyCode::Esc, _) if app.is_busy() => AppEvent::CancelRunningTask,
+                (KeyCode::Esc, _) => AppEvent::Noop,
+                (KeyCode::Enter, KeyModifiers::SHIFT)
+                | (KeyCode::Char('j'), KeyModifiers::CONTROL) => AppEvent::InsertNewline,
+                (KeyCode::Enter, _) => AppEvent::SubmitComposer,
+                (KeyCode::Left, _) => AppEvent::MoveCursorLeft,
+                (KeyCode::Right, _) => AppEvent::MoveCursorRight,
+                (KeyCode::Home, _) | (KeyCode::Char('a'), KeyModifiers::CONTROL) => {
+                    AppEvent::MoveCursorHome
+                }
+                (KeyCode::End, _) | (KeyCode::Char('e'), KeyModifiers::CONTROL) => {
+                    AppEvent::MoveCursorEnd
+                }
+                (KeyCode::Up, _) if app.should_handle_input_history_navigation(-1) => {
+                    AppEvent::NavigateInputHistory(-1)
+                }
+                (KeyCode::Up, _) => AppEvent::MoveCursorUp,
+                (KeyCode::Down, _) if app.should_handle_input_history_navigation(1) => {
+                    AppEvent::NavigateInputHistory(1)
+                }
+                (KeyCode::Down, _) => AppEvent::MoveCursorDown,
+                (KeyCode::Char('k'), _) if app.input.is_empty() => AppEvent::ScrollTranscript(-1),
+                (KeyCode::Char('j'), _) if app.input.is_empty() => AppEvent::ScrollTranscript(1),
+                (KeyCode::PageUp, _) if app.input.is_empty() => AppEvent::ScrollTranscript(-8),
+                (KeyCode::PageDown, _) if app.input.is_empty() => AppEvent::ScrollTranscript(8),
+                (KeyCode::Char('1'), _)
+                    if app.input.is_empty() && app.has_pending_planning_suggestion() =>
+                {
+                    AppEvent::SelectPendingOption(0)
+                }
+                (KeyCode::Char('2'), _)
+                    if app.input.is_empty() && app.has_pending_planning_suggestion() =>
+                {
+                    AppEvent::SelectPendingOption(1)
+                }
+                (KeyCode::Backspace, _) => AppEvent::Backspace,
+                (KeyCode::Delete, _) | (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
+                    AppEvent::DeleteForward
+                }
+                (KeyCode::Char(c), _) => AppEvent::InputChar(c),
+                _ => AppEvent::Noop,
             }
-            (KeyCode::Char('3'), _)
-                if app.input.is_empty()
-                    && app.active_pending_interaction().is_some_and(|pending| {
-                        pending.kind != super::state::ActivePendingInteractionKind::PlanApproval
-                    }) =>
-            {
-                AppEvent::SelectPendingOption(2)
-            }
-            (KeyCode::Backspace, _) => AppEvent::Backspace,
-            (KeyCode::Delete, _) | (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
-                AppEvent::DeleteForward
-            }
-            (KeyCode::Char(c), _) => AppEvent::InputChar(c),
-            _ => AppEvent::Noop,
-        },
+        }
     }
+}
+
+fn pending_shortcut_index(code: KeyCode, app: &TuiApp) -> Option<usize> {
+    let KeyCode::Char(ch) = code else {
+        return None;
+    };
+
+    let index = match ch.to_digit(10) {
+        Some(digit @ 1..=9) => digit as usize - 1,
+        _ => return None,
+    };
+
+    (index < app.active_pending_option_count()).then_some(index)
 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1532,6 +1532,23 @@ impl TuiApp {
         None
     }
 
+    pub fn active_pending_option_count(&self) -> usize {
+        let Some(pending) = self.active_pending_interaction() else {
+            return 0;
+        };
+        match pending.kind {
+            ActivePendingInteractionKind::PlanApproval => 2,
+            ActivePendingInteractionKind::ShellApproval => 4,
+            ActivePendingInteractionKind::PlanningQuestion
+            | ActivePendingInteractionKind::ExplorationQuestion
+            | ActivePendingInteractionKind::SubAgentQuestion
+            | ActivePendingInteractionKind::RequestInput => self
+                .pending_request_input()
+                .map(|interaction| interaction.options.len().min(3))
+                .unwrap_or(0),
+        }
+    }
+
     pub fn set_pending_plan_approval(&mut self, pending: bool) {
         self.set_plan_approval_interaction(pending);
         self.persist_runtime_state();

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -6,6 +6,8 @@ use super::command::{palette_command_by_index, parse_local_command};
 use super::runtime::{execute_local_command, start_query_task};
 use super::state::{LocalCommandKind, OpenAiModelPickerAction, Overlay, TaskKind, TuiApp};
 
+mod pending;
+
 pub(crate) async fn handle_submit(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
@@ -68,6 +70,9 @@ pub(crate) async fn handle_submit(
     }
 
     if app.has_pending_plan_approval() && !trimmed.starts_with('/') {
+        if pending::handle_pending_option_submit(app, agent_slot, &trimmed) {
+            return Ok(false);
+        }
         handle_pending_plan_approval_submit(app);
         return Ok(false);
     }
@@ -77,39 +82,12 @@ pub(crate) async fn handle_submit(
         }
     } else if trimmed.starts_with('/') {
         app.push_notice(format!("Unknown command '{}'. Use /help.", trimmed));
+    } else if pending::handle_pending_option_submit(app, agent_slot, &trimmed) {
+        return Ok(false);
     } else if let Some(agent) = agent_slot.take() {
-        let mut agent = agent;
         if app.pending_request_input().is_some() {
-            if app.has_local_pending_request_input() {
-                let interaction = app.pending_request_input().cloned();
-                if let Some(interaction) = interaction {
-                    let source = interaction
-                        .source
-                        .clone()
-                        .unwrap_or_else(|| "sub-agent".to_string());
-                    let answer = trimmed.clone();
-                    app.record_completed_interaction(
-                        crate::tui::state::InteractionKind::RequestInput,
-                        interaction.title.clone(),
-                        format!("Answered with: {}", answer),
-                        interaction.source.clone(),
-                    );
-                    app.clear_local_request_input();
-                    let mut prompt = format!(
-                        "Continue the same task. A delegated {source} requested additional user input.\nQuestion: {}\nAnswer: {}",
-                        interaction.title, answer
-                    );
-                    if let Some(note) = interaction.note.as_deref() {
-                        if !note.trim().is_empty() {
-                            prompt.push_str(&format!("\nContext: {}", note.trim()));
-                        }
-                    }
-                    start_query_task(app, prompt, agent);
-                    return Ok(false);
-                }
-            } else {
-                agent.consume_pending_user_input(&trimmed);
-            }
+            pending::handle_request_input_answer(app, agent_slot, agent, trimmed);
+            return Ok(false);
         }
         let prompt = trimmed;
         app.clear_pending_planning_suggestion();

--- a/src/tui/submit/pending.rs
+++ b/src/tui/submit/pending.rs
@@ -1,0 +1,116 @@
+use crate::agent::{Agent, BashApprovalDecision};
+
+use crate::tui::runtime::{
+    start_pending_approval_task, start_plan_approval_resume_task, start_query_task,
+};
+use crate::tui::state::{ActivePendingInteractionKind, InteractionKind, TuiApp};
+
+pub(super) fn handle_pending_option_submit(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    trimmed: &str,
+) -> bool {
+    let Some(index) = pending_option_index_from_text(trimmed) else {
+        return false;
+    };
+    if index >= app.active_pending_option_count() {
+        return false;
+    }
+    let Some(interaction) = app.active_pending_interaction() else {
+        return false;
+    };
+    match interaction.kind {
+        ActivePendingInteractionKind::PlanApproval => {
+            if let Some(agent) = agent_slot.take() {
+                start_plan_approval_resume_task(app, index == 1, agent);
+            } else {
+                app.push_notice("Approval is still preparing. Try the shortcut again.");
+            }
+            true
+        }
+        ActivePendingInteractionKind::ShellApproval => {
+            if let Some(agent) = agent_slot.take() {
+                let selection = match index {
+                    0 => BashApprovalDecision::Once,
+                    1 => BashApprovalDecision::Prefix,
+                    2 => BashApprovalDecision::Always,
+                    _ => BashApprovalDecision::Suggestion,
+                };
+                start_pending_approval_task(app, selection, agent);
+            } else {
+                app.push_notice("Approval is still preparing. Try the shortcut again.");
+            }
+            true
+        }
+        ActivePendingInteractionKind::PlanningQuestion
+        | ActivePendingInteractionKind::ExplorationQuestion
+        | ActivePendingInteractionKind::SubAgentQuestion
+        | ActivePendingInteractionKind::RequestInput => {
+            if let Some(label) = app.pending_question_option_label(index) {
+                if let Some(agent) = agent_slot.take() {
+                    handle_request_input_answer(app, agent_slot, agent, label);
+                } else {
+                    app.push_notice("Request input is still preparing. Try the shortcut again.");
+                }
+                return true;
+            }
+            false
+        }
+    }
+}
+
+pub(super) fn handle_request_input_answer(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    mut agent: Agent,
+    answer: String,
+) {
+    if app.has_local_pending_request_input() {
+        start_local_request_input_continuation(app, agent, answer);
+        return;
+    }
+
+    agent.consume_pending_user_input(&answer);
+    app.sync_snapshot(&agent);
+    app.clear_pending_planning_suggestion();
+    start_query_task(app, answer, agent);
+    *agent_slot = None;
+}
+
+fn start_local_request_input_continuation(app: &mut TuiApp, agent: Agent, answer: String) {
+    let Some(interaction) = app.pending_request_input().cloned() else {
+        app.clear_pending_planning_suggestion();
+        start_query_task(app, answer, agent);
+        return;
+    };
+
+    let source = interaction
+        .source
+        .clone()
+        .unwrap_or_else(|| "sub-agent".to_string());
+    app.record_completed_interaction(
+        InteractionKind::RequestInput,
+        interaction.title.clone(),
+        format!("Answered with: {}", answer),
+        interaction.source.clone(),
+    );
+    app.clear_local_request_input();
+
+    let mut prompt = format!(
+        "Continue the same task. A delegated {source} requested additional user input.\nQuestion: {}\nAnswer: {}",
+        interaction.title, answer
+    );
+    if let Some(note) = interaction.note.as_deref()
+        && !note.trim().is_empty()
+    {
+        prompt.push_str(&format!("\nContext: {}", note.trim()));
+    }
+    start_query_task(app, prompt, agent);
+}
+
+fn pending_option_index_from_text(input: &str) -> Option<usize> {
+    match input.trim().parse::<usize>() {
+        Ok(index @ 1..=9) => Some(index - 1),
+        _ => None,
+    }
+}

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -33,7 +33,10 @@ fn mouse_scroll(kind: MouseEventKind) -> Event {
         modifiers: KeyModifiers::NONE,
     })
 }
-use super::state::{Overlay, ProviderFamily, RunningTask, TaskKind, TuiApp};
+use super::state::{
+    InteractionKind, Overlay, PendingApprovalSnapshot, PendingInteractionSnapshot, ProviderFamily,
+    RunningTask, TaskKind, TuiApp,
+};
 use super::{dispatch_event, map_key_to_event};
 
 fn provider_family_idx(family: ProviderFamily) -> usize {
@@ -121,6 +124,35 @@ async fn pending_plan_approval_blocks_plain_submit() {
         app.notice
             .as_deref()
             .is_some_and(|value| value.contains("Press 1 to start implementation"))
+    );
+}
+
+#[tokio::test]
+async fn submit_numeric_input_handles_pending_shell_approval() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    add_pending_shell_approval(&mut app);
+    app.input = "4".into();
+
+    let mut agent_slot = None;
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let should_quit = super::handle_submit(&mut app, &mut agent_slot, &oauth_manager)
+        .await
+        .expect("submit");
+
+    assert!(!should_quit);
+    assert!(app.running_task.is_none());
+    assert_eq!(app.input, "");
+    assert!(
+        app.notice
+            .as_deref()
+            .is_some_and(|value| value.contains("Approval is still preparing"))
     );
 }
 
@@ -269,6 +301,99 @@ fn auth_mode_picker_prefers_selection_navigation() {
     assert!(matches!(
         map_key_to_event(key(KeyCode::Char('3')), &app),
         AppEvent::SetAuthModeSelection(2)
+    ));
+}
+
+fn add_pending_shell_approval(app: &mut TuiApp) {
+    app.snapshot
+        .pending_interactions
+        .push(PendingInteractionSnapshot {
+            kind: InteractionKind::Approval,
+            title: "Pending Approval".into(),
+            summary: "git rebase --continue".into(),
+            options: Vec::new(),
+            note: None,
+            approval: Some(PendingApprovalSnapshot {
+                tool_use_id: "tool-1".into(),
+                command: "git rebase --continue".into(),
+                allow_net: false,
+                payload: Default::default(),
+            }),
+            source: None,
+        });
+}
+
+fn add_pending_request_input(app: &mut TuiApp, option_count: usize) {
+    app.snapshot
+        .pending_interactions
+        .push(PendingInteractionSnapshot {
+            kind: InteractionKind::RequestInput,
+            title: "Choose one".into(),
+            summary: String::new(),
+            options: (1..=option_count)
+                .map(|index| (format!("option {index}"), String::new()))
+                .collect(),
+            note: None,
+            approval: None,
+            source: None,
+        });
+}
+
+#[test]
+fn pending_shell_approval_number_shortcuts_work_in_local_and_ssh() {
+    for ssh in [false, true] {
+        let _ssh_env = super::terminal_ui::test_env::set_ssh_session(ssh);
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        add_pending_shell_approval(&mut app);
+
+        assert!(matches!(
+            map_key_to_event(key(KeyCode::Char('1')), &app),
+            AppEvent::SelectPendingOption(0)
+        ));
+        assert!(matches!(
+            map_key_to_event(key(KeyCode::Char('4')), &app),
+            AppEvent::SelectPendingOption(3)
+        ));
+    }
+}
+
+#[test]
+fn pending_shell_approval_does_not_render_as_request_input() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    add_pending_shell_approval(&mut app);
+
+    assert_eq!(
+        app.active_pending_interaction().map(|item| item.kind),
+        Some(super::state::ActivePendingInteractionKind::ShellApproval)
+    );
+    assert_eq!(app.active_pending_option_count(), 4);
+}
+
+#[test]
+fn request_input_shortcuts_match_advertised_three_options() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    add_pending_request_input(&mut app, 4);
+
+    assert_eq!(app.active_pending_option_count(), 3);
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Char('3')), &app),
+        AppEvent::SelectPendingOption(2)
+    ));
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Char('4')), &app),
+        AppEvent::InputChar('4')
     ));
 }
 


### PR DESCRIPTION
## Summary

- Keep bash command approval on the structured `ShellApproval` path instead of also creating generic request input.
- Fix pending-option shortcut routing so shell approval supports `1` through `4`, including deny.
- Add exact numeric submit fallback for pending interaction options.
- Cover both local and SSH shortcut mapping in tests.

## Motivation

The approval card could render as a generic `Request Input` card and show the wrong `1/2/3 shortcut` hint. In that state, typing `1` could look like it did nothing or be treated as composer input instead of approving the pending shell command.

## Testing

- `cargo fmt --check`
- `cargo test pending_shell_approval_number_shortcuts_work_in_local_and_ssh -- --nocapture`
- `cargo test pending_shell_approval_does_not_render_as_request_input -- --nocapture`
- `cargo test suggestion_mode_uses_escalated_sandbox_justification_for_approval -- --nocapture`
- `cargo check`
