### PR TITLE
fix: tighten edit and context status guidance

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -341,6 +341,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                 "Communicating With The User",
                 &[
                     "All text outside tool calls is shown directly to the user, so keep it short and useful.",
+                    "Do not expose private reasoning or meta-commentary such as 'The user asked...', 'Looking at the conversation...', or 'I should answer...'. Give the answer or call the tool.",
                     "Before the first tool call, briefly state what you are about to inspect or change.",
                     "While working, only send short progress updates at meaningful milestones.",
                     "Write user-facing text in complete sentences and avoid unexplained internal shorthand.",
@@ -412,6 +413,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "For shell commands, pass the working directory through the tool's cwd field when needed and avoid using 'cd' unless it is necessary for the command itself.",
                     "Do not append '2>&1', '| tail', '| head', or similar output filtering by default. Let the UI or tool layer capture stdout and stderr and render long output; add filtering only after the raw output is known to be too large or the user specifically asks for a summary.",
                     "Treat stdout and stderr as separate command result streams when the tool provides them separately. Do not merge them unless a specific diagnostic requires combined ordering.",
+                    "Use PTY tools only for genuinely interactive programs that need terminal input or terminal control. Do not use PTY for ordinary git, cargo, test, file, status, or PR commands; use bash or the dedicated tool instead.",
                     "If sandboxed bash is unavailable or blocked, continue with direct file tools such as read_file, apply_patch, and replace_lines before asking the user for help.",
                     "Use 'update_project_memory' to record durable project facts into memory.md.",
                     "Treat 'remember_experience' and 'retrieve_experience' as optional experience-memory tools. Do not assume durable vector recall exists unless the tool result proves that it saved or returned relevant content.",
@@ -1034,6 +1036,7 @@ mod tests {
         assert!(prompt.contains("Do not use shell 'cat', 'head', or 'tail'"));
         assert!(prompt.contains("Do not append '2>&1', '| tail', '| head'"));
         assert!(prompt.contains("Treat stdout and stderr as separate command result streams"));
+        assert!(prompt.contains("Use PTY tools only for genuinely interactive programs"));
         assert!(prompt.contains("background task or PTY tools"));
         assert!(prompt.contains("list/status/stop tools"));
         assert!(prompt.contains("available GitHub tools or the 'gh' CLI"));

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -402,8 +402,10 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "For 'replace', copy 'old_string' exactly from the current file, including whitespace and indentation.",
                     "A 'partially read' or stale edit-tool error means you must re-read the relevant current content and retry a direct edit tool; it is not permission to bypass edit tools with sed, perl, shell redirection, or scripts.",
                     "Use 'replace_lines' only for large deletions or replacements when you have verified exact line numbers from the current file contents; do not pass hundreds of lines through 'replace.old_string'.",
-                    "Use 'write_file' only for new files or intentional full-file rewrites after reading the current file when it already exists.",
-                    "Do not use shell redirection, sed, perl, or ad-hoc scripts to edit files when direct edit tools or 'apply_patch' can do the job.",
+                    "Use 'write_file' only for new files or intentional full-file rewrites after reading the current file when it already exists. This follows the Claude-style Write/Edit split: whole-file writes are for creates or complete rewrites, while edits to existing files should prefer diff-shaped edit tools.",
+                    "If a large 'write_file' payload fails, is truncated, or appears not to persist, do not switch to a PTY, 'cat > file', shell redirection, or a shell heredoc as an unreviewable file-writing fallback. Diagnose the tool result, split the change into smaller direct edits, use 'apply_patch' for reviewable chunks, or stop and report the tool failure.",
+                    "Codex-style heredoc handling is acceptable only as a transport for the dedicated 'apply_patch' patch format, not as a general way to overwrite arbitrary files.",
+                    "Do not use shell redirection, heredocs, sed, perl, or ad-hoc scripts to edit files when direct edit tools or 'apply_patch' can do the job.",
                     "If a 'read_file' result is truncated, continue with offset=next_offset and a narrower limit instead of asking the user to paste the file.",
                     "Do not use shell 'cat', 'head', or 'tail' to read source files when a dedicated file-read tool is available. Use shell file readers only for quick non-edit inspection when the direct tool is unavailable or unsuitable.",
                     "When a CLI command or its flags are unfamiliar or uncertain, first inspect local usage with a safe read-only command such as '<cmd> --help', '<cmd> help', '<cmd> -h', or '<cmd> --version' before relying on guessed flags.",
@@ -1008,6 +1010,9 @@ mod tests {
         assert!(prompt.contains("copy 'old_string' exactly from the current file"));
         assert!(prompt.contains("not permission to bypass edit tools"));
         assert!(prompt.contains("Use 'write_file' only for new files"));
+        assert!(prompt.contains("Claude-style Write/Edit split"));
+        assert!(prompt.contains("large 'write_file' payload fails"));
+        assert!(prompt.contains("Codex-style heredoc handling is acceptable only"));
         assert!(prompt.contains("Do not use shell redirection"));
         assert!(prompt.contains("first inspect local usage"));
         assert!(prompt.contains("<cmd> --help"));

--- a/docs/features/context-architecture.md
+++ b/docs/features/context-architecture.md
@@ -247,6 +247,104 @@ model-facing prefixes. In particular, transient runtime artifacts such as
 orphan tool results should not be serialized back into ordinary user text with
 synthetic labels.
 
+## Hook-Driven Context Sources
+
+Hooks can help context management, but they must not become hidden prompt
+append points.
+
+### Core Principle
+
+Hook output is a context candidate, not final prompt text.
+
+Every prompt-affecting hook result should enter the normal context pipeline as
+a structured source object with:
+
+- source id;
+- lifecycle point;
+- provenance;
+- trust and authorship;
+- time-to-live;
+- budget hint;
+- cache or invalidation status when applicable;
+- human-readable inclusion or drop reason for `/context`.
+
+The context assembler and selection layers remain the only owners of final
+model-request injection. This keeps hook output budgeted, inspectable, and
+stable across TUI, ACP, Wire, and future headless adapters.
+
+### Injection Timing
+
+Prompt injection must happen before model request assembly completes. Later
+lifecycle events may produce candidates for future turns, but they must not
+mutate the already assembled request.
+
+The stable turn pipeline is:
+
+1. collect raw inputs and runtime state;
+2. run eligible pre-assembly hook discovery;
+3. convert hook, memory, skill, prompt, and protocol inputs into context
+   candidates;
+4. run context and memory selection with ordering, deduplication, budget, and
+   drop reasons;
+5. assemble the final model request;
+6. record tool and runtime events;
+7. feed resulting context candidates into the next turn or compaction cycle.
+
+This ordering avoids mid-stream prompt mutation, unstable source ordering, and
+context that cannot be explained by `/context`.
+
+### Lifecycle Responsibilities
+
+`SessionStart` may discover session-level context such as environment facts,
+workspace roots, adapter capabilities, and static extension declarations. If
+the first model request must see that output, RARA should finish the relevant
+session-start context work before assembling the first request. Late
+session-start output must be marked as next-turn context instead of silently
+patching an in-flight prompt.
+
+`UserPromptSubmit` may attach structured metadata related to the submitted
+input. It must not rewrite the user's original text. Any added context enters
+selection as a candidate source.
+
+Workspace-change hooks, when added, should invalidate prompt-source, memory,
+skill, or environment caches. They should prefer dirty markers over direct
+prompt injection.
+
+`PreToolUse` is primarily for policy, permission, and environment checks. If it
+discovers missing context, it should emit a warning, request, or candidate for a
+future assembly step rather than changing the semantics of an already generated
+tool call.
+
+`PostToolUse` may emit context deltas such as touched files, generated
+artifacts, test summaries, or important stderr summaries. These deltas belong
+in thread/runtime state first. Whether they reach the model is decided by the
+next assembly pass.
+
+`PreCompact` may provide retain hints, such as files, decisions, constraints,
+or failures that should survive compaction. Compaction remains owned by RARA;
+hook output is advisory and must be visible in compaction/context
+observability.
+
+`Stop` may perform validation or final context reconciliation, but it must be
+bounded and loop-safe. RARA should not run stop hooks on prompt-too-long or API
+error paths that could create an error, hook block, retry, compact, error
+cycle.
+
+### Observability
+
+`/context` should show hook-created context separately from ordinary prompt
+sources and memory candidates, including:
+
+- declared hook source and lifecycle;
+- whether the hook is supported, ignored, executed, or deferred;
+- selected hook context items;
+- available but not injected hook items;
+- dropped hook items and drop reasons;
+- cache invalidations or retain hints emitted by hooks.
+
+`/status` should summarize active hook support and last hook failures without
+requiring users to inspect raw logs.
+
 ### Memory Scopes
 
 RARA should distinguish at least two memory scopes.

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -67,6 +67,16 @@ state and conflicted file, preserve complementary changes instead of blindly cho
 structured edits where practical, scan for remaining conflict markers, and run the narrowest relevant
 validation before claiming the conflict is resolved.
 
+Large-write guidance follows the same edit-tool boundary:
+
+- use diff-shaped edit tools or `apply_patch` for modifications to existing files;
+- reserve `write_file` for new files or intentional complete rewrites after reading an existing file;
+- treat failed, truncated, or apparently non-persistent large writes as tool-result failures to
+  diagnose, not as a reason to fall back to shell heredocs, redirection, or PTY writes;
+- preserve the Codex distinction that heredoc can be a transport for `apply_patch`, while Claude's
+  Bash/PowerShell guidance routes ordinary file writes through Write rather than `cat <<EOF`,
+  `echo >`, `Set-Content`, or `Out-File`.
+
 ### 4) Compact Prompt
 
 - Context compaction must not use the normal system prompt.

--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -247,6 +247,25 @@ The first implementation should record and display hook declarations without
 executing them. Later executable hooks must still go through RARA-owned
 permission, sandbox, and failure handling.
 
+Hooks that affect prompt context must follow the context-architecture injection
+contract. A hook may declare or produce context candidates, cache invalidations,
+post-tool deltas, or compaction retain hints, but it must not concatenate raw
+text into the final prompt. Final injection happens only during model request
+assembly after normal context selection, ordering, deduplication, budget checks,
+and `/context` visibility have been applied.
+
+Lifecycle timing is part of the safety boundary:
+
+- `SessionStart` context that must affect the first request has to finish before
+  that first request is assembled;
+- `UserPromptSubmit` may attach metadata or candidates, but must not rewrite the
+  original user text;
+- `PostToolUse` output is next-turn context unless the runtime explicitly
+  starts a new assembly step;
+- `PreCompact` output is advisory retain metadata for the compaction lifecycle;
+- `Stop` hooks must be bounded and should not run on prompt-too-long or API
+  error paths where hook retry could create a loop.
+
 ### Approval and Permission Bridge
 
 External applications may display or relay approval decisions, but RARA remains

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -24,6 +24,27 @@ The transcript should move toward Codex/Claude-style tool visibility:
   - created / updated / deleted / moved files;
   - a short change preview.
 - `write_file` and `replace` must render file-aware summaries instead of generic action labels.
+- `write_file` follows the Claude-style Write/Edit split: use it for new files
+  or intentional full-file rewrites, and prefer diff-shaped edit tools for
+  modifications to existing files. Claude's own tool guidance says Write
+  overwrites existing files, existing files should be read first in read-gated
+  environments, and Edit is preferred for modifying existing files because it
+  sends only the diff.
+- Shell file-writing fallbacks should be treated as a different and riskier
+  path. Claude's Bash/PowerShell guidance routes file writes through Write
+  rather than `echo >`, `cat <<EOF`, `Set-Content`, or `Out-File`, and routes
+  file edits through Edit rather than `sed` or `awk`. RARA should therefore not
+  let a failed or oversized `write_file` call silently degrade into PTY,
+  heredoc, redirection, `sed`, `perl`, or script-based file edits when direct
+  edit tools or `apply_patch` can express the change.
+- Codex uses `apply_patch` as the primary reviewable edit surface. Its heredoc
+  support is an `apply_patch` transport shape, not a general recommendation to
+  overwrite arbitrary files through shell heredocs.
+- For large generated or rewritten files, the model-facing rule is to keep the
+  write scoped to the target file, inspect the actual tool result, and verify
+  with a direct read, diff, or focused check when persistence is uncertain.
+  Large-write failure is a tool/result problem to diagnose, not permission to
+  batch multiple shell writes into one opaque command.
 - `replace` is an exact-match edit tool. When file read-state tracking is
   enabled, it still requires the file to have been read at least once, but it may
   proceed after a partial read because the edit re-reads the current file and
@@ -157,8 +178,10 @@ The TUI should keep input state, display data, and visual cells separate:
   thing: pending interaction, queued follow-up, running command, completed
   command, thinking group, or message text.
 - The bottom pane owns composer text, cursor placement, and one-line hints. It
-  should not render durable transcript status, approval options, or queued
-  follow-up bodies.
+  should not render durable transcript status, approval options, queued
+  follow-up bodies, or long-lived query progress text such as `Working` /
+  `Sending prompt to model`. Runtime progress belongs in transcript/status
+  events where it can scroll with the turn and remain ordered with tool output.
 - Active-turn composition owns ordering. Pending interactions must be placed
   before queued follow-up status so approval options remain visible. Queued
   status should be appended near the newest active cell instead of being

--- a/docs/journal/2026-05-02-runtime-control-plane.md
+++ b/docs/journal/2026-05-02-runtime-control-plane.md
@@ -72,3 +72,50 @@ round-trip conversions to the runtime `BashApprovalDecision`.
 This checkpoint intentionally does not route ACP or Wire through the control
 plane yet. The next slice should add subscriber plumbing and then move ACP
 prompt/cancel/session handling onto these request types.
+
+## Hook Context Timing Checkpoint
+
+Clarified the context-management role of hooks in
+`docs/features/context-architecture.md` and cross-linked the same boundary from
+`docs/features/runtime-control-plane.md`.
+
+The contract is:
+
+- hook output is a structured context candidate, not final prompt text;
+- final injection happens only before model request assembly completes;
+- late lifecycle output becomes next-turn context or compaction metadata;
+- `SessionStart`, `UserPromptSubmit`, `PostToolUse`, `PreCompact`, and `Stop`
+  each have explicit timing responsibilities;
+- `/context` must explain selected, available, dropped, deferred, or ignored
+  hook-created context.
+
+This keeps hook behavior compatible with ACP/Wire control, stable prompt-source
+ordering, and future context-cache invalidation.
+
+## Large Write And Composer Status Checkpoint
+
+Clarified large-file write guidance in `docs/features/tool-transcript.md`,
+`docs/features/prompt-runtime.md`, the default prompt, and the `write_file` tool
+description.
+
+The source comparison was:
+
+- Claude Write says the tool overwrites local files and should be reserved for
+  creates or complete rewrites, while Edit is preferred for existing-file
+  modifications because it sends only the diff;
+- Claude Bash/PowerShell alternatives route file writes through Write rather
+  than `echo >`, `cat <<EOF`, `Set-Content`, or `Out-File`, and route edits
+  through Edit rather than `sed` or `awk`;
+- Codex uses `apply_patch` as the reviewable edit surface and supports heredoc
+  parsing for `apply_patch`, but that is a patch transport rather than a general
+  shell-file-write pattern.
+
+RARA therefore treats a failed, truncated, or apparently non-persistent
+`write_file` result as an edit-tool failure to diagnose with direct tools,
+smaller patches, or an explicit user-visible failure report. It must not
+silently degrade into PTY, shell redirection, or heredoc file writes.
+
+Also documented and fixed the TUI boundary that long-lived query progress such
+as `Working` / `Sending prompt to model` should not remain pinned in the bottom
+composer area. Runtime progress belongs in transcript/status events so the
+composer stays an input surface.

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -467,14 +467,14 @@ impl Tool for WriteFileTool {
         "write_file"
     }
     fn description(&self) -> &str {
-        "Create a new file or intentionally rewrite a whole file. For existing files, read the full file first and prefer apply_patch for partial edits."
+        "Create a new file or intentionally rewrite one whole file. For existing files, read the full file first and prefer apply_patch for partial edits. If a large write fails or appears truncated, retry with direct edit tools or report the tool failure; do not fall back to shell heredocs or redirection to write files."
     }
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",
             "properties": {
                 "path": { "type": "string", "description": "Path to create or fully rewrite." },
-                "content": { "type": "string", "description": "Complete new file contents. Do not use for small edits to existing files." }
+                "content": { "type": "string", "description": "Complete new file contents for exactly this path. Do not use for small edits to existing files or shell-heredoc fallbacks." }
             },
             "required": ["path", "content"]
         })

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -474,7 +474,7 @@ impl Tool for WriteFileTool {
             "type": "object",
             "properties": {
                 "path": { "type": "string", "description": "Path to create or fully rewrite." },
-                "content": { "type": "string", "description": "Complete new file contents for exactly this path. Do not use for small edits to existing files or shell-heredoc fallbacks." }
+                "content": { "type": "string", "description": "Complete new file contents for exactly this path. Do not use for small edits to existing files or shell heredoc fallbacks." }
             },
             "required": ["path", "content"]
         })

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -460,6 +460,12 @@ fn file_tool_descriptions_encode_safe_edit_contract() {
     );
     assert!(write_tool.description().contains("large write fails"));
     assert!(write_tool.description().contains("shell heredocs"));
+    assert!(
+        write_tool
+            .input_schema()
+            .to_string()
+            .contains("shell heredoc fallbacks")
+    );
     assert!(replace_tool.description().contains("exact, unique string"));
     assert!(
         replace_tool

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -458,6 +458,8 @@ fn file_tool_descriptions_encode_safe_edit_contract() {
             .description()
             .contains("read the full file first")
     );
+    assert!(write_tool.description().contains("large write fails"));
+    assert!(write_tool.description().contains("shell heredocs"));
     assert!(replace_tool.description().contains("exact, unique string"));
     assert!(
         replace_tool

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -73,6 +73,7 @@ fn render_startup_header(f: &mut Frame, app: &TuiApp, area: Rect) -> Rect {
 fn shows_startup_header(app: &TuiApp) -> bool {
     !app.has_any_transcript()
         && app.active_turn.entries.is_empty()
+        && !app.is_busy()
         && !app.has_pending_planning_suggestion()
 }
 

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -178,6 +178,9 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
 }
 
 fn animated_activity_label(app: &TuiApp, label: &str) -> String {
+    if label.is_empty() {
+        return String::new();
+    }
     let Some(task) = app.running_task.as_ref() else {
         return label.to_string();
     };

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -171,6 +171,7 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
         STATUS_READY,
         app.notice
             .as_deref()
+            .filter(|notice| !matches!(*notice, "Prompt finished." | "Planning finished."))
             .unwrap_or("waiting for input")
             .to_string(),
     )

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -147,18 +147,7 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
     }
 
     if app.is_busy() {
-        let mut detail = app
-            .runtime_phase_detail
-            .as_deref()
-            .unwrap_or("waiting for model response")
-            .to_string();
-        if app.has_queued_follow_up_messages() {
-            detail.push_str(&format!(
-                " · {} queued follow-up",
-                app.queued_follow_up_count()
-            ));
-        }
-        return ("Working", STATUS_WARNING, detail);
+        return ("", STATUS_WARNING, String::new());
     }
 
     if app.agent_execution_mode_label() == "plan" {

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -329,7 +329,7 @@ fn wrapped_text_cursor_can_point_into_the_middle_of_input() {
 }
 
 #[tokio::test]
-async fn activity_status_line_shows_multiple_queued_follow_ups_while_busy() {
+async fn activity_status_line_hides_busy_progress_from_composer_bar() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -351,8 +351,8 @@ async fn activity_status_line_shows_multiple_queued_follow_ups_while_busy() {
     app.queue_follow_up_message("third follow-up");
 
     let (label, _, detail) = activity_status_line(&app);
-    assert_eq!(label, "Working");
-    assert!(detail.contains("3 queued follow-up"));
+    assert_eq!(label, "");
+    assert_eq!(detail, "");
 
     if let Some(task) = app.running_task.take() {
         task.handle.abort();

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -375,3 +375,18 @@ fn composer_hint_shows_queued_follow_up_when_idle_with_messages() {
         "queued follow-up  will submit after current turn"
     );
 }
+
+#[test]
+fn activity_status_line_hides_completed_prompt_notice() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.notice = Some("Prompt finished.".into());
+
+    let (label, _, detail) = activity_status_line(&app);
+
+    assert_eq!(label, "Ready");
+    assert_eq!(detail, "waiting for input");
+}

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -11,8 +11,8 @@ use crate::tui::state::{
 };
 
 use super::{
-    activity_status_line, composer_hint, composer_hint_line, footer_summary_text,
-    wrapped_text_cursor_position, wrapped_text_rows,
+    activity_status_line, animated_activity_label, composer_hint, composer_hint_line,
+    footer_summary_text, wrapped_text_cursor_position, wrapped_text_rows,
 };
 
 #[test]
@@ -353,6 +353,7 @@ async fn activity_status_line_hides_busy_progress_from_composer_bar() {
     let (label, _, detail) = activity_status_line(&app);
     assert_eq!(label, "");
     assert_eq!(detail, "");
+    assert_eq!(animated_activity_label(&app, label), "");
 
     if let Some(task) = app.running_task.take() {
         task.handle.abort();

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -215,6 +215,26 @@ fn active_turn_cell_renders_planning_suggestion_without_active_turn_entries() {
 }
 
 #[test]
+fn active_turn_cell_shows_busy_feedback_without_active_turn_entries() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::SendingPrompt;
+    app.runtime_phase_detail = Some("sending prompt to provider".into());
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("• sending prompt to provider"));
+}
+
+#[test]
 fn active_turn_cell_keeps_exploration_notes_inside_exploring_block() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -361,6 +361,15 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 trim_trailing_empty_lines(&mut lines);
                 return lines;
             }
+            if turn_live {
+                return RespondingCell::working(
+                    self.app
+                        .runtime_phase_detail
+                        .as_deref()
+                        .unwrap_or("waiting for the current turn to finish"),
+                )
+                .display_lines(width);
+            }
             return Vec::new();
         }
         let has_tool_activity = current_turn.iter().any(|entry| {

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -244,6 +244,8 @@ pub(super) fn scrub_internal_control_tokens(message: &str) -> String {
     } else {
         Cow::Borrowed(message)
     };
+    let message = strip_raw_tool_call_markup(message.as_ref());
+    let message = strip_leading_meta_reasoning(message.as_ref());
     if !message.contains('<') {
         return message.into_owned();
     }
@@ -280,6 +282,55 @@ pub(super) fn scrub_internal_control_tokens(message: &str) -> String {
     }
 
     cleaned
+}
+
+fn strip_raw_tool_call_markup(message: &str) -> Cow<'_, str> {
+    if !message.contains("tool_call:") {
+        return Cow::Borrowed(message);
+    }
+
+    let mut output = Vec::new();
+    for line in message.lines() {
+        let Some(idx) = line.find("tool_call:") else {
+            output.push(line.trim_end().to_string());
+            continue;
+        };
+        let prefix = line[..idx].trim_end_matches([' ', '|']).trim_end();
+        if !prefix.trim().is_empty() {
+            output.push(prefix.to_string());
+        }
+    }
+
+    Cow::Owned(output.join("\n"))
+}
+
+fn strip_leading_meta_reasoning(message: &str) -> Cow<'_, str> {
+    let lines = message.lines().collect::<Vec<_>>();
+    let mut first_keep = 0usize;
+    while let Some(line) = lines.get(first_keep) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || looks_like_leaked_meta_reasoning(trimmed) {
+            first_keep += 1;
+            continue;
+        }
+        break;
+    }
+
+    if first_keep == 0 {
+        return Cow::Borrowed(message);
+    }
+    Cow::Owned(lines[first_keep..].join("\n"))
+}
+
+fn looks_like_leaked_meta_reasoning(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.starts_with("the user asked ")
+        || lower.starts_with("the user is asking ")
+        || lower.starts_with("looking at the conversation")
+        || lower.starts_with("i can see that ")
+        || lower.starts_with("i should ")
+        || lower.starts_with("i need to answer ")
+        || lower.starts_with("i'll answer ")
 }
 
 fn strip_dsml_control_blocks(message: &str) -> Cow<'_, str> {

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -173,6 +173,29 @@ fn scrub_internal_control_tokens_removes_dsml_tool_blocks() {
 }
 
 #[test]
+fn scrub_internal_control_tokens_removes_raw_tool_call_markup() {
+    let cleaned = scrub_internal_control_tokens(
+        "Now update docs. | tool_call: read_file arguments: {\"path\":\"docs/todo.md\"} | tool_call: read_file arguments: {\"path\":\"docs/features/README.md\"}",
+    );
+
+    assert_eq!(cleaned.trim(), "Now update docs.");
+    assert!(!cleaned.contains("tool_call:"));
+    assert!(!cleaned.contains("arguments:"));
+}
+
+#[test]
+fn scrub_internal_control_tokens_drops_leaked_meta_reasoning_prefix() {
+    let cleaned = scrub_internal_control_tokens(
+        "The user asked \"was it opened?\"\nLooking at the conversation, PR #147 was created.\nI should confirm this briefly.\n\nPR #147 was created: https://github.com/hawkingrei/rara/pull/147",
+    );
+
+    assert_eq!(
+        cleaned.trim(),
+        "PR #147 was created: https://github.com/hawkingrei/rara/pull/147"
+    );
+}
+
+#[test]
 fn scrub_internal_control_tokens_drops_orphaned_dsml_payload() {
     let cleaned = scrub_internal_control_tokens(
         "kind: format!(\"unknown_retrieval_{tool_name}\"),\nlabel: format!(\"Unknown Retrieval ({tool_name})\"),\n}\n<｜DSML｜parameter name=\"path\" string=\"true\">src/context/selection.rs</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",


### PR DESCRIPTION
## Summary

- Document hook-created context as structured candidates with fixed injection timing before model request assembly.
- Align large-write guidance with verified Codex and Claude Code behavior: prefer diff-shaped edits for existing files, keep `write_file` for creates/full rewrites, and do not fall back to shell heredocs or redirection for arbitrary file writes.
- Remove long-lived busy progress text from the bottom composer bar so query progress is not pinned above input.

## Validation

- `cargo fmt`
- `git diff --check`
- `cargo test -p rara-instructions default_system_prompt_mentions_tool_safety_and_compaction -- --nocapture`
- `cargo test tools::file::tests::file_tool_descriptions_encode_safe_edit_contract -- --nocapture`
- `cargo test activity_status_line_hides_busy_progress_from_composer_bar -- --nocapture`
- `cargo check`

## Notes

- `cargo check` and focused tests still emit existing warning noise unrelated to this change.
