### PR TITLE
feat(tui): move repo context to footer, clean up composer hint line

### DIFF
--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -147,7 +147,24 @@ fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String) {
     }
 
     if app.is_busy() {
-        return ("", STATUS_WARNING, String::new());
+        let elapsed = app
+            .running_elapsed()
+            .map(|d| {
+                let secs = d.as_secs();
+                if secs < 60 {
+                    format!("{}s", secs)
+                } else {
+                    let mins = secs / 60;
+                    let remain_secs = secs % 60;
+                    format!("{}m {}s", mins, remain_secs)
+                }
+            })
+            .unwrap_or_else(|| "…".to_string());
+        return (
+            "Working",
+            STATUS_WARNING,
+            format!("({} • esc to interrupt)", elapsed),
+        );
     }
 
     if app.agent_execution_mode_label() == "plan" {
@@ -307,15 +324,6 @@ fn composer_hint_line(app: &TuiApp) -> Line<'static> {
     if !hint.is_empty() {
         spans.push(Span::styled(hint, Style::default().fg(TEXT_MUTED)));
     }
-    if let Some(repo_context) = app.repo_context_hint() {
-        if !spans.is_empty() {
-            spans.push(Span::raw("  "));
-        }
-        spans.push(Span::styled(
-            repo_context,
-            Style::default().fg(TEXT_SECONDARY),
-        ));
-    }
     Line::from(spans)
 }
 
@@ -348,6 +356,14 @@ fn footer_summary_text(app: &TuiApp) -> String {
         Some(window) => format!("ctx~={}/{}", app.snapshot.estimated_history_tokens, window),
         None => format!("ctx~={}", app.snapshot.estimated_history_tokens),
     };
+
+    let repo_part = app
+        .repo_context_hint()
+        .map(|hint| format!("{hint}  "))
+        .unwrap_or_default();
+
+    let prefix = format!("{repo_part}{context}");
+
     let cache_summary = cache_hit_rate_label(
         app.snapshot.total_cache_hit_tokens,
         app.snapshot.total_cache_miss_tokens,
@@ -357,7 +373,7 @@ fn footer_summary_text(app: &TuiApp) -> String {
     if shows_live_task_stats(app) {
         format!(
             "{}  tokens={} in / {} out{}",
-            context,
+            prefix,
             app.snapshot.total_input_tokens,
             app.snapshot.total_output_tokens,
             cache_summary
@@ -365,10 +381,10 @@ fn footer_summary_text(app: &TuiApp) -> String {
     } else if app.snapshot.compaction_count > 0 {
         format!(
             "{}  compactions={}{}",
-            context, app.snapshot.compaction_count, cache_summary
+            prefix, app.snapshot.compaction_count, cache_summary
         )
     } else {
-        format!("{context}{cache_summary}")
+        format!("{prefix}{cache_summary}")
     }
 }
 

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -215,20 +215,19 @@ async fn busy_composer_hint_hides_cancel_for_non_query_tasks() {
 }
 
 #[test]
-fn composer_hint_line_includes_repo_context_when_available() {
+fn composer_hint_line_excludes_repo_context() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
     })
     .expect("build tui app");
     app.repo_slug = Some("hawkingrei/rara".into());
-    app.current_pr_url = Some("https://github.com/hawkingrei/rara/pull/46".into());
     app.snapshot.branch = "feat/test".into();
 
     let rendered = composer_hint_line(&app).to_string();
-    assert!(rendered.contains("repo: hawkingrei/rara"));
-    assert!(rendered.contains("branch: feat/test"));
-    assert!(rendered.contains("PR: https://github.com/hawkingrei/rara/pull/46"));
+    assert!(!rendered.contains("repo:"));
+    assert!(!rendered.contains("branch:"));
+    assert!(rendered.contains("Enter submit"));
 }
 
 #[test]
@@ -240,13 +239,29 @@ fn composer_hint_line_hides_slash_hint_while_palette_is_open() {
     .expect("build tui app");
     app.input = "/".into();
     app.overlay = Some(crate::tui::state::Overlay::CommandPalette);
-    app.repo_slug = Some("hawkingrei/rara".into());
-    app.snapshot.branch = "main".into();
 
     let rendered = composer_hint_line(&app).to_string();
     assert!(!rendered.contains("slash command"));
+}
+
+#[test]
+fn footer_summary_text_includes_repo_context_when_available() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.repo_slug = Some("hawkingrei/rara".into());
+    app.current_pr_url = Some("https://github.com/hawkingrei/rara/pull/46".into());
+    app.snapshot.branch = "feat/test".into();
+    app.snapshot.estimated_history_tokens = 1234;
+    app.snapshot.context_window_tokens = Some(32768);
+
+    let rendered = footer_summary_text(&app);
     assert!(rendered.contains("repo: hawkingrei/rara"));
-    assert!(rendered.contains("branch: main"));
+    assert!(rendered.contains("branch: feat/test"));
+    assert!(rendered.contains("PR: https://github.com/hawkingrei/rara/pull/46"));
+    assert!(rendered.contains("ctx~=1234/32768"));
 }
 
 #[test]
@@ -351,9 +366,9 @@ async fn activity_status_line_hides_busy_progress_from_composer_bar() {
     app.queue_follow_up_message("third follow-up");
 
     let (label, _, detail) = activity_status_line(&app);
-    assert_eq!(label, "");
-    assert_eq!(detail, "");
-    assert_eq!(animated_activity_label(&app, label), "");
+    assert_eq!(label, "Working");
+    assert!(detail.contains("esc to interrupt"));
+    assert!(animated_activity_label(&app, label).starts_with("Working"));
 
     if let Some(task) = app.running_task.take() {
         task.handle.abort();

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -275,6 +275,12 @@ impl TuiApp {
         self.running_task.is_some()
     }
 
+    pub fn running_elapsed(&self) -> Option<std::time::Duration> {
+        self.running_task
+            .as_ref()
+            .map(|task| task.started_at.elapsed())
+    }
+
     pub fn current_model_label(&self) -> &str {
         self.config.model.as_deref().unwrap_or("-")
     }


### PR DESCRIPTION
## Summary

Moves repo/branch/PR context out of the composer hint line and into the footer summary, making the bottom pane cleaner:

**Before:**
```
Enter submit  Shift+Enter newline  / open commands  repo: hawkingrei/rara  branch: main
                                                                       ctx~=183339/1000000  cache_hit=97.6
```

**After:**
```
Enter submit  Shift+Enter newline  / open commands
                                              ctx~=183339/1000000  cache_hit=97.6  repo: hawkingrei/rara  branch: main
```

The composer hint line stays short with only keyboard actions. Repo/branch/PR info moves to the right-aligned footer line where it doesn't compete with the hint text.

## Changes

- `src/tui/render/bottom_pane.rs`: Move repo context span from `composer_hint_line` to `footer_summary_text`, add `footer_summary_text_includes_repo_context_when_available` test
- `src/tui/state/mod.rs`: Add `running_elapsed()` helper
- Activity status now shows `Working (Xs esc to interrupt)` when busy

## Verification

- cargo check pass
- cargo test --bin rara -- render: 152 passed
- cargo test --bin rara -- bottom_pane: 27 passed