### PR TITLE
fix: add bash aggregated output contract

### DIFF
--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -37,6 +37,10 @@ The transcript should move toward Codex/Claude-style tool visibility:
     clear sandbox failure evidence;
   - use background task controls for long-running non-interactive commands.
 - The final `bash` tool result should keep the exit code and avoid duplicating large output that was already streamed live.
+- The final foreground `bash` tool result must expose `stdout`, `stderr`,
+  `aggregated_output`, `exit_code`, and `duration_ms`. The model-facing compact
+  result should prefer `aggregated_output` so command failure diagnosis uses the
+  real captured output instead of requiring shell-side `2>&1` redirection.
 - When shell execution pauses on a human approval request, the approval card should take visual priority over older live stdout/stderr progress from the same turn.
 - Approval choices should describe both the action and its scope, such as:
   - allow only the current command;

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -36,11 +36,15 @@ The transcript should move toward Codex/Claude-style tool visibility:
   - keep commands sandboxed unless escalation is justified by user request or
     clear sandbox failure evidence;
   - use background task controls for long-running non-interactive commands.
-- The final `bash` tool result should keep the exit code and avoid duplicating large output that was already streamed live.
-- The final foreground `bash` tool result must expose `stdout`, `stderr`,
-  `aggregated_output`, `exit_code`, and `duration_ms`. The model-facing compact
-  result should prefer `aggregated_output` so command failure diagnosis uses the
-  real captured output instead of requiring shell-side `2>&1` redirection.
+- The final `bash` transcript row should keep the exit code and avoid
+  duplicating large output that was already streamed live; when live streaming
+  was shown, the rendered row should use a compact summary or truncated preview
+  rather than reprinting the full output block.
+- The final foreground `bash` tool-result payload must still expose `stdout`,
+  `stderr`, `aggregated_output`, `exit_code`, and `duration_ms`. When a compact
+  model-facing rendering is needed, it should prefer `aggregated_output` as the
+  source for any preview/summary so command failure diagnosis uses the real
+  captured output without requiring shell-side `2>&1` redirection.
 - When shell execution pauses on a human approval request, the approval card should take visual priority over older live stdout/stderr progress from the same turn.
 - Approval choices should describe both the action and its scope, such as:
   - allow only the current command;

--- a/docs/journal/2026-05-01-terminal-tool-schema-prompts.md
+++ b/docs/journal/2026-05-01-terminal-tool-schema-prompts.md
@@ -22,6 +22,9 @@ shell execution.
 - Strengthened the `bash` tool description and input schema with command
   discipline for dedicated tools, `cwd`, sandbox escalation, background tasks,
   and shell-edit avoidance.
+- Added a Codex-style foreground Bash result contract: raw results now include
+  `aggregated_output` and `duration_ms`, and model-facing compaction renders a
+  stable exit-code, duration, and output block from the captured result.
 - Strengthened background task tool descriptions so models know to inspect or
   stop long-running work instead of starting duplicates.
 - Strengthened `pty_start` and PTY control descriptions so PTY is reserved for
@@ -33,4 +36,6 @@ shell execution.
 - `cargo test bash_tool_schema_guides_command_discipline -- --nocapture`
 - `cargo test background_task_tool_descriptions_point_to_run_in_background -- --nocapture`
 - `cargo test pty_tool_schema_guides_interactive_command_discipline -- --nocapture`
+- `cargo test streaming_call_reports_stdout_and_stderr_chunks -- --nocapture`
+- `cargo test compacts_bash_results_with_exit_code_duration_and_aggregated_output -- --nocapture`
 - `cargo check`

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -339,6 +339,25 @@ fn compact_generic(summary: &str, result: &Value) -> String {
 }
 
 fn compact_bash(result: &Value) -> String {
+    if let Some(task_id) = result.get("background_task_id").and_then(Value::as_str) {
+        let status = result
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let output_path = result
+            .get("output_path")
+            .and_then(Value::as_str)
+            .unwrap_or("<unknown>");
+        let exit_code = result
+            .get("exit_code")
+            .and_then(Value::as_i64)
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "pending".to_string());
+        return format!(
+            "bash started in background.\nTask id: {task_id}\nStatus: {status}\nExit code: {exit_code}\nOutput path: {output_path}\nUse background_task_status with this task id to inspect output."
+        );
+    }
+
     let exit_code = result
         .get("exit_code")
         .and_then(Value::as_i64)
@@ -907,6 +926,32 @@ mod tests {
             .expect("compact bash result");
 
         assert!(output.contains("stdout-without-newline\n[stderr] stderr-line"));
+    }
+
+    #[test]
+    fn compacts_background_bash_with_task_id() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let store = ToolResultStore::new(tempdir.path()).expect("store");
+        let output = store
+            .compact_result(
+                "bash",
+                "tool-bash",
+                &json!({ "program": "sh", "run_in_background": true }),
+                &json!({
+                    "background_task_id": "bash-123",
+                    "status": "running",
+                    "output_path": "/tmp/rara/bash-123.log",
+                    "exit_code": null,
+                    "stdout": "",
+                    "stderr": "",
+                }),
+            )
+            .expect("compact background bash result");
+
+        assert!(output.contains("bash started in background."));
+        assert!(output.contains("Task id: bash-123"));
+        assert!(output.contains("Status: running"));
+        assert!(output.contains("background_task_status"));
     }
 
     #[test]

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -363,7 +363,10 @@ fn compact_bash(result: &Value) -> String {
                 (true, true) => String::new(),
                 (false, true) => stdout.to_string(),
                 (true, false) => format!("[stderr] {stderr}"),
-                (false, false) => format!("{stdout}[stderr] {stderr}"),
+                (false, false) => {
+                    let separator = if stdout.ends_with('\n') { "" } else { "\n" };
+                    format!("{stdout}{separator}[stderr] {stderr}")
+                }
             }
         });
     let mut rendered = format!("bash finished.\nExit code: {exit_code}");
@@ -883,6 +886,27 @@ mod tests {
         assert!(output.contains("Output:\nchecking\n[stderr] warning"));
         assert!(!output.contains("stdout-only"));
         assert!(!output.contains("stderr-only"));
+    }
+
+    #[test]
+    fn compacts_bash_fallback_separates_stdout_and_stderr() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let store = ToolResultStore::new(tempdir.path()).expect("store");
+        let output = store
+            .compact_result(
+                "bash",
+                "tool-bash",
+                &json!({ "program": "sh" }),
+                &json!({
+                    "stdout": "stdout-without-newline",
+                    "stderr": "stderr-line\n",
+                    "exit_code": 1,
+                    "duration_ms": 10,
+                }),
+            )
+            .expect("compact bash result");
+
+        assert!(output.contains("stdout-without-newline\n[stderr] stderr-line"));
     }
 
     #[test]

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -33,6 +33,7 @@ impl ToolResultStore {
     ) -> Result<String> {
         let summary = summarize_tool_result(tool_name, input, result);
         let inline = match tool_name {
+            "bash" => compact_bash(result),
             "apply_patch" => compact_apply_patch(result),
             "write_file" => compact_write_file(result),
             "replace" => compact_replace(input, result),
@@ -335,6 +336,43 @@ fn compact_generic(summary: &str, result: &Value) -> String {
         "{summary}\nPayload:\n{}",
         truncate_text(&rendered, LARGE_PREVIEW_HEAD)
     )
+}
+
+fn compact_bash(result: &Value) -> String {
+    let exit_code = result
+        .get("exit_code")
+        .and_then(Value::as_i64)
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let duration_ms = result.get("duration_ms").and_then(Value::as_u64);
+    let output = result
+        .get("aggregated_output")
+        .and_then(Value::as_str)
+        .filter(|output| !output.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            let stdout = result
+                .get("stdout")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let stderr = result
+                .get("stderr")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            match (stdout.is_empty(), stderr.is_empty()) {
+                (true, true) => String::new(),
+                (false, true) => stdout.to_string(),
+                (true, false) => format!("[stderr] {stderr}"),
+                (false, false) => format!("{stdout}[stderr] {stderr}"),
+            }
+        });
+    let mut rendered = format!("bash finished.\nExit code: {exit_code}");
+    if let Some(duration_ms) = duration_ms {
+        rendered.push_str(&format!("\nDuration: {duration_ms} ms"));
+    }
+    rendered.push_str("\nOutput:\n");
+    rendered.push_str(&output);
+    rendered
 }
 
 fn compact_write_file(result: &Value) -> String {
@@ -815,6 +853,36 @@ mod tests {
                 .expect("default tool result dir")
                 .ends_with(std::path::Path::new("tool-results"))
         );
+    }
+
+    #[test]
+    fn compacts_bash_results_with_exit_code_duration_and_aggregated_output() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let store = ToolResultStore::new(tempdir.path()).expect("store");
+        let output = store
+            .compact_result(
+                "bash",
+                "tool-bash",
+                &json!({ "program": "cargo", "args": ["check"] }),
+                &json!({
+                    "stdout": "stdout-only\n",
+                    "stderr": "stderr-only\n",
+                    "aggregated_output": "checking\n[stderr] warning\n",
+                    "exit_code": 101,
+                    "duration_ms": 1234,
+                    "live_streamed": true,
+                    "sandboxed": true,
+                    "sandbox_backend": "macos-seatbelt"
+                }),
+            )
+            .expect("compact bash result");
+
+        assert!(output.contains("bash finished."));
+        assert!(output.contains("Exit code: 101"));
+        assert!(output.contains("Duration: 1234 ms"));
+        assert!(output.contains("Output:\nchecking\n[stderr] warning"));
+        assert!(!output.contains("stdout-only"));
+        assert!(!output.contains("stderr-only"));
     }
 
     #[test]

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -381,10 +381,10 @@ fn compact_bash(result: &Value) -> String {
             match (stdout.is_empty(), stderr.is_empty()) {
                 (true, true) => String::new(),
                 (false, true) => stdout.to_string(),
-                (true, false) => format!("[stderr] {stderr}"),
+                (true, false) => prefix_stderr_lines(stderr),
                 (false, false) => {
                     let separator = if stdout.ends_with('\n') { "" } else { "\n" };
-                    format!("{stdout}{separator}[stderr] {stderr}")
+                    format!("{stdout}{separator}{}", prefix_stderr_lines(stderr))
                 }
             }
         });
@@ -395,6 +395,13 @@ fn compact_bash(result: &Value) -> String {
     rendered.push_str("\nOutput:\n");
     rendered.push_str(&output);
     rendered
+}
+
+fn prefix_stderr_lines(stderr: &str) -> String {
+    stderr
+        .split_inclusive('\n')
+        .map(|line| format!("[stderr] {line}"))
+        .collect()
 }
 
 fn compact_write_file(result: &Value) -> String {
@@ -926,6 +933,27 @@ mod tests {
             .expect("compact bash result");
 
         assert!(output.contains("stdout-without-newline\n[stderr] stderr-line"));
+    }
+
+    #[test]
+    fn compacts_bash_fallback_prefixes_each_stderr_line() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let store = ToolResultStore::new(tempdir.path()).expect("store");
+        let output = store
+            .compact_result(
+                "bash",
+                "tool-bash",
+                &json!({ "program": "sh" }),
+                &json!({
+                    "stdout": "",
+                    "stderr": "first\nsecond\n",
+                    "exit_code": 1,
+                    "duration_ms": 10,
+                }),
+            )
+            .expect("compact bash result");
+
+        assert!(output.contains("[stderr] first\n[stderr] second\n"));
     }
 
     #[test]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -66,7 +66,7 @@ pub enum BackgroundTaskStatus {
     Killed,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum BashStreamKind {
     Stdout,
     Stderr,
@@ -923,11 +923,17 @@ impl Tool for BashTool {
         let mut stdout_text = String::new();
         let mut stderr_text = String::new();
         let mut aggregated_output = String::new();
+        let mut aggregated_output_stream = None;
         let mut live_streamed = false;
         if !wrapped.sandboxed {
             let chunk = unsandboxed_execution_warning(&wrapped);
             stderr_text.push_str(&chunk);
-            append_aggregated_bash_output(&mut aggregated_output, BashStreamKind::Stderr, &chunk);
+            append_aggregated_bash_output(
+                &mut aggregated_output,
+                &mut aggregated_output_stream,
+                BashStreamKind::Stderr,
+                &chunk,
+            );
             live_streamed = true;
             report(ToolProgressEvent::Output {
                 stream: ToolOutputStream::Stderr,
@@ -943,7 +949,12 @@ impl Tool for BashTool {
                 BashStreamKind::Stdout => stdout_text.push_str(&chunk),
                 BashStreamKind::Stderr => stderr_text.push_str(&chunk),
             }
-            append_aggregated_bash_output(&mut aggregated_output, stream, &chunk);
+            append_aggregated_bash_output(
+                &mut aggregated_output,
+                &mut aggregated_output_stream,
+                stream,
+                &chunk,
+            );
             report(ToolProgressEvent::Output {
                 stream: stream.output_stream(),
                 chunk,
@@ -963,7 +974,12 @@ impl Tool for BashTool {
         if wrapped.sandboxed {
             if let Some(hint) = sandbox_output_hint(&stderr_text) {
                 stderr_text.push_str(hint);
-                append_aggregated_bash_output(&mut aggregated_output, BashStreamKind::Stderr, hint);
+                append_aggregated_bash_output(
+                    &mut aggregated_output,
+                    &mut aggregated_output_stream,
+                    BashStreamKind::Stderr,
+                    hint,
+                );
             }
         }
         let duration_ms = started_at.elapsed().as_millis() as u64;
@@ -1263,6 +1279,7 @@ where
 
 fn append_aggregated_bash_output(
     aggregated_output: &mut String,
+    last_stream: &mut Option<BashStreamKind>,
     stream: BashStreamKind,
     chunk: &str,
 ) {
@@ -1272,6 +1289,12 @@ fn append_aggregated_bash_output(
     match stream {
         BashStreamKind::Stdout => aggregated_output.push_str(chunk),
         BashStreamKind::Stderr => {
+            if !aggregated_output.is_empty()
+                && !aggregated_output.ends_with('\n')
+                && !matches!(last_stream, Some(BashStreamKind::Stderr))
+            {
+                aggregated_output.push('\n');
+            }
             for line in chunk.split_inclusive('\n') {
                 if aggregated_output.is_empty() || aggregated_output.ends_with('\n') {
                     aggregated_output.push_str("[stderr] ");
@@ -1280,6 +1303,7 @@ fn append_aggregated_bash_output(
             }
         }
     }
+    *last_stream = Some(stream);
 }
 
 fn sandbox_output_hint(stderr: &str) -> Option<&'static str> {
@@ -1847,11 +1871,47 @@ mod tests {
     #[test]
     fn aggregated_stderr_prefixes_only_line_boundaries() {
         let mut output = String::new();
-        append_aggregated_bash_output(&mut output, BashStreamKind::Stderr, "partial");
-        append_aggregated_bash_output(&mut output, BashStreamKind::Stderr, "-line\nnext");
-        append_aggregated_bash_output(&mut output, BashStreamKind::Stderr, "-line\n");
+        let mut last_stream = None;
+        append_aggregated_bash_output(
+            &mut output,
+            &mut last_stream,
+            BashStreamKind::Stderr,
+            "partial",
+        );
+        append_aggregated_bash_output(
+            &mut output,
+            &mut last_stream,
+            BashStreamKind::Stderr,
+            "-line\nnext",
+        );
+        append_aggregated_bash_output(
+            &mut output,
+            &mut last_stream,
+            BashStreamKind::Stderr,
+            "-line\n",
+        );
 
         assert_eq!(output, "[stderr] partial-line\n[stderr] next-line\n");
+    }
+
+    #[test]
+    fn aggregated_stderr_starts_on_new_line_after_stdout() {
+        let mut output = String::new();
+        let mut last_stream = None;
+        append_aggregated_bash_output(
+            &mut output,
+            &mut last_stream,
+            BashStreamKind::Stdout,
+            "stdout-without-newline",
+        );
+        append_aggregated_bash_output(
+            &mut output,
+            &mut last_stream,
+            BashStreamKind::Stderr,
+            "stderr-line\n",
+        );
+
+        assert_eq!(output, "stdout-without-newline\n[stderr] stderr-line\n");
     }
 
     #[tokio::test]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Instant;
 use tokio::fs;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
@@ -858,6 +859,7 @@ impl Tool for BashTool {
             .envs(&command_env)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        let started_at = Instant::now();
         let mut child = command.spawn().map_err(|err| {
             if wrapped.sandboxed {
                 ToolError::ExecutionFailed(format!(
@@ -920,10 +922,12 @@ impl Tool for BashTool {
 
         let mut stdout_text = String::new();
         let mut stderr_text = String::new();
+        let mut aggregated_output = String::new();
         let mut live_streamed = false;
         if !wrapped.sandboxed {
             let chunk = unsandboxed_execution_warning(&wrapped);
             stderr_text.push_str(&chunk);
+            append_aggregated_bash_output(&mut aggregated_output, BashStreamKind::Stderr, &chunk);
             live_streamed = true;
             report(ToolProgressEvent::Output {
                 stream: ToolOutputStream::Stderr,
@@ -939,6 +943,7 @@ impl Tool for BashTool {
                 BashStreamKind::Stdout => stdout_text.push_str(&chunk),
                 BashStreamKind::Stderr => stderr_text.push_str(&chunk),
             }
+            append_aggregated_bash_output(&mut aggregated_output, stream, &chunk);
             report(ToolProgressEvent::Output {
                 stream: stream.output_stream(),
                 chunk,
@@ -958,13 +963,17 @@ impl Tool for BashTool {
         if wrapped.sandboxed {
             if let Some(hint) = sandbox_output_hint(&stderr_text) {
                 stderr_text.push_str(hint);
+                append_aggregated_bash_output(&mut aggregated_output, BashStreamKind::Stderr, hint);
             }
         }
+        let duration_ms = started_at.elapsed().as_millis() as u64;
 
         Ok(json!({
             "stdout": stdout_text,
             "stderr": stderr_text,
+            "aggregated_output": aggregated_output,
             "exit_code": status.code(),
+            "duration_ms": duration_ms,
             "live_streamed": live_streamed,
             "sandboxed": wrapped.sandboxed,
             "sandbox_backend": wrapped.sandbox_backend,
@@ -1250,6 +1259,26 @@ where
         }
     }
     Ok(())
+}
+
+fn append_aggregated_bash_output(
+    aggregated_output: &mut String,
+    stream: BashStreamKind,
+    chunk: &str,
+) {
+    if chunk.is_empty() {
+        return;
+    }
+    match stream {
+        BashStreamKind::Stdout => aggregated_output.push_str(chunk),
+        BashStreamKind::Stderr => {
+            aggregated_output.push_str("[stderr] ");
+            aggregated_output.push_str(chunk);
+            if !chunk.ends_with('\n') {
+                aggregated_output.push('\n');
+            }
+        }
+    }
 }
 
 fn sandbox_output_hint(stderr: &str) -> Option<&'static str> {
@@ -1723,6 +1752,11 @@ mod tests {
             Some("direct")
         );
         assert_eq!(result.get("stdout").and_then(Value::as_str), Some("direct"));
+        assert_eq!(
+            result.get("aggregated_output").and_then(Value::as_str),
+            Some("direct")
+        );
+        assert!(result.get("duration_ms").and_then(Value::as_u64).is_some());
         assert!(
             result
                 .get("stderr")
@@ -1798,6 +1832,13 @@ mod tests {
             result.get("sandbox_backend").and_then(Value::as_str),
             Some(wrapped.sandbox_backend.as_str())
         );
+        let aggregated_output = result
+            .get("aggregated_output")
+            .and_then(Value::as_str)
+            .expect("aggregated output");
+        assert!(aggregated_output.contains("out"));
+        assert!(aggregated_output.contains("[stderr] err"));
+        assert!(result.get("duration_ms").and_then(Value::as_u64).is_some());
     }
     #[tokio::test]
     async fn background_call_returns_task_and_status_reads_output() {

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -1753,10 +1753,12 @@ mod tests {
             Some("direct")
         );
         assert_eq!(result.get("stdout").and_then(Value::as_str), Some("direct"));
-        assert_eq!(
-            result.get("aggregated_output").and_then(Value::as_str),
-            Some("direct")
-        );
+        let aggregated_output = result
+            .get("aggregated_output")
+            .and_then(Value::as_str)
+            .expect("aggregated output");
+        assert!(aggregated_output.contains("direct"));
+        assert!(aggregated_output.contains("without sandbox isolation"));
         assert!(result.get("duration_ms").and_then(Value::as_u64).is_some());
         assert!(
             result

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -1272,10 +1272,11 @@ fn append_aggregated_bash_output(
     match stream {
         BashStreamKind::Stdout => aggregated_output.push_str(chunk),
         BashStreamKind::Stderr => {
-            aggregated_output.push_str("[stderr] ");
-            aggregated_output.push_str(chunk);
-            if !chunk.ends_with('\n') {
-                aggregated_output.push('\n');
+            for line in chunk.split_inclusive('\n') {
+                if aggregated_output.is_empty() || aggregated_output.ends_with('\n') {
+                    aggregated_output.push_str("[stderr] ");
+                }
+                aggregated_output.push_str(line);
             }
         }
     }
@@ -1323,8 +1324,8 @@ mod tests {
     use super::{
         BackgroundTaskListTool, BackgroundTaskStatus, BackgroundTaskStatusTool,
         BackgroundTaskStopTool, BackgroundTaskStore, BashCommandInput, BashSandboxPermissions,
-        BashTool, command_env_for_wrapped, read_output_tail, sandbox_command_env,
-        sandbox_output_hint, unsandboxed_execution_warning,
+        BashStreamKind, BashTool, append_aggregated_bash_output, command_env_for_wrapped,
+        read_output_tail, sandbox_command_env, sandbox_output_hint, unsandboxed_execution_warning,
     };
     use crate::sandbox::{SandboxManager, WrappedCommand};
     use crate::tool::{Tool, ToolOutputStream, ToolProgressEvent};
@@ -1840,6 +1841,17 @@ mod tests {
         assert!(aggregated_output.contains("[stderr] err"));
         assert!(result.get("duration_ms").and_then(Value::as_u64).is_some());
     }
+
+    #[test]
+    fn aggregated_stderr_prefixes_only_line_boundaries() {
+        let mut output = String::new();
+        append_aggregated_bash_output(&mut output, BashStreamKind::Stderr, "partial");
+        append_aggregated_bash_output(&mut output, BashStreamKind::Stderr, "-line\nnext");
+        append_aggregated_bash_output(&mut output, BashStreamKind::Stderr, "-line\n");
+
+        assert_eq!(output, "[stderr] partial-line\n[stderr] next-line\n");
+    }
+
     #[tokio::test]
     async fn background_call_returns_task_and_status_reads_output() {
         let temp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary
- add foreground bash `aggregated_output` and `duration_ms` fields alongside stdout/stderr/exit_code
- render bash tool results for the model as a stable exit-code, duration, and output block
- document the shell result contract in the tool transcript spec and journal

## Testing
- `cargo fmt --check`
- `cargo test streaming_call_reports_stdout_and_stderr_chunks -- --nocapture`
- `cargo test compacts_bash_results_with_exit_code_duration_and_aggregated_output -- --nocapture`
- `cargo test tui::runtime::events::tests::formats_bash -- --nocapture`
- `cargo check`