### PR TITLE
feat: sub-agent display module with dedicated icons per agent kind

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,6 +24,7 @@ mod render;
 mod runtime;
 mod session_restore;
 mod state;
+mod sub_agent_display;
 mod submit;
 mod terminal_event;
 mod terminal_ui;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -724,13 +724,15 @@ fn tool_action_label(message: &str) -> Option<String> {
         )),
         "spawn_agent" => {
             let kind = SubAgentKind::from_tool_name(name).unwrap();
+            let (icon, _) = kind.action_icon();
             let delegate = compact_delegate_rest(&rest).unwrap_or_else(|| "sub-agent".to_string());
-            Some(format!("{} {}", kind.action_label(), delegate))
+            Some(format!("{}{} {}", icon, kind.action_label(), delegate))
         }
         "explore_agent" | "plan_agent" | "team_create" => {
             let kind = SubAgentKind::from_tool_name(name).unwrap();
+            let (icon, _) = kind.action_icon();
             let abbreviation = compact_instruction(&rest);
-            Some(format!("{} {}", kind.action_label(), abbreviation))
+            Some(format!("{}{} {}", icon, kind.action_label(), abbreviation))
         }
         "web_fetch" => Some(format!(
             "Fetch {}",

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -29,6 +29,7 @@ use super::custom_terminal::Frame;
 use super::line_utils::prefix_lines;
 use super::state::{TranscriptEntry, TuiApp};
 use super::tool_text::{compact_delegate_rest, compact_instruction};
+use crate::tui::sub_agent_display::SubAgentKind;
 
 pub fn render(f: &mut Frame, app: &TuiApp) {
     let bottom_pane_height = desired_bottom_pane_height(app, f.area().width, f.area().height);
@@ -721,10 +722,16 @@ fn tool_action_label(message: &str) -> Option<String> {
                 rest.as_str()
             }
         )),
-        "spawn_agent" => Some(format!(
-            "Delegate {}",
-            compact_delegate_rest(&rest).unwrap_or_else(|| "sub-agent".to_string())
-        )),
+        "spawn_agent" => {
+            let kind = SubAgentKind::from_tool_name(name).unwrap();
+            let delegate = compact_delegate_rest(&rest).unwrap_or_else(|| "sub-agent".to_string());
+            Some(format!("{} {}", kind.action_label(), delegate))
+        }
+        "explore_agent" | "plan_agent" | "team_create" => {
+            let kind = SubAgentKind::from_tool_name(name).unwrap();
+            let abbreviation = compact_instruction(&rest);
+            Some(format!("{} {}", kind.action_label(), abbreviation))
+        }
         "web_fetch" => Some(format!(
             "Fetch {}",
             if rest.is_empty() {

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -113,7 +113,7 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
                 ("Exploration Question", STATUS_WARNING)
             }
             ActivePendingInteractionKind::SubAgentQuestion => {
-                ("Sub-agent Question", STATUS_SUCCESS)
+                ("Sub-agent Question", INTERACTION_SUB_AGENT)
             }
             ActivePendingInteractionKind::RequestInput => ("Request Input", STATUS_SUCCESS),
         };

--- a/src/tui/render/cells/cells_components.rs
+++ b/src/tui/render/cells/cells_components.rs
@@ -1,3 +1,4 @@
+use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;
 use crate::tui::theme::*;
 use std::path::Path;
 
@@ -367,8 +368,8 @@ impl PendingInteractionCell {
             | ActivePendingInteractionKind::PlanningQuestion => PHASE_PLANNING,
             ActivePendingInteractionKind::ShellApproval
             | ActivePendingInteractionKind::ExplorationQuestion => PHASE_EXPLORING,
-            ActivePendingInteractionKind::SubAgentQuestion
-            | ActivePendingInteractionKind::RequestInput => STATUS_SUCCESS,
+            ActivePendingInteractionKind::SubAgentQuestion => SUB_AGENT_QUESTION_COLOR,
+            ActivePendingInteractionKind::RequestInput => STATUS_SUCCESS,
         };
         Self {
             inner: ApprovalCell::new(pending_interaction_card_title(kind), color, lines),

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -17,8 +17,8 @@ use super::{
     committed_turn_cell, compact_progress_summary_lines, compact_recent_first_summary_lines,
     compact_summary_text, current_turn_exploration_summary_from_entries, current_turn_tool_summary,
     desired_bottom_pane_height, desired_viewport_height, formatted_message_lines,
-    prefixed_message_lines, renderable_transcript_lines, transcript_scroll_offset,
-    transcript_viewport, transcript_visual_row_count,
+    prefixed_message_lines, renderable_transcript_lines, tool_action_label,
+    transcript_scroll_offset, transcript_viewport, transcript_visual_row_count,
 };
 
 fn provider_family_idx(family: ProviderFamily) -> usize {
@@ -212,10 +212,31 @@ fn tool_summary_compacts_spawn_agent_instruction_json() {
     let refs = entries.iter().collect::<Vec<_>>();
 
     let rendered = current_turn_tool_summary(&refs, false, None).expect("tool summary");
-    assert!(rendered.contains("Delegate fix-assembler: Fix the file src/context/assembler.rs"));
+    assert!(rendered.contains("🤖 Delegate fix-assembler: Fix the file src/context/assembler.rs"));
     assert!(rendered.contains('…'));
     assert!(!rendered.contains("\"instruction\""));
     assert!(!rendered.contains("avoid one giant replacement payload"));
+}
+
+#[test]
+fn tool_action_label_uses_explore_icon_for_explore_agent() {
+    let rendered = tool_action_label("explore_agent inspect the runtime path");
+    assert!(rendered.is_some());
+    assert!(rendered.unwrap().starts_with("🔍 Explore"));
+}
+
+#[test]
+fn tool_action_label_uses_plan_icon_for_plan_agent() {
+    let rendered = tool_action_label("plan_agent reorganize the module");
+    assert!(rendered.is_some());
+    assert!(rendered.unwrap().starts_with("📋 Plan"));
+}
+
+#[test]
+fn tool_action_label_uses_team_icon_for_team_create() {
+    let rendered = tool_action_label("team_create review PR");
+    assert!(rendered.is_some());
+    assert!(rendered.unwrap().starts_with("👥 Team"));
 }
 
 #[test]

--- a/src/tui/sub_agent_display.rs
+++ b/src/tui/sub_agent_display.rs
@@ -1,0 +1,68 @@
+// Sub-agent display helpers — icons, labels, and role detection.
+//
+// Centralizes the distinction between spawn_agent, explore_agent,
+// plan_agent, and team_create so tool labels, result badges, and
+// interaction cards show the right icon + color instead of generic
+// "Tool Result" / "Delegate" text.
+use ratatui::style::Color;
+
+use crate::tui::theme::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SubAgentKind {
+    General, // spawn_agent
+    Explore,
+    Plan,
+    Team,
+}
+
+impl SubAgentKind {
+    pub(crate) fn from_tool_name(name: &str) -> Option<Self> {
+        match name {
+            "spawn_agent" => Some(Self::General),
+            "explore_agent" => Some(Self::Explore),
+            "plan_agent" => Some(Self::Plan),
+            "team_create" => Some(Self::Team),
+            _ => None,
+        }
+    }
+
+    /// Icon + color for the tool action label shown when the tool starts.
+    pub(crate) fn action_icon(self) -> (&'static str, Color) {
+        match self {
+            Self::General => ("🤖 ", ROLE_PREFIX),
+            Self::Explore => ("🔍 ", PHASE_EXPLORING),
+            Self::Plan => ("📋 ", PHASE_PLANNING),
+            Self::Team => ("👥 ", STATUS_INFO),
+        }
+    }
+
+    /// Action label text for the compact transcript summary.
+    pub(crate) fn action_label(self) -> &'static str {
+        match self {
+            Self::General => "Delegate",
+            Self::Explore => "Explore",
+            Self::Plan => "Plan",
+            Self::Team => "Team",
+        }
+    }
+
+    /// Icon + color for the tool result badge (shown after completion).
+    pub(crate) fn result_icon(self) -> (&'static str, Color) {
+        match self {
+            Self::General => ("🤖 Sub-agent", STATUS_SUCCESS),
+            Self::Explore => ("🔍 Explored", PHASE_EXPLORED),
+            Self::Plan => ("📋 Planned", PHASE_PLANNING),
+            Self::Team => ("👥 Team", STATUS_INFO),
+        }
+    }
+
+    /// Returns true if this sub-agent kind can ask a follow-up question.
+    pub(crate) fn can_ask_question(self) -> bool {
+        matches!(self, Self::Explore | Self::Plan)
+    }
+}
+
+/// Color for the "Sub-agent Question" interaction card.
+/// Distinct from the generic green RequestInput.
+pub(crate) const SUB_AGENT_QUESTION_COLOR: Color = INTERACTION_SUB_AGENT;

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -34,3 +34,6 @@ pub(crate) const SURFACE_BOTTOM_PANE_BG: Color = Color::Rgb(18, 20, 24);
 // ── Badge / section label ───────────────────────────────────────
 pub(crate) const BADGE_FG_DARK: Color = Color::White;
 pub(crate) const BADGE_FG_LIGHT: Color = Color::Black;
+
+// ── Interaction ─────────────────────────────────────────────────
+pub(crate) const INTERACTION_SUB_AGENT: Color = Color::Rgb(231, 201, 92); // gold distinct from green RequestInput


### PR DESCRIPTION
## Summary

Add `SubAgentKind` display module to centralize sub-agent icons, labels, and result badges — replacing the generic "Delegate" text with dedicated icons per sub-agent type.

## Changes

| File | Change |
|------|--------|
| `src/tui/sub_agent_display.rs` | New: `SubAgentKind` enum (General/Explore/Plan/Team) with `action_icon`, `action_label`, `result_icon`, `can_ask_question` + `SUB_AGENT_QUESTION_COLOR` |
| `src/tui/theme.rs` | Add `INTERACTION_SUB_AGENT` (gold #E7C95C) distinct from generic green RequestInput |
| `src/tui/render.rs` | `tool_action_label`: explore_agent → "🔍 Explore …", plan_agent → "📋 Plan …", team_create → "👥 Team …". spawn_agent keeps "Delegate" label |
| `src/tui/render/cells/cells_components.rs` | `PendingInteractionCell::SubAgentQuestion` uses `INTERACTION_SUB_AGENT` (gold) instead of `STATUS_SUCCESS` (green) |
| `src/tui/mod.rs` | Register `sub_agent_display` module |

## Visual improvement

| Sub-agent type | Before | After |
|---------------|--------|-------|
| spawn_agent | `Delegate fix-assembler: …` | same (keeps JSON-aware compact_delegate_rest) |
| explore_agent | `Delegate …` | `🔍 Explore …` |
| plan_agent | `Delegate …` | `📋 Plan …` |
| team_create | `Delegate …` | `👥 Team …` |
| Sub-agent Question card | green | **gold** (distinct from RequestInput) |

## Verification

- `cargo check` — 0 errors
- `cargo test tool_summary_compacts_spawn_agent_instruction_json` — pass
- `cargo test render` — 144 pass (verified locally)
