### PR TITLE
fix: continue initial reasoning-only plan turns

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -103,6 +103,7 @@ struct TurnOutput {
     malformed_proposed_plan: bool,
     continue_inspection: bool,
     had_text_response: bool,
+    had_reasoning_response: bool,
 }
 
 pub struct Agent {
@@ -314,6 +315,7 @@ impl Agent {
         );
 
         let mut streamed_any_text_delta = false;
+        let mut streamed_any_reasoning_delta = false;
         let response = self
             .llm_backend
             .ask_streaming_with_context(&messages, tool_schemas, turn_metadata, &mut |event| {
@@ -323,6 +325,7 @@ impl Agent {
                         report(AgentEvent::AssistantDelta(delta));
                     }
                     LlmStreamEvent::ReasoningDelta(delta) => {
+                        streamed_any_reasoning_delta |= !delta.trim().is_empty();
                         report(AgentEvent::AssistantThinkingDelta(delta));
                     }
                 }
@@ -341,6 +344,7 @@ impl Agent {
         let mut malformed_proposed_plan = false;
         let mut continue_inspection = false;
         let mut had_text_response = false;
+        let mut had_reasoning_response = streamed_any_reasoning_delta;
         let mut sanitized_content = Vec::new();
         for block in &response.content {
             match block {
@@ -392,6 +396,11 @@ impl Agent {
                         key: key.clone(),
                         value: value.clone(),
                     });
+                    if key == "reasoning_content"
+                        && value.as_str().is_some_and(|text| !text.trim().is_empty())
+                    {
+                        had_reasoning_response = true;
+                    }
                 }
             }
         }
@@ -406,6 +415,7 @@ impl Agent {
             malformed_proposed_plan,
             continue_inspection,
             had_text_response,
+            had_reasoning_response,
         })
     }
 
@@ -476,11 +486,13 @@ impl Agent {
                     turn_output.plan_updated,
                     turn_output.continue_inspection,
                     turn_output.had_text_response,
+                    turn_output.had_reasoning_response,
                     *agentic_turns,
                 ) {
                     report(AgentEvent::Status(
                         "Plan mode needs more evidence. Continuing in read-only mode.".to_string(),
                     ));
+                    *agentic_turns += 1;
                     let phase = RuntimeContinuationPhase::PlanContinuationRequired;
                     self.push_history_message(
                         self.runtime_continuation_message(phase, *agentic_turns),
@@ -496,6 +508,7 @@ impl Agent {
                         "Repository review needs more code inspection. Continuing the same turn."
                             .to_string(),
                     ));
+                    *agentic_turns += 1;
                     self.push_history_message(self.runtime_continuation_message(
                         RuntimeContinuationPhase::ExecutionContinuationRequired,
                         *agentic_turns,

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -477,23 +477,30 @@ impl Agent {
         plan_updated: bool,
         continue_inspection: bool,
         had_text_response: bool,
+        had_reasoning_response: bool,
         agentic_turns: usize,
     ) -> bool {
         let shallow_initial_plan =
             plan_updated && agentic_turns == 0 && self.current_plan.len() <= 1;
+        let reasoning_only_initial_turn =
+            had_reasoning_response && !had_text_response && agentic_turns == 0;
         let has_inspection_evidence = self.inspection_progress.has_any_evidence();
         let still_missing_inspection_evidence = agentic_turns > 0
             && !plan_updated
             && has_inspection_evidence
             && !self.inspection_progress.has_minimum_review_evidence();
         matches!(self.execution_mode, AgentExecutionMode::Plan)
-            && (continue_inspection || shallow_initial_plan || still_missing_inspection_evidence)
+            && (continue_inspection
+                || shallow_initial_plan
+                || still_missing_inspection_evidence
+                || reasoning_only_initial_turn)
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
             && (continue_inspection
                 || has_inspection_evidence
                 || !self.current_plan.is_empty()
-                || had_text_response)
+                || had_text_response
+                || reasoning_only_initial_turn)
     }
 
     pub(super) fn should_continue_execute_without_tools(

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -252,6 +252,123 @@ async fn reasoning_only_turn_is_not_persisted_as_empty_assistant_message() {
 }
 
 #[tokio::test]
+async fn plan_mode_reasoning_only_initial_turn_continues_to_next_model_turn() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: json!("Need to inspect cells before planning."),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "I need to inspect the TUI cell code before proposing the split.".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.set_execution_mode(AgentExecutionMode::Plan);
+
+    agent
+        .query_with_mode(
+            "plan the cells split".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("reasoning-only plan turn should continue once");
+
+    let observed_messages = backend.observed_messages();
+    assert_eq!(observed_messages.len(), 2);
+    assert!(observed_messages[1].iter().any(|message| {
+        message
+            .content
+            .to_string()
+            .contains("plan_continuation_required")
+    }));
+    assert!(agent.history.last().is_some_and(|message| {
+        message
+            .content
+            .to_string()
+            .contains("I need to inspect the TUI cell code")
+    }));
+}
+
+#[tokio::test]
+async fn plan_mode_consecutive_reasoning_only_turns_stop_after_one_continuation() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: json!("Need one more pass."),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: json!("Still thinking only."),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "This response should not be reached.".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.set_execution_mode(AgentExecutionMode::Plan);
+
+    agent
+        .query_with_mode(
+            "plan the cells split".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("consecutive reasoning-only plan turns should stop after one retry");
+
+    let observed_messages = backend.observed_messages();
+    assert_eq!(observed_messages.len(), 2);
+    let continuation_text = observed_messages[1]
+        .iter()
+        .filter_map(|message| message.content.get(0)?.get("text")?.as_str())
+        .find(|text| text.contains("<agent_runtime>"))
+        .expect("continuation message text");
+    assert!(continuation_text.contains("\"agentic_turns\": 1"));
+    assert!(!agent.history.iter().any(|message| {
+        message
+            .content
+            .to_string()
+            .contains("This response should not be reached.")
+    }));
+}
+
+#[tokio::test]
 async fn suggestion_mode_auto_allows_read_only_bash_commands() {
     let backend = Arc::new(SequencedBackend::new(vec![
         LlmResponse {
@@ -743,12 +860,13 @@ async fn does_not_append_continuation_without_tools() {
         usage: Some(TokenUsage::default()),
     }]));
 
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
     let mut agent = Agent::new(
         ToolManager::new(),
         backend.clone(),
-        Arc::new(VectorDB::new("data/lancedb")),
-        Arc::new(SessionManager::new().expect("session manager")),
-        Arc::new(WorkspaceMemory::new().expect("workspace memory")),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
     );
 
     agent
@@ -1265,7 +1383,7 @@ fn shallow_initial_plan_continues_even_after_plan_update() {
         status: PlanStepStatus::Pending,
     }];
 
-    assert!(agent.should_continue_plan_without_tools(true, false, true, 0,));
+    assert!(agent.should_continue_plan_without_tools(true, false, true, false, 0,));
 }
 
 #[test]
@@ -1273,7 +1391,15 @@ fn missing_minimum_review_evidence_continues_without_plan_update() {
     let mut agent = new_planning_agent();
     agent.inspection_progress.source_reads = 1;
 
-    assert!(agent.should_continue_plan_without_tools(false, false, true, 1,));
+    assert!(agent.should_continue_plan_without_tools(false, false, true, false, 1,));
+}
+
+#[test]
+fn reasoning_only_initial_plan_turn_continues_once() {
+    let agent = new_planning_agent();
+
+    assert!(agent.should_continue_plan_without_tools(false, false, false, true, 0,));
+    assert!(!agent.should_continue_plan_without_tools(false, false, false, true, 1,));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Treat non-empty reasoning/thinking metadata as a plan-mode signal that the model is still working.
- Continue the initial plan-mode turn once when the provider returns only reasoning metadata with no text or tool call.
- Keep reasoning-only execute-mode turns from being persisted as empty assistant messages.
- Make the no-continuation planning test use isolated test storage instead of real user/session paths.

## Tests

- `cargo test agent::tests::planning -- --nocapture`
- `cargo check`
