### PR TITLE
fix: improve tool output previews

### DIFF
--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -38,6 +38,11 @@ The transcript should move toward Codex/Claude-style tool visibility:
   - prefer dedicated RARA tools for file search, reads, and edits;
   - use `cwd` instead of prepending `cd`;
   - avoid newline-separated shell chaining;
+  - issue independent validation commands as separate tool calls instead of
+    combining them with `&&`, `;`, or pipelines only to run them together;
+  - avoid adding `2>&1`, `head`, `tail`, or `grep` only to reduce displayed
+    output, because the tool/result layer preserves stdout/stderr and provides a
+    bounded model-facing preview;
   - keep commands sandboxed unless escalation is justified by user request or
     clear sandbox failure evidence;
   - use background task controls for long-running non-interactive commands.
@@ -56,7 +61,8 @@ The transcript should move toward Codex/Claude-style tool visibility:
   preview. The full JSON payload remains inspectable from that path.
 - A single tool-result batch should enforce an aggregate model-facing budget so
   parallel tool calls cannot combine many individually acceptable results into
-  one oversized follow-up turn.
+  one oversized follow-up turn. The final compacted batch must fit the aggregate
+  budget, not only shorten the first oversized item encountered.
 - When shell execution pauses on a human approval request, the approval card should take visual priority over older live stdout/stderr progress from the same turn.
 - Approval choices should describe both the action and its scope, such as:
   - allow only the current command;

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -24,6 +24,11 @@ The transcript should move toward Codex/Claude-style tool visibility:
   - created / updated / deleted / moved files;
   - a short change preview.
 - `write_file` and `replace` must render file-aware summaries instead of generic action labels.
+- `replace` is an exact-match edit tool. When file read-state tracking is
+  enabled, it still requires the file to have been read at least once, but it may
+  proceed after a partial read because the edit re-reads the current file and
+  requires `old_string` to match exactly once. Line-number-only edits such as
+  `replace_lines` must continue to require a full read first.
 
 ### Shell execution
 
@@ -41,10 +46,17 @@ The transcript should move toward Codex/Claude-style tool visibility:
   was shown, the rendered row should use a compact summary or truncated preview
   rather than reprinting the full output block.
 - The final foreground `bash` tool-result payload must still expose `stdout`,
-  `stderr`, `aggregated_output`, `exit_code`, and `duration_ms`. When a compact
-  model-facing rendering is needed, it should prefer `aggregated_output` as the
-  source for any preview/summary so command failure diagnosis uses the real
-  captured output without requiring shell-side `2>&1` redirection.
+  `stderr`, `aggregated_output`, `model_preview_output`, `exit_code`, and
+  `duration_ms`. `aggregated_output` remains the raw combined capture.
+  `model_preview_output` is the model-facing head/tail preview, with failed
+  commands biased toward the tail so error diagnostics remain visible without
+  requiring shell-side `2>&1` redirection.
+- Oversized tool results should be persisted to disk and replaced in model
+  context with a `<persisted-output>` message containing the path and a bounded
+  preview. The full JSON payload remains inspectable from that path.
+- A single tool-result batch should enforce an aggregate model-facing budget so
+  parallel tool calls cannot combine many individually acceptable results into
+  one oversized follow-up turn.
 - When shell execution pauses on a human approval request, the approval card should take visual priority over older live stdout/stderr progress from the same turn.
 - Approval choices should describe both the action and its scope, such as:
   - allow only the current command;

--- a/docs/journal/2026-05-01-bash-output-preview-budget.md
+++ b/docs/journal/2026-05-01-bash-output-preview-budget.md
@@ -1,0 +1,40 @@
+# Bash Output Preview Budget
+
+## Context
+
+The foreground Bash result already captured `stdout`, `stderr`, and
+`aggregated_output`, but long model-facing output still used a head-only preview.
+That made failing commands easy to misread when the useful error appeared near the
+tail.
+
+## Upstream Alignment
+
+- Codex formats exec output from aggregated output and truncates model-facing
+  content with head/tail retention.
+- Claude Code persists oversized tool results to a session `tool-results`
+  directory and replaces model context with a bounded preview plus the full output
+  path. It also applies an aggregate tool-result budget per model-visible message.
+
+## Implementation Checkpoint
+
+- Kept `aggregated_output` as the raw combined Bash capture and added
+  `model_preview_output` as an independent head/tail preview field.
+- Biased failed Bash previews toward the tail so compiler and test errors remain
+  visible.
+- Replaced oversized model-facing tool results with a `<persisted-output>` block
+  that includes the saved full-result path and bounded preview.
+- Added a lightweight tool-result batch budget before feeding parallel tool
+  results back to the model.
+- Relaxed `replace` read-state validation for partial reads. This follows the
+  Codex apply-patch safety shape: the edit re-reads the current file and must
+  match the expected old text, so a large-file preview should not deadlock exact
+  string replacement. `replace_lines` remains full-read-only because it is based
+  on line numbers instead of old text context.
+
+## Validation
+
+- `cargo test tool_result`
+- `cargo test model_preview_bash_output_preserves_error_tail`
+- `cargo test agent::tests::planning`
+- `cargo test tools::file::tests`
+- `cargo check`

--- a/docs/journal/2026-05-01-bash-output-preview-budget.md
+++ b/docs/journal/2026-05-01-bash-output-preview-budget.md
@@ -20,11 +20,19 @@ tail.
 - Kept `aggregated_output` as the raw combined Bash capture and added
   `model_preview_output` as an independent head/tail preview field.
 - Biased failed Bash previews toward the tail so compiler and test errors remain
-  visible.
+  visible. Missing or unknown exit status now uses the same error-oriented
+  preview instead of being treated as success.
+- Centralized Bash preview shaping in the tool-result layer so foreground Bash
+  execution and persisted-result fallback use the same head/tail behavior.
 - Replaced oversized model-facing tool results with a `<persisted-output>` block
   that includes the saved full-result path and bounded preview.
 - Added a lightweight tool-result batch budget before feeding parallel tool
-  results back to the model.
+  results back to the model. The final compacted batch is constrained to the
+  aggregate budget even when many large tool results arrive together.
+- Strengthened Bash tool descriptions with Codex/Claude-aligned command
+  discipline: prefer dedicated file tools, use `cwd` instead of `cd`, split
+  independent validation commands into separate tool calls, and avoid shell-side
+  `2>&1`/`head`/`tail` trimming only to manage model-visible output.
 - Relaxed `replace` read-state validation for partial reads. This follows the
   Codex apply-patch safety shape: the edit re-reads the current file and must
   match the expected old text, so a large-file preview should not deadlock exact

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -12,7 +12,8 @@ use crate::session::SessionManager;
 use crate::tool::ToolManager;
 use crate::tool::ToolOutputStream;
 use crate::tool_result::{
-    ToolResultStore, default_tool_result_store_dir, repair_tool_result_history,
+    ToolResultStore, default_tool_result_store_dir, enforce_tool_result_batch_budget,
+    repair_tool_result_history,
 };
 use crate::tools::bash::BashCommandInput;
 use crate::tools::planning::{ENTER_PLAN_MODE_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME};
@@ -719,7 +720,7 @@ impl Agent {
                 }
             }
         }
-        Ok(tool_results)
+        Ok(enforce_tool_result_batch_budget(tool_results))
     }
 }
 

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -10,6 +10,10 @@ const INLINE_CHAR_BUDGET: usize = 8_000;
 const FILE_LIST_PREVIEW_LIMIT: usize = 200;
 const MATCH_PREVIEW_LIMIT: usize = 40;
 const LARGE_PREVIEW_HEAD: usize = 4_000;
+const LARGE_PREVIEW_TAIL: usize = 4_000;
+const TOOL_RESULT_BATCH_BUDGET: usize = 24_000;
+const BATCH_PREVIEW_HEAD: usize = 1_000;
+const BATCH_PREVIEW_TAIL: usize = 1_000;
 
 pub struct ToolResultStore {
     base_dir: PathBuf,
@@ -59,10 +63,10 @@ impl ToolResultStore {
         }
 
         let stored_path = self.persist_full_result(tool_use_id, tool_name, input, result)?;
-        Ok(format!(
-            "{}\n\n[tool_result truncated]\nfull_result_path={}",
-            truncate_text(&inline, LARGE_PREVIEW_HEAD),
-            stored_path.display()
+        Ok(persisted_output_message(
+            &stored_path,
+            full_rendered.chars().count(),
+            &head_tail_text(&inline, LARGE_PREVIEW_HEAD, LARGE_PREVIEW_TAIL),
         ))
     }
 
@@ -141,6 +145,90 @@ pub fn repair_tool_result_history(history: &[Message]) -> Vec<Message> {
     }
 
     repaired
+}
+
+pub fn enforce_tool_result_batch_budget(mut messages: Vec<Message>) -> Vec<Message> {
+    let mut candidates = tool_result_content_candidates(&messages);
+    let mut total_chars: usize = candidates.iter().map(|candidate| candidate.chars).sum();
+    if total_chars <= TOOL_RESULT_BATCH_BUDGET {
+        return messages;
+    }
+
+    candidates.sort_by(|left, right| right.chars.cmp(&left.chars));
+    for candidate in candidates {
+        if total_chars <= TOOL_RESULT_BATCH_BUDGET {
+            break;
+        }
+        let Some(content) = tool_result_content_mut(
+            &mut messages,
+            candidate.message_index,
+            candidate.block_index,
+        ) else {
+            continue;
+        };
+        let replacement = shortened_batch_tool_result(content);
+        total_chars = total_chars
+            .saturating_sub(candidate.chars)
+            .saturating_add(replacement.chars().count());
+        *content = replacement;
+    }
+
+    messages
+}
+
+#[derive(Debug)]
+struct ToolResultContentCandidate {
+    message_index: usize,
+    block_index: usize,
+    chars: usize,
+}
+
+fn tool_result_content_candidates(messages: &[Message]) -> Vec<ToolResultContentCandidate> {
+    let mut candidates = Vec::new();
+    for (message_index, message) in messages.iter().enumerate() {
+        let Some(blocks) = message.content.as_array() else {
+            continue;
+        };
+        for (block_index, block) in blocks.iter().enumerate() {
+            if block.get("type").and_then(Value::as_str) != Some("tool_result") {
+                continue;
+            }
+            let Some(content) = block.get("content").and_then(Value::as_str) else {
+                continue;
+            };
+            candidates.push(ToolResultContentCandidate {
+                message_index,
+                block_index,
+                chars: content.chars().count(),
+            });
+        }
+    }
+    candidates
+}
+
+fn tool_result_content_mut(
+    messages: &mut [Message],
+    message_index: usize,
+    block_index: usize,
+) -> Option<&mut String> {
+    messages
+        .get_mut(message_index)?
+        .content
+        .as_array_mut()?
+        .get_mut(block_index)?
+        .get_mut("content")
+        .and_then(|value| match value {
+            Value::String(content) => Some(content),
+            _ => None,
+        })
+}
+
+fn shortened_batch_tool_result(content: &str) -> String {
+    let original_chars = content.chars().count();
+    let preview = head_tail_text(content, BATCH_PREVIEW_HEAD, BATCH_PREVIEW_TAIL);
+    format!(
+        "{preview}\n\n[tool_result shortened]\nreason=tool result batch exceeded {TOOL_RESULT_BATCH_BUDGET} chars\noriginal_chars={original_chars}"
+    )
 }
 
 fn synthetic_tool_result_message(ids: &[String]) -> Message {
@@ -365,10 +453,27 @@ fn compact_bash(result: &Value) -> String {
         .unwrap_or_else(|| "unknown".to_string());
     let duration_ms = result.get("duration_ms").and_then(Value::as_u64);
     let output = result
-        .get("aggregated_output")
+        .get("model_preview_output")
         .and_then(Value::as_str)
         .filter(|output| !output.is_empty())
         .map(str::to_string)
+        .or_else(|| {
+            result
+                .get("aggregated_output")
+                .and_then(Value::as_str)
+                .filter(|output| !output.is_empty())
+                .map(|output| {
+                    let exit_code = result
+                        .get("exit_code")
+                        .and_then(Value::as_i64)
+                        .unwrap_or_default();
+                    if exit_code == 0 {
+                        head_tail_text(output, 2_000, 2_000)
+                    } else {
+                        head_tail_text(output, 1_000, 3_000)
+                    }
+                })
+        })
         .unwrap_or_else(|| {
             let stdout = result
                 .get("stdout")
@@ -799,6 +904,29 @@ fn truncate_text(text: &str, max_chars: usize) -> String {
     collected
 }
 
+fn head_tail_text(text: &str, head_chars: usize, tail_chars: usize) -> String {
+    let total_chars = text.chars().count();
+    let budget = head_chars.saturating_add(tail_chars);
+    if total_chars <= budget {
+        return text.to_string();
+    }
+
+    let head = text.chars().take(head_chars).collect::<String>();
+    let tail_start = total_chars.saturating_sub(tail_chars);
+    let tail = text.chars().skip(tail_start).collect::<String>();
+    let omitted = total_chars
+        .saturating_sub(head_chars)
+        .saturating_sub(tail_chars);
+    format!("{head}\n... [{omitted} chars truncated from middle] ...\n{tail}")
+}
+
+fn persisted_output_message(path: &PathBuf, original_chars: usize, preview: &str) -> String {
+    format!(
+        "<persisted-output>\nOutput too large ({original_chars} chars). Full output saved to: {}\n\nPreview:\n{preview}\n</persisted-output>",
+        path.display()
+    )
+}
+
 pub fn default_tool_result_store_dir() -> Result<PathBuf> {
     let root = std::env::current_dir()?;
     Ok(rara_config::workspace_data_dir_for(&root)?.join("tool-results"))
@@ -808,7 +936,8 @@ pub fn default_tool_result_store_dir() -> Result<PathBuf> {
 mod tests {
     use super::{
         ToolResultStore, compact_read_file, compact_subagent_result, compact_web_search,
-        default_tool_result_store_dir, repair_tool_result_history,
+        default_tool_result_store_dir, enforce_tool_result_batch_budget,
+        repair_tool_result_history,
     };
     use crate::agent::Message;
     use serde_json::json;
@@ -874,7 +1003,8 @@ mod tests {
                 &json!({ "content": "x".repeat(20_000) }),
             )
             .expect("compact result");
-        assert!(output.contains("full_result_path="));
+        assert!(output.contains("<persisted-output>"));
+        assert!(output.contains("Full output saved to:"));
         assert!(output.contains("Fetched https://example.com"));
         assert!(tempdir.path().join("tool-1.json").exists());
         assert!(
@@ -912,6 +1042,91 @@ mod tests {
         assert!(output.contains("Output:\nchecking\n[stderr] warning"));
         assert!(!output.contains("stdout-only"));
         assert!(!output.contains("stderr-only"));
+    }
+
+    #[test]
+    fn compacts_bash_prefers_independent_model_preview_output() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let store = ToolResultStore::new(tempdir.path()).expect("store");
+        let output = store
+            .compact_result(
+                "bash",
+                "tool-bash",
+                &json!({ "program": "cargo", "args": ["test"] }),
+                &json!({
+                    "stdout": "stdout-only\n",
+                    "stderr": "stderr-only\n",
+                    "aggregated_output": "full aggregated output\n",
+                    "model_preview_output": "model preview output\n",
+                    "exit_code": 1,
+                    "duration_ms": 10
+                }),
+            )
+            .expect("compact bash result");
+
+        assert!(output.contains("model preview output"));
+        assert!(!output.contains("full aggregated output"));
+        assert!(!output.contains("stdout-only"));
+        assert!(!output.contains("stderr-only"));
+    }
+
+    #[test]
+    fn compacts_bash_long_aggregated_output_with_head_and_tail() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let store = ToolResultStore::new(tempdir.path()).expect("store");
+        let output = store
+            .compact_result(
+                "bash",
+                "tool-bash",
+                &json!({ "program": "cargo", "args": ["test"] }),
+                &json!({
+                    "aggregated_output": format!("head\n{}tail-error\n", "middle\n".repeat(2_000)),
+                    "exit_code": 1,
+                    "duration_ms": 10
+                }),
+            )
+            .expect("compact bash result");
+
+        assert!(output.contains("head"));
+        assert!(output.contains("tail-error"));
+        assert!(output.contains("chars truncated from middle"));
+    }
+
+    #[test]
+    fn batch_budget_shortens_largest_tool_results() {
+        let large = "large-start\n".to_string() + &"middle\n".repeat(4_000) + "large-tail\n";
+        let small = "small-result\n".to_string();
+        let messages = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!([{
+                    "type": "tool_result",
+                    "tool_use_id": "large",
+                    "content": large,
+                }]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([{
+                    "type": "tool_result",
+                    "tool_use_id": "small",
+                    "content": small,
+                }]),
+            },
+        ];
+
+        let budgeted = enforce_tool_result_batch_budget(messages);
+        let large_content = budgeted[0].content[0]["content"]
+            .as_str()
+            .expect("large content");
+        let small_content = budgeted[1].content[0]["content"]
+            .as_str()
+            .expect("small content");
+
+        assert!(large_content.contains("large-start"));
+        assert!(large_content.contains("large-tail"));
+        assert!(large_content.contains("tool_result shortened"));
+        assert_eq!(small_content, "small-result\n");
     }
 
     #[test]

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -14,6 +14,10 @@ const LARGE_PREVIEW_TAIL: usize = 4_000;
 const TOOL_RESULT_BATCH_BUDGET: usize = 24_000;
 const BATCH_PREVIEW_HEAD: usize = 1_000;
 const BATCH_PREVIEW_TAIL: usize = 1_000;
+const BASH_SUCCESS_HEAD_CHARS: usize = 2_000;
+const BASH_SUCCESS_TAIL_CHARS: usize = 2_000;
+const BASH_ERROR_HEAD_CHARS: usize = 1_000;
+const BASH_ERROR_TAIL_CHARS: usize = 3_000;
 
 pub struct ToolResultStore {
     base_dir: PathBuf,
@@ -166,7 +170,9 @@ pub fn enforce_tool_result_batch_budget(mut messages: Vec<Message>) -> Vec<Messa
         ) else {
             continue;
         };
-        let replacement = shortened_batch_tool_result(content);
+        let available_chars =
+            TOOL_RESULT_BATCH_BUDGET.saturating_sub(total_chars.saturating_sub(candidate.chars));
+        let replacement = shortened_batch_tool_result(content, available_chars);
         total_chars = total_chars
             .saturating_sub(candidate.chars)
             .saturating_add(replacement.chars().count());
@@ -223,12 +229,26 @@ fn tool_result_content_mut(
         })
 }
 
-fn shortened_batch_tool_result(content: &str) -> String {
+fn shortened_batch_tool_result(content: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+
     let original_chars = content.chars().count();
-    let preview = head_tail_text(content, BATCH_PREVIEW_HEAD, BATCH_PREVIEW_TAIL);
-    format!(
-        "{preview}\n\n[tool_result shortened]\nreason=tool result batch exceeded {TOOL_RESULT_BATCH_BUDGET} chars\noriginal_chars={original_chars}"
-    )
+    let marker = format!(
+        "\n\n[tool_result shortened]\nreason=tool result batch exceeded {TOOL_RESULT_BATCH_BUDGET} chars\noriginal_chars={original_chars}"
+    );
+    let marker_chars = marker.chars().count();
+    if marker_chars >= max_chars {
+        return truncate_text(&marker, max_chars);
+    }
+
+    let preview_budget = max_chars - marker_chars;
+    let preview_head = BATCH_PREVIEW_HEAD.min(preview_budget / 2);
+    let preview_tail = BATCH_PREVIEW_TAIL.min(preview_budget.saturating_sub(preview_head));
+    let preview = head_tail_text(content, preview_head, preview_tail);
+    let preview = truncate_text(&preview, preview_budget);
+    format!("{preview}{marker}")
 }
 
 fn synthetic_tool_result_message(ids: &[String]) -> Message {
@@ -463,15 +483,8 @@ fn compact_bash(result: &Value) -> String {
                 .and_then(Value::as_str)
                 .filter(|output| !output.is_empty())
                 .map(|output| {
-                    let exit_code = result
-                        .get("exit_code")
-                        .and_then(Value::as_i64)
-                        .unwrap_or_default();
-                    if exit_code == 0 {
-                        head_tail_text(output, 2_000, 2_000)
-                    } else {
-                        head_tail_text(output, 1_000, 3_000)
-                    }
+                    let exit_code = result.get("exit_code").and_then(Value::as_i64);
+                    model_preview_bash_output(output, exit_code)
                 })
         })
         .unwrap_or_else(|| {
@@ -904,20 +917,48 @@ fn truncate_text(text: &str, max_chars: usize) -> String {
     collected
 }
 
-fn head_tail_text(text: &str, head_chars: usize, tail_chars: usize) -> String {
-    let total_chars = text.chars().count();
+pub(crate) fn model_preview_bash_output(output: &str, exit_code: Option<i64>) -> String {
+    let (head_chars, tail_chars) = if exit_code == Some(0) {
+        (BASH_SUCCESS_HEAD_CHARS, BASH_SUCCESS_TAIL_CHARS)
+    } else {
+        (BASH_ERROR_HEAD_CHARS, BASH_ERROR_TAIL_CHARS)
+    };
+    head_tail_text(output, head_chars, tail_chars)
+}
+
+pub(crate) fn head_tail_text(text: &str, head_chars: usize, tail_chars: usize) -> String {
     let budget = head_chars.saturating_add(tail_chars);
-    if total_chars <= budget {
+    if text.chars().nth(budget).is_none() {
         return text.to_string();
     }
 
-    let head = text.chars().take(head_chars).collect::<String>();
-    let tail_start = total_chars.saturating_sub(tail_chars);
-    let tail = text.chars().skip(tail_start).collect::<String>();
-    let omitted = total_chars
-        .saturating_sub(head_chars)
-        .saturating_sub(tail_chars);
+    let head_end = char_boundary_after_n_chars(text, head_chars);
+    let tail_start = char_boundary_before_last_n_chars(text, tail_chars);
+    let head = &text[..head_end];
+    let tail = &text[tail_start..];
+    let omitted = text[head_end..tail_start].chars().count();
     format!("{head}\n... [{omitted} chars truncated from middle] ...\n{tail}")
+}
+
+fn char_boundary_after_n_chars(text: &str, n: usize) -> usize {
+    if n == 0 {
+        return 0;
+    }
+    text.char_indices()
+        .nth(n)
+        .map(|(idx, _)| idx)
+        .unwrap_or(text.len())
+}
+
+fn char_boundary_before_last_n_chars(text: &str, n: usize) -> usize {
+    if n == 0 {
+        return text.len();
+    }
+    text.char_indices()
+        .rev()
+        .nth(n.saturating_sub(1))
+        .map(|(idx, _)| idx)
+        .unwrap_or(0)
 }
 
 fn persisted_output_message(path: &PathBuf, original_chars: usize, preview: &str) -> String {
@@ -935,9 +976,9 @@ pub fn default_tool_result_store_dir() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ToolResultStore, compact_read_file, compact_subagent_result, compact_web_search,
-        default_tool_result_store_dir, enforce_tool_result_batch_budget,
-        repair_tool_result_history,
+        TOOL_RESULT_BATCH_BUDGET, ToolResultStore, compact_read_file, compact_subagent_result,
+        compact_web_search, default_tool_result_store_dir, enforce_tool_result_batch_budget,
+        repair_tool_result_history, tool_result_content_candidates,
     };
     use crate::agent::Message;
     use serde_json::json;
@@ -1093,6 +1134,27 @@ mod tests {
     }
 
     #[test]
+    fn compacts_bash_unknown_exit_status_as_error_preview() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let store = ToolResultStore::new(tempdir.path()).expect("store");
+        let output = store
+            .compact_result(
+                "bash",
+                "tool-bash",
+                &json!({ "program": "cargo", "args": ["test"] }),
+                &json!({
+                    "aggregated_output": format!("head\n{}tail-error\n", "middle\n".repeat(2_000)),
+                    "duration_ms": 10
+                }),
+            )
+            .expect("compact bash result");
+
+        assert!(output.contains("head"));
+        assert!(output.contains("tail-error"));
+        assert!(output.contains("chars truncated from middle"));
+    }
+
+    #[test]
     fn batch_budget_shortens_largest_tool_results() {
         let large = "large-start\n".to_string() + &"middle\n".repeat(4_000) + "large-tail\n";
         let small = "small-result\n".to_string();
@@ -1127,6 +1189,35 @@ mod tests {
         assert!(large_content.contains("large-tail"));
         assert!(large_content.contains("tool_result shortened"));
         assert_eq!(small_content, "small-result\n");
+    }
+
+    #[test]
+    fn batch_budget_enforces_final_total_for_many_large_results() {
+        let large = "large-start\n".to_string() + &"middle\n".repeat(4_000) + "large-tail\n";
+        let messages = (0..20)
+            .map(|idx| Message {
+                role: "user".to_string(),
+                content: json!([{
+                    "type": "tool_result",
+                    "tool_use_id": format!("large-{idx}"),
+                    "content": large,
+                }]),
+            })
+            .collect::<Vec<_>>();
+
+        let budgeted = enforce_tool_result_batch_budget(messages);
+        let total_chars = tool_result_content_candidates(&budgeted)
+            .iter()
+            .map(|candidate| candidate.chars)
+            .sum::<usize>();
+
+        assert!(total_chars <= TOOL_RESULT_BATCH_BUDGET);
+        assert!(
+            budgeted
+                .iter()
+                .filter_map(|message| message.content[0]["content"].as_str())
+                .any(|content| content.contains("tool_result shortened"))
+        );
     }
 
     #[test]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -983,11 +983,14 @@ impl Tool for BashTool {
             }
         }
         let duration_ms = started_at.elapsed().as_millis() as u64;
+        let model_preview_output =
+            model_preview_bash_output(&aggregated_output, status.code().unwrap_or(1));
 
         Ok(json!({
             "stdout": stdout_text,
             "stderr": stderr_text,
             "aggregated_output": aggregated_output,
+            "model_preview_output": model_preview_output,
             "exit_code": status.code(),
             "duration_ms": duration_ms,
             "live_streamed": live_streamed,
@@ -1306,6 +1309,36 @@ fn append_aggregated_bash_output(
     *last_stream = Some(stream);
 }
 
+fn model_preview_bash_output(output: &str, exit_code: i32) -> String {
+    const SUCCESS_HEAD_CHARS: usize = 2_000;
+    const SUCCESS_TAIL_CHARS: usize = 2_000;
+    const ERROR_HEAD_CHARS: usize = 1_000;
+    const ERROR_TAIL_CHARS: usize = 3_000;
+
+    let (head_chars, tail_chars) = if exit_code == 0 {
+        (SUCCESS_HEAD_CHARS, SUCCESS_TAIL_CHARS)
+    } else {
+        (ERROR_HEAD_CHARS, ERROR_TAIL_CHARS)
+    };
+    head_tail_text(output, head_chars, tail_chars)
+}
+
+fn head_tail_text(text: &str, head_chars: usize, tail_chars: usize) -> String {
+    let total_chars = text.chars().count();
+    let budget = head_chars.saturating_add(tail_chars);
+    if total_chars <= budget {
+        return text.to_string();
+    }
+
+    let head = text.chars().take(head_chars).collect::<String>();
+    let tail_start = total_chars.saturating_sub(tail_chars);
+    let tail = text.chars().skip(tail_start).collect::<String>();
+    let omitted = total_chars
+        .saturating_sub(head_chars)
+        .saturating_sub(tail_chars);
+    format!("{head}\n... [{omitted} chars truncated from middle] ...\n{tail}")
+}
+
 fn sandbox_output_hint(stderr: &str) -> Option<&'static str> {
     let lower = stderr.to_ascii_lowercase();
     if lower.contains("sandbox: violation")
@@ -1349,7 +1382,8 @@ mod tests {
         BackgroundTaskListTool, BackgroundTaskStatus, BackgroundTaskStatusTool,
         BackgroundTaskStopTool, BackgroundTaskStore, BashCommandInput, BashSandboxPermissions,
         BashStreamKind, BashTool, append_aggregated_bash_output, command_env_for_wrapped,
-        read_output_tail, sandbox_command_env, sandbox_output_hint, unsandboxed_execution_warning,
+        model_preview_bash_output, read_output_tail, sandbox_command_env, sandbox_output_hint,
+        unsandboxed_execution_warning,
     };
     use crate::sandbox::{SandboxManager, WrappedCommand};
     use crate::tool::{Tool, ToolOutputStream, ToolProgressEvent};
@@ -1865,6 +1899,12 @@ mod tests {
             .expect("aggregated output");
         assert!(aggregated_output.contains("out"));
         assert!(aggregated_output.contains("[stderr] err"));
+        let model_preview_output = result
+            .get("model_preview_output")
+            .and_then(Value::as_str)
+            .expect("model preview output");
+        assert!(model_preview_output.contains("out"));
+        assert!(model_preview_output.contains("[stderr] err"));
         assert!(result.get("duration_ms").and_then(Value::as_u64).is_some());
     }
 
@@ -1912,6 +1952,17 @@ mod tests {
         );
 
         assert_eq!(output, "stdout-without-newline\n[stderr] stderr-line\n");
+    }
+
+    #[test]
+    fn model_preview_bash_output_preserves_error_tail() {
+        let output = format!("head\n{}tail-error\n", "middle\n".repeat(2_000));
+
+        let preview = model_preview_bash_output(&output, 1);
+
+        assert!(preview.contains("head"));
+        assert!(preview.contains("tail-error"));
+        assert!(preview.contains("chars truncated from middle"));
     }
 
     #[tokio::test]

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -1,5 +1,6 @@
 use crate::sandbox::{SandboxManager, WrappedCommand, sandbox_failure_hint};
 use crate::tool::{Tool, ToolError, ToolOutputStream, ToolProgressEvent};
+use crate::tool_result::model_preview_bash_output;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -741,7 +742,7 @@ impl Tool for BashTool {
         "bash"
     }
     fn description(&self) -> &str {
-        "Run a shell command in the sandbox for commands that need process execution. Prefer dedicated RARA tools for file search, file reads, and file edits; do not use shell redirection, sed, awk, perl, or ad-hoc scripts to edit files when apply_patch or direct file tools can do the job. Use the cwd field instead of prepending cd, avoid newline-separated command chaining, and keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop."
+        "Run a shell command in the sandbox for commands that need process execution. Prefer dedicated RARA tools for file search, file reads, and file edits; do not use shell redirection, sed, awk, perl, or ad-hoc scripts to edit files when apply_patch or direct file tools can do the job. Use the cwd field instead of prepending cd. Do not use newlines to separate commands. If commands are independent and can run in parallel, make multiple bash tool calls in one assistant turn instead of joining them with &&, ;, or pipelines. Do not add 2>&1, head, tail, or grep only to reduce displayed output; RARA preserves stdout/stderr and provides bounded model-facing previews. Keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop."
     }
     fn input_schema(&self) -> Value {
         json!({
@@ -749,7 +750,7 @@ impl Tool for BashTool {
             "properties": {
                 "command": {
                     "type": "string",
-                    "description": "Legacy shell command string. Prefer program+args for new calls. Avoid newline-separated command chaining, and do not use this field for file edits when apply_patch or direct file tools can do the job."
+                    "description": "Legacy shell command string. Prefer program+args for new calls. Do not use newlines to separate commands. Do not join independent validation commands with &&, ;, or pipelines just to run them together; make multiple bash tool calls instead. Do not add 2>&1, head, tail, or grep only to trim output for the model. Do not use this field for file edits when apply_patch or direct file tools can do the job."
                 },
                 "program": {
                     "type": "string",
@@ -984,7 +985,7 @@ impl Tool for BashTool {
         }
         let duration_ms = started_at.elapsed().as_millis() as u64;
         let model_preview_output =
-            model_preview_bash_output(&aggregated_output, status.code().unwrap_or(1));
+            model_preview_bash_output(&aggregated_output, status.code().map(i64::from));
 
         Ok(json!({
             "stdout": stdout_text,
@@ -1309,36 +1310,6 @@ fn append_aggregated_bash_output(
     *last_stream = Some(stream);
 }
 
-fn model_preview_bash_output(output: &str, exit_code: i32) -> String {
-    const SUCCESS_HEAD_CHARS: usize = 2_000;
-    const SUCCESS_TAIL_CHARS: usize = 2_000;
-    const ERROR_HEAD_CHARS: usize = 1_000;
-    const ERROR_TAIL_CHARS: usize = 3_000;
-
-    let (head_chars, tail_chars) = if exit_code == 0 {
-        (SUCCESS_HEAD_CHARS, SUCCESS_TAIL_CHARS)
-    } else {
-        (ERROR_HEAD_CHARS, ERROR_TAIL_CHARS)
-    };
-    head_tail_text(output, head_chars, tail_chars)
-}
-
-fn head_tail_text(text: &str, head_chars: usize, tail_chars: usize) -> String {
-    let total_chars = text.chars().count();
-    let budget = head_chars.saturating_add(tail_chars);
-    if total_chars <= budget {
-        return text.to_string();
-    }
-
-    let head = text.chars().take(head_chars).collect::<String>();
-    let tail_start = total_chars.saturating_sub(tail_chars);
-    let tail = text.chars().skip(tail_start).collect::<String>();
-    let omitted = total_chars
-        .saturating_sub(head_chars)
-        .saturating_sub(tail_chars);
-    format!("{head}\n... [{omitted} chars truncated from middle] ...\n{tail}")
-}
-
 fn sandbox_output_hint(stderr: &str) -> Option<&'static str> {
     let lower = stderr.to_ascii_lowercase();
     if lower.contains("sandbox: violation")
@@ -1382,11 +1353,11 @@ mod tests {
         BackgroundTaskListTool, BackgroundTaskStatus, BackgroundTaskStatusTool,
         BackgroundTaskStopTool, BackgroundTaskStore, BashCommandInput, BashSandboxPermissions,
         BashStreamKind, BashTool, append_aggregated_bash_output, command_env_for_wrapped,
-        model_preview_bash_output, read_output_tail, sandbox_command_env, sandbox_output_hint,
-        unsandboxed_execution_warning,
+        read_output_tail, sandbox_command_env, sandbox_output_hint, unsandboxed_execution_warning,
     };
     use crate::sandbox::{SandboxManager, WrappedCommand};
     use crate::tool::{Tool, ToolOutputStream, ToolProgressEvent};
+    use crate::tool_result::model_preview_bash_output;
     use serde_json::{Value, json};
     use std::collections::HashMap;
     use std::env;
@@ -1958,7 +1929,7 @@ mod tests {
     fn model_preview_bash_output_preserves_error_tail() {
         let output = format!("head\n{}tail-error\n", "middle\n".repeat(2_000));
 
-        let preview = model_preview_bash_output(&output, 1);
+        let preview = model_preview_bash_output(&output, Some(1));
 
         assert!(preview.contains("head"));
         assert!(preview.contains("tail-error"));

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -742,7 +742,7 @@ impl Tool for BashTool {
         "bash"
     }
     fn description(&self) -> &str {
-        "Run a shell command in the sandbox for commands that need process execution. Prefer dedicated RARA tools for file search, file reads, and file edits; do not use shell redirection, sed, awk, perl, or ad-hoc scripts to edit files when apply_patch or direct file tools can do the job. Use the cwd field instead of prepending cd. Do not use newlines to separate commands. If commands are independent and can run in parallel, make multiple bash tool calls in one assistant turn instead of joining them with &&, ;, or pipelines. Do not add 2>&1, head, tail, or grep only to reduce displayed output; RARA preserves stdout/stderr and provides bounded model-facing previews. Keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop."
+        "Run a shell command in the sandbox for commands that need process execution. Prefer dedicated RARA tools for file search, file reads, and file edits; do not use shell redirection, sed, awk, perl, or ad-hoc scripts to edit files when apply_patch or direct file tools can do the job. Use the cwd field instead of prepending cd. Avoid newline-separated command chaining. If commands are independent and can run in parallel, make multiple bash tool calls in one assistant turn instead of joining them with &&, ;, or pipelines. Do not add 2>&1, head, tail, or grep only to reduce displayed output; RARA preserves stdout/stderr and provides bounded model-facing previews. Keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop."
     }
     fn input_schema(&self) -> Value {
         json!({
@@ -750,7 +750,7 @@ impl Tool for BashTool {
             "properties": {
                 "command": {
                     "type": "string",
-                    "description": "Legacy shell command string. Prefer program+args for new calls. Do not use newlines to separate commands. Do not join independent validation commands with &&, ;, or pipelines just to run them together; make multiple bash tool calls instead. Do not add 2>&1, head, tail, or grep only to trim output for the model. Do not use this field for file edits when apply_patch or direct file tools can do the job."
+                    "description": "Legacy shell command string. Prefer program+args for new calls. Avoid newline-separated command chaining. Do not join independent validation commands with &&, ;, or pipelines just to run them together; make multiple bash tool calls instead. Do not add 2>&1, head, tail, or grep only to trim output for the model. Do not use this field for file edits when apply_patch or direct file tools can do the job."
                 },
                 "program": {
                     "type": "string",

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -94,6 +94,21 @@ impl FileReadState {
         Ok(())
     }
 
+    pub(crate) fn validate_exact_replace_edit(&self, path: &str) -> Result<(), ToolError> {
+        let key = canonical_existing_path(path)?;
+        let files = self.files.lock().expect("file read state lock");
+        let Some(entry) = files.get(&key) else {
+            return Err(ToolError::ExecutionFailed(
+                "File has not been read yet. Read it first before writing to it.".into(),
+            ));
+        };
+        if entry.is_partial {
+            return Ok(());
+        }
+        drop(files);
+        self.validate_existing_edit(path)
+    }
+
     pub(crate) fn record_write(&self, path: &str, content: &str) -> Result<(), ToolError> {
         let key = canonical_existing_path(path)?;
         let metadata = fs::metadata(&key)?;
@@ -522,7 +537,7 @@ impl Tool for ReplaceTool {
         "replace"
     }
     fn description(&self) -> &str {
-        "Replace one exact, unique string in a file. Read the full file first and prefer apply_patch for structured multi-line edits."
+        "Replace one exact, unique string in a file. Read the relevant file content first and prefer apply_patch for structured multi-line edits."
     }
     fn input_schema(&self) -> Value {
         json!({
@@ -546,7 +561,7 @@ impl Tool for ReplaceTool {
             .as_str()
             .ok_or(ToolError::InvalidInput("new".into()))?;
         if let Some(read_state) = &self.read_state {
-            read_state.validate_existing_edit(p)?;
+            read_state.validate_exact_replace_edit(p)?;
         }
         let c = fs::read_to_string(p)?;
         if c.matches(o).count() != 1 {

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -271,7 +271,7 @@ async fn replace_requires_prior_full_read_when_state_is_enabled() {
 }
 
 #[tokio::test]
-async fn replace_rejects_partial_read_state() {
+async fn replace_allows_partial_read_when_old_string_is_unique() {
     let tempdir = tempfile::tempdir().expect("tempdir");
     let path = tempdir.path().join("sample.txt");
     std::fs::write(&path, "one\ntwo\nthree\n").expect("write sample");
@@ -287,14 +287,47 @@ async fn replace_rejects_partial_read_state() {
         }))
         .await
         .expect("partial read");
-    let error = replace_tool
+    replace_tool
         .call(json!({
             "path": path.display().to_string(),
             "old_string": "two",
             "new_string": "second"
         }))
         .await
-        .expect_err("partial read should be rejected");
+        .expect("replace after partial read");
+
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read updated"),
+        "one\nsecond\nthree\n"
+    );
+}
+
+#[tokio::test]
+async fn replace_lines_rejects_partial_read_state() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "one\ntwo\nthree\n").expect("write sample");
+    let read_state = Arc::new(FileReadState::default());
+    let read_tool = ReadFileTool::new(read_state.clone());
+    let replace_lines_tool = ReplaceLinesTool::new(read_state);
+
+    read_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "offset": 1,
+            "limit": 1
+        }))
+        .await
+        .expect("partial read");
+    let error = replace_lines_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "start_line": 2,
+            "end_line": 2,
+            "new_string": "second"
+        }))
+        .await
+        .expect_err("line-only edit should still require full read");
     assert!(error.to_string().contains("only partially read"));
 }
 
@@ -429,7 +462,7 @@ fn file_tool_descriptions_encode_safe_edit_contract() {
     assert!(
         replace_tool
             .description()
-            .contains("Read the full file first")
+            .contains("Read the relevant file content first")
     );
     assert!(
         replace_lines_tool

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -685,7 +685,7 @@ pub(super) fn format_tool_result(name: &str, content: &str) -> String {
     {
         let summary = normalize_tool_result_summary(name, summary);
         let mut rendered = format!("{name}: {summary}");
-        if content.contains("full_result_path=") {
+        if content.contains("<persisted-output>") {
             rendered.push_str("\\nfull result stored on disk");
         } else if let Some(preview) = tool_result_preview(content) {
             rendered.push_str(&format!("\n{preview}"));


### PR DESCRIPTION
## Summary

- add an independent Bash `model_preview_output` field while preserving raw `aggregated_output`
- use head/tail previews, persisted oversized output blocks, and an aggregate tool-result batch budget for model-facing tool results
- allow exact `replace` edits after partial reads while keeping `replace_lines` full-read-only

## Motivation

Large command output should not push models toward shell-side truncation such as `2>&1 | tail`.
RARA should preserve the raw output, provide a bounded model-facing preview, and keep failure tails visible.

Exact string edits should also avoid the large-file partial-read deadlock. This follows the Codex apply-patch safety shape: re-read the current file at edit time and require the expected old text to match, instead of depending on a prior full read state.

## Tests

- `cargo fmt`
- `cargo test tool_result`
- `cargo test tools::file::tests`
- `cargo test agent::tests::planning`
- `cargo check`
- `git diff --check`
