### PR TITLE
fix: repair malformed plan exits

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -741,7 +741,11 @@ fn resolve_sections(sections: Vec<PromptSection>) -> Vec<String> {
 }
 
 fn plan_mode_prompt() -> String {
-    PLAN_MODE_PROMPT.clone()
+    let mut prompt = PLAN_MODE_PROMPT.clone();
+    prompt.push_str(
+        "\n- Markdown headings such as '## Plan', plain bullets, or prose like 'Plan ready' are not valid substitutes for a <proposed_plan> block.\n- Prefer the API-structured path: call exit_plan_mode with a proposed_plan object containing summary, steps, and validation fields.\n- If structured tool arguments are unavailable, the <proposed_plan> artifact should use this structure exactly:\n<proposed_plan>\nsummary: One concise sentence describing the implementation.\nsteps:\n- [pending] First concrete implementation step\n- [pending] Second concrete implementation step\nvalidation:\n- Focused test or command to run\n</proposed_plan>",
+    );
+    prompt
 }
 
 fn default_compact_prompt() -> String {
@@ -980,6 +984,13 @@ mod tests {
             "The opening <proposed_plan> tag and closing </proposed_plan> tag must both appear"
         ));
         assert!(prompt.contains("Do not ask 'should I proceed?'"));
+        assert!(prompt.contains("Markdown headings such as '## Plan'"));
+        assert!(prompt.contains("not valid substitutes for a <proposed_plan> block"));
+        assert!(prompt.contains("Prefer the API-structured path"));
+        assert!(prompt.contains("proposed_plan object containing summary, steps, and validation"));
+        assert!(prompt.contains("summary: One concise sentence"));
+        assert!(prompt.contains("steps:\n- [pending] First concrete implementation step"));
+        assert!(prompt.contains("validation:\n- Focused test or command to run"));
     }
 
     #[test]

--- a/docs/features/planning-mode.md
+++ b/docs/features/planning-mode.md
@@ -30,7 +30,11 @@ RARA planning mode is a read-only collaboration mode for non-trivial tasks.
 - planning-mode progress updates should stay short and grounded in inspected code instead of narrating each next file-by-file action;
 - planning mode must not describe file edits, patches, or implementation steps as if they are already happening.
 - plan approval must not be requested in ordinary prose; the model must use `<proposed_plan>` followed by `exit_plan_mode` when the plan is ready, or `<request_user_input>` when a key decision still blocks it.
-- `exit_plan_mode` requires a complete `<proposed_plan>...</proposed_plan>` block in the same assistant response. A message that opens `<proposed_plan>` without the exact closing `</proposed_plan>` tag is treated as malformed and must not enter approval.
+- `exit_plan_mode` should submit plans through structured tool arguments: `proposed_plan.summary`, `proposed_plan.steps`, and `proposed_plan.validation`.
+- For OpenAI native Chat Completions and Responses tool calls, RARA marks strict-compatible tool schemas with `strict: true`, so providers that implement Structured Outputs can enforce the `proposed_plan` argument shape at the API layer.
+- `exit_plan_mode` also accepts a complete `<proposed_plan>...</proposed_plan>` block in the same assistant response as a text fallback. A message that opens `<proposed_plan>` without the exact closing `</proposed_plan>` tag is treated as malformed and must not enter approval.
+- Markdown headings such as `## Plan`, plain bullets, and prose like "plan ready" are not valid plan submissions. They may be rendered as ordinary assistant text, but they must not trigger plan approval.
+- A structured proposed plan should use `summary:`, `steps:`, and `validation:` fields. Runtime treats only entries under `steps:` as executable plan steps; validation bullets are preserved as plan explanation instead of being mixed into the step list.
 
 Plain narration or status updates are valid only when they are the final answer to a research, review, or planning-advice task. They must not be treated as approval requests.
 
@@ -51,9 +55,12 @@ Plain narration or status updates are valid only when they are the final answer 
 When planning mode needs to continue, runtime records a structured continuation message with one of these phases:
 
 - `plan_continuation_required`
+- `plan_exit_repair_required`
 - `plan_approved`
 
 `plan_continuation_required` means the agent explicitly requested another read-only inspection pass before answering or requesting implementation approval.
+
+`plan_exit_repair_required` means the model called `exit_plan_mode` without a complete same-turn `<proposed_plan>...</proposed_plan>` block. The runtime records a structured repair instruction and gives the model one immediate retry. The retry must either submit a proper `<proposed_plan>` block followed by `exit_plan_mode`, or provide a final planning answer without calling `exit_plan_mode`.
 
 Execute-mode repository inspection follows the same structured continuation boundary: prior inspection evidence is not enough to keep a turn open after a no-tool model response. The model must either call another inspection tool or emit `<continue_inspection/>`.
 

--- a/docs/journal/2026-05-03-plan-exit-repair.md
+++ b/docs/journal/2026-05-03-plan-exit-repair.md
@@ -1,0 +1,38 @@
+# 2026-05-03 Plan Exit Repair
+
+## Summary
+
+Plan mode now treats an `exit_plan_mode` call without a complete same-turn
+`<proposed_plan>...</proposed_plan>` block as a recoverable submission error.
+Instead of only displaying the tool error to the TUI and ending the turn, the
+runtime records a structured `plan_exit_repair_required` continuation message
+and gives the model one immediate repair attempt.
+
+## Runtime Contract
+
+- The repair message is written into the model-visible history as structured
+  runtime context.
+- `exit_plan_mode` now exposes a structured `proposed_plan` tool argument with
+  `summary`, `steps`, and `validation` fields. This is the preferred transport
+  because it uses the provider's function/tool-call argument channel instead of
+  relying on free-form assistant text.
+- OpenAI-native Chat Completions and Responses requests mark strict-compatible
+  tool schemas with `strict: true`, allowing providers with Structured Outputs
+  support to enforce the plan argument shape at the API layer.
+- The model is told that Markdown headings, plain bullets, and ordinary prose
+  are not substitutes for `<proposed_plan>`.
+- The preferred `<proposed_plan>` artifact uses `summary:`, `steps:`, and
+  `validation:` fields. Runtime parses executable plan steps only from the
+  `steps:` field so validation commands do not become plan items.
+- The repair attempt must either emit a complete `<proposed_plan>` block and
+  call `exit_plan_mode`, or answer normally without calling `exit_plan_mode`.
+- RARA still rejects stale plan state: the accepted plan must come from the
+  same assistant response as the `exit_plan_mode` call.
+- RARA still reports a specific malformed-plan error when the opening
+  `<proposed_plan>` tag has no matching `</proposed_plan>` closing tag.
+
+## Validation
+
+- `cargo test exit_plan_mode -- --nocapture`
+- `cargo test -p rara-instructions plan_mode_prompt_requires_short_progress_and_structured_approval -- --nocapture`
+- `cargo check`

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -26,6 +26,7 @@ use std::sync::{Arc, atomic::AtomicBool};
 use uuid::Uuid;
 
 const MAX_RUNTIME_ERROR_RECOVERY_ATTEMPTS: usize = 1;
+const MAX_PLAN_EXIT_REPAIR_ATTEMPTS: usize = 1;
 
 pub use self::compact::{CompactBoundaryMetadata, CompactState, latest_compact_boundary_metadata};
 pub use self::planning::{
@@ -372,6 +373,18 @@ impl Agent {
                     }
                 }
                 ContentBlock::ToolUse { id, name, input } => {
+                    if matches!(self.execution_mode, AgentExecutionMode::Plan)
+                        && name == EXIT_PLAN_MODE_TOOL_NAME
+                        && !plan_updated
+                    {
+                        if let Some((steps, explanation)) =
+                            planning::parse_exit_plan_tool_input(input)
+                        {
+                            self.current_plan = steps;
+                            self.plan_explanation = explanation;
+                            plan_updated = true;
+                        }
+                    }
                     sanitized_content.push(ContentBlock::ToolUse {
                         id: id.clone(),
                         name: name.clone(),
@@ -454,6 +467,7 @@ impl Agent {
     where
         F: FnMut(AgentEvent) + Send,
     {
+        let mut plan_exit_repair_attempts = 0usize;
         loop {
             self.ensure_active_plan_step();
             let mut turn_output = self.run_model_turn(output_mode, report).await?;
@@ -471,9 +485,23 @@ impl Agent {
                 };
                 report(AgentEvent::ToolResult {
                     name: EXIT_PLAN_MODE_TOOL_NAME.to_string(),
-                    content,
+                    content: content.clone(),
                     is_error: true,
                 });
+                if plan_exit_repair_attempts < MAX_PLAN_EXIT_REPAIR_ATTEMPTS {
+                    plan_exit_repair_attempts += 1;
+                    *agentic_turns += 1;
+                    report(AgentEvent::Status(
+                        "Plan exit was missing a structured proposed plan. Asking the model to repair the submission."
+                            .to_string(),
+                    ));
+                    self.push_history_message(self.runtime_continuation_message(
+                        RuntimeContinuationPhase::PlanExitRepairRequired,
+                        *agentic_turns,
+                    ));
+                    self.checkpoint_session()?;
+                    continue;
+                }
                 self.checkpoint_session()?;
                 break;
             }

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -49,6 +49,7 @@ pub(super) struct InspectionProgress {
 pub(super) enum RuntimeContinuationPhase {
     ToolResultsAvailable,
     PlanContinuationRequired,
+    PlanExitRepairRequired,
     ExecutionContinuationRequired,
     ReasoningOnlyContinuationRequired,
     PlanApproved,
@@ -654,6 +655,12 @@ pub(super) fn parse_plan_block(text: &str) -> Option<(Vec<PlanStep>, Option<Stri
     }
 
     let block = &text[start + start_tag.len()..end];
+    let trailing_explanation = text[end + end_tag.len()..].trim();
+    if start_tag == "<proposed_plan>" && is_structured_proposed_plan(block) {
+        let (steps, explanation) = parse_structured_proposed_plan(block, trailing_explanation);
+        return (!steps.is_empty()).then_some((steps, explanation));
+    }
+
     let mut steps = Vec::new();
     for line in block.lines().map(str::trim).filter(|line| !line.is_empty()) {
         if let Some(step) = parse_plan_step_line(line) {
@@ -661,7 +668,7 @@ pub(super) fn parse_plan_block(text: &str) -> Option<(Vec<PlanStep>, Option<Stri
         }
     }
 
-    let mut explanation = text[end + end_tag.len()..].trim().to_string();
+    let mut explanation = trailing_explanation.to_string();
     if steps.is_empty() && start_tag == "<proposed_plan>" {
         let fallback = block
             .lines()
@@ -681,6 +688,168 @@ pub(super) fn parse_plan_block(text: &str) -> Option<(Vec<PlanStep>, Option<Stri
         steps,
         (!explanation.is_empty()).then(|| explanation.to_string()),
     ))
+}
+
+pub(super) fn parse_exit_plan_tool_input(input: &Value) -> Option<(Vec<PlanStep>, Option<String>)> {
+    let proposed_plan = input.get("proposed_plan")?;
+    let steps = proposed_plan
+        .get("steps")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(parse_proposed_plan_step_value)
+        .collect::<Vec<_>>();
+    if steps.is_empty() {
+        return None;
+    }
+
+    let mut explanation_lines = Vec::new();
+    if let Some(summary) = proposed_plan
+        .get("summary")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|summary| !summary.is_empty())
+    {
+        explanation_lines.push(format!("summary: {summary}"));
+    }
+    if let Some(validation) = proposed_plan.get("validation").and_then(Value::as_array) {
+        let validation_lines = validation
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>();
+        if !validation_lines.is_empty() {
+            explanation_lines.push("validation:".to_string());
+            explanation_lines.extend(validation_lines.into_iter().map(|line| format!("- {line}")));
+        }
+    }
+
+    let explanation = explanation_lines.join("\n").trim().to_string();
+    Some((steps, (!explanation.is_empty()).then_some(explanation)))
+}
+
+fn parse_proposed_plan_step_value(value: &Value) -> Option<PlanStep> {
+    if let Some(step) = value
+        .as_str()
+        .map(str::trim)
+        .filter(|step| !step.is_empty())
+    {
+        return Some(PlanStep {
+            step: step.to_string(),
+            status: PlanStepStatus::Pending,
+        });
+    }
+
+    let step = value
+        .get("step")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|step| !step.is_empty())?;
+    let status = value
+        .get("status")
+        .and_then(Value::as_str)
+        .and_then(parse_plan_status)
+        .unwrap_or(PlanStepStatus::Pending);
+    Some(PlanStep {
+        step: step.to_string(),
+        status,
+    })
+}
+
+fn parse_plan_status(status: &str) -> Option<PlanStepStatus> {
+    match status.trim() {
+        "pending" => Some(PlanStepStatus::Pending),
+        "in_progress" => Some(PlanStepStatus::InProgress),
+        "completed" => Some(PlanStepStatus::Completed),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProposedPlanSection {
+    None,
+    Steps,
+    Validation,
+}
+
+fn is_structured_proposed_plan(block: &str) -> bool {
+    block
+        .lines()
+        .map(str::trim)
+        .any(|line| header_key(line) == Some("steps"))
+}
+
+fn parse_structured_proposed_plan(
+    block: &str,
+    trailing_explanation: &str,
+) -> (Vec<PlanStep>, Option<String>) {
+    let mut section = ProposedPlanSection::None;
+    let mut steps = Vec::new();
+    let mut explanation_lines = Vec::new();
+
+    for line in block.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        if let Some(key) = header_key(line) {
+            match key {
+                "steps" => {
+                    section = ProposedPlanSection::Steps;
+                    continue;
+                }
+                "validation" | "tests" => {
+                    section = ProposedPlanSection::Validation;
+                    explanation_lines.push("validation:".to_string());
+                    continue;
+                }
+                "summary" | "title" => {
+                    section = ProposedPlanSection::None;
+                    if let Some(value) = header_value(line) {
+                        explanation_lines.push(format!("{key}: {}", value.trim()));
+                    }
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        match section {
+            ProposedPlanSection::Steps => {
+                if let Some(step) = parse_plan_step_line(line) {
+                    steps.push(step);
+                }
+            }
+            ProposedPlanSection::Validation => {
+                explanation_lines.push(line.to_string());
+            }
+            ProposedPlanSection::None => {
+                explanation_lines.push(line.to_string());
+            }
+        }
+    }
+
+    if !trailing_explanation.is_empty() {
+        if !explanation_lines.is_empty() {
+            explanation_lines.push(String::new());
+        }
+        explanation_lines.push(trailing_explanation.to_string());
+    }
+
+    let explanation = explanation_lines.join("\n").trim().to_string();
+    (steps, (!explanation.is_empty()).then_some(explanation))
+}
+
+fn header_key(line: &str) -> Option<&'static str> {
+    let (key, _) = line.split_once(':')?;
+    match key.trim().to_ascii_lowercase().as_str() {
+        "steps" => Some("steps"),
+        "validation" => Some("validation"),
+        "tests" => Some("tests"),
+        "summary" => Some("summary"),
+        "title" => Some("title"),
+        _ => None,
+    }
+}
+
+fn header_value(line: &str) -> Option<&str> {
+    line.split_once(':').map(|(_, value)| value)
 }
 
 fn find_plan_block_bounds(text: &str) -> Option<(&'static str, &'static str, usize, usize)> {
@@ -812,6 +981,7 @@ impl RuntimeContinuationPhase {
         match self {
             Self::ToolResultsAvailable => "tool_results_available",
             Self::PlanContinuationRequired => "plan_continuation_required",
+            Self::PlanExitRepairRequired => "plan_exit_repair_required",
             Self::ExecutionContinuationRequired => "execution_continuation_required",
             Self::ReasoningOnlyContinuationRequired => "reasoning_only_continuation_required",
             Self::PlanApproved => "plan_approved",
@@ -834,6 +1004,14 @@ impl RuntimeContinuationPhase {
                 "Use <proposed_plan> only when you are requesting approval to implement a concrete plan.",
                 "Use <request_user_input> when a key decision blocks the answer.",
                 "Use <continue_inspection/> when more repository inspection is still required.",
+                "Do not ask the user to continue.",
+            ],
+            Self::PlanExitRepairRequired => vec![
+                "The previous exit_plan_mode call failed because the same assistant response did not contain a complete <proposed_plan>...</proposed_plan> block.",
+                "Continue the same planning task immediately.",
+                "If implementation approval is still needed, start the next response with <proposed_plan>, write summary:, steps:, and validation: fields, close it with the exact </proposed_plan> tag, and then call exit_plan_mode.",
+                "Do not use Markdown headings, plain bullets, or ordinary prose as a substitute for the <proposed_plan> block.",
+                "If no implementation approval is needed, provide the final answer without calling exit_plan_mode.",
                 "Do not ask the user to continue.",
             ],
             Self::ExecutionContinuationRequired => vec![

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use serde_json::json;
 
 use crate::agent::planning::{
-    has_unclosed_proposed_plan_block, parse_plan_block, parse_request_user_input_block,
-    strip_continue_inspection_control,
+    has_unclosed_proposed_plan_block, parse_exit_plan_tool_input, parse_plan_block,
+    parse_request_user_input_block, strip_continue_inspection_control,
 };
 use crate::agent::{
     Agent, AgentEvent, AgentExecutionMode, BashApprovalDecision, ContentBlock, PendingUserInput,
@@ -1091,16 +1091,95 @@ async fn exit_plan_mode_persists_plan_and_waits_for_approval() {
 }
 
 #[tokio::test]
-async fn exit_plan_mode_without_plan_stops_without_retrying_model() {
+async fn exit_plan_mode_accepts_structured_tool_plan_input() {
     let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
         content: vec![ContentBlock::ToolUse {
             id: "exit-plan".to_string(),
             name: "exit_plan_mode".to_string(),
-            input: json!({}),
+            input: json!({
+                "proposed_plan": {
+                    "summary": "Repair malformed plan exits.",
+                    "steps": [
+                        { "step": "Capture proposed_plan from tool arguments", "status": "pending" },
+                        { "step": "Persist the structured plan before approval", "status": "pending" }
+                    ],
+                    "validation": [
+                        "cargo test exit_plan_mode -- --nocapture"
+                    ]
+                }
+            }),
         }],
         stop_reason: Some("tool_use".to_string()),
         usage: Some(TokenUsage::default()),
     }]));
+
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(ExitPlanModeTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend,
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager.clone(),
+        workspace,
+    );
+    agent.set_execution_mode(AgentExecutionMode::Plan);
+
+    agent
+        .query_with_mode(
+            "plan the implementation".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("structured tool plan should stop at plan approval");
+
+    assert!(agent.has_pending_plan_exit_approval());
+    assert_eq!(agent.current_plan.len(), 2);
+    assert_eq!(
+        agent.current_plan[0].step,
+        "Capture proposed_plan from tool arguments"
+    );
+    assert_eq!(
+        agent.plan_explanation.as_deref(),
+        Some(
+            "summary: Repair malformed plan exits.\nvalidation:\n- cargo test exit_plan_mode -- --nocapture"
+        )
+    );
+    let plan_file = session_manager.plan_file_path(&agent.session_id);
+    let plan = std::fs::read_to_string(plan_file).expect("plan file should be persisted");
+    assert!(plan.contains("summary: Repair malformed plan exits."));
+    assert!(plan.contains("- [pending] Capture proposed_plan from tool arguments"));
+    assert!(plan.contains("cargo test exit_plan_mode -- --nocapture"));
+}
+
+#[tokio::test]
+async fn exit_plan_mode_without_plan_gets_one_structured_repair_turn() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "exit-plan-invalid".to_string(),
+                name: "exit_plan_mode".to_string(),
+                input: json!({}),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![
+                ContentBlock::Text {
+                    text: "<proposed_plan>\n- [pending] Fix plan exit handling\n</proposed_plan>"
+                        .to_string(),
+                },
+                ContentBlock::ToolUse {
+                    id: "exit-plan-valid".to_string(),
+                    name: "exit_plan_mode".to_string(),
+                    input: json!({}),
+                },
+            ],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
 
     let mut tool_manager = ToolManager::new();
     tool_manager.register(Box::new(ExitPlanModeTool));
@@ -1120,37 +1199,45 @@ async fn exit_plan_mode_without_plan_stops_without_retrying_model() {
             super::super::AgentOutputMode::Silent,
         )
         .await
-        .expect("invalid plan exit should stop the turn without retrying");
+        .expect("invalid plan exit should get one repair turn");
 
-    assert_eq!(backend.observed_messages().len(), 1);
+    let observed_messages = backend.observed_messages();
+    assert_eq!(observed_messages.len(), 2);
+    assert!(observed_messages[1].iter().any(|message| {
+        let content = message.content.to_string();
+        content.contains("plan_exit_repair_required")
+            && content.contains("Markdown headings")
+            && content.contains("<proposed_plan>")
+    }));
     assert_eq!(agent.execution_mode, AgentExecutionMode::Plan);
-    assert!(!agent.has_pending_plan_exit_approval());
-    assert!(
-        !agent
-            .history
-            .iter()
-            .any(|message| message.role == "assistant")
-    );
-    assert!(
-        !agent
-            .history
-            .iter()
-            .map(|message| message.content.to_string())
-            .any(|content| content.contains("exit_plan_mode requires a proposed plan"))
-    );
+    assert!(agent.has_pending_plan_exit_approval());
+    assert!(agent.current_plan.iter().any(|step| {
+        step.step == "Fix plan exit handling" && matches!(step.status, PlanStepStatus::Pending)
+    }));
 }
 
 #[tokio::test]
 async fn exit_plan_mode_requires_plan_from_same_assistant_turn() {
-    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
-        content: vec![ContentBlock::ToolUse {
-            id: "exit-plan".to_string(),
-            name: "exit_plan_mode".to_string(),
-            input: json!({}),
-        }],
-        stop_reason: Some("tool_use".to_string()),
-        usage: Some(TokenUsage::default()),
-    }]));
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "exit-plan-first".to_string(),
+                name: "exit_plan_mode".to_string(),
+                input: json!({}),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "exit-plan-second".to_string(),
+                name: "exit_plan_mode".to_string(),
+                input: json!({}),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
 
     let mut tool_manager = ToolManager::new();
     tool_manager.register(Box::new(ExitPlanModeTool));
@@ -1176,11 +1263,19 @@ async fn exit_plan_mode_requires_plan_from_same_assistant_turn() {
             |event| events.push(event),
         )
         .await
-        .expect("stale plan exit should stop the turn without retrying");
+        .expect("stale plan exit should get one repair attempt before stopping");
 
-    assert_eq!(backend.observed_messages().len(), 1);
+    assert_eq!(backend.observed_messages().len(), 2);
     assert_eq!(agent.execution_mode, AgentExecutionMode::Plan);
     assert!(!agent.has_pending_plan_exit_approval());
+    let repair_status_seen = events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::Status(status)
+                if status.contains("missing a structured proposed plan")
+        )
+    });
+    assert!(repair_status_seen);
     assert!(events.iter().any(|event| matches!(
         event,
         AgentEvent::ToolResult {
@@ -1194,20 +1289,36 @@ async fn exit_plan_mode_requires_plan_from_same_assistant_turn() {
 
 #[tokio::test]
 async fn exit_plan_mode_with_unclosed_proposed_plan_reports_specific_error() {
-    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
-        content: vec![
-            ContentBlock::Text {
-                text: "<proposed_plan>\n- [pending] Update planning state".to_string(),
-            },
-            ContentBlock::ToolUse {
-                id: "exit-plan".to_string(),
-                name: "exit_plan_mode".to_string(),
-                input: json!({}),
-            },
-        ],
-        stop_reason: Some("tool_use".to_string()),
-        usage: Some(TokenUsage::default()),
-    }]));
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![
+                ContentBlock::Text {
+                    text: "<proposed_plan>\n- [pending] Update planning state".to_string(),
+                },
+                ContentBlock::ToolUse {
+                    id: "exit-plan-first".to_string(),
+                    name: "exit_plan_mode".to_string(),
+                    input: json!({}),
+                },
+            ],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![
+                ContentBlock::Text {
+                    text: "<proposed_plan>\n- [pending] Update planning state".to_string(),
+                },
+                ContentBlock::ToolUse {
+                    id: "exit-plan-second".to_string(),
+                    name: "exit_plan_mode".to_string(),
+                    input: json!({}),
+                },
+            ],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
 
     let mut tool_manager = ToolManager::new();
     tool_manager.register(Box::new(ExitPlanModeTool));
@@ -1229,9 +1340,9 @@ async fn exit_plan_mode_with_unclosed_proposed_plan_reports_specific_error() {
             |event| events.push(event),
         )
         .await
-        .expect("invalid plan exit should stop the turn without retrying");
+        .expect("invalid plan exit should get one repair attempt before stopping");
 
-    assert_eq!(backend.observed_messages().len(), 1);
+    assert_eq!(backend.observed_messages().len(), 2);
     assert_eq!(agent.execution_mode, AgentExecutionMode::Plan);
     assert!(!agent.has_pending_plan_exit_approval());
     assert!(agent.current_plan.is_empty());
@@ -1343,6 +1454,92 @@ fn parses_structured_plan_block() {
     assert_eq!(
         parsed.1.as_deref(),
         Some("Focus on agent.rs and tui/runtime.rs first.")
+    );
+}
+
+#[test]
+fn parses_structured_proposed_plan_fields_without_mixing_validation_into_steps() {
+    let text = "<proposed_plan>\nsummary: Tighten plan exit handling.\nsteps:\n- [pending] Add structured plan prompt guidance\n- [pending] Parse only step entries from the steps section\nvalidation:\n- cargo test exit_plan_mode -- --nocapture\n- cargo check\n</proposed_plan>";
+    let parsed = parse_plan_block(text).expect("plan block should parse");
+    assert_eq!(
+        parsed.0,
+        vec![
+            PlanStep {
+                step: "Add structured plan prompt guidance".to_string(),
+                status: PlanStepStatus::Pending,
+            },
+            PlanStep {
+                step: "Parse only step entries from the steps section".to_string(),
+                status: PlanStepStatus::Pending,
+            },
+        ]
+    );
+    let explanation = parsed.1.expect("structured metadata should be preserved");
+    assert!(explanation.contains("summary: Tighten plan exit handling."));
+    assert!(explanation.contains("validation:"));
+    assert!(explanation.contains("cargo test exit_plan_mode -- --nocapture"));
+    assert!(!parsed.0.iter().any(|step| step.step.contains("cargo test")));
+}
+
+#[test]
+fn parses_structured_proposed_plan_headers_case_insensitively() {
+    let text = "<proposed_plan>\nSummary: Tighten plan exit handling.\nSteps:\n- [pending] Add structured plan prompt guidance\nValidation:\n- cargo test exit_plan_mode -- --nocapture\n</proposed_plan>";
+    let parsed = parse_plan_block(text).expect("plan block should parse");
+
+    assert_eq!(
+        parsed.0,
+        vec![PlanStep {
+            step: "Add structured plan prompt guidance".to_string(),
+            status: PlanStepStatus::Pending,
+        }]
+    );
+    let explanation = parsed.1.expect("structured metadata should be preserved");
+    assert!(explanation.contains("summary: Tighten plan exit handling."));
+    assert!(explanation.contains("validation:"));
+    assert!(explanation.contains("cargo test exit_plan_mode -- --nocapture"));
+}
+
+#[test]
+fn rejects_structured_proposed_plan_without_executable_steps() {
+    let text = "<proposed_plan>\nsummary: Missing executable steps.\nsteps:\nvalidation:\n- cargo check\n</proposed_plan>";
+
+    assert!(parse_plan_block(text).is_none());
+}
+
+#[test]
+fn parses_structured_plan_from_exit_tool_input() {
+    let parsed = parse_exit_plan_tool_input(&json!({
+        "proposed_plan": {
+            "summary": "Use tool arguments as the primary plan transport.",
+            "steps": [
+                { "step": "Add a proposed_plan schema to exit_plan_mode", "status": "completed" },
+                { "step": "Capture structured tool input in plan mode", "status": "pending" }
+            ],
+            "validation": [
+                "cargo test exit_plan_mode -- --nocapture"
+            ]
+        }
+    }))
+    .expect("structured tool input should parse");
+
+    assert_eq!(
+        parsed.0,
+        vec![
+            PlanStep {
+                step: "Add a proposed_plan schema to exit_plan_mode".to_string(),
+                status: PlanStepStatus::Completed,
+            },
+            PlanStep {
+                step: "Capture structured tool input in plan mode".to_string(),
+                status: PlanStepStatus::Pending,
+            },
+        ]
+    );
+    assert_eq!(
+        parsed.1.as_deref(),
+        Some(
+            "summary: Use tool arguments as the primary plan transport.\nvalidation:\n- cargo test exit_plan_mode -- --nocapture"
+        )
     );
 }
 

--- a/src/llm/codex_tools_compat.rs
+++ b/src/llm/codex_tools_compat.rs
@@ -99,14 +99,53 @@ pub fn create_tools_json_for_responses_api(
 }
 
 pub fn tool_definition_to_responses_api_tool(tool_definition: ToolDefinition) -> ResponsesApiTool {
+    let strict = supports_strict_structured_outputs(&tool_definition.input_schema);
     ResponsesApiTool {
         name: tool_definition.name,
         description: tool_definition.description,
-        strict: false,
+        strict,
         defer_loading: tool_definition.defer_loading.then_some(true),
         parameters: tool_definition.input_schema,
         output_schema: tool_definition.output_schema,
     }
+}
+
+fn supports_strict_structured_outputs(schema: &JsonSchema) -> bool {
+    if schema_is_object(schema)
+        && !matches!(
+            schema.additional_properties,
+            Some(AdditionalProperties::Boolean(false))
+        )
+    {
+        return false;
+    }
+
+    schema
+        .properties
+        .as_ref()
+        .into_iter()
+        .flat_map(|properties| properties.values())
+        .all(supports_strict_structured_outputs)
+        && schema
+            .items
+            .as_deref()
+            .is_none_or(supports_strict_structured_outputs)
+        && schema
+            .any_of
+            .as_ref()
+            .into_iter()
+            .flat_map(|schemas| schemas.iter())
+            .all(supports_strict_structured_outputs)
+}
+
+fn schema_is_object(schema: &JsonSchema) -> bool {
+    matches!(
+        schema.schema_type,
+        Some(JsonSchemaType::Single(JsonSchemaPrimitiveType::Object))
+    ) || matches!(
+        schema.schema_type.as_ref(),
+        Some(JsonSchemaType::Multiple(types)) if types.contains(&JsonSchemaPrimitiveType::Object)
+    ) || schema.properties.is_some()
 }
 
 pub fn parse_tool_input_schema(input_schema: &JsonValue) -> Result<JsonSchema, serde_json::Error> {

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -579,13 +579,17 @@ pub(super) fn build_chat_completion_request_body(
     let openai_tools: Vec<Value> = tools
         .iter()
         .map(|t| {
+            let mut function = json!({
+                "name": t["name"],
+                "description": t["description"],
+                "parameters": t["input_schema"]
+            });
+            if supports_strict_structured_outputs(&t["input_schema"]) {
+                function["strict"] = json!(true);
+            }
             json!({
                 "type": "function",
-                "function": {
-                    "name": t["name"],
-                    "description": t["description"],
-                    "parameters": t["input_schema"]
-                }
+                "function": function
             })
         })
         .collect();
@@ -608,6 +612,54 @@ pub(super) fn build_chat_completion_request_body(
         strong_reasoning,
     );
     body
+}
+
+fn supports_strict_structured_outputs(schema: &Value) -> bool {
+    if schema_is_object(schema)
+        && schema.get("additionalProperties").and_then(Value::as_bool) != Some(false)
+    {
+        return false;
+    }
+
+    schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|properties| properties.values())
+        .all(supports_strict_structured_outputs)
+        && schema
+            .get("$defs")
+            .and_then(Value::as_object)
+            .into_iter()
+            .flat_map(|defs| defs.values())
+            .all(supports_strict_structured_outputs)
+        && schema
+            .get("definitions")
+            .and_then(Value::as_object)
+            .into_iter()
+            .flat_map(|defs| defs.values())
+            .all(supports_strict_structured_outputs)
+        && schema
+            .get("items")
+            .is_none_or(supports_strict_structured_outputs)
+        && ["anyOf", "oneOf", "allOf"].into_iter().all(|key| {
+            schema
+                .get(key)
+                .and_then(Value::as_array)
+                .into_iter()
+                .flat_map(|schemas| schemas.iter())
+                .all(supports_strict_structured_outputs)
+        })
+}
+
+fn schema_is_object(schema: &Value) -> bool {
+    let Some(schema_type) = schema.get("type") else {
+        return schema.get("properties").is_some();
+    };
+    schema_type.as_str() == Some("object")
+        || schema_type
+            .as_array()
+            .is_some_and(|types| types.iter().any(|value| value.as_str() == Some("object")))
 }
 
 fn fold_deepseek_legacy_reasoning_history(openai_messages: Vec<Value>) -> Vec<Value> {

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -4,6 +4,8 @@ use serde_json::json;
 use crate::agent::Message;
 use crate::config::OpenAiEndpointKind;
 use crate::llm::{ContentBlock, LlmStreamEvent, LlmTurnMetadata};
+use crate::tool::Tool;
+use crate::tools::planning::ExitPlanModeTool;
 
 use super::ollama::{
     apply_ollama_stream_event, build_ollama_options, ensure_ollama_stream_completed,
@@ -662,6 +664,69 @@ fn deepseek_v4_explicit_thinking_enables_controls_for_tools() {
 }
 
 #[test]
+fn openai_chat_tools_enable_strict_for_structured_plan_schema() {
+    let tool = ExitPlanModeTool;
+    let body = build_chat_completion_request_body(
+        "gpt-4o",
+        &[Message {
+            role: "user".to_string(),
+            content: json!("Plan the implementation."),
+        }],
+        &[json!({
+            "name": tool.name(),
+            "description": tool.description(),
+            "input_schema": tool.input_schema()
+        })],
+        OpenAiEndpointKind::Custom,
+        None,
+        None,
+        LlmTurnMetadata::plan(),
+    );
+
+    assert_eq!(body["tools"][0]["type"], "function");
+    assert_eq!(body["tools"][0]["function"]["name"], "exit_plan_mode");
+    assert_eq!(body["tools"][0]["function"]["strict"], true);
+    assert_eq!(
+        body["tools"][0]["function"]["parameters"]["properties"]["proposed_plan"]["required"],
+        json!(["summary", "steps", "validation"])
+    );
+}
+
+#[test]
+fn openai_chat_tools_skip_strict_when_nested_object_is_not_strict_compatible() {
+    let body = build_chat_completion_request_body(
+        "gpt-4o",
+        &[Message {
+            role: "user".to_string(),
+            content: json!("Plan the implementation."),
+        }],
+        &[json!({
+            "name": "nested_tool",
+            "description": "Tool with a nested object schema",
+            "input_schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "payload": {
+                        "type": "object",
+                        "properties": {
+                            "title": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        })],
+        OpenAiEndpointKind::Custom,
+        None,
+        None,
+        LlmTurnMetadata::default(),
+    );
+
+    assert_eq!(body["tools"][0]["type"], "function");
+    assert!(body["tools"][0]["function"].get("strict").is_none());
+}
+
+#[test]
 fn deepseek_reasoner_plan_with_explicit_thinking_uses_max_effort() {
     let body = build_chat_completion_request_body(
         "deepseek-reasoner",
@@ -1268,10 +1333,70 @@ fn codex_responses_tools_use_upstream_schema_defaults_and_chatgpt_normalization(
 
     let parameters = &request["tools"][0]["parameters"];
     assert_eq!(request["tools"][0]["type"], "function");
+    assert_eq!(request["tools"][0]["strict"], false);
     assert_eq!(parameters["type"], "object");
     assert!(parameters.get("anyOf").is_none());
     assert_eq!(parameters["properties"]["tasks"]["type"], "array");
     assert_eq!(parameters["properties"]["tasks"]["items"]["type"], "string");
+}
+
+#[test]
+fn codex_responses_tools_enable_strict_for_structured_plan_schema() {
+    let tool = ExitPlanModeTool;
+    let request = build_codex_responses_request(
+        "gpt-5.4",
+        &[Message {
+            role: "user".to_string(),
+            content: json!("Plan the implementation."),
+        }],
+        &[json!({
+            "name": tool.name(),
+            "description": tool.description(),
+            "input_schema": tool.input_schema()
+        })],
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(request["tools"][0]["type"], "function");
+    assert_eq!(request["tools"][0]["name"], "exit_plan_mode");
+    assert_eq!(request["tools"][0]["strict"], true);
+    assert_eq!(
+        request["tools"][0]["parameters"]["properties"]["proposed_plan"]["required"],
+        json!(["summary", "steps", "validation"])
+    );
+}
+
+#[test]
+fn codex_responses_tools_disable_strict_when_nested_object_is_not_strict_compatible() {
+    let request = build_codex_responses_request(
+        "gpt-5.4",
+        &[Message {
+            role: "user".to_string(),
+            content: json!("Plan the implementation."),
+        }],
+        &[json!({
+            "name": "nested_tool",
+            "description": "Tool with a nested object schema",
+            "input_schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "payload": {
+                        "type": "object",
+                        "properties": {
+                            "title": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        })],
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(request["tools"][0]["type"], "function");
+    assert_eq!(request["tools"][0]["strict"], false);
 }
 
 #[test]

--- a/src/tools/planning.rs
+++ b/src/tools/planning.rs
@@ -40,6 +40,30 @@ impl Tool for EnterPlanModeTool {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{EXIT_PLAN_MODE_TOOL_NAME, ExitPlanModeTool};
+    use crate::tool::Tool;
+
+    #[test]
+    fn exit_plan_mode_schema_accepts_structured_proposed_plan() {
+        let tool = ExitPlanModeTool;
+        let schema = tool.input_schema();
+
+        assert_eq!(tool.name(), EXIT_PLAN_MODE_TOOL_NAME);
+        assert_eq!(schema["required"][0], "proposed_plan");
+        assert_eq!(
+            schema["properties"]["proposed_plan"]["required"],
+            serde_json::json!(["summary", "steps", "validation"])
+        );
+        assert_eq!(
+            schema["properties"]["proposed_plan"]["properties"]["steps"]["items"]["properties"]["status"]
+                ["enum"],
+            serde_json::json!(["pending", "in_progress", "completed"])
+        );
+    }
+}
+
 #[async_trait]
 impl Tool for ExitPlanModeTool {
     fn name(&self) -> &str {
@@ -47,13 +71,53 @@ impl Tool for ExitPlanModeTool {
     }
 
     fn description(&self) -> &str {
-        "Submit user approval only after this same assistant response has emitted a complete <proposed_plan>...</proposed_plan> block with the exact closing </proposed_plan> tag. Never call this tool without a complete proposed plan."
+        "Submit a concrete implementation plan for structured user approval. Prefer passing the plan in the proposed_plan argument. If structured tool arguments are unavailable, this same assistant response must emit a complete <proposed_plan>...</proposed_plan> block before calling this tool."
     }
 
     fn input_schema(&self) -> Value {
         json!({
             "type": "object",
-            "properties": {},
+            "properties": {
+                "proposed_plan": {
+                    "type": "object",
+                    "description": "Structured implementation plan to submit for approval.",
+                    "properties": {
+                        "summary": {
+                            "type": "string",
+                            "description": "One concise sentence describing the implementation goal."
+                        },
+                        "steps": {
+                            "type": "array",
+                            "description": "Concrete implementation steps. Runtime treats only this array as executable plan state.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "step": {
+                                        "type": "string",
+                                        "description": "One concrete implementation step."
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "enum": ["pending", "in_progress", "completed"],
+                                        "description": "Current step status. Use pending for new plans unless a step is already complete."
+                                    }
+                                },
+                                "required": ["step", "status"],
+                                "additionalProperties": false
+                            }
+                        },
+                        "validation": {
+                            "type": "array",
+                            "description": "Focused tests or commands that should validate the implementation.",
+                            "items": { "type": "string" }
+                        }
+                    },
+                    "required": ["summary", "steps", "validation"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["proposed_plan"],
+            "additionalProperties": false,
         })
     }
 


### PR DESCRIPTION
## Summary

- add one automatic repair turn when `exit_plan_mode` is called without a same-turn `<proposed_plan>` block
- tighten plan-mode guidance so Markdown headings or ordinary bullets are not treated as plan submissions
- make `<proposed_plan>` prefer structured `summary:`, `steps:`, and `validation:` fields, and parse executable plan steps only from `steps:`

## Testing

- `cargo test exit_plan_mode -- --nocapture`
- `cargo test parses_structured_proposed_plan_fields_without_mixing_validation_into_steps -- --nocapture`
- `cargo test -p rara-instructions plan_mode_prompt_requires_short_progress_and_structured_approval -- --nocapture`
- `cargo check`
