### PR TITLE
chore: document commit title rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,17 @@ The current product direction is to make local inference a first-class path inst
 - Better onboarding and runtime status transparency.
 - Stronger local-model prompt formatting and stop-sequence handling.
 - A real embedding backend for local memory retrieval quality.
+
+## 7. Commit Rules
+
+- Use short conventional commit titles.
+- Allowed commit title types:
+  - `feat`: user-visible feature or capability.
+  - `fix`: bug fix or behavior correction.
+  - `chore`: maintenance, dependency, tooling, or non-user-facing cleanup.
+  - `test`: test-only changes.
+- Format commit titles as `type: subject`.
+- Keep the subject concise, imperative, and lowercase unless a proper noun or
+  code identifier requires otherwise.
+- Do not use unlisted types such as `docs`, `refactor`, or `style`; fold those
+  changes into the closest allowed type.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,14 +67,19 @@ The current product direction is to make local inference a first-class path inst
 
 ## 7. Commit Rules
 
-- Use short conventional commit titles.
+- Use short project-specific conventional commit titles. This is an intentional
+  subset of Conventional Commits, not the full upstream type set.
 - Allowed commit title types:
   - `feat`: user-visible feature or capability.
   - `fix`: bug fix or behavior correction.
   - `chore`: maintenance, dependency, tooling, or non-user-facing cleanup.
   - `test`: test-only changes.
-- Format commit titles as `type: subject`.
+- Format commit titles as `type: subject` or `type(scope): subject`.
+- Do not use `!` breaking-change markers in commit titles; describe unusual
+  compatibility impact in the PR body instead.
 - Keep the subject concise, imperative, and lowercase unless a proper noun or
   code identifier requires otherwise.
 - Do not use unlisted types such as `docs`, `refactor`, or `style`; fold those
-  changes into the closest allowed type.
+  changes into the closest allowed type. Documentation-only and spec-only
+  changes should use `chore` unless they are part of a user-visible `feat` or
+  behavior `fix`.


### PR DESCRIPTION
## Summary

- Add RARA commit title rules to `AGENTS.md`.
- Restrict commit title types to `feat`, `fix`, `chore`, and `test`.
- Document the expected `type: subject` title format.

## Testing

- Not run. Documentation-only change.
