### PR TITLE
docs: add git conflict prompt guidance

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -439,6 +439,20 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
             ),
         ),
         PromptSection::new(
+            "git_conflict_resolution",
+            section(
+                "Git Conflict Resolution",
+                &[
+                    "When you encounter Git conflict markers such as '<<<<<<<', '=======', or '>>>>>>>', treat the file as unresolved until every marker has been removed.",
+                    "Before resolving a conflict, inspect the current git state and read the conflicted file with enough surrounding context to understand both sides and the intended local change.",
+                    "Do not blindly choose one side. Preserve both sides when they are complementary, remove obsolete code only when the inspected context proves it is obsolete, and keep imports, names, formatting, and control flow consistent after the merge.",
+                    "Prefer structured edit tools or 'apply_patch' for the resolved hunks. Avoid full-file rewrites unless the file is small or the conflict truly requires rewriting the whole file.",
+                    "After resolving conflicts, run a targeted marker scan such as 'rg \"<<<<<<<|=======|>>>>>>>\"' and the narrowest relevant formatter, test, build, or check command before claiming the conflict is resolved.",
+                    "If the conflict semantics are ambiguous, state which side is verified, which side is inferred, and what validation remains instead of inventing intent.",
+                ],
+            ),
+        ),
+        PromptSection::new(
             "tool_workflow_discipline",
             section(
                 "Tool Workflow Discipline",
@@ -1085,6 +1099,36 @@ mod tests {
             effective
                 .text
                 .contains("verify current repository facts before acting on them")
+        );
+    }
+
+    #[test]
+    fn default_system_prompt_includes_git_conflict_resolution_guidance() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = root.join(".rara");
+        fs::create_dir_all(&rara_dir).expect("mkdir .rara");
+        let workspace = WorkspaceMemory::from_paths(root, rara_dir);
+
+        let effective = build_effective_prompt(
+            &workspace,
+            &PromptRuntimeConfig::default(),
+            PromptMode::Execute,
+        );
+
+        assert!(effective.section_keys.contains(&"git_conflict_resolution"));
+        assert!(effective.text.contains("# Git Conflict Resolution"));
+        assert!(
+            effective
+                .text
+                .contains("treat the file as unresolved until every marker has been removed")
+        );
+        assert!(effective.text.contains("Do not blindly choose one side"));
+        assert!(effective.text.contains("rg \"<<<<<<<|=======|>>>>>>>\""));
+        assert!(
+            effective
+                .text
+                .contains("If the conflict semantics are ambiguous")
         );
     }
 

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -52,6 +52,20 @@ The effective prompt is assembled in this order:
 5. mode-specific addenda such as plan mode;
 6. append prompt.
 
+### 3.1) Built-In Engineering Workflow Guidance
+
+The default base prompt includes source-grounded engineering workflow guidance for:
+
+- factual verification before claims about repository, PR, CI, provider, or local-tool behavior;
+- structured tool use, including edit-tool discipline and unfiltered command-output inspection;
+- reviewable implementation workflow, focused validation, and PR hygiene;
+- Git conflict resolution when conflict markers are present.
+
+Git conflict guidance is intentionally conservative. It tells the model to inspect the current git
+state and conflicted file, preserve complementary changes instead of blindly choosing one side, use
+structured edits where practical, scan for remaining conflict markers, and run the narrowest relevant
+validation before claiming the conflict is resolved.
+
 ### 4) Compact Prompt
 
 - Context compaction must not use the normal system prompt.
@@ -137,3 +151,4 @@ The effective prompt is assembled in this order:
 - [2026-04-17-prompt-runtime](../journal/2026-04-17-prompt-runtime.md)
 - [2026-04-24-context-observability-and-restore](../journal/2026-04-24-context-observability-and-restore.md)
 - [2026-04-25-context-assembly-stage1](../journal/2026-04-25-context-assembly-stage1.md)
+- [2026-05-02-git-conflict-prompt-guidance](../journal/2026-05-02-git-conflict-prompt-guidance.md)

--- a/docs/journal/2026-05-02-git-conflict-prompt-guidance.md
+++ b/docs/journal/2026-05-02-git-conflict-prompt-guidance.md
@@ -1,0 +1,25 @@
+# Git Conflict Prompt Guidance
+
+## Context
+
+RARA already had prompt guidance for factual verification, edit-tool safety, command-output
+inspection, and reviewable implementation workflow. Merge-conflict handling still relied on those
+general rules, which left too much room for models to choose one side by habit or claim resolution
+without checking for remaining markers.
+
+## Implementation Checkpoint
+
+- Added a built-in `Git Conflict Resolution` prompt section to the default instruction family.
+- The guidance is source-grounded rather than attributed to a fixed upstream protocol:
+  - inspect git state and the conflicted file before editing;
+  - preserve complementary changes and remove obsolete code only with inspected evidence;
+  - prefer structured edits or `apply_patch` over whole-file rewrites;
+  - scan for remaining conflict markers after resolving;
+  - run the narrowest relevant formatter, test, build, or check before claiming completion.
+- Updated the prompt runtime spec to record Git conflict handling as part of the built-in
+  engineering workflow guidance.
+- Added a focused prompt test to lock the section into the default prompt.
+
+## Validation
+
+- `cargo test -p rara-instructions git_conflict_resolution -- --nocapture`


### PR DESCRIPTION
## Summary

- Add built-in prompt guidance for Git conflict resolution.
- Document the prompt-runtime contract for source-grounded engineering workflow guidance.
- Add a journal checkpoint and focused prompt test coverage.

## Why

RARA already guides models to verify facts, inspect real command output, and use safe edit tools.
Git conflicts need a narrower rule set so the agent does not blindly pick one side or claim
resolution while conflict markers remain.

## Validation

- `cargo fmt --check`
- `cargo test -p rara-instructions git_conflict_resolution -- --nocapture`
- `cargo test -p rara-instructions`
