### PR TITLE
feat: Claude-style /status display with sectioned layout

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,6 +24,7 @@ mod render;
 mod runtime;
 mod session_restore;
 mod state;
+mod status_display;
 mod sub_agent_display;
 mod submit;
 mod terminal_event;

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -26,6 +26,7 @@ use super::super::custom_terminal::Frame;
 use super::super::interaction_text::status_active_pending_interaction_text;
 use super::super::plan_display::status_plan_text;
 use super::super::state::{CommandSpec, HelpTab, Overlay, TuiApp};
+use crate::tui::status_display::render_status_lines;
 
 pub(super) fn render_overlay(
     f: &mut Frame,

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -410,108 +410,21 @@ mod tests {
         assert!(popup.width >= 90);
     }
 }
-
 fn render_status_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
+    let lines = render_status_lines(app);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(8),
-            Constraint::Length(6),
-            Constraint::Length(8),
-            Constraint::Length(8),
-            Constraint::Min(6),
-            Constraint::Length(2),
-        ])
+        .constraints([Constraint::Fill(1), Constraint::Length(1)])
         .split(area);
-    let top = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage(34),
-            Constraint::Percentage(33),
-            Constraint::Percentage(33),
-        ])
-        .split(chunks[0]);
-    let middle = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(chunks[1]);
     f.render_widget(
-        Paragraph::new(panel_text("runtime", &status_runtime_text(app)))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-            .wrap(Wrap { trim: false }),
-        top[0],
+        Paragraph::new(lines).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
+        chunks[0],
     );
     f.render_widget(
-        Paragraph::new(panel_text("workspace", &status_workspace_text(app)))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-            .wrap(Wrap { trim: false }),
-        top[1],
-    );
-    f.render_widget(
-        Paragraph::new(panel_text("resources", &status_resources_text(app)))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-            .wrap(Wrap { trim: false }),
-        top[2],
-    );
-    f.render_widget(
-        Paragraph::new(panel_text(
-            "prompt sources",
-            &status_prompt_sources_text(app),
-        ))
-        .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-        .wrap(Wrap { trim: false }),
+        Paragraph::new(" ↑↓ scroll  Esc close  /context detailed view")
+            .style(Style::default().fg(Color::DarkGray))
+            .alignment(Alignment::Center),
         chunks[1],
-    );
-    let right_panel = download_status_text(app).unwrap_or_else(|| quick_actions_text().to_string());
-    f.render_widget(
-        Paragraph::new(panel_text("models", &model_help_text(app)))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-            .wrap(Wrap { trim: false }),
-        middle[0],
-    );
-    f.render_widget(
-        Paragraph::new(panel_text("downloads / actions", &right_panel))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-            .wrap(Wrap { trim: false }),
-        middle[1],
-    );
-    f.render_widget(
-        Paragraph::new(panel_text("updated plan", &status_plan_text(app)))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-            .wrap(Wrap { trim: false }),
-        chunks[2],
-    );
-    let lower = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(chunks[3]);
-    let interaction_text = status_active_pending_interaction_text(app)
-        .map(|(_, text)| text)
-        .unwrap_or_else(|| "No pending interaction.".to_string());
-    f.render_widget(
-        Paragraph::new(panel_text("request input", &interaction_text))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-            .wrap(Wrap { trim: false }),
-        lower[0],
-    );
-    f.render_widget(
-        Paragraph::new(panel_text("current turn", &current_turn_preview(app, 10)))
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-            .wrap(Wrap { trim: false }),
-        lower[1],
-    );
-    f.render_widget(
-        Paragraph::new(panel_text(
-            "recent activity",
-            &recent_transcript_preview(app, 8),
-        ))
-        .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-        .wrap(Wrap { trim: false }),
-        chunks[4],
-    );
-    f.render_widget(
-        Paragraph::new("esc close  enter close  /help  /model").alignment(Alignment::Center),
-        chunks[5],
     );
 }
 

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -1,25 +1,30 @@
-// Claude-style /status display — clean, minimal, sectioned layout.
+// Claude-style /status display — clean, sectioned, color-styled output.
 //
-// Replaces the dense key=value grid with semantically grouped
-// sections that use visual hierarchy and color for emphasis.
-use crate::tui::theme::*;
-use ratatui::style::Color;
+// Each line is a ratatui Line with Span-styled values so colors
+// actually render in the TUI, not just plain text.
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
 
 use crate::tui::state::TuiApp;
 
-pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<String> {
-    let mut lines = Vec::new();
+pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
 
     // ── Provider & Model ──
     section_header(&mut lines, "Provider & Model");
-    kv(&mut lines, "provider", &app.config.provider, TEXT_ACCENT);
-    kv(&mut lines, "model", app.current_model_label(), STATUS_INFO);
+    kv(&mut lines, "provider", &app.config.provider, Color::Cyan);
+    kv(
+        &mut lines,
+        "model",
+        app.current_model_label(),
+        Color::LightBlue,
+    );
     if app.config.provider == "openai-compatible" {
         kv(
             &mut lines,
             "endpoint",
             app.config.active_openai_profile_label().unwrap_or("-"),
-            TEXT_SECONDARY,
+            Color::DarkGray,
         );
     }
 
@@ -30,22 +35,22 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<String> {
         &mut lines,
         "mode",
         app.agent_execution_mode_label(),
-        STATUS_INFO,
+        Color::LightBlue,
     );
     kv(
         &mut lines,
         "phase",
         app.runtime_phase_label(),
-        TEXT_SECONDARY,
+        Color::DarkGray,
     );
     if let Some(detail) = &app.runtime_phase_detail {
-        kv(&mut lines, "detail", detail, TEXT_MUTED);
+        kv(&mut lines, "detail", detail, Color::Gray);
     }
     kv(
         &mut lines,
         "bash",
         app.bash_approval_mode_label(),
-        TEXT_SECONDARY,
+        Color::DarkGray,
     );
 
     // ── Context ──
@@ -56,14 +61,14 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<String> {
         &mut lines,
         "history",
         &format!("{} tokens", snap.estimated_history_tokens),
-        TEXT_SECONDARY,
+        Color::DarkGray,
     );
     if let Some(window) = snap.context_window_tokens {
         kv(
             &mut lines,
             "window",
             &format_metric(window as u64),
-            STATUS_INFO,
+            Color::LightBlue,
         );
     }
     if let Some(remaining) = snap.remaining_input_budget {
@@ -72,9 +77,9 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<String> {
             "budget",
             &format!("{} tokens remaining", remaining),
             if remaining < 1024 {
-                STATUS_WARNING
+                Color::Yellow
             } else {
-                TEXT_SECONDARY
+                Color::DarkGray
             },
         );
     }
@@ -91,7 +96,7 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<String> {
             &mut lines,
             "cache",
             &format!("{}% hit ({} hits / {} misses)", rate, hit, miss),
-            STATUS_SUCCESS,
+            Color::LightGreen,
         );
     }
     if snap.compaction_count > 0 {
@@ -99,38 +104,38 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<String> {
             &mut lines,
             "compactions",
             &snap.compaction_count.to_string(),
-            TEXT_SECONDARY,
+            Color::DarkGray,
         );
     }
 
     // ── Workspace ──
     section_spacer(&mut lines);
     section_header(&mut lines, "Workspace");
-    kv_short(&mut lines, "dir", &home_path(&snap.cwd), TEXT_SECONDARY);
-    kv_short(&mut lines, "branch", &snap.branch, TEXT_SECONDARY);
-    kv_short(&mut lines, "session", &snap.session_id, TEXT_MUTED);
+    kv(&mut lines, "dir", &home_path(&snap.cwd), Color::DarkGray);
+    kv(&mut lines, "branch", &snap.branch, Color::DarkGray);
+    kv(&mut lines, "session", &snap.session_id, Color::Gray);
 
     // ── API & Auth ──
     section_spacer(&mut lines);
     section_header(&mut lines, "API & Auth");
     let surface = app.config.effective_provider_surface();
-    kv_short(
+    kv(
         &mut lines,
         "base_url",
         surface.base_url.display_or("-"),
-        TEXT_SECONDARY,
+        Color::DarkGray,
     );
-    kv_short(
+    kv(
         &mut lines,
         "api_key",
         &api_key_label(app),
         if app.config.has_api_key() {
-            STATUS_SUCCESS
+            Color::LightGreen
         } else {
-            STATUS_WARNING
+            Color::Yellow
         },
     );
-    kv_short(
+    kv(
         &mut lines,
         "reasoning",
         &format!(
@@ -138,14 +143,14 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<String> {
             surface.reasoning_summary.display_or("auto"),
             surface.reasoning_summary.source.label()
         ),
-        TEXT_SECONDARY,
+        Color::DarkGray,
     );
 
     // ── Network & Sandbox ──
     section_spacer(&mut lines);
     section_header(&mut lines, "Network & Sandbox");
-    kv_short(&mut lines, "sandbox", &sandbox_label(app), STATUS_INFO);
-    kv_short(
+    kv(&mut lines, "sandbox", &sandbox_label(app), Color::LightBlue);
+    kv(
         &mut lines,
         "network",
         if app.config.sandbox_workspace_write.network_access {
@@ -154,30 +159,38 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<String> {
             "restricted"
         },
         if app.config.sandbox_workspace_write.network_access {
-            STATUS_WARNING
+            Color::Yellow
         } else {
-            STATUS_SUCCESS
+            Color::LightGreen
         },
     );
 
     lines
 }
 
-fn section_header(lines: &mut Vec<String>, title: &str) {
-    lines.push(format!("│ {title}"));
-    lines.push("│".to_string());
+// ── helpers ──
+
+fn section_header(lines: &mut Vec<Line<'static>>, title: &str) {
+    lines.push(Line::from(Span::styled(
+        title.to_string(),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(""));
 }
 
-fn section_spacer(lines: &mut Vec<String>) {
-    lines.push("│".to_string());
+fn section_spacer(lines: &mut Vec<Line<'static>>) {
+    lines.push(Line::from(""));
 }
 
-fn kv(lines: &mut Vec<String>, key: &str, value: &str, _color: Color) {
-    lines.push(format!("│  {key:<14} {value}"));
-}
-
-fn kv_short(lines: &mut Vec<String>, key: &str, value: &str, _color: Color) {
-    lines.push(format!("│  {key:<14} {value}"));
+fn kv(lines: &mut Vec<Line<'static>>, key: &str, value: &str, value_color: Color) {
+    let key_span = Span::styled(
+        format!("  {key:<14} "),
+        Style::default().fg(Color::DarkGray),
+    );
+    let value_span = Span::styled(value.to_string(), Style::default().fg(value_color));
+    lines.push(Line::from(vec![key_span, value_span]));
 }
 
 fn format_metric(n: u64) -> String {
@@ -213,7 +226,7 @@ fn api_key_label(app: &TuiApp) -> String {
     }
 }
 
-fn sandbox_label(app: &TuiApp) -> String {
+fn sandbox_label(_app: &TuiApp) -> String {
     if cfg!(target_os = "macos") {
         "macos-seatbelt"
     } else if cfg!(target_os = "linux") {

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -1,0 +1,225 @@
+// Claude-style /status display — clean, minimal, sectioned layout.
+//
+// Replaces the dense key=value grid with semantically grouped
+// sections that use visual hierarchy and color for emphasis.
+use crate::tui::theme::*;
+use ratatui::style::Color;
+
+use crate::tui::state::TuiApp;
+
+pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    // ── Provider & Model ──
+    section_header(&mut lines, "Provider & Model");
+    kv(&mut lines, "provider", &app.config.provider, TEXT_ACCENT);
+    kv(&mut lines, "model", app.current_model_label(), STATUS_INFO);
+    if app.config.provider == "openai-compatible" {
+        kv(
+            &mut lines,
+            "endpoint",
+            app.config.active_openai_profile_label().unwrap_or("-"),
+            TEXT_SECONDARY,
+        );
+    }
+
+    // ── Execution ──
+    section_spacer(&mut lines);
+    section_header(&mut lines, "Execution");
+    kv(
+        &mut lines,
+        "mode",
+        app.agent_execution_mode_label(),
+        STATUS_INFO,
+    );
+    kv(
+        &mut lines,
+        "phase",
+        app.runtime_phase_label(),
+        TEXT_SECONDARY,
+    );
+    if let Some(detail) = &app.runtime_phase_detail {
+        kv(&mut lines, "detail", detail, TEXT_MUTED);
+    }
+    kv(
+        &mut lines,
+        "bash",
+        app.bash_approval_mode_label(),
+        TEXT_SECONDARY,
+    );
+
+    // ── Context ──
+    section_spacer(&mut lines);
+    section_header(&mut lines, "Context");
+    let snap = &app.snapshot;
+    kv(
+        &mut lines,
+        "history",
+        &format!("{} tokens", snap.estimated_history_tokens),
+        TEXT_SECONDARY,
+    );
+    if let Some(window) = snap.context_window_tokens {
+        kv(
+            &mut lines,
+            "window",
+            &format_metric(window as u64),
+            STATUS_INFO,
+        );
+    }
+    if let Some(remaining) = snap.remaining_input_budget {
+        kv(
+            &mut lines,
+            "budget",
+            &format!("{} tokens remaining", remaining),
+            if remaining < 1024 {
+                STATUS_WARNING
+            } else {
+                TEXT_SECONDARY
+            },
+        );
+    }
+    if snap.total_input_tokens > 0 || snap.total_output_tokens > 0 {
+        let hit = snap.total_cache_hit_tokens;
+        let miss = snap.total_cache_miss_tokens;
+        let total = hit + miss;
+        let rate = if total > 0 {
+            (hit as f64 / total as f64 * 100.0) as u32
+        } else {
+            0
+        };
+        kv(
+            &mut lines,
+            "cache",
+            &format!("{}% hit ({} hits / {} misses)", rate, hit, miss),
+            STATUS_SUCCESS,
+        );
+    }
+    if snap.compaction_count > 0 {
+        kv(
+            &mut lines,
+            "compactions",
+            &snap.compaction_count.to_string(),
+            TEXT_SECONDARY,
+        );
+    }
+
+    // ── Workspace ──
+    section_spacer(&mut lines);
+    section_header(&mut lines, "Workspace");
+    kv_short(&mut lines, "dir", &home_path(&snap.cwd), TEXT_SECONDARY);
+    kv_short(&mut lines, "branch", &snap.branch, TEXT_SECONDARY);
+    kv_short(&mut lines, "session", &snap.session_id, TEXT_MUTED);
+
+    // ── API & Auth ──
+    section_spacer(&mut lines);
+    section_header(&mut lines, "API & Auth");
+    let surface = app.config.effective_provider_surface();
+    kv_short(
+        &mut lines,
+        "base_url",
+        surface.base_url.display_or("-"),
+        TEXT_SECONDARY,
+    );
+    kv_short(
+        &mut lines,
+        "api_key",
+        &api_key_label(app),
+        if app.config.has_api_key() {
+            STATUS_SUCCESS
+        } else {
+            STATUS_WARNING
+        },
+    );
+    kv_short(
+        &mut lines,
+        "reasoning",
+        &format!(
+            "{} ({})",
+            surface.reasoning_summary.display_or("auto"),
+            surface.reasoning_summary.source.label()
+        ),
+        TEXT_SECONDARY,
+    );
+
+    // ── Network & Sandbox ──
+    section_spacer(&mut lines);
+    section_header(&mut lines, "Network & Sandbox");
+    kv_short(&mut lines, "sandbox", &sandbox_label(app), STATUS_INFO);
+    kv_short(
+        &mut lines,
+        "network",
+        if app.config.sandbox_workspace_write.network_access {
+            "permitted"
+        } else {
+            "restricted"
+        },
+        if app.config.sandbox_workspace_write.network_access {
+            STATUS_WARNING
+        } else {
+            STATUS_SUCCESS
+        },
+    );
+
+    lines
+}
+
+fn section_header(lines: &mut Vec<String>, title: &str) {
+    lines.push(format!("│ {title}"));
+    lines.push("│".to_string());
+}
+
+fn section_spacer(lines: &mut Vec<String>) {
+    lines.push("│".to_string());
+}
+
+fn kv(lines: &mut Vec<String>, key: &str, value: &str, _color: Color) {
+    lines.push(format!("│  {key:<14} {value}"));
+}
+
+fn kv_short(lines: &mut Vec<String>, key: &str, value: &str, _color: Color) {
+    lines.push(format!("│  {key:<14} {value}"));
+}
+
+fn format_metric(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{}K", n / 1_000)
+    } else {
+        n.to_string()
+    }
+}
+
+fn home_path(cwd: &str) -> String {
+    if let Ok(home) = std::env::var("HOME") {
+        if let Some(stripped) = cwd.strip_prefix(&home) {
+            return format!("~{}", stripped);
+        }
+    }
+    cwd.to_string()
+}
+
+fn api_key_label(app: &TuiApp) -> String {
+    if app.config.has_api_key() {
+        let source = app
+            .config
+            .effective_provider_surface()
+            .api_key
+            .source
+            .label();
+        format!("●●●●● ({source})")
+    } else {
+        "not set".to_string()
+    }
+}
+
+fn sandbox_label(app: &TuiApp) -> String {
+    if cfg!(target_os = "macos") {
+        "macos-seatbelt"
+    } else if cfg!(target_os = "linux") {
+        "linux-bubblewrap"
+    } else {
+        "none"
+    }
+    .to_string()
+}


### PR DESCRIPTION
## Summary

Replace the dense 6-row grid /status layout with a clean, Claude-style single-panel sectioned view.

## Before

```
┌runtime──────────┬workspace─────────┬resources─────────┐
│provider=openai..│workspace=/rara   │history=2048      │
│model=kimi-k2.6  │branch=main       │window=256K       │
│...              │                  │                  │
└─────────────────┴──────────────────┴──────────────────┘
```

## After

```
│ Provider & Model
│
│  provider        openai-compatible
│  model           kimi-k2.6
│  endpoint        Kimi (kimi-k2.6)
│
│ Execution
│  mode            execute
│  phase           idle
│
│ Context
│  history         2048 tokens
│  window          256K
│  budget          240K tokens remaining
│  cache           85% hit (17 hits / 3 misses)
│
│ Workspace
│  dir             ~/rara
│  branch          main
│
│ API & Auth
│  base_url        api.moonshot.ai/v1
│  api_key         ●●●●● (env:MOONSHOT_API_KEY)
│  reasoning       auto (default)
│
│ Network & Sandbox
│  sandbox         macos-seatbelt
│  network         restricted
```

## Changes

| File | Change |
|------|--------|
| `src/tui/status_display.rs` | New: sectioned status lines generator |
| `src/tui/render/overlay.rs` | Replace 6-row grid with single panel |
| `src/tui/mod.rs` | Register status_display module |

## Verification

- `cargo check` — 0 errors
- `cargo test render` — passes