### PR TITLE
fix: route delegated subagent input

### DIFF
--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -48,10 +48,12 @@ impl SubAgentKind {
             SubAgentKind::General => {
                 concat!(
                     "## Sub-Agent Role\n",
-                    "- You are a direct worker sub-agent.\n",
+                    "- You are a no-tool reasoning sub-agent.\n",
                     "- Treat the assigned instruction as the complete task contract.\n",
                     "- Honor every constraint in the assigned instruction, including workspace, branch, network, and output limits.\n",
                     "- Stay inside the current workspace unless the assigned instruction explicitly allows another path.\n",
+                    "- You do not have repository, shell, editing, patching, or browser tools in this role.\n",
+                    "- If the assigned instruction requires inspection or mutation, report the limitation and answer only from the provided instruction/context.\n",
                     "- Do not delegate to another agent or spawn sub-agents; complete the assigned work directly."
                 )
             }
@@ -121,7 +123,7 @@ impl Tool for AgentTool {
     }
 
     fn description(&self) -> &str {
-        "Spawn a general-purpose sub-agent"
+        "Spawn a no-tool reasoning sub-agent. It cannot inspect files, run shell commands, edit files, or spawn other agents; use explore_agent or plan_agent for read-only repository inspection."
     }
 
     fn input_schema(&self) -> Value {
@@ -503,6 +505,17 @@ mod tests {
         assert!(prompt.contains("Treat the assigned instruction as the complete task contract."));
         assert!(prompt.contains("Honor every constraint in the assigned instruction"));
         assert!(prompt.contains("Stay inside the current workspace"));
+    }
+
+    #[test]
+    fn general_subagent_prompt_declares_no_tool_access() {
+        let prompt = SubAgentKind::General.append_prompt();
+
+        assert!(prompt.contains("no-tool reasoning sub-agent"));
+        assert!(
+            prompt.contains("do not have repository, shell, editing, patching, or browser tools")
+        );
+        assert!(prompt.contains("answer only from the provided instruction/context"));
     }
 
     #[test]

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -44,6 +44,32 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                     } else if let Some(action) = tool_action_label(&message) {
                         app.record_running_action(action);
                     }
+                } else if let Some(request) = subagent_request_input(&message) {
+                    app.advance_running_tool_boundary();
+                    let source = if message.starts_with("explore_agent ") {
+                        if let Some(note) = exploration_result_note(&message) {
+                            app.record_exploration_note(note);
+                        }
+                        "explore_agent"
+                    } else if message.starts_with("plan_agent ") {
+                        if let Some(note) = planning_result_note(&message) {
+                            app.record_planning_note(note);
+                        }
+                        "plan_agent"
+                    } else {
+                        "spawn_agent"
+                    };
+                    app.record_local_request_input(
+                        source,
+                        request.question,
+                        request.options,
+                        request.note,
+                    );
+                    app.set_runtime_phase(
+                        RuntimePhase::RunningTool,
+                        Some(message.lines().next().unwrap_or(role).trim().to_string()),
+                    );
+                    return;
                 } else if let Some(note) = exploration_result_note(&message) {
                     app.advance_running_tool_boundary();
                     app.record_exploration_note(note);
@@ -55,32 +81,6 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                 } else if let Some(note) = planning_result_note(&message) {
                     app.advance_running_tool_boundary();
                     app.record_planning_note(note);
-                    app.set_runtime_phase(
-                        RuntimePhase::RunningTool,
-                        Some(message.lines().next().unwrap_or(role).trim().to_string()),
-                    );
-                    if let Some(request) = subagent_request_input(&message) {
-                        app.record_local_request_input(
-                            "plan_agent",
-                            request.question,
-                            request.options,
-                            request.note,
-                        );
-                    }
-                    return;
-                } else if let Some(request) = subagent_request_input(&message) {
-                    app.advance_running_tool_boundary();
-                    let source = if message.starts_with("explore_agent ") {
-                        "explore_agent"
-                    } else {
-                        "plan_agent"
-                    };
-                    app.record_local_request_input(
-                        source,
-                        request.question,
-                        request.options,
-                        request.note,
-                    );
                     app.set_runtime_phase(
                         RuntimePhase::RunningTool,
                         Some(message.lines().next().unwrap_or(role).trim().to_string()),

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -1008,7 +1008,10 @@ pub(super) struct DelegatedRequestInput {
 }
 
 pub(super) fn subagent_request_input(message: &str) -> Option<DelegatedRequestInput> {
-    if !(message.starts_with("explore_agent ") || message.starts_with("plan_agent ")) {
+    if !(message.starts_with("explore_agent ")
+        || message.starts_with("plan_agent ")
+        || message.starts_with("spawn_agent "))
+    {
         return None;
     }
 

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -10,7 +10,7 @@ use super::{apply_tui_event, convert_agent_event};
 use crate::agent::{AgentEvent, AgentExecutionMode};
 use crate::config::ConfigManager;
 use crate::tool::ToolOutputStream;
-use crate::tui::state::TranscriptEntryPayload;
+use crate::tui::state::{ActivePendingInteractionKind, TranscriptEntryPayload};
 use crate::tui::state::{RuntimePhase, TuiApp, TuiEvent};
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
@@ -28,6 +28,114 @@ fn parses_delegated_request_input_from_subagent_result() {
     assert_eq!(
         parsed.note.as_deref(),
         Some("We need one product decision before editing.")
+    );
+}
+
+#[test]
+fn parses_delegated_request_input_from_spawn_agent_result() {
+    let parsed = subagent_request_input(
+        "spawn_agent worker: Need a decision\nrequest_user_input: Which branch should continue?\noption: Main | Continue on main.",
+    )
+    .expect("spawn_agent request input should parse");
+
+    assert_eq!(parsed.question, "Which branch should continue?");
+    assert_eq!(
+        parsed.options,
+        vec![("Main".into(), "Continue on main.".into())]
+    );
+}
+
+#[test]
+fn explore_agent_result_with_request_input_records_note_and_pending_question() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+
+    apply_tui_event(
+        &mut app,
+        TuiEvent::Transcript {
+            role: "Tool Result".into(),
+            message: "explore_agent Found two workspace discovery paths.\nrequest_user_input: Which discovery strategy should we keep?\noption: Minimal | Keep root-level files only.\noption: Generic | Scan instruction markdown files.".into(),
+        },
+    );
+
+    assert_eq!(
+        app.active_live.exploration_notes,
+        vec!["Sub-agent summary: Found two workspace discovery paths.".to_string()]
+    );
+    let pending = app
+        .pending_request_input()
+        .expect("delegated request should become pending input");
+    assert_eq!(pending.source.as_deref(), Some("explore_agent"));
+    assert_eq!(pending.title, "Which discovery strategy should we keep?");
+    assert_eq!(pending.options.len(), 2);
+    assert_eq!(
+        app.active_pending_interaction().map(|item| item.kind),
+        Some(ActivePendingInteractionKind::ExplorationQuestion)
+    );
+}
+
+#[test]
+fn plan_agent_result_with_request_input_records_note_and_pending_question() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+
+    apply_tui_event(
+        &mut app,
+        TuiEvent::Transcript {
+            role: "Tool Result".into(),
+            message: "plan_agent Need to choose a rollout boundary.\nrequest_user_input: Which phase should land first?\noption: Runtime | Wire the runtime path first.\noption: UI | Start with visibility.".into(),
+        },
+    );
+
+    assert_eq!(
+        app.active_live.planning_notes,
+        vec!["Sub-agent summary: Need to choose a rollout boundary.".to_string()]
+    );
+    let pending = app
+        .pending_request_input()
+        .expect("delegated request should become pending input");
+    assert_eq!(pending.source.as_deref(), Some("plan_agent"));
+    assert_eq!(pending.title, "Which phase should land first?");
+    assert_eq!(pending.options.len(), 2);
+    assert_eq!(
+        app.active_pending_interaction().map(|item| item.kind),
+        Some(ActivePendingInteractionKind::PlanningQuestion)
+    );
+}
+
+#[test]
+fn spawn_agent_result_with_request_input_records_subagent_question() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+
+    apply_tui_event(
+        &mut app,
+        TuiEvent::Transcript {
+            role: "Tool Result".into(),
+            message: "spawn_agent Need user input before continuing.\nrequest_user_input: Which branch should continue?\noption: Current | Continue on the current branch.\noption: New | Create a new branch.".into(),
+        },
+    );
+
+    assert!(app.active_live.exploration_notes.is_empty());
+    assert!(app.active_live.planning_notes.is_empty());
+    let pending = app
+        .pending_request_input()
+        .expect("delegated request should become pending input");
+    assert_eq!(pending.source.as_deref(), Some("spawn_agent"));
+    assert_eq!(pending.title, "Which branch should continue?");
+    assert_eq!(pending.options.len(), 2);
+    assert_eq!(
+        app.active_pending_interaction().map(|item| item.kind),
+        Some(ActivePendingInteractionKind::SubAgentQuestion)
     );
 }
 

--- a/src/tui/submit/pending.rs
+++ b/src/tui/submit/pending.rs
@@ -97,7 +97,7 @@ fn start_local_request_input_continuation(app: &mut TuiApp, agent: Agent, answer
     app.clear_local_request_input();
 
     let mut prompt = format!(
-        "Continue the same task. A delegated {source} requested additional user input.\nQuestion: {}\nAnswer: {}",
+        "Continue the parent task after a delegated {source} requested additional user input.\nQuestion: {}\nAnswer: {}\n\nUse the delegated result already present in the transcript as context; do not assume the child sub-agent session is still attached.",
         interaction.title, answer
     );
     if let Some(note) = interaction.note.as_deref()


### PR DESCRIPTION
## Summary

- Route delegated `request_user_input` results before generic sub-agent summary handling.
- Preserve `explore_agent` and `plan_agent` notes while also surfacing their pending questions.
- Accept `spawn_agent` request input and classify it as a generic sub-agent question.
- Clarify that the general `spawn_agent` is a no-tool reasoning sub-agent.
- Continue an initial plan-mode turn once when the provider returns only reasoning/thinking metadata and no text or tool call.

## Tests

- `cargo test agent::tests::planning -- --nocapture`
- `cargo test tui::runtime::events::tests -- --nocapture`
- `cargo test tools::agent::tests -- --nocapture`
- `cargo check`
