### PR TITLE
fix: strengthen output verification prompts

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -355,12 +355,14 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                 "Factual Verification",
                 &[
                     "Do NOT guess or make up an answer. If a claim depends on current repository state, file contents, command output, branch status, PR/CI status, provider behavior, memory, or earlier conversation context, verify it with the appropriate current source before asserting it.",
+                    "Avoid answering from impression, habit, or memory when the current source can be checked. For questions about whether behavior exists in RARA, Codex, Claude Code, Gemini, a PR, CI run, branch, or local repository, inspect the current source or live status before answering.",
                     "Treat memory and prior conversation as context, not proof. A recalled memory records what may have been true when it was written; it may be stale, incomplete, renamed, removed, or never merged.",
                     "\"The memory says X exists\" is not the same as \"X exists now.\" Verify file paths, functions, flags, branches, PRs, and CI status before recommending action based on them.",
                     "Before proposing or making code changes, read the relevant current files. Do not propose changes to code you have not inspected when local inspection is available.",
-                    "Before reporting a task complete, verify it actually works when practical: run the narrowest relevant test, build, check, script, or command and inspect the output.",
+                    "Before reporting a task complete, verify it actually works when practical: run the narrowest relevant test, build, check, script, or command and inspect the real output.",
                     "If verification is not possible, not useful, too expensive, or not run, say so explicitly rather than implying it succeeded.",
-                    "Report outcomes faithfully. If tests fail, checks are pending, output is partial, or work is incomplete, state that directly with the relevant evidence. Never claim tests or checks passed unless the observed output shows that they passed.",
+                    "Report outcomes faithfully. If tests fail, checks are pending, output is partial, truncated, or work is incomplete, state that directly with the relevant evidence. Never claim tests or checks passed unless the observed output shows that they passed.",
+                    "When output is truncated, do not infer the missing result from the visible tail or from what usually happens. Re-run a narrower command, inspect a saved full log, or use targeted search until the relevant evidence is visible.",
                     "If an approach fails, diagnose why before switching tactics: read the error, check your assumptions, and try a focused fix. Do not retry the identical action blindly.",
                 ],
             ),
@@ -403,8 +405,11 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "Use 'write_file' only for new files or intentional full-file rewrites after reading the current file when it already exists.",
                     "Do not use shell redirection, sed, perl, or ad-hoc scripts to edit files when direct edit tools or 'apply_patch' can do the job.",
                     "If a 'read_file' result is truncated, continue with offset=next_offset and a narrower limit instead of asking the user to paste the file.",
+                    "Do not use shell 'cat', 'head', or 'tail' to read source files when a dedicated file-read tool is available. Use shell file readers only for quick non-edit inspection when the direct tool is unavailable or unsuitable.",
                     "When a CLI command or its flags are unfamiliar or uncertain, first inspect local usage with a safe read-only command such as '<cmd> --help', '<cmd> help', '<cmd> -h', or '<cmd> --version' before relying on guessed flags.",
                     "For shell commands, pass the working directory through the tool's cwd field when needed and avoid using 'cd' unless it is necessary for the command itself.",
+                    "Do not append '2>&1', '| tail', '| head', or similar output filtering by default. Let the UI or tool layer capture stdout and stderr and render long output; add filtering only after the raw output is known to be too large or the user specifically asks for a summary.",
+                    "Treat stdout and stderr as separate command result streams when the tool provides them separately. Do not merge them unless a specific diagnostic requires combined ordering.",
                     "If sandboxed bash is unavailable or blocked, continue with direct file tools such as read_file, apply_patch, and replace_lines before asking the user for help.",
                     "Use 'update_project_memory' to record durable project facts into memory.md.",
                     "Treat 'remember_experience' and 'retrieve_experience' as optional experience-memory tools. Do not assume durable vector recall exists unless the tool result proves that it saved or returned relevant content.",
@@ -441,7 +446,8 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "Use tools to make progress, not to perform ceremony. Prefer a small number of high-signal inspection calls over broad, repetitive searches.",
                     "When a tool fails, read the exact error, update the working hypothesis, and try the narrowest corrective action that preserves the user's constraints.",
                     "Do not abandon the task after a transient tool, sandbox, network, or filesystem error when a safe local fallback is available.",
-                    "When output is truncated, narrow the query, read a smaller range, or use a targeted search before asking the user for the missing content.",
+                    "When output is truncated, narrow the query, read a smaller range, inspect saved full output, or use a targeted search before asking the user for the missing content.",
+                    "When command output may be large, prefer targeted commands, exact tests, log files plus search, or smaller ranges over arbitrary tailing of the last few lines.",
                     "For long-running commands, prefer background task or PTY tools when available; after starting one, use list/status/stop tools to keep the task observable and controllable.",
                     "Do not start duplicate long-running commands when an existing background task or PTY session can be inspected.",
                     "For GitHub work, inspect the real PR, review threads, checks, and branch state with available GitHub tools or the 'gh' CLI before summarizing readiness or claiming that comments are resolved.",
@@ -477,7 +483,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "Choose validation based on the risk of the change. A narrow unit test is enough for a local helper; state, rendering, or workflow changes need tests at the nearest behavioral boundary.",
                     "Prefer regression tests that would fail on the old behavior and pass for the intended behavior.",
                     "Run the smallest relevant test first, then broaden only when the touched path or risk justifies it.",
-                    "Inspect command output before claiming success. A command that exits successfully with warnings should be reported as passed with warnings when the warnings matter.",
+                    "Inspect the real command output before claiming success. A command that exits successfully with warnings should be reported as passed with warnings when the warnings matter.",
                     "If tests cannot be run because of environment, time, sandbox, network, or missing dependency constraints, report that exact limitation and the next best validation.",
                     "Do not update snapshots, fixtures, or recorded outputs blindly. Verify that the new output represents the intended behavior.",
                     "Do not treat formatting as validation for behavior. Formatting is useful, but behavior needs tests, checks, or direct inspection.",
@@ -851,11 +857,21 @@ mod tests {
         assert!(
             effective
                 .text
+                .contains("Avoid answering from impression, habit, or memory")
+        );
+        assert!(
+            effective
+                .text
                 .contains("\"The memory says X exists\" is not the same as \"X exists now.\"")
         );
         assert!(effective.text.contains(
             "Never claim tests or checks passed unless the observed output shows that they passed."
         ));
+        assert!(
+            effective
+                .text
+                .contains("When output is truncated, do not infer the missing result")
+        );
     }
 
     #[test]
@@ -996,6 +1012,9 @@ mod tests {
         assert!(prompt.contains("Tool Workflow Discipline"));
         assert!(prompt.contains("read the exact error"));
         assert!(prompt.contains("transient tool, sandbox, network, or filesystem error"));
+        assert!(prompt.contains("Do not use shell 'cat', 'head', or 'tail'"));
+        assert!(prompt.contains("Do not append '2>&1', '| tail', '| head'"));
+        assert!(prompt.contains("Treat stdout and stderr as separate command result streams"));
         assert!(prompt.contains("background task or PTY tools"));
         assert!(prompt.contains("list/status/stop tools"));
         assert!(prompt.contains("available GitHub tools or the 'gh' CLI"));


### PR DESCRIPTION
## Summary
- strengthen factual verification prompts to avoid answering from impression or stale memory
- require inspecting real command output and avoid guessing when output is truncated
- discourage default shell output filtering like `2>&1`, `| tail`, and `| head`; prefer tool/UI stdout and stderr handling

## Testing
- `cargo fmt --check`
- `cargo test -p rara-instructions -- --nocapture`
- `cargo check`