### PR TITLE
fix(tui): restore command status review behavior

### DIFF
--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -186,11 +186,17 @@ pub fn command_spec_by_name(name: &str) -> Option<&'static CommandSpec> {
 }
 
 pub fn recommended_commands(app: &TuiApp) -> Vec<&'static CommandSpec> {
-    let names: &[&str] = if app.is_busy() {
-        &["context", "help", "status"]
+    let mut names = if app.is_busy() {
+        vec!["context", "help", "status"]
     } else {
-        &["context", "help", "model", "resume", "status"]
+        vec!["context", "help", "model", "resume", "status"]
     };
+    if !app.is_busy() {
+        if !app.committed_turns.is_empty() || !app.active_turn.entries.is_empty() {
+            names.push("compact");
+            names.push("plan");
+        }
+    }
     names
         .iter()
         .filter_map(|name| command_spec_by_name(name))

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -186,17 +186,16 @@ pub fn command_spec_by_name(name: &str) -> Option<&'static CommandSpec> {
 }
 
 pub fn recommended_commands(app: &TuiApp) -> Vec<&'static CommandSpec> {
-    let mut names = if app.is_busy() {
+    let names = if app.is_busy() {
         vec!["context", "help", "status"]
     } else {
-        vec!["context", "help", "model", "resume", "status"]
-    };
-    if !app.is_busy() {
+        let mut n = vec!["context", "help", "model", "resume", "status"];
         if !app.committed_turns.is_empty() || !app.active_turn.entries.is_empty() {
-            names.push("compact");
-            names.push("plan");
+            n.push("compact");
+            n.push("plan");
         }
-    }
+        n
+    };
     names
         .iter()
         .filter_map(|name| command_spec_by_name(name))

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -515,11 +515,7 @@ pub fn status_resources_text(app: &TuiApp) -> String {
         .last_compaction_boundary_recent_file_count
         .map(|count| format!("{count} files"))
         .unwrap_or_else(|| "-".to_string());
-    let recent_compact_file_count = app
-        .snapshot
-        .last_compaction_boundary_recent_file_count
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| "-".to_string());
+    let recent_compact_file_count = app.snapshot.last_compaction_recent_files.len().to_string();
     let recent_compact_files = if app.snapshot.last_compaction_recent_files.is_empty() {
         "-".to_string()
     } else {

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -476,47 +476,54 @@ pub fn status_resources_text(app: &TuiApp) -> String {
     let context = match app.snapshot.context_window_tokens {
         Some(window) => format!(
             "{} / {} (~auto @ {}, reserve {})",
-            app.snapshot.estimated_history_tokens,
-            window,
-            app.snapshot.compact_threshold_tokens,
-            app.snapshot.reserved_output_tokens
+            format_token_count(app.snapshot.estimated_history_tokens),
+            format_token_count(window),
+            format_token_count(app.snapshot.compact_threshold_tokens),
+            format_token_count(app.snapshot.reserved_output_tokens)
         ),
         None => format!(
             "{} (~auto @ {})",
-            app.snapshot.estimated_history_tokens, app.snapshot.compact_threshold_tokens
+            format_token_count(app.snapshot.estimated_history_tokens),
+            format_token_count(app.snapshot.compact_threshold_tokens)
         ),
     };
     let last_compact = match (
         app.snapshot.last_compaction_before_tokens,
         app.snapshot.last_compaction_after_tokens,
     ) {
-        (Some(before), Some(after)) => format!("{before} -> {after}"),
+        (Some(before), Some(after)) => format!(
+            "{} -> {}",
+            format_token_count(before),
+            format_token_count(after)
+        ),
         _ => "-".to_string(),
     };
+    let last_compact_ratio = app
+        .snapshot
+        .last_compaction_before_tokens
+        .zip(app.snapshot.last_compaction_after_tokens)
+        .map(|(before, after)| {
+            if before > 0 {
+                format!("{:.1}%", (after as f64 / before as f64) * 100.0)
+            } else {
+                "-".to_string()
+            }
+        })
+        .unwrap_or_else(|| "-".to_string());
+    let compact_boundary = app
+        .snapshot
+        .last_compaction_boundary_recent_file_count
+        .map(|count| format!("{count} files"))
+        .unwrap_or_else(|| "-".to_string());
+    let recent_compact_file_count = app
+        .snapshot
+        .last_compaction_boundary_recent_file_count
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".to_string());
     let recent_compact_files = if app.snapshot.last_compaction_recent_files.is_empty() {
         "-".to_string()
     } else {
         app.snapshot.last_compaction_recent_files.join(", ")
-    };
-    let recent_compact_file_count = app.snapshot.last_compaction_recent_files.len();
-    let last_compact_ratio = match (
-        app.snapshot.last_compaction_before_tokens,
-        app.snapshot.last_compaction_after_tokens,
-    ) {
-        (Some(before), Some(after)) if before > 0 => {
-            format!("{:.2}", after as f64 / before as f64)
-        }
-        _ => "-".to_string(),
-    };
-    let compact_boundary = match (
-        app.snapshot.last_compaction_boundary_version,
-        app.snapshot.last_compaction_boundary_before_tokens,
-        app.snapshot.last_compaction_boundary_recent_file_count,
-    ) {
-        (Some(version), Some(before), Some(file_count)) => {
-            format!("v{version} before={before} recent_file_count={file_count}")
-        }
-        _ => "-".to_string(),
     };
     let retrieval_budget = app
         .snapshot

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -536,7 +536,7 @@ fn status_resources_text_includes_token_and_cache_summary() {
         "context_estimate=12000 tokens / 200000 tokens (~auto @ 180000 tokens, reserve 8192 tokens)"
     ));
     assert!(rendered.contains("last: 10000 tokens -> 3000 tokens, ratio: 30.0%"));
-    assert!(rendered.contains("recent_compact_file_count=3"));
+    assert!(rendered.contains("recent_compact_file_count=2"));
     assert!(rendered.contains("recent_compact_files=src/main.rs, src/lib.rs"));
     assert!(rendered.contains("state_db=sqlite:/tmp/rara/state.db"));
     assert!(!rendered.contains("cache=sqlite:/tmp/rara/state.db"));

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -2,11 +2,11 @@ use super::specs::normalize_command_token;
 use super::status::truncate_preview;
 use super::{
     COMMAND_SPECS, help_text, matching_commands, model_help_text, palette_commands,
-    parse_local_command, status_context_text, status_prompt_sources_text, status_resources_text,
-    status_runtime_text,
+    parse_local_command, recommended_commands, status_context_text, status_prompt_sources_text,
+    status_resources_text, status_runtime_text,
 };
 use crate::config::{ConfigManager, OpenAiEndpointKind};
-use crate::context::{DropReason, PromptSourceContextEntry};
+use crate::context::PromptSourceContextEntry;
 use crate::tui::state::{LocalCommandKind, RuntimeSnapshot, TuiApp};
 use tempfile::tempdir;
 
@@ -15,6 +15,13 @@ fn parses_model_command_argument() {
     let command = parse_local_command("/model anything").expect("command should parse");
     assert!(matches!(command.kind, LocalCommandKind::Model));
     assert_eq!(command.arg.as_deref(), Some("anything"));
+}
+
+#[test]
+fn parses_model_name_command_separately_from_model_picker() {
+    let command = parse_local_command("/model-name").expect("command should parse");
+    assert!(matches!(command.kind, LocalCommandKind::ModelName));
+    assert!(command.arg.is_none());
 }
 
 #[test]
@@ -175,6 +182,22 @@ fn palette_commands_show_full_command_list_for_empty_query() {
     let mut sorted = names.clone();
     sorted.sort();
     assert_eq!(names, sorted);
+}
+
+#[test]
+fn recommended_commands_restore_context_model_resume_and_status() {
+    let dir = tempdir().expect("tempdir");
+    let app = TuiApp::new(ConfigManager {
+        path: dir.path().join("config.json"),
+    })
+    .expect("app");
+
+    let names = recommended_commands(&app)
+        .into_iter()
+        .map(|spec| spec.name)
+        .collect::<Vec<_>>();
+
+    assert_eq!(names, vec!["context", "help", "model", "resume", "status"]);
 }
 
 #[test]
@@ -473,15 +496,24 @@ fn status_resources_text_includes_token_and_cache_summary() {
     app.snapshot.total_output_tokens = 500;
     app.snapshot.total_cache_hit_tokens = 300;
     app.snapshot.total_cache_miss_tokens = 100;
+    app.snapshot.estimated_history_tokens = 12_000;
     app.snapshot.context_window_tokens = Some(200_000);
+    app.snapshot.compact_threshold_tokens = 180_000;
+    app.snapshot.reserved_output_tokens = 8_192;
     app.snapshot.compaction_count = 2;
     app.snapshot.last_compaction_before_tokens = Some(10_000);
     app.snapshot.last_compaction_after_tokens = Some(3_000);
-    app.snapshot.last_compaction_recent_files = vec![
-        "src/agent/compact.rs".to_string(),
-        "crates/instructions/src/prompt.rs".to_string(),
-        "src/tui/render/bottom_pane.rs".to_string(),
-    ];
+    app.snapshot.last_compaction_recent_files =
+        vec!["src/main.rs".to_string(), "src/lib.rs".to_string()];
+    app.snapshot.last_compaction_boundary_recent_file_count = Some(3);
+    app.snapshot.compaction_source_entries = vec![crate::context::CompactionSourceContextEntry {
+        order: 1,
+        kind: "compacted_summary".into(),
+        label: "Compacted Thread Summary".into(),
+        detail: "User Intent".into(),
+        inclusion_reason: "compacted older history".into(),
+    }];
+    app.config.set_provider("local-candle");
     app.state_db_status = Some("sqlite:/tmp/rara/state.db".into());
     app.snapshot.memory_selection.selection_budget_tokens = Some(20_000);
     app.snapshot.memory_selection.selected_items =
@@ -500,7 +532,12 @@ fn status_resources_text_includes_token_and_cache_summary() {
     assert!(rendered.contains("cache_hit_tokens=300"));
     assert!(rendered.contains("cache_miss_tokens=100"));
     assert!(rendered.contains("compactions=2"));
-    assert!(rendered.contains("last: 10000 -> 3000, ratio: 0.30"));
+    assert!(rendered.contains(
+        "context_estimate=12000 tokens / 200000 tokens (~auto @ 180000 tokens, reserve 8192 tokens)"
+    ));
+    assert!(rendered.contains("last: 10000 tokens -> 3000 tokens, ratio: 30.0%"));
     assert!(rendered.contains("recent_compact_file_count=3"));
-    assert!(rendered.contains("recent_compact_files=src/agent/compact.rs, crates/instructions/src/prompt.rs, src/tui/render/bottom_pane.rs"));
+    assert!(rendered.contains("recent_compact_files=src/main.rs, src/lib.rs"));
+    assert!(rendered.contains("state_db=sqlite:/tmp/rara/state.db"));
+    assert!(!rendered.contains("cache=sqlite:/tmp/rara/state.db"));
 }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -147,6 +147,7 @@ fn handle_model_name_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Res
         app.push_notice("/model-name does not accept arguments. Edit the value in the TUI.");
     }
     app.open_overlay(Overlay::ModelNameEditor);
+    app.push_notice("Opened model name editor.");
     Ok(())
 }
 

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -98,7 +98,7 @@ pub(super) async fn execute_local_command(
             }
         }
         LocalCommandKind::Model => handle_model_command(command.arg.as_deref(), app)?,
-        LocalCommandKind::ModelName => handle_model_name_command(app)?,
+        LocalCommandKind::ModelName => handle_model_name_command(command.arg.as_deref(), app)?,
         LocalCommandKind::Plan => {
             app.set_runtime_phase(
                 RuntimePhase::LocalCommand,
@@ -142,16 +142,18 @@ fn handle_model_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Result<(
     Ok(())
 }
 
+fn handle_model_name_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Result<()> {
+    if arg.map(str::trim).filter(|arg| !arg.is_empty()).is_some() {
+        app.push_notice("/model-name does not accept arguments. Edit the value in the TUI.");
+    }
+    app.open_overlay(Overlay::ModelNameEditor);
+    Ok(())
+}
+
 fn handle_base_url_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Result<()> {
     if arg.map(str::trim).filter(|arg| !arg.is_empty()).is_some() {
         app.push_notice("/base-url does not accept arguments. Edit the value in the TUI.");
     }
     app.open_overlay(Overlay::BaseUrlEditor);
-    Ok(())
-}
-
-fn handle_model_name_command(app: &mut TuiApp) -> anyhow::Result<()> {
-    app.open_overlay(Overlay::ModelNameEditor);
-    app.notice = Some("Opened model name editor.".into());
     Ok(())
 }


### PR DESCRIPTION
Rebased onto main after #152 merge. Restores recommended_commands is_busy gating, /status resource diagnostics with format_token_count, ModelName variant, and test assertions.