### PR TITLE
feat: add compact utility model routing

### DIFF
--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -29,6 +29,8 @@ pub struct ProviderConfigState {
     pub api_key: Option<SecretString>,
     pub base_url: Option<String>,
     pub model: Option<String>,
+    #[serde(default, alias = "utility_model")]
+    pub auxiliary_model: Option<String>,
     pub reasoning_effort: Option<String>,
     pub reasoning_summary: Option<String>,
     pub revision: Option<String>,
@@ -112,6 +114,8 @@ pub struct OpenAiEndpointProfile {
     pub api_key: Option<SecretString>,
     pub base_url: Option<String>,
     pub model: Option<String>,
+    #[serde(default, alias = "utility_model")]
+    pub auxiliary_model: Option<String>,
     pub reasoning_effort: Option<String>,
     pub reasoning_summary: Option<String>,
     pub revision: Option<String>,
@@ -154,6 +158,8 @@ pub struct RaraConfig {
     pub runtime_api_key: Option<SecretString>,
     pub base_url: Option<String>,
     pub model: Option<String>,
+    #[serde(default, alias = "utility_model")]
+    pub auxiliary_model: Option<String>,
     pub reasoning_effort: Option<String>,
     pub reasoning_summary: Option<String>,
     pub revision: Option<String>,
@@ -301,6 +307,11 @@ impl RaraConfig {
         self.sync_active_provider_state();
     }
 
+    pub fn set_auxiliary_model(&mut self, value: Option<String>) {
+        self.auxiliary_model = normalize_optional_string(value);
+        self.sync_active_provider_state();
+    }
+
     pub fn set_reasoning_effort(&mut self, value: Option<String>) {
         self.reasoning_effort = normalize_optional_string(value);
         self.sync_active_provider_state();
@@ -367,6 +378,14 @@ impl RaraConfig {
                     .and_then(|state| state.model.as_deref())
                     .or_else(|| profile.and_then(|profile| profile.model.as_deref())),
                 self.model.as_deref(),
+                None,
+                None,
+            ),
+            auxiliary_model: resolve_provider_value(
+                provider_state
+                    .and_then(|state| state.auxiliary_model.as_deref())
+                    .or_else(|| profile.and_then(|profile| profile.auxiliary_model.as_deref())),
+                self.auxiliary_model.as_deref(),
                 None,
                 None,
             ),
@@ -506,6 +525,7 @@ impl RaraConfig {
             api_key: self.api_key.clone(),
             base_url: self.base_url.clone(),
             model: self.model.clone(),
+            auxiliary_model: self.auxiliary_model.clone(),
             reasoning_effort: self.reasoning_effort.clone(),
             reasoning_summary: self.reasoning_summary.clone(),
             revision: self.revision.clone(),
@@ -519,6 +539,7 @@ impl RaraConfig {
         self.api_key = state.api_key;
         self.base_url = state.base_url;
         self.model = state.model;
+        self.auxiliary_model = state.auxiliary_model;
         self.reasoning_effort = state.reasoning_effort;
         self.reasoning_summary = state.reasoning_summary;
         self.revision = state.revision;
@@ -531,6 +552,7 @@ impl RaraConfig {
         self.api_key = profile.api_key;
         self.base_url = profile.base_url;
         self.model = profile.model;
+        self.auxiliary_model = profile.auxiliary_model;
         self.reasoning_effort = profile.reasoning_effort;
         self.reasoning_summary = profile.reasoning_summary;
         self.revision = profile.revision;
@@ -543,6 +565,7 @@ impl RaraConfig {
         self.api_key = None;
         self.base_url = None;
         self.model = None;
+        self.auxiliary_model = None;
         self.reasoning_effort = None;
         self.reasoning_summary = Some(DEFAULT_REASONING_SUMMARY.to_string());
         self.revision = None;
@@ -567,6 +590,7 @@ impl RaraConfig {
         profile.api_key = self.api_key.clone();
         profile.base_url = self.base_url.clone();
         profile.model = self.model.clone();
+        profile.auxiliary_model = self.auxiliary_model.clone();
         profile.reasoning_effort = self.reasoning_effort.clone();
         profile.reasoning_summary = self.reasoning_summary.clone();
         profile.revision = self.revision.clone();
@@ -595,6 +619,7 @@ impl RaraConfig {
             api_key: None,
             base_url: Some(kind.default_base_url().to_string()),
             model: Some(kind.default_model().to_string()),
+            auxiliary_model: None,
             reasoning_effort: None,
             reasoning_summary: Some(DEFAULT_REASONING_SUMMARY.to_string()),
             revision: None,
@@ -636,6 +661,7 @@ impl RaraConfig {
                             .or_else(|| Some(kind.default_base_url().to_string())),
                         model: normalize_optional_string(state.model)
                             .or_else(|| Some(kind.default_model().to_string())),
+                        auxiliary_model: normalize_optional_string(state.auxiliary_model),
                         reasoning_effort: normalize_optional_string(state.reasoning_effort),
                         reasoning_summary: normalize_reasoning_summary(state.reasoning_summary)
                             .or_else(|| Some(DEFAULT_REASONING_SUMMARY.to_string())),
@@ -680,6 +706,7 @@ impl RaraConfig {
                             .or_else(|| Some(target_kind.default_base_url().to_string())),
                         model: normalize_optional_string(self.model.clone())
                             .or_else(|| Some(target_kind.default_model().to_string())),
+                        auxiliary_model: normalize_optional_string(self.auxiliary_model.clone()),
                         reasoning_effort: normalize_optional_string(self.reasoning_effort.clone()),
                         reasoning_summary: normalize_reasoning_summary(
                             self.reasoning_summary.clone(),
@@ -986,6 +1013,49 @@ mod tests {
     }
 
     #[test]
+    fn auxiliary_model_reads_legacy_utility_model_key() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "deepseek",
+                "utility_model": "deepseek-v4-lite",
+                "provider_states": {
+                    "codex": {
+                        "utility_model": "gpt-5.4-mini"
+                    }
+                },
+                "openai_profiles": {
+                    "deepseek-default": {
+                        "id": "deepseek-default",
+                        "label": "DeepSeek",
+                        "kind": "deepseek",
+                        "utility_model": "deepseek-v4-lite"
+                    }
+                }
+            }"#,
+        )
+        .expect("deserialize config");
+
+        assert_eq!(config.auxiliary_model.as_deref(), Some("deepseek-v4-lite"));
+        assert_eq!(
+            config
+                .provider_states
+                .get("codex")
+                .and_then(|state| state.auxiliary_model.as_deref()),
+            Some("gpt-5.4-mini")
+        );
+        assert_eq!(
+            config
+                .openai_profiles
+                .get("deepseek-default")
+                .and_then(|profile| profile.auxiliary_model.as_deref()),
+            Some("deepseek-v4-lite")
+        );
+        let json = serde_json::to_string(&config).expect("serialize config");
+        assert!(json.contains("auxiliary_model"));
+        assert!(!json.contains("utility_model"));
+    }
+
+    #[test]
     fn provider_switch_restores_provider_specific_settings() {
         let mut config = RaraConfig {
             provider: "codex".to_string(),
@@ -993,6 +1063,7 @@ mod tests {
         };
         config.set_api_key("sk-codex");
         config.set_model(Some("codex".to_string()));
+        config.set_auxiliary_model(Some("gpt-5.4-mini".to_string()));
         config.set_reasoning_effort(Some("high".to_string()));
         config.set_reasoning_summary(Some("detailed".to_string()));
         config.set_base_url(Some("http://localhost:8080".to_string()));
@@ -1010,6 +1081,7 @@ mod tests {
         config.set_provider("codex");
         assert_eq!(config.api_key(), Some("sk-codex"));
         assert_eq!(config.model.as_deref(), Some("codex"));
+        assert_eq!(config.auxiliary_model.as_deref(), Some("gpt-5.4-mini"));
         assert_eq!(config.reasoning_effort.as_deref(), Some("high"));
         assert_eq!(config.reasoning_summary.as_deref(), Some("detailed"));
         assert_eq!(config.base_url.as_deref(), Some("http://localhost:8080"));
@@ -1017,6 +1089,7 @@ mod tests {
 
         config.set_provider("ollama");
         assert_eq!(config.model.as_deref(), Some("qwen3"));
+        assert!(config.auxiliary_model.is_none());
         assert_eq!(config.reasoning_effort, None);
         assert_eq!(
             config.reasoning_summary.as_deref(),

--- a/crates/config/src/provider_surface.rs
+++ b/crates/config/src/provider_surface.rs
@@ -38,6 +38,7 @@ impl<'a> ResolvedProviderValue<'a> {
 pub struct EffectiveProviderSurface<'a> {
     pub provider: &'a str,
     pub model: ResolvedProviderValue<'a>,
+    pub auxiliary_model: ResolvedProviderValue<'a>,
     pub base_url: ResolvedProviderValue<'a>,
     pub revision: ResolvedProviderValue<'a>,
     pub reasoning_effort: ResolvedProviderValue<'a>,

--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -32,13 +32,26 @@ For long coding sessions, this increases the risk of losing:
 
 ## Architecture
 
-### 1) Structured Compact Prompt
+### 1) Compact Planning Boundary
+
+- Compaction planning must operate on API-round groups rather than raw history item counts.
+- An API-round group starts when a new assistant response begins and includes the user tool results
+  that answer that assistant response.
+- The planner should summarize an older prefix and retain a recent suffix only at group
+  boundaries, so assistant `tool_use` items are not separated from their matching user
+  `tool_result` items.
+- The retained suffix is token-budget aware. The default target is a fraction of the current
+  compact threshold, while still retaining at least the newest API-round group.
+- Raw item-count heuristics such as "summarize the oldest 80%" are fallback-quality behavior and
+  should not be used as the normal planning strategy.
+
+### 2) Structured Compact Prompt
 
 - The default compact prompt should require a stable markdown schema instead of a generic prose
   summary.
 - The first phase keeps the schema simple and directly usable by the next turn.
 
-### 2) Required Compression Sections
+### 3) Required Compression Sections
 
 The default compact output should preserve, in order:
 
@@ -51,7 +64,7 @@ The default compact output should preserve, in order:
 7. `Unresolved Risks`
 8. `Next Best Action`
 
-### 3) Stored History Shape
+### 4) Stored History Shape
 
 - After compaction, RARA should store a clearly labeled structured summary in history instead of a
   generic `"SUMMARY OF PREVIOUS CONVERSATION"` marker.
@@ -61,6 +74,79 @@ The default compact output should preserve, in order:
   compaction boundaries without scraping free-form summary text.
 - Compact boundary metadata should also be mirrored into persisted session state so resume flows and
   status views can recover the latest compaction boundary without reparsing full history.
+
+### 5) Post-Compact Carry-Over Stages
+
+Post-compact history is assembled in ordered stages:
+
+1. compact boundary metadata;
+2. structured summary of the summarized API-round prefix;
+3. source-aware carry-over such as recent files and recent file excerpts;
+4. retained recent API-round suffix.
+
+Future memory, hook, skill, MCP, and runtime-state reinjection should plug into the source-aware
+carry-over stage instead of being special-cased inside the split planner. This mirrors Claude Code's
+separation between the summary replacement and the post-compact attachments that restore current
+working context.
+
+### 6) Prefix Stability
+
+- Context cache reuse depends on stable prompt prefixes. Compaction must not reorder stable context
+  sources as a side effect of summarizing history.
+- Post-compact carry-over stages are append-only and ordered by source class. New source classes
+  must be added at an explicit slot instead of being mixed into existing free-form text.
+- Within a source class, entries should use deterministic ordering when the source is stable. Runtime
+  recency ordering is acceptable only for explicitly recent artifacts such as recent files and file
+  excerpts.
+- The retained recent API-round suffix always comes after compact metadata, summary, and carry-over
+  sources. This keeps deterministic system/context material before volatile conversation history.
+
+### 7) Dedicated Compact Worker
+
+Compaction can be executed by a dedicated internal worker, but it should not be exposed as a normal
+model-callable sub-agent tool. Compact is a runtime lifecycle operation, not delegated task work.
+
+The compact worker should receive a structured request:
+
+- compact instruction;
+- summarized API-round prefix;
+- retained suffix plan;
+- stable source descriptors for memory, hooks, skills, MCP, and runtime state;
+- token budget and retry limits.
+
+It should return a structured result:
+
+- summary markdown;
+- extracted carry-over items grouped by source class;
+- warnings such as prompt-too-long truncation or schema drift;
+- model usage, latency, and cache metrics when available.
+
+The worker may use an auxiliary model for low-risk runtime reasoning that supports the main agent
+turn but does not answer the user directly. This is intended for compression, context routing,
+classification, and similar deterministic helper work where a smaller or cheaper model is
+acceptable. It must not change the configured main chat model, tool policy, or conversation
+ownership.
+
+This mirrors Gemini's use of dedicated `chat-compression-*` model configs. The routing rule is:
+
+- prefer an explicitly configured `auxiliary_model` for helper work;
+- otherwise use a provider-specific lite model only when it can be derived conservatively;
+- if no lite model is configured or derivable, use the main model;
+- if an auxiliary/lite request fails because the provider does not support it, retry with the main
+  model instead of failing compaction;
+- persist metrics in a way that lets `/status` and `/context` distinguish main-model calls from
+  auxiliary-model calls.
+
+The parent agent should only apply the returned result through the post-compact assembly pipeline.
+The worker transcript must not be appended to the parent conversation. This keeps prefix order
+stable and preserves a clear boundary between main task history and compaction implementation
+details.
+
+This is similar in spirit to sub-agent isolation, but its storage model is different:
+
+- normal sub-agents are child threads with task/result lineage;
+- compact workers are lifecycle jobs attached to one compaction event;
+- only the compact event, summary, carry-over, metrics, and warnings are persisted.
 
 ## Contracts
 
@@ -72,6 +158,8 @@ The default compact output should preserve, in order:
   names.
 - Preserve the current plan and any pending approval or request-user-input state.
 - Preserve the immediate next useful action instead of ending with a vague recap.
+- Preserve tool-use integrity by cutting compacted and retained history only at API-round
+  boundaries.
 
 ### 2) Failure Tolerance
 

--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -134,8 +134,22 @@ This mirrors Gemini's use of dedicated `chat-compression-*` model configs. The r
 - if no lite model is configured or derivable, use the main model;
 - if an auxiliary/lite request fails because the provider does not support it, retry with the main
   model instead of failing compaction;
+- for Codex/Responses streaming, classify `response.failed.error.code` structurally and treat
+  `context_length_exceeded` as a context-window failure, matching Codex's upstream behavior;
+- do not retry with the main model for authentication, rate-limit, network, or other provider
+  failures because those are not auxiliary-model selection failures;
+- when the helper model has a known smaller context window than the main model, compute compaction
+  thresholds against the smaller helper budget so helper prompts are planned conservatively instead
+  of relying on provider error-message parsing;
 - persist metrics in a way that lets `/status` and `/context` distinguish main-model calls from
   auxiliary-model calls.
+
+These controls are runtime-plane behavior, not TUI-only behavior. A compaction request should carry
+the selected main model, optional auxiliary model, budget source, and trigger reason through the
+shared request path. The resulting runtime event should report the model actually used, fallback
+reason when fallback occurred, token usage/cache metrics when available, and any warning that should
+be visible in `/status` or `/context`. TUI surfaces render those events; they must not infer routing
+or fallback behavior from display text.
 
 The parent agent should only apply the returned result through the post-compact assembly pipeline.
 The worker transcript must not be appended to the parent conversation. This keeps prefix order

--- a/docs/journal/2026-05-02-claude-style-compact-planning.md
+++ b/docs/journal/2026-05-02-claude-style-compact-planning.md
@@ -1,0 +1,35 @@
+# 2026-05-02 Claude-Style Compact Planning
+
+## Summary
+
+Aligned RARA's compaction split decision with Claude Code's API-round boundary model.
+
+## Changes
+
+- Replaced the raw `history.len() * 0.8` split with a compact planning step that groups history by
+  assistant API rounds.
+- Kept assistant `tool_use` messages together with their matching user `tool_result` messages in
+  the retained suffix.
+- Added a token-budget-aware retained suffix target while always preserving at least the newest API
+  round.
+- Extracted post-compact carry-over assembly so future memory, hook, skill, MCP, or runtime-state
+  reinjection can plug into one ordered stage.
+- Fixed manual compaction to keep only the newest API round by default, so on-demand compaction
+  actually summarizes the recent inspected context instead of retaining almost the whole suffix.
+- Documented the context-cache prefix stability rule for post-compact history assembly.
+- Added the auxiliary-model routing contract for compact workers: auxiliary models are reserved for
+  low-risk helper reasoning such as compression or routing, use an explicit or conservatively
+  inferred lite model when available, and fall back to the main model if no lite model exists.
+- Updated the context compression spec to record the new boundary and carry-over contract.
+
+## Validation
+
+- Focused compact unit tests cover API-round grouping and retained-suffix planning.
+- Agent compact tests cover retaining a recent tool-use/tool-result pair after manual compaction.
+
+## Follow-Up
+
+- Add explicit memory and hook carry-over stages once those runtime records have stable source
+  descriptors.
+- Add prompt-too-long retry logic that drops oldest API-round groups from the compaction request.
+- Add partial compact support around a selected message boundary.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -53,6 +53,10 @@ Active backlog only. Keep this file small and current.
 - [ ] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.
 - [ ] Define background task restart/reattach semantics.
 - [ ] Compaction as first-class lifecycle event: persist summaries, token counters, metadata ownership.
+- [ ] Add prompt-too-long retry for compaction by dropping oldest API-round groups.
+- [ ] Add partial compact support around a selected message boundary (`from` / `up_to`).
+- [ ] Add post-compact memory/hook/skill carry-over stages once source descriptors are stable.
+- [ ] Surface main model vs auxiliary model routing in `/status` and `/context`.
 - [ ] `ThreadStore` / `ThreadRecorder`: from façade over `SessionManager`+`StateDb` to true structured thread store.
 - [ ] Thread-scoped and workspace-scoped `MemoryRecord` storage with promotion rules.
 - [ ] Retrieval orchestration layer from `docs/features/context-architecture.md`.

--- a/src/agent/compact.rs
+++ b/src/agent/compact.rs
@@ -10,6 +10,7 @@ const RECENT_FILE_EXCERPT_CHAR_LIMIT: usize = 600;
 const RETAINED_HISTORY_BUDGET_FRACTION: usize = 2;
 const COMPACT_BOUNDARY_KIND: &str = "compact_boundary";
 const COMPACT_BOUNDARY_VERSION: u32 = 1;
+const ROLE_ASSISTANT: &str = "assistant";
 // Wait for about two 4K chunks of new context before retrying automatic
 // compaction after a timeout or backend failure.
 const AUTO_COMPACTION_RETRY_HYSTERESIS_TOKENS: usize = 8_192;
@@ -279,15 +280,19 @@ fn build_compact_plan(
 
     let groups = group_history_by_api_round(history)?;
     if groups.len() < 2 {
-        return Ok(Some(CompactPlan {
-            summarize_end: history.len() - 1,
-            retained_start: history.len() - 1,
-        }));
+        return Ok(None);
     }
 
     let retained_budget = retained_history_budget(threshold, force);
     let mut retained_tokens = 0usize;
     let mut retained_group_index = groups.len() - 1;
+    let latest_group = &groups[retained_group_index];
+    if !force && latest_group.token_estimate > retained_budget {
+        return Ok(Some(CompactPlan {
+            summarize_end: history.len(),
+            retained_start: history.len(),
+        }));
+    }
 
     for group_index in (1..groups.len()).rev() {
         let group = &groups[group_index];
@@ -323,12 +328,13 @@ fn retained_history_budget(threshold: usize, force: bool) -> usize {
 }
 
 fn group_history_by_api_round(history: &[Message]) -> Result<Vec<ApiRoundGroup>> {
+    let bpe = tokenizer()?;
     let mut groups = Vec::new();
     let mut group_start = 0usize;
     let mut current_tokens = 0usize;
 
     for (idx, message) in history.iter().enumerate() {
-        let starts_new_round = message.role == "assistant" && idx > group_start;
+        let starts_new_round = message.role == ROLE_ASSISTANT && idx > group_start;
         if starts_new_round {
             debug_assert!(idx > group_start);
             groups.push(ApiRoundGroup {
@@ -339,7 +345,8 @@ fn group_history_by_api_round(history: &[Message]) -> Result<Vec<ApiRoundGroup>>
             group_start = idx;
             current_tokens = 0;
         }
-        current_tokens = current_tokens.saturating_add(estimate_message_tokens(message)?);
+        current_tokens =
+            current_tokens.saturating_add(estimate_message_tokens_with_bpe(message, bpe)?);
     }
 
     if group_start < history.len() {
@@ -759,7 +766,7 @@ mod tests {
             Message {
                 role: "user".to_string(),
                 content: json!([
-                    {"type":"tool_result","tool_use_id":"tool-1","content":"old output"}
+                    {"type":"tool_result","tool_use_id":"tool-1","content":"old output ".repeat(1_000)}
                 ]),
             },
             Message {
@@ -776,11 +783,70 @@ mod tests {
             },
         ];
 
-        let plan = build_compact_plan(&history, 1, false)
+        let plan = build_compact_plan(&history, 600, false)
             .expect("plan")
             .expect("compact plan");
 
         assert_eq!(plan.summarize_end, 3);
         assert_eq!(plan.retained_start, 3);
+    }
+
+    #[test]
+    fn compact_plan_does_not_split_single_assistant_tool_round() {
+        let history = vec![
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/main.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content":"fn main() {}"}
+                ]),
+            },
+        ];
+
+        let plan = build_compact_plan(&history, 1, false).expect("plan");
+
+        assert!(
+            plan.is_none(),
+            "single API round must not retain a detached tool_result"
+        );
+    }
+
+    #[test]
+    fn compact_plan_summarizes_oversized_latest_api_round() {
+        let large_tool_output = "recent output ".repeat(2_000);
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!("old request"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!("old answer"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/main.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content": large_tool_output}
+                ]),
+            },
+        ];
+
+        let plan = build_compact_plan(&history, 100, false)
+            .expect("plan")
+            .expect("compact plan");
+
+        assert_eq!(plan.summarize_end, history.len());
+        assert_eq!(plan.retained_start, history.len());
     }
 }

--- a/src/agent/compact.rs
+++ b/src/agent/compact.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 const RECENT_FILE_CARRY_OVER_LIMIT: usize = 5;
 const RECENT_FILE_EXCERPT_LIMIT: usize = 3;
 const RECENT_FILE_EXCERPT_CHAR_LIMIT: usize = 600;
+const RETAINED_HISTORY_BUDGET_FRACTION: usize = 2;
 const COMPACT_BOUNDARY_KIND: &str = "compact_boundary";
 const COMPACT_BOUNDARY_VERSION: u32 = 1;
 // Wait for about two 4K chunks of new context before retrying automatic
@@ -30,6 +31,26 @@ struct RecentFileExcerpt {
     path: String,
     line_range: Option<(usize, usize)>,
     snippet: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ApiRoundGroup {
+    start: usize,
+    end: usize,
+    token_estimate: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CompactPlan {
+    summarize_end: usize,
+    retained_start: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CompactCarryOver {
+    summary: String,
+    recent_files: Vec<String>,
+    recent_file_excerpts: Vec<RecentFileExcerpt>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -117,12 +138,13 @@ impl Agent {
             "Compacting long conversation history.".to_string()
         }));
 
-        let split_idx = (self.history.len() as f64 * 0.8) as usize;
-        let split_idx = split_idx.clamp(1, self.history.len().saturating_sub(1));
+        let Some(plan) = build_compact_plan(&self.history, threshold, force)? else {
+            return Ok(());
+        };
         let summary_result = tokio::time::timeout(
             compaction_summary_timeout(),
             self.llm_backend.summarize(
-                &self.history[..split_idx],
+                &self.history[..plan.summarize_end],
                 &self.context_assembler().compact_instruction(),
             ),
         )
@@ -154,52 +176,13 @@ impl Agent {
                 ));
             }
         };
-        let recent_files =
-            collect_recent_files(&self.history[..split_idx], RECENT_FILE_CARRY_OVER_LIMIT);
-        let recent_file_excerpts = collect_recent_file_excerpts(
-            &self.history[..split_idx],
-            RECENT_FILE_EXCERPT_LIMIT,
-            RECENT_FILE_EXCERPT_CHAR_LIMIT,
+        let carry_over =
+            build_compact_carry_over(summary.clone(), &self.history[..plan.summarize_end]);
+        let new_history = build_post_compact_history(
+            current_tokens,
+            &carry_over,
+            &self.history[plan.retained_start..],
         );
-        let mut new_history = vec![
-            build_compact_boundary_message(current_tokens, recent_files.len()),
-            Message {
-                role: "system".to_string(),
-                content: json!(format!(
-                    "STRUCTURED SUMMARY OF PREVIOUS CONVERSATION:\n{}",
-                    summary
-                )),
-            },
-        ];
-        if !recent_files.is_empty() {
-            let recent_files_block = recent_files
-                .iter()
-                .map(|path| format!("- {path}"))
-                .collect::<Vec<_>>()
-                .join("\n");
-            new_history.push(Message {
-                role: "system".to_string(),
-                content: json!(format!(
-                    "RECENT FILES FROM COMPACTED HISTORY:\n{}",
-                    recent_files_block
-                )),
-            });
-        }
-        if !recent_file_excerpts.is_empty() {
-            let excerpt_block = recent_file_excerpts
-                .iter()
-                .map(render_recent_file_excerpt)
-                .collect::<Vec<_>>()
-                .join("\n\n");
-            new_history.push(Message {
-                role: "system".to_string(),
-                content: json!(format!(
-                    "RECENT FILE EXCERPTS FROM COMPACTED HISTORY:\n{}",
-                    excerpt_block
-                )),
-            });
-        }
-        new_history.extend_from_slice(&self.history[split_idx..]);
         self.replace_history(new_history);
         self.session_manager
             .save_session(&self.session_id, &self.history)?;
@@ -208,7 +191,7 @@ impl Agent {
         self.compact_state.compaction_count += 1;
         self.compact_state.last_compaction_before_tokens = Some(current_tokens);
         self.compact_state.last_compaction_after_tokens = Some(compacted_tokens);
-        self.compact_state.last_compaction_recent_files = recent_files;
+        self.compact_state.last_compaction_recent_files = carry_over.recent_files;
         self.compact_state.last_compaction_boundary = Some(CompactBoundaryMetadata {
             version: COMPACT_BOUNDARY_VERSION,
             before_tokens: current_tokens,
@@ -282,6 +265,159 @@ impl Agent {
     fn recompute_history_token_estimate(&mut self) {
         self.compact_state.estimated_history_tokens =
             estimate_history_tokens(&self.history).unwrap_or_default();
+    }
+}
+
+fn build_compact_plan(
+    history: &[Message],
+    threshold: usize,
+    force: bool,
+) -> Result<Option<CompactPlan>> {
+    if history.len() < 2 {
+        return Ok(None);
+    }
+
+    let groups = group_history_by_api_round(history)?;
+    if groups.len() < 2 {
+        return Ok(Some(CompactPlan {
+            summarize_end: history.len() - 1,
+            retained_start: history.len() - 1,
+        }));
+    }
+
+    let retained_budget = retained_history_budget(threshold, force);
+    let mut retained_tokens = 0usize;
+    let mut retained_group_index = groups.len() - 1;
+
+    for group_index in (1..groups.len()).rev() {
+        let group = &groups[group_index];
+        let next_tokens = retained_tokens.saturating_add(group.token_estimate);
+        if retained_tokens > 0 && next_tokens > retained_budget {
+            break;
+        }
+        retained_tokens = next_tokens;
+        retained_group_index = group_index;
+    }
+
+    let retained_start = groups[retained_group_index].start;
+    if retained_start == 0 {
+        return Ok(Some(CompactPlan {
+            summarize_end: groups[1].start,
+            retained_start: groups[1].start,
+        }));
+    }
+
+    Ok(Some(CompactPlan {
+        summarize_end: retained_start,
+        retained_start,
+    }))
+}
+
+fn retained_history_budget(threshold: usize, force: bool) -> usize {
+    if force {
+        return 1;
+    }
+    threshold
+        .saturating_div(RETAINED_HISTORY_BUDGET_FRACTION)
+        .max(1)
+}
+
+fn group_history_by_api_round(history: &[Message]) -> Result<Vec<ApiRoundGroup>> {
+    let mut groups = Vec::new();
+    let mut group_start = 0usize;
+    let mut current_tokens = 0usize;
+
+    for (idx, message) in history.iter().enumerate() {
+        let starts_new_round = message.role == "assistant" && idx > group_start;
+        if starts_new_round {
+            debug_assert!(idx > group_start);
+            groups.push(ApiRoundGroup {
+                start: group_start,
+                end: idx,
+                token_estimate: current_tokens,
+            });
+            group_start = idx;
+            current_tokens = 0;
+        }
+        current_tokens = current_tokens.saturating_add(estimate_message_tokens(message)?);
+    }
+
+    if group_start < history.len() {
+        groups.push(ApiRoundGroup {
+            start: group_start,
+            end: history.len(),
+            token_estimate: current_tokens,
+        });
+    }
+    debug_assert_eq!(groups.last().map(|group| group.end), Some(history.len()));
+
+    Ok(groups)
+}
+
+fn build_compact_carry_over(summary: String, compacted_history: &[Message]) -> CompactCarryOver {
+    CompactCarryOver {
+        summary,
+        recent_files: collect_recent_files(compacted_history, RECENT_FILE_CARRY_OVER_LIMIT),
+        recent_file_excerpts: collect_recent_file_excerpts(
+            compacted_history,
+            RECENT_FILE_EXCERPT_LIMIT,
+            RECENT_FILE_EXCERPT_CHAR_LIMIT,
+        ),
+    }
+}
+
+fn build_post_compact_history(
+    before_tokens: usize,
+    carry_over: &CompactCarryOver,
+    retained_history: &[Message],
+) -> Vec<Message> {
+    let mut history = vec![
+        build_compact_boundary_message(before_tokens, carry_over.recent_files.len()),
+        Message {
+            role: "system".to_string(),
+            content: json!(format!(
+                "STRUCTURED SUMMARY OF PREVIOUS CONVERSATION:\n{}",
+                carry_over.summary
+            )),
+        },
+    ];
+
+    append_post_compact_carry_over(&mut history, carry_over);
+    history.extend_from_slice(retained_history);
+    history
+}
+
+fn append_post_compact_carry_over(history: &mut Vec<Message>, carry_over: &CompactCarryOver) {
+    if !carry_over.recent_files.is_empty() {
+        let recent_files_block = carry_over
+            .recent_files
+            .iter()
+            .map(|path| format!("- {path}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        history.push(Message {
+            role: "system".to_string(),
+            content: json!(format!(
+                "RECENT FILES FROM COMPACTED HISTORY:\n{}",
+                recent_files_block
+            )),
+        });
+    }
+
+    if !carry_over.recent_file_excerpts.is_empty() {
+        let excerpt_block = carry_over
+            .recent_file_excerpts
+            .iter()
+            .map(render_recent_file_excerpt)
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        history.push(Message {
+            role: "system".to_string(),
+            content: json!(format!(
+                "RECENT FILE EXCERPTS FROM COMPACTED HISTORY:\n{}",
+                excerpt_block
+            )),
+        });
     }
 }
 
@@ -543,7 +679,8 @@ pub fn latest_compact_boundary_metadata(history: &[Message]) -> Option<CompactBo
 
 #[cfg(test)]
 mod tests {
-    use super::read_file_line_range;
+    use super::{build_compact_plan, group_history_by_api_round, read_file_line_range};
+    use crate::agent::Message;
     use serde_json::{Map, Value, json};
 
     fn object(value: Value) -> Map<String, Value> {
@@ -568,5 +705,82 @@ mod tests {
         }));
 
         assert_eq!(read_file_line_range(&input), Some((10, 12)));
+    }
+
+    #[test]
+    fn api_round_grouping_keeps_tool_result_with_assistant_round() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!("start"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/main.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content":"fn main() {}"}
+                ]),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!("done"),
+            },
+        ];
+
+        let groups = group_history_by_api_round(&history).expect("groups");
+
+        assert_eq!(
+            groups
+                .iter()
+                .map(|group| (group.start, group.end))
+                .collect::<Vec<_>>(),
+            vec![(0, 1), (1, 3), (3, 4)]
+        );
+    }
+
+    #[test]
+    fn compact_plan_uses_api_round_boundary_for_retained_suffix() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!("old request"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/old.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content":"old output"}
+                ]),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-2","name":"read_file","input":{"path":"src/new.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-2","content":"new output"}
+                ]),
+            },
+        ];
+
+        let plan = build_compact_plan(&history, 1, false)
+            .expect("plan")
+            .expect("compact plan");
+
+        assert_eq!(plan.summarize_end, 3);
+        assert_eq!(plan.retained_start, 3);
     }
 }

--- a/src/agent/tests/compaction.rs
+++ b/src/agent/tests/compaction.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde_json::json;
 
 use crate::agent::{Agent, AgentEvent, CompactState, ContentBlock, Message};
-use crate::llm::{LlmBackend, LlmResponse, TokenUsage};
+use crate::llm::{ContextBudget, LlmBackend, LlmResponse, TokenUsage};
 use crate::session::SessionManager;
 use crate::tool::ToolManager;
 use crate::vectordb::VectorDB;
@@ -14,6 +14,8 @@ use crate::workspace::WorkspaceMemory;
 use super::support::SequencedBackend;
 
 struct SlowSummarizeBackend;
+
+struct TinyBudgetSummaryBackend;
 
 #[async_trait]
 impl LlmBackend for SlowSummarizeBackend {
@@ -38,6 +40,43 @@ impl LlmBackend for SlowSummarizeBackend {
     async fn summarize(&self, _messages: &[Message], _instruction: &str) -> Result<String> {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         Ok("slow summary".to_string())
+    }
+}
+
+#[async_trait]
+impl LlmBackend for TinyBudgetSummaryBackend {
+    async fn ask(
+        &self,
+        _messages: &[Message],
+        _tools: &[serde_json::Value],
+    ) -> Result<LlmResponse> {
+        Ok(LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "query completed".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        })
+    }
+
+    async fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+        Ok(vec![0.0; 8])
+    }
+
+    async fn summarize(&self, _messages: &[Message], _instruction: &str) -> Result<String> {
+        Ok("summary".to_string())
+    }
+
+    fn context_budget(
+        &self,
+        _messages: &[Message],
+        _tools: &[serde_json::Value],
+    ) -> Option<ContextBudget> {
+        Some(ContextBudget {
+            context_window_tokens: 16,
+            reserved_output_tokens: 4,
+            compact_threshold_tokens: 1,
+        })
     }
 }
 
@@ -338,4 +377,70 @@ async fn manual_compact_prefers_latest_excerpt_and_tracks_apply_patch() {
     assert!(excerpts.contains("new snippet"));
     assert!(!excerpts.contains("old snippet"));
     assert!(excerpts.contains("lines 10-12"));
+}
+
+#[tokio::test]
+async fn manual_compact_preserves_recent_api_round_pair() {
+    let backend = Arc::new(TinyBudgetSummaryBackend);
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new("data/lancedb")),
+        Arc::new(SessionManager::new().expect("session manager")),
+        Arc::new(WorkspaceMemory::new().expect("workspace memory")),
+    );
+    agent.history = vec![
+        Message {
+            role: "user".to_string(),
+            content: json!("inspect old state"),
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: json!([
+                {"type":"tool_use","id":"tool-old","name":"read_file","input":{"path":"src/old.rs"}}
+            ]),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([
+                {"type":"tool_result","tool_use_id":"tool-old","content":"old output"}
+            ]),
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: json!([
+                {"type":"tool_use","id":"tool-recent","name":"read_file","input":{"path":"src/recent.rs"}}
+            ]),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([
+                {"type":"tool_result","tool_use_id":"tool-recent","content":"recent output"}
+            ]),
+        },
+    ];
+
+    let compacted = agent
+        .compact_now_with_reporter(|_| {})
+        .await
+        .expect("compact should succeed");
+
+    assert!(compacted);
+    let recent_tool_use_index = agent
+        .history
+        .iter()
+        .position(|message| message.content.to_string().contains("tool-recent"))
+        .expect("recent tool use should be retained");
+    assert_eq!(agent.history[recent_tool_use_index].role, "assistant");
+    assert_eq!(
+        agent.history[recent_tool_use_index + 1].role,
+        "user",
+        "tool result should stay with the retained assistant API round"
+    );
+    assert!(
+        agent.history[recent_tool_use_index + 1]
+            .content
+            .to_string()
+            .contains("tool-recent")
+    );
 }

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -2,11 +2,13 @@ mod codex;
 mod usage;
 
 use std::borrow::Cow;
+use std::fmt;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use eventsource_stream::Eventsource;
+use reqwest::{Response, StatusCode};
 use secrecy::{ExposeSecret, SecretString};
 use serde_json::{Value, json};
 
@@ -25,6 +27,58 @@ use self::usage::parse_openai_token_usage;
 
 const STREAM_IDLE_RETRY_ATTEMPTS: usize = 1;
 const STREAM_IDLE_ERROR_FRAGMENT: &str = "stream produced no events";
+
+#[derive(Debug)]
+pub(crate) struct OpenAiApiError {
+    status: Option<StatusCode>,
+    sanitized_body: String,
+    error_type: Option<String>,
+    error_code: Option<String>,
+}
+
+impl OpenAiApiError {
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        status: Option<StatusCode>,
+        error_type: Option<&str>,
+        error_code: Option<&str>,
+    ) -> Self {
+        Self {
+            status,
+            sanitized_body: "{}".to_string(),
+            error_type: error_type.map(ToString::to_string),
+            error_code: error_code.map(ToString::to_string),
+        }
+    }
+
+    pub(crate) fn from_response_failed_error(error: &Value) -> Self {
+        let sanitized_body = redact_secrets(error.to_string());
+        Self {
+            status: None,
+            sanitized_body,
+            error_type: error
+                .get("type")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            error_code: error
+                .get("code")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+        }
+    }
+}
+
+impl fmt::Display for OpenAiApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(status) = self.status {
+            write!(f, "API Error (status {status}): {}", self.sanitized_body)
+        } else {
+            write!(f, "API Error: {}", self.sanitized_body)
+        }
+    }
+}
+
+impl std::error::Error for OpenAiApiError {}
 
 #[cfg(test)]
 pub(crate) use self::codex::{
@@ -358,16 +412,39 @@ impl LlmBackend for OpenAiCompatibleBackend {
         let summary = self
             .summarize_with_model(summary_model.as_ref(), &msgs)
             .await;
-        if summary.is_err() && summary_model.as_ref() != self.model.as_str() {
+        if summary_model.as_ref() != self.model.as_str()
+            && summary
+                .as_ref()
+                .is_err_and(|error| is_auxiliary_model_retryable_error(error))
+        {
             return self.summarize_with_model(self.model.as_str(), &msgs).await;
         }
         summary
     }
 
     fn context_budget(&self, _messages: &[Message], _tools: &[Value]) -> Option<ContextBudget> {
-        self.context_window_override
+        let main_budget = self
+            .context_window_override
             .map(|w| context_budget_from_window(w))
-            .or_else(|| model_context_budget(self.model.as_str()))
+            .or_else(|| model_context_budget(self.model.as_str()));
+        let summary_model = self.summary_model();
+        let summary_budget = if summary_model.as_ref() == self.model.as_str() {
+            main_budget
+        } else {
+            model_context_budget(summary_model.as_ref()).or(main_budget)
+        };
+        match (main_budget, summary_budget) {
+            (Some(main), Some(summary)) => {
+                if summary.context_window_tokens < main.context_window_tokens {
+                    Some(summary)
+                } else {
+                    Some(main)
+                }
+            }
+            (Some(main), None) => Some(main),
+            (None, Some(summary)) => Some(summary),
+            (None, None) => None,
+        }
     }
 }
 
@@ -391,11 +468,9 @@ impl OpenAiCompatibleBackend {
         }
         let res = request.json(&body).send().await?;
         if !res.status().is_success() {
-            return Err(anyhow!(
-                "API Error at {}: {}",
-                sanitize_url_for_display(&completions_url),
-                redact_secrets(res.text().await?)
-            ));
+            return Err(api_error_from_response(res)
+                .await
+                .context_url(&completions_url));
         }
         let resp_json: Value = res.json().await?;
         Ok(
@@ -410,6 +485,62 @@ impl OpenAiCompatibleBackend {
             .or_else(|| infer_openai_compatible_auxiliary_model(&self.model, self.endpoint_kind))
             .unwrap_or_else(|| Cow::Borrowed(self.model.as_str()))
     }
+}
+
+trait OpenAiApiErrorContext {
+    fn context_url(self, url: &str) -> anyhow::Error;
+}
+
+impl OpenAiApiErrorContext for OpenAiApiError {
+    fn context_url(self, url: &str) -> anyhow::Error {
+        anyhow::Error::new(self).context(format!("API Error at {}", sanitize_url_for_display(url)))
+    }
+}
+
+pub(super) async fn api_error_from_response(response: Response) -> OpenAiApiError {
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    let sanitized_body = redact_secrets(body);
+    let parsed = serde_json::from_str::<Value>(&sanitized_body).ok();
+    let error = parsed.as_ref().and_then(|value| value.get("error"));
+    OpenAiApiError {
+        status: Some(status),
+        sanitized_body,
+        error_type: error
+            .and_then(|value| value.get("type"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        error_code: error
+            .and_then(|value| value.get("code"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+    }
+}
+
+pub(crate) fn is_auxiliary_model_unsupported_error(error: &anyhow::Error) -> bool {
+    let Some(api_error) = error.downcast_ref::<OpenAiApiError>() else {
+        return false;
+    };
+    api_error.status == Some(StatusCode::NOT_FOUND)
+        || matches!(
+            api_error.error_code.as_deref(),
+            Some("model_not_found" | "model_not_supported" | "invalid_model")
+        )
+        || matches!(
+            api_error.error_type.as_deref(),
+            Some("model_not_found" | "model_not_supported" | "invalid_model")
+        )
+}
+
+pub(crate) fn is_auxiliary_model_retryable_error(error: &anyhow::Error) -> bool {
+    is_auxiliary_model_unsupported_error(error) || is_context_window_error(error)
+}
+
+pub(crate) fn is_context_window_error(error: &anyhow::Error) -> bool {
+    let Some(api_error) = error.downcast_ref::<OpenAiApiError>() else {
+        return false;
+    };
+    api_error.error_code.as_deref() == Some("context_length_exceeded")
 }
 
 pub(crate) fn infer_openai_compatible_auxiliary_model(
@@ -429,10 +560,8 @@ fn infer_deepseek_lite_model(model: &str) -> Option<Cow<'_, str>> {
         return None;
     }
     if lower.contains("v4") && lower.ends_with("-pro") {
-        return trimmed
-            .strip_suffix("-pro")
-            .map(|prefix| format!("{prefix}-lite"))
-            .map(Cow::Owned);
+        let prefix = &trimmed[..trimmed.len().saturating_sub("-pro".len())];
+        return Some(Cow::Owned(format!("{prefix}-lite")));
     }
     None
 }
@@ -1197,6 +1326,7 @@ pub struct CodexBackend {
     api_key: Option<SecretString>,
     base_url: String,
     model: String,
+    auxiliary_model: Option<String>,
 }
 
 pub struct GeminiBackend {

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -1,6 +1,7 @@
 mod codex;
 mod usage;
 
+use std::borrow::Cow;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
@@ -37,6 +38,7 @@ pub struct OpenAiCompatibleBackend {
     pub base_url: String,
     pub context_window_override: Option<usize>,
     pub model: String,
+    pub auxiliary_model: Option<String>,
     pub endpoint_kind: OpenAiEndpointKind,
     pub reasoning_effort: Option<String>,
     pub thinking: Option<bool>,
@@ -77,10 +79,18 @@ impl OpenAiCompatibleBackend {
             base_url,
             context_window_override: None,
             model,
+            auxiliary_model: None,
             endpoint_kind,
             reasoning_effort,
             thinking,
         })
+    }
+
+    pub fn with_auxiliary_model(mut self, auxiliary_model: Option<String>) -> Self {
+        self.auxiliary_model = auxiliary_model
+            .map(|model| model.trim().to_string())
+            .filter(|model| !model.is_empty());
+        self
     }
 
     fn endpoint_url(&self, path: &str) -> String {
@@ -344,9 +354,28 @@ impl LlmBackend for OpenAiCompatibleBackend {
             role: "user".to_string(),
             content: json!(instruction),
         });
+        let summary_model = self.summary_model();
+        let summary = self
+            .summarize_with_model(summary_model.as_ref(), &msgs)
+            .await;
+        if summary.is_err() && summary_model.as_ref() != self.model.as_str() {
+            return self.summarize_with_model(self.model.as_str(), &msgs).await;
+        }
+        summary
+    }
+
+    fn context_budget(&self, _messages: &[Message], _tools: &[Value]) -> Option<ContextBudget> {
+        self.context_window_override
+            .map(|w| context_budget_from_window(w))
+            .or_else(|| model_context_budget(self.model.as_str()))
+    }
+}
+
+impl OpenAiCompatibleBackend {
+    async fn summarize_with_model(&self, model: &str, msgs: &[Message]) -> Result<String> {
         let body = build_chat_completion_request_body(
-            &self.model,
-            &msgs,
+            model,
+            msgs,
             &[],
             self.endpoint_kind,
             self.reasoning_effort.as_deref(),
@@ -374,12 +403,38 @@ impl LlmBackend for OpenAiCompatibleBackend {
                 .unwrap_or_default(),
         )
     }
-
-    fn context_budget(&self, _messages: &[Message], _tools: &[Value]) -> Option<ContextBudget> {
-        self.context_window_override
-            .map(|w| context_budget_from_window(w))
-            .or_else(|| model_context_budget(self.model.as_str()))
+    fn summary_model(&self) -> Cow<'_, str> {
+        self.auxiliary_model
+            .as_deref()
+            .map(Cow::Borrowed)
+            .or_else(|| infer_openai_compatible_auxiliary_model(&self.model, self.endpoint_kind))
+            .unwrap_or_else(|| Cow::Borrowed(self.model.as_str()))
     }
+}
+
+pub(crate) fn infer_openai_compatible_auxiliary_model(
+    model: &str,
+    endpoint_kind: OpenAiEndpointKind,
+) -> Option<Cow<'_, str>> {
+    if endpoint_kind != OpenAiEndpointKind::Deepseek {
+        return None;
+    }
+    infer_deepseek_lite_model(model)
+}
+
+fn infer_deepseek_lite_model(model: &str) -> Option<Cow<'_, str>> {
+    let trimmed = model.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    if !lower.contains("deepseek") || lower.contains("lite") {
+        return None;
+    }
+    if lower.contains("v4") && lower.ends_with("-pro") {
+        return trimmed
+            .strip_suffix("-pro")
+            .map(|prefix| format!("{prefix}-lite"))
+            .map(Cow::Owned);
+    }
+    None
 }
 
 pub(super) fn build_chat_completion_request_body(

--- a/src/llm/openai_compatible/codex.rs
+++ b/src/llm/openai_compatible/codex.rs
@@ -7,7 +7,7 @@ use serde_json::{Value, json};
 
 use crate::agent::Message;
 use crate::llm::{ContentBlock, LlmResponse};
-use crate::redaction::{redact_secrets, sanitize_url_for_display};
+use crate::redaction::sanitize_url_for_display;
 
 use super::super::codex_tools_compat::ToolDefinition;
 use super::super::codex_tools_compat::ToolSpec;
@@ -18,7 +18,10 @@ use super::super::shared::{
     ContextBudget, LlmBackend, LlmStreamEvent, collect_assistant_content, model_context_budget,
     next_stream_item_with_idle_timeout, parse_tool_arguments, render_openai_message_content,
 };
-use super::{CodexBackend, OpenAiCompatibleBackend};
+use super::{
+    CodexBackend, OpenAiApiError, OpenAiCompatibleBackend, api_error_from_response,
+    is_auxiliary_model_retryable_error,
+};
 
 impl CodexBackend {
     pub fn new(
@@ -32,8 +35,22 @@ impl CodexBackend {
             api_key,
             base_url,
             model,
+            auxiliary_model: None,
             reasoning_effort,
         })
+    }
+
+    pub fn with_auxiliary_model(mut self, auxiliary_model: Option<String>) -> Self {
+        self.auxiliary_model = auxiliary_model
+            .map(|model| model.trim().to_string())
+            .filter(|model| !model.is_empty());
+        self
+    }
+
+    fn summary_model(&self) -> &str {
+        self.auxiliary_model
+            .as_deref()
+            .unwrap_or(self.model.as_str())
     }
 
     fn endpoint_url(&self, path: &str) -> String {
@@ -44,13 +61,14 @@ impl CodexBackend {
 
     async fn ask_responses_streaming(
         &self,
+        model: &str,
         messages: &[Message],
         tools: &[Value],
         metadata: crate::llm::LlmTurnMetadata,
         mut on_event: Option<&mut (dyn FnMut(LlmStreamEvent) + Send)>,
     ) -> Result<LlmResponse> {
         let body = build_codex_responses_request(
-            &self.model,
+            model,
             messages,
             tools,
             self.reasoning_effort.as_deref(),
@@ -68,11 +86,12 @@ impl CodexBackend {
 
         let res = request.json(&body).send().await?;
         if !res.status().is_success() {
-            return Err(anyhow!(
-                "API Error at {}: {}",
-                sanitize_url_for_display(&responses_url),
-                redact_secrets(res.text().await?)
-            ));
+            return Err(
+                anyhow::Error::new(api_error_from_response(res).await).context(format!(
+                    "API Error at {}",
+                    sanitize_url_for_display(&responses_url)
+                )),
+            );
         }
 
         let mut stream = res.bytes_stream().eventsource();
@@ -118,8 +137,14 @@ impl CodexBackend {
 #[async_trait]
 impl LlmBackend for CodexBackend {
     async fn ask(&self, m: &[Message], t: &[Value]) -> Result<LlmResponse> {
-        self.ask_responses_streaming(m, t, crate::llm::LlmTurnMetadata::default(), None)
-            .await
+        self.ask_responses_streaming(
+            self.model.as_str(),
+            m,
+            t,
+            crate::llm::LlmTurnMetadata::default(),
+            None,
+        )
+        .await
     }
 
     async fn ask_streaming(
@@ -129,6 +154,7 @@ impl LlmBackend for CodexBackend {
         on_event: &mut (dyn FnMut(LlmStreamEvent) + Send),
     ) -> Result<LlmResponse> {
         self.ask_responses_streaming(
+            self.model.as_str(),
             messages,
             tools,
             crate::llm::LlmTurnMetadata::default(),
@@ -144,8 +170,14 @@ impl LlmBackend for CodexBackend {
         metadata: crate::llm::LlmTurnMetadata,
         on_event: &mut (dyn FnMut(LlmStreamEvent) + Send),
     ) -> Result<LlmResponse> {
-        self.ask_responses_streaming(messages, tools, metadata, Some(on_event))
-            .await
+        self.ask_responses_streaming(
+            self.model.as_str(),
+            messages,
+            tools,
+            metadata,
+            Some(on_event),
+        )
+        .await
     }
 
     async fn embed(&self, t: &str) -> Result<Vec<f32>> {
@@ -164,7 +196,32 @@ impl LlmBackend for CodexBackend {
             role: "user".to_string(),
             content: json!(instruction),
         });
-        let response = self.ask(&messages, &[]).await?;
+        let summary_model = self.summary_model();
+        let response = self
+            .ask_responses_streaming(
+                summary_model,
+                &messages,
+                &[],
+                crate::llm::LlmTurnMetadata::default(),
+                None,
+            )
+            .await;
+        let response = if summary_model != self.model.as_str()
+            && response
+                .as_ref()
+                .is_err_and(|error| is_auxiliary_model_retryable_error(error))
+        {
+            self.ask_responses_streaming(
+                self.model.as_str(),
+                &messages,
+                &[],
+                crate::llm::LlmTurnMetadata::default(),
+                None,
+            )
+            .await?
+        } else {
+            response?
+        };
         Ok(response
             .content
             .into_iter()
@@ -177,7 +234,7 @@ impl LlmBackend for CodexBackend {
     }
 
     fn context_budget(&self, messages: &[Message], tools: &[Value]) -> Option<ContextBudget> {
-        model_context_budget(self.model.as_str()).or_else(|| {
+        let main_budget = model_context_budget(self.model.as_str()).or_else(|| {
             let inner = OpenAiCompatibleBackend::new(
                 self.api_key.clone(),
                 self.base_url.clone(),
@@ -185,7 +242,25 @@ impl LlmBackend for CodexBackend {
             )
             .ok()?;
             inner.context_budget(messages, tools)
-        })
+        });
+        let summary_model = self.summary_model();
+        let summary_budget = if summary_model == self.model.as_str() {
+            main_budget
+        } else {
+            model_context_budget(summary_model).or(main_budget)
+        };
+        match (main_budget, summary_budget) {
+            (Some(main), Some(summary)) => {
+                if summary.context_window_tokens < main.context_window_tokens {
+                    Some(summary)
+                } else {
+                    Some(main)
+                }
+            }
+            (Some(main), None) => Some(main),
+            (None, Some(summary)) => Some(summary),
+            (None, None) => None,
+        }
     }
 }
 
@@ -315,15 +390,17 @@ pub(crate) fn apply_codex_stream_event(
             });
             Ok(true)
         }
-        Some("response.failed") => Err(anyhow!(
-            "{}",
-            payload
+        Some("response.failed") => {
+            let Some(error) = payload
                 .get("response")
                 .and_then(|response| response.get("error"))
-                .and_then(|error| error.get("message"))
-                .and_then(Value::as_str)
-                .unwrap_or("response.failed event received")
-        )),
+            else {
+                return Err(anyhow!("response.failed event received"));
+            };
+            Err(anyhow::Error::new(
+                OpenAiApiError::from_response_failed_error(error),
+            ))
+        }
         Some("response.incomplete") => Err(anyhow!(
             "Incomplete response returned, reason: {}",
             payload

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -10,8 +10,9 @@ use super::ollama::{
 };
 use super::openai_compatible::{
     apply_codex_stream_event, build_chat_completion_request_body, build_codex_responses_request,
-    build_streaming_response_content, is_openai_stream_idle_error, merge_streaming_tool_calls,
-    parse_chat_completion_response, parse_codex_response, to_codex_input_items, to_openai_messages,
+    build_streaming_response_content, infer_openai_compatible_auxiliary_model,
+    is_openai_stream_idle_error, merge_streaming_tool_calls, parse_chat_completion_response,
+    parse_codex_response, to_codex_input_items, to_openai_messages,
     to_openai_messages_for_endpoint,
 };
 use super::shared::{
@@ -413,6 +414,23 @@ fn deepseek_reasoner_defaults_preserve_standard_body() {
         body["tools"]
             .as_array()
             .is_some_and(|tools| tools.len() == 1)
+    );
+}
+
+#[test]
+fn deepseek_v4_pro_infers_lite_auxiliary_model() {
+    assert_eq!(
+        infer_openai_compatible_auxiliary_model("deepseek-v4-pro", OpenAiEndpointKind::Deepseek)
+            .as_deref(),
+        Some("deepseek-v4-lite")
+    );
+    assert_eq!(
+        infer_openai_compatible_auxiliary_model("deepseek-v4-lite", OpenAiEndpointKind::Deepseek),
+        None
+    );
+    assert_eq!(
+        infer_openai_compatible_auxiliary_model("deepseek-v4-pro", OpenAiEndpointKind::Custom),
+        None
     );
 }
 

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -1,3 +1,4 @@
+use reqwest::StatusCode;
 use serde_json::json;
 
 use crate::agent::Message;
@@ -9,11 +10,12 @@ use super::ollama::{
     suggest_ollama_num_ctx, to_ollama_messages,
 };
 use super::openai_compatible::{
-    apply_codex_stream_event, build_chat_completion_request_body, build_codex_responses_request,
-    build_streaming_response_content, infer_openai_compatible_auxiliary_model,
-    is_openai_stream_idle_error, merge_streaming_tool_calls, parse_chat_completion_response,
-    parse_codex_response, to_codex_input_items, to_openai_messages,
-    to_openai_messages_for_endpoint,
+    OpenAiApiError, apply_codex_stream_event, build_chat_completion_request_body,
+    build_codex_responses_request, build_streaming_response_content,
+    infer_openai_compatible_auxiliary_model, is_auxiliary_model_retryable_error,
+    is_auxiliary_model_unsupported_error, is_context_window_error, is_openai_stream_idle_error,
+    merge_streaming_tool_calls, parse_chat_completion_response, parse_codex_response,
+    to_codex_input_items, to_openai_messages, to_openai_messages_for_endpoint,
 };
 use super::shared::{
     extract_message_text, model_context_budget, parse_tool_arguments, should_bypass_proxy,
@@ -425,6 +427,11 @@ fn deepseek_v4_pro_infers_lite_auxiliary_model() {
         Some("deepseek-v4-lite")
     );
     assert_eq!(
+        infer_openai_compatible_auxiliary_model("DeepSeek-V4-PRO", OpenAiEndpointKind::Deepseek)
+            .as_deref(),
+        Some("DeepSeek-V4-lite")
+    );
+    assert_eq!(
         infer_openai_compatible_auxiliary_model("deepseek-v4-lite", OpenAiEndpointKind::Deepseek),
         None
     );
@@ -432,6 +439,48 @@ fn deepseek_v4_pro_infers_lite_auxiliary_model() {
         infer_openai_compatible_auxiliary_model("deepseek-v4-pro", OpenAiEndpointKind::Custom),
         None
     );
+}
+
+#[test]
+fn auxiliary_model_fallback_is_limited_to_model_support_errors() {
+    assert!(is_auxiliary_model_unsupported_error(&anyhow::Error::new(
+        OpenAiApiError::for_test(
+            Some(StatusCode::NOT_FOUND),
+            Some("invalid_request_error"),
+            None
+        )
+    )));
+    assert!(is_auxiliary_model_unsupported_error(&anyhow::Error::new(
+        OpenAiApiError::for_test(
+            Some(StatusCode::BAD_REQUEST),
+            Some("invalid_request_error"),
+            Some("model_not_supported")
+        )
+    )));
+    assert!(!is_auxiliary_model_unsupported_error(&anyhow::anyhow!(
+        "API Error: rate limit exceeded"
+    )));
+    assert!(!is_auxiliary_model_unsupported_error(&anyhow::Error::new(
+        OpenAiApiError::for_test(
+            Some(StatusCode::UNAUTHORIZED),
+            Some("invalid_api_key"),
+            None
+        )
+    )));
+}
+
+#[test]
+fn auxiliary_model_retry_uses_structured_context_window_code() {
+    let error = anyhow::Error::new(OpenAiApiError::from_response_failed_error(&json!({
+        "code": "context_length_exceeded",
+        "message": "Your input exceeds the context window of this model."
+    })));
+
+    assert!(is_context_window_error(&error));
+    assert!(is_auxiliary_model_retryable_error(&error));
+    assert!(!is_context_window_error(&anyhow::anyhow!(
+        "Your input exceeds the context window of this model."
+    )));
 }
 
 #[test]
@@ -1492,6 +1541,33 @@ fn codex_stream_response_done_marks_completion() {
 
     assert_eq!(usage.as_ref().unwrap()["input_tokens"], 5);
     assert_eq!(usage.as_ref().unwrap()["output_tokens"], 3);
+}
+
+#[test]
+fn codex_stream_response_failed_preserves_structured_error_code() {
+    let mut output_items = Vec::new();
+    let mut usage = None;
+    let mut streamed_text = String::new();
+    let mut no_delta_callback: Option<&mut (dyn FnMut(LlmStreamEvent) + Send)> = None;
+
+    let error = apply_codex_stream_event(
+        &json!({
+            "type": "response.failed",
+            "response": {
+                "error": {
+                    "code": "context_length_exceeded",
+                    "message": "Your input exceeds the context window of this model."
+                }
+            }
+        }),
+        &mut output_items,
+        &mut usage,
+        &mut streamed_text,
+        &mut no_delta_callback,
+    )
+    .expect_err("response.failed should error");
+
+    assert!(is_context_window_error(&error));
 }
 
 #[test]

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -149,7 +149,8 @@ pub(crate) async fn build_backend_with_progress(
                 kind,
                 config.reasoning_effort.clone(),
                 config.thinking,
-            )?;
+            )?
+            .with_auxiliary_model(config.auxiliary_model.clone());
             if backend.context_budget(&[], &[]).is_none() {
                 backend.context_window_override = fetch_model_context_window(
                     &backend.client,

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -113,18 +113,21 @@ pub(crate) async fn build_backend_with_progress(
     progress: Option<LocalProgressReporter>,
 ) -> Result<Box<dyn LlmBackend>> {
     match config.provider.as_str() {
-        "codex" => Ok(Box::new(CodexBackend::new(
-            config.api_key_secret(),
-            config
-                .base_url
-                .clone()
-                .unwrap_or_else(|| DEFAULT_CODEX_BASE_URL.to_string()),
-            config
-                .model
-                .clone()
-                .unwrap_or_else(|| DEFAULT_CODEX_MODEL.to_string()),
-            config.reasoning_effort.clone(),
-        )?)),
+        "codex" => Ok(Box::new(
+            CodexBackend::new(
+                config.api_key_secret(),
+                config
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_CODEX_BASE_URL.to_string()),
+                config
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_CODEX_MODEL.to_string()),
+                config.reasoning_effort.clone(),
+            )?
+            .with_auxiliary_model(config.auxiliary_model.clone()),
+        )),
         provider if RaraConfig::is_openai_compatible_family(provider) => {
             let kind = config
                 .active_openai_profile_kind()
@@ -174,17 +177,20 @@ pub(crate) async fn build_backend_with_progress(
             ollama_thinking_enabled(config),
             config.num_ctx,
         )?)),
-        "ollama-openai" => Ok(Box::new(OpenAiCompatibleBackend::new(
-            config.api_key_secret(),
-            config
-                .base_url
-                .clone()
-                .unwrap_or_else(|| "http://localhost:11434".to_string()),
-            config
-                .model
-                .clone()
-                .context("Model required for Ollama OpenAI provider")?,
-        )?)),
+        "ollama-openai" => Ok(Box::new(
+            OpenAiCompatibleBackend::new(
+                config.api_key_secret(),
+                config
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "http://localhost:11434".to_string()),
+                config
+                    .model
+                    .clone()
+                    .context("Model required for Ollama OpenAI provider")?,
+            )?
+            .with_auxiliary_model(config.auxiliary_model.clone()),
+        )),
         "gemini" => Ok(Box::new(GeminiBackend {
             api_key: config
                 .api_key

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -62,6 +62,44 @@ fn active_turn_cell_keeps_sections_in_stable_order() {
 }
 
 #[test]
+fn active_turn_cell_renders_pending_approval_without_transcript_entries() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.runtime_phase_detail = Some("resuming after approval".into());
+    app.snapshot
+        .pending_interactions
+        .push(crate::tui::state::PendingInteractionSnapshot {
+            kind: crate::tui::state::InteractionKind::Approval,
+            title: "Pending Approval".into(),
+            summary: "git diff origin/main -- src/context/assembler.rs".into(),
+            options: Vec::new(),
+            note: None,
+            approval: Some(crate::tui::state::PendingApprovalSnapshot {
+                tool_use_id: "toolu_123".into(),
+                command: "git diff origin/main -- src/context/assembler.rs".into(),
+                allow_net: false,
+                payload: Default::default(),
+            }),
+            source: None,
+        });
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains(" Shell Approval "));
+    assert!(rendered.contains("git diff origin/main -- src/context/assembler.rs"));
+    assert!(!rendered.contains("resuming after approval"));
+}
+
+#[test]
 fn active_turn_cell_renders_progress_sections_as_compact_stack() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -362,15 +362,26 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 return lines;
             }
             if turn_live {
-                return RespondingCell::working(
-                    self.app
-                        .runtime_phase_detail
-                        .as_deref()
-                        .unwrap_or("waiting for the current turn to finish"),
-                )
-                .display_lines(width);
+                let has_pending_surface = self.app.active_pending_interaction().is_some()
+                    || self.app.has_queued_follow_up_messages()
+                    || self.app.has_pending_planning_suggestion();
+                if has_pending_surface {
+                    // Continue through the normal section assembly so resumed approval
+                    // and request-input turns can render their actionable cards even
+                    // before the first transcript entry arrives.
+                } else {
+                    return RespondingCell::working(
+                        self.app
+                            .runtime_phase_detail
+                            .as_deref()
+                            .unwrap_or("waiting for the current turn to finish"),
+                    )
+                    .display_lines(width);
+                }
             }
-            return Vec::new();
+            if !turn_live {
+                return Vec::new();
+            }
         }
         let has_tool_activity = current_turn.iter().any(|entry| {
             matches!(

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -239,13 +239,25 @@ pub(super) fn planning_note_lines(message: &str) -> Vec<String> {
 }
 
 pub(super) fn scrub_internal_control_tokens(message: &str) -> String {
-    let message = if message.contains("｜DSML｜") {
-        strip_dsml_control_blocks(message)
+    let had_deepseek_dsml = message.contains("｜DSML｜");
+    let had_deepseek_eos = message.contains("<｜end▁of▁sentence｜>");
+
+    let message = if had_deepseek_dsml {
+        strip_deepseek_v4_dsml_control_blocks(message)
     } else {
         Cow::Borrowed(message)
     };
-    let message = strip_raw_tool_call_markup(message.as_ref());
-    let message = strip_leading_meta_reasoning(message.as_ref());
+    let message =
+        if (had_deepseek_dsml || had_deepseek_eos) && message.trim_start().starts_with("<think>") {
+            strip_deepseek_leading_think_block(&message)
+        } else {
+            message
+        };
+    let message = if had_deepseek_eos {
+        Cow::Owned(message.replace("<｜end▁of▁sentence｜>", ""))
+    } else {
+        message
+    };
     if !message.contains('<') {
         return message.into_owned();
     }
@@ -284,59 +296,26 @@ pub(super) fn scrub_internal_control_tokens(message: &str) -> String {
     cleaned
 }
 
-fn strip_raw_tool_call_markup(message: &str) -> Cow<'_, str> {
-    if !message.contains("tool_call:") {
+fn strip_deepseek_leading_think_block(message: &str) -> Cow<'_, str> {
+    const THINK_OPEN: &str = "<think>";
+    const THINK_CLOSE: &str = "</think>";
+
+    let trimmed = message.trim_start();
+    if !trimmed.starts_with(THINK_OPEN) {
         return Cow::Borrowed(message);
     }
 
-    let mut output = Vec::new();
-    for line in message.lines() {
-        let Some(idx) = line.find("tool_call:") else {
-            output.push(line.trim_end().to_string());
-            continue;
-        };
-        let prefix = line[..idx].trim_end_matches([' ', '|']).trim_end();
-        if !prefix.trim().is_empty() {
-            output.push(prefix.to_string());
-        }
-    }
-
-    Cow::Owned(output.join("\n"))
-}
-
-fn strip_leading_meta_reasoning(message: &str) -> Cow<'_, str> {
-    let lines = message.lines().collect::<Vec<_>>();
-    let mut first_keep = 0usize;
-    while let Some(line) = lines.get(first_keep) {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || looks_like_leaked_meta_reasoning(trimmed) {
-            first_keep += 1;
-            continue;
-        }
-        break;
-    }
-
-    if first_keep == 0 {
+    let block = &trimmed[THINK_OPEN.len()..];
+    let Some(close_idx) = block.find(THINK_CLOSE) else {
         return Cow::Borrowed(message);
-    }
-    Cow::Owned(lines[first_keep..].join("\n"))
+    };
+
+    Cow::Owned(block[close_idx + THINK_CLOSE.len()..].to_string())
 }
 
-fn looks_like_leaked_meta_reasoning(line: &str) -> bool {
-    let lower = line.to_ascii_lowercase();
-    lower.starts_with("the user asked ")
-        || lower.starts_with("the user is asking ")
-        || lower.starts_with("looking at the conversation")
-        || lower.starts_with("i can see that ")
-        || lower.starts_with("i should ")
-        || lower.starts_with("i need to answer ")
-        || lower.starts_with("i'll answer ")
-}
-
-fn strip_dsml_control_blocks(message: &str) -> Cow<'_, str> {
-    const DSML_OPEN: &str = "<｜DSML｜";
+fn strip_deepseek_v4_dsml_control_blocks(message: &str) -> Cow<'_, str> {
+    const TOOL_CALLS_OPEN: &str = "<｜DSML｜tool_calls>";
     const TOOL_CALLS_CLOSE: &str = "</｜DSML｜tool_calls>";
-    const INVOKE_CLOSE: &str = "</｜DSML｜invoke>";
 
     if !message.contains("｜DSML｜") {
         return Cow::Borrowed(message);
@@ -344,32 +323,135 @@ fn strip_dsml_control_blocks(message: &str) -> Cow<'_, str> {
 
     let mut output = String::new();
     let mut rest = message;
-    while let Some(start) = rest.find(DSML_OPEN) {
+    while let Some(start) = rest.find(TOOL_CALLS_OPEN) {
         output.push_str(&rest[..start]);
         let block = &rest[start..];
-        let Some(skip_len) = block
-            .find(TOOL_CALLS_CLOSE)
-            .map(|idx| idx + TOOL_CALLS_CLOSE.len())
-            .or_else(|| block.find(INVOKE_CLOSE).map(|idx| idx + INVOKE_CLOSE.len()))
-        else {
+        let Some(close_idx) = block.find(TOOL_CALLS_CLOSE) else {
             output.push_str(block);
             rest = "";
             break;
         };
+        let skip_len = close_idx + TOOL_CALLS_CLOSE.len();
+        let candidate = &block[..skip_len];
+        if parse_deepseek_v4_dsml_tool_calls_block(candidate).is_none() {
+            output.push_str(candidate);
+            rest = &block[skip_len..];
+            continue;
+        }
         rest = &block[skip_len..];
         if !output.ends_with('\n') && !rest.trim_start().is_empty() {
             output.push('\n');
         }
     }
     output.push_str(rest);
-    if looks_like_orphaned_dsml_payload(output.trim()) {
+    if looks_like_orphaned_deepseek_v4_dsml_payload(output.trim()) {
         Cow::Owned(String::new())
     } else {
         Cow::Owned(output)
     }
 }
 
-fn looks_like_orphaned_dsml_payload(text: &str) -> bool {
+#[derive(Debug, PartialEq, Eq)]
+struct DeepSeekV4DsmlToolCall<'a> {
+    name: &'a str,
+    parameters: Vec<DeepSeekV4DsmlParameter<'a>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct DeepSeekV4DsmlParameter<'a> {
+    name: &'a str,
+    value: &'a str,
+    is_string: bool,
+}
+
+fn parse_deepseek_v4_dsml_tool_calls_block(block: &str) -> Option<Vec<DeepSeekV4DsmlToolCall<'_>>> {
+    const TOOL_CALLS_OPEN: &str = "<｜DSML｜tool_calls>";
+    const TOOL_CALLS_CLOSE: &str = "</｜DSML｜tool_calls>";
+
+    let body = block
+        .strip_prefix(TOOL_CALLS_OPEN)?
+        .strip_suffix(TOOL_CALLS_CLOSE)?;
+    let mut rest = body.trim();
+    let mut calls = Vec::new();
+    while !rest.is_empty() {
+        let (call, next) = parse_deepseek_v4_dsml_invoke(rest)?;
+        calls.push(call);
+        rest = next.trim_start();
+    }
+    if calls.is_empty() { None } else { Some(calls) }
+}
+
+fn parse_deepseek_v4_dsml_invoke(input: &str) -> Option<(DeepSeekV4DsmlToolCall<'_>, &str)> {
+    const INVOKE_OPEN: &str = "<｜DSML｜invoke";
+    const INVOKE_CLOSE: &str = "</｜DSML｜invoke>";
+
+    let input = input.trim_start();
+    if !input.starts_with(INVOKE_OPEN) {
+        return None;
+    }
+    let open_end = input.find('>')?;
+    let open_tag = &input[..open_end];
+    let name = parse_deepseek_v4_dsml_quoted_attr(open_tag, "name")?;
+    if name.is_empty() {
+        return None;
+    }
+
+    let after_open = &input[open_end + 1..];
+    let close_start = after_open.find(INVOKE_CLOSE)?;
+    let mut body = after_open[..close_start].trim();
+    let mut parameters = Vec::new();
+    while !body.is_empty() {
+        let (parameter, next) = parse_deepseek_v4_dsml_parameter(body)?;
+        parameters.push(parameter);
+        body = next.trim_start();
+    }
+    let after_close = &after_open[close_start + INVOKE_CLOSE.len()..];
+    Some((DeepSeekV4DsmlToolCall { name, parameters }, after_close))
+}
+
+fn parse_deepseek_v4_dsml_parameter(input: &str) -> Option<(DeepSeekV4DsmlParameter<'_>, &str)> {
+    const PARAM_OPEN: &str = "<｜DSML｜parameter";
+    const PARAM_CLOSE: &str = "</｜DSML｜parameter>";
+
+    let input = input.trim_start();
+    if !input.starts_with(PARAM_OPEN) {
+        return None;
+    }
+    let open_end = input.find('>')?;
+    let open_tag = &input[..open_end];
+    let name = parse_deepseek_v4_dsml_quoted_attr(open_tag, "name")?;
+    if name.is_empty() {
+        return None;
+    }
+    let is_string = match parse_deepseek_v4_dsml_quoted_attr(open_tag, "string") {
+        Some("true") => true,
+        Some("false") | None => false,
+        Some(_) => return None,
+    };
+
+    let after_open = &input[open_end + 1..];
+    let close_start = after_open.find(PARAM_CLOSE)?;
+    let value = &after_open[..close_start];
+    let after_close = &after_open[close_start + PARAM_CLOSE.len()..];
+    Some((
+        DeepSeekV4DsmlParameter {
+            name,
+            value,
+            is_string,
+        },
+        after_close,
+    ))
+}
+
+fn parse_deepseek_v4_dsml_quoted_attr<'a>(tag: &'a str, name: &str) -> Option<&'a str> {
+    let needle = format!("{name}=\"");
+    let start = tag.find(&needle)? + needle.len();
+    let rest = &tag[start..];
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}
+
+fn looks_like_orphaned_deepseek_v4_dsml_payload(text: &str) -> bool {
     let lines = text
         .lines()
         .map(str::trim)

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -173,25 +173,110 @@ fn scrub_internal_control_tokens_removes_dsml_tool_blocks() {
 }
 
 #[test]
-fn scrub_internal_control_tokens_removes_raw_tool_call_markup() {
+fn scrub_internal_control_tokens_removes_structured_dsml_tool_block_with_json_parameter() {
     let cleaned = scrub_internal_control_tokens(
-        "Now update docs. | tool_call: read_file arguments: {\"path\":\"docs/todo.md\"} | tool_call: read_file arguments: {\"path\":\"docs/features/README.md\"}",
+        "Before\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read_file\">\n<｜DSML｜parameter name=\"options\" string=\"false\">{\"path\":\"src/lib.rs\",\"limit\":20}</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nAfter",
     );
 
-    assert_eq!(cleaned.trim(), "Now update docs.");
-    assert!(!cleaned.contains("tool_call:"));
-    assert!(!cleaned.contains("arguments:"));
+    assert_eq!(cleaned.trim(), "Before\n\nAfter");
+    assert!(!cleaned.contains("read_file"));
 }
 
 #[test]
-fn scrub_internal_control_tokens_drops_leaked_meta_reasoning_prefix() {
+fn scrub_internal_control_tokens_removes_dsml_after_thinking_like_deepseek_completion() {
     let cleaned = scrub_internal_control_tokens(
-        "The user asked \"was it opened?\"\nLooking at the conversation, PR #147 was created.\nI should confirm this briefly.\n\nPR #147 was created: https://github.com/hawkingrei/rara/pull/147",
+        "<think>The user wants weather. I should use the get_weather tool.</think>\n\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"get_weather\">\n<｜DSML｜parameter name=\"location\" string=\"true\">Beijing</｜DSML｜parameter>\n<｜DSML｜parameter name=\"unit\" string=\"true\">celsius</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls><｜end▁of▁sentence｜>",
+    );
+
+    assert_eq!(cleaned.trim(), "");
+    assert!(!cleaned.contains("<think>"));
+    assert!(!cleaned.contains("</think>"));
+    assert!(!cleaned.contains("<｜DSML｜tool_calls>"));
+    assert!(!cleaned.contains("<｜DSML｜invoke"));
+    assert!(!cleaned.contains("<｜DSML｜parameter"));
+    assert!(!cleaned.contains("<｜end▁of▁sentence｜>"));
+}
+
+#[test]
+fn scrub_internal_control_tokens_preserves_malformed_think_block() {
+    let cleaned = scrub_internal_control_tokens(
+        "The literal malformed marker <think> has no closing tag in this answer.",
     );
 
     assert_eq!(
-        cleaned.trim(),
-        "PR #147 was created: https://github.com/hawkingrei/rara/pull/147"
+        cleaned,
+        "The literal malformed marker <think> has no closing tag in this answer."
+    );
+}
+
+#[test]
+fn scrub_internal_control_tokens_preserves_literal_balanced_think_text() {
+    let cleaned = scrub_internal_control_tokens("Use <think>inner</think> in this XML example.");
+
+    assert_eq!(cleaned, "Use <think>inner</think> in this XML example.");
+}
+
+#[test]
+fn scrub_internal_control_tokens_removes_dsml_block_with_multiple_invokes() {
+    let cleaned = scrub_internal_control_tokens(
+        "Before\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read_file\">\n<｜DSML｜parameter name=\"path\" string=\"true\">src/lib.rs</｜DSML｜parameter>\n</｜DSML｜invoke>\n<｜DSML｜invoke name=\"list_files\">\n<｜DSML｜parameter name=\"path\" string=\"true\">src</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nAfter",
+    );
+
+    assert_eq!(cleaned.trim(), "Before\n\nAfter");
+    assert!(!cleaned.contains("read_file"));
+    assert!(!cleaned.contains("list_files"));
+}
+
+#[test]
+fn scrub_internal_control_tokens_removes_dsml_tool_block_without_string_attribute() {
+    let input = "Before\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read_file\">\n<｜DSML｜parameter name=\"options\">{\"path\":\"src/lib.rs\"}</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nAfter";
+    let cleaned = scrub_internal_control_tokens(input);
+
+    assert_eq!(cleaned.trim(), "Before\n\nAfter");
+    assert!(!cleaned.contains("read_file"));
+}
+
+#[test]
+fn scrub_internal_control_tokens_removes_dsml_tool_block_with_duplicate_parameter_names() {
+    let input = "Before\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read_file\">\n<｜DSML｜parameter name=\"path\" string=\"true\">src/lib.rs</｜DSML｜parameter>\n<｜DSML｜parameter name=\"path\" string=\"true\">src/main.rs</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nAfter";
+    let cleaned = scrub_internal_control_tokens(input);
+
+    assert_eq!(cleaned.trim(), "Before\n\nAfter");
+    assert!(!cleaned.contains("read_file"));
+}
+
+#[test]
+fn scrub_internal_control_tokens_preserves_literal_tool_call_text() {
+    let cleaned =
+        scrub_internal_control_tokens("The literal marker `tool_call:` appears in this log line.");
+
+    assert_eq!(
+        cleaned,
+        "The literal marker `tool_call:` appears in this log line."
+    );
+}
+
+#[test]
+fn scrub_internal_control_tokens_preserves_raw_tool_call_text() {
+    let cleaned = scrub_internal_control_tokens(
+        "Here is the raw log: `| tool_call: read_file arguments: {\"path\":\"src/lib.rs\"}`",
+    );
+
+    assert_eq!(
+        cleaned,
+        "Here is the raw log: `| tool_call: read_file arguments: {\"path\":\"src/lib.rs\"}`"
+    );
+}
+
+#[test]
+fn scrub_internal_control_tokens_preserves_single_meta_intro_line() {
+    let cleaned = scrub_internal_control_tokens(
+        "The user asked a good question about plan mode.\nThis answer explains the runtime boundary.",
+    );
+
+    assert_eq!(
+        cleaned,
+        "The user asked a good question about plan mode.\nThis answer explains the runtime boundary."
     );
 }
 


### PR DESCRIPTION
## Summary

- Plan compaction at API-round boundaries instead of raw history item counts.
- Preserve post-compact context in stable stages: boundary metadata, summary, carry-over, and retained recent rounds.
- Add `auxiliary_model` config support for compact helper work, with legacy `utility_model` read compatibility and main-model fallback.
- Document the compact worker contract, prefix-stability rules, and follow-up context-compression tasks.

## Tests

- `cargo fmt`
- `cargo check`
- `cargo check -p rara-config`
- `cargo test compaction -- --nocapture`
- `cargo test deepseek_v4_pro_infers_lite_utility_model -- --nocapture`
- `cargo test deepseek_v4_pro_infers_lite_auxiliary_model -- --nocapture` attempted, but the full test binary link failed with `No space left on device` before cleaning `target`.
- `cargo test -p rara-config auxiliary_model_reads_legacy_utility_model_key -- --nocapture`
- `cargo test -p rara-config provider_switch_restores_provider_specific_settings -- --nocapture`

## Notes

- `target` was cleaned after the disk filled during test binary linking.
