### PR TITLE
feat: surface todo state in context status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8641,6 +8641,7 @@ dependencies = [
  "textwrap 0.16.2",
  "thiserror 2.0.18",
  "tiktoken-rs",
+ "time",
  "tokenizers 0.23.1",
  "tokio",
  "two-face",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ reqwest = { version = "0.13", features = ["json", "stream"] }
 async-trait = "0.1"
 anyhow = "1.0"
 thiserror = "2.0"
+time = { version = "0.3", features = ["formatting"] }
 owo-colors = "4.0"
 indicatif = "0.18"
 tiktoken-rs = "0.11"

--- a/docs/features/todo-runtime.md
+++ b/docs/features/todo-runtime.md
@@ -164,6 +164,8 @@ conversion:
   the list changes.
 - The runtime-control event stream emits a structured `todo.updated` event for Wire/ACP consumers
   instead of requiring them to parse transcript text.
+- `/context` renders the current todo artifact path, counts, active item, and bounded item list from
+  `TodoContextView`; `/status` renders a compact todo summary.
 
 ## Open Risks
 
@@ -173,8 +175,8 @@ conversion:
   clearer ownership model.
 - The UI should avoid permanent todo cards; stale completed lists can become visual noise in long
   sessions.
-- `/context` and `/status` should still get first-class todo sections on top of the structured
-  runtime view.
+- Future context compaction should decide whether to carry the active todo only or a bounded pending
+  projection.
 
 ## Source Journals
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -85,7 +85,7 @@ Active backlog only. Keep this file small and current.
 - [ ] High-fidelity render pass for `write/update`, inline diffs, approval cards, message-card hierarchy.
 - [ ] Expand TUI snapshot coverage.
 - [ ] Keep transcript and pending-interaction state backed by structured events that ACP/Wire output subscribers can reuse.
-- [ ] Add first-class todo sections to `/context` and `/status` from `TodoContextView`.
+- [x] Add first-class todo sections to `/context` and `/status` from `TodoContextView`.
 
 ## Security / Reliability / Performance
 

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -134,9 +134,10 @@ impl PlanContextView {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TodoContextView {
     pub summary: TodoSummary,
+    pub updated_at: Option<i64>,
     pub items: Vec<(String, String, String)>,
 }
 
@@ -145,6 +146,7 @@ impl TodoContextView {
         match state {
             Some(state) => Self {
                 summary: state.summary(),
+                updated_at: Some(state.updated_at),
                 items: state
                     .items
                     .into_iter()
@@ -153,6 +155,7 @@ impl TodoContextView {
             },
             None => Self {
                 summary: TodoSummary::default(),
+                updated_at: None,
                 items: Vec::new(),
             },
         }

--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -1,4 +1,4 @@
-use super::state::{HelpTab, Overlay};
+use super::state::{HelpTab, Overlay, StatusTab};
 
 #[derive(Debug, Clone)]
 pub enum AppEvent {
@@ -42,6 +42,7 @@ pub enum AppEvent {
     DeleteOpenAiProfile,
     RefreshDeepSeekModels,
     SelectHelpTab(HelpTab),
+    SelectStatusTab(StatusTab),
     ApplyOverlaySelection,
     CancelRunningTask,
 }

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -242,6 +242,69 @@ fn render_context_usage_summary(app: &TuiApp) -> String {
     lines.join("\n")
 }
 
+fn todo_summary_line(app: &TuiApp) -> String {
+    let summary = &app.snapshot.todo.summary;
+    if summary.total == 0 {
+        return "none".to_string();
+    }
+    let active = summary.active_item.as_deref().unwrap_or("-");
+    format!(
+        "{} total, {} pending, {} in_progress, {} completed, {} cancelled, active={}",
+        summary.total,
+        summary.pending,
+        summary.in_progress,
+        summary.completed,
+        summary.cancelled,
+        truncate_preview(active, 80)
+    )
+}
+
+fn render_todo_context(app: &TuiApp) -> String {
+    let summary = &app.snapshot.todo.summary;
+    if summary.total == 0 {
+        return "Todo\n  artifact: -\n  items: none".to_string();
+    }
+    let artifact = app.snapshot.todo_artifact_path.as_deref().unwrap_or("-");
+    let updated_at = app
+        .snapshot
+        .todo
+        .updated_at
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    let active = summary.active_item.as_deref().unwrap_or("-");
+    let items = if app.snapshot.todo.items.is_empty() {
+        "  items: none".to_string()
+    } else {
+        let rendered_items = app
+            .snapshot
+            .todo
+            .items
+            .iter()
+            .take(8)
+            .map(|(id, status, content)| {
+                format!("    - [{status}] {} ({id})", truncate_preview(content, 100))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let omitted = app.snapshot.todo.items.len().saturating_sub(8);
+        if omitted == 0 {
+            format!("  items:\n{rendered_items}")
+        } else {
+            format!("  items:\n{rendered_items}\n    ... {omitted} more")
+        }
+    };
+    format!(
+        "Todo\n  artifact: {artifact}\n  updated_at: {updated_at}\n  total: {}  pending: {}  in_progress: {}  completed: {}  cancelled: {}\n  active: {}\n{}",
+        summary.total,
+        summary.pending,
+        summary.in_progress,
+        summary.completed,
+        summary.cancelled,
+        truncate_preview(active, 100),
+        items,
+    )
+}
+
 pub fn status_context_text(app: &TuiApp) -> String {
     let prompt_warnings = if app.snapshot.prompt_warnings.is_empty() {
         None
@@ -341,6 +404,7 @@ pub fn status_context_text(app: &TuiApp) -> String {
             app.snapshot.plan_explanation.as_deref().unwrap_or("-"),
             plan_lines
         ),
+        render_todo_context(app),
         format!("Pending\n{}", pending_interactions),
         render_context_assembly_entries(app, "stable_instructions", "Stable Instructions"),
         render_context_assembly_entries(
@@ -421,7 +485,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
         ("remote".to_string(), "-".to_string())
     };
     format!(
-        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\ndevice={}\ndtype={}\nfocused={}\nphase={}\ndetail={}",
+        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\ntodo={}\ndevice={}\ndtype={}\nfocused={}\nphase={}\ndetail={}",
         surface.provider,
         endpoint_profile,
         endpoint_kind,
@@ -445,6 +509,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
             .reasoning_effort
             .display_or(reasoning_effort_label.as_str()),
         surface.reasoning_effort.source.label(),
+        todo_summary_line(app),
         device,
         dtype,
         app.terminal_focused,

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -5,6 +5,7 @@ use crate::tui::session_restore::provider_requires_api_key;
 use crate::tui::state::{
     PROVIDER_FAMILIES, PendingInteractionSnapshot, ProviderFamily, TuiApp, current_model_presets,
 };
+use time::{OffsetDateTime, format_description};
 
 fn format_pending_interaction(snapshot: &PendingInteractionSnapshot) -> String {
     let kind = match snapshot.kind {
@@ -313,29 +314,13 @@ fn render_todo_context(app: &TuiApp) -> String {
 }
 
 fn format_unix_timestamp_utc(timestamp: i64) -> String {
-    let days = timestamp.div_euclid(86_400);
-    let seconds_of_day = timestamp.rem_euclid(86_400);
-    let (year, month, day) = civil_from_days(days);
-    let hour = seconds_of_day / 3_600;
-    let minute = seconds_of_day % 3_600 / 60;
-    let second = seconds_of_day % 60;
-    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02} UTC")
-}
+    let format = format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second] UTC")
+        .expect("static timestamp format should be valid");
 
-fn civil_from_days(days_since_unix_epoch: i64) -> (i64, u32, u32) {
-    let z = days_since_unix_epoch + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 }.div_euclid(146_097);
-    let day_of_era = z - era * 146_097;
-    let year_of_era = (day_of_era - day_of_era / 1_460 + day_of_era / 36_524
-        - day_of_era / 146_096)
-        .div_euclid(365);
-    let year = year_of_era + era * 400;
-    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
-    let month_prime = (5 * day_of_year + 2).div_euclid(153);
-    let day = day_of_year - (153 * month_prime + 2).div_euclid(5) + 1;
-    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
-    let year = year + if month <= 2 { 1 } else { 0 };
-    (year, month as u32, day as u32)
+    OffsetDateTime::from_unix_timestamp(timestamp)
+        .ok()
+        .and_then(|dt| dt.format(&format).ok())
+        .unwrap_or_else(|| "invalid timestamp".to_string())
 }
 
 pub fn status_context_text(app: &TuiApp) -> String {

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -269,9 +269,9 @@ fn render_todo_context(app: &TuiApp) -> String {
         .snapshot
         .todo
         .updated_at
-        .map(|value| value.to_string())
+        .map(format_unix_timestamp_utc)
         .unwrap_or_else(|| "-".to_string());
-    let active = summary.active_item.as_deref().unwrap_or("-");
+    let active = summary.active_item.as_deref();
     let items = if app.snapshot.todo.items.is_empty() {
         "  items: none".to_string()
     } else {
@@ -282,7 +282,15 @@ fn render_todo_context(app: &TuiApp) -> String {
             .iter()
             .take(8)
             .map(|(id, status, content)| {
-                format!("    - [{status}] {} ({id})", truncate_preview(content, 100))
+                let suffix = if active == Some(content.as_str()) {
+                    format!("{id}, active")
+                } else {
+                    id.to_string()
+                };
+                format!(
+                    "    - [{status}] {} ({suffix})",
+                    truncate_preview(content, 100)
+                )
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -294,15 +302,40 @@ fn render_todo_context(app: &TuiApp) -> String {
         }
     };
     format!(
-        "Todo\n  artifact: {artifact}\n  updated_at: {updated_at}\n  total: {}  pending: {}  in_progress: {}  completed: {}  cancelled: {}\n  active: {}\n{}",
+        "Todo\n  artifact: {artifact}\n  updated_at: {updated_at}\n  total: {}  pending: {}  in_progress: {}  completed: {}  cancelled: {}\n{}",
         summary.total,
         summary.pending,
         summary.in_progress,
         summary.completed,
         summary.cancelled,
-        truncate_preview(active, 100),
         items,
     )
+}
+
+fn format_unix_timestamp_utc(timestamp: i64) -> String {
+    let days = timestamp.div_euclid(86_400);
+    let seconds_of_day = timestamp.rem_euclid(86_400);
+    let (year, month, day) = civil_from_days(days);
+    let hour = seconds_of_day / 3_600;
+    let minute = seconds_of_day % 3_600 / 60;
+    let second = seconds_of_day % 60;
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02} UTC")
+}
+
+fn civil_from_days(days_since_unix_epoch: i64) -> (i64, u32, u32) {
+    let z = days_since_unix_epoch + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 }.div_euclid(146_097);
+    let day_of_era = z - era * 146_097;
+    let year_of_era = (day_of_era - day_of_era / 1_460 + day_of_era / 36_524
+        - day_of_era / 146_096)
+        .div_euclid(365);
+    let year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2).div_euclid(153);
+    let day = day_of_year - (153 * month_prime + 2).div_euclid(5) + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    let year = year + if month <= 2 { 1 } else { 0 };
+    (year, month as u32, day as u32)
 }
 
 pub fn status_context_text(app: &TuiApp) -> String {
@@ -896,4 +929,18 @@ pub fn is_local_provider(provider: &str) -> bool {
         provider,
         "local" | "local-candle" | "gemma4" | "qwen3" | "qwn3"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_unix_timestamp_utc;
+
+    #[test]
+    fn format_unix_timestamp_utc_renders_readable_utc_time() {
+        assert_eq!(format_unix_timestamp_utc(0), "1970-01-01 00:00:00 UTC");
+        assert_eq!(
+            format_unix_timestamp_utc(1_777_584_000),
+            "2026-04-30 21:20:00 UTC"
+        );
+    }
 }

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -510,9 +510,10 @@ fn status_context_text_includes_prompt_sources_and_plan_state() {
     assert!(rendered.contains("[pending] Implement /context"));
     assert!(rendered.contains("Todo"));
     assert!(rendered.contains("artifact: /workspace/rara/.rara/sessions/session-123/todo.json"));
+    assert!(rendered.contains("updated_at: 2026-04-30 21:20:00 UTC"));
     assert!(rendered.contains("total: 3  pending: 1  in_progress: 1  completed: 1"));
-    assert!(rendered.contains("active: Wire todo state into /context"));
-    assert!(rendered.contains("[in_progress] Wire todo state into /context (todo-2)"));
+    assert!(!rendered.contains("active: Wire todo state into /context"));
+    assert!(rendered.contains("[in_progress] Wire todo state into /context (todo-2, active)"));
     assert!(rendered.contains("Pending"));
 }
 

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -6,7 +6,8 @@ use super::{
     status_resources_text, status_runtime_text,
 };
 use crate::config::{ConfigManager, OpenAiEndpointKind};
-use crate::context::PromptSourceContextEntry;
+use crate::context::{PromptSourceContextEntry, TodoContextView};
+use crate::todo::TodoSummary;
 use crate::tui::state::{LocalCommandKind, RuntimeSnapshot, TuiApp};
 use tempfile::tempdir;
 
@@ -460,6 +461,31 @@ fn status_context_text_includes_prompt_sources_and_plan_state() {
             },
         ],
         plan_steps: vec![("pending".into(), "Implement /context".into())],
+        todo: TodoContextView {
+            summary: TodoSummary {
+                total: 3,
+                pending: 1,
+                in_progress: 1,
+                completed: 1,
+                cancelled: 0,
+                active_item: Some("Wire todo state into /context".into()),
+            },
+            updated_at: Some(1_777_584_000),
+            items: vec![
+                (
+                    "todo-1".into(),
+                    "completed".into(),
+                    "Implement todo_write runtime".into(),
+                ),
+                (
+                    "todo-2".into(),
+                    "in_progress".into(),
+                    "Wire todo state into /context".into(),
+                ),
+                ("todo-3".into(), "pending".into(), "Add status coverage".into()),
+            ],
+        },
+        todo_artifact_path: Some("/workspace/rara/.rara/sessions/session-123/todo.json".into()),
         ..RuntimeSnapshot::default()
     };
 
@@ -482,7 +508,48 @@ fn status_context_text_includes_prompt_sources_and_plan_state() {
     assert!(rendered.contains("Retrieval-ready"));
     assert!(rendered.contains("Plan"));
     assert!(rendered.contains("[pending] Implement /context"));
+    assert!(rendered.contains("Todo"));
+    assert!(rendered.contains("artifact: /workspace/rara/.rara/sessions/session-123/todo.json"));
+    assert!(rendered.contains("total: 3  pending: 1  in_progress: 1  completed: 1"));
+    assert!(rendered.contains("active: Wire todo state into /context"));
+    assert!(rendered.contains("[in_progress] Wire todo state into /context (todo-2)"));
     assert!(rendered.contains("Pending"));
+}
+
+#[test]
+fn status_runtime_text_reports_todo_summary() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.snapshot = RuntimeSnapshot {
+        todo: TodoContextView {
+            summary: TodoSummary {
+                total: 2,
+                pending: 1,
+                in_progress: 1,
+                completed: 0,
+                cancelled: 0,
+                active_item: Some("Run focused tests".into()),
+            },
+            updated_at: Some(1_777_584_000),
+            items: vec![
+                (
+                    "todo-1".into(),
+                    "in_progress".into(),
+                    "Run focused tests".into(),
+                ),
+                ("todo-2".into(), "pending".into(), "Push PR update".into()),
+            ],
+        },
+        ..RuntimeSnapshot::default()
+    };
+
+    let rendered = status_runtime_text(&app);
+    assert!(rendered.contains(
+        "todo=2 total, 1 pending, 1 in_progress, 0 completed, 0 cancelled, active=Run focused tests"
+    ));
 }
 
 #[test]

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -329,6 +329,9 @@ pub(crate) async fn dispatch_event(
         AppEvent::SelectHelpTab(tab) => {
             app.open_overlay(Overlay::Help(tab));
         }
+        AppEvent::SelectStatusTab(tab) => {
+            app.open_overlay(Overlay::Status(tab));
+        }
         AppEvent::SetModelSelection(idx) => {
             app.model_picker_idx = idx.min(app.current_model_picker_len().saturating_sub(1));
         }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -1,7 +1,7 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::app_event::AppEvent;
-use super::state::{HelpTab, Overlay, ProviderFamily, TuiApp};
+use super::state::{HelpTab, Overlay, ProviderFamily, StatusTab, TuiApp};
 
 pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
     let code = key.code;
@@ -39,8 +39,13 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             KeyCode::Char(c) => AppEvent::InputChar(c),
             _ => AppEvent::Noop,
         },
-        Some(Overlay::Status) => match code {
+        Some(Overlay::Status(tab)) => match code {
             KeyCode::Esc | KeyCode::Enter => AppEvent::CloseOverlay,
+            KeyCode::Char('1') => AppEvent::SelectStatusTab(StatusTab::Overview),
+            KeyCode::Char('2') => AppEvent::SelectStatusTab(StatusTab::Config),
+            KeyCode::Char('3') => AppEvent::SelectStatusTab(StatusTab::Context),
+            KeyCode::Right | KeyCode::Tab => AppEvent::SelectStatusTab(next_status_tab(tab)),
+            KeyCode::Left | KeyCode::BackTab => AppEvent::SelectStatusTab(prev_status_tab(tab)),
             _ => AppEvent::Noop,
         },
         Some(Overlay::Context) => match code {
@@ -277,6 +282,22 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
                 _ => AppEvent::Noop,
             }
         }
+    }
+}
+
+fn next_status_tab(tab: StatusTab) -> StatusTab {
+    match tab {
+        StatusTab::Overview => StatusTab::Config,
+        StatusTab::Config => StatusTab::Context,
+        StatusTab::Context => StatusTab::Overview,
+    }
+}
+
+fn prev_status_tab(tab: StatusTab) -> StatusTab {
+    match tab {
+        StatusTab::Overview => StatusTab::Context,
+        StatusTab::Config => StatusTab::Overview,
+        StatusTab::Context => StatusTab::Config,
     }
 }
 

--- a/src/tui/queued_input.rs
+++ b/src/tui/queued_input.rs
@@ -13,11 +13,11 @@ pub fn queued_follow_up_heading() -> &'static str {
 }
 
 pub fn pending_follow_up_hint() -> &'static str {
-    "pending follow-up  will submit after next tool call"
+    "queued: after tool"
 }
 
 pub fn queued_follow_up_hint() -> &'static str {
-    "queued follow-up  will submit after current turn"
+    "queued: after turn"
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -314,7 +314,7 @@ fn composer_hint(app: &TuiApp) -> &'static str {
     } else if app.agent_execution_mode_label() == "plan" {
         "planning mode  read-only planning; approve to execute"
     } else {
-        "Enter submit  Shift+Enter newline  / open commands"
+        ""
     }
 }
 

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -227,7 +227,7 @@ fn composer_hint_line_excludes_repo_context() {
     let rendered = composer_hint_line(&app).to_string();
     assert!(!rendered.contains("repo:"));
     assert!(!rendered.contains("branch:"));
-    assert!(rendered.contains("Enter submit"));
+    assert!(!rendered.contains("Enter submit"));
 }
 
 #[test]

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -146,7 +146,7 @@ fn activity_status_line_renders_warning_notice_in_yellow() {
 }
 
 #[test]
-fn queued_follow_up_hint_overrides_busy_hint() {
+fn queued_follow_up_hint_stays_compact_while_busy() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -156,10 +156,7 @@ fn queued_follow_up_hint_overrides_busy_hint() {
     app.begin_running_turn();
     app.queue_follow_up_message_after_next_tool_boundary("follow-up");
 
-    assert_eq!(
-        composer_hint(&app),
-        "pending follow-up  will submit after next tool call"
-    );
+    assert_eq!(composer_hint(&app), "queued: after tool");
 }
 
 #[tokio::test]
@@ -376,7 +373,7 @@ async fn activity_status_line_hides_busy_progress_from_composer_bar() {
 }
 
 #[test]
-fn composer_hint_shows_queued_follow_up_when_idle_with_messages() {
+fn composer_hint_shows_compact_queued_follow_up_when_idle() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -386,10 +383,7 @@ fn composer_hint_shows_queued_follow_up_when_idle_with_messages() {
     app.queue_follow_up_message("second hint");
 
     assert_eq!(app.queued_follow_up_count(), 2);
-    assert_eq!(
-        composer_hint(&app),
-        "queued follow-up  will submit after current turn"
-    );
+    assert_eq!(composer_hint(&app), "queued: after turn");
 }
 
 #[test]

--- a/src/tui/render/cells/cells_components.rs
+++ b/src/tui/render/cells/cells_components.rs
@@ -12,7 +12,9 @@ use crate::tui::interaction_text::{
 };
 use crate::tui::markdown_render::render_markdown_text_with_width;
 use crate::tui::plan_display::updated_plan_lines;
-use crate::tui::queued_input::QueuedFollowUpSection;
+use crate::tui::queued_input::{
+    QueuedFollowUpSection, pending_follow_up_heading, queued_follow_up_heading,
+};
 use crate::tui::render::diff::render_patch_preview;
 use crate::tui::render::{
     display_width, formatted_message_lines, prefixed_message_lines, rendered_markdown_lines,
@@ -420,18 +422,27 @@ impl QueuedFollowUpCell {
 
 impl HistoryCell for QueuedFollowUpCell {
     fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
-        let mut lines = vec![Line::from(section_span("Queued Follow-up", PHASE_PLANNING))];
-        for section in &self.sections {
-            lines.push(Line::from(format!("  {}", section.title)));
-            lines.push(Line::from(format!("    -> {}", section.preview)));
-            if section.remaining > 0 {
-                lines.push(Line::from(format!(
-                    "    ... {} {}",
-                    section.remaining, section.remaining_label
-                )));
-            }
-        }
-        lines
+        self.sections
+            .iter()
+            .map(|section| {
+                let phase = if section.title == pending_follow_up_heading() {
+                    "after tool"
+                } else if section.title == queued_follow_up_heading() {
+                    "after turn"
+                } else {
+                    "queued"
+                };
+                let remaining = if section.remaining > 0 {
+                    format!(" (+{})", section.remaining)
+                } else {
+                    String::new()
+                };
+                Line::from(vec![
+                    section_span("Queued", PHASE_PLANNING),
+                    Span::raw(format!(" · {phase} · {}{remaining}", section.preview)),
+                ])
+            })
+            .collect()
     }
 }
 

--- a/src/tui/render/cells/cells_tests/active_plan.rs
+++ b/src/tui/render/cells/cells_tests/active_plan.rs
@@ -251,8 +251,9 @@ fn active_turn_cell_renders_queued_follow_up_without_hiding_shell_approval() {
 
     assert!(rendered.contains(" Shell Approval "));
     assert!(rendered.contains("1. Allow once"));
-    assert!(rendered.contains(" Queued Follow-up "));
-    assert!(rendered.contains("Queued follow-up messages"));
+    assert!(rendered.contains(" Queued "));
+    assert!(rendered.contains("after turn"));
+    assert!(!rendered.contains("Queued follow-up messages"));
     assert!(rendered.contains("then review the diff"));
 }
 

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -251,8 +251,9 @@ fn active_turn_cell_renders_queued_follow_up_without_hiding_shell_approval() {
 
     assert!(rendered.contains(" Shell Approval "));
     assert!(rendered.contains("1. Allow once"));
-    assert!(rendered.contains(" Queued Follow-up "));
-    assert!(rendered.contains("Queued follow-up messages"));
+    assert!(rendered.contains(" Queued "));
+    assert!(rendered.contains("after turn"));
+    assert!(!rendered.contains("Queued follow-up messages"));
     assert!(rendered.contains("then review the diff"));
 }
 

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -17,14 +17,12 @@ use self::overlay_setup::{
     render_reasoning_effort_picker_modal, render_resume_picker_modal,
 };
 use super::super::command::{
-    current_turn_preview, download_status_text, general_help_text, matching_commands,
-    model_help_text, palette_commands, quick_actions_text, recent_transcript_preview,
-    status_prompt_sources_text, status_resources_text, status_runtime_text, status_workspace_text,
+    general_help_text, matching_commands, model_help_text, palette_commands,
+    recent_transcript_preview, status_prompt_sources_text, status_resources_text,
+    status_runtime_text, status_workspace_text,
 };
 use super::super::custom_terminal::Frame;
-use super::super::interaction_text::status_active_pending_interaction_text;
-use super::super::plan_display::status_plan_text;
-use super::super::state::{CommandSpec, HelpTab, Overlay, TuiApp};
+use super::super::state::{CommandSpec, HelpTab, Overlay, StatusTab, TuiApp};
 use crate::tui::context_display::render_context_lines;
 use crate::tui::status_display::render_status_lines;
 
@@ -47,10 +45,10 @@ pub(super) fn render_overlay(
             render_command_palette(f, app, popup);
             None
         }
-        Overlay::Status => {
+        Overlay::Status(tab) => {
             let popup = centered_rect(78, 70, f.area());
             f.render_widget(Clear, popup);
-            render_status_modal(f, app, popup);
+            render_status_modal(f, app, popup, tab);
             None
         }
         Overlay::Context => {
@@ -410,22 +408,50 @@ mod tests {
         assert!(popup.width >= 90);
     }
 }
-fn render_status_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
-    let lines = render_status_lines(app);
+fn render_status_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: StatusTab) {
+    let lines = render_status_lines(app, tab);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Fill(1), Constraint::Length(1)])
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Fill(1),
+            Constraint::Length(1),
+        ])
         .split(area);
+    let titles = status_tab_titles();
     f.render_widget(
-        Paragraph::new(lines).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
+        Tabs::new(titles)
+            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
+            .select(status_tab_index(tab))
+            .style(Style::default().fg(TEXT_SECONDARY))
+            .highlight_style(help_selected_tab_style()),
         chunks[0],
     );
     f.render_widget(
-        Paragraph::new(" ↑↓ scroll  Esc close  /context detailed view")
-            .style(Style::default().fg(Color::DarkGray))
-            .alignment(Alignment::Center),
+        Paragraph::new(lines).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
         chunks[1],
     );
+    f.render_widget(
+        Paragraph::new("Esc close  1 overview  2 config  3 context  <-> switch")
+            .style(Style::default().fg(Color::DarkGray))
+            .alignment(Alignment::Center),
+        chunks[2],
+    );
+}
+
+fn status_tab_titles() -> Vec<Line<'static>> {
+    ["Overview", "Config", "Context"]
+        .into_iter()
+        .map(Line::from)
+        .collect()
+}
+
+fn status_tab_index(tab: StatusTab) -> usize {
+    match tab {
+        StatusTab::Overview => 0,
+        StatusTab::Config => 1,
+        StatusTab::Context => 2,
+    }
 }
 
 fn render_context_modal(f: &mut Frame, app: &TuiApp, area: Rect) {

--- a/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
@@ -25,4 +25,5 @@ Prompt ideas:
 Warning  Warning: openai-compatible is missing an API key. Use /model to configure the current provi
 › Ask about the repo, request a code change, or type /help to browse commands.
 
+
                                                                                               ctx~=0

--- a/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
@@ -25,5 +25,4 @@ Prompt ideas:
 Warning  Warning: openai-compatible is missing an API key. Use /model to configure the current provi
 › Ask about the repo, request a code change, or type /help to browse commands.
 
-Enter submit  Shift+Enter newline  / open commands
                                                                                               ctx~=0

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -10,7 +10,7 @@ use tempfile::tempdir;
 use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::{
-    Overlay, ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp,
+    Overlay, ProviderFamily, RuntimeSnapshot, StatusTab, TranscriptEntry, TranscriptTurn, TuiApp,
 };
 
 use super::cells::HistoryCell;
@@ -480,7 +480,7 @@ fn transcript_viewport_is_independent_from_overlay_state() {
     });
 
     let base = transcript_viewport(&app, 80, 18);
-    app.overlay = Some(Overlay::Status);
+    app.overlay = Some(Overlay::Status(StatusTab::Overview));
     let with_overlay = transcript_viewport(&app, 80, 18);
 
     let base_rendered = base
@@ -525,7 +525,7 @@ fn transcript_viewport_keeps_manual_scroll_when_overlay_opens() {
     app.scroll_transcript(-3);
 
     let base = transcript_viewport(&app, 60, 8);
-    app.overlay = Some(Overlay::Status);
+    app.overlay = Some(Overlay::Status(StatusTab::Overview));
     let with_overlay = transcript_viewport(&app, 60, 8);
 
     assert_eq!(base.scroll_offset, with_overlay.scroll_offset);

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
 use crate::oauth::OAuthManager;
 
-use super::super::state::{HelpTab, LocalCommand, LocalCommandKind, Overlay, RuntimePhase, TuiApp};
+use super::super::state::{
+    HelpTab, LocalCommand, LocalCommandKind, Overlay, RuntimePhase, StatusTab, TuiApp,
+};
 use super::tasks::{start_compact_task, start_rebuild_task};
 
 pub(super) async fn execute_local_command(
@@ -124,7 +126,7 @@ pub(super) async fn execute_local_command(
         }
         LocalCommandKind::Status => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening status".into()));
-            app.open_overlay(Overlay::Status);
+            app.open_overlay(Overlay::Status(StatusTab::Overview));
         }
     }
     if let Some(agent) = agent_slot.as_ref() {

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -858,15 +858,14 @@ fn tool_result_preview(content: &str) -> Option<String> {
 }
 
 pub(super) fn format_tool_progress(name: &str, stream: ToolOutputStream, chunk: &str) -> String {
-    let trimmed = chunk.trim_end_matches('\n');
-    if trimmed.trim().is_empty() {
+    let Some(visible_chunk) = output_tail_preview(chunk) else {
         return String::new();
-    }
+    };
     let stream_label = match stream {
         ToolOutputStream::Stdout => "stdout",
         ToolOutputStream::Stderr => "stderr",
     };
-    format!("{name} {stream_label}:\n{trimmed}\n")
+    format!("{name} {stream_label}:\n{visible_chunk}\n")
 }
 
 pub(super) fn append_tool_progress(

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -773,12 +773,7 @@ pub(super) fn format_tool_result(name: &str, content: &str) -> String {
         if live_streamed {
             summary.push_str("\noutput streamed above");
         }
-        if let Some(stdout_preview) = output_tail_preview(stdout) {
-            summary.push_str(&format!("\nstdout:\n{stdout_preview}"));
-        }
-        if let Some(stderr_preview) = output_tail_preview(stderr) {
-            summary.push_str(&format!("\nstderr:\n{stderr_preview}"));
-        }
+        append_bash_output_preview(&mut summary, stdout, stderr);
         return summary;
     }
     if name == "apply_patch"
@@ -1025,6 +1020,23 @@ fn append_path_group(lines: &mut Vec<String>, label: &str, value: Option<&serde_
 
 fn output_tail_preview(output: &str) -> Option<String> {
     terminal_output_tail_preview(output).map(|lines| lines.join("\n"))
+}
+
+fn append_bash_output_preview(summary: &mut String, stdout: &str, stderr: &str) {
+    match (output_tail_preview(stdout), output_tail_preview(stderr)) {
+        (Some(stdout_preview), Some(stderr_preview)) => {
+            summary.push_str(&format!("\nstdout:\n{stdout_preview}"));
+            summary.push_str(&format!("\nstderr:\n{stderr_preview}"));
+        }
+        (Some(stdout_preview), None) => {
+            summary.push('\n');
+            summary.push_str(&stdout_preview);
+        }
+        (None, Some(stderr_preview)) => {
+            summary.push_str(&format!("\nstderr:\n{stderr_preview}"));
+        }
+        (None, None) => {}
+    }
 }
 
 fn format_write_file_result(value: &serde_json::Value) -> String {

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -817,6 +817,17 @@ fn formats_tool_progress_with_stream_label() {
 }
 
 #[test]
+fn skips_tool_progress_when_stderr_has_no_visible_output() {
+    let rendered = format_tool_progress(
+        "background task",
+        ToolOutputStream::Stderr,
+        "\u{1b}[2K\r\n   \n",
+    );
+
+    assert_eq!(rendered, "");
+}
+
+#[test]
 fn runtime_device_code_messages_update_prompt_and_polling_phases() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -528,6 +528,7 @@ fn formats_bash_tool_result_with_output_tail() {
 
     assert!(rendered.contains("bash finished with exit code 0"));
     assert!(rendered.contains("stdout:"));
+    assert!(rendered.contains("stderr:"));
     assert!(rendered.contains("line 7"));
     assert!(rendered.contains("line 6"));
     assert!(!rendered.contains("line 1"));
@@ -548,8 +549,27 @@ fn formats_live_bash_tool_result_with_output_tail() {
 
     assert!(rendered.contains("bash finished with exit code 0"));
     assert!(rendered.contains("output streamed above"));
-    assert!(rendered.contains("stdout:"));
+    assert!(!rendered.contains("stdout:"));
+    assert!(!rendered.contains("stderr:"));
     assert!(rendered.contains("line 2"));
+}
+
+#[test]
+fn formats_stderr_only_bash_tool_result_with_stream_label() {
+    let rendered = format_tool_result(
+        "bash",
+        &json!({
+            "exit_code": 1,
+            "stdout": "",
+            "stderr": "warn 1\nwarn 2\n"
+        })
+        .to_string(),
+    );
+
+    assert!(rendered.contains("bash failed with exit code 1"));
+    assert!(!rendered.contains("stdout:"));
+    assert!(rendered.contains("stderr:"));
+    assert!(rendered.contains("warn 2"));
 }
 
 #[test]

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -19,8 +19,8 @@ pub use self::types::{
     AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, HelpTab, InteractionKind,
     LocalCommand, LocalCommandKind, OAuthLoginMode, OpenAiModelPickerAction, Overlay,
     PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot, ProviderFamily,
-    RebuildSuccess, RunningTask, RuntimePhase, RuntimeSnapshot, TaskCompletion, TaskKind,
-    TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent,
+    RebuildSuccess, RunningTask, RuntimePhase, RuntimeSnapshot, StatusTab, TaskCompletion,
+    TaskKind, TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent,
 };
 
 const OPENAI_PROFILE_SETUP_KINDS: [OpenAiEndpointKind; 3] = [

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1004,6 +1004,18 @@ impl TuiApp {
             plan_explanation: runtime_context.plan.explanation,
             pending_interactions,
             completed_interactions,
+            todo_artifact_path: if agent.todo_state.is_some() {
+                Some(
+                    agent
+                        .session_manager
+                        .todo_file_path(&agent.session_id)
+                        .display()
+                        .to_string(),
+                )
+            } else {
+                None
+            },
+            todo: runtime_context.todo,
             prompt_base_kind: runtime_context.prompt.base_prompt_kind,
             prompt_section_keys: runtime_context.prompt.section_keys,
             prompt_source_entries: runtime_context.prompt.source_entries,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -31,10 +31,17 @@ pub enum HelpTab {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum StatusTab {
+    Overview,
+    Config,
+    Context,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Overlay {
     Help(HelpTab),
     CommandPalette,
-    Status,
+    Status(StatusTab),
     Context,
     ProviderPicker,
     ModelPicker,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -151,6 +151,8 @@ pub struct RuntimeSnapshot {
     pub plan_explanation: Option<String>,
     pub pending_interactions: Vec<PendingInteractionSnapshot>,
     pub completed_interactions: Vec<CompletedInteractionSnapshot>,
+    pub todo: crate::context::TodoContextView,
+    pub todo_artifact_path: Option<String>,
     pub prompt_base_kind: String,
     pub prompt_section_keys: Vec<String>,
     pub prompt_source_entries: Vec<PromptSourceContextEntry>,

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -5,67 +5,121 @@
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
-use crate::tui::state::TuiApp;
+use crate::tui::state::{StatusTab, TuiApp};
 
-pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<Line<'static>> {
+pub(crate) fn render_status_lines(app: &TuiApp, tab: StatusTab) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
 
-    // ── Provider & Model ──
-    section_header(&mut lines, "Provider & Model");
-    kv(&mut lines, "provider", &app.config.provider, Color::Cyan);
-    kv(
-        &mut lines,
-        "model",
-        app.current_model_label(),
-        Color::LightBlue,
-    );
+    match tab {
+        StatusTab::Overview => render_overview_status(app, &mut lines),
+        StatusTab::Config => render_config_status(app, &mut lines),
+        StatusTab::Context => render_context_status(app, &mut lines),
+    }
+
+    lines
+}
+
+fn render_overview_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
+    section_header(lines, "Provider & Model");
+    kv(lines, "provider", &app.config.provider, Color::Cyan);
+    kv(lines, "model", app.current_model_label(), Color::LightBlue);
     if app.config.provider == "openai-compatible" {
         kv(
-            &mut lines,
+            lines,
             "endpoint",
             app.config.active_openai_profile_label().unwrap_or("-"),
             Color::DarkGray,
         );
     }
 
-    // ── Execution ──
-    section_spacer(&mut lines);
-    section_header(&mut lines, "Execution");
+    section_spacer(lines);
+    section_header(lines, "Execution");
     kv(
-        &mut lines,
+        lines,
         "mode",
         app.agent_execution_mode_label(),
         Color::LightBlue,
     );
-    kv(
-        &mut lines,
-        "phase",
-        app.runtime_phase_label(),
-        Color::DarkGray,
-    );
+    kv(lines, "phase", app.runtime_phase_label(), Color::DarkGray);
     if let Some(detail) = &app.runtime_phase_detail {
-        kv(&mut lines, "detail", detail, Color::Gray);
+        kv(lines, "detail", detail, Color::Gray);
     }
     kv(
-        &mut lines,
+        lines,
         "bash",
         app.bash_approval_mode_label(),
         Color::DarkGray,
     );
 
-    // ── Context ──
-    section_spacer(&mut lines);
-    section_header(&mut lines, "Context");
+    section_spacer(lines);
+    section_header(lines, "Workspace");
+    let snap = &app.snapshot;
+    kv(lines, "dir", &home_path(&snap.cwd), Color::DarkGray);
+    kv(lines, "branch", &snap.branch, Color::DarkGray);
+    kv(lines, "session", &snap.session_id, Color::Gray);
+}
+
+fn render_config_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
+    section_header(lines, "API & Auth");
+    let surface = app.config.effective_provider_surface();
+    kv(
+        lines,
+        "base_url",
+        surface.base_url.display_or("-"),
+        Color::DarkGray,
+    );
+    kv(
+        lines,
+        "api_key",
+        &api_key_label(app),
+        if app.config.has_api_key() {
+            Color::LightGreen
+        } else {
+            Color::Yellow
+        },
+    );
+    kv(
+        lines,
+        "reasoning",
+        &format!(
+            "{} ({})",
+            surface.reasoning_summary.display_or("auto"),
+            surface.reasoning_summary.source.label()
+        ),
+        Color::DarkGray,
+    );
+
+    section_spacer(lines);
+    section_header(lines, "Network & Sandbox");
+    kv(lines, "sandbox", &sandbox_label(app), Color::LightBlue);
+    kv(
+        lines,
+        "network",
+        if app.config.sandbox_workspace_write.network_access {
+            "permitted"
+        } else {
+            "restricted"
+        },
+        if app.config.sandbox_workspace_write.network_access {
+            Color::Yellow
+        } else {
+            Color::LightGreen
+        },
+    );
+}
+
+fn render_context_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
+    section_header(lines, "Context Summary");
     let snap = &app.snapshot;
     kv(
-        &mut lines,
+        lines,
         "history",
         &format!("{} tokens", snap.estimated_history_tokens),
         Color::DarkGray,
     );
     if let Some(window) = snap.context_window_tokens {
         kv(
-            &mut lines,
+            lines,
             "window",
             &format_metric(window as u64),
             Color::LightBlue,
@@ -73,7 +127,7 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<Line<'static>> {
     }
     if let Some(remaining) = snap.remaining_input_budget {
         kv(
-            &mut lines,
+            lines,
             "budget",
             &format!("{} tokens remaining", remaining),
             if remaining < 1024 {
@@ -93,7 +147,7 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<Line<'static>> {
             0
         };
         kv(
-            &mut lines,
+            lines,
             "cache",
             &format!("{}% hit ({} hits / {} misses)", rate, hit, miss),
             Color::LightGreen,
@@ -101,71 +155,33 @@ pub(crate) fn render_status_lines(app: &TuiApp) -> Vec<Line<'static>> {
     }
     if snap.compaction_count > 0 {
         kv(
-            &mut lines,
+            lines,
             "compactions",
             &snap.compaction_count.to_string(),
             Color::DarkGray,
         );
     }
 
-    // ── Workspace ──
-    section_spacer(&mut lines);
-    section_header(&mut lines, "Workspace");
-    kv(&mut lines, "dir", &home_path(&snap.cwd), Color::DarkGray);
-    kv(&mut lines, "branch", &snap.branch, Color::DarkGray);
-    kv(&mut lines, "session", &snap.session_id, Color::Gray);
-
-    // ── API & Auth ──
-    section_spacer(&mut lines);
-    section_header(&mut lines, "API & Auth");
-    let surface = app.config.effective_provider_surface();
     kv(
-        &mut lines,
-        "base_url",
-        surface.base_url.display_or("-"),
-        Color::DarkGray,
-    );
-    kv(
-        &mut lines,
-        "api_key",
-        &api_key_label(app),
-        if app.config.has_api_key() {
-            Color::LightGreen
-        } else {
-            Color::Yellow
-        },
-    );
-    kv(
-        &mut lines,
-        "reasoning",
+        lines,
+        "todo",
         &format!(
-            "{} ({})",
-            surface.reasoning_summary.display_or("auto"),
-            surface.reasoning_summary.source.label()
+            "{} total, {} active, {} done",
+            snap.todo.summary.total,
+            snap.todo.summary.pending + snap.todo.summary.in_progress,
+            snap.todo.summary.completed
         ),
-        Color::DarkGray,
+        Color::LightBlue,
     );
 
-    // ── Network & Sandbox ──
-    section_spacer(&mut lines);
-    section_header(&mut lines, "Network & Sandbox");
-    kv(&mut lines, "sandbox", &sandbox_label(app), Color::LightBlue);
+    section_spacer(lines);
+    section_header(lines, "More Detail");
     kv(
-        &mut lines,
-        "network",
-        if app.config.sandbox_workspace_write.network_access {
-            "permitted"
-        } else {
-            "restricted"
-        },
-        if app.config.sandbox_workspace_write.network_access {
-            Color::Yellow
-        } else {
-            Color::LightGreen
-        },
+        lines,
+        "context",
+        "open /context for layer detail",
+        Color::Gray,
     );
-
-    lines
 }
 
 // ── helpers ──

--- a/src/tui/terminal_event.rs
+++ b/src/tui/terminal_event.rs
@@ -117,14 +117,14 @@ impl TerminalEvent {
             "bash" | "background_task_status" => TerminalTarget::BackgroundTask,
             _ => return None,
         };
-        if chunk.trim().is_empty() {
+        let Some(chunk) = output_tail_preview(chunk).map(|lines| lines.join("\n")) else {
             return None;
-        }
+        };
         Some(Self::OutputDelta(TerminalOutputDeltaEvent {
             target,
             id: None,
             stream: stream.into(),
-            chunk: chunk.to_string(),
+            chunk,
         }))
     }
 
@@ -449,7 +449,7 @@ fn strip_ansi_control_sequences(input: &str) -> String {
     let mut chars = input.chars().peekable();
     while let Some(ch) = chars.next() {
         if ch != '\u{1b}' {
-            if ch != '\r' {
+            if ch == '\t' || !ch.is_control() {
                 output.push(ch);
             }
             continue;
@@ -487,7 +487,9 @@ fn strip_ansi_control_sequences(input: &str) -> String {
 mod tests {
     use serde_json::json;
 
-    use super::{TerminalEvent, TerminalTarget, output_tail_preview};
+    use super::{
+        TerminalEvent, TerminalTarget, output_tail_preview, sanitize_terminal_output_line,
+    };
 
     #[test]
     fn builds_background_start_event_from_bash_result() {
@@ -529,6 +531,27 @@ mod tests {
             event.to_transcript_message(),
             "pty pty-1 completed: cargo test\noutput:\nred\nok"
         );
+    }
+
+    #[test]
+    fn sanitizer_removes_ansi_and_non_printing_control_characters() {
+        assert_eq!(
+            sanitize_terminal_output_line(
+                "\u{1b}[4munder\u{1b}[0m\u{8}line\u{7}\u{1b}]0;title\u{7}\tend\r"
+            ),
+            "underline\tend"
+        );
+    }
+
+    #[test]
+    fn skips_progress_event_when_sanitized_chunk_is_empty() {
+        let event = TerminalEvent::from_tool_progress(
+            "bash",
+            crate::tool::ToolOutputStream::Stderr,
+            "\u{1b}]0;title\u{7}\u{7}\r\n",
+        );
+
+        assert!(event.is_none());
     }
 
     #[test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -35,7 +35,7 @@ fn mouse_scroll(kind: MouseEventKind) -> Event {
 }
 use super::state::{
     InteractionKind, Overlay, PendingApprovalSnapshot, PendingInteractionSnapshot, ProviderFamily,
-    RunningTask, TaskKind, TuiApp,
+    RunningTask, StatusTab, TaskKind, TuiApp,
 };
 use super::{dispatch_event, map_key_to_event};
 
@@ -96,6 +96,35 @@ async fn busy_submit_queues_follow_up_message() {
     if let Some(task) = app.running_task.take() {
         task.handle.abort();
     }
+}
+
+#[test]
+fn status_overlay_shortcuts_switch_tabs() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    app.overlay = Some(Overlay::Status(StatusTab::Overview));
+
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Char('2')), &app),
+        AppEvent::SelectStatusTab(StatusTab::Config)
+    ));
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Right), &app),
+        AppEvent::SelectStatusTab(StatusTab::Config)
+    ));
+
+    app.overlay = Some(Overlay::Status(StatusTab::Context));
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Right), &app),
+        AppEvent::SelectStatusTab(StatusTab::Overview)
+    ));
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Left), &app),
+        AppEvent::SelectStatusTab(StatusTab::Config)
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Surface session todo state in `/context` from `TodoContextView`, including artifact path, counts, active item, update time, and a bounded item list.
- Add a compact todo summary line to `/status`.
- Mark the todo context/status backlog item complete and update the todo runtime spec checkpoint.

## Testing

- `cargo fmt`
- `cargo test status_context_text_includes_prompt_sources_and_plan_state -- --nocapture`
- `cargo test status_runtime_text_reports_todo_summary -- --nocapture`
- `cargo check`
