### PR TITLE
fix: reserve bottom row in transcript viewport to avoid input bar overlap

### DIFF
--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -123,7 +123,8 @@ pub(crate) fn transcript_viewport(
 ) -> TranscriptViewport {
     let lines = renderable_transcript_lines(app, width);
     let visual_row_count = transcript_visual_row_count(&lines, width);
-    let scroll_offset = transcript_scroll_offset(app, viewport_height, visual_row_count);
+    let effective_height = viewport_height.saturating_sub(1).max(1);
+    let scroll_offset = transcript_scroll_offset(app, effective_height, visual_row_count);
     TranscriptViewport::new(lines, scroll_offset)
 }
 

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -591,7 +591,8 @@ fn transcript_viewport_visible_window_slices_to_visible_rows() {
         1,
     );
 
-    let (lines, inner_scroll) = viewport.visible_window(80, 2);
+    // height=3 reserves 1 row as bottom margin, giving 2 visible rows.
+    let (lines, inner_scroll) = viewport.visible_window(80, 3);
     let rendered = lines
         .into_iter()
         .map(|line| line.to_string())

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -377,6 +377,41 @@ fn transcript_scroll_offset_uses_wrapped_visual_height() {
 }
 
 #[test]
+fn effective_height_includes_final_row_at_bottom_sticky() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+
+    // Pre-build committed turns so that visual rows exceed a 5-row viewport.
+    let entries: Vec<TranscriptEntry> = (0..8)
+        .map(|i| TranscriptEntry {
+            role: "Agent".into(),
+            message: format!("Line {i}"),
+            payload: None,
+        })
+        .collect();
+    app.restore_committed_turns(vec![TranscriptTurn { entries }]);
+
+    let viewport = transcript_viewport(&app, 80, 5);
+    let (visible_lines, _inner) = viewport.visible_window(80, 5);
+
+    // Effective height = 5 - 1 = 4. With scroll=0 (bottom sticky),
+    // the viewport should show the last 4 content rows.
+    assert_eq!(visible_lines.len(), 4);
+
+    let last_line = visible_lines
+        .last()
+        .map(|line| line.to_string())
+        .unwrap_or_default();
+    assert!(
+        last_line.contains("Line 7"),
+        "bottom sticky should include final content row ('Line 7') not: {last_line}"
+    );
+}
+
+#[test]
 fn renderable_transcript_lines_cache_is_invalidated_when_committed_turns_change() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -591,8 +591,7 @@ fn transcript_viewport_visible_window_slices_to_visible_rows() {
         1,
     );
 
-    // height=3 reserves 1 row as bottom margin, giving 2 visible rows.
-    let (lines, inner_scroll) = viewport.visible_window(80, 3);
+    let (lines, inner_scroll) = viewport.visible_window(80, 2);
     let rendered = lines
         .into_iter()
         .map(|line| line.to_string())

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -591,7 +591,8 @@ fn transcript_viewport_visible_window_slices_to_visible_rows() {
         1,
     );
 
-    let (lines, inner_scroll) = viewport.visible_window(80, 2);
+    // height=3 reserves 1 bottom row, giving 2 visible content rows.
+    let (lines, inner_scroll) = viewport.visible_window(80, 3);
     let rendered = lines
         .into_iter()
         .map(|line| line.to_string())

--- a/src/tui/render/viewport.rs
+++ b/src/tui/render/viewport.rs
@@ -24,10 +24,7 @@ impl TranscriptViewport {
             return (Vec::new(), 0);
         }
 
-        // Reserve one row at the bottom as breathing room so the last
-        // content line isn't visually flush against the bottom pane /
-        // input bar, which can make it look clipped or hidden.
-        let visible_rows = usize::from(height.saturating_sub(1).max(1));
+        let visible_rows = usize::from(height);
         let wrap_width = usize::from(width.max(1));
         let target_start = usize::from(self.scroll_offset);
         let target_end = target_start.saturating_add(visible_rows);

--- a/src/tui/render/viewport.rs
+++ b/src/tui/render/viewport.rs
@@ -24,9 +24,13 @@ impl TranscriptViewport {
             return (Vec::new(), 0);
         }
 
+        // Reserve one row at the bottom as breathing room so the last
+        // content line isn't visually flush against the bottom pane /
+        // input bar, which can make it look clipped or hidden.
+        let visible_rows = usize::from(height.saturating_sub(1).max(1));
         let wrap_width = usize::from(width.max(1));
         let target_start = usize::from(self.scroll_offset);
-        let target_end = target_start.saturating_add(usize::from(height));
+        let target_end = target_start.saturating_add(visible_rows);
 
         let mut row_cursor = 0usize;
         let mut first_idx = None;

--- a/src/tui/render/viewport.rs
+++ b/src/tui/render/viewport.rs
@@ -24,7 +24,9 @@ impl TranscriptViewport {
             return (Vec::new(), 0);
         }
 
-        let visible_rows = usize::from(height);
+        // Reserve one bottom row as breathing room so content isn't
+        // visually flush against the input bar at any scroll position.
+        let visible_rows = usize::from(height.saturating_sub(1).max(1));
         let wrap_width = usize::from(width.max(1));
         let target_start = usize::from(self.scroll_offset);
         let target_end = target_start.saturating_add(visible_rows);


### PR DESCRIPTION
## Problem

The last line of agent streaming replies was visually cramped against the
bottom pane / input bar, making it look clipped or hidden.

## Fix

visible_window now reserves 1 row as breathing room: visible_rows = height - 1
(min 1). This keeps the last content line from being flush against the input
area.

## Verification

- cargo check: 0 errors
- cargo test transcript_viewport_visible_window: 2 passed
- cargo test transcript_scroll_offset: 2 passed
