### PR TITLE
chore: add Memory Records and Threads feature specs

### DIFF
--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -1,0 +1,90 @@
+# Memory Records and Storage
+
+## Problem
+
+RARA needs structured, agent-authored memory. The mock `VectorDB` returns empty
+results, so retrieval is limited to tool-result extraction from conversation
+history. Without real memory records, each session starts fresh.
+
+## Scope
+
+`MemoryRecord` is the durable, independently meaningful unit of memory — one
+decision, insight, fact, procedure, or experience. `MemoryStore` replaces the
+mock `VectorDB` with a real LanceDB backend.
+
+## Six Design Laws (Cross-Industry Consensus)
+
+### Law 1: Non-Derivable Principle
+Don't persist what can be retrieved live. Stale memory > no memory.
+
+### Law 2: Human Memory Priority
+`memory.md` unconditional; AI memories compete for budget.
+
+### Law 3: Multi-Layer Isolation
+User scope (`~/.rara/memories/`), project scope (`memory.md`), session scope.
+
+### Law 4: Path as Primary Signal
+`MemoryStore::search` accepts `scope_path`; local results rank above global.
+
+### Law 5: Human Memories Immune to Forgetting
+`UserCreated` records exempt from automatic cleanup.
+
+### Law 6: Negative Space First
+`create_memory` prompt includes what-NOT-to-save section.
+
+## RARA Positioning (Five Axes)
+
+| Axis | Position |
+|------|----------|
+| Extraction | Automation-first (novice users), human override available |
+| Storage | LanceDB structured, `memory.md` stays flat-file |
+| Injection | Zero-call for human sources, budgeted vector retrieval for AI |
+| Forgetting | Discrete with importance gating; `UserCreated` exempt |
+| Architecture | Core built-in now, plugin surface deferred |
+
+## Data Model
+
+```rust
+pub struct MemoryRecord {
+    pub id: Uuid,
+    pub title: String,
+    pub content: String,       // Markdown
+    pub labels: Vec<MemoryLabel>,
+    pub importance: f32,       // 0.1–1.0
+    pub source: MemorySource,
+    pub created_at: DateTime,
+    pub embedding: Option<Vec<f32>>,
+}
+
+pub enum MemoryLabel { Insight, Decision, Fact, Procedure, Experience }
+pub enum MemorySource { AgentTurn, UserCreated, ThreadDistill, FileImport }
+```
+
+## MemoryStore API
+
+- `insert(record) -> Uuid` — persist with auto-embedding
+- `search(query, labels?, min_importance, limit) -> Vec<(MemoryRecord, f32)>`
+- `get(id) -> Option<MemoryRecord>`
+- `delete(id) -> ()`
+
+Storage: `~/.rara/memories/` (LanceDB).
+
+## Integration
+
+| Component | Integration |
+|-----------|-------------|
+| `create_memory` tool | Agent persists records with auto-labels |
+| `retrieve_experience` | Searches MemoryStore instead of conversation history |
+| `MemorySelection` | `vector_memory_candidate` becomes `selectable: true` |
+| `MemoryDistiller` | Thread → MemoryRecords with auto-labels + importance |
+
+## Migration
+
+1. Add `MemoryStore` alongside mock `VectorDB`.
+2. Wire `memory_selection` and tools to `MemoryStore`.
+3. Deprecate `VectorDB`.
+4. Remove `VectorDB`.
+
+## Source Journals
+
+- 2026-05-03-memory-records-and-threads-spec.md

--- a/docs/features/threads.md
+++ b/docs/features/threads.md
@@ -1,0 +1,112 @@
+# Threads
+
+## Problem
+
+Sessions saved as flat JSON by `SessionManager` — no browse, search, pin,
+export, or distillation surface. Cannot recall past conversations or distill
+durable memories.
+
+## Scope
+
+`Thread` is a durable conversation record. Threads are the raw material from
+which `MemoryRecord`s are distilled.
+
+## Data Model
+
+```rust
+pub struct Thread {
+    pub id: Uuid,
+    pub title: String,
+    pub source: ThreadSource,
+    pub created_at: DateTime,
+    pub updated_at: DateTime,
+    pub messages: Vec<ThreadMessage>,
+    pub distilled_memory_ids: Vec<Uuid>,
+    pub pinned: bool,
+}
+
+pub enum ThreadSource {
+    RaraSession { session_id: String },
+    CodexImport { source_session_id: String },
+    FileImport { path: String, format: ImportFormat },
+    ManualCapture,
+}
+```
+
+## Lifecycle
+
+```
+Session Active
+  ├─ stop hook → save_thread(auto)
+  ├─ /save → save_thread(manual)
+  ├─ /save-handoff → summary only
+  ▼
+Thread stored (LanceDB)
+  ├─ /distill → MemoryRecords
+  ├─ /export → Conversation Markdown
+  ├─ /threads → browse, search, pin
+```
+
+## Save Triggers
+
+| Trigger | Behavior |
+|---------|----------|
+| Stop hook | Auto-save after each response |
+| Session end | Final turn batch on clean exit |
+| `/save` | Explicit full-session save |
+| `/save-handoff` | Concise continuation summary (not full thread) |
+
+## ThreadStore API (LanceDB)
+
+- `save(thread) -> Uuid`
+- `get(id) -> Option<Thread>`
+- `list(pinned_only?, source_filter?, limit, offset) -> Vec<ThreadSummary>`
+- `search(query, limit) -> Vec<ThreadSummary>`
+- `search_messages(thread_id, query) -> Vec<ThreadMessage>`
+- `pin(id, pinned) -> ()`
+- `delete(id) -> ()`
+
+Storage: `~/.rara/threads/`.
+
+## Conversation Markdown Format
+
+```markdown
+---
+title: Python Async Patterns
+source: rara
+date: 2026-05-03
+---
+
+## User
+How does async/await work?
+
+## Assistant
+Python's async/await lets you write concurrent code...
+
+## Tool
+read_file path="src/main.rs"
+```
+
+Headers: `## User`, `## Assistant`, `## System`, `## Tool`, `## Tool Result`.
+Optional YAML frontmatter with `title`, `source`, `date`.
+
+## Import Paths
+
+| Source | Format |
+|--------|--------|
+| Conversation Markdown | `.md` with `## User`/`## Assistant` |
+| ChatGPT | `chat.html` |
+| Claude | `conversations.json` |
+| DeepSeek | `deepseek_conversations.json` |
+
+## Thread Distillation
+
+`MemoryDistiller`: Thread → 2-8 MemoryRecords.
+- Read full thread messages.
+- Identify independently meaningful units.
+- Auto-generate title, labels, importance.
+- For >50 messages: chunked Smart Background Distillation.
+
+## Source Journals
+
+- 2026-05-03-memory-records-and-threads-spec.md

--- a/docs/journal/2026-05-03-memory-records-and-threads-spec.md
+++ b/docs/journal/2026-05-03-memory-records-and-threads-spec.md
@@ -1,0 +1,48 @@
+# Memory Records and Threads Spec Checkpoint
+
+## Date
+2026-05-03
+
+## Context
+
+Reviewed Nowledge Mem's memory and thread architecture. Two gaps: no structured
+memory records, no thread abstraction above SessionManager.
+
+## Decisions
+
+### Memory Records
+
+- `MemoryRecord`: durable unit with title, content, labels (Insight/Decision/
+  Fact/Procedure/Experience), importance (0.1–1.0), source provenance.
+- `MemoryStore`: LanceDB backend replacing mock VectorDB.
+- Search ranking = importance × cosine_similarity.
+- Six cross-industry design laws adopted as correctness baseline.
+
+### Threads
+
+- `Thread`: durable conversation record with messages, source, pin.
+- Save triggers: stop hook, session end, /save, /save-handoff.
+- Conversation Markdown format for import/export.
+- `MemoryDistiller`: Thread → 2-8 MemoryRecords.
+
+### RARA Positioning
+
+- **Extraction**: Automation-first (novice users), human override available.
+- **Storage**: LanceDB structured, `memory.md` flat-file.
+- **Injection**: Zero-call human, budgeted vector AI.
+- **Forgetting**: Discrete with importance gating; UserCreated exempt.
+- **Architecture**: Core built-in now, plugin deferred.
+
+## Implementation Order
+
+```
+C.1a: MemoryRecord + MemoryStore (LanceDB, replace mock VectorDB)
+C.1b: ThreadStore upgrade (save/list/get/export)
+C.2:  Embedding backend + Thread → Memory distillation
+C.3:  Crash-safe SessionManager + cross-session search + import
+```
+
+## Follow-Up
+
+- Update `docs/todo.md` Phase C.
+- Implement `src/memory_record.rs` and `src/memory_store.rs`.


### PR DESCRIPTION
## Summary

Add two new feature specs based on Nowledge Mem architecture review and
cross-industry analysis of 7+ coding agent memory systems.

## New Files

| File | Content |
|------|---------|
| `docs/features/memory-records.md` | MemoryRecord data model, MemoryStore API, label semantics, importance scale, six design laws, five divergence axes with RARA positioning |
| `docs/features/threads.md` | Thread model, ThreadStore API, save triggers, Conversation Markdown format, Thread→Memory distillation |
| `docs/journal/2026-05-03-memory-records-and-threads-spec.md` | Implementation checkpoint |

## Key Design Decisions

**Six Laws** (verified against Claude Code, Codex, Gemini CLI, OpenCode):
1. Non-Derivable — do not store what can be retrieved live
2. Human Priority — `memory.md` unconditional, AI memories compete
3. Multi-Layer — user/project/session scope tiers
4. Path Signal — local results rank above global
5. Human Immunity — `UserCreated` exempt from auto-forgetting
6. Negative First — define what NOT to save before what to save

**RARA Positioning:**
- Extraction: automation-first (novice users), human override
- Storage: LanceDB + flat `memory.md`
- Injection: zero-call human, budgeted vector AI
- Forgetting: discrete + importance gating
- Architecture: core built-in now, plugin deferred

## Implementation Order

```
C.1: MemoryRecord + MemoryStore (LanceDB, replace mock VectorDB)
C.2: ThreadStore + Thread→Memory distillation
C.3: Crash-safe SessionManager + cross-session search
```
