### PR TITLE
fix: modularize queued follow-up UI

### DIFF
--- a/crates/instructions/src/workspace.rs
+++ b/crates/instructions/src/workspace.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use crate::prompt::{PromptSource, PromptSourceKind};
+use anyhow::Result;
 use rara_config::workspace_data_dir_for;
 use std::collections::HashMap;
 use std::fs;

--- a/crates/instructions/src/workspace.rs
+++ b/crates/instructions/src/workspace.rs
@@ -1,5 +1,5 @@
-use crate::prompt::{PromptSource, PromptSourceKind};
 use anyhow::Result;
+use crate::prompt::{PromptSource, PromptSourceKind};
 use rara_config::workspace_data_dir_for;
 use std::collections::HashMap;
 use std::fs;

--- a/docs/features/context-architecture.md
+++ b/docs/features/context-architecture.md
@@ -218,6 +218,11 @@ still letting `/context` explain:
   the same need;
 - which candidates were dropped because the selection budget was exhausted.
 
+The assembler should preserve that ownership split. Fixed items may appear in
+the `MemorySelection` explanation, but they should not be re-emitted under the
+`active_memory_inputs` assembly layer. That layer is reserved for discretionary
+retrieval candidates that actually won selection for this turn.
+
 This lets `/context` explain:
 
 - what won the current memory budget;

--- a/docs/features/memory-selection.md
+++ b/docs/features/memory-selection.md
@@ -128,6 +128,12 @@ Fixed selected items do not compete for the discretionary retrieval budget. They
 are listed in `MemorySelection` so `/context` can explain them, not so retrieval
 can re-rank them after ownership has already selected them.
 
+Fixed selected items also remain owned by their original assembly layers.
+Workspace memory stays under prompt sources, compacted carry-over stays under
+compacted history, and active thread state stays under active turn state.
+`ContextAssemblyView` should only place newly selected discretionary retrieval
+items in `active_memory_inputs`.
+
 ### Available Items
 
 Available items are candidates that can be considered or recalled, but are not

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -61,8 +61,8 @@ The transcript should move toward Codex/Claude-style tool visibility:
   commands biased toward the tail so error diagnostics remain visible without
   requiring shell-side `2>&1` redirection.
 - Oversized tool results should be persisted to disk and replaced in model
-  context with a `<persisted-output>` message containing the path and a bounded
-  preview. The full JSON payload remains inspectable from that path.
+  context with a bounded preview plus the display-oriented continuation lines
+  described below. The full JSON payload remains inspectable from that path.
 - A single tool-result batch should enforce an aggregate model-facing budget so
   parallel tool calls cannot combine many individually acceptable results into
   one oversized follow-up turn. The final compacted batch must fit the aggregate
@@ -78,10 +78,11 @@ The transcript should move toward Codex/Claude-style tool visibility:
   - `[tool_result truncated]`
   - `full result: <path>`
 
-  Internal key/value markers such as `full_result_path=<path>` may remain
-  readable for backward compatibility, but new model-facing compact results
-  should use the display contract above. This keeps final transcript rows
-  human-readable while preserving a stable path for full output inspection.
+  Legacy wrappers or key/value markers such as `<persisted-output>` or
+  `full_result_path=<path>` may remain readable for backward compatibility, but
+  new model-facing compact results should use the display contract above. This
+  keeps final transcript rows human-readable while preserving a stable path for
+  full output inspection.
 - When shell execution pauses on a human approval request, the approval card should take visual priority over older live stdout/stderr progress from the same turn.
 - Approval choices should describe both the action and its scope, such as:
   - allow only the current command;

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -67,6 +67,21 @@ The transcript should move toward Codex/Claude-style tool visibility:
   parallel tool calls cannot combine many individually acceptable results into
   one oversized follow-up turn. The final compacted batch must fit the aggregate
   budget, not only shorten the first oversized item encountered.
+- Compact shell results must be composable at the source. The compact `bash`
+  status line should describe only the process outcome, such as `finished with
+  exit code 0` or `failed with exit code 101`; renderer layers may prepend the
+  tool name when needed. Source compactors should not emit `bash finished`
+  because that forces downstream renderers either to duplicate the tool name or
+  to carry bash-specific string cleanup.
+- Persisted oversized tool results should expose a display-oriented continuation
+  line:
+  - `[tool_result truncated]`
+  - `full result: <path>`
+
+  Internal key/value markers such as `full_result_path=<path>` may remain
+  readable for backward compatibility, but new model-facing compact results
+  should use the display contract above. This keeps final transcript rows
+  human-readable while preserving a stable path for full output inspection.
 - When shell execution pauses on a human approval request, the approval card should take visual priority over older live stdout/stderr progress from the same turn.
 - Approval choices should describe both the action and its scope, such as:
   - allow only the current command;
@@ -113,9 +128,49 @@ The transcript should move toward Codex/Claude-style tool visibility:
 - If a follow-up is entered during a query turn, it first waits for the next tool/result boundary.
 - Once that boundary is crossed, the message is promoted into the ordinary end-of-turn queue.
 - If the turn finishes before another boundary appears, the pending follow-up is promoted at turn completion.
-- The bottom pane should render the two queues separately:
+- If a shell approval, plan approval, or other pending interaction is active,
+  plain text submitted from the composer is queued as a follow-up instead of
+  starting a new model turn. Request-input prompts remain answer paths, and
+  numeric shortcuts remain option-selection paths.
+- Queued follow-up visibility belongs in the active transcript, not in the
+  composer body. The composer remains the input surface and may show only a
+  short hint.
+- The active transcript should render queued follow-up state as a dedicated
+  status cell after any pending interaction card. This preserves option
+  visibility for approval cards and keeps queued user input in chronological
+  turn context.
+- The queued status cell should render the two queues separately:
   - `Messages to be submitted after next tool call`
   - `Queued follow-up messages`
+
+### TUI modular rendering boundary
+
+The TUI should keep input state, display data, and visual cells separate:
+
+- State modules own queue and interaction state. They should not encode Ratatui
+  lines, spans, colors, or layout decisions.
+- Small display-data builders, such as the queued follow-up section builder,
+  may translate state into renderer-neutral structs. These builders should be
+  deterministic and cheap to test without a terminal frame.
+- History cells own transcript rendering. A cell should render one semantic
+  thing: pending interaction, queued follow-up, running command, completed
+  command, thinking group, or message text.
+- The bottom pane owns composer text, cursor placement, and one-line hints. It
+  should not render durable transcript status, approval options, or queued
+  follow-up bodies.
+- Active-turn composition owns ordering. Pending interactions must be placed
+  before queued follow-up status so approval options remain visible. Queued
+  status should be appended near the newest active cell instead of being
+  rewritten into an older transcript location.
+- Tool-result compactors should emit renderer-neutral text. Renderer helpers
+  may add the tool name, styling, and truncation frame, but should not need
+  bash-specific source cleanup for normal output.
+
+This mirrors the Codex-style split where queued follow-up input is active
+transcript status and the composer remains a prompt/input surface. It also keeps
+future cells composable: adding a new pending interaction or queue type should
+usually require a new display-data section or cell, not another special case in
+the bottom pane.
 
 ### Running query cancellation
 

--- a/docs/journal/2026-05-01-cache-status-context.md
+++ b/docs/journal/2026-05-01-cache-status-context.md
@@ -1,0 +1,37 @@
+# Cache Status In /context
+
+## Date
+
+2026-05-01
+
+## Summary
+
+Added a `CacheStatus` enum to `src/context/runtime.rs` and threaded it through
+the `/context` debugger so users can see whether each prompt source was served
+from the in-memory workspace cache.
+
+## Changes
+
+- Added `CacheStatus` (`Hit` / `Miss` / `NoCache`) to `src/context/runtime.rs`.
+- Added `cache_status: Option<CacheStatus>` to `ContextAssemblyEntry` and
+  `PromptSourceContextEntry`.
+- Updated `assemble_context_view` in `src/context/assembly_view.rs` to
+  populate `cache_status: None` on every entry (reserving the field for
+  future wiring when the `WorkspaceMemory` cached_file_content signal is
+  propagated).
+- Updated the `/context` render in `src/tui/command.rs` to show "cache: hit",
+  "cache: miss", or "cache: -" for each assembly entry.
+- Re-exported `CacheStatus` from `src/context/mod.rs`.
+
+## Key Decision
+
+`PromptSource` and `PromptSourceContextEntry` do not carry transient cache
+signals directly. The cache status field is reserved for the display layer
+(`ContextAssemblyEntry`) and the retrieval layer (`retrieval_view.rs` already
+reports workspace memory availability). This avoids breaking the equality
+contracts that `assemble_turn_context == shared_runtime_context` depends on.
+
+## Validation
+
+- `cargo test context` — 37 passed
+- `cargo test thread_store` — 14 passed

--- a/docs/journal/2026-05-01-cache-status-context.md
+++ b/docs/journal/2026-05-01-cache-status-context.md
@@ -7,20 +7,20 @@
 ## Summary
 
 Added a `CacheStatus` enum to `src/context/runtime.rs` and threaded it through
-the `/context` debugger so users can see whether each prompt source was served
-from the in-memory workspace cache.
+the `/context` debugger so assembly entries can expose whether a source was
+served from the in-memory workspace cache once that signal is wired.
 
 ## Changes
 
 - Added `CacheStatus` (`Hit` / `Miss` / `NoCache`) to `src/context/runtime.rs`.
-- Added `cache_status: Option<CacheStatus>` to `ContextAssemblyEntry` and
-  `PromptSourceContextEntry`.
+- Added `cache_status: Option<CacheStatus>` to `ContextAssemblyEntry`.
 - Updated `assemble_context_view` in `src/context/assembly_view.rs` to
   populate `cache_status: None` on every entry (reserving the field for
   future wiring when the `WorkspaceMemory` cached_file_content signal is
   propagated).
-- Updated the `/context` render in `src/tui/command.rs` to show "cache: hit",
-  "cache: miss", or "cache: -" for each assembly entry.
+- Updated the `/context` render in `src/tui/command.rs` to show cache state as
+  compact markers for entries with a known status: `●` for hit, `○` for miss,
+  and `-` for no-cache. Unknown or not-yet-wired status renders no marker.
 - Re-exported `CacheStatus` from `src/context/mod.rs`.
 
 ## Key Decision

--- a/docs/journal/2026-05-01-phase1-architecture-closure.md
+++ b/docs/journal/2026-05-01-phase1-architecture-closure.md
@@ -49,7 +49,7 @@ Updated `docs/todo.md` to reflect completed Phase 1 items:
 - Marked ThreadStore lineage/provenance as complete.
 - Left remaining items explicitly tagged with `[ ]`:
   - 1B: LanceDB-backed vector retrieval.
-  - Cache hit/refresh status in `/context`.
+  - Wire actual cache hit/miss signals from `WorkspaceMemory` into `/context` cache status.
   - Tightening `CompactState` / `CompactionRecord` ownership.
 
 ## Validation
@@ -63,6 +63,6 @@ Updated `docs/todo.md` to reflect completed Phase 1 items:
 ## Follow-up
 
 - The largest remaining Phase 1 gap is replacing the mock `VectorDB` with real Lance/LanceDB
-  retrieval (`docs/todo.md` Phase 1, item 2B).
+  retrieval (`docs/todo.md` Phase 1, item 1B).
 - Compaction ownership tightening (`CompactState` vs `CompactionRecord`) can be addressed
   when the durable in-turn checkpoint work begins.

--- a/docs/journal/2026-05-01-phase1-architecture-closure.md
+++ b/docs/journal/2026-05-01-phase1-architecture-closure.md
@@ -66,3 +66,6 @@ Updated `docs/todo.md` to reflect completed Phase 1 items:
   retrieval (`docs/todo.md` Phase 1, item 1B).
 - Compaction ownership tightening (`CompactState` vs `CompactionRecord`) can be addressed
   when the durable in-turn checkpoint work begins.
+- Cache hit/refresh status is now wired through `CacheStatus` enum and `/context` rendering;
+  actual WorkspaceMemory cache signals will populate the field once the `cached_file_content`
+  return type is promoted to return `CacheStatus` alongside content.

--- a/docs/journal/2026-05-01-phase1-architecture-closure.md
+++ b/docs/journal/2026-05-01-phase1-architecture-closure.md
@@ -1,0 +1,68 @@
+# Phase 1 Architecture Closure Checkpoint
+
+## Date
+
+2026-05-01
+
+## Context
+
+Phase 1 of the architecture closure (per `docs/todo.md`) targeted four areas:
+`/context`, `MemorySelection`, `ThreadStore`/`ThreadRecorder`, and compaction lifecycle.
+
+## Changes
+
+### 1. MemorySelection Focused Tests (`src/context/memory_selection.rs`)
+
+Added 6 focused tests that lock down the non-vector selection contract:
+
+- `thread_history_selected_when_no_compacted_history_and_budget_allows` — proves the non-vector
+  thread-history path selects when no compacted history exists and budget allows.
+- `thread_history_available_not_selected_when_compacted_history_exists` — proves the compacted-history
+  deduplication rule moves thread_history to available.
+- `vector_memory_is_available_but_not_selectable` — proves the vector-memory placeholder stays in
+  available with an explicit "not implemented" reason.
+- `retrieval_tool_results_from_history_are_captured_as_candidates` — proves that
+  `retrieve_experience`/`retrieve_session_context` tool results from the conversation history are
+  captured as discretionary candidates.
+- `retrieval_tool_results_selected_when_budget_allows` — proves retrieval tool results win the
+  budget-aware selection when budget is sufficient.
+- `memory_selection_reports_all_three_categories` — proves that selected, available, and dropped
+  items are all populated in the same call.
+
+### 2. ThreadStore Boundary (`src/thread_store.rs`)
+
+Added explicit lineage and provenance inspection:
+
+- `ThreadMetadata::is_fork()` — returns true when `origin_kind == "fork"` and a source thread id exists.
+- `ThreadMetadata::lineage()` — returns `(origin_kind, Option<forked_from_thread_id>)`.
+- `ThreadSnapshot::provenance_description()` — human-readable string summarizing where metadata,
+  history, and non-turn rollout items were sourced from.
+- `ThreadMaterializationProvenance::describe()` — maps each `Thread*Source` variant to a concise
+  label, making the canonical / legacy-backfill / StateDb-fallback hierarchy explicit.
+
+### 3. Todo Updated
+
+Updated `docs/todo.md` to reflect completed Phase 1 items:
+
+- Marked MemorySelection non-vector path as complete.
+- Marked `/context` data pipeline as solid.
+- Marked ThreadStore lineage/provenance as complete.
+- Left remaining items explicitly tagged with `[ ]`:
+  - 1B: LanceDB-backed vector retrieval.
+  - Cache hit/refresh status in `/context`.
+  - Tightening `CompactState` / `CompactionRecord` ownership.
+
+## Validation
+
+- `cargo check` passes.
+- `cargo test context::memory_selection` — 7 passed.
+- `cargo test context::assembler` — 7 passed.
+- `cargo test thread_store::tests` — 14 passed.
+- `cargo test context` (all context-filtered tests including TUI context rendering) — 37 passed.
+
+## Follow-up
+
+- The largest remaining Phase 1 gap is replacing the mock `VectorDB` with real Lance/LanceDB
+  retrieval (`docs/todo.md` Phase 1, item 2B).
+- Compaction ownership tightening (`CompactState` vs `CompactionRecord`) can be addressed
+  when the durable in-turn checkpoint work begins.

--- a/docs/journal/2026-05-01-tui-modular-queued-follow-up.md
+++ b/docs/journal/2026-05-01-tui-modular-queued-follow-up.md
@@ -1,0 +1,96 @@
+# 2026-05-01 · TUI modular queued follow-up and compact shell results
+
+## Summary
+
+This checkpoint records two UI lessons from the shell approval and queued
+follow-up path:
+
+- final compact tool output should be fixed at the source contract, not cleaned
+  up later by renderer-specific string patches;
+- queued follow-up status should live in the active transcript, while the
+  composer remains only the input and hint surface.
+
+## Source-level compact results
+
+The previous persisted shell result path could render as:
+
+```text
+bash: bash finished.
+full result stored on disk
+```
+
+That was a source contract problem. The `bash` compactor emitted a tool-specific
+sentence, then the TUI renderer prepended the tool name again. The oversized
+result marker also exposed an internal key/value field that the UI had to
+translate into human copy.
+
+The corrected contract is composable:
+
+- `bash` compact output starts with process status only:
+  - `finished with exit code 0`
+  - `failed with exit code <code>`
+  - `finished with unknown exit status`
+- oversized compact output uses:
+  - `[tool_result truncated]`
+  - `full result: <path>`
+- TUI rendering can prepend `bash:` once without knowing how the shell compactor
+  phrased its status.
+
+This keeps model-facing output and transcript output aligned. It also avoids a
+fragile renderer helper that has to recognize every historical bash sentence.
+
+## Queued follow-up rendering
+
+The earlier bottom-pane preview made queued follow-up messages compete with
+approval options. In practice, a pending shell approval card could be present
+while the composer area displayed queued text, making the option surface feel
+hidden or blocked.
+
+The new boundary is:
+
+- `queued_input` builds renderer-neutral `QueuedFollowUpSection` values.
+- `ActiveTurnCell` decides where queued state belongs in the active transcript.
+- `QueuedFollowUpCell` renders that state as transcript status.
+- `bottom_pane` renders the composer text and a short hint only.
+
+The ordering rule is explicit: pending interaction cards are rendered before
+queued follow-up status. This keeps approval options visible and places queued
+input after the newest relevant active cell, matching the append-oriented
+transcript behavior used elsewhere in the TUI.
+
+## Submission routing
+
+Plain text submitted while a pending approval is active is now queued as a
+follow-up. It does not start a second model turn and does not steal focus from
+the approval decision.
+
+The exceptions are intentionally narrow:
+
+- numeric option shortcuts still answer the pending approval;
+- request-input prompts still consume plain text as the requested answer.
+
+This gives queued messages more chances to be captured without weakening the
+structured approval path.
+
+## TUI modularity rule
+
+Future TUI work should preserve these layers:
+
+- state owns facts;
+- small builders shape facts into display data;
+- cells render semantic transcript units;
+- the bottom pane owns only composer layout and hints;
+- active-turn composition owns ordering and priority.
+
+When a new UI behavior needs to be visible during a turn, prefer adding a cell
+or a display-data section. Avoid adding durable status bodies to the composer,
+because the composer has to stay predictable for approval shortcuts, text input,
+cursor placement, and terminal selection.
+
+## Validation
+
+- `cargo test tui::render::bottom_pane::tests:: -- --nocapture`
+- `cargo test tool_result::tests:: -- --nocapture`
+- `cargo test tui::runtime::events::tests::formats_ -- --nocapture`
+- `cargo test plain_submit_queues_while_shell_approval_is_pending -- --nocapture`
+- `cargo test active_turn_cell_renders_queued_follow_up_without_hiding_shell_approval -- --nocapture`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -26,47 +26,27 @@ Acceptance:
 Priority order for this phase:
 
 1. Strengthen `/context` as the primary context and memory-selection debugger
-   - The first target is not a prettier command output; it is a stable inspection contract.
-   - `/context` should show:
-     - context source categories and order;
-     - source paths and provenance;
-     - selected, available, and dropped memory-selection items;
-     - selection/drop reasons;
-     - token or budget contribution;
-     - cache hit or refresh status when known.
+   - ✅ The data pipeline is solid: `ContextAssemblyView` → `RuntimeSnapshot` → `status_context_text`.
+   - ✅ Rendering includes all layers, memory selection (selected/available/dropped), budget, compaction, and retrieval sources.
+   - ✅ Added `CacheStatus` enum (`Hit`/`Miss`/`NoCache`) to `src/context/runtime.rs`, threading through `ContextAssemblyEntry`, `PromptSourceContextEntry`, and the `/context` render in `src/tui/command.rs` ("cache: hit", "cache: miss", "cache: -").
 
 2. Complete `MemorySelection` as the authoritative bounded retrieval-selection pipeline
-   - The current Stage 1 skeleton exists:
-     - candidate pool;
-     - selected/dropped reason reporting;
-     - selection budget surface;
-   - The next step is to make it the real runtime path for bounded recall.
-   - Rollout order:
-     - 1A. promote selection logic into the primary path for thread/workspace candidates;
-     - 1B. replace placeholder retrieval with real vector-backed retrieval for thread and workspace memory.
+   - ✅ 1A. Selection logic is the primary path — `memory_selection()` assembles fixed + discretionary items with budget-aware ranking. 6 focused tests added to `src/context/memory_selection.rs`.
+   - [ ] 1B. Replace placeholder retrieval with real vector-backed retrieval for thread and workspace memory (requires LanceDB backend).
 
 3. Deepen the `ThreadStore` / `ThreadRecorder` boundary into a real thread domain
-   - The current thread boundary and lifecycle surface now exist:
-     - `threads`
-     - `thread`
-     - `resume --last`
-     - `fork`
-   - The remaining work is to define:
-     - authoritative thread metadata ownership;
-     - rollout-item ownership;
-     - lineage / fork source / latest-thread contract;
-     - which legacy files remain fallback-only.
+   - ✅ Added `ThreadMetadata::is_fork()`, `ThreadMetadata::lineage()`, `ThreadSnapshot::provenance_description()`, `ThreadMaterializationProvenance::describe()` for explicit lineage and fallback-hierarchy inspection.
+   - ✅ Provenance tracking distinguishes canonical sources from legacy backfill and StateDb fallback.
 
 4. Continue promoting compaction into a first-class runtime lifecycle event
-   - Build on the current persisted summaries, token counters, and boundary metadata.
-   - Tighten ownership between compaction state and thread/runtime persistence.
-   - Keep this coupled to the thread-domain work instead of treating it as a UI-only follow-up.
+   - ✅ Compaction events persist through `PersistedCompactionEvent` in the structured rollout events log.
+   - [ ] Tighten ownership between `CompactState` (runtime) and `CompactionRecord` (persisted) so compaction metadata flows through one authoritative boundary instead of two parallel representations.
 
 ## Architecture / Runtime
 
-- [ ] Promote the current `MemorySelection` skeleton into the authoritative bounded retrieval-selection pipeline for thread and workspace recall.
-- [ ] Finish the first non-vector cut of `MemorySelection` so thread memory, workspace memory, active thread state, pending interaction state, and recent tool results all flow through one selected/available/dropped explanation path.
-- [ ] Treat `/context` as the high-priority debugger for context and memory selection before expanding retrieval breadth.
+- [x] Promote the current `MemorySelection` skeleton into the authoritative bounded retrieval-selection pipeline for thread and workspace recall.
+- [x] Finish the first non-vector cut of `MemorySelection` so thread memory, workspace memory, active thread state, pending interaction state, and recent tool results all flow through one selected/available/dropped explanation path.
+- [x] Treat `/context` as the high-priority debugger for context and memory selection before expanding retrieval breadth.
 
 ## Configuration / Provider Surface
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -28,7 +28,7 @@ Priority order for this phase:
 1. Strengthen `/context` as the primary context and memory-selection debugger
    - ✅ The data pipeline is solid: `ContextAssemblyView` → `RuntimeSnapshot` → `status_context_text`.
    - ✅ Rendering includes all layers, memory selection (selected/available/dropped), budget, compaction, and retrieval sources.
-   - ✅ Added `CacheStatus` enum (`Hit`/`Miss`/`NoCache`) to `src/context/runtime.rs`, threading through `ContextAssemblyEntry`, `PromptSourceContextEntry`, and the `/context` render in `src/tui/command.rs` ("cache: hit", "cache: miss", "cache: -").
+   - ✅ Added `CacheStatus` enum (`Hit`/`Miss`/`NoCache`) to `src/context/runtime.rs`, threading it through `ContextAssemblyEntry`, and rendering known cache state in `/context` with compact markers (`●` hit, `○` miss, `-` no-cache).
 
 2. Complete `MemorySelection` as the authoritative bounded retrieval-selection pipeline
    - ✅ 1A. Selection logic is the primary path — `memory_selection()` assembles fixed + discretionary items with budget-aware ranking. 6 focused tests added to `src/context/memory_selection.rs`.

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -657,6 +657,19 @@ mod tests {
         assert!(selected_kinds.contains(&"approval"));
         assert!(selected_kinds.contains(&"latest_user_request"));
         assert!(selected_kinds.contains(&"tool_result"));
+
+        let active_memory_assembly_kinds = runtime_context
+            .assembly
+            .entries
+            .iter()
+            .filter(|entry| entry.layer == "active_memory_inputs")
+            .map(|entry| entry.kind.as_str())
+            .collect::<Vec<_>>();
+        assert!(!active_memory_assembly_kinds.contains(&"plan_explanation"));
+        assert!(!active_memory_assembly_kinds.contains(&"plan_steps"));
+        assert!(!active_memory_assembly_kinds.contains(&"approval"));
+        assert!(!active_memory_assembly_kinds.contains(&"latest_user_request"));
+        assert!(!active_memory_assembly_kinds.contains(&"tool_result"));
     }
 
     #[test]

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -163,12 +163,7 @@ impl<'a> ContextAssembler<'a> {
             .memory_selection
             .selected_items
             .iter()
-            .filter(|item| {
-                matches!(
-                    item.kind.as_str(),
-                    "retrieved_workspace_memory" | "retrieved_thread_context"
-                )
-            })
+            .filter(|item| crate::context::is_retrieved_memory_kind(item.kind.as_str()))
             .map(|item| item.budget_impact_tokens.unwrap_or_default())
             .sum();
         let assembly = assemble_context_view(

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -589,8 +589,8 @@ mod tests {
                         "retrieved_workspace_memory" | "retrieved_thread_context"
                     ) && item
                         .dropped_reason
-                        .as_deref()
-                        .is_some_and(|reason| reason.contains("memory-selection budget"))
+                        .as_ref()
+                        .is_some_and(|r| r.reason().contains("memory-selection budget"))
                 })
         );
     }

--- a/src/context/assembly_view.rs
+++ b/src/context/assembly_view.rs
@@ -111,8 +111,8 @@ pub(crate) fn assemble_context_view(
             label: interaction.title.clone(),
             source_path: interaction.source.clone(),
             injected: true,
-            inclusion_reason: "included because pending interactions are active runtime obligations"
-                .to_string(),
+            inclusion_reason:
+                "included because pending interactions are active runtime obligations".to_string(),
             budget_impact_tokens: Some(
                 estimate_text_tokens(interaction.title.as_str())
                     + estimate_text_tokens(interaction.summary.as_str()),

--- a/src/context/assembly_view.rs
+++ b/src/context/assembly_view.rs
@@ -1,7 +1,7 @@
 use crate::agent::{Message, PlanStepStatus};
 use crate::context::{
     CompactionSourceContextEntry, ContextAssemblyEntry, ContextAssemblyView,
-    MemorySelectionItemContextEntry,
+    MemorySelectionItemContextEntry, is_retrieved_memory_kind,
 };
 use crate::prompt::EffectivePrompt;
 
@@ -172,7 +172,7 @@ pub(crate) fn assemble_context_view(
 
     for item in selected_memory_items
         .iter()
-        .filter(|item| is_memory_assembly_input(item.kind.as_str()))
+        .filter(|item| is_retrieved_memory_kind(item.kind.as_str()))
     {
         push(ContextAssemblyEntry {
             order: 0,
@@ -219,11 +219,4 @@ pub(crate) fn assemble_context_view(
     }
 
     ContextAssemblyView { entries }
-}
-
-fn is_memory_assembly_input(kind: &str) -> bool {
-    matches!(
-        kind,
-        "retrieved_workspace_memory" | "retrieved_thread_context"
-    )
 }

--- a/src/context/assembly_view.rs
+++ b/src/context/assembly_view.rs
@@ -199,7 +199,7 @@ pub(crate) fn assemble_context_view(
             injected: false,
             inclusion_reason: item.selection_reason.clone(),
             budget_impact_tokens: item.budget_impact_tokens,
-            dropped_reason: item.dropped_reason.clone(),
+            dropped_reason: item.dropped_reason.as_ref().map(|r| r.reason().to_string()),
         });
     }
 
@@ -214,7 +214,7 @@ pub(crate) fn assemble_context_view(
             injected: false,
             inclusion_reason: item.selection_reason.clone(),
             budget_impact_tokens: item.budget_impact_tokens,
-            dropped_reason: item.dropped_reason.clone(),
+            dropped_reason: item.dropped_reason.as_ref().map(|r| r.reason().to_string()),
         });
     }
 

--- a/src/context/assembly_view.rs
+++ b/src/context/assembly_view.rs
@@ -170,7 +170,10 @@ pub(crate) fn assemble_context_view(
         });
     }
 
-    for item in selected_memory_items {
+    for item in selected_memory_items
+        .iter()
+        .filter(|item| is_memory_assembly_input(item.kind.as_str()))
+    {
         push(ContextAssemblyEntry {
             order: 0,
             cache_status: None,
@@ -216,4 +219,11 @@ pub(crate) fn assemble_context_view(
     }
 
     ContextAssemblyView { entries }
+}
+
+fn is_memory_assembly_input(kind: &str) -> bool {
+    matches!(
+        kind,
+        "retrieved_workspace_memory" | "retrieved_thread_context"
+    )
 }

--- a/src/context/assembly_view.rs
+++ b/src/context/assembly_view.rs
@@ -29,6 +29,7 @@ pub(crate) fn assemble_context_view(
 
     push(ContextAssemblyEntry {
         order: 0,
+        cache_status: None,
         layer: "stable_instructions".to_string(),
         kind: format!("base_prompt:{}", effective_prompt.base_prompt_kind.label()),
         label: "Base System Prompt".to_string(),
@@ -50,6 +51,7 @@ pub(crate) fn assemble_context_view(
         };
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: layer.to_string(),
             kind,
             label: source.label.clone(),
@@ -64,6 +66,7 @@ pub(crate) fn assemble_context_view(
     if let Some(plan_explanation) = plan_explanation.filter(|value| !value.trim().is_empty()) {
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: "active_turn_state".to_string(),
             kind: "plan_explanation".to_string(),
             label: "Plan Explanation".to_string(),
@@ -85,6 +88,7 @@ pub(crate) fn assemble_context_view(
             .join("\n");
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: "active_turn_state".to_string(),
             kind: "plan_steps".to_string(),
             label: "Plan Steps".to_string(),
@@ -101,13 +105,18 @@ pub(crate) fn assemble_context_view(
     for interaction in pending_interactions {
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: "active_turn_state".to_string(),
             kind: interaction.kind.clone(),
             label: interaction.title.clone(),
             source_path: interaction.source.clone(),
             injected: true,
-            inclusion_reason: "included because a pending interaction must survive restore and remain visible to the active runtime".to_string(),
-            budget_impact_tokens: Some(estimate_text_tokens(interaction.summary.as_str())),
+            inclusion_reason: "included because pending interactions are active runtime obligations"
+                .to_string(),
+            budget_impact_tokens: Some(
+                estimate_text_tokens(interaction.title.as_str())
+                    + estimate_text_tokens(interaction.summary.as_str()),
+            ),
             dropped_reason: None,
         });
     }
@@ -115,6 +124,7 @@ pub(crate) fn assemble_context_view(
     if let Some(user_request) = latest_user_request(history) {
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: "active_turn_state".to_string(),
             kind: "latest_user_request".to_string(),
             label: "Latest User Request".to_string(),
@@ -131,6 +141,7 @@ pub(crate) fn assemble_context_view(
     for (label, detail) in latest_tool_results(history) {
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: "active_turn_state".to_string(),
             kind: "tool_result".to_string(),
             label,
@@ -147,6 +158,7 @@ pub(crate) fn assemble_context_view(
     for entry in compaction_entries {
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: "compacted_history".to_string(),
             kind: entry.kind.clone(),
             label: entry.label.clone(),
@@ -161,6 +173,7 @@ pub(crate) fn assemble_context_view(
     for item in selected_memory_items {
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: "active_memory_inputs".to_string(),
             kind: item.kind.clone(),
             label: item.label.clone(),
@@ -175,6 +188,7 @@ pub(crate) fn assemble_context_view(
     for item in available_memory_items {
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: "retrieval_ready".to_string(),
             kind: item.kind.clone(),
             label: item.label.clone(),
@@ -189,6 +203,7 @@ pub(crate) fn assemble_context_view(
     for item in dropped_memory_items {
         push(ContextAssemblyEntry {
             order: 0,
+            cache_status: None,
             layer: "retrieval_ready".to_string(),
             kind: item.kind.clone(),
             label: item.label.clone(),

--- a/src/context/memory_selection.rs
+++ b/src/context/memory_selection.rs
@@ -754,17 +754,7 @@ mod tests {
         ];
         // Budget of 1 token forces the retrieval candidate to be dropped,
         // proving it was captured as a candidate.
-        let result = memory_selection(
-            &[],
-            None,
-            &[],
-            &[],
-            &[],
-            &history,
-            "session-1",
-            "",
-            Some(1),
-        );
+        let result = memory_selection(&[], None, &[], &[], &[], &history, "session-1", "", Some(1));
 
         let dropped_kinds: Vec<&str> = result
             .dropped_items
@@ -863,7 +853,10 @@ mod tests {
         );
 
         // Selected: at least latest_user_request + thread_history (if budget allows)
-        assert!(!result.selected_items.is_empty(), "should have selected items");
+        assert!(
+            !result.selected_items.is_empty(),
+            "should have selected items"
+        );
         // Available: vector_memory should be there
         let available_kinds: Vec<&str> = result
             .available_items
@@ -876,6 +869,9 @@ mod tests {
         );
         // workspace_memory_available_item is also pushed when not already selected
         let has_workspace_available = available_kinds.contains(&"workspace_memory");
-        assert!(has_workspace_available, "workspace_memory should be in available when no workspace prompt source is active");
+        assert!(
+            has_workspace_available,
+            "workspace_memory should be in available when no workspace prompt source is active"
+        );
     }
 }

--- a/src/context/memory_selection.rs
+++ b/src/context/memory_selection.rs
@@ -1,6 +1,7 @@
 use crate::agent::{Message, PlanStepStatus};
 use crate::context::{
-    CompactionSourceContextEntry, MemorySelectionContextView, MemorySelectionItemContextEntry,
+    CompactionSourceContextEntry, DropReason, MemorySelectionContextView,
+    MemorySelectionItemContextEntry,
 };
 use crate::prompt::PromptSource;
 use serde_json::Value;
@@ -76,7 +77,7 @@ struct MemorySelectionCandidate {
     budget_impact_tokens: Option<usize>,
     priority: usize,
     selectable: bool,
-    dropped_reason: String,
+    dropped_reason: DropReason,
 }
 
 #[derive(Debug, Default)]
@@ -333,8 +334,6 @@ fn select_memory_candidates(
     selection_budget_tokens: Option<usize>,
     fixed_selected_kinds: &[String],
 ) -> MemorySelectionDecision {
-    const BUDGET_DROP_REASON_PREFIX: &str =
-        "not selected because it would exceed the remaining memory-selection budget";
     candidates.sort_by_key(|candidate| candidate.priority);
     let mut remaining_budget = selection_budget_tokens;
     let has_compacted_history = fixed_selected_kinds.iter().any(|kind| {
@@ -347,29 +346,34 @@ fn select_memory_candidates(
     let mut selected_kinds = fixed_selected_kinds.to_vec();
 
     for candidate in candidates {
-        let should_drop = if !candidate.selectable {
+        let should_drop: Option<DropReason> = if !candidate.selectable {
             Some(candidate.dropped_reason.clone())
         } else if candidate.kind == "thread_history" && has_compacted_history {
-            Some(
-                "not selected because compacted thread history already provides a more focused carried-over thread view".to_string(),
-            )
+            Some(DropReason::NotSelected {
+                reason: "not selected because compacted thread history already provides a more focused carried-over thread view".to_string(),
+            })
         } else if selected_kinds
             .iter()
             .any(|kind| kind == "retrieved_thread_context" && candidate.kind == "thread_history")
         {
-            Some(
-                "not selected because a more focused retrieved thread-context candidate already won the current memory selection".to_string(),
-            )
+            Some(DropReason::NotSelected {
+                reason:
+                    "not selected because a more focused retrieved thread-context candidate already won the current memory selection".to_string(),
+            })
         } else if let (Some(remaining), Some(cost)) =
             (remaining_budget, candidate.budget_impact_tokens)
         {
-            (cost > remaining)
-                .then(|| format!("{BUDGET_DROP_REASON_PREFIX} ({cost} > {remaining})"))
+            (cost > remaining).then(|| DropReason::BudgetExceeded {
+                reason: format!(
+                    "not selected because it would exceed the remaining memory-selection budget ({cost} > {remaining})"
+                ),
+            })
         } else {
             None
         };
 
         if let Some(dropped_reason) = should_drop {
+            let is_budget = matches!(dropped_reason, DropReason::BudgetExceeded { .. });
             let item = MemorySelectionItemContextEntry {
                 order: 0,
                 kind: candidate.kind,
@@ -379,11 +383,7 @@ fn select_memory_candidates(
                 budget_impact_tokens: candidate.budget_impact_tokens,
                 dropped_reason: Some(dropped_reason),
             };
-            if item
-                .dropped_reason
-                .as_deref()
-                .is_some_and(|reason| reason.starts_with(BUDGET_DROP_REASON_PREFIX))
-            {
+            if is_budget {
                 decision.dropped_items.push(item);
             } else {
                 decision.available_items.push(item);
@@ -430,11 +430,11 @@ fn workspace_memory_available_item(
         },
         selection_reason: "workspace memory participates in the selection contract even when it is not part of the current assembled working set".to_string(),
         budget_impact_tokens: None,
-        dropped_reason: Some(if workspace_memory_available {
+        dropped_reason: Some(DropReason::NotSelected { reason: if workspace_memory_available {
             "available for recall, but not selected into the current turn because workspace memory was not activated as a prompt input".to_string()
         } else {
             "no workspace memory candidate is currently available".to_string()
-        }),
+        }}),
     }
 }
 
@@ -449,11 +449,11 @@ fn thread_history_candidate(history: &[Message], session_id: &str) -> MemorySele
         )),
         priority: 30,
         selectable: !history.is_empty(),
-        dropped_reason: if history.is_empty() {
+        dropped_reason: DropReason::NotSelected { reason: if history.is_empty() {
             "no thread history is available for selection".to_string()
         } else {
             "raw thread history was not selected directly because the current turn already has sufficient active-turn and compacted-history context".to_string()
-        },
+        }},
     }
 }
 
@@ -470,11 +470,11 @@ fn vector_memory_candidate(vdb_uri: &str) -> MemorySelectionCandidate {
         budget_impact_tokens: None,
         priority: 40,
         selectable: false,
-        dropped_reason: if vdb_uri.is_empty() {
+        dropped_reason: DropReason::NotSelected { reason: if vdb_uri.is_empty() {
             "no vector-backed memory store is configured".to_string()
         } else {
             "not selected because vector-backed candidate ranking is not implemented yet".to_string()
-        },
+        }},
     }
 }
 
@@ -505,7 +505,7 @@ fn retrieval_tool_candidate(
                 selection_reason: "selected because the retrieval tool returned relevant durable memory candidates for the current task".to_string(),
                 priority: 10,
                 selectable: true,
-                dropped_reason: "not selected after ranking the retrieved workspace-memory candidates against the current memory-selection budget".to_string(),
+                dropped_reason: DropReason::NotSelected { reason: "not selected after ranking the retrieved workspace-memory candidates against the current memory-selection budget".to_string() },
             }
         }
         "retrieve_session_context" => {
@@ -521,7 +521,7 @@ fn retrieval_tool_candidate(
                 selection_reason: "selected because the retrieval tool returned focused thread-context material for the current task".to_string(),
                 priority: 20,
                 selectable: true,
-                dropped_reason: "not selected after ranking the retrieved thread-context candidate against the current memory-selection budget".to_string(),
+                dropped_reason: DropReason::NotSelected { reason: "not selected after ranking the retrieved thread-context candidate against the current memory-selection budget".to_string() },
             }
         }
         other => MemorySelectionCandidate {
@@ -534,7 +534,7 @@ fn retrieval_tool_candidate(
             budget_impact_tokens: Some(estimate_text_tokens(content)),
             priority: 50,
             selectable: true,
-            dropped_reason: "not selected after ranking the retrieval candidate against the current memory-selection budget".to_string(),
+            dropped_reason: DropReason::NotSelected { reason: "not selected after ranking the retrieval candidate against the current memory-selection budget".to_string() },
         },
     }
 }
@@ -721,8 +721,8 @@ mod tests {
         assert!(
             vector_entry
                 .dropped_reason
-                .as_deref()
-                .is_some_and(|reason| reason.contains("not implemented")),
+                .as_ref()
+                .is_some_and(|r| r.reason().contains("not implemented")),
             "vector_memory should explain it is not implemented yet"
         );
     }

--- a/src/context/memory_selection.rs
+++ b/src/context/memory_selection.rs
@@ -373,7 +373,7 @@ fn select_memory_candidates(
         };
 
         if let Some(dropped_reason) = should_drop {
-            let is_budget = matches!(dropped_reason, DropReason::BudgetExceeded { .. });
+            let is_budget = matches!(&dropped_reason, DropReason::BudgetExceeded { .. });
             let item = MemorySelectionItemContextEntry {
                 order: 0,
                 kind: candidate.kind,

--- a/src/context/memory_selection.rs
+++ b/src/context/memory_selection.rs
@@ -601,4 +601,281 @@ mod tests {
             Some("plain json payload without wrapper")
         );
     }
+
+    // ── Non-vector selection path ──────────────────────────────────────────
+
+    #[test]
+    fn thread_history_selected_when_no_compacted_history_and_budget_allows() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!("hello"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!("hi there"),
+            },
+        ];
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[], // no compacted history
+            &history,
+            "session-1",
+            "",
+            Some(10_000),
+        );
+
+        let selected_kinds: Vec<&str> = result
+            .selected_items
+            .iter()
+            .map(|item| item.kind.as_str())
+            .collect();
+        assert!(
+            selected_kinds.contains(&"latest_user_request"),
+            "latest user request should be a fixed selected item"
+        );
+        assert!(
+            selected_kinds.contains(&"thread_history"),
+            "thread_history should be selected when no compacted history exists and budget allows"
+        );
+        assert!(result.dropped_items.is_empty());
+    }
+
+    #[test]
+    fn thread_history_available_not_selected_when_compacted_history_exists() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!("hello"),
+        }];
+        let compacted = vec![CompactionSourceContextEntry {
+            order: 1,
+            kind: "compacted_summary".to_string(),
+            label: "Compacted Summary".to_string(),
+            detail: "previous work".to_string(),
+            inclusion_reason: "carried forward".to_string(),
+        }];
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &compacted,
+            &history,
+            "session-1",
+            "",
+            Some(10_000),
+        );
+
+        let available_kinds: Vec<&str> = result
+            .available_items
+            .iter()
+            .map(|item| item.kind.as_str())
+            .collect();
+        assert!(
+            available_kinds.contains(&"thread_history"),
+            "thread_history should be available but not selected when compacted history already covers it"
+        );
+        let selected_kinds: Vec<&str> = result
+            .selected_items
+            .iter()
+            .map(|item| item.kind.as_str())
+            .collect();
+        assert!(
+            !selected_kinds.contains(&"thread_history"),
+            "thread_history should not be selected when compacted history exists"
+        );
+    }
+
+    #[test]
+    fn vector_memory_is_available_but_not_selectable() {
+        let history: Vec<Message> = vec![];
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "memory://vdb",
+            Some(10_000),
+        );
+
+        let available_kinds: Vec<&str> = result
+            .available_items
+            .iter()
+            .map(|item| item.kind.as_str())
+            .collect();
+        assert!(
+            available_kinds.contains(&"vector_memory"),
+            "vector_memory should appear in available when a vdb URI is configured"
+        );
+        let vector_entry = result
+            .available_items
+            .iter()
+            .find(|item| item.kind == "vector_memory")
+            .expect("vector_memory should be present");
+        assert!(
+            vector_entry
+                .dropped_reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("not implemented")),
+            "vector_memory should explain it is not implemented yet"
+        );
+    }
+
+    #[test]
+    fn retrieval_tool_results_from_history_are_captured_as_candidates() {
+        let history = vec![
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {
+                        "type": "tool_use",
+                        "id": "tool-retrieve-1",
+                        "name": "retrieve_experience",
+                        "input": { "query": "bootstrap contract" }
+                    }
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-retrieve-1",
+                        "content": "Tool retrieve_experience completed.\nPayload:\n{\n  \"relevant_experiences\": [\"Use shared bootstrap.\"]\n}"
+                    }
+                ]),
+            },
+        ];
+        // Budget of 1 token forces the retrieval candidate to be dropped,
+        // proving it was captured as a candidate.
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "",
+            Some(1),
+        );
+
+        let dropped_kinds: Vec<&str> = result
+            .dropped_items
+            .iter()
+            .map(|item| item.kind.as_str())
+            .collect();
+        let selected_kinds: Vec<&str> = result
+            .selected_items
+            .iter()
+            .map(|item| item.kind.as_str())
+            .collect();
+        let available_kinds: Vec<&str> = result
+            .available_items
+            .iter()
+            .map(|item| item.kind.as_str())
+            .collect();
+        // The retrieval candidate should appear in one of the three lists,
+        // proving it was captured from history.
+        let all_kinds: Vec<&&str> = dropped_kinds
+            .iter()
+            .chain(selected_kinds.iter())
+            .chain(available_kinds.iter())
+            .collect();
+        assert!(
+            all_kinds.contains(&&"retrieved_workspace_memory"),
+            "retrieval tool candidate from history must appear in selected, available, or dropped"
+        );
+    }
+
+    #[test]
+    fn retrieval_tool_results_selected_when_budget_allows() {
+        let history = vec![
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {
+                        "type": "tool_use",
+                        "id": "tool-retrieve-1",
+                        "name": "retrieve_session_context",
+                        "input": { "query": "auth flow" }
+                    }
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-retrieve-1",
+                        "content": "Tool retrieve_session_context completed.\nPayload:\n{\n  \"status\": \"ok\",\n  \"summary\": \"Auth picker moved.\"\n}"
+                    }
+                ]),
+            },
+        ];
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "",
+            Some(10_000),
+        );
+
+        let selected_kinds: Vec<&str> = result
+            .selected_items
+            .iter()
+            .map(|item| item.kind.as_str())
+            .collect();
+        assert!(
+            selected_kinds.contains(&"retrieved_thread_context"),
+            "retrieve_session_context results should be selected when budget allows"
+        );
+    }
+
+    // ── Category completeness ──────────────────────────────────────────────
+
+    #[test]
+    fn memory_selection_reports_all_three_categories() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!("hello"),
+        }];
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "memory://vdb",
+            Some(10_000),
+        );
+
+        // Selected: at least latest_user_request + thread_history (if budget allows)
+        assert!(!result.selected_items.is_empty(), "should have selected items");
+        // Available: vector_memory should be there
+        let available_kinds: Vec<&str> = result
+            .available_items
+            .iter()
+            .map(|item| item.kind.as_str())
+            .collect();
+        assert!(
+            available_kinds.contains(&"vector_memory"),
+            "vector_memory should be in available"
+        );
+        // workspace_memory_available_item is also pushed when not already selected
+        let has_workspace_available = available_kinds.contains(&"workspace_memory");
+        assert!(has_workspace_available, "workspace_memory should be in available when no workspace prompt source is active");
+    }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -15,8 +15,9 @@ pub use self::assembler::{
     RuntimeInteractionInput,
 };
 pub use self::runtime::{
-    CompactionContextView, CompactionSourceContextEntry, ContextAssemblyEntry, ContextAssemblyView,
-    ContextBudgetView, MemorySelectionContextView, MemorySelectionItemContextEntry,
-    PlanContextView, PromptContextView, PromptSourceContextEntry, RetrievalContextView,
-    RetrievalSourceContextEntry, SharedRuntimeContext,
+    CacheStatus, CompactionContextView, CompactionSourceContextEntry, ContextAssemblyEntry,
+    ContextAssemblyView, ContextBudgetView, MemorySelectionContextView,
+    MemorySelectionItemContextEntry, PlanContextView, PromptContextView,
+    PromptSourceContextEntry, RetrievalContextView, RetrievalSourceContextEntry,
+    SharedRuntimeContext,
 };

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -16,7 +16,7 @@ pub use self::assembler::{
 };
 pub use self::runtime::{
     CacheStatus, CompactionContextView, CompactionSourceContextEntry, ContextAssemblyEntry,
-    ContextAssemblyView, ContextBudgetView, MemorySelectionContextView,
+    ContextAssemblyView, ContextBudgetView, DropReason, MemorySelectionContextView,
     MemorySelectionItemContextEntry, PlanContextView, PromptContextView, PromptSourceContextEntry,
     RetrievalContextView, RetrievalSourceContextEntry, SharedRuntimeContext,
 };

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -19,4 +19,5 @@ pub use self::runtime::{
     ContextAssemblyView, ContextBudgetView, DropReason, MemorySelectionContextView,
     MemorySelectionItemContextEntry, PlanContextView, PromptContextView, PromptSourceContextEntry,
     RetrievalContextView, RetrievalSourceContextEntry, SharedRuntimeContext,
+    is_retrieved_memory_kind,
 };

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -17,7 +17,6 @@ pub use self::assembler::{
 pub use self::runtime::{
     CacheStatus, CompactionContextView, CompactionSourceContextEntry, ContextAssemblyEntry,
     ContextAssemblyView, ContextBudgetView, MemorySelectionContextView,
-    MemorySelectionItemContextEntry, PlanContextView, PromptContextView,
-    PromptSourceContextEntry, RetrievalContextView, RetrievalSourceContextEntry,
-    SharedRuntimeContext,
+    MemorySelectionItemContextEntry, PlanContextView, PromptContextView, PromptSourceContextEntry,
+    RetrievalContextView, RetrievalSourceContextEntry, SharedRuntimeContext,
 };

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -11,6 +11,16 @@ pub enum CacheStatus {
     NoCache,
 }
 
+pub const RETRIEVED_WORKSPACE_MEMORY_KIND: &str = "retrieved_workspace_memory";
+pub const RETRIEVED_THREAD_CONTEXT_KIND: &str = "retrieved_thread_context";
+
+pub fn is_retrieved_memory_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        RETRIEVED_WORKSPACE_MEMORY_KIND | RETRIEVED_THREAD_CONTEXT_KIND
+    )
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextAssemblyEntry {
     pub order: usize,

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -258,6 +258,25 @@ pub struct MemorySelectionContextView {
     pub dropped_items: Vec<MemorySelectionItemContextEntry>,
 }
 
+/// Reason an item was not selected into the current turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DropReason {
+    /// Did not win the selection contest (ranking, dedup, not selectable,
+    /// compacted history already covers it). Appears in available_items.
+    NotSelected { reason: String },
+    /// Would have exceeded the remaining memory-selection budget.
+    /// Appears in dropped_items.
+    BudgetExceeded { reason: String },
+}
+
+impl DropReason {
+    pub fn reason(&self) -> &str {
+        match self {
+            DropReason::NotSelected { reason } | DropReason::BudgetExceeded { reason } => reason,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MemorySelectionItemContextEntry {
     pub order: usize,
@@ -266,5 +285,5 @@ pub struct MemorySelectionItemContextEntry {
     pub detail: String,
     pub selection_reason: String,
     pub budget_impact_tokens: Option<usize>,
-    pub dropped_reason: Option<String>,
+    pub dropped_reason: Option<DropReason>,
 }

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -1,9 +1,20 @@
 use crate::agent::{CompactState, PlanStepStatus};
 use crate::prompt::{EffectivePrompt, PromptSource};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheStatus {
+    /// Content was served from the in-memory cache (mtime unchanged).
+    Hit,
+    /// Content was re-read from disk (mtime changed or first read).
+    Miss,
+    /// Cache does not apply (non-file source, e.g. append-system-prompt).
+    NoCache,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextAssemblyEntry {
     pub order: usize,
+    pub cache_status: Option<CacheStatus>,
     pub layer: String,
     pub kind: String,
     pub label: String,

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -108,6 +108,30 @@ pub struct ThreadMaterializationProvenance {
     pub non_turn_rollout_source: ThreadNonTurnRolloutSource,
 }
 
+impl ThreadMaterializationProvenance {
+    /// Human-readable description of where each piece of the thread snapshot
+    /// was sourced from, making the legacy-fallback hierarchy explicit.
+    pub fn describe(&self) -> String {
+        let metadata = match self.metadata_source {
+            ThreadMetadataSource::StateDb => "StateDb (canonical)",
+        };
+        let history = match self.history_source {
+            ThreadHistorySource::CanonicalHistory => "canonical history.json",
+            ThreadHistorySource::LegacyHistoryBackfilled => "legacy session JSON (backfilled)",
+            ThreadHistorySource::Missing => "missing",
+        };
+        let rollout = match self.non_turn_rollout_source {
+            ThreadNonTurnRolloutSource::StructuredEventsLog => "structured events log (canonical)",
+            ThreadNonTurnRolloutSource::LegacyBackfilled => "legacy rollout (backfilled)",
+            ThreadNonTurnRolloutSource::StateDbFallback => "StateDb fallback",
+            ThreadNonTurnRolloutSource::Empty => "empty",
+        };
+        format!(
+            "metadata={metadata} history={history} non-turn-rollout={rollout}"
+        )
+    }
+}
+
 impl From<PersistedThreadRecord> for ThreadMetadata {
     fn from(value: PersistedThreadRecord) -> Self {
         Self {
@@ -126,6 +150,19 @@ impl From<PersistedThreadRecord> for ThreadMetadata {
             transcript_len: value.transcript_len,
             updated_at: value.updated_at,
         }
+    }
+}
+
+impl ThreadMetadata {
+    /// Returns true when this thread was forked from another thread.
+    pub fn is_fork(&self) -> bool {
+        self.origin_kind == "fork" && self.forked_from_thread_id.is_some()
+    }
+
+    /// Returns the origin kind and optional source thread id, making the
+    /// lineage explicit for callers that need to trace thread ancestry.
+    pub fn lineage(&self) -> (&str, Option<&str>) {
+        (self.origin_kind.as_str(), self.forked_from_thread_id.as_deref())
     }
 }
 
@@ -189,6 +226,22 @@ pub struct ThreadSnapshot {
     pub plan_steps: Vec<PersistedPlanStep>,
     pub interactions: Vec<PersistedInteraction>,
     pub rollout_items: Vec<RolloutItem>,
+}
+
+impl ThreadSnapshot {
+    /// Human-readable provenance description showing the source hierarchy.
+    pub fn provenance_description(&self) -> String {
+        self.provenance.describe()
+    }
+
+    /// Returns true when this snapshot was forked from another thread.
+    pub fn is_fork(&self) -> bool {
+        self.metadata.is_fork()
+    }
+
+    pub fn lineage(&self) -> (&str, Option<&str>) {
+        self.metadata.lineage()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -126,9 +126,7 @@ impl ThreadMaterializationProvenance {
             ThreadNonTurnRolloutSource::StateDbFallback => "StateDb fallback",
             ThreadNonTurnRolloutSource::Empty => "empty",
         };
-        format!(
-            "metadata={metadata} history={history} non-turn-rollout={rollout}"
-        )
+        format!("metadata={metadata} history={history} non-turn-rollout={rollout}")
     }
 }
 
@@ -162,7 +160,10 @@ impl ThreadMetadata {
     /// Returns the origin kind and optional source thread id, making the
     /// lineage explicit for callers that need to trace thread ancestry.
     pub fn lineage(&self) -> (&str, Option<&str>) {
-        (self.origin_kind.as_str(), self.forked_from_thread_id.as_deref())
+        (
+            self.origin_kind.as_str(),
+            self.forked_from_thread_id.as_deref(),
+        )
     }
 }
 

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -445,7 +445,7 @@ fn compact_generic(summary: &str, result: &Value) -> String {
 fn render_persisted_compact_result(inline: &str, stored_path: &std::path::Path) -> String {
     format!(
         "{}\n\n[tool_result truncated]\nfull result: {}",
-        truncate_text(inline, LARGE_PREVIEW_HEAD),
+        head_tail_text(inline, LARGE_PREVIEW_HEAD, LARGE_PREVIEW_TAIL),
         stored_path.display()
     )
 }

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -67,11 +67,7 @@ impl ToolResultStore {
         }
 
         let stored_path = self.persist_full_result(tool_use_id, tool_name, input, result)?;
-        Ok(persisted_output_message(
-            &stored_path,
-            full_rendered.chars().count(),
-            &head_tail_text(&inline, LARGE_PREVIEW_HEAD, LARGE_PREVIEW_TAIL),
-        ))
+        Ok(render_persisted_compact_result(&inline, &stored_path))
     }
 
     fn persist_full_result(
@@ -446,6 +442,14 @@ fn compact_generic(summary: &str, result: &Value) -> String {
     )
 }
 
+fn render_persisted_compact_result(inline: &str, stored_path: &std::path::Path) -> String {
+    format!(
+        "{}\n\n[tool_result truncated]\nfull result: {}",
+        truncate_text(inline, LARGE_PREVIEW_HEAD),
+        stored_path.display()
+    )
+}
+
 fn compact_bash(result: &Value) -> String {
     if let Some(task_id) = result.get("background_task_id").and_then(Value::as_str) {
         let status = result
@@ -506,7 +510,11 @@ fn compact_bash(result: &Value) -> String {
                 }
             }
         });
-    let mut rendered = format!("bash finished.\nExit code: {exit_code}");
+    let mut rendered = match exit_code.as_str() {
+        "0" => "finished with exit code 0".to_string(),
+        "unknown" => "finished with unknown exit status".to_string(),
+        _ => format!("failed with exit code {exit_code}"),
+    };
     if let Some(duration_ms) = duration_ms {
         rendered.push_str(&format!("\nDuration: {duration_ms} ms"));
     }
@@ -961,13 +969,6 @@ fn char_boundary_before_last_n_chars(text: &str, n: usize) -> usize {
         .unwrap_or(0)
 }
 
-fn persisted_output_message(path: &PathBuf, original_chars: usize, preview: &str) -> String {
-    format!(
-        "<persisted-output>\nOutput too large ({original_chars} chars). Full output saved to: {}\n\nPreview:\n{preview}\n</persisted-output>",
-        path.display()
-    )
-}
-
 pub fn default_tool_result_store_dir() -> Result<PathBuf> {
     let root = std::env::current_dir()?;
     Ok(rara_config::workspace_data_dir_for(&root)?.join("tool-results"))
@@ -1044,8 +1045,7 @@ mod tests {
                 &json!({ "content": "x".repeat(20_000) }),
             )
             .expect("compact result");
-        assert!(output.contains("<persisted-output>"));
-        assert!(output.contains("Full output saved to:"));
+        assert!(output.contains("full result:"));
         assert!(output.contains("Fetched https://example.com"));
         assert!(tempdir.path().join("tool-1.json").exists());
         assert!(
@@ -1077,8 +1077,7 @@ mod tests {
             )
             .expect("compact bash result");
 
-        assert!(output.contains("bash finished."));
-        assert!(output.contains("Exit code: 101"));
+        assert!(output.contains("failed with exit code 101"));
         assert!(output.contains("Duration: 1234 ms"));
         assert!(output.contains("Output:\nchecking\n[stderr] warning"));
         assert!(!output.contains("stdout-only"));

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -372,12 +372,11 @@ fn render_memory_selection(app: &TuiApp) -> String {
         .map(|v| format!("{v}t"))
         .unwrap_or_else(|| "unlimited".to_string());
 
-    let render_items =
-        |items: &[crate::context::MemorySelectionItemContextEntry]| -> String {
-            if items.is_empty() {
-                return "    (none)".to_string();
-            }
-            items
+    let render_items = |items: &[crate::context::MemorySelectionItemContextEntry]| -> String {
+        if items.is_empty() {
+            return "    (none)".to_string();
+        }
+        items
             .iter()
             .enumerate()
             .map(|(idx, item)| {
@@ -405,7 +404,7 @@ fn render_memory_selection(app: &TuiApp) -> String {
             })
             .collect::<Vec<_>>()
             .join("\n")
-        };
+    };
 
     format!(
         "Memory Selection  (budget: {budget})\n  ├── selected:\n{}\n  ├── available:\n{}\n  └── dropped:\n{}",
@@ -420,7 +419,13 @@ fn truncate_preview(text: &str, max_len: usize) -> String {
     if condensed.chars().count() <= max_len {
         condensed
     } else {
-        format!("{}…", &condensed[..condensed.char_indices().nth(max_len - 1).map_or(max_len - 1, |(i, _)| i)])
+        format!(
+            "{}…",
+            &condensed[..condensed
+                .char_indices()
+                .nth(max_len - 1)
+                .map_or(max_len - 1, |(i, _)| i)]
+        )
     }
 }
 

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -1,4 +1,5 @@
 use crate::config::RaraConfig;
+use crate::context::CacheStatus;
 
 use super::state::{
     CommandSpec, LocalCommand, LocalCommandKind, PROVIDER_FAMILIES, PendingInteractionSnapshot,
@@ -312,40 +313,45 @@ fn format_pending_interaction(snapshot: &PendingInteractionSnapshot) -> String {
 }
 
 fn render_context_assembly_entries(app: &TuiApp, layer: &str, title: &str) -> String {
-    let entries = app
+    let entries: Vec<&crate::context::ContextAssemblyEntry> = app
         .snapshot
         .assembly_entries
         .iter()
         .filter(|entry| entry.layer == layer)
         .collect::<Vec<_>>();
+    let count = entries.len();
     if entries.is_empty() {
-        return format!("{title}\n  - None.");
+        return format!("{title}\n  (none)");
     }
 
     let body = entries
         .into_iter()
-        .map(|entry| {
+        .enumerate()
+        .map(|(idx, entry)| {
+            let connector = if idx + 1 == count { "└──" } else { "├──" };
             let path = entry
                 .source_path
                 .as_deref()
-                .filter(|value| !value.is_empty())
+                .filter(|v| !v.is_empty())
                 .unwrap_or("-");
-            let injected = if entry.injected { "yes" } else { "no" };
+            let injected = if entry.injected { "" } else { " (not injected)" };
+            let cache = match entry.cache_status {
+                Some(CacheStatus::Hit) => "●",
+                Some(CacheStatus::Miss) => "○",
+                _ => "",
+            };
             let budget = entry
                 .budget_impact_tokens
-                .map(|value| value.to_string())
-                .unwrap_or_else(|| "-".to_string());
-            let dropped = entry.dropped_reason.as_deref().unwrap_or("-");
+                .map(|v| format!(" {v}t"))
+                .unwrap_or_default();
+            let drop_note = match entry.dropped_reason.as_deref() {
+                Some(r) if !r.is_empty() && r != "-" => format!(" ── dropped: {r}"),
+                _ => String::new(),
+            };
             format!(
-                "  {}. {} ({})\n     path: {}\n     injected: {}\n     budget impact: {}\n     why: {}\n     dropped: {}",
-                entry.order,
-                entry.label,
-                entry.kind,
-                path,
-                injected,
-                budget,
-                entry.inclusion_reason,
-                dropped,
+                "  {connector} {cache}[{kind}] {label}{injected}{budget}\n  │   path: {path}{drop_note}",
+                kind = entry.kind,
+                label = entry.label,
             )
         })
         .collect::<Vec<_>>()
@@ -359,65 +365,33 @@ fn render_memory_selection(app: &TuiApp) -> String {
         .snapshot
         .memory_selection
         .selection_budget_tokens
-        .map(|value| value.to_string())
-        .unwrap_or_else(|| "-".to_string());
-    let selected = if app.snapshot.memory_selection.selected_items.is_empty() {
-        "  - None.".to_string()
-    } else {
-        app.snapshot
-            .memory_selection
-            .selected_items
+        .map(|v| format!("{v}t"))
+        .unwrap_or_else(|| "unlimited".to_string());
+
+    let render_items = |items: &[crate::context::MemorySelectionItemContextEntry]| -> String {
+        if items.is_empty() {
+            return "    (none)".to_string();
+        }
+        items
             .iter()
-            .map(|item| {
+            .enumerate()
+            .map(|(idx, item)| {
+                let connector = if idx + 1 == items.len() { "└──" } else { "├──" };
                 let budget = item
                     .budget_impact_tokens
-                    .map(|value| value.to_string())
-                    .unwrap_or_else(|| "-".to_string());
+                    .map(|v| format!(" {v}t"))
+                    .unwrap_or_default();
+                let detail_preview = truncate_preview(&item.detail, 60);
+                let drop_note = match item.dropped_reason.as_deref() {
+                    Some(r) if !r.is_empty() && r != "-" => {
+                        format!(" ── {r}")
+                    }
+                    _ => String::new(),
+                };
                 format!(
-                    "  {}. {} ({})\n     detail: {}\n     budget impact: {}\n     why selected: {}",
-                    item.order, item.label, item.kind, item.detail, budget, item.selection_reason
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    };
-    let available = if app.snapshot.memory_selection.available_items.is_empty() {
-        "  - None.".to_string()
-    } else {
-        app.snapshot
-            .memory_selection
-            .available_items
-            .iter()
-            .map(|item| {
-                format!(
-                    "  {}. {} ({})\n     detail: {}\n     why available: {}\n     not injected: {}",
-                    item.order,
-                    item.label,
-                    item.kind,
-                    item.detail,
-                    item.selection_reason,
-                    item.dropped_reason.as_deref().unwrap_or("-")
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    };
-    let dropped = if app.snapshot.memory_selection.dropped_items.is_empty() {
-        "  - None.".to_string()
-    } else {
-        app.snapshot
-            .memory_selection
-            .dropped_items
-            .iter()
-            .map(|item| {
-                format!(
-                    "  {}. {} ({})\n     detail: {}\n     why considered: {}\n     dropped: {}",
-                    item.order,
-                    item.label,
-                    item.kind,
-                    item.detail,
-                    item.selection_reason,
-                    item.dropped_reason.as_deref().unwrap_or("-")
+                    "    {connector} [{kind}] {label}{budget}\n    │   {detail_preview}{drop_note}",
+                    kind = item.kind,
+                    label = item.label,
                 )
             })
             .collect::<Vec<_>>()
@@ -425,9 +399,20 @@ fn render_memory_selection(app: &TuiApp) -> String {
     };
 
     format!(
-        "Memory Selection\n  selection budget: {}\n  selected now:\n{}\n  available but not injected:\n{}\n  dropped by ranking or budget:\n{}",
-        budget, selected, available, dropped
+        "Memory Selection  (budget: {budget})\n  ├── selected:\n{}\n  ├── available:\n{}\n  └── dropped:\n{}",
+        render_items(&app.snapshot.memory_selection.selected_items),
+        render_items(&app.snapshot.memory_selection.available_items),
+        render_items(&app.snapshot.memory_selection.dropped_items),
     )
+}
+
+fn truncate_preview(text: &str, max_len: usize) -> String {
+    let condensed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if condensed.len() <= max_len {
+        condensed
+    } else {
+        format!("{}…", &condensed[..max_len - 1])
+    }
 }
 
 pub fn status_context_text(app: &TuiApp) -> String {
@@ -483,7 +468,7 @@ pub fn status_context_text(app: &TuiApp) -> String {
     };
     let mut sections = vec![
         format!(
-            "Current Session\n  cwd: {}\n  branch: {}\n  session: {}\n  history messages: {}\n  transcript entries: {}",
+            "Session\n  cwd: {}\n  branch: {}\n  session: {}\n  history: {} msgs  {} entries",
             app.snapshot.cwd,
             app.snapshot.branch,
             app.snapshot.session_id,
@@ -491,51 +476,26 @@ pub fn status_context_text(app: &TuiApp) -> String {
             app.transcript_entry_count(),
         ),
         format!(
-            "Context Budget\n  context window: {}\n  reserved output: {}\n  stable instructions: {}\n  workspace prompt sources: {}\n  active turn: {}\n  compacted history: {}\n  retrieved memory: {}\n  remaining input budget: {}",
+            "Budget\n  window: {}  reserved: {}  remaining: {}\n  stable: {}  workspace: {}  active: {}  compacted: {}  retrieved: {}",
             app.snapshot
                 .context_window_tokens
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "-".to_string()),
             app.snapshot.reserved_output_tokens,
+            app.snapshot
+                .remaining_input_budget
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "-".to_string()),
             app.snapshot.stable_instructions_budget,
             app.snapshot.workspace_prompt_budget,
             app.snapshot.active_turn_budget,
             app.snapshot.compacted_history_budget,
             app.snapshot.retrieved_memory_budget,
-            app.snapshot
-                .remaining_input_budget
-                .map(|value| value.to_string())
-                .unwrap_or_else(|| "-".to_string()),
-        ),
-        render_context_assembly_entries(app, "stable_instructions", "Stable Instructions"),
-        render_context_assembly_entries(
-            app,
-            "workspace_prompt_sources",
-            "Workspace Prompt Sources",
-        ),
-        render_context_assembly_entries(app, "active_memory_inputs", "Active Memory Inputs"),
-        render_memory_selection(app),
-        render_context_assembly_entries(app, "compacted_history", "Compacted History"),
-        render_context_assembly_entries(app, "active_turn_state", "Active Turn State"),
-        render_context_assembly_entries(
-            app,
-            "retrieval_ready",
-            "Retrieval-ready but not injected items",
         ),
         format!(
-            "Plan State\n  explanation: {}\n{}",
-            app.snapshot.plan_explanation.as_deref().unwrap_or("-"),
-            plan_lines
-        ),
-        format!(
-            "Compaction State\n  estimated history tokens: {}\n  context window: {}\n  threshold: {}\n  reserved output: {}\n  compactions: {}\n  last compaction: {} -> {}\n  last boundary: {}",
+            "Compaction\n  estimated: {}t  threshold: {}t  count: {}\n  last: {}t → {}t  boundary: {}",
             app.snapshot.estimated_history_tokens,
-            app.snapshot
-                .context_window_tokens
-                .map(|value| value.to_string())
-                .unwrap_or_else(|| "-".to_string()),
             app.snapshot.compact_threshold_tokens,
-            app.snapshot.reserved_output_tokens,
             app.snapshot.compaction_count,
             app.snapshot
                 .last_compaction_before_tokens
@@ -547,7 +507,20 @@ pub fn status_context_text(app: &TuiApp) -> String {
                 .unwrap_or_else(|| "-".to_string()),
             last_boundary
         ),
-        format!("Pending Interaction\n{}", pending_interactions),
+        format!(
+            "Plan\n  mode: {}  explanation: {}\n{}",
+            app.agent_execution_mode_label(),
+            app.snapshot.plan_explanation.as_deref().unwrap_or("-"),
+            plan_lines
+        ),
+        format!("Pending\n{}", pending_interactions),
+        render_context_assembly_entries(app, "stable_instructions", "Stable Instructions"),
+        render_context_assembly_entries(app, "workspace_prompt_sources", "Workspace Prompt Sources"),
+        render_context_assembly_entries(app, "active_memory_inputs", "Active Memory Inputs"),
+        render_memory_selection(app),
+        render_context_assembly_entries(app, "compacted_history", "Compacted History"),
+        render_context_assembly_entries(app, "active_turn_state", "Active Turn State"),
+        render_context_assembly_entries(app, "retrieval_ready", "Retrieval-ready"),
     ];
     if let Some(warnings) = prompt_warnings {
         sections.insert(2, warnings);
@@ -1485,6 +1458,7 @@ mod tests {
             ],
             assembly_entries: vec![
                 crate::context::ContextAssemblyEntry {
+                    cache_status: None,
                     order: 1,
                     layer: "stable_instructions".into(),
                     kind: "project_instruction".into(),
@@ -1497,6 +1471,7 @@ mod tests {
                     dropped_reason: None,
                 },
                 crate::context::ContextAssemblyEntry {
+                    cache_status: None,
                     order: 2,
                     layer: "workspace_prompt_sources".into(),
                     kind: "local_memory".into(),
@@ -1509,6 +1484,7 @@ mod tests {
                     dropped_reason: None,
                 },
                 crate::context::ContextAssemblyEntry {
+                    cache_status: None,
                     order: 3,
                     layer: "active_memory_inputs".into(),
                     kind: "retrieved_workspace_memory".into(),
@@ -1521,6 +1497,7 @@ mod tests {
                     dropped_reason: None,
                 },
                 crate::context::ContextAssemblyEntry {
+                    cache_status: None,
                     order: 4,
                     layer: "compacted_history".into(),
                     kind: "compacted_summary".into(),
@@ -1533,6 +1510,7 @@ mod tests {
                     dropped_reason: None,
                 },
                 crate::context::ContextAssemblyEntry {
+                    cache_status: None,
                     order: 5,
                     layer: "active_turn_state".into(),
                     kind: "plan_steps".into(),
@@ -1545,6 +1523,7 @@ mod tests {
                     dropped_reason: None,
                 },
                 crate::context::ContextAssemblyEntry {
+                    cache_status: None,
                     order: 6,
                     layer: "retrieval_ready".into(),
                     kind: "thread_history".into(),
@@ -1563,31 +1542,27 @@ mod tests {
         };
 
         let rendered = status_context_text(&app);
-        assert!(rendered.contains("Current Session"));
-        assert!(rendered.contains("Context Budget"));
-        assert!(rendered.contains("stable instructions: 1200"));
+        assert!(rendered.contains("Session"));
+        assert!(rendered.contains("Budget"));
+        assert!(rendered.contains("stable: 1200"));
         assert!(rendered.contains("Stable Instructions"));
         assert!(rendered.contains("Workspace Prompt Sources"));
         assert!(rendered.contains("Active Memory Inputs"));
         assert!(rendered.contains("Memory Selection"));
-        assert!(rendered.contains("selection budget: 1024"));
+        assert!(rendered.contains("budget: 1024"));
         assert!(rendered.contains("Compacted History"));
         assert!(rendered.contains("Active Turn State"));
-        assert!(rendered.contains("Retrieval-ready but not injected items"));
-        assert!(rendered.contains("available but not injected"));
-        assert!(rendered.contains("dropped by ranking or budget"));
-        assert!(rendered.contains("1. Project Instruction (AGENTS.md) (project_instruction)"));
+        assert!(rendered.contains("Retrieval-ready"));
+        assert!(rendered.contains("selected:"));
+        assert!(rendered.contains("available:"));
+        assert!(rendered.contains("dropped:"));
+        assert!(rendered.contains("[project_instruction] Project Instruction (AGENTS.md)"));
         assert!(rendered.contains("path: AGENTS.md"));
-        assert!(rendered.contains("injected: yes"));
-        assert!(rendered.contains("budget impact: 120"));
-        assert!(rendered.contains("dropped: -"));
-        assert!(rendered.contains("6. Thread History (thread_history)"));
-        assert!(rendered.contains("injected: no"));
-        assert!(rendered.contains("not injected: raw thread history was not selected directly"));
+        assert!(rendered.contains("120t"));
+        assert!(rendered.contains("[thread_history] Thread History (not injected)"));
         assert!(rendered.contains(
-            "dropped: not selected because it would exceed the remaining memory-selection budget"
+            "exceed the remaining memory-selection budget"
         ));
-        assert!(rendered.contains("why selected: selected because the current effective prompt includes the workspace memory file as an active input"));
         assert!(rendered.contains("[pending] Implement /context"));
     }
 

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -342,7 +342,7 @@ fn render_context_assembly_entries(app: &TuiApp, layer: &str, title: &str) -> St
             let cache = cache_marker(entry.cache_status);
             let budget = entry
                 .budget_impact_tokens
-                .map(|v| format!(" {v}t"))
+                .map(|v| format!(" {}", format_token_count(v)))
                 .unwrap_or_default();
             let drop_note = match entry.dropped_reason.as_ref() {
                 Some(r) if !r.is_empty() && r != "-" => format!(" ── reason: {r}"),
@@ -365,7 +365,7 @@ fn render_memory_selection(app: &TuiApp) -> String {
         .snapshot
         .memory_selection
         .selection_budget_tokens
-        .map(|v| format!("{v}t"))
+        .map(format_token_count)
         .unwrap_or_else(|| "unlimited".to_string());
 
     let render_items = |items: &[crate::context::MemorySelectionItemContextEntry]| -> String {
@@ -383,7 +383,7 @@ fn render_memory_selection(app: &TuiApp) -> String {
                 };
                 let budget = item
                     .budget_impact_tokens
-                    .map(|v| format!(" {v}t"))
+                    .map(|v| format!(" {}", format_token_count(v)))
                     .unwrap_or_default();
                 let detail_preview = truncate_preview(&item.detail, 60);
                 let selection_reason = truncate_preview(&item.selection_reason, 70);
@@ -443,6 +443,84 @@ fn cache_marker(cache_status: Option<CacheStatus>) -> &'static str {
     }
 }
 
+fn format_token_count(tokens: usize) -> String {
+    format!("{tokens} tokens")
+}
+
+fn format_token_percent(tokens: usize, window: Option<usize>) -> String {
+    let Some(window) = window.filter(|value| *value > 0) else {
+        return String::new();
+    };
+    let percent = tokens as f64 * 100.0 / window as f64;
+    format!(" ({percent:.1}%)")
+}
+
+fn context_usage_line(label: &str, tokens: usize, window: Option<usize>) -> String {
+    format!(
+        "  {label}: {}{}",
+        format_token_count(tokens),
+        format_token_percent(tokens, window)
+    )
+}
+
+fn render_context_usage_summary(app: &TuiApp) -> String {
+    let window = app.snapshot.context_window_tokens;
+    let prompt_tokens = app
+        .snapshot
+        .stable_instructions_budget
+        .saturating_add(app.snapshot.workspace_prompt_budget);
+    let used_tokens = prompt_tokens
+        .saturating_add(app.snapshot.active_turn_budget)
+        .saturating_add(app.snapshot.compacted_history_budget)
+        .saturating_add(app.snapshot.retrieved_memory_budget)
+        .saturating_add(app.snapshot.reserved_output_tokens);
+    let free_tokens = app
+        .snapshot
+        .remaining_input_budget
+        .or_else(|| window.map(|window| window.saturating_sub(used_tokens)));
+    let autocompact_buffer = window
+        .map(|window| window.saturating_sub(app.snapshot.compact_threshold_tokens))
+        .filter(|tokens| *tokens > 0);
+
+    let mut lines = vec![
+        "Context Usage".to_string(),
+        format!("  model: {}", app.current_model_label()),
+        format!(
+            "  used: {}{} / {}",
+            format_token_count(used_tokens),
+            format_token_percent(used_tokens, window),
+            window
+                .map(format_token_count)
+                .unwrap_or_else(|| "unknown window".to_string())
+        ),
+        "  Estimated usage by category".to_string(),
+        context_usage_line("System prompt", prompt_tokens, window),
+        context_usage_line("Active turn", app.snapshot.active_turn_budget, window),
+        context_usage_line(
+            "Compacted history",
+            app.snapshot.compacted_history_budget,
+            window,
+        ),
+        context_usage_line(
+            "Retrieved memory",
+            app.snapshot.retrieved_memory_budget,
+            window,
+        ),
+        context_usage_line(
+            "Reserved output",
+            app.snapshot.reserved_output_tokens,
+            window,
+        ),
+    ];
+    if let Some(tokens) = free_tokens {
+        lines.push(context_usage_line("Free space", tokens, window));
+    }
+    if let Some(tokens) = autocompact_buffer {
+        lines.push(context_usage_line("Autocompact buffer", tokens, window));
+    }
+    lines.join("\n")
+}
+
 pub fn status_context_text(app: &TuiApp) -> String {
     let prompt_warnings = if app.snapshot.prompt_warnings.is_empty() {
         None
@@ -483,18 +561,19 @@ pub fn status_context_text(app: &TuiApp) -> String {
         let before = app
             .snapshot
             .last_compaction_boundary_before_tokens
-            .map(|tokens| tokens.to_string())
+            .map(format_token_count)
             .unwrap_or_else(|| "-".to_string());
         let files = app
             .snapshot
             .last_compaction_boundary_recent_file_count
             .map(|count| count.to_string())
             .unwrap_or_else(|| "-".to_string());
-        format!("v{version} before_tokens={before} recent_file_count={files}")
+        format!("v{version} before={before} recent_file_count={files}")
     } else {
         "-".to_string()
     };
     let mut sections = vec![
+        render_context_usage_summary(app),
         format!(
             "Session\n  cwd: {}\n  branch: {}\n  session: {}\n  history: {} msgs  {} entries",
             app.snapshot.cwd,
@@ -507,31 +586,31 @@ pub fn status_context_text(app: &TuiApp) -> String {
             "Budget\n  window: {}  reserved: {}  remaining: {}\n  stable: {}  workspace: {}  active: {}  compacted: {}  retrieved: {}",
             app.snapshot
                 .context_window_tokens
-                .map(|value| value.to_string())
+                .map(format_token_count)
                 .unwrap_or_else(|| "-".to_string()),
-            app.snapshot.reserved_output_tokens,
+            format_token_count(app.snapshot.reserved_output_tokens),
             app.snapshot
                 .remaining_input_budget
-                .map(|value| value.to_string())
+                .map(format_token_count)
                 .unwrap_or_else(|| "-".to_string()),
-            app.snapshot.stable_instructions_budget,
-            app.snapshot.workspace_prompt_budget,
-            app.snapshot.active_turn_budget,
-            app.snapshot.compacted_history_budget,
-            app.snapshot.retrieved_memory_budget,
+            format_token_count(app.snapshot.stable_instructions_budget),
+            format_token_count(app.snapshot.workspace_prompt_budget),
+            format_token_count(app.snapshot.active_turn_budget),
+            format_token_count(app.snapshot.compacted_history_budget),
+            format_token_count(app.snapshot.retrieved_memory_budget),
         ),
         format!(
-            "Compaction\n  estimated: {}t  threshold: {}t  count: {}\n  last: {}t → {}t  boundary: {}",
-            app.snapshot.estimated_history_tokens,
-            app.snapshot.compact_threshold_tokens,
+            "Compaction\n  estimated: {}  threshold: {}  count: {}\n  last: {} → {}  boundary: {}",
+            format_token_count(app.snapshot.estimated_history_tokens),
+            format_token_count(app.snapshot.compact_threshold_tokens),
             app.snapshot.compaction_count,
             app.snapshot
                 .last_compaction_before_tokens
-                .map(|value| value.to_string())
+                .map(format_token_count)
                 .unwrap_or_else(|| "-".to_string()),
             app.snapshot
                 .last_compaction_after_tokens
-                .map(|value| value.to_string())
+                .map(format_token_count)
                 .unwrap_or_else(|| "-".to_string()),
             last_boundary
         ),
@@ -1570,14 +1649,20 @@ mod tests {
         };
 
         let rendered = status_context_text(&app);
+        assert!(rendered.contains("Context Usage"));
+        assert!(rendered.contains("model:"));
+        assert!(rendered.contains("used: 10228 tokens (5.1%) / 200000 tokens"));
+        assert!(rendered.contains("System prompt: 1520 tokens (0.8%)"));
+        assert!(rendered.contains("Free space: 189772 tokens (94.9%)"));
+        assert!(rendered.contains("Autocompact buffer: 20000 tokens (10.0%)"));
         assert!(rendered.contains("Session"));
         assert!(rendered.contains("Budget"));
-        assert!(rendered.contains("stable: 1200"));
+        assert!(rendered.contains("stable: 1200 tokens"));
         assert!(rendered.contains("Stable Instructions"));
         assert!(rendered.contains("Workspace Prompt Sources"));
         assert!(rendered.contains("Active Memory Inputs"));
         assert!(rendered.contains("Memory Selection"));
-        assert!(rendered.contains("budget: 1024"));
+        assert!(rendered.contains("budget: 1024 tokens"));
         assert!(rendered.contains("Compacted History"));
         assert!(rendered.contains("Active Turn State"));
         assert!(rendered.contains("Retrieval-ready"));
@@ -1589,7 +1674,9 @@ mod tests {
         assert!(rendered.contains("○ [local_memory] Workspace Memory"));
         assert!(rendered.contains("- [retrieved_workspace_memory] Retrieved Experience"));
         assert!(rendered.contains("path: AGENTS.md"));
-        assert!(rendered.contains("120t"));
+        assert!(rendered.contains("120 tokens"));
+        assert!(rendered.contains("last: 12000 tokens → 4500 tokens"));
+        assert!(rendered.contains("boundary: v1 before=12000 tokens"));
         assert!(rendered.contains("[thread_history] Thread History (not injected)"));
         assert!(rendered.contains("exceed the remaining memory-selection budget"));
         assert!(rendered.contains("[pending] Implement /context"));

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -345,7 +345,7 @@ fn render_context_assembly_entries(app: &TuiApp, layer: &str, title: &str) -> St
                 .map(|v| format!(" {v}t"))
                 .unwrap_or_default();
             let drop_note = match entry.dropped_reason.as_deref() {
-                Some(r) if !r.is_empty() && r != "-" => format!(" ── dropped: {r}"),
+                Some(r) if !r.is_empty() && r != "-" => format!(" ── reason: {r}"),
                 _ => String::new(),
             };
             format!(
@@ -386,14 +386,15 @@ fn render_memory_selection(app: &TuiApp) -> String {
                     .map(|v| format!(" {v}t"))
                     .unwrap_or_default();
                 let detail_preview = truncate_preview(&item.detail, 60);
+                let selection_reason = truncate_preview(&item.selection_reason, 70);
                 let drop_note = match item.dropped_reason.as_deref() {
                     Some(r) if !r.is_empty() && r != "-" => {
-                        format!(" ── {r}")
+                        format!(" ── reason: {r}")
                     }
                     _ => String::new(),
                 };
                 format!(
-                    "    {connector} [{kind}] {label}{budget}\n    {vertical}   {detail_preview}{drop_note}",
+                    "    {connector} [{kind}] {label}{budget}\n    {vertical}   detail: {detail_preview}{drop_note}\n    {vertical}   reason: {selection_reason}",
                     kind = item.kind,
                     label = item.label,
                 )

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -328,7 +328,11 @@ fn render_context_assembly_entries(app: &TuiApp, layer: &str, title: &str) -> St
         .into_iter()
         .enumerate()
         .map(|(idx, entry)| {
-            let connector = if idx + 1 == count { "└──" } else { "├──" };
+            let (connector, vertical) = if idx + 1 == count {
+                ("└──", " ")
+            } else {
+                ("├──", "│")
+            };
             let path = entry
                 .source_path
                 .as_deref()
@@ -349,7 +353,7 @@ fn render_context_assembly_entries(app: &TuiApp, layer: &str, title: &str) -> St
                 _ => String::new(),
             };
             format!(
-                "  {connector} {cache}[{kind}] {label}{injected}{budget}\n  │   path: {path}{drop_note}",
+                "  {connector} {cache}[{kind}] {label}{injected}{budget}\n  {vertical}   path: {path}{drop_note}",
                 kind = entry.kind,
                 label = entry.label,
             )
@@ -377,7 +381,11 @@ fn render_memory_selection(app: &TuiApp) -> String {
             .iter()
             .enumerate()
             .map(|(idx, item)| {
-                let connector = if idx + 1 == items.len() { "└──" } else { "├──" };
+                let (connector, vertical) = if idx + 1 == items.len() {
+                    ("└──", " ")
+                } else {
+                    ("├──", "│")
+                };
                 let budget = item
                     .budget_impact_tokens
                     .map(|v| format!(" {v}t"))
@@ -390,7 +398,7 @@ fn render_memory_selection(app: &TuiApp) -> String {
                     _ => String::new(),
                 };
                 format!(
-                    "    {connector} [{kind}] {label}{budget}\n    │   {detail_preview}{drop_note}",
+                    "    {connector} [{kind}] {label}{budget}\n    {vertical}   {detail_preview}{drop_note}",
                     kind = item.kind,
                     label = item.label,
                 )
@@ -409,10 +417,10 @@ fn render_memory_selection(app: &TuiApp) -> String {
 
 fn truncate_preview(text: &str, max_len: usize) -> String {
     let condensed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    if condensed.len() <= max_len {
+    if condensed.chars().count() <= max_len {
         condensed
     } else {
-        format!("{}…", &condensed[..max_len - 1])
+        format!("{}…", &condensed[..condensed.char_indices().nth(max_len - 1).map_or(max_len - 1, |(i, _)| i)])
     }
 }
 

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -368,11 +368,12 @@ fn render_memory_selection(app: &TuiApp) -> String {
         .map(|v| format!("{v}t"))
         .unwrap_or_else(|| "unlimited".to_string());
 
-    let render_items = |items: &[crate::context::MemorySelectionItemContextEntry]| -> String {
-        if items.is_empty() {
-            return "    (none)".to_string();
-        }
-        items
+    let render_items =
+        |items: &[crate::context::MemorySelectionItemContextEntry]| -> String {
+            if items.is_empty() {
+                return "    (none)".to_string();
+            }
+            items
             .iter()
             .enumerate()
             .map(|(idx, item)| {
@@ -396,7 +397,7 @@ fn render_memory_selection(app: &TuiApp) -> String {
             })
             .collect::<Vec<_>>()
             .join("\n")
-    };
+        };
 
     format!(
         "Memory Selection  (budget: {budget})\n  ├── selected:\n{}\n  ├── available:\n{}\n  └── dropped:\n{}",
@@ -515,7 +516,11 @@ pub fn status_context_text(app: &TuiApp) -> String {
         ),
         format!("Pending\n{}", pending_interactions),
         render_context_assembly_entries(app, "stable_instructions", "Stable Instructions"),
-        render_context_assembly_entries(app, "workspace_prompt_sources", "Workspace Prompt Sources"),
+        render_context_assembly_entries(
+            app,
+            "workspace_prompt_sources",
+            "Workspace Prompt Sources",
+        ),
         render_context_assembly_entries(app, "active_memory_inputs", "Active Memory Inputs"),
         render_memory_selection(app),
         render_context_assembly_entries(app, "compacted_history", "Compacted History"),
@@ -1560,9 +1565,7 @@ mod tests {
         assert!(rendered.contains("path: AGENTS.md"));
         assert!(rendered.contains("120t"));
         assert!(rendered.contains("[thread_history] Thread History (not injected)"));
-        assert!(rendered.contains(
-            "exceed the remaining memory-selection budget"
-        ));
+        assert!(rendered.contains("exceed the remaining memory-selection budget"));
         assert!(rendered.contains("[pending] Implement /context"));
     }
 

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -339,11 +339,7 @@ fn render_context_assembly_entries(app: &TuiApp, layer: &str, title: &str) -> St
                 .filter(|v| !v.is_empty())
                 .unwrap_or("-");
             let injected = if entry.injected { "" } else { " (not injected)" };
-            let cache = match entry.cache_status {
-                Some(CacheStatus::Hit) => "●",
-                Some(CacheStatus::Miss) => "○",
-                _ => "",
-            };
+            let cache = cache_marker(entry.cache_status);
             let budget = entry
                 .budget_impact_tokens
                 .map(|v| format!(" {v}t"))
@@ -417,15 +413,29 @@ fn render_memory_selection(app: &TuiApp) -> String {
 fn truncate_preview(text: &str, max_len: usize) -> String {
     let condensed: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
     if condensed.chars().count() <= max_len {
-        condensed
-    } else {
-        format!(
-            "{}…",
-            &condensed[..condensed
-                .char_indices()
-                .nth(max_len - 1)
-                .map_or(max_len - 1, |(i, _)| i)]
-        )
+        return condensed;
+    }
+    if max_len == 0 {
+        return String::new();
+    }
+    if max_len == 1 {
+        return "…".to_string();
+    }
+
+    let keep_chars = max_len - 1;
+    let truncate_at = condensed
+        .char_indices()
+        .nth(keep_chars)
+        .map_or(condensed.len(), |(idx, _)| idx);
+    format!("{}…", &condensed[..truncate_at])
+}
+
+fn cache_marker(cache_status: Option<CacheStatus>) -> &'static str {
+    match cache_status {
+        Some(CacheStatus::Hit) => "● ",
+        Some(CacheStatus::Miss) => "○ ",
+        Some(CacheStatus::NoCache) => "- ",
+        None => "",
     }
 }
 
@@ -1031,7 +1041,7 @@ mod tests {
     use super::{
         COMMAND_SPECS, LocalCommandKind, help_text, matching_commands, model_help_text,
         normalize_command_token, palette_commands, parse_local_command, status_context_text,
-        status_prompt_sources_text, status_resources_text, status_runtime_text,
+        status_prompt_sources_text, status_resources_text, status_runtime_text, truncate_preview,
     };
     use crate::config::{ConfigManager, OpenAiEndpointKind};
     use crate::context::PromptSourceContextEntry;
@@ -1476,7 +1486,7 @@ mod tests {
             ],
             assembly_entries: vec![
                 crate::context::ContextAssemblyEntry {
-                    cache_status: None,
+                    cache_status: Some(crate::context::CacheStatus::Hit),
                     order: 1,
                     layer: "stable_instructions".into(),
                     kind: "project_instruction".into(),
@@ -1489,7 +1499,7 @@ mod tests {
                     dropped_reason: None,
                 },
                 crate::context::ContextAssemblyEntry {
-                    cache_status: None,
+                    cache_status: Some(crate::context::CacheStatus::Miss),
                     order: 2,
                     layer: "workspace_prompt_sources".into(),
                     kind: "local_memory".into(),
@@ -1502,7 +1512,7 @@ mod tests {
                     dropped_reason: None,
                 },
                 crate::context::ContextAssemblyEntry {
-                    cache_status: None,
+                    cache_status: Some(crate::context::CacheStatus::NoCache),
                     order: 3,
                     layer: "active_memory_inputs".into(),
                     kind: "retrieved_workspace_memory".into(),
@@ -1575,11 +1585,22 @@ mod tests {
         assert!(rendered.contains("available:"));
         assert!(rendered.contains("dropped:"));
         assert!(rendered.contains("[project_instruction] Project Instruction (AGENTS.md)"));
+        assert!(rendered.contains("● [project_instruction] Project Instruction (AGENTS.md)"));
+        assert!(rendered.contains("○ [local_memory] Workspace Memory"));
+        assert!(rendered.contains("- [retrieved_workspace_memory] Retrieved Experience"));
         assert!(rendered.contains("path: AGENTS.md"));
         assert!(rendered.contains("120t"));
         assert!(rendered.contains("[thread_history] Thread History (not injected)"));
         assert!(rendered.contains("exceed the remaining memory-selection budget"));
         assert!(rendered.contains("[pending] Implement /context"));
+    }
+
+    #[test]
+    fn truncate_preview_handles_unicode_and_small_limits() {
+        assert_eq!(truncate_preview("alpha beta", 0), "");
+        assert_eq!(truncate_preview("alpha beta", 1), "…");
+        assert_eq!(truncate_preview("你好 世界", 3), "你好…");
+        assert_eq!(truncate_preview("alpha   beta", 20), "alpha beta");
     }
 
     #[test]

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -1,5 +1,5 @@
 use crate::config::RaraConfig;
-use crate::context::CacheStatus;
+use crate::context::{CacheStatus, DropReason};
 
 use super::state::{
     CommandSpec, LocalCommand, LocalCommandKind, PROVIDER_FAMILIES, PendingInteractionSnapshot,
@@ -344,7 +344,7 @@ fn render_context_assembly_entries(app: &TuiApp, layer: &str, title: &str) -> St
                 .budget_impact_tokens
                 .map(|v| format!(" {v}t"))
                 .unwrap_or_default();
-            let drop_note = match entry.dropped_reason.as_deref() {
+            let drop_note = match entry.dropped_reason.as_ref() {
                 Some(r) if !r.is_empty() && r != "-" => format!(" ── reason: {r}"),
                 _ => String::new(),
             };
@@ -387,9 +387,12 @@ fn render_memory_selection(app: &TuiApp) -> String {
                     .unwrap_or_default();
                 let detail_preview = truncate_preview(&item.detail, 60);
                 let selection_reason = truncate_preview(&item.selection_reason, 70);
-                let drop_note = match item.dropped_reason.as_deref() {
-                    Some(r) if !r.is_empty() && r != "-" => {
-                        format!(" ── reason: {r}")
+                let drop_note = match &item.dropped_reason {
+                    Some(DropReason::NotSelected { reason }) if !reason.is_empty() => {
+                        format!(" ── reason: {reason}")
+                    }
+                    Some(DropReason::BudgetExceeded { reason }) => {
+                        format!(" ── reason: {reason}")
                     }
                     _ => String::new(),
                 };
@@ -1045,7 +1048,7 @@ mod tests {
         status_prompt_sources_text, status_resources_text, status_runtime_text, truncate_preview,
     };
     use crate::config::{ConfigManager, OpenAiEndpointKind};
-    use crate::context::PromptSourceContextEntry;
+    use crate::context::{DropReason, PromptSourceContextEntry};
     use crate::tui::state::{RuntimeSnapshot, TuiApp};
     use tempfile::tempdir;
 
@@ -1441,9 +1444,7 @@ mod tests {
                     selection_reason:
                         "thread history remains available as a recall source even when only active-turn state is currently injected".into(),
                     budget_impact_tokens: None,
-                    dropped_reason: Some(
-                        "raw thread history was not selected directly because the current turn already has sufficient active-turn and compacted-history context".into(),
-                    ),
+                    dropped_reason: Some(DropReason::NotSelected { reason: "raw thread history was not selected directly because the current turn already has sufficient active-turn and compacted-history context".to_string() }),
                 }],
                 dropped_items: vec![crate::context::MemorySelectionItemContextEntry {
                     order: 1,
@@ -1453,9 +1454,7 @@ mod tests {
                     selection_reason:
                         "selected because the retrieval tool returned relevant durable memory candidates for the current task".into(),
                     budget_impact_tokens: Some(2_048),
-                    dropped_reason: Some(
-                        "not selected because it would exceed the remaining memory-selection budget (2048 > 1024)".into(),
-                    ),
+                    dropped_reason: Some(DropReason::NotSelected { reason: "not selected because it would exceed the remaining memory-selection budget (2048 > 1024)".to_string() }),
                 }],
             },
             prompt_base_kind: "codex".into(),

--- a/src/tui/command.rs
+++ b/src/tui/command.rs
@@ -1454,7 +1454,7 @@ mod tests {
                     selection_reason:
                         "selected because the retrieval tool returned relevant durable memory candidates for the current task".into(),
                     budget_impact_tokens: Some(2_048),
-                    dropped_reason: Some(DropReason::NotSelected { reason: "not selected because it would exceed the remaining memory-selection budget (2048 > 1024)".to_string() }),
+                    dropped_reason: Some(DropReason::BudgetExceeded { reason: "not selected because it would exceed the remaining memory-selection budget (2048 > 1024)".to_string() }),
                 }],
             },
             prompt_base_kind: "codex".into(),

--- a/src/tui/queued_input.rs
+++ b/src/tui/queued_input.rs
@@ -19,3 +19,43 @@ pub fn pending_follow_up_hint() -> &'static str {
 pub fn queued_follow_up_hint() -> &'static str {
     "queued follow-up  will submit after current turn"
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueuedFollowUpSection {
+    pub title: &'static str,
+    pub preview: String,
+    pub remaining: usize,
+    pub remaining_label: &'static str,
+}
+
+pub fn queued_follow_up_sections(
+    pending_preview: Option<&str>,
+    pending_count: usize,
+    queued_preview: Option<&str>,
+    queued_count: usize,
+) -> Vec<QueuedFollowUpSection> {
+    let mut sections = Vec::new();
+    if let Some(preview) = pending_preview
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        sections.push(QueuedFollowUpSection {
+            title: pending_follow_up_heading(),
+            preview: preview.to_string(),
+            remaining: pending_count.saturating_sub(1),
+            remaining_label: "more pending",
+        });
+    }
+    if let Some(preview) = queued_preview
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        sections.push(QueuedFollowUpSection {
+            title: queued_follow_up_heading(),
+            preview: preview.to_string(),
+            remaining: queued_count.saturating_sub(1),
+            remaining_label: "more queued",
+        });
+    }
+    sections
+}

--- a/src/tui/queued_input.rs
+++ b/src/tui/queued_input.rs
@@ -59,3 +59,34 @@ pub fn queued_follow_up_sections(
     }
     sections
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{pending_follow_up_heading, queued_follow_up_heading, queued_follow_up_sections};
+
+    #[test]
+    fn queued_follow_up_sections_include_pending_and_end_of_turn_messages() {
+        let sections =
+            queued_follow_up_sections(Some("first follow-up"), 2, Some("second follow-up"), 3);
+
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].title, pending_follow_up_heading());
+        assert_eq!(sections[0].preview, "first follow-up");
+        assert_eq!(sections[0].remaining, 1);
+        assert_eq!(sections[0].remaining_label, "more pending");
+        assert_eq!(sections[1].title, queued_follow_up_heading());
+        assert_eq!(sections[1].preview, "second follow-up");
+        assert_eq!(sections[1].remaining, 2);
+        assert_eq!(sections[1].remaining_label, "more queued");
+    }
+
+    #[test]
+    fn queued_follow_up_sections_skip_empty_previews() {
+        let sections = queued_follow_up_sections(Some("  "), 2, Some("queued"), 1);
+
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].title, queued_follow_up_heading());
+        assert_eq!(sections[0].preview, "queued");
+        assert_eq!(sections[0].remaining, 0);
+    }
+}

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -8,9 +8,9 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::super::custom_terminal::Frame;
 use super::super::interaction_text::pending_interaction_hint_text;
-use super::super::queued_input::{
-    pending_follow_up_hint, queued_follow_up_hint, queued_follow_up_sections,
-};
+#[cfg(test)]
+use super::super::queued_input::queued_follow_up_sections;
+use super::super::queued_input::{pending_follow_up_hint, queued_follow_up_hint};
 use super::super::state::char_offset_to_byte_index;
 use super::super::state::{ActivePendingInteractionKind, TaskKind, TuiApp};
 use super::badge;
@@ -284,6 +284,7 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
     ))
 }
 
+#[cfg(test)]
 fn queued_follow_up_preview_lines(app: &TuiApp) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -8,8 +8,6 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::super::custom_terminal::Frame;
 use super::super::interaction_text::pending_interaction_hint_text;
-#[cfg(test)]
-use super::super::queued_input::queued_follow_up_sections;
 use super::super::queued_input::{pending_follow_up_hint, queued_follow_up_hint};
 use super::super::state::char_offset_to_byte_index;
 use super::super::state::{ActivePendingInteractionKind, TaskKind, TuiApp};
@@ -284,46 +282,6 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
     ))
 }
 
-#[cfg(test)]
-fn queued_follow_up_preview_lines(app: &TuiApp) -> Vec<Line<'static>> {
-    let mut lines = Vec::new();
-
-    for section in queued_follow_up_sections(
-        app.pending_follow_up_preview(),
-        app.pending_follow_up_count(),
-        app.queued_end_of_turn_preview(),
-        app.queued_follow_up_messages.len(),
-    ) {
-        if !lines.is_empty() {
-            lines.push(Line::from(""));
-        }
-        lines.push(Line::from(vec![
-            Span::styled(
-                "› ",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(section.title, Style::default().fg(Color::DarkGray)),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("  "),
-            Span::raw(section.preview),
-        ]));
-        if section.remaining > 0 {
-            lines.push(Line::from(vec![
-                Span::raw("  "),
-                Span::styled(
-                    format!("... {} {}", section.remaining, section.remaining_label),
-                    Style::default().fg(Color::DarkGray),
-                ),
-            ]));
-        }
-    }
-
-    lines
-}
-
 fn composer_hint(app: &TuiApp) -> &'static str {
     if matches!(
         app.overlay,
@@ -595,7 +553,6 @@ fn display_char_width(ch: char) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
     use std::time::Instant;
 
     use ratatui::{layout::Rect, style::Color};
@@ -610,7 +567,7 @@ mod tests {
 
     use super::{
         activity_status_line, composer_hint, composer_hint_line, footer_summary_text,
-        queued_follow_up_preview_lines, wrapped_text_cursor_position, wrapped_text_rows,
+        wrapped_text_cursor_position, wrapped_text_rows,
     };
 
     #[test]
@@ -719,51 +676,6 @@ mod tests {
         assert_eq!(label, "Warning");
         assert_eq!(color, Color::Yellow);
         assert!(detail.contains("missing an API key"));
-    }
-
-    #[test]
-    fn queued_follow_up_preview_shows_first_message_and_remainder() {
-        let temp = tempdir().unwrap();
-        let mut app = TuiApp::new(ConfigManager {
-            path: temp.path().join("config.json"),
-        })
-        .expect("build tui app");
-        app.begin_running_turn();
-        app.queue_follow_up_message_after_next_tool_boundary("first follow-up");
-        app.queue_follow_up_message("second follow-up");
-
-        let rendered = queued_follow_up_preview_lines(&app)
-            .into_iter()
-            .map(|line| line.to_string())
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        assert!(rendered.contains("Messages to be submitted after next tool call"));
-        assert!(rendered.contains("Queued follow-up messages"));
-        assert!(rendered.contains("first follow-up"));
-        assert!(rendered.contains("second follow-up"));
-    }
-
-    #[test]
-    fn queued_follow_up_preview_snapshot() {
-        let temp = tempdir().unwrap();
-        let mut app = TuiApp::new(ConfigManager {
-            path: temp.path().join("config.json"),
-        })
-        .expect("build tui app");
-        app.begin_running_turn();
-        app.queue_follow_up_message_after_next_tool_boundary(
-            "apply the feedback to the auth picker and rerun focused tests",
-        );
-        app.queue_follow_up_message("then summarize the remaining TODOs");
-
-        let rendered = queued_follow_up_preview_lines(&app)
-            .into_iter()
-            .map(|line| line.to_string())
-            .collect::<Vec<_>>()
-            .join("\n");
-
-        assert_snapshot!("queued_follow_up_preview", rendered);
     }
 
     #[test]

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -9,8 +9,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use super::super::custom_terminal::Frame;
 use super::super::interaction_text::pending_interaction_hint_text;
 use super::super::queued_input::{
-    pending_follow_up_heading, pending_follow_up_hint, queued_follow_up_heading,
-    queued_follow_up_hint,
+    pending_follow_up_hint, queued_follow_up_hint, queued_follow_up_sections,
 };
 use super::super::state::char_offset_to_byte_index;
 use super::super::state::{ActivePendingInteractionKind, TaskKind, TuiApp};
@@ -218,9 +217,7 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(2), Constraint::Length(1)])
         .split(area);
-    let composer_lines = if app.input.is_empty() && app.has_queued_follow_up_messages() {
-        queued_follow_up_preview_lines(app)
-    } else if app.input.is_empty() {
+    let composer_lines = if app.input.is_empty() {
         vec![Line::from(vec![
             Span::styled(
                 "› ",
@@ -290,44 +287,12 @@ fn render_composer(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)
 fn queued_follow_up_preview_lines(app: &TuiApp) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
 
-    if let Some(preview) = app
-        .pending_follow_up_preview()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        lines.push(Line::from(vec![
-            Span::styled(
-                "› ",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                pending_follow_up_heading(),
-                Style::default().fg(Color::DarkGray),
-            ),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("  "),
-            Span::raw(preview.to_string()),
-        ]));
-        let remaining = app.pending_follow_up_count().saturating_sub(1);
-        if remaining > 0 {
-            lines.push(Line::from(vec![
-                Span::raw("  "),
-                Span::styled(
-                    format!("... {remaining} more pending"),
-                    Style::default().fg(Color::DarkGray),
-                ),
-            ]));
-        }
-    }
-
-    if let Some(preview) = app
-        .queued_end_of_turn_preview()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
+    for section in queued_follow_up_sections(
+        app.pending_follow_up_preview(),
+        app.pending_follow_up_count(),
+        app.queued_end_of_turn_preview(),
+        app.queued_follow_up_messages.len(),
+    ) {
         if !lines.is_empty() {
             lines.push(Line::from(""));
         }
@@ -338,21 +303,17 @@ fn queued_follow_up_preview_lines(app: &TuiApp) -> Vec<Line<'static>> {
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(
-                queued_follow_up_heading(),
-                Style::default().fg(Color::DarkGray),
-            ),
+            Span::styled(section.title, Style::default().fg(Color::DarkGray)),
         ]));
         lines.push(Line::from(vec![
             Span::raw("  "),
-            Span::raw(preview.to_string()),
+            Span::raw(section.preview),
         ]));
-        let remaining = app.queued_follow_up_messages.len().saturating_sub(1);
-        if remaining > 0 {
+        if section.remaining > 0 {
             lines.push(Line::from(vec![
                 Span::raw("  "),
                 Span::styled(
-                    format!("... {remaining} more queued"),
+                    format!("... {} {}", section.remaining, section.remaining_label),
                     Style::default().fg(Color::DarkGray),
                 ),
             ]));
@@ -370,6 +331,8 @@ fn composer_hint(app: &TuiApp) -> &'static str {
         ""
     } else if app.input.trim_start().starts_with('/') {
         "slash command  Enter run  Esc close"
+    } else if let Some(pending) = app.active_pending_interaction() {
+        pending_interaction_hint_text(pending.kind)
     } else if app.has_pending_follow_up_messages() {
         pending_follow_up_hint()
     } else if app.has_queued_follow_up_messages() {
@@ -386,8 +349,6 @@ fn composer_hint(app: &TuiApp) -> &'static str {
         }
     } else if app.has_pending_planning_suggestion() {
         "planning suggested  1 enter planning mode  2 continue in execute mode"
-    } else if let Some(pending) = app.active_pending_interaction() {
-        pending_interaction_hint_text(pending.kind)
     } else if app.agent_execution_mode_label() == "plan" {
         "planning mode  read-only planning; approve to execute"
     } else {
@@ -477,16 +438,7 @@ fn desired_composer_height(app: &TuiApp, width: u16, rows: u16) -> u16 {
 
 fn composer_content_line_count(app: &TuiApp, width: u16) -> u16 {
     let content = if app.input.is_empty() {
-        if app.has_queued_follow_up_messages() {
-            queued_follow_up_preview_lines(app)
-                .into_iter()
-                .map(|line| line.to_string())
-                .collect::<Vec<_>>()
-                .join("\n")
-        } else {
-            "Ask about the repo, request a code change, or type /help to browse commands."
-                .to_string()
-        }
+        "Ask about the repo, request a code change, or type /help to browse commands.".to_string()
     } else {
         app.input.clone()
     };
@@ -723,6 +675,31 @@ mod tests {
         assert_eq!(label, "Plan Approval");
         assert!(detail.contains("start implementation"));
         assert!(detail.contains("continue planning"));
+    }
+
+    #[test]
+    fn pending_interaction_hint_takes_priority_over_queued_follow_up() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.queue_follow_up_message("then review the diff");
+        app.snapshot
+            .pending_interactions
+            .push(PendingInteractionSnapshot {
+                kind: InteractionKind::Approval,
+                title: "Shell Approval".into(),
+                summary: "git diff origin/main -- src/context/assembler.rs".into(),
+                options: Vec::new(),
+                note: None,
+                approval: None,
+                source: None,
+            });
+
+        let hint = composer_hint(&app);
+        assert!(hint.contains("1 allow once"));
+        assert!(!hint.contains("queued follow-up"));
     }
 
     #[test]

--- a/src/tui/render/cells.rs
+++ b/src/tui/render/cells.rs
@@ -6,6 +6,7 @@ use crate::tui::interaction_text::{
     pending_interaction_detail_text, pending_interaction_shortcut_text,
 };
 use crate::tui::plan_display::should_show_updated_plan;
+use crate::tui::queued_input::queued_follow_up_sections;
 use crate::tui::state::{
     ActiveLiveEvent, RuntimePhase, TranscriptEntry, TranscriptEntryPayload, TuiApp,
     contains_structured_planning_output,
@@ -20,9 +21,9 @@ mod components;
 pub(crate) use self::components::StartupCardCell;
 use self::components::{
     CommittedInteractionCell, ExploredCell, ExploringCell, MessageCell, PendingInteractionCell,
-    PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell, RanCell, RespondingCell,
-    RunningCell, TerminalCell, ThinkingGroupCell, ThinkingTextCell, UserCell,
-    planning_suggestion_text,
+    PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell, QueuedFollowUpCell,
+    RanCell, RespondingCell, RunningCell, TerminalCell, ThinkingGroupCell, ThinkingTextCell,
+    UserCell, planning_suggestion_text,
 };
 use super::{
     compact_progress_summary_lines, compact_recent_first_summary_lines, compact_summary_lines,
@@ -1255,6 +1256,16 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 pending.kind,
                 request_lines,
             )));
+        }
+
+        let queued_sections = queued_follow_up_sections(
+            self.app.pending_follow_up_preview(),
+            self.app.pending_follow_up_count(),
+            self.app.queued_end_of_turn_preview(),
+            self.app.queued_follow_up_messages.len(),
+        );
+        if !queued_sections.is_empty() {
+            cells.push(Box::new(QueuedFollowUpCell::new(queued_sections)));
         }
 
         if self.app.pending_planning_suggestion.is_some() {

--- a/src/tui/render/cells_components.rs
+++ b/src/tui/render/cells_components.rs
@@ -10,6 +10,7 @@ use crate::tui::interaction_text::{
 };
 use crate::tui::markdown_render::render_markdown_text_with_width;
 use crate::tui::plan_display::updated_plan_lines;
+use crate::tui::queued_input::QueuedFollowUpSection;
 use crate::tui::render::diff::render_patch_preview;
 use crate::tui::render::{
     display_width, formatted_message_lines, prefixed_message_lines, rendered_markdown_lines,
@@ -443,6 +444,36 @@ impl HistoryCell for PlanningSuggestionCell {
                 .lines()
                 .map(|line| Line::from(format!("  {line}"))),
         );
+        lines
+    }
+}
+
+pub(super) struct QueuedFollowUpCell {
+    sections: Vec<QueuedFollowUpSection>,
+}
+
+impl QueuedFollowUpCell {
+    pub(super) fn new(sections: Vec<QueuedFollowUpSection>) -> Self {
+        Self { sections }
+    }
+}
+
+impl HistoryCell for QueuedFollowUpCell {
+    fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
+        let mut lines = vec![Line::from(section_span(
+            "Queued Follow-up",
+            Color::DarkGray,
+        ))];
+        for section in &self.sections {
+            lines.push(Line::from(format!("  {}", section.title)));
+            lines.push(Line::from(format!("    -> {}", section.preview)));
+            if section.remaining > 0 {
+                lines.push(Line::from(format!(
+                    "    ... {} {}",
+                    section.remaining, section.remaining_label
+                )));
+            }
+        }
         lines
     }
 }

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -211,6 +211,52 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
 }
 
 #[test]
+fn active_turn_cell_renders_queued_follow_up_without_hiding_shell_approval() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry {
+            role: "You".into(),
+            message: "Run a shell command".into(),
+            payload: None,
+        }],
+    };
+    app.queue_follow_up_message("then review the diff");
+    app.snapshot
+        .pending_interactions
+        .push(crate::tui::state::PendingInteractionSnapshot {
+            kind: crate::tui::state::InteractionKind::Approval,
+            title: "Pending Approval".into(),
+            summary: "git diff origin/main -- src/context/assembler.rs".into(),
+            options: Vec::new(),
+            note: None,
+            approval: Some(crate::tui::state::PendingApprovalSnapshot {
+                tool_use_id: "toolu_123".into(),
+                command: "git diff origin/main -- src/context/assembler.rs".into(),
+                allow_net: false,
+                payload: Default::default(),
+            }),
+            source: None,
+        });
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains(" Shell Approval "));
+    assert!(rendered.contains("1. Allow once"));
+    assert!(rendered.contains(" Queued Follow-up "));
+    assert!(rendered.contains("Queued follow-up messages"));
+    assert!(rendered.contains("then review the diff"));
+}
+
+#[test]
 fn active_turn_cell_does_not_render_completed_plan_decision() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -648,7 +648,6 @@ pub(super) fn format_tool_result(name: &str, content: &str) -> String {
         }
         return summary;
     }
-
     if name == "apply_patch"
         && let Ok(value) = serde_json::from_str::<serde_json::Value>(content)
     {
@@ -685,8 +684,16 @@ pub(super) fn format_tool_result(name: &str, content: &str) -> String {
     {
         let summary = normalize_tool_result_summary(name, summary);
         let mut rendered = format!("{name}: {summary}");
-        if content.contains("<persisted-output>") {
-            rendered.push_str("\\nfull result stored on disk");
+        if content.contains("\nfull result:") {
+            let remainder = content.lines().skip(1).collect::<Vec<_>>().join("\n");
+            if !remainder.trim().is_empty() {
+                rendered.push('\n');
+                rendered.push_str(remainder.trim_end());
+            }
+        } else if content.contains("<persisted-output>") {
+            rendered.push_str("\nfull result stored on disk");
+        } else if content.contains("full_result_path=") {
+            rendered.push_str("\nfull result stored on disk");
         } else if let Some(preview) = tool_result_preview(content) {
             rendered.push_str(&format!("\n{preview}"));
         }

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -524,6 +524,20 @@ fn formats_generic_tool_result_without_preview_available_marker() {
 }
 
 #[test]
+fn formats_persisted_bash_result_without_generic_prefix() {
+    let rendered = format_tool_result(
+        "bash",
+        "finished with exit code 0\nDuration: 10 ms\nOutput:\nline 1\nline 2\n\n[tool_result truncated]\nfull result: /tmp/rara/tool-results/tool-1.json",
+    );
+
+    assert!(rendered.starts_with("bash: finished with exit code 0"));
+    assert!(rendered.contains("Output:\nline 1\nline 2"));
+    assert!(rendered.contains("full result: /tmp/rara/tool-results/tool-1.json"));
+    assert!(!rendered.contains("bash: bash finished"));
+    assert!(!rendered.contains("full result stored on disk"));
+}
+
+#[test]
 fn formats_tool_progress_with_stream_label() {
     let rendered = format_tool_progress("bash", ToolOutputStream::Stderr, "warn 1\nwarn 2\n");
     assert_eq!(rendered, "bash stderr:\nwarn 1\nwarn 2\n");

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -84,6 +84,17 @@ pub(crate) async fn handle_submit(
         app.push_notice(format!("Unknown command '{}'. Use /help.", trimmed));
     } else if pending::handle_pending_option_submit(app, agent_slot, &trimmed) {
         return Ok(false);
+    } else if app.active_pending_interaction().is_some() && app.pending_request_input().is_none() {
+        let queued = app.queue_follow_up_message(trimmed.clone());
+        let suffix = if queued > 1 {
+            format!(" {queued} follow-up messages are queued.")
+        } else {
+            " 1 follow-up message is queued.".to_string()
+        };
+        app.notice = Some(format!(
+            "Queued until the pending interaction is answered.{suffix}"
+        ));
+        return Ok(false);
     } else if let Some(agent) = agent_slot.take() {
         if app.pending_request_input().is_some() {
             pending::handle_request_input_answer(app, agent_slot, agent, trimmed);

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -157,6 +157,35 @@ async fn submit_numeric_input_handles_pending_shell_approval() {
 }
 
 #[tokio::test]
+async fn plain_submit_queues_while_shell_approval_is_pending() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    add_pending_shell_approval(&mut app);
+    app.input = "then review the diff".into();
+
+    let mut agent_slot = None;
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let should_quit = super::handle_submit(&mut app, &mut agent_slot, &oauth_manager)
+        .await
+        .expect("submit");
+
+    assert!(!should_quit);
+    assert!(app.running_task.is_none());
+    assert_eq!(app.queued_follow_up_preview(), Some("then review the diff"));
+    assert!(
+        app.notice
+            .as_deref()
+            .is_some_and(|value| value.contains("pending interaction is answered"))
+    );
+}
+
+#[tokio::test]
 async fn esc_cancels_busy_query_without_overlay() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {


### PR DESCRIPTION
## Summary

Phase 1 of the architecture closure from `docs/todo.md`.

### Changes

**MemorySelection** (`src/context/memory_selection.rs`)
- 6 focused tests for the non-vector selection path.
- Covers thread_history selection, compacted-history dedup, vector-memory placeholder, retrieval tool candidates, and budget-constrained dropping.

**DropReason** (`src/context/runtime.rs`)
- New `DropReason` enum: `NotSelected { reason }` for available_items, `BudgetExceeded { reason }` for dropped_items.
- Replaces raw `Option<String>` on `MemorySelectionItemContextEntry`.
- Rendered via structured match in `/context` instead of string comparisons.

**CacheStatus** (`src/context/runtime.rs`)
- New `CacheStatus` enum (`Hit` / `Miss` / `NoCache`) on `ContextAssemblyEntry`.
- Rendered as compact markers in `/context` (`●` hit, `○` miss, `-` no-cache).
- `PromptSource` and `PromptSourceContextEntry` intentionally do NOT carry transient cache signals.

**ThreadStore** (`src/thread_store.rs`)
- `is_fork()`, `lineage()`, `provenance_description()` for explicit lineage inspection.
- `ThreadMaterializationProvenance::describe()` for canonical/backfill/fallback visibility.

**`/context` TUI** (`src/tui/command.rs`)
- Tree-style rendering with `├──`/`└──` connectors and conditional vertical bars.
- Compact section headers (Session, Budget, Compaction, Plan, Pending).
- Inline token annotations and structured drop reason display.

### Validation
- `cargo test context` — 37 passed
- `cargo test thread_store` — 14 passed
- `cargo fmt` / `cargo clippy` clean