### PR TITLE
fix: continue reasoning-only agent turns

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -503,16 +503,29 @@ impl Agent {
                 if self.should_continue_execute_without_tools(
                     *agentic_turns,
                     turn_output.continue_inspection,
+                    turn_output.had_text_response,
+                    turn_output.had_reasoning_response,
                 ) {
-                    report(AgentEvent::Status(
-                        "Repository review needs more code inspection. Continuing the same turn."
-                            .to_string(),
-                    ));
+                    let phase = if turn_output.had_reasoning_response
+                        && !turn_output.had_text_response
+                        && *agentic_turns == 0
+                    {
+                        report(AgentEvent::Status(
+                            "Model produced reasoning only. Continuing for a visible answer or tool call."
+                                .to_string(),
+                        ));
+                        RuntimeContinuationPhase::ReasoningOnlyContinuationRequired
+                    } else {
+                        report(AgentEvent::Status(
+                            "Repository review needs more code inspection. Continuing the same turn."
+                                .to_string(),
+                        ));
+                        RuntimeContinuationPhase::ExecutionContinuationRequired
+                    };
                     *agentic_turns += 1;
-                    self.push_history_message(self.runtime_continuation_message(
-                        RuntimeContinuationPhase::ExecutionContinuationRequired,
-                        *agentic_turns,
-                    ));
+                    self.push_history_message(
+                        self.runtime_continuation_message(phase, *agentic_turns),
+                    );
                     self.checkpoint_session()?;
                     continue;
                 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -506,10 +506,11 @@ impl Agent {
                     turn_output.had_text_response,
                     turn_output.had_reasoning_response,
                 ) {
-                    let phase = if turn_output.had_reasoning_response
-                        && !turn_output.had_text_response
-                        && *agentic_turns == 0
-                    {
+                    let phase = if Self::is_reasoning_only_initial_turn(
+                        turn_output.had_text_response,
+                        turn_output.had_reasoning_response,
+                        *agentic_turns,
+                    ) {
                         report(AgentEvent::Status(
                             "Model produced reasoning only. Continuing for a visible answer or tool call."
                                 .to_string(),

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -50,6 +50,7 @@ pub(super) enum RuntimeContinuationPhase {
     ToolResultsAvailable,
     PlanContinuationRequired,
     ExecutionContinuationRequired,
+    ReasoningOnlyContinuationRequired,
     PlanApproved,
 }
 
@@ -505,11 +506,15 @@ impl Agent {
 
     pub(super) fn should_continue_execute_without_tools(
         &self,
-        _agentic_turns: usize,
+        agentic_turns: usize,
         continue_inspection: bool,
+        had_text_response: bool,
+        had_reasoning_response: bool,
     ) -> bool {
+        let reasoning_only_initial_turn =
+            had_reasoning_response && !had_text_response && agentic_turns == 0;
         matches!(self.execution_mode, AgentExecutionMode::Execute)
-            && continue_inspection
+            && (continue_inspection || reasoning_only_initial_turn)
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
     }
@@ -794,6 +799,7 @@ impl RuntimeContinuationPhase {
             Self::ToolResultsAvailable => "tool_results_available",
             Self::PlanContinuationRequired => "plan_continuation_required",
             Self::ExecutionContinuationRequired => "execution_continuation_required",
+            Self::ReasoningOnlyContinuationRequired => "reasoning_only_continuation_required",
             Self::PlanApproved => "plan_approved",
         }
     }
@@ -821,6 +827,13 @@ impl RuntimeContinuationPhase {
                 "Keep gathering the next relevant code context now.",
                 "If you mentioned a next file or next inspection step, call the tool for it directly.",
                 "Only stop when you can provide concrete, evidence-based suggestions or when structured user input is required.",
+                "Do not ask the user to continue.",
+            ],
+            Self::ReasoningOnlyContinuationRequired => vec![
+                "The previous model turn produced internal reasoning but no visible assistant text and no tool call.",
+                "Continue the same task immediately.",
+                "Do not rely on the hidden reasoning as an action.",
+                "Either call the next needed tool directly, or provide a visible final answer.",
                 "Do not ask the user to continue.",
             ],
             Self::PlanApproved => vec![

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -483,8 +483,11 @@ impl Agent {
     ) -> bool {
         let shallow_initial_plan =
             plan_updated && agentic_turns == 0 && self.current_plan.len() <= 1;
-        let reasoning_only_initial_turn =
-            had_reasoning_response && !had_text_response && agentic_turns == 0;
+        let reasoning_only_initial_turn = Self::is_reasoning_only_initial_turn(
+            had_text_response,
+            had_reasoning_response,
+            agentic_turns,
+        );
         let has_inspection_evidence = self.inspection_progress.has_any_evidence();
         let still_missing_inspection_evidence = agentic_turns > 0
             && !plan_updated
@@ -511,12 +514,23 @@ impl Agent {
         had_text_response: bool,
         had_reasoning_response: bool,
     ) -> bool {
-        let reasoning_only_initial_turn =
-            had_reasoning_response && !had_text_response && agentic_turns == 0;
+        let reasoning_only_initial_turn = Self::is_reasoning_only_initial_turn(
+            had_text_response,
+            had_reasoning_response,
+            agentic_turns,
+        );
         matches!(self.execution_mode, AgentExecutionMode::Execute)
             && (continue_inspection || reasoning_only_initial_turn)
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
+    }
+
+    pub(super) fn is_reasoning_only_initial_turn(
+        had_text_response: bool,
+        had_reasoning_response: bool,
+        agentic_turns: usize,
+    ) -> bool {
+        had_reasoning_response && !had_text_response && agentic_turns == 0
     }
 
     pub(super) fn ensure_active_plan_step(&mut self) {

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -217,19 +217,28 @@ async fn recoverable_runtime_error_is_returned_to_model_once() {
 
 #[tokio::test]
 async fn reasoning_only_turn_is_not_persisted_as_empty_assistant_message() {
-    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
-        content: vec![ContentBlock::ProviderMetadata {
-            provider: "deepseek".to_string(),
-            key: "reasoning_content".to_string(),
-            value: json!("internal planning only"),
-        }],
-        stop_reason: Some("end_turn".to_string()),
-        usage: Some(TokenUsage::default()),
-    }]));
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: json!("internal planning only"),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "Visible answer after structured continuation.".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
     let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
     let mut agent = Agent::new(
         ToolManager::new(),
-        backend,
+        backend.clone(),
         Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
         session_manager,
         workspace,
@@ -241,13 +250,27 @@ async fn reasoning_only_turn_is_not_persisted_as_empty_assistant_message() {
             super::super::AgentOutputMode::Silent,
         )
         .await
-        .expect("reasoning-only response should complete without empty history");
+        .expect("reasoning-only response should continue once");
 
+    let observed_messages = backend.observed_messages();
+    assert_eq!(observed_messages.len(), 2);
+    assert!(observed_messages[1].iter().any(|message| {
+        message
+            .content
+            .to_string()
+            .contains("reasoning_only_continuation_required")
+    }));
+    let assistant_messages = agent
+        .history
+        .iter()
+        .filter(|message| message.role == "assistant")
+        .collect::<Vec<_>>();
+    assert_eq!(assistant_messages.len(), 1);
     assert!(
-        !agent
-            .history
-            .iter()
-            .any(|message| message.role == "assistant")
+        assistant_messages[0]
+            .content
+            .to_string()
+            .contains("Visible answer after structured continuation.")
     );
 }
 
@@ -1408,11 +1431,13 @@ fn execute_mode_continuation_requires_structured_inspection_marker() {
     agent.set_execution_mode(AgentExecutionMode::Execute);
     agent.inspection_progress.source_reads = 1;
 
-    assert!(!agent.should_continue_execute_without_tools(1, false));
-    assert!(agent.should_continue_execute_without_tools(1, true));
+    assert!(!agent.should_continue_execute_without_tools(1, false, true, false));
+    assert!(agent.should_continue_execute_without_tools(1, true, true, false));
+    assert!(agent.should_continue_execute_without_tools(0, false, false, true));
+    assert!(!agent.should_continue_execute_without_tools(1, false, false, true));
 
     agent.inspection_progress.source_reads = 2;
-    assert!(agent.should_continue_execute_without_tools(1, true));
+    assert!(agent.should_continue_execute_without_tools(1, true, true, false));
 }
 
 #[test]

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -22,6 +22,9 @@ use super::shared::{
 
 use self::usage::parse_openai_token_usage;
 
+const STREAM_IDLE_RETRY_ATTEMPTS: usize = 1;
+const STREAM_IDLE_ERROR_FRAGMENT: &str = "stream produced no events";
+
 #[cfg(test)]
 pub(crate) use self::codex::{
     apply_codex_stream_event, build_codex_responses_request, build_codex_stream_response,
@@ -90,87 +93,8 @@ impl OpenAiCompatibleBackend {
         };
         format!("{normalized_base}/{path}")
     }
-}
 
-/// Fetch the model's context window size from GET /v1/models.
-/// Falls back to None if the API call fails or the model is not found.
-pub async fn fetch_model_context_window(
-    client: &reqwest::Client,
-    base_url: &str,
-    api_key: Option<&SecretString>,
-    model: &str,
-) -> Option<usize> {
-    let base = base_url.trim_end_matches('/');
-    let url = if base.ends_with("/v1") {
-        format!("{base}/models")
-    } else {
-        format!("{base}/v1/models")
-    };
-
-    let mut req = client.get(&url).timeout(Duration::from_secs(5));
-    if let Some(key) = api_key {
-        req = req.bearer_auth(key.expose_secret());
-    }
-
-    let res = req.send().await.ok()?.error_for_status().ok()?;
-    let body: Value = res.json().await.ok()?;
-    let models = body["data"].as_array()?;
-
-    for m in models {
-        if m["id"].as_str() == Some(model) {
-            return m["context_length"]
-                .as_u64()
-                .and_then(|tokens| usize::try_from(tokens).ok())
-                .filter(|tokens| *tokens > 0);
-        }
-    }
-    None
-}
-
-#[async_trait]
-impl LlmBackend for OpenAiCompatibleBackend {
-    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
-        self.ask_with_context(messages, tools, LlmTurnMetadata::default())
-            .await
-    }
-
-    async fn ask_with_context(
-        &self,
-        messages: &[Message],
-        tools: &[Value],
-        metadata: LlmTurnMetadata,
-    ) -> Result<LlmResponse> {
-        let body = build_chat_completion_request_body(
-            &self.model,
-            messages,
-            tools,
-            self.endpoint_kind,
-            self.reasoning_effort.as_deref(),
-            self.thinking,
-            metadata.clone(),
-        );
-
-        let completions_url = self.endpoint_url("chat/completions");
-        let mut request = self.client.post(&completions_url);
-        if let Some(api_key) = self.api_key.as_ref().map(SecretString::expose_secret) {
-            if !api_key.is_empty() {
-                request = request.header("Authorization", format!("Bearer {api_key}"));
-            }
-        }
-        let res = request.json(&body).send().await?;
-
-        if !res.status().is_success() {
-            return Err(anyhow!(
-                "API Error at {}: {}",
-                sanitize_url_for_display(&completions_url),
-                redact_secrets(res.text().await?)
-            ));
-        }
-        let resp_json: Value = res.json().await?;
-        parse_chat_completion_response(&resp_json, self.endpoint_kind)
-    }
-
-    async fn ask_streaming_with_context(
+    async fn ask_streaming_once(
         &self,
         messages: &[Message],
         tools: &[Value],
@@ -273,6 +197,118 @@ impl LlmBackend for OpenAiCompatibleBackend {
             stop_reason,
             usage: usage.as_ref().map(parse_openai_token_usage),
         })
+    }
+}
+
+/// Fetch the model's context window size from GET /v1/models.
+/// Falls back to None if the API call fails or the model is not found.
+pub async fn fetch_model_context_window(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: Option<&SecretString>,
+    model: &str,
+) -> Option<usize> {
+    let base = base_url.trim_end_matches('/');
+    let url = if base.ends_with("/v1") {
+        format!("{base}/models")
+    } else {
+        format!("{base}/v1/models")
+    };
+
+    let mut req = client.get(&url).timeout(Duration::from_secs(5));
+    if let Some(key) = api_key {
+        req = req.bearer_auth(key.expose_secret());
+    }
+
+    let res = req.send().await.ok()?.error_for_status().ok()?;
+    let body: Value = res.json().await.ok()?;
+    let models = body["data"].as_array()?;
+
+    for m in models {
+        if m["id"].as_str() == Some(model) {
+            return m["context_length"]
+                .as_u64()
+                .and_then(|tokens| usize::try_from(tokens).ok())
+                .filter(|tokens| *tokens > 0);
+        }
+    }
+    None
+}
+
+#[async_trait]
+impl LlmBackend for OpenAiCompatibleBackend {
+    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
+        self.ask_with_context(messages, tools, LlmTurnMetadata::default())
+            .await
+    }
+
+    async fn ask_with_context(
+        &self,
+        messages: &[Message],
+        tools: &[Value],
+        metadata: LlmTurnMetadata,
+    ) -> Result<LlmResponse> {
+        let body = build_chat_completion_request_body(
+            &self.model,
+            messages,
+            tools,
+            self.endpoint_kind,
+            self.reasoning_effort.as_deref(),
+            self.thinking,
+            metadata.clone(),
+        );
+
+        let completions_url = self.endpoint_url("chat/completions");
+        let mut request = self.client.post(&completions_url);
+        if let Some(api_key) = self.api_key.as_ref().map(SecretString::expose_secret) {
+            if !api_key.is_empty() {
+                request = request.header("Authorization", format!("Bearer {api_key}"));
+            }
+        }
+        let res = request.json(&body).send().await?;
+
+        if !res.status().is_success() {
+            return Err(anyhow!(
+                "API Error at {}: {}",
+                sanitize_url_for_display(&completions_url),
+                redact_secrets(res.text().await?)
+            ));
+        }
+        let resp_json: Value = res.json().await?;
+        parse_chat_completion_response(&resp_json, self.endpoint_kind)
+    }
+
+    async fn ask_streaming_with_context(
+        &self,
+        messages: &[Message],
+        tools: &[Value],
+        metadata: LlmTurnMetadata,
+        on_event: &mut (dyn FnMut(LlmStreamEvent) + Send),
+    ) -> Result<LlmResponse> {
+        let mut attempts = 0usize;
+        loop {
+            let mut emitted_delta = false;
+            let mut relay_event = |event: LlmStreamEvent| {
+                emitted_delta = true;
+                on_event(event);
+            };
+            let result = self
+                .ask_streaming_once(messages, tools, metadata.clone(), &mut relay_event)
+                .await;
+            match result {
+                Ok(response) => return Ok(response),
+                Err(error)
+                    if attempts < STREAM_IDLE_RETRY_ATTEMPTS
+                        && !emitted_delta
+                        && is_openai_stream_idle_error(&error) =>
+                {
+                    attempts += 1;
+                    metadata.ensure_not_cancelled()?;
+                    continue;
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     async fn embed(&self, text: &str) -> Result<Vec<f32>> {
@@ -537,6 +573,12 @@ fn render_legacy_openai_content(content: &Value) -> String {
         Value::Null => String::new(),
         other => other.to_string(),
     }
+}
+
+pub(super) fn is_openai_stream_idle_error(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.to_string().contains(STREAM_IDLE_ERROR_FRAGMENT))
 }
 
 fn apply_deepseek_thinking_options(

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -10,8 +10,8 @@ use super::ollama::{
 };
 use super::openai_compatible::{
     apply_codex_stream_event, build_chat_completion_request_body, build_codex_responses_request,
-    build_streaming_response_content, merge_streaming_tool_calls, parse_chat_completion_response,
-    parse_codex_response, to_codex_input_items, to_openai_messages,
+    build_streaming_response_content, is_openai_stream_idle_error, merge_streaming_tool_calls,
+    parse_chat_completion_response, parse_codex_response, to_codex_input_items, to_openai_messages,
     to_openai_messages_for_endpoint,
 };
 use super::shared::{
@@ -1766,4 +1766,13 @@ fn bypasses_proxy_for_local_ollama_hosts() {
     assert!(should_bypass_proxy("http://localhost:11434"));
     assert!(should_bypass_proxy("http://127.0.0.1:11434"));
     assert!(!should_bypass_proxy("https://openrouter.ai/api/v1"));
+}
+
+#[test]
+fn detects_openai_stream_idle_timeout_as_retryable() {
+    let error = anyhow::anyhow!("OpenAI-compatible SSE stream produced no events for 120 seconds");
+    assert!(is_openai_stream_idle_error(&error));
+
+    let parse_error = anyhow::anyhow!("Failed to parse SSE payload: expected value");
+    assert!(!is_openai_stream_idle_error(&parse_error));
 }


### PR DESCRIPTION
## Summary

- continue one extra turn when an execute-mode model response contains reasoning only, with no visible answer or tool call
- add a structured `reasoning_only_continuation_required` runtime message so the next turn must produce a visible answer or call a tool
- retry OpenAI-compatible SSE requests once when the stream idles before emitting any text or reasoning delta

## Motivation

Some OpenAI-compatible models can produce internal reasoning without a visible assistant message or tool call. RARA previously treated that as a completed turn in execute mode. Separately, an SSE connection that produced no events for 120 seconds surfaced directly as a query failure without a backend retry.

This keeps reasoning as a side channel, matching Codex/Claude-style boundaries, while giving the runtime a structured continuation path for empty reasoning-only turns.

## Tests

- `cargo test reasoning_only_turn_is_not_persisted_as_empty_assistant_message -- --nocapture`
- `cargo test execute_mode_continuation_requires_structured_inspection_marker -- --nocapture`
- `cargo test detects_openai_stream_idle_timeout_as_retryable -- --nocapture`
- `cargo check`
