### PR TITLE
fix: honor approved prefixes for escalated bash

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -639,9 +639,7 @@ impl Agent {
                 && (request.requires_escalated_permissions()
                     || matches!(self.bash_approval_mode, BashApprovalMode::Suggestion))
             {
-                if !request.requires_escalated_permissions()
-                    && (request.is_read_only() || self.is_bash_prefix_approved(request))
-                {
+                if request.is_read_only() || self.is_bash_prefix_approved(request) {
                     report(AgentEvent::Status(format!(
                         "Shell command allowed by policy: {}",
                         request.summary()

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -157,9 +157,6 @@ impl Agent {
     }
 
     pub fn is_bash_prefix_approved(&self, request: &BashCommandInput) -> bool {
-        if request.requires_escalated_permissions() {
-            return false;
-        }
         self.approved_bash_prefixes
             .iter()
             .any(|prefix| request.matches_approval_prefix(prefix))

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -421,21 +421,30 @@ async fn always_mode_still_requires_approval_for_escalated_sandbox_request() {
 }
 
 #[tokio::test]
-async fn approved_sandboxed_prefix_does_not_auto_allow_escalated_request() {
-    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
-        content: vec![ContentBlock::ToolUse {
-            id: "tool-escalated-bash".to_string(),
-            name: "bash".to_string(),
-            input: json!({
-                "program": "cargo",
-                "args": ["check"],
-                "sandbox_permissions": "require_escalated",
-                "prefix_rule": ["cargo", "check"]
-            }),
-        }],
-        stop_reason: Some("tool_use".to_string()),
-        usage: Some(TokenUsage::default()),
-    }]));
+async fn approved_prefix_auto_allows_matching_escalated_request() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "tool-escalated-bash".to_string(),
+                name: "bash".to_string(),
+                input: json!({
+                    "program": "cargo",
+                    "args": ["check"],
+                    "sandbox_permissions": "require_escalated",
+                    "prefix_rule": ["cargo", "check"]
+                }),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "done".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
     let mut tool_manager = ToolManager::new();
     tool_manager.register(Box::new(StubBashTool));
     let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
@@ -455,10 +464,10 @@ async fn approved_sandboxed_prefix_does_not_auto_allow_escalated_request() {
             super::super::AgentOutputMode::Silent,
         )
         .await
-        .expect("query should pause on escalated bash approval");
+        .expect("query should auto-allow escalated bash by approved prefix");
 
-    assert!(agent.pending_approval.is_some());
-    assert_eq!(backend.observed_messages().len(), 1);
+    assert!(agent.pending_approval.is_none());
+    assert_eq!(backend.observed_messages().len(), 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Allow approved bash prefixes to match escalated sandbox requests.
- Keep escalated commands without a matching approved prefix on the structured approval path.
- Add a regression test for approved prefix reuse on escalated bash commands.

## Testing

- `cargo test agent::tests::planning`
- `git diff --check`
