### PR TITLE
docs: add runtime control plane spec

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -21,3 +21,11 @@ Each active feature spec should include:
 - `docs/features/`: stable theme/domain docs only
 - `docs/journal/`: date-prefixed implementation records
 - When a feature evolves, update the canonical feature doc and add or append a journal note.
+
+## Control-Plane Readiness
+
+Features that affect skills, memory, prompt sources, hooks, planning, approvals,
+tool output, `/context`, or `/status` must describe how the behavior can be
+driven through the runtime control plane. Local TUI behavior should be one
+adapter over the same structured request/event contract that ACP, Wire, and
+future appserver integrations can use.

--- a/docs/features/agenthub-team-mode.md
+++ b/docs/features/agenthub-team-mode.md
@@ -39,6 +39,9 @@ intentionally distinct from any future local-only team mode:
 - AgentHub should talk to RARA through ACP session and prompt requests.
 - AgentHub team mode is therefore a worker-runtime concern inside ACP request handling, not a
   parallel CLI surface with a separate protocol.
+- ACP should be an adapter over RARA's runtime control plane. AgentHub team mode
+  must not create a separate skills, memory, prompt, hook, approval, or output
+  path.
 - The first implementation target is:
   - ACP prompt arrives;
   - team router evaluates worker relevance;
@@ -116,6 +119,9 @@ The router must return strict JSON:
 
 ## Follow-Up
 
+- Define and implement the runtime control-plane boundary that ACP uses for
+  session, prompt, cancel, output, skills, memory, prompt-source, and hook
+  interactions.
 - Add TUI/router observability.
 - Route sub-agent or worker approvals through the same team runtime boundary.
 - Complete the ACP runtime path so AgentHub can actually use RARA as a worker runtime.

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -31,6 +31,7 @@ The effective prompt may draw from:
 - an optional append prompt;
 - workspace instruction files;
 - local memory files;
+- protocol-registered prompt sources routed through the runtime control plane;
 - runtime context;
 - plan-mode specific guidance.
 
@@ -115,13 +116,24 @@ validation before claiming the conflict is resolved.
   text blobs.
 - Prompt source discovery must remain reusable across agent runtime and TUI status reporting.
 
-### 3) Agent Loop Integration
+### 3) Protocol Prompt Sources
+
+- ACP, Wire, and future appserver integrations may register prompt-affecting
+  material only through structured prompt source objects.
+- Protocol prompt sources must carry provenance, source id, scope, lifetime,
+  layer or priority, and budget metadata.
+- Protocol adapters must not concatenate raw text directly into the system
+  prompt or rename top-level prompt sections.
+- `/context`, `/status`, and protocol output subscribers must be able to inspect
+  the same prompt source objects.
+
+### 4) Agent Loop Integration
 
 - `Agent::build_system_prompt()` must delegate to the prompt runtime instead of hand-building the
   prompt inline.
 - Compaction must pass the dedicated compact instruction down to every backend summarization path.
 
-### 4) Runtime Bootstrap Contract
+### 5) Runtime Bootstrap Contract
 
 - Runtime/bootstrap callers must initialize workspace, prompt runtime config, skills, and tools
   through one shared entrypoint instead of wiring those pieces independently in `main.rs` and TUI
@@ -145,6 +157,8 @@ validation before claiming the conflict is resolved.
 - Prompt observability now exists in both `/status` and `/context`, including active selected
   workspace/thread memory items, but deeper memory inspection still needs to cover real recalled
   vector/thread selection instead of only prompt-injected or compacted carry-over.
+- Protocol-registered prompt sources need strict provenance and lifetime rules
+  before ACP/Wire can safely control prompt material.
 
 ## Source Journals
 
@@ -152,3 +166,4 @@ validation before claiming the conflict is resolved.
 - [2026-04-24-context-observability-and-restore](../journal/2026-04-24-context-observability-and-restore.md)
 - [2026-04-25-context-assembly-stage1](../journal/2026-04-25-context-assembly-stage1.md)
 - [2026-05-02-git-conflict-prompt-guidance](../journal/2026-05-02-git-conflict-prompt-guidance.md)
+- [Runtime Control Plane](runtime-control-plane.md)

--- a/docs/features/repo-extension-surface.md
+++ b/docs/features/repo-extension-surface.md
@@ -93,6 +93,7 @@ points:
 - a memory or retrieval candidate produced for `MemorySelection`;
 - a lifecycle event handled behind the hook runtime boundary;
 - a child-thread or imported-agent profile executed through the thread domain.
+- a protocol-registered source routed through the runtime control plane.
 
 They should not:
 
@@ -102,6 +103,9 @@ They should not:
 - serialize hook, skill, or agent metadata as ordinary user text;
 - add synthetic context prefixes for transient runtime artifacts such as orphan
   tool results.
+- let ACP, Wire, or another protocol adapter bypass the same source,
+  `MemorySelection`, hook, skill, and permission boundaries used by local
+  runtime paths.
 
 If a new source needs a label for explainability, that label should be attached
 to the structured source object and rendered by `/context` or `/status`, not
@@ -126,6 +130,11 @@ RARA should separate:
    - how discovered files are mapped into RARA-owned objects;
 3. **execution**
    - when and how those normalized objects affect runtime behavior.
+
+Protocol adapters add a fourth entrypoint shape but not a fourth semantic
+model. ACP, Wire, local TUI commands, and future appserver integrations should
+all adapt into RARA-owned source, hook, skill, memory, thread, and control-event
+objects instead of defining parallel extension semantics.
 
 The first milestone should complete discovery and normalization before adding
 runtime execution.
@@ -347,6 +356,8 @@ That means:
 - context injection still flows through `ContextAssembler` and
   `MemorySelection`;
 - thread persistence still flows through `ThreadStore` / `ThreadRecorder`.
+- third-party protocol control still flows through the runtime control plane
+  before reaching prompt, skill, memory, hook, approval, or output domains.
 
 Compatibility should adapt external formats into RARA-owned objects instead of
 letting external directory conventions define runtime semantics directly.

--- a/docs/features/repo-extension-surface.md
+++ b/docs/features/repo-extension-surface.md
@@ -92,7 +92,7 @@ points:
 - a normalized extension object surfaced by this repository extension contract;
 - a memory or retrieval candidate produced for `MemorySelection`;
 - a lifecycle event handled behind the hook runtime boundary;
-- a child-thread or imported-agent profile executed through the thread domain.
+- a child-thread or imported-agent profile executed through the thread domain;
 - a protocol-registered source routed through the runtime control plane.
 
 They should not:
@@ -102,7 +102,7 @@ They should not:
 - rename existing stable prompt sections just to match an external ecosystem;
 - serialize hook, skill, or agent metadata as ordinary user text;
 - add synthetic context prefixes for transient runtime artifacts such as orphan
-  tool results.
+  tool results;
 - let ACP, Wire, or another protocol adapter bypass the same source,
   `MemorySelection`, hook, skill, and permission boundaries used by local
   runtime paths.

--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -148,6 +148,15 @@ The first typed request set should include these families.
 Input control must use the same pending-interaction state as the TUI. Protocol
 adapters must not invent parallel approval or question state.
 
+Submitting a follow-up while a turn is running is a queued input operation by
+default. It does not imply cancellation or interruption. Runtime adapters should
+preserve submission order and deliver queued follow-ups after the active turn
+reaches a safe continuation boundary or completes. If queue policy or capacity
+prevents accepting the follow-up, the runtime should return a busy or rejected
+status with a structured reason. Adapters that need preemption must use the
+explicit cancel or interrupt request family instead of overloading follow-up
+submission.
+
 ### Output Subscription
 
 External applications should subscribe to structured runtime events:
@@ -176,12 +185,17 @@ External applications may register prompt sources through structured objects:
 - scope;
 - priority or layer;
 - budget hint;
-- time-to-live or session lifetime;
+- turn-based time-to-live or session lifetime;
 - content;
 - provenance.
 
 Registered prompt sources enter normal prompt assembly and `/context`. They must
 not bypass `PromptRuntime` or introduce unstable top-level prompt prefixes.
+Prompt-source time-to-live is turn-based: a transient source may be active for
+the next N assembled model turns, or for the lifetime of the session. Wall-clock
+expiry is only suitable for adapter leases or connection handles and must not
+silently remove prompt context in the middle of a model turn. Persistent sources
+must be updated or unregistered explicitly.
 
 ### Skill Source Registration
 
@@ -195,6 +209,15 @@ External applications may register:
 These registrations flow into `SkillRegistry` and `SkillTool`. They must expose
 override and parse status through the same observability contract as local
 skills.
+
+Source precedence hints are advisory inside the protocol-registered source
+layer. They must not override the root-based local precedence defined in
+`repo-extension-surface.md` for home, repository, and current-working-directory
+sources. A protocol source may only outrank a local source when the user grants
+that adapter an explicit higher-trust policy. Conflicts between protocol sources
+should be resolved by declared priority first, then registration order, then a
+stable source-id tie breaker. Conflict and shadowing decisions must preserve
+provenance for `/context` and protocol observability.
 
 ### Memory Control
 
@@ -265,7 +288,13 @@ Minimum event families:
 - `MemoryEvent`;
 - `HookEvent`;
 - `ContextEvent`;
+- `WarningEvent`;
 - `ErrorEvent`.
+
+`WarningEvent` carries non-fatal runtime issues that should be visible to
+protocol adapters without aborting the current request, such as skipped prompt
+sources, bootstrap warnings, degraded provider metadata, cache-read misses, or
+ignored unsupported adapter options.
 
 ## Domain Contracts
 

--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -1,0 +1,381 @@
+# Runtime Control Plane
+
+## Problem
+
+RARA is growing several runtime capabilities that need to be controlled by both
+local surfaces and external applications:
+
+- skills;
+- memory;
+- prompt sources;
+- hooks;
+- planning and approvals;
+- input submission and cancellation;
+- output and transcript streaming.
+
+If each feature is implemented only for the TUI or only for a local command,
+later ACP, Wire, AgentHub, or appserver integration will need separate ad hoc
+paths for the same runtime state. That would make prompt assembly unstable,
+permission decisions harder to audit, and `/context` inconsistent with external
+protocol views.
+
+RARA therefore needs a protocol-neutral control plane before these features
+become deeply coupled to one UI.
+
+## Scope
+
+This spec defines the architecture boundary for a runtime control plane that can
+be driven by:
+
+- the local TUI;
+- CLI commands;
+- ACP;
+- Wire protocol adapters;
+- future HTTP, MCP, or appserver integrations.
+
+The control plane owns structured requests and events for:
+
+- session lifecycle;
+- user input and pending-interaction answers;
+- output subscriptions;
+- prompt-source registration;
+- skill-source registration and invocation;
+- memory mutations, queries, and selection inspection;
+- hook declaration and lifecycle dispatch;
+- approval and permission decisions.
+
+## Non-Goals
+
+- Implementing full ACP or Wire protocol support in the first slice.
+- Letting external applications bypass RARA sandbox, approval, or tool policy.
+- Letting third-party protocol adapters concatenate raw text directly into the
+  final system prompt.
+- Executing arbitrary hook files as soon as they are discovered.
+- Replacing the TUI runtime with a protocol server.
+
+## Architecture
+
+### Layering
+
+The target shape is:
+
+1. protocol adapters;
+2. runtime control plane;
+3. runtime domains;
+4. execution and display surfaces.
+
+Protocol adapters include ACP, Wire, local TUI commands, and future appserver
+entrypoints. They translate external protocol messages into RARA-owned control
+requests and translate RARA events back into protocol-specific responses.
+
+The runtime control plane is protocol-neutral. It validates requests, attaches
+provenance, routes to the right domain, records lifecycle events, and emits
+structured output events.
+
+Runtime domains remain the source of truth:
+
+- `PromptRuntime`;
+- `SkillRegistry`;
+- `MemoryStore` and `MemorySelection`;
+- `HookRuntime`;
+- `ThreadStore` and `ThreadRecorder`;
+- approval and sandbox policy;
+- transcript and output event streams.
+
+Execution surfaces such as the TUI, ACP worker mode, AgentHub team mode, and
+headless evaluation read the same domain state and event stream.
+
+### Control-Plane-Ready Rule
+
+New features that touch skills, memory, prompt sources, hooks, planning,
+approval, tool output, `/context`, or `/status` must be implemented so they can
+later be controlled through ACP or Wire without duplicating local-only code.
+
+That means:
+
+- core logic lives in runtime or domain modules, not directly in TUI widgets;
+- inputs and outputs use structured request and event objects;
+- every external or local source carries provenance;
+- prompt-affecting data enters through source objects, not string append points;
+- visible runtime state can be consumed by `/context`, `/status`, and protocol
+  subscribers;
+- sandbox, approval, and permission decisions remain centralized in RARA;
+- new state is either persisted or explicitly marked transient.
+
+### Provenance
+
+Every control-plane source must carry provenance:
+
+- `local_tui`;
+- `local_cli`;
+- `home`;
+- `repo`;
+- `protocol`;
+- `runtime`;
+- later: `plugin`.
+
+Protocol provenance should also include:
+
+- adapter name, such as `acp` or `wire`;
+- session id when available;
+- source id or connection id when available;
+- whether the source is trusted, user-provided, or generated.
+
+Provenance is required for explainability and safety. `/context`, `/status`,
+and protocol output must be able to show where a prompt source, skill, memory
+record, or hook came from.
+
+## Control Requests
+
+The first typed request set should include these families.
+
+### Session Control
+
+- create session;
+- resume session;
+- cancel current turn;
+- interrupt current turn;
+- query current runtime state.
+
+### Input Control
+
+- submit user prompt;
+- answer pending request input;
+- answer plan approval;
+- answer shell approval;
+- submit follow-up while a turn is running.
+
+Input control must use the same pending-interaction state as the TUI. Protocol
+adapters must not invent parallel approval or question state.
+
+### Output Subscription
+
+External applications should subscribe to structured runtime events:
+
+- assistant text delta;
+- assistant thinking delta;
+- tool use;
+- tool progress;
+- tool result;
+- approval request;
+- request-user-input prompt;
+- plan state update;
+- context snapshot update;
+- final response;
+- failure or cancellation.
+
+The event stream should remain richer than a plain text stream. Plain text can
+be derived from it, but protocol adapters should not be the only owner of
+structured output.
+
+### Prompt Source Registration
+
+External applications may register prompt sources through structured objects:
+
+- source id;
+- scope;
+- priority or layer;
+- budget hint;
+- time-to-live or session lifetime;
+- content;
+- provenance.
+
+Registered prompt sources enter normal prompt assembly and `/context`. They must
+not bypass `PromptRuntime` or introduce unstable top-level prompt prefixes.
+
+### Skill Source Registration
+
+External applications may register:
+
+- skill roots;
+- single skill definitions;
+- disabled or shadowed skill metadata;
+- source precedence hints.
+
+These registrations flow into `SkillRegistry` and `SkillTool`. They must expose
+override and parse status through the same observability contract as local
+skills.
+
+### Memory Control
+
+External applications may:
+
+- add workspace or thread memory records;
+- query memory metadata;
+- request a memory-selection snapshot;
+- mark memory records as available, selected, or ineligible through structured
+  metadata only when the runtime permits that control.
+
+They may not directly edit the final prompt. Memory must enter the model
+working set through `MemorySelection` and context assembly.
+
+### Hook Declaration
+
+External applications may declare hooks for lifecycle points such as:
+
+- `SessionStart`;
+- `UserPromptSubmit`;
+- `PreToolUse`;
+- `PostToolUse`;
+- `Stop`;
+- `PreCompact`.
+
+The first implementation should record and display hook declarations without
+executing them. Later executable hooks must still go through RARA-owned
+permission, sandbox, and failure handling.
+
+### Approval and Permission Bridge
+
+External applications may display or relay approval decisions, but RARA remains
+the authority for:
+
+- static deny rules;
+- sandbox policy;
+- prefix allow rules;
+- plan approval state;
+- command approval state.
+
+Protocol adapters can submit a user decision back to RARA. They cannot directly
+mark a tool call as allowed without the runtime recording the decision.
+
+## Control Events
+
+The control plane should emit a single structured event stream that can feed:
+
+- TUI transcript cells;
+- ACP prompt responses;
+- Wire output;
+- `/status`;
+- `/context`;
+- future headless evaluation traces.
+
+Events should be stable enough to record in thread history or derived runtime
+snapshots when they affect recovery.
+
+Minimum event families:
+
+- `SessionEvent`;
+- `InputEvent`;
+- `AssistantEvent`;
+- `ToolEvent`;
+- `ApprovalEvent`;
+- `PlanEvent`;
+- `PromptSourceEvent`;
+- `SkillEvent`;
+- `MemoryEvent`;
+- `HookEvent`;
+- `ContextEvent`;
+- `ErrorEvent`.
+
+## Domain Contracts
+
+### Prompt Runtime
+
+Third-party prompt input must be represented as prompt source objects with
+provenance, layer, and budget metadata. The prompt runtime decides whether and
+where the source is injected.
+
+### Skills
+
+Third-party skills are local instruction content, not executable authority.
+They participate in normal skill precedence and cannot override built-in tools,
+sandbox policy, approval rules, or slash commands.
+
+### Memory
+
+Third-party memory writes create `MemoryRecord`-style data. They may contribute
+to the current turn only through `MemorySelection`.
+
+### Hooks
+
+Hook declarations are metadata until the hook runtime explicitly supports an
+event and handler kind. Hook execution cannot bypass RARA policy.
+
+### Output
+
+Output control is subscription and rendering control, not model control.
+External applications can choose how to display events, but the runtime event
+stream remains the source of truth.
+
+## ACP and Wire Integration
+
+ACP and Wire should be adapters over the same control plane.
+
+The first ACP milestone should:
+
+- initialize a RARA session;
+- submit prompts through input control;
+- stream structured output events or map them to ACP response chunks;
+- route cancel requests to runtime cancellation;
+- expose final stop reasons from the runtime.
+
+The first Wire milestone should reuse the same request and event families. Wire
+may define different transport framing, but it should not define a separate
+skills, memory, prompt, or hook runtime model.
+
+## Observability
+
+`/context` should show:
+
+- local and protocol prompt sources;
+- active skills and skill roots;
+- overridden or failed skill loads;
+- memory selected, available, and dropped groups;
+- protocol-registered memory records or candidates;
+- declared hooks and their support status;
+- current controller or protocol source when available.
+
+`/status` should show:
+
+- active protocol adapters;
+- current session id;
+- provider/model state;
+- sandbox/network state;
+- pending approvals or questions;
+- current plan state;
+- active output subscribers when useful.
+
+Both views should read from the same runtime snapshots exposed to protocol
+adapters.
+
+## Contracts
+
+- Protocol adapters do not own runtime semantics.
+- Runtime domains do not depend on one protocol crate.
+- Prompt-affecting inputs must use structured source objects.
+- Permission and sandbox policy cannot be bypassed by third-party control.
+- Control events are the shared output surface for TUI, ACP, Wire, and headless
+  evaluation.
+- Features that add user-visible state must define whether that state is
+  persisted, compacted, or transient.
+
+## Validation Matrix
+
+- Unit tests for request routing from adapter-neutral inputs to runtime domains.
+- Unit tests for provenance propagation on prompt, skill, memory, and hook
+  sources.
+- Tests proving protocol prompt sources appear in `/context` without changing
+  stable prompt-prefix order.
+- Tests proving protocol skill sources follow normal precedence and override
+  reporting.
+- Tests proving memory writes cannot bypass `MemorySelection`.
+- ACP adapter tests for prompt, cancellation, and output events once the adapter
+  is wired.
+- Wire adapter tests should reuse the same control-plane fixtures.
+
+## Open Risks
+
+- ACP and Wire may have different streaming and session semantics. The control
+  plane must avoid leaking one protocol's lifecycle into core runtime state.
+- Prompt-source registration can become a prompt-injection risk if provenance
+  and trust boundaries are not visible.
+- Hook execution is high-risk and should remain declaration-only until the
+  permission model is explicit.
+- Persisting protocol-controlled state requires careful session ownership and
+  cleanup rules.
+
+## Source Journals
+
+- [2026-05-01-skilltool-and-verify-specs](../journal/2026-05-01-skilltool-and-verify-specs.md)
+- [2026-05-01-memory-selection-spec](../journal/2026-05-01-memory-selection-spec.md)
+- [2026-05-01-tui-modular-queued-follow-up](../journal/2026-05-01-tui-modular-queued-follow-up.md)

--- a/docs/journal/2026-05-02-runtime-control-plane.md
+++ b/docs/journal/2026-05-02-runtime-control-plane.md
@@ -1,0 +1,42 @@
+# Runtime Control Plane Spec
+
+## Context
+
+RARA needs to support ACP and Wire-style integrations where third-party
+applications can control or observe skills, memory, prompt sources, hooks,
+input, and output.
+
+The existing roadmap already includes skills, memory selection, prompt-source
+observability, hook discovery, ACP, and AgentHub team mode. Without a shared
+runtime control boundary, those features risk becoming TUI-only or protocol-
+specific implementations.
+
+## Decision
+
+Added `docs/features/runtime-control-plane.md` as the canonical architecture
+spec for adapter-neutral control requests and structured runtime events.
+
+The new control-plane-ready rule says future work touching skills, memory,
+prompt sources, hooks, planning, approvals, tool output, `/context`, or
+`/status` must keep core behavior in runtime/domain layers and expose structured
+request/event contracts that ACP, Wire, TUI, CLI, and future appserver adapters
+can reuse.
+
+## Scope
+
+This checkpoint is documentation-only.
+
+It updates:
+
+- `docs/todo.md` with a new runtime control plane rollout section;
+- `docs/features/README.md` with the control-plane readiness rule;
+- `docs/features/prompt-runtime.md` with protocol prompt-source constraints;
+- `docs/features/repo-extension-surface.md` with protocol adapter boundaries;
+- `docs/features/agenthub-team-mode.md` with ACP-as-control-plane-adapter
+  constraints.
+
+## Follow-Up
+
+Next implementation work should start with adapter-neutral request/event types
+and a structured output event bridge before attempting full ACP or Wire feature
+coverage.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,7 +21,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Support protocol-registered skill sources through the same `SkillRegistry` precedence and override reporting as local skills.
 - [ ] Add protocol-safe memory mutation/query scaffolding that creates memory records and selection views without bypassing `MemorySelection`.
 - [ ] Add hook declaration scaffolding for protocol and repo extensions; keep execution disabled until permission and sandbox policy are explicit.
-- [ ] Ensure every new skills, memory, prompt, hook, planning, approval, and output feature is control-plane-ready rather than TUI-only.
+- [ ] Ensure every new skill, memory, prompt, hook, planning, approval, and output feature is control-plane-ready rather than TUI-only.
 
 ## Configuration / Provider Surface
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,12 +4,24 @@ Active backlog only. Keep this file small and current.
 
 ## Suggested Rollout Order
 
-1. Runtime bootstrap and context contracts
-2. Configuration and provider-surface cleanup
-3. Workspace / skill observability and cache correctness
-4. Memory / retrieval / thread persistence
-5. TUI transcript parity and command-surface polish
-6. Terminal-Bench evaluation readiness
+1. Runtime control plane and ACP/Wire-ready context contracts
+2. Runtime bootstrap and source-object unification
+3. Configuration and provider-surface cleanup
+4. Workspace / skill observability and cache correctness
+5. Memory / retrieval / thread persistence
+6. TUI transcript parity and command-surface polish
+7. Terminal-Bench evaluation readiness
+
+## Runtime Control Plane / ACP / Wire
+
+- [ ] Define adapter-neutral runtime control request/event types for ACP, Wire, TUI, CLI, and future appserver entrypoints (see `docs/features/runtime-control-plane.md`).
+- [ ] Route ACP prompt/cancel/session handling through the normal RARA runtime path instead of the current stub.
+- [ ] Add a structured output event bridge from `AgentEvent` / TUI runtime events to protocol subscribers.
+- [ ] Support protocol-registered prompt sources with provenance, scope, budget hints, and `/context` visibility.
+- [ ] Support protocol-registered skill sources through the same `SkillRegistry` precedence and override reporting as local skills.
+- [ ] Add protocol-safe memory mutation/query scaffolding that creates memory records and selection views without bypassing `MemorySelection`.
+- [ ] Add hook declaration scaffolding for protocol and repo extensions; keep execution disabled until permission and sandbox policy are explicit.
+- [ ] Ensure every new skills, memory, prompt, hook, planning, approval, and output feature is control-plane-ready rather than TUI-only.
 
 ## Configuration / Provider Surface
 
@@ -25,7 +37,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Tests for workspace prompt-source discovery and cache invalidation (cwd changes, git branches, nested workspaces).
 - [ ] Define `WorkspaceMemory` cache invalidation rules for prompt files and environment info.
 - [ ] Unify `discover_prompt_sources()` and TUI `/status` source reporting.
-- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events — not ad hoc text.
+- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.
 - [ ] Claude-style `verify` skill and `verifier-*` convention (see `docs/features/verify-skill.md`).
 - [ ] Evolve `SkillTool` to Codex/Claude contract (see `docs/features/skill-tool.md`): frontmatter, scopes, override visibility.
@@ -45,6 +57,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Thread-scoped and workspace-scoped `MemoryRecord` storage with promotion rules.
 - [ ] Retrieval orchestration layer from `docs/features/context-architecture.md`.
 - [ ] Initialize LanceDB and wire vector index for memory selection.
+- [ ] Make memory mutation/query control-plane-ready so ACP/Wire can inspect and add memory without directly editing prompt text.
 
 ## TUI / Transcript
 
@@ -59,6 +72,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Live `bash` transcript: lifecycle framing, streamed stdout/stderr, long-output folding.
 - [ ] High-fidelity render pass for `write/update`, inline diffs, approval cards, message-card hierarchy.
 - [ ] Expand TUI snapshot coverage.
+- [ ] Keep transcript and pending-interaction state backed by structured events that ACP/Wire output subscribers can reuse.
 
 ## Security / Reliability / Performance
 


### PR DESCRIPTION
## Summary

- Add a runtime control plane feature spec for ACP, Wire, TUI, CLI, and future appserver adapters.
- Define control-plane-ready constraints for skills, memory, prompt sources, hooks, planning, approvals, and output events.
- Update TODO rollout order so ACP/Wire-ready runtime contracts come before feature-specific implementation.
- Align prompt runtime, repository extension surface, and AgentHub team mode specs with the control-plane boundary.
- Record the documentation checkpoint in `docs/journal/`.

## Tests

- Documentation-only change; no runtime tests run.
