### PR TITLE
fix: hide empty sessions from resume

### DIFF
--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -13,6 +13,13 @@ use crate::thread_rollout_log;
 #[cfg(test)]
 mod tests;
 
+const RESUMABLE_SESSION_WHERE: &str = "s.history_len > 0
+                OR s.compaction_count > 0
+                OR s.plan_explanation IS NOT NULL
+                OR EXISTS (SELECT 1 FROM turns WHERE session_id = s.id)
+                OR EXISTS (SELECT 1 FROM plan_steps WHERE session_id = s.id)
+                OR EXISTS (SELECT 1 FROM interactions WHERE session_id = s.id)";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersistedTurnEntry {
     pub role: String,
@@ -751,17 +758,13 @@ impl StateDb {
 
     pub fn latest_thread_id(&self) -> Result<Option<String>> {
         let conn = self.conn.lock().expect("state db mutex poisoned");
-        let thread_id = conn.query_row(
+        let sql = format!(
             "SELECT id FROM sessions s
-             WHERE s.history_len > 0
-                OR EXISTS (SELECT 1 FROM turns WHERE session_id = s.id)
-                OR EXISTS (SELECT 1 FROM plan_steps WHERE session_id = s.id)
-                OR EXISTS (SELECT 1 FROM interactions WHERE session_id = s.id)
+             WHERE {RESUMABLE_SESSION_WHERE}
              ORDER BY updated_at DESC
-             LIMIT 1",
-            [],
-            |row| row.get::<_, String>(0),
+             LIMIT 1"
         );
+        let thread_id = conn.query_row(&sql, [], |row| row.get::<_, String>(0));
         match thread_id {
             Ok(id) => Ok(Some(id)),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
@@ -812,7 +815,7 @@ impl StateDb {
         limit: usize,
     ) -> Result<Vec<PersistedRecentThreadSummary>> {
         let conn = self.conn.lock().expect("state db mutex poisoned");
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "SELECT s.id, s.provider, s.model, s.branch, s.updated_at,
                     s.compaction_count, s.last_compaction_before_tokens,
                     s.last_compaction_after_tokens, s.last_compaction_recent_file_count,
@@ -824,13 +827,11 @@ impl StateDb {
                         LIMIT 1
                     ), '') AS preview
              FROM sessions s
-             WHERE s.history_len > 0
-                OR EXISTS (SELECT 1 FROM turns WHERE session_id = s.id)
-                OR EXISTS (SELECT 1 FROM plan_steps WHERE session_id = s.id)
-                OR EXISTS (SELECT 1 FROM interactions WHERE session_id = s.id)
+             WHERE {RESUMABLE_SESSION_WHERE}
              ORDER BY s.updated_at DESC
-             LIMIT ?",
-        )?;
+             LIMIT ?"
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map(params![limit as i64], |row| {
             Ok(PersistedRecentThreadSummary {
                 session_id: row.get(0)?,
@@ -866,7 +867,7 @@ impl StateDb {
         limit: usize,
     ) -> Result<Vec<PersistedRecentThreadRecord>> {
         let conn = self.conn.lock().expect("state db mutex poisoned");
-        let mut stmt = conn.prepare(
+        let sql = format!(
             "SELECT s.id, s.cwd, s.branch, s.provider, s.model, s.base_url,
                     s.agent_mode, s.bash_approval, s.created_at, s.history_len, s.transcript_len,
                     s.updated_at, s.origin_kind, s.forked_from_thread_id,
@@ -880,13 +881,11 @@ impl StateDb {
                         LIMIT 1
                     ), '') AS preview
              FROM sessions s
-             WHERE s.history_len > 0
-                OR EXISTS (SELECT 1 FROM turns WHERE session_id = s.id)
-                OR EXISTS (SELECT 1 FROM plan_steps WHERE session_id = s.id)
-                OR EXISTS (SELECT 1 FROM interactions WHERE session_id = s.id)
+             WHERE {RESUMABLE_SESSION_WHERE}
              ORDER BY s.updated_at DESC
-             LIMIT ?",
-        )?;
+             LIMIT ?"
+        );
+        let mut stmt = conn.prepare(&sql)?;
         let rows = stmt.query_map(params![limit as i64], |row| {
             Ok(PersistedRecentThreadRecord {
                 session_id: row.get(0)?,

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -752,7 +752,13 @@ impl StateDb {
     pub fn latest_thread_id(&self) -> Result<Option<String>> {
         let conn = self.conn.lock().expect("state db mutex poisoned");
         let thread_id = conn.query_row(
-            "SELECT id FROM sessions ORDER BY updated_at DESC LIMIT 1",
+            "SELECT id FROM sessions s
+             WHERE s.history_len > 0
+                OR EXISTS (SELECT 1 FROM turns WHERE session_id = s.id)
+                OR EXISTS (SELECT 1 FROM plan_steps WHERE session_id = s.id)
+                OR EXISTS (SELECT 1 FROM interactions WHERE session_id = s.id)
+             ORDER BY updated_at DESC
+             LIMIT 1",
             [],
             |row| row.get::<_, String>(0),
         );
@@ -818,6 +824,10 @@ impl StateDb {
                         LIMIT 1
                     ), '') AS preview
              FROM sessions s
+             WHERE s.history_len > 0
+                OR EXISTS (SELECT 1 FROM turns WHERE session_id = s.id)
+                OR EXISTS (SELECT 1 FROM plan_steps WHERE session_id = s.id)
+                OR EXISTS (SELECT 1 FROM interactions WHERE session_id = s.id)
              ORDER BY s.updated_at DESC
              LIMIT ?",
         )?;
@@ -870,6 +880,10 @@ impl StateDb {
                         LIMIT 1
                     ), '') AS preview
              FROM sessions s
+             WHERE s.history_len > 0
+                OR EXISTS (SELECT 1 FROM turns WHERE session_id = s.id)
+                OR EXISTS (SELECT 1 FROM plan_steps WHERE session_id = s.id)
+                OR EXISTS (SELECT 1 FROM interactions WHERE session_id = s.id)
              ORDER BY s.updated_at DESC
              LIMIT ?",
         )?;

--- a/src/state_db/tests.rs
+++ b/src/state_db/tests.rs
@@ -316,6 +316,39 @@ fn recent_threads_ignore_sessions_without_resume_data() -> Result<()> {
         &PersistedCompactState::default(),
     )?;
     db.upsert_session(
+        "plan-backed",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "plan",
+        "suggestion",
+        Some("Plan-only sessions should remain resumable."),
+        &PersistedPromptRuntimeState::default(),
+        0,
+        0,
+        &PersistedCompactState::default(),
+    )?;
+    db.upsert_session(
+        "compact-backed",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "execute",
+        "suggestion",
+        None,
+        &PersistedPromptRuntimeState::default(),
+        0,
+        0,
+        &PersistedCompactState {
+            compaction_count: 1,
+            ..PersistedCompactState::default()
+        },
+    )?;
+    db.upsert_session(
         "turn-backed",
         "/tmp/workspace",
         "main",
@@ -346,6 +379,8 @@ fn recent_threads_ignore_sessions_without_resume_data() -> Result<()> {
         .collect::<Vec<_>>();
     assert!(!summary_ids.contains(&"slash-resume-only"));
     assert!(summary_ids.contains(&"history-backed"));
+    assert!(summary_ids.contains(&"plan-backed"));
+    assert!(summary_ids.contains(&"compact-backed"));
     assert!(summary_ids.contains(&"turn-backed"));
 
     let records = db.list_recent_thread_records(10)?;
@@ -355,7 +390,55 @@ fn recent_threads_ignore_sessions_without_resume_data() -> Result<()> {
         .collect::<Vec<_>>();
     assert!(!record_ids.contains(&"slash-resume-only"));
     assert!(record_ids.contains(&"history-backed"));
+    assert!(record_ids.contains(&"plan-backed"));
+    assert!(record_ids.contains(&"compact-backed"));
     assert!(record_ids.contains(&"turn-backed"));
+    Ok(())
+}
+
+#[test]
+fn latest_thread_id_keeps_plan_and_compaction_only_sessions_resumable() -> Result<()> {
+    let temp = tempdir()?;
+    let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;
+
+    db.upsert_session(
+        "plan-only",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "plan",
+        "suggestion",
+        Some("Plan approval is enough resume state."),
+        &PersistedPromptRuntimeState::default(),
+        0,
+        0,
+        &PersistedCompactState::default(),
+    )?;
+    assert_eq!(db.latest_thread_id()?.as_deref(), Some("plan-only"));
+
+    let temp = tempdir()?;
+    let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;
+    db.upsert_session(
+        "compact-only",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "execute",
+        "suggestion",
+        None,
+        &PersistedPromptRuntimeState::default(),
+        0,
+        0,
+        &PersistedCompactState {
+            compaction_count: 1,
+            ..PersistedCompactState::default()
+        },
+    )?;
+    assert_eq!(db.latest_thread_id()?.as_deref(), Some("compact-only"));
     Ok(())
 }
 

--- a/src/state_db/tests.rs
+++ b/src/state_db/tests.rs
@@ -279,6 +279,87 @@ fn persists_compact_state_for_restore() -> Result<()> {
 }
 
 #[test]
+fn recent_threads_ignore_sessions_without_resume_data() -> Result<()> {
+    let temp = tempdir()?;
+    let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;
+
+    db.upsert_session(
+        "slash-resume-only",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "execute",
+        "suggestion",
+        None,
+        &PersistedPromptRuntimeState::default(),
+        0,
+        3,
+        &PersistedCompactState::default(),
+    )?;
+    assert_eq!(db.latest_thread_id()?, None);
+
+    db.upsert_session(
+        "history-backed",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "execute",
+        "suggestion",
+        None,
+        &PersistedPromptRuntimeState::default(),
+        1,
+        0,
+        &PersistedCompactState::default(),
+    )?;
+    db.upsert_session(
+        "turn-backed",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "execute",
+        "suggestion",
+        None,
+        &PersistedPromptRuntimeState::default(),
+        0,
+        0,
+        &PersistedCompactState::default(),
+    )?;
+    db.persist_turn(
+        "turn-backed",
+        0,
+        &[PersistedTurnEntry {
+            role: "User".to_string(),
+            message: "Real request".to_string(),
+        }],
+    )?;
+
+    let summaries = db.list_recent_thread_summaries(10)?;
+    let summary_ids = summaries
+        .iter()
+        .map(|thread| thread.session_id.as_str())
+        .collect::<Vec<_>>();
+    assert!(!summary_ids.contains(&"slash-resume-only"));
+    assert!(summary_ids.contains(&"history-backed"));
+    assert!(summary_ids.contains(&"turn-backed"));
+
+    let records = db.list_recent_thread_records(10)?;
+    let record_ids = records
+        .iter()
+        .map(|thread| thread.session_id.as_str())
+        .collect::<Vec<_>>();
+    assert!(!record_ids.contains(&"slash-resume-only"));
+    assert!(record_ids.contains(&"history-backed"));
+    assert!(record_ids.contains(&"turn-backed"));
+    Ok(())
+}
+
+#[test]
 fn load_rollout_events_prefers_append_only_log_without_snapshot_rewrite() -> Result<()> {
     let temp = tempdir()?;
     let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -729,7 +729,7 @@ fn resume_picker_refreshes_recent_threads_on_open() {
             "always",
             None,
             &PersistedPromptRuntimeState::default(),
-            0,
+            1,
             0,
             &PersistedCompactState::default(),
         )


### PR DESCRIPTION
## Summary

- Filter resume/recent-thread data to sessions with real restorable content.
- Exclude runtime-only or slash-command-only sessions where only transcript counters changed.
- Keep resume picker tests aligned with the stricter data contract.

## Testing

- cargo test recent_threads -- --nocapture
- cargo check
