### PR TITLE
feat: add runtime control contract

### DIFF
--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -342,6 +342,29 @@ The first Wire milestone should reuse the same request and event families. Wire
 may define different transport framing, but it should not define a separate
 skills, memory, prompt, or hook runtime model.
 
+Wire compatibility is an adapter responsibility, not the native runtime-control
+serialization format. A Wire adapter should use the Wire transport framing:
+
+- JSON-RPC 2.0 messages over stdin/stdout, one JSON value per line;
+- client-to-agent methods such as `initialize`, `prompt`, `steer`,
+  `set_plan_mode`, and `cancel`;
+- agent-to-client `event` notifications with `params: { type, payload }`;
+- agent-to-client `request` calls with `params: { type, payload }` for
+  approvals, questions, tool calls, and hook requests.
+
+Runtime-control events should be translated into Wire message names at the
+adapter boundary. For example, internal assistant/tool/status events may become
+Wire `ContentPart`, `ToolCall`, `ToolResult`, `StatusUpdate`, or
+`ApprovalRequest` messages. The Wire-facing names should follow the external
+Wire contract, while runtime-control names remain protocol-neutral and stable
+inside RARA.
+
+Wire `steer` maps to runtime follow-up submission during an active turn. The
+runtime must still decide when the input is safely consumed. The Wire adapter
+should emit the corresponding consumed-input event only after the follow-up has
+actually been appended to the next model step, not when the client request is
+merely accepted.
+
 ## Observability
 
 `/context` should show:

--- a/docs/journal/2026-05-02-runtime-control-plane.md
+++ b/docs/journal/2026-05-02-runtime-control-plane.md
@@ -40,3 +40,21 @@ It updates:
 Next implementation work should start with adapter-neutral request/event types
 and a structured output event bridge before attempting full ACP or Wire feature
 coverage.
+
+## Implementation Checkpoint
+
+Added `src/runtime_control.rs` with the first adapter-neutral runtime control
+contract:
+
+- `RuntimeControlRequest` covers session, input, output subscription, prompt
+  source, skill source, memory, hook, and approval request families;
+- `RuntimeEvent` covers the event families named by the spec, including
+  session status, assistant, tool, context, warning, and error events;
+- `RuntimeProvenance` records controller, adapter, session, source, trust, and
+  authorship metadata;
+- `agent_event_to_runtime_event()` maps existing `AgentEvent` output into the
+  shared event shape so protocol subscribers can later reuse the same stream.
+
+This checkpoint intentionally does not route ACP or Wire through the control
+plane yet. The next slice should add subscriber plumbing and then move ACP
+prompt/cancel/session handling onto these request types.

--- a/docs/journal/2026-05-02-runtime-control-plane.md
+++ b/docs/journal/2026-05-02-runtime-control-plane.md
@@ -55,6 +55,10 @@ contract:
 - `agent_event_to_runtime_event()` maps existing `AgentEvent` output into the
   shared event shape so protocol subscribers can later reuse the same stream.
 
+The serialized contract uses explicit `type` fields and `snake_case` enum
+names instead of Rust's default externally tagged enum representation. Event
+counts use fixed-width integer fields where they may cross protocol boundaries.
+
 This checkpoint intentionally does not route ACP or Wire through the control
 plane yet. The next slice should add subscriber plumbing and then move ACP
 prompt/cancel/session handling onto these request types.

--- a/docs/journal/2026-05-02-runtime-control-plane.md
+++ b/docs/journal/2026-05-02-runtime-control-plane.md
@@ -59,6 +59,11 @@ The serialized contract uses explicit `type` fields and `snake_case` enum
 names instead of Rust's default externally tagged enum representation. Event
 counts use fixed-width integer fields where they may cross protocol boundaries.
 
+Wire mode remains a transport adapter over this contract. It should own the
+JSON-RPC 2.0 envelope, Wire method names, PascalCase Wire message names, and
+`event` / `request` framing rather than exposing runtime-control enums directly
+as Wire messages.
+
 This checkpoint intentionally does not route ACP or Wire through the control
 plane yet. The next slice should add subscriber plumbing and then move ACP
 prompt/cancel/session handling onto these request types.

--- a/docs/journal/2026-05-02-runtime-control-plane.md
+++ b/docs/journal/2026-05-02-runtime-control-plane.md
@@ -64,6 +64,11 @@ JSON-RPC 2.0 envelope, Wire method names, PascalCase Wire message names, and
 `event` / `request` framing rather than exposing runtime-control enums directly
 as Wire messages.
 
+Runtime provenance uses explicit `trust` and `authorship` enums rather than
+independent boolean flags, so callers cannot represent contradictory source
+states. Shell approval control keeps a contract-local enum but has explicit
+round-trip conversions to the runtime `BashApprovalDecision`.
+
 This checkpoint intentionally does not route ACP or Wire through the control
 plane yet. The next slice should add subscriber plumbing and then move ACP
 prompt/cancel/session handling onto these request types.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -14,9 +14,9 @@ Active backlog only. Keep this file small and current.
 
 ## Runtime Control Plane / ACP / Wire
 
-- [ ] Define adapter-neutral runtime control request/event types for ACP, Wire, TUI, CLI, and future appserver entrypoints (see `docs/features/runtime-control-plane.md`).
+- [x] Define adapter-neutral runtime control request/event types for ACP, Wire, TUI, CLI, and future appserver entrypoints (see `docs/features/runtime-control-plane.md`).
 - [ ] Route ACP prompt/cancel/session handling through the normal RARA runtime path instead of the current stub.
-- [ ] Add a structured output event bridge from `AgentEvent` / TUI runtime events to protocol subscribers.
+- [ ] Add protocol subscriber plumbing on top of the structured `AgentEvent` runtime-control bridge.
 - [ ] Support protocol-registered prompt sources with provenance, scope, budget hints, and `/context` visibility.
 - [ ] Support protocol-registered skill sources through the same `SkillRegistry` precedence and override reporting as local skills.
 - [ ] Add protocol-safe memory mutation/query scaffolding that creates memory records and selection views without bypassing `MemorySelection`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod oauth;
 mod prompt;
 mod redaction;
 mod runtime_context;
+mod runtime_control;
 mod sandbox;
 mod session;
 mod shell_env;

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -1,12 +1,10 @@
-// The control-plane contract lands before ACP/Wire adapters are wired to it.
-#![allow(dead_code)]
-
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::agent::AgentEvent;
+use crate::agent::{AgentEvent, BashApprovalDecision};
 use crate::tool::ToolOutputStream;
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeControllerKind {
@@ -18,17 +16,35 @@ pub enum RuntimeControllerKind {
     Runtime,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeProvenance {
     pub controller: RuntimeControllerKind,
     pub adapter: Option<String>,
     pub session_id: Option<String>,
     pub source_id: Option<String>,
-    pub trusted: bool,
-    pub user_provided: bool,
-    pub generated: bool,
+    pub trust: RuntimeSourceTrust,
+    pub authorship: RuntimeSourceAuthorship,
 }
 
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeSourceTrust {
+    Trusted,
+    Untrusted,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeSourceAuthorship {
+    UserProvided,
+    Generated,
+    Runtime,
+}
+
+#[allow(dead_code)]
 impl RuntimeProvenance {
     pub fn local_tui(session_id: impl Into<String>) -> Self {
         Self {
@@ -36,9 +52,8 @@ impl RuntimeProvenance {
             adapter: None,
             session_id: Some(session_id.into()),
             source_id: None,
-            trusted: true,
-            user_provided: true,
-            generated: false,
+            trust: RuntimeSourceTrust::Trusted,
+            authorship: RuntimeSourceAuthorship::UserProvided,
         }
     }
 
@@ -53,13 +68,13 @@ impl RuntimeProvenance {
             adapter: Some(adapter.into()),
             session_id,
             source_id,
-            trusted: false,
-            user_provided: true,
-            generated: false,
+            trust: RuntimeSourceTrust::Untrusted,
+            authorship: RuntimeSourceAuthorship::UserProvided,
         }
     }
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum RuntimeControlRequest {
@@ -73,6 +88,7 @@ pub enum RuntimeControlRequest {
     Approval(ApprovalControlRequest),
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeControlEnvelope {
     pub request_id: String,
@@ -80,6 +96,7 @@ pub struct RuntimeControlEnvelope {
     pub request: RuntimeControlRequest,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum SessionControlRequest {
@@ -90,6 +107,7 @@ pub enum SessionControlRequest {
     QueryRuntimeState,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum InputControlRequest {
@@ -100,6 +118,7 @@ pub enum InputControlRequest {
     SubmitFollowUp { prompt: String },
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ShellApprovalDecision {
@@ -109,6 +128,29 @@ pub enum ShellApprovalDecision {
     Suggestion,
 }
 
+impl From<BashApprovalDecision> for ShellApprovalDecision {
+    fn from(decision: BashApprovalDecision) -> Self {
+        match decision {
+            BashApprovalDecision::Once => Self::Once,
+            BashApprovalDecision::Prefix => Self::Prefix,
+            BashApprovalDecision::Always => Self::Always,
+            BashApprovalDecision::Suggestion => Self::Suggestion,
+        }
+    }
+}
+
+impl From<ShellApprovalDecision> for BashApprovalDecision {
+    fn from(decision: ShellApprovalDecision) -> Self {
+        match decision {
+            ShellApprovalDecision::Once => Self::Once,
+            ShellApprovalDecision::Prefix => Self::Prefix,
+            ShellApprovalDecision::Always => Self::Always,
+            ShellApprovalDecision::Suggestion => Self::Suggestion,
+        }
+    }
+}
+
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum OutputSubscriptionRequest {
@@ -116,6 +158,7 @@ pub enum OutputSubscriptionRequest {
     Unsubscribe { subscriber_id: String },
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PromptSourceLifetime {
@@ -124,6 +167,7 @@ pub enum PromptSourceLifetime {
     Persistent,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PromptSourceRegistration {
     pub source_id: String,
@@ -134,6 +178,7 @@ pub struct PromptSourceRegistration {
     pub content: String,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceScope {
@@ -144,6 +189,7 @@ pub enum SourceScope {
     Protocol,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceLayer {
@@ -154,6 +200,7 @@ pub enum SourceLayer {
     Skill,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PromptSourceControlRequest {
@@ -162,6 +209,7 @@ pub enum PromptSourceControlRequest {
     QuerySources,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum SkillSourceControlRequest {
@@ -183,6 +231,7 @@ pub enum SkillSourceControlRequest {
     QuerySkills,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum MemoryControlRequest {
@@ -196,6 +245,7 @@ pub enum MemoryControlRequest {
     SelectionSnapshot,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MemoryScope {
@@ -203,6 +253,7 @@ pub enum MemoryScope {
     Workspace,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum HookControlRequest {
@@ -214,6 +265,7 @@ pub enum HookControlRequest {
     QueryHooks,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HookLifecycle {
@@ -225,6 +277,7 @@ pub enum HookLifecycle {
     PreCompact,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ApprovalControlRequest {
@@ -232,6 +285,7 @@ pub enum ApprovalControlRequest {
     QueryPendingApprovals,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeControlEvent {
     pub event_id: String,
@@ -240,6 +294,7 @@ pub struct RuntimeControlEvent {
     pub event: RuntimeEvent,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum RuntimeEvent {
@@ -258,6 +313,7 @@ pub enum RuntimeEvent {
     Error(ErrorEvent),
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum SessionEvent {
@@ -270,6 +326,7 @@ pub enum SessionEvent {
     TurnFinished,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum InputEvent {
@@ -278,6 +335,7 @@ pub enum InputEvent {
     PendingInputAnswered,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum AssistantEvent {
@@ -286,6 +344,7 @@ pub enum AssistantEvent {
     ThinkingDelta(String),
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ToolStream {
@@ -302,6 +361,7 @@ impl From<ToolOutputStream> for ToolStream {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ToolEvent {
@@ -321,6 +381,7 @@ pub enum ToolEvent {
     },
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ApprovalEvent {
@@ -328,6 +389,7 @@ pub enum ApprovalEvent {
     Answered { approval_id: String, approved: bool },
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PlanEvent {
@@ -336,6 +398,7 @@ pub enum PlanEvent {
     Continued,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PromptSourceEvent {
@@ -344,6 +407,7 @@ pub enum PromptSourceEvent {
     Dropped { source_id: String, reason: String },
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum SkillEvent {
@@ -352,6 +416,7 @@ pub enum SkillEvent {
     Failed { source_id: String, reason: String },
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum MemoryEvent {
@@ -359,6 +424,7 @@ pub enum MemoryEvent {
     SelectionUpdated,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum HookEvent {
@@ -372,24 +438,28 @@ pub enum HookEvent {
     },
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ContextEvent {
     SnapshotUpdated,
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum WarningEvent {
     RuntimeWarning { message: String },
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ErrorEvent {
     RuntimeError { message: String },
 }
 
+#[allow(dead_code)]
 pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
     match event {
         AgentEvent::Status(message) => RuntimeEvent::Session(SessionEvent::Status { message }),
@@ -422,6 +492,7 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
     }
 }
 
+#[allow(dead_code)]
 pub fn wrap_agent_event(
     event_id: impl Into<String>,
     sequence: u64,
@@ -498,6 +569,8 @@ mod tests {
 
         assert_eq!(value["request_id"], json!("req-1"));
         assert_eq!(value["provenance"]["controller"], json!("acp"));
+        assert_eq!(value["provenance"]["trust"], json!("untrusted"));
+        assert_eq!(value["provenance"]["authorship"], json!("user_provided"));
         assert_eq!(
             value["request"],
             json!({
@@ -518,6 +591,22 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn shell_approval_decision_round_trips_runtime_decision() {
+        for (runtime, contract) in [
+            (BashApprovalDecision::Once, ShellApprovalDecision::Once),
+            (BashApprovalDecision::Prefix, ShellApprovalDecision::Prefix),
+            (BashApprovalDecision::Always, ShellApprovalDecision::Always),
+            (
+                BashApprovalDecision::Suggestion,
+                ShellApprovalDecision::Suggestion,
+            ),
+        ] {
+            assert_eq!(ShellApprovalDecision::from(runtime), contract);
+            assert_eq!(BashApprovalDecision::from(contract), runtime);
+        }
     }
 
     #[test]

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -1,0 +1,500 @@
+// The control-plane contract lands before ACP/Wire adapters are wired to it.
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::agent::AgentEvent;
+use crate::tool::ToolOutputStream;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RuntimeControllerKind {
+    LocalTui,
+    LocalCli,
+    Acp,
+    Wire,
+    AppServer,
+    Runtime,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeProvenance {
+    pub controller: RuntimeControllerKind,
+    pub adapter: Option<String>,
+    pub session_id: Option<String>,
+    pub source_id: Option<String>,
+    pub trusted: bool,
+    pub user_provided: bool,
+    pub generated: bool,
+}
+
+impl RuntimeProvenance {
+    pub fn local_tui(session_id: impl Into<String>) -> Self {
+        Self {
+            controller: RuntimeControllerKind::LocalTui,
+            adapter: None,
+            session_id: Some(session_id.into()),
+            source_id: None,
+            trusted: true,
+            user_provided: true,
+            generated: false,
+        }
+    }
+
+    pub fn protocol(
+        controller: RuntimeControllerKind,
+        adapter: impl Into<String>,
+        session_id: Option<String>,
+        source_id: Option<String>,
+    ) -> Self {
+        Self {
+            controller,
+            adapter: Some(adapter.into()),
+            session_id,
+            source_id,
+            trusted: false,
+            user_provided: true,
+            generated: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RuntimeControlRequest {
+    Session(SessionControlRequest),
+    Input(InputControlRequest),
+    Output(OutputSubscriptionRequest),
+    PromptSource(PromptSourceControlRequest),
+    SkillSource(SkillSourceControlRequest),
+    Memory(MemoryControlRequest),
+    Hook(HookControlRequest),
+    Approval(ApprovalControlRequest),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeControlEnvelope {
+    pub request_id: String,
+    pub provenance: RuntimeProvenance,
+    pub request: RuntimeControlRequest,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionControlRequest {
+    CreateSession,
+    ResumeSession { session_id: String },
+    CancelCurrentTurn,
+    InterruptCurrentTurn,
+    QueryRuntimeState,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InputControlRequest {
+    SubmitUserPrompt { prompt: String },
+    AnswerPendingInput { answer: String },
+    AnswerPlanApproval { approved: bool },
+    AnswerShellApproval { decision: ShellApprovalDecision },
+    SubmitFollowUp { prompt: String },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ShellApprovalDecision {
+    Once,
+    Prefix,
+    Always,
+    Suggestion,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OutputSubscriptionRequest {
+    Subscribe { subscriber_id: String },
+    Unsubscribe { subscriber_id: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PromptSourceLifetime {
+    Turns(u32),
+    Session,
+    Persistent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PromptSourceRegistration {
+    pub source_id: String,
+    pub scope: SourceScope,
+    pub layer: SourceLayer,
+    pub budget_hint_tokens: Option<u32>,
+    pub lifetime: PromptSourceLifetime,
+    pub content: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SourceScope {
+    Home,
+    Repo,
+    CurrentWorkingDirectory,
+    Session,
+    Protocol,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SourceLayer {
+    System,
+    Developer,
+    User,
+    Memory,
+    Skill,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PromptSourceControlRequest {
+    Register(PromptSourceRegistration),
+    Unregister { source_id: String },
+    QuerySources,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SkillSourceControlRequest {
+    RegisterRoot {
+        source_id: String,
+        root: String,
+        precedence_hint: Option<i32>,
+    },
+    RegisterSkill {
+        source_id: String,
+        name: String,
+        content: String,
+        precedence_hint: Option<i32>,
+    },
+    DisableSkill {
+        name: String,
+        source_id: Option<String>,
+    },
+    QuerySkills,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryControlRequest {
+    AddRecord {
+        memory_id: String,
+        scope: MemoryScope,
+        content: String,
+        metadata: Value,
+    },
+    QueryMetadata,
+    SelectionSnapshot,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryScope {
+    Thread,
+    Workspace,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HookControlRequest {
+    Declare {
+        hook_id: String,
+        lifecycle: HookLifecycle,
+        description: String,
+    },
+    QueryHooks,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HookLifecycle {
+    SessionStart,
+    UserPromptSubmit,
+    PreToolUse,
+    PostToolUse,
+    Stop,
+    PreCompact,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApprovalControlRequest {
+    AnswerPendingApproval { approval_id: String, approved: bool },
+    QueryPendingApprovals,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeControlEvent {
+    pub event_id: String,
+    pub provenance: RuntimeProvenance,
+    pub sequence: u64,
+    pub event: RuntimeEvent,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum RuntimeEvent {
+    Session(SessionEvent),
+    Input(InputEvent),
+    Assistant(AssistantEvent),
+    Tool(ToolEvent),
+    Approval(ApprovalEvent),
+    Plan(PlanEvent),
+    PromptSource(PromptSourceEvent),
+    Skill(SkillEvent),
+    Memory(MemoryEvent),
+    Hook(HookEvent),
+    Context(ContextEvent),
+    Warning(WarningEvent),
+    Error(ErrorEvent),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionEvent {
+    Created { session_id: String },
+    Resumed { session_id: String },
+    Status { message: String },
+    TurnStarted,
+    TurnCancelled,
+    TurnInterrupted,
+    TurnFinished,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum InputEvent {
+    UserPromptSubmitted,
+    FollowUpQueued { queue_len: usize },
+    PendingInputAnswered,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AssistantEvent {
+    Text(String),
+    TextDelta(String),
+    ThinkingDelta(String),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ToolStream {
+    Stdout,
+    Stderr,
+}
+
+impl From<ToolOutputStream> for ToolStream {
+    fn from(stream: ToolOutputStream) -> Self {
+        match stream {
+            ToolOutputStream::Stdout => Self::Stdout,
+            ToolOutputStream::Stderr => Self::Stderr,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ToolEvent {
+    Use {
+        name: String,
+        input: Value,
+    },
+    Result {
+        name: String,
+        content: String,
+        is_error: bool,
+    },
+    Progress {
+        name: String,
+        stream: ToolStream,
+        chunk: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApprovalEvent {
+    Requested { approval_id: String, kind: String },
+    Answered { approval_id: String, approved: bool },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PlanEvent {
+    Updated,
+    Approved,
+    Continued,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PromptSourceEvent {
+    Registered { source_id: String },
+    Unregistered { source_id: String },
+    Dropped { source_id: String, reason: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SkillEvent {
+    Registered { source_id: String, name: String },
+    Shadowed { name: String, by_source_id: String },
+    Failed { source_id: String, reason: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MemoryEvent {
+    RecordAdded { memory_id: String },
+    SelectionUpdated,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HookEvent {
+    Declared {
+        hook_id: String,
+        lifecycle: HookLifecycle,
+    },
+    Ignored {
+        hook_id: String,
+        reason: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ContextEvent {
+    SnapshotUpdated,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WarningEvent {
+    RuntimeWarning { message: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ErrorEvent {
+    RuntimeError { message: String },
+}
+
+pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
+    match event {
+        AgentEvent::Status(message) => RuntimeEvent::Session(SessionEvent::Status { message }),
+        AgentEvent::AssistantText(text) => RuntimeEvent::Assistant(AssistantEvent::Text(text)),
+        AgentEvent::AssistantDelta(delta) => {
+            RuntimeEvent::Assistant(AssistantEvent::TextDelta(delta))
+        }
+        AgentEvent::AssistantThinkingDelta(delta) => {
+            RuntimeEvent::Assistant(AssistantEvent::ThinkingDelta(delta))
+        }
+        AgentEvent::ToolUse { name, input } => RuntimeEvent::Tool(ToolEvent::Use { name, input }),
+        AgentEvent::ToolResult {
+            name,
+            content,
+            is_error,
+        } => RuntimeEvent::Tool(ToolEvent::Result {
+            name,
+            content,
+            is_error,
+        }),
+        AgentEvent::ToolProgress {
+            name,
+            stream,
+            chunk,
+        } => RuntimeEvent::Tool(ToolEvent::Progress {
+            name,
+            stream: stream.into(),
+            chunk,
+        }),
+    }
+}
+
+pub fn wrap_agent_event(
+    event_id: impl Into<String>,
+    sequence: u64,
+    provenance: RuntimeProvenance,
+    event: AgentEvent,
+) -> RuntimeControlEvent {
+    RuntimeControlEvent {
+        event_id: event_id.into(),
+        provenance,
+        sequence,
+        event: agent_event_to_runtime_event(event),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn agent_tool_progress_maps_to_structured_runtime_event() {
+        let event = agent_event_to_runtime_event(AgentEvent::ToolProgress {
+            name: "bash".to_string(),
+            stream: ToolOutputStream::Stderr,
+            chunk: "error\n".to_string(),
+        });
+
+        assert_eq!(
+            event,
+            RuntimeEvent::Tool(ToolEvent::Progress {
+                name: "bash".to_string(),
+                stream: ToolStream::Stderr,
+                chunk: "error\n".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn agent_status_maps_to_session_status_not_warning() {
+        let event = agent_event_to_runtime_event(AgentEvent::Status("Sending prompt.".to_string()));
+
+        assert_eq!(
+            event,
+            RuntimeEvent::Session(SessionEvent::Status {
+                message: "Sending prompt.".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn prompt_source_lifetime_serializes_as_turn_based_contract() {
+        let request = RuntimeControlEnvelope {
+            request_id: "req-1".to_string(),
+            provenance: RuntimeProvenance::protocol(
+                RuntimeControllerKind::Acp,
+                "acp",
+                Some("session-1".to_string()),
+                Some("source-1".to_string()),
+            ),
+            request: RuntimeControlRequest::PromptSource(PromptSourceControlRequest::Register(
+                PromptSourceRegistration {
+                    source_id: "source-1".to_string(),
+                    scope: SourceScope::Protocol,
+                    layer: SourceLayer::User,
+                    budget_hint_tokens: Some(256),
+                    lifetime: PromptSourceLifetime::Turns(2),
+                    content: "adapter context".to_string(),
+                },
+            )),
+        };
+
+        let value = serde_json::to_value(&request).unwrap();
+
+        assert_eq!(value["request_id"], json!("req-1"));
+        assert_eq!(value["provenance"]["controller"], json!("Acp"));
+        assert_eq!(
+            value["request"]["PromptSource"]["Register"]["lifetime"],
+            json!({ "Turns": 2 })
+        );
+    }
+
+    #[test]
+    fn wrapped_agent_event_preserves_provenance_and_sequence() {
+        let control_event = wrap_agent_event(
+            "evt-1",
+            42,
+            RuntimeProvenance::local_tui("session-1"),
+            AgentEvent::AssistantDelta("hello".to_string()),
+        );
+
+        assert_eq!(control_event.event_id, "evt-1");
+        assert_eq!(control_event.sequence, 42);
+        assert_eq!(
+            control_event.provenance.controller,
+            RuntimeControllerKind::LocalTui
+        );
+        assert_eq!(
+            control_event.provenance.session_id.as_deref(),
+            Some("session-1")
+        );
+        assert_eq!(
+            control_event.event,
+            RuntimeEvent::Assistant(AssistantEvent::TextDelta("hello".to_string()))
+        );
+    }
+}

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -8,6 +8,7 @@ use crate::agent::AgentEvent;
 use crate::tool::ToolOutputStream;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum RuntimeControllerKind {
     LocalTui,
     LocalCli,
@@ -59,7 +60,8 @@ impl RuntimeProvenance {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum RuntimeControlRequest {
     Session(SessionControlRequest),
     Input(InputControlRequest),
@@ -71,7 +73,7 @@ pub enum RuntimeControlRequest {
     Approval(ApprovalControlRequest),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeControlEnvelope {
     pub request_id: String,
     pub provenance: RuntimeProvenance,
@@ -79,6 +81,7 @@ pub struct RuntimeControlEnvelope {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum SessionControlRequest {
     CreateSession,
     ResumeSession { session_id: String },
@@ -88,6 +91,7 @@ pub enum SessionControlRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum InputControlRequest {
     SubmitUserPrompt { prompt: String },
     AnswerPendingInput { answer: String },
@@ -97,6 +101,7 @@ pub enum InputControlRequest {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ShellApprovalDecision {
     Once,
     Prefix,
@@ -105,12 +110,14 @@ pub enum ShellApprovalDecision {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum OutputSubscriptionRequest {
     Subscribe { subscriber_id: String },
     Unsubscribe { subscriber_id: String },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PromptSourceLifetime {
     Turns(u32),
     Session,
@@ -128,6 +135,7 @@ pub struct PromptSourceRegistration {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SourceScope {
     Home,
     Repo,
@@ -137,6 +145,7 @@ pub enum SourceScope {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SourceLayer {
     System,
     Developer,
@@ -146,6 +155,7 @@ pub enum SourceLayer {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PromptSourceControlRequest {
     Register(PromptSourceRegistration),
     Unregister { source_id: String },
@@ -153,6 +163,7 @@ pub enum PromptSourceControlRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum SkillSourceControlRequest {
     RegisterRoot {
         source_id: String,
@@ -172,7 +183,8 @@ pub enum SkillSourceControlRequest {
     QuerySkills,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum MemoryControlRequest {
     AddRecord {
         memory_id: String,
@@ -185,12 +197,14 @@ pub enum MemoryControlRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum MemoryScope {
     Thread,
     Workspace,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum HookControlRequest {
     Declare {
         hook_id: String,
@@ -201,6 +215,7 @@ pub enum HookControlRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum HookLifecycle {
     SessionStart,
     UserPromptSubmit,
@@ -211,6 +226,7 @@ pub enum HookLifecycle {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ApprovalControlRequest {
     AnswerPendingApproval { approval_id: String, approved: bool },
     QueryPendingApprovals,
@@ -225,6 +241,7 @@ pub struct RuntimeControlEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum RuntimeEvent {
     Session(SessionEvent),
     Input(InputEvent),
@@ -242,6 +259,7 @@ pub enum RuntimeEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum SessionEvent {
     Created { session_id: String },
     Resumed { session_id: String },
@@ -253,13 +271,15 @@ pub enum SessionEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum InputEvent {
     UserPromptSubmitted,
-    FollowUpQueued { queue_len: usize },
+    FollowUpQueued { queue_len: u32 },
     PendingInputAnswered,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum AssistantEvent {
     Text(String),
     TextDelta(String),
@@ -267,6 +287,7 @@ pub enum AssistantEvent {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ToolStream {
     Stdout,
     Stderr,
@@ -282,6 +303,7 @@ impl From<ToolOutputStream> for ToolStream {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ToolEvent {
     Use {
         name: String,
@@ -300,12 +322,14 @@ pub enum ToolEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ApprovalEvent {
     Requested { approval_id: String, kind: String },
     Answered { approval_id: String, approved: bool },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PlanEvent {
     Updated,
     Approved,
@@ -313,6 +337,7 @@ pub enum PlanEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PromptSourceEvent {
     Registered { source_id: String },
     Unregistered { source_id: String },
@@ -320,6 +345,7 @@ pub enum PromptSourceEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum SkillEvent {
     Registered { source_id: String, name: String },
     Shadowed { name: String, by_source_id: String },
@@ -327,12 +353,14 @@ pub enum SkillEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum MemoryEvent {
     RecordAdded { memory_id: String },
     SelectionUpdated,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum HookEvent {
     Declared {
         hook_id: String,
@@ -345,16 +373,19 @@ pub enum HookEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ContextEvent {
     SnapshotUpdated,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum WarningEvent {
     RuntimeWarning { message: String },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ErrorEvent {
     RuntimeError { message: String },
 }
@@ -466,10 +497,47 @@ mod tests {
         let value = serde_json::to_value(&request).unwrap();
 
         assert_eq!(value["request_id"], json!("req-1"));
-        assert_eq!(value["provenance"]["controller"], json!("Acp"));
+        assert_eq!(value["provenance"]["controller"], json!("acp"));
         assert_eq!(
-            value["request"]["PromptSource"]["Register"]["lifetime"],
-            json!({ "Turns": 2 })
+            value["request"],
+            json!({
+                "type": "prompt_source",
+                "payload": {
+                    "type": "register",
+                    "payload": {
+                        "source_id": "source-1",
+                        "scope": "protocol",
+                        "layer": "user",
+                        "budget_hint_tokens": 256,
+                        "lifetime": {
+                            "type": "turns",
+                            "payload": 2
+                        },
+                        "content": "adapter context"
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn input_event_uses_fixed_width_queue_length_and_stable_wire_shape() {
+        let value = serde_json::to_value(RuntimeEvent::Input(InputEvent::FollowUpQueued {
+            queue_len: 3,
+        }))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "type": "input",
+                "payload": {
+                    "type": "follow_up_queued",
+                    "payload": {
+                        "queue_len": 3
+                    }
+                }
+            })
         );
     }
 


### PR DESCRIPTION
## Summary

- Add the first adapter-neutral runtime control request and event contract.
- Add provenance metadata for local, protocol, and runtime-controlled sources.
- Add a structured `AgentEvent` to runtime-control event bridge.
- Update the runtime control plane journal and TODO checkpoint.

## Purpose

This closes the first runtime control plane rollout item by defining the shared
types that ACP, Wire, TUI, CLI, and future appserver adapters can target before
their routing code is moved onto the control plane.

## Tests

- `cargo fmt`
- `cargo test runtime_control -- --nocapture`
- `cargo check`

## Related Issues

- None
