### PR TITLE
feat: add todo_write runtime state

### DIFF
--- a/docs/features/todo-runtime.md
+++ b/docs/features/todo-runtime.md
@@ -149,6 +149,22 @@ This keeps Todo visible as execution state without turning it into persistent tr
 - TUI state/render tests for `Todo Updated` display and `/context` todo reporting.
 - Restore tests that todo state survives session reload without mutating `plan.md`.
 
+## Implementation Checkpoint
+
+The first runtime slice implements Claude-style write semantics without automatic plan-to-todo
+conversion:
+
+- `todo_write` accepts a complete replacement list and normalizes item ids, statuses, timestamps,
+  and the single-`in_progress` invariant.
+- Successful writes update `Agent.todo_state`, atomically persist
+  `.rara/sessions/<session_id>/todo.json`, and restore that state when the session is resumed.
+- Runtime context exposes todo state as structured data so future `/context`, compaction, and
+  protocol subscribers can consume the same source.
+- TUI output hides the raw tool JSON and renders a compact `Todo Updated` transcript card only when
+  the list changes.
+- The runtime-control event stream emits a structured `todo.updated` event for Wire/ACP consumers
+  instead of requiring them to parse transcript text.
+
 ## Open Risks
 
 - The first implementation should avoid automatic plan-to-todo conversion. Automatic conversion can
@@ -157,7 +173,10 @@ This keeps Todo visible as execution state without turning it into persistent tr
   clearer ownership model.
 - The UI should avoid permanent todo cards; stale completed lists can become visual noise in long
   sessions.
+- `/context` and `/status` should still get first-class todo sections on top of the structured
+  runtime view.
 
 ## Source Journals
 
 - [2026-05-01-todo-and-review-specs](../journal/2026-05-01-todo-and-review-specs.md)
+- [2026-05-03-todo-write-runtime](../journal/2026-05-03-todo-write-runtime.md)

--- a/docs/journal/2026-05-03-todo-write-runtime.md
+++ b/docs/journal/2026-05-03-todo-write-runtime.md
@@ -1,0 +1,34 @@
+# Todo Write Runtime
+
+## Context
+
+RARA already had approved plan state through `plan.md`, but execution progress was still implicit in
+transcript text. Claude Code separates those concepts with a mutable todo list. RARA now follows that
+shape while keeping the artifact structured and protocol-ready.
+
+## Implemented
+
+- Added `todo_write` as a complete-list replacement tool.
+- Validated the todo contract with normalized ids, timestamps, supported statuses, and at most one
+  `in_progress` item.
+- Persisted todo state at `.rara/sessions/<session_id>/todo.json` through `SessionManager` atomic
+  replacement.
+- Restored todo state into `Agent.todo_state` on session resume and preserved it across runtime
+  rebuilds.
+- Added structured `AgentEvent::TodoUpdated` and runtime-control `todo.updated` events so TUI and
+  Wire/ACP subscribers consume the same update.
+- Rendered `Todo Updated` as a compact transcript card while suppressing raw `todo_write` tool JSON.
+- Increased queued-follow-up title contrast by using the planning phase badge color instead of a
+  low-contrast secondary surface color.
+
+## Deferred
+
+- Add first-class `/context` and `/status` todo sections using the existing `TodoContextView`.
+- Decide whether compaction summaries should include the active item only or a bounded pending-list
+  projection.
+- Define multi-agent todo ownership before allowing more than one `in_progress` item.
+
+## Validation
+
+- `cargo test todo_write -- --nocapture`
+

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -15,6 +15,7 @@ Active backlog only. Keep this file small and current.
 ## Runtime Control Plane / ACP / Wire
 
 - [x] Define adapter-neutral runtime control request/event types for ACP, Wire, TUI, CLI, and future appserver entrypoints (see `docs/features/runtime-control-plane.md`).
+- [x] Add Claude-style `todo_write` runtime state with session persistence, TUI update cards, and structured Wire/ACP-ready events.
 - [ ] Route ACP prompt/cancel/session handling through the normal RARA runtime path instead of the current stub.
 - [ ] Add protocol subscriber plumbing on top of the structured `AgentEvent` runtime-control bridge.
 - [ ] Support protocol-registered prompt sources with provenance, scope, budget hints, and `/context` visibility.
@@ -84,6 +85,7 @@ Active backlog only. Keep this file small and current.
 - [ ] High-fidelity render pass for `write/update`, inline diffs, approval cards, message-card hierarchy.
 - [ ] Expand TUI snapshot coverage.
 - [ ] Keep transcript and pending-interaction state backed by structured events that ACP/Wire output subscribers can reuse.
+- [ ] Add first-class todo sections to `/context` and `/status` from `TodoContextView`.
 
 ## Security / Reliability / Performance
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -768,8 +768,14 @@ impl Agent {
                     Ok(result) => {
                         if tool_name == TODO_WRITE_TOOL_NAME {
                             let state: TodoState = serde_json::from_value(result.clone())?;
-                            self.session_manager
-                                .save_todo_state(&self.session_id, &state)?;
+                            if let Err(err) = self
+                                .session_manager
+                                .save_todo_state(&self.session_id, &state)
+                            {
+                                report(AgentEvent::Status(format!(
+                                    "Warning: failed to persist todo state: {err}"
+                                )));
+                            }
                             self.todo_state = Some(state.clone());
                             report(AgentEvent::TodoUpdated(state));
                         }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -9,6 +9,7 @@ use crate::llm::{ContentBlock, LlmBackend, LlmStreamEvent, LlmTurnMetadata};
 use crate::prompt::{self, PromptMode, PromptRuntimeConfig};
 use crate::redaction::redact_secrets;
 use crate::session::SessionManager;
+use crate::todo::TodoState;
 use crate::tool::ToolOutputStream;
 use crate::tool::{ToolCallContext, ToolManager, ToolProgressEvent};
 use crate::tool_result::{
@@ -17,6 +18,7 @@ use crate::tool_result::{
 };
 use crate::tools::bash::BashCommandInput;
 use crate::tools::planning::{ENTER_PLAN_MODE_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME};
+use crate::tools::todo::TODO_WRITE_TOOL_NAME;
 use crate::vectordb::{MemoryMetadata, VectorDB};
 use crate::workspace::WorkspaceMemory;
 use anyhow::Result;
@@ -87,6 +89,7 @@ pub enum AgentEvent {
         stream: ToolOutputStream,
         chunk: String,
     },
+    TodoUpdated(TodoState),
 }
 
 #[derive(Debug)]
@@ -126,6 +129,7 @@ pub struct Agent {
     pub plan_explanation: Option<String>,
     pub pending_user_input: Option<PendingUserInput>,
     pub pending_approval: Option<PendingApproval>,
+    pub todo_state: Option<TodoState>,
     pub completed_user_input: Option<CompletedInteraction>,
     pub completed_approval: Option<CompletedInteraction>,
     pub approved_bash_prefixes: Vec<String>,
@@ -167,6 +171,7 @@ impl Agent {
             plan_explanation: None,
             pending_user_input: None,
             pending_approval: None,
+            todo_state: None,
             completed_user_input: None,
             completed_approval: None,
             approved_bash_prefixes: Vec::new(),
@@ -761,6 +766,13 @@ impl Agent {
                     .await
                 {
                     Ok(result) => {
+                        if tool_name == TODO_WRITE_TOOL_NAME {
+                            let state: TodoState = serde_json::from_value(result.clone())?;
+                            self.session_manager
+                                .save_todo_state(&self.session_id, &state)?;
+                            self.todo_state = Some(state.clone());
+                            report(AgentEvent::TodoUpdated(state));
+                        }
                         let result_text = self.tool_result_store.compact_result(
                             &tool_name,
                             &tool_id,

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::tool::ToolProgressEvent;
 use crate::tools::bash::BashCommandInput;
 use crate::tools::planning::{ENTER_PLAN_MODE_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME};
+use crate::tools::todo::TODO_WRITE_TOOL_NAME;
 use anyhow::anyhow;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -376,6 +377,7 @@ impl Agent {
                     | "replace_lines"
                     | "apply_patch"
                     | "update_project_memory"
+                    | TODO_WRITE_TOOL_NAME
                     | "remember_experience"
                     | "spawn_agent"
                     | "team_create"

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -53,6 +53,7 @@ impl Agent {
                 .map(|step| (step.status.clone(), step.step.clone()))
                 .collect(),
             plan_explanation: self.plan_explanation.clone(),
+            todo_state: self.todo_state.clone(),
             compact_state: self.compact_state.clone(),
             history: &self.history,
             vdb_uri: self.vdb.uri(),

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -17,6 +17,7 @@ use crate::session::SessionManager;
 use crate::tool::ToolManager;
 use crate::tool_result::ToolResultStore;
 use crate::tools::planning::{EnterPlanModeTool, ExitPlanModeTool};
+use crate::tools::todo::TodoWriteTool;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
 
@@ -174,6 +175,78 @@ async fn appends_continuation_after_tool_result() {
         second_round
             .iter()
             .any(|message| { message.content.to_string().contains("tool_result") })
+    );
+}
+
+#[tokio::test]
+async fn todo_write_updates_session_state_and_emits_event() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "todo-tool-1".to_string(),
+                name: "todo_write".to_string(),
+                input: json!({
+                    "todos": [
+                        {"content": "Implement todo runtime", "status": "in_progress"},
+                        {"content": "Run focused tests", "status": "pending"}
+                    ]
+                }),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "Todo state is recorded.".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(TodoWriteTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend,
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager.clone(),
+        workspace,
+    );
+    agent.session_id = "todo-session".to_string();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    agent
+        .query_with_mode_and_events(
+            "track the implementation".to_string(),
+            super::super::AgentOutputMode::Silent,
+            {
+                let events = events.clone();
+                move |event| events.lock().expect("events").push(event)
+            },
+        )
+        .await
+        .expect("query should succeed");
+
+    let state = agent.todo_state.expect("agent should keep todo state");
+    assert_eq!(state.items.len(), 2);
+    assert_eq!(
+        state.summary().active_item.as_deref(),
+        Some("Implement todo runtime")
+    );
+    assert_eq!(
+        session_manager
+            .load_todo_state("todo-session")
+            .expect("todo state should load"),
+        Some(state.clone())
+    );
+    assert!(
+        events
+            .lock()
+            .expect("events")
+            .iter()
+            .any(|event| matches!(event, AgentEvent::TodoUpdated(updated) if *updated == state))
     );
 }
 

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::json;
+use tempfile::tempdir;
 
 use crate::agent::planning::{
     has_unclosed_proposed_plan_block, parse_exit_plan_tool_input, parse_plan_block,
@@ -248,6 +249,121 @@ async fn todo_write_updates_session_state_and_emits_event() {
             .iter()
             .any(|event| matches!(event, AgentEvent::TodoUpdated(updated) if *updated == state))
     );
+}
+
+#[tokio::test]
+async fn todo_write_persistence_failure_warns_without_aborting_turn() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "todo-tool-1".to_string(),
+                name: "todo_write".to_string(),
+                input: json!({
+                    "todos": [
+                        {"content": "Keep going after persistence failure", "status": "in_progress"}
+                    ]
+                }),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "Todo state is still usable.".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(TodoWriteTool));
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().to_path_buf();
+    let rara_dir = root.join(".rara");
+    std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+    let blocked_legacy_path = rara_dir.join("sessions");
+    std::fs::write(&blocked_legacy_path, "not a directory").expect("blocked sessions path");
+    let session_manager = Arc::new(SessionManager {
+        storage_dir: rara_dir.join("rollouts"),
+        legacy_storage_dir: blocked_legacy_path,
+    });
+    let workspace = Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone()));
+    let mut agent = Agent::new(
+        tool_manager,
+        backend,
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.session_id = "todo-session".to_string();
+    let events = Arc::new(Mutex::new(Vec::new()));
+
+    agent
+        .query_with_mode_and_events(
+            "track the implementation".to_string(),
+            super::super::AgentOutputMode::Silent,
+            {
+                let events = events.clone();
+                move |event| events.lock().expect("events").push(event)
+            },
+        )
+        .await
+        .expect("todo persistence failure should not abort the turn");
+
+    let state = agent.todo_state.expect("agent should keep todo state");
+    assert_eq!(state.items.len(), 1);
+    let events = events.lock().expect("events");
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AgentEvent::Status(message)
+            if message.contains("Warning: failed to persist todo state")
+    )));
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::TodoUpdated(updated) if *updated == state))
+    );
+}
+
+#[test]
+fn plan_mode_does_not_expose_todo_write_schema() {
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(TodoWriteTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        Arc::new(SequencedBackend::new(Vec::new())),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+
+    agent.set_execution_mode(AgentExecutionMode::Plan);
+    let plan_tool_names = agent
+        .visible_tool_schemas()
+        .into_iter()
+        .filter_map(|schema| {
+            schema
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+    assert!(!plan_tool_names.iter().any(|name| name == "todo_write"));
+
+    agent.set_execution_mode(AgentExecutionMode::Execute);
+    let execute_tool_names = agent
+        .visible_tool_schemas()
+        .into_iter()
+        .filter_map(|schema| {
+            schema
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+    assert!(execute_tool_names.iter().any(|name| name == "todo_write"));
 }
 
 #[tokio::test]

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -5,10 +5,11 @@ use crate::context::memory_selection::memory_selection;
 use crate::context::retrieval_view::retrieval_source_entries;
 use crate::context::{
     CompactionContextView, ContextBudgetView, PlanContextView, PromptContextView,
-    RetrievalContextView, SharedRuntimeContext,
+    RetrievalContextView, SharedRuntimeContext, TodoContextView,
 };
 use crate::llm::{ContextBudget, LlmBackend};
 use crate::prompt::{self, EffectivePrompt, PromptMode, PromptRuntimeConfig};
+use crate::todo::TodoState;
 use crate::workspace::WorkspaceMemory;
 use serde_json::Value;
 
@@ -37,6 +38,7 @@ pub struct RuntimeContextInputs<'a> {
     pub execution_mode: String,
     pub plan_steps: Vec<(PlanStepStatus, String)>,
     pub plan_explanation: Option<String>,
+    pub todo_state: Option<TodoState>,
     pub compact_state: CompactState,
     pub history: &'a [Message],
     pub vdb_uri: &'a str,
@@ -209,6 +211,7 @@ impl<'a> ContextAssembler<'a> {
                 inputs.plan_steps.into_iter(),
                 inputs.plan_explanation,
             ),
+            todo: TodoContextView::from_state(inputs.todo_state),
             compaction,
             retrieval,
         }
@@ -415,6 +418,7 @@ mod tests {
                 execution_mode: "plan".to_string(),
                 plan_steps: vec![(PlanStepStatus::Pending, "inspect bootstrap".to_string())],
                 plan_explanation: Some("Keep one assembly path.".to_string()),
+                todo_state: None,
                 compact_state: crate::agent::CompactState {
                     estimated_history_tokens: 1234,
                     context_window_tokens: Some(8192),
@@ -472,6 +476,7 @@ mod tests {
                 execution_mode: "plan".to_string(),
                 plan_steps: vec![(PlanStepStatus::Pending, "inspect bootstrap".to_string())],
                 plan_explanation: Some("Keep one assembly path.".to_string()),
+                todo_state: None,
                 compact_state: crate::agent::CompactState {
                     estimated_history_tokens: 1234,
                     context_window_tokens: Some(8192),
@@ -551,6 +556,7 @@ mod tests {
                 execution_mode: "plan".to_string(),
                 plan_steps: Vec::new(),
                 plan_explanation: None,
+                todo_state: None,
                 compact_state: crate::agent::CompactState {
                     estimated_history_tokens: 1234,
                     context_window_tokens: Some(1_500),
@@ -635,6 +641,7 @@ mod tests {
                 execution_mode: "plan".to_string(),
                 plan_steps: vec![(PlanStepStatus::Pending, "inspect bootstrap".to_string())],
                 plan_explanation: Some("Keep one assembly path.".to_string()),
+                todo_state: None,
                 compact_state: crate::agent::CompactState {
                     context_window_tokens: Some(8_192),
                     compact_threshold_tokens: 7_000,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -18,6 +18,6 @@ pub use self::runtime::{
     CacheStatus, CompactionContextView, CompactionSourceContextEntry, ContextAssemblyEntry,
     ContextAssemblyView, ContextBudgetView, DropReason, MemorySelectionContextView,
     MemorySelectionItemContextEntry, PlanContextView, PromptContextView, PromptSourceContextEntry,
-    RetrievalContextView, RetrievalSourceContextEntry, SharedRuntimeContext,
+    RetrievalContextView, RetrievalSourceContextEntry, SharedRuntimeContext, TodoContextView,
     is_retrieved_memory_kind,
 };

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -1,5 +1,6 @@
 use crate::agent::{CompactState, PlanStepStatus};
 use crate::prompt::{EffectivePrompt, PromptSource};
+use crate::todo::{TodoState, TodoSummary};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheStatus {
@@ -134,6 +135,31 @@ impl PlanContextView {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TodoContextView {
+    pub summary: TodoSummary,
+    pub items: Vec<(String, String, String)>,
+}
+
+impl TodoContextView {
+    pub fn from_state(state: Option<TodoState>) -> Self {
+        match state {
+            Some(state) => Self {
+                summary: state.summary(),
+                items: state
+                    .items
+                    .into_iter()
+                    .map(|item| (item.id, item.status.as_str().to_string(), item.content))
+                    .collect(),
+            },
+            None => Self {
+                summary: TodoSummary::default(),
+                items: Vec::new(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextBudgetView {
     pub context_window_tokens: Option<usize>,
     pub compact_threshold_tokens: usize,
@@ -242,6 +268,7 @@ pub struct SharedRuntimeContext {
     pub assembly: ContextAssemblyView,
     pub prompt: PromptContextView,
     pub plan: PlanContextView,
+    pub todo: TodoContextView,
     pub compaction: CompactionContextView,
     pub retrieval: RetrievalContextView,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod state_db;
 mod thread_cli;
 mod thread_rollout_log;
 mod thread_store;
+mod todo;
 mod tool;
 mod tool_result;
 mod tools;

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -24,6 +24,7 @@ use crate::tools::pty::{
 };
 use crate::tools::search::{GlobTool, GrepTool};
 use crate::tools::skill::SkillTool;
+use crate::tools::todo::TodoWriteTool;
 use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
 use crate::tools::web::{WebFetchTool, WebSearchTool};
 use crate::tools::workspace::UpdateProjectMemoryTool;
@@ -101,6 +102,7 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(GrepTool));
     tm.register(Box::new(EnterPlanModeTool));
     tm.register(Box::new(ExitPlanModeTool));
+    tm.register(Box::new(TodoWriteTool));
     tm.register(Box::new(RememberExperienceTool {
         backend: backend.clone(),
         vdb: vdb.clone(),

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::agent::{AgentEvent, BashApprovalDecision};
+use crate::todo::TodoState;
 use crate::tool::ToolOutputStream;
 
 #[allow(dead_code)]
@@ -309,6 +310,7 @@ pub enum RuntimeEvent {
     Memory(MemoryEvent),
     Hook(HookEvent),
     Context(ContextEvent),
+    Todo(TodoEvent),
     Warning(WarningEvent),
     Error(ErrorEvent),
 }
@@ -448,6 +450,13 @@ pub enum ContextEvent {
 #[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
+pub enum TodoEvent {
+    Updated { state: TodoState },
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum WarningEvent {
     RuntimeWarning { message: String },
 }
@@ -489,6 +498,7 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
             stream: stream.into(),
             chunk,
         }),
+        AgentEvent::TodoUpdated(state) => RuntimeEvent::Todo(TodoEvent::Updated { state }),
     }
 }
 
@@ -624,6 +634,43 @@ mod tests {
                     "type": "follow_up_queued",
                     "payload": {
                         "queue_len": 3
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn todo_updated_event_uses_structured_wire_shape() {
+        let state = crate::todo::normalize_todo_write_input(&json!({
+            "todos": [
+                {"content": "Implement todo runtime", "status": "in_progress"}
+            ]
+        }))
+        .expect("todo state");
+        let value =
+            serde_json::to_value(agent_event_to_runtime_event(AgentEvent::TodoUpdated(state)))
+                .unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "type": "todo",
+                "payload": {
+                    "type": "updated",
+                    "payload": {
+                        "state": {
+                            "version": 1,
+                            "items": [
+                                {
+                                    "id": "todo-1",
+                                    "content": "Implement todo runtime",
+                                    "status": "in_progress",
+                                    "updated_at": value["payload"]["payload"]["state"]["updated_at"]
+                                }
+                            ],
+                            "updated_at": value["payload"]["payload"]["state"]["updated_at"]
+                        }
                     }
                 }
             })

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,6 +1,7 @@
 use crate::agent::Message;
 use crate::state_db::PersistedStructuredRolloutEvent;
 use crate::thread_rollout_log;
+use crate::todo::TodoState;
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -94,6 +95,10 @@ impl SessionManager {
         self.legacy_storage_dir.join(session_id).join("plan.md")
     }
 
+    pub fn todo_file_path(&self, session_id: &str) -> PathBuf {
+        self.legacy_storage_dir.join(session_id).join("todo.json")
+    }
+
     pub fn save_plan_file(&self, session_id: &str, plan: &str) -> Result<()> {
         let path = self.plan_file_path(session_id);
         if let Some(parent) = path.parent() {
@@ -106,6 +111,30 @@ impl SessionManager {
             return Err(err);
         }
         Ok(())
+    }
+
+    pub fn save_todo_state(&self, session_id: &str, state: &TodoState) -> Result<()> {
+        let path = self.todo_file_path(session_id);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content = serde_json::to_string_pretty(state)?;
+        let tmp_path = path.with_extension(format!("json.tmp-{}", uuid::Uuid::new_v4()));
+        fs::write(&tmp_path, content)?;
+        if let Err(err) = Self::replace_file(&tmp_path, &path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    pub fn load_todo_state(&self, session_id: &str) -> Result<Option<TodoState>> {
+        let path = self.todo_file_path(session_id);
+        match fs::read_to_string(path) {
+            Ok(content) => Ok(Some(serde_json::from_str(&content)?)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err.into()),
+        }
     }
 
     #[cfg(not(windows))]
@@ -428,6 +457,37 @@ mod tests {
             .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp-"))
             .count();
         assert_eq!(leftovers, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn save_and_load_todo_state_roundtrips_session_artifact() -> Result<()> {
+        let temp = tempdir()?;
+        let session_manager = SessionManager::new_for_rara_dir(temp.path().join(".rara"))?;
+        let state = crate::todo::TodoState {
+            version: 1,
+            updated_at: 42,
+            items: vec![crate::todo::TodoItem {
+                id: "todo-1".to_string(),
+                content: "Implement todo runtime".to_string(),
+                status: crate::todo::TodoStatus::InProgress,
+                updated_at: 42,
+            }],
+        };
+
+        session_manager.save_todo_state("thread-todo", &state)?;
+
+        assert_eq!(session_manager.load_todo_state("thread-todo")?, Some(state));
+        assert!(session_manager.todo_file_path("thread-todo").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn load_todo_state_returns_none_when_missing() -> Result<()> {
+        let temp = tempdir()?;
+        let session_manager = SessionManager::new_for_rara_dir(temp.path().join(".rara"))?;
+
+        assert_eq!(session_manager.load_todo_state("missing-thread")?, None);
         Ok(())
     }
 

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -1,0 +1,229 @@
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TodoState {
+    pub version: u32,
+    pub items: Vec<TodoItem>,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TodoItem {
+    pub id: String,
+    pub content: String,
+    pub status: TodoStatus,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TodoStatus {
+    Pending,
+    InProgress,
+    Completed,
+    Cancelled,
+}
+
+impl TodoStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TodoStatus::Pending => "pending",
+            TodoStatus::InProgress => "in_progress",
+            TodoStatus::Completed => "completed",
+            TodoStatus::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl TodoState {
+    pub fn summary(&self) -> TodoSummary {
+        let mut summary = TodoSummary::default();
+        summary.total = self.items.len();
+        for item in &self.items {
+            match item.status {
+                TodoStatus::Pending => summary.pending += 1,
+                TodoStatus::InProgress => {
+                    summary.in_progress += 1;
+                    if summary.active_item.is_none() {
+                        summary.active_item = Some(item.content.clone());
+                    }
+                }
+                TodoStatus::Completed => summary.completed += 1,
+                TodoStatus::Cancelled => summary.cancelled += 1,
+            }
+        }
+        summary
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TodoSummary {
+    pub total: usize,
+    pub pending: usize,
+    pub in_progress: usize,
+    pub completed: usize,
+    pub cancelled: usize,
+    pub active_item: Option<String>,
+}
+
+pub fn normalize_todo_write_input(input: &Value) -> Result<TodoState> {
+    let todos = input
+        .get("todos")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("todo_write requires a todos array"))?;
+    let updated_at = epoch_seconds();
+    let mut items = Vec::with_capacity(todos.len());
+    let mut in_progress_count = 0usize;
+
+    for (idx, item) in todos.iter().enumerate() {
+        let object = item
+            .as_object()
+            .ok_or_else(|| anyhow!("todo item {} must be an object", idx + 1))?;
+        let content = object
+            .get("content")
+            .or_else(|| object.get("description"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|content| !content.is_empty())
+            .ok_or_else(|| anyhow!("todo item {} requires non-empty content", idx + 1))?;
+        let status = object
+            .get("status")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("todo item {} requires status", idx + 1))?;
+        let status = parse_todo_status(status)
+            .ok_or_else(|| anyhow!("todo item {} has invalid status '{}'", idx + 1, status))?;
+        if status == TodoStatus::InProgress {
+            in_progress_count += 1;
+        }
+        let id = object
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("todo-{}", idx + 1));
+        items.push(TodoItem {
+            id,
+            content: content.to_string(),
+            status,
+            updated_at,
+        });
+    }
+
+    if in_progress_count > 1 {
+        return Err(anyhow!("todo_write allows at most one in_progress item"));
+    }
+
+    Ok(TodoState {
+        version: 1,
+        items,
+        updated_at,
+    })
+}
+
+pub fn format_todo_update(state: &TodoState) -> String {
+    let summary = state.summary();
+    let mut lines = vec![format!(
+        "Todo Updated: {} total, {} pending, {} in progress, {} completed, {} cancelled",
+        summary.total, summary.pending, summary.in_progress, summary.completed, summary.cancelled
+    )];
+    if let Some(active) = summary.active_item {
+        lines.push(format!("Active: {active}"));
+    }
+    for item in state.items.iter().take(8) {
+        lines.push(format!(
+            "{} {}",
+            status_marker(&item.status),
+            item.content.trim()
+        ));
+    }
+    if state.items.len() > 8 {
+        lines.push(format!("... {} more", state.items.len() - 8));
+    }
+    lines.join("\n")
+}
+
+fn status_marker(status: &TodoStatus) -> &'static str {
+    match status {
+        TodoStatus::Pending => "[ ]",
+        TodoStatus::InProgress => "[>]",
+        TodoStatus::Completed => "[x]",
+        TodoStatus::Cancelled => "[-]",
+    }
+}
+
+fn parse_todo_status(status: &str) -> Option<TodoStatus> {
+    match status {
+        "pending" => Some(TodoStatus::Pending),
+        "in_progress" => Some(TodoStatus::InProgress),
+        "completed" => Some(TodoStatus::Completed),
+        "cancelled" => Some(TodoStatus::Cancelled),
+        _ => None,
+    }
+}
+
+fn epoch_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn normalizes_todo_write_input() {
+        let state = normalize_todo_write_input(&json!({
+            "todos": [
+                {"content": "Inspect planning runtime", "status": "in_progress"},
+                {"id": "verify", "content": "Run focused tests", "status": "pending"}
+            ]
+        }))
+        .expect("todo input should normalize");
+
+        assert_eq!(state.version, 1);
+        assert_eq!(state.items[0].id, "todo-1");
+        assert_eq!(state.items[0].status, TodoStatus::InProgress);
+        assert_eq!(state.items[1].id, "verify");
+        assert_eq!(
+            state.summary().active_item.as_deref(),
+            Some("Inspect planning runtime")
+        );
+    }
+
+    #[test]
+    fn rejects_multiple_in_progress_items() {
+        let err = normalize_todo_write_input(&json!({
+            "todos": [
+                {"content": "First", "status": "in_progress"},
+                {"content": "Second", "status": "in_progress"}
+            ]
+        }))
+        .expect_err("multiple active todos should be rejected");
+
+        assert!(err.to_string().contains("at most one in_progress"));
+    }
+
+    #[test]
+    fn formats_compact_todo_update() {
+        let state = normalize_todo_write_input(&json!({
+            "todos": [
+                {"content": "Implement todo_write", "status": "completed"},
+                {"content": "Wire todo updates", "status": "in_progress"}
+            ]
+        }))
+        .expect("todo input should normalize");
+
+        let rendered = format_todo_update(&state);
+        assert!(rendered.contains("Todo Updated: 2 total"));
+        assert!(rendered.contains("Active: Wire todo updates"));
+        assert!(rendered.contains("[x] Implement todo_write"));
+        assert!(rendered.contains("[>] Wire todo updates"));
+    }
+}

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -1,6 +1,7 @@
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashSet;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -77,6 +78,7 @@ pub fn normalize_todo_write_input(input: &Value) -> Result<TodoState> {
     let updated_at = epoch_seconds();
     let mut items = Vec::with_capacity(todos.len());
     let mut in_progress_count = 0usize;
+    let mut seen_ids = HashSet::new();
 
     for (idx, item) in todos.iter().enumerate() {
         let object = item
@@ -105,6 +107,9 @@ pub fn normalize_todo_write_input(input: &Value) -> Result<TodoState> {
             .filter(|id| !id.is_empty())
             .map(str::to_string)
             .unwrap_or_else(|| format!("todo-{}", idx + 1));
+        if !seen_ids.insert(id.clone()) {
+            return Err(anyhow!("todo item {} has duplicate id '{}'", idx + 1, id));
+        }
         items.push(TodoItem {
             id,
             content: content.to_string(),
@@ -208,6 +213,19 @@ mod tests {
         .expect_err("multiple active todos should be rejected");
 
         assert!(err.to_string().contains("at most one in_progress"));
+    }
+
+    #[test]
+    fn rejects_duplicate_todo_ids() {
+        let err = normalize_todo_write_input(&json!({
+            "todos": [
+                {"content": "Generated id", "status": "pending"},
+                {"id": "todo-1", "content": "Explicit collision", "status": "pending"}
+            ]
+        }))
+        .expect_err("duplicate todo ids should be rejected");
+
+        assert!(err.to_string().contains("duplicate id 'todo-1'"));
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -7,6 +7,7 @@ pub mod planning;
 pub mod pty;
 pub mod search;
 pub mod skill;
+pub mod todo;
 pub mod vector;
 pub mod web;
 pub mod workspace;

--- a/src/tools/todo.rs
+++ b/src/tools/todo.rs
@@ -1,0 +1,96 @@
+use crate::todo::normalize_todo_write_input;
+use crate::tool::{Tool, ToolError};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+pub const TODO_WRITE_TOOL_NAME: &str = "todo_write";
+
+pub struct TodoWriteTool;
+
+#[async_trait]
+impl Tool for TodoWriteTool {
+    fn name(&self) -> &str {
+        TODO_WRITE_TOOL_NAME
+    }
+
+    fn description(&self) -> &str {
+        "Create or replace the session todo list for complex multi-step execution. Use this to track mutable execution progress, not to request plan approval."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "todos": {
+                    "type": "array",
+                    "description": "Complete replacement list of todo items for the current session.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "Optional stable id. If omitted, RARA assigns todo-1, todo-2, and so on."
+                            },
+                            "content": {
+                                "type": "string",
+                                "description": "Imperative description of the task."
+                            },
+                            "status": {
+                                "type": "string",
+                                "enum": ["pending", "in_progress", "completed", "cancelled"],
+                                "description": "Current task status. Keep at most one item in_progress."
+                            }
+                        },
+                        "required": ["content", "status"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "required": ["todos"],
+            "additionalProperties": false
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let state = normalize_todo_write_input(&input)
+            .map_err(|err| ToolError::InvalidInput(err.to_string()))?;
+        serde_json::to_value(state).map_err(|err| ToolError::ExecutionFailed(err.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::todo::TodoStatus;
+
+    #[tokio::test]
+    async fn todo_write_returns_normalized_state() {
+        let tool = TodoWriteTool;
+        let result = tool
+            .call(json!({
+                "todos": [
+                    {"content": "Implement todo_write", "status": "in_progress"},
+                    {"content": "Run tests", "status": "pending"}
+                ]
+            }))
+            .await
+            .expect("todo_write should normalize state");
+        let state: crate::todo::TodoState =
+            serde_json::from_value(result).expect("result should be todo state");
+
+        assert_eq!(state.items.len(), 2);
+        assert_eq!(state.items[0].id, "todo-1");
+        assert_eq!(state.items[0].status, TodoStatus::InProgress);
+    }
+
+    #[test]
+    fn todo_write_schema_is_strict_compatible() {
+        let schema = TodoWriteTool.input_schema();
+
+        assert_eq!(schema["additionalProperties"], false);
+        assert_eq!(
+            schema["properties"]["todos"]["items"]["additionalProperties"],
+            false
+        );
+    }
+}

--- a/src/tui/message_role.rs
+++ b/src/tui/message_role.rs
@@ -18,6 +18,7 @@ pub(crate) enum MessageRole {
     Planning,
     Running,
     Thinking,
+    Todo,
 }
 
 impl MessageRole {
@@ -36,6 +37,7 @@ impl MessageRole {
             Self::Planning => "Planning",
             Self::Running => "Running",
             Self::Thinking => "Thinking",
+            Self::Todo => "Todo",
         }
     }
 
@@ -54,6 +56,7 @@ impl MessageRole {
             "Planning" => Some(Self::Planning),
             "Running" => Some(Self::Running),
             "Thinking" => Some(Self::Thinking),
+            "Todo" => Some(Self::Todo),
             _ => None,
         }
     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -459,6 +459,7 @@ fn role_prefix_icon(role: &str) -> (&'static str, Color) {
         Some(MessageRole::Planning) => ("📋 ", PHASE_PLANNING),
         Some(MessageRole::Running) => ("▶ ", PHASE_RUNNING),
         Some(MessageRole::Agent) => ("🤖 ", ROLE_PREFIX),
+        Some(MessageRole::Todo) => ("☑ ", PHASE_PLANNING),
         _ => ("", TEXT_SECONDARY),
     }
 }

--- a/src/tui/render/cells/cells_components.rs
+++ b/src/tui/render/cells/cells_components.rs
@@ -420,7 +420,7 @@ impl QueuedFollowUpCell {
 
 impl HistoryCell for QueuedFollowUpCell {
     fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
-        let mut lines = vec![Line::from(section_span("Queued Follow-up", TEXT_SECONDARY))];
+        let mut lines = vec![Line::from(section_span("Queued Follow-up", PHASE_PLANNING))];
         for section in &self.sections {
             lines.push(Line::from(format!("  {}", section.title)));
             lines.push(Line::from(format!("    -> {}", section.preview)));

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -10,6 +10,7 @@ use self::helpers::{
 };
 use super::super::state::{RuntimePhase, TuiApp, TuiEvent, contains_structured_planning_output};
 use crate::agent::AgentEvent;
+use crate::todo::format_todo_update;
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
 const TOOL_PROGRESS_LINE_LIMIT: usize = 16;
@@ -263,6 +264,9 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
             message: text,
         }),
         AgentEvent::ToolUse { name, input } => {
+            if name == crate::tools::todo::TODO_WRITE_TOOL_NAME {
+                return None;
+            }
             if let Some(event) = TerminalEvent::from_tool_use(&name, &input) {
                 return Some(TuiEvent::Terminal(event));
             }
@@ -276,6 +280,9 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
             content,
             is_error,
         } => {
+            if name == crate::tools::todo::TODO_WRITE_TOOL_NAME {
+                return None;
+            }
             if is_exploration_tool_name(&name) {
                 return None;
             }
@@ -304,6 +311,10 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
                     chunk,
                 })
             }),
+        AgentEvent::TodoUpdated(state) => Some(TuiEvent::Transcript {
+            role: "Todo",
+            message: format_todo_update(&state),
+        }),
     }
 }
 

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -693,6 +693,43 @@ fn converts_terminal_tool_result_to_typed_event() {
 }
 
 #[test]
+fn todo_write_events_render_as_compact_todo_transcript() {
+    let state = crate::todo::normalize_todo_write_input(&json!({
+        "todos": [
+            {"content": "Implement todo runtime", "status": "in_progress"},
+            {"content": "Run tests", "status": "pending"}
+        ]
+    }))
+    .expect("todo state");
+
+    assert!(
+        convert_agent_event(AgentEvent::ToolUse {
+            name: crate::tools::todo::TODO_WRITE_TOOL_NAME.to_string(),
+            input: json!({"todos": []}),
+        })
+        .is_none()
+    );
+    assert!(
+        convert_agent_event(AgentEvent::ToolResult {
+            name: crate::tools::todo::TODO_WRITE_TOOL_NAME.to_string(),
+            content: "{}".to_string(),
+            is_error: false,
+        })
+        .is_none()
+    );
+
+    let event = convert_agent_event(AgentEvent::TodoUpdated(state)).expect("todo event");
+    match event {
+        TuiEvent::Transcript { role, message } => {
+            assert_eq!(role, "Todo");
+            assert!(message.contains("Todo Updated: 2 total"));
+            assert!(message.contains("Active: Implement todo runtime"));
+        }
+        _ => panic!("unexpected event"),
+    }
+}
+
+#[test]
 fn applies_terminal_begin_event_as_running_action() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -40,6 +40,7 @@ fn merge_rebuilt_agent(mut rebuilt: Agent, previous: Agent) -> Agent {
     rebuilt.plan_explanation = previous.plan_explanation;
     rebuilt.pending_user_input = previous.pending_user_input;
     rebuilt.pending_approval = previous.pending_approval;
+    rebuilt.todo_state = previous.todo_state;
     rebuilt.completed_user_input = previous.completed_user_input;
     rebuilt.completed_approval = previous.completed_approval;
     rebuilt.compact_state.estimated_history_tokens =

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -52,6 +52,7 @@ pub(super) fn restore_thread_by_id(
     } = thread;
     agent.history = history;
     agent.session_id = metadata.session_id;
+    agent.todo_state = agent.session_manager.load_todo_state(thread_id)?;
     if let Some(runtime_state) = state_db.load_session_runtime_state(thread_id)? {
         agent.set_bash_approval_mode(parse_bash_approval_mode(
             runtime_state.bash_approval.as_str(),
@@ -232,6 +233,7 @@ mod tests {
     use crate::llm::MockLlm;
     use crate::prompt::PromptRuntimeConfig;
     use crate::state_db::StateDb;
+    use crate::todo::{TodoItem, TodoState, TodoStatus};
     use crate::tool::ToolManager;
     use crate::tui::state::TuiApp;
     use crate::vectordb::VectorDB;
@@ -279,6 +281,22 @@ mod tests {
         }];
         original_agent.plan_explanation =
             Some("Restore should rebuild the same context surface.".to_string());
+        original_agent.todo_state = Some(TodoState {
+            version: 1,
+            updated_at: 42,
+            items: vec![TodoItem {
+                id: "todo-1".to_string(),
+                content: "Restore todo state".to_string(),
+                status: TodoStatus::InProgress,
+                updated_at: 42,
+            }],
+        });
+        session_manager
+            .save_todo_state(
+                &original_agent.session_id,
+                original_agent.todo_state.as_ref().expect("todo state"),
+            )
+            .expect("save todo state");
         original_agent.compact_state.compaction_count = 1;
         original_agent.compact_state.last_compaction_before_tokens = Some(2400);
         original_agent.compact_state.last_compaction_after_tokens = Some(900);
@@ -362,6 +380,7 @@ mod tests {
             restored_runtime.plan.explanation,
             expected_runtime.plan.explanation
         );
+        assert_eq!(restored_runtime.todo, expected_runtime.todo);
         assert_eq!(
             restored_runtime.assembly.entries,
             expected_runtime.assembly.entries


### PR DESCRIPTION
## Summary

- Add Claude-style `todo_write` as a complete-list runtime todo tool.
- Persist session todo state to `.rara/sessions/<session_id>/todo.json` and restore it on resume.
- Emit structured `todo.updated` runtime-control events for Wire/ACP consumers and render compact TUI `Todo Updated` cards.
- Improve `Queued Follow-up` badge contrast by using the planning phase badge color.

## Testing

- `cargo test todo_write -- --nocapture`
- `cargo test todo_state -- --nocapture`
- `cargo test todo_updated_event_uses_structured_wire_shape -- --nocapture`
- `cargo test restore_session_keeps_runtime_context_and_snapshot_aligned -- --nocapture`
- `cargo test active_turn_cell_renders_queued_follow_up_without_hiding_shell_approval -- --nocapture`
- `cargo check`

