### PR TITLE
chore: simplify /context budget bar and add assembly details

### DIFF
--- a/src/tui/context_display.rs
+++ b/src/tui/context_display.rs
@@ -231,8 +231,61 @@ pub(crate) fn render_context_lines(app: &TuiApp, available_width: u16) -> Vec<Li
             Color::Yellow,
         );
     }
+    // ── Assembly ──
+    render_assembly_layer(
+        &mut lines,
+        app,
+        "stable_instructions",
+        "Stable Instructions",
+    );
+    render_assembly_layer(
+        &mut lines,
+        app,
+        "workspace_prompt_sources",
+        "Workspace Prompt Sources",
+    );
+    render_assembly_layer(
+        &mut lines,
+        app,
+        "active_memory_inputs",
+        "Active Memory Inputs",
+    );
+    render_assembly_layer(&mut lines, app, "compacted_history", "Compacted History");
+    render_assembly_layer(&mut lines, app, "active_turn_state", "Active Turn State");
+    render_assembly_layer(&mut lines, app, "retrieval_ready", "Retrieval-ready");
 
     lines
+}
+
+fn render_assembly_layer(lines: &mut Vec<Line<'static>>, app: &TuiApp, layer: &str, title: &str) {
+    let entries: Vec<&crate::context::ContextAssemblyEntry> = app
+        .snapshot
+        .assembly_entries
+        .iter()
+        .filter(|e| e.layer == layer)
+        .collect();
+    if entries.is_empty() {
+        return;
+    }
+    section_header(lines, title);
+    for entry in entries {
+        let tokens = entry
+            .budget_impact_tokens
+            .map(|n| format_token_count(n))
+            .unwrap_or_else(|| "-".to_string());
+        let path = entry
+            .source_path
+            .as_deref()
+            .filter(|p| !p.is_empty())
+            .unwrap_or("-");
+        kv(
+            lines,
+            &entry.kind,
+            &format!("{}  {} tokens", path, tokens),
+            Color::DarkGray,
+        );
+    }
+    section_spacer(lines);
 }
 
 // ── budget bar ──

--- a/src/tui/context_display.rs
+++ b/src/tui/context_display.rs
@@ -46,7 +46,7 @@ pub(crate) fn render_context_lines(app: &TuiApp, available_width: u16) -> Vec<Li
 
     // Visual budget bar
     let bar_width = (available_width.saturating_sub(6)).max(20) as usize;
-    let bar_line = budget_bar(app, bar_width);
+    let bar_line = budget_bar(app, bar_width, used);
     lines.push(bar_line);
 
     // Usage summary with color-coded percentage
@@ -60,7 +60,7 @@ pub(crate) fn render_context_lines(app: &TuiApp, available_width: u16) -> Vec<Li
     } else if pct_value > 50.0 {
         Color::Yellow
     } else {
-        Color::LightGreen
+        STATUS_SUCCESS
     };
     let pct_str = format!("{:.1}%", pct_value);
     let window_str = window
@@ -282,7 +282,7 @@ fn render_assembly_layer(lines: &mut Vec<Line<'static>>, app: &TuiApp, layer: &s
             lines,
             &entry.kind,
             &format!("{}  {} tokens", path, tokens),
-            Color::DarkGray,
+            TEXT_SECONDARY,
         );
     }
     section_spacer(lines);
@@ -290,17 +290,9 @@ fn render_assembly_layer(lines: &mut Vec<Line<'static>>, app: &TuiApp, layer: &s
 
 // ── budget bar ──
 
-fn budget_bar(app: &TuiApp, width: usize) -> Line<'static> {
+fn budget_bar(app: &TuiApp, width: usize, used: usize) -> Line<'static> {
     let snap = &app.snapshot;
     let total = snap.context_window_tokens.unwrap_or(1).max(1);
-
-    let used = snap
-        .stable_instructions_budget
-        .saturating_add(snap.workspace_prompt_budget)
-        .saturating_add(snap.active_turn_budget)
-        .saturating_add(snap.compacted_history_budget)
-        .saturating_add(snap.retrieved_memory_budget)
-        .saturating_add(snap.reserved_output_tokens);
 
     let used_width = ((used as f64 / total as f64) * width as f64).round() as usize;
     let used_width = used_width.min(width);

--- a/src/tui/context_display.rs
+++ b/src/tui/context_display.rs
@@ -49,19 +49,41 @@ pub(crate) fn render_context_lines(app: &TuiApp, available_width: u16) -> Vec<Li
     let bar_line = budget_bar(app, bar_width);
     lines.push(bar_line);
 
-    // Usage summary
+    // Usage summary with color-coded percentage
     let used_str = format_token_count(used);
-    let pct = window
+    let pct_value = window
         .filter(|w| *w > 0)
-        .map(|w| format!(" ({:.2}%)", used as f64 * 100.0 / w as f64))
-        .unwrap_or_default();
+        .map(|w| used as f64 * 100.0 / w as f64)
+        .unwrap_or(0.0);
+    let pct_color = if pct_value > 80.0 {
+        Color::Red
+    } else if pct_value > 50.0 {
+        Color::Yellow
+    } else {
+        Color::LightGreen
+    };
+    let pct_str = format!("{:.1}%", pct_value);
     let window_str = window
         .map(format_token_count)
         .unwrap_or_else(|| "?".to_string());
-    lines.push(Line::from(Span::styled(
-        format!("  {used_str}{pct} of {window_str} used"),
-        Style::default().fg(TEXT_MUTED),
-    )));
+    lines.push(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            used_str,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!(" / {window_str}  "),
+            Style::default().fg(TEXT_MUTED),
+        ),
+        Span::styled(
+            pct_str,
+            Style::default().fg(pct_color).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" used", Style::default().fg(TEXT_MUTED)),
+    ]));
     section_spacer(&mut lines);
 
     // ── Budget Breakdown ──
@@ -219,40 +241,32 @@ fn budget_bar(app: &TuiApp, width: usize) -> Line<'static> {
     let snap = &app.snapshot;
     let total = snap.context_window_tokens.unwrap_or(1).max(1);
 
-    let segments: &[(usize, Color)] = &[
-        (snap.stable_instructions_budget, BUDGET_SYSTEM),
-        (snap.workspace_prompt_budget, BUDGET_WORKSPACE),
-        (snap.active_turn_budget, BUDGET_ACTIVE),
-        (snap.compacted_history_budget, BUDGET_HISTORY),
-        (snap.retrieved_memory_budget, BUDGET_MEMORY),
-        (snap.reserved_output_tokens, BUDGET_OUTPUT),
-    ];
+    let used = snap
+        .stable_instructions_budget
+        .saturating_add(snap.workspace_prompt_budget)
+        .saturating_add(snap.active_turn_budget)
+        .saturating_add(snap.compacted_history_budget)
+        .saturating_add(snap.retrieved_memory_budget)
+        .saturating_add(snap.reserved_output_tokens);
+
+    let used_width = ((used as f64 / total as f64) * width as f64).round() as usize;
+    let used_width = used_width.min(width);
+    let free_width = width.saturating_sub(used_width);
 
     let mut spans: Vec<Span<'static>> = Vec::new();
-    let mut used_width = 0usize;
-
-    for &(tokens, color) in segments {
-        let seg_width = ((tokens as f64 / total as f64) * width as f64).round() as usize;
-        let seg_width = seg_width.min(width.saturating_sub(used_width));
-        if seg_width > 0 {
-            spans.push(Span::styled(
-                "█".repeat(seg_width),
-                Style::default().fg(color),
-            ));
-            used_width += seg_width;
-        }
-    }
-
-    // Fill remaining with free color
-    if used_width < width {
+    spans.push(Span::raw("  "));
+    if used_width > 0 {
         spans.push(Span::styled(
-            "█".repeat(width - used_width),
+            "░".repeat(used_width),
+            Style::default().fg(Color::White),
+        ));
+    }
+    if free_width > 0 {
+        spans.push(Span::styled(
+            "□".repeat(free_width),
             Style::default().fg(BUDGET_FREE),
         ));
     }
-
-    // Prefix with two spaces for alignment with kv lines
-    spans.insert(0, Span::raw("  "));
     Line::from(spans)
 }
 

--- a/src/tui/render/snapshots/rara__tui__render__tests__context_overlay_typical_budget.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__context_overlay_typical_budget.snap
@@ -1,0 +1,47 @@
+---
+source: src/tui/render/tests.rs
+assertion_line: 1114
+expression: rendered
+---
+Context Usage
+
+  model          anthropic/claude-sonnet-4
+  window         200.0K tokens
+  ░░░░□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□
+  10.2K / 200.0K  5.1% used
+
+Budget Breakdown
+
+  System prompt  1.2K (0.60%)
+  Workspace      320 (0.16%)
+  Active turn    280 (0.14%)
+  History        140 (0.07%)
+  Memory         96 (0.05%)
+  Output reserve 8.2K (4.10%)
+  Free           189.8K (94.89%)
+
+Session
+
+  cwd            /workspace/rara
+  branch         main
+  session        session-abc
+  history        42 msgs  0 entries
+
+Compaction
+
+  estimated      12.0K tokens
+  threshold      180.0K tokens
+  count          1
+  last           12.0K → 4.5K tokens
+
+Active Turn
+
+  mode           execute
+  step 0         [pending] Implement /context
+Stable Instructions
+
+  project_instruction AGENTS.md  240 tokens
+
+Active Memory Inputs
+
+  workspace_memory .rara/memory.md  64 tokens

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -9,7 +9,9 @@ use tempfile::tempdir;
 
 use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
 use crate::tui::custom_terminal::Frame;
-use crate::tui::state::{Overlay, ProviderFamily, TranscriptEntry, TranscriptTurn, TuiApp};
+use crate::tui::state::{
+    Overlay, ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp,
+};
 
 use super::cells::HistoryCell;
 use super::viewport::TranscriptViewport;
@@ -1036,4 +1038,81 @@ fn formatted_agent_markdown_keeps_first_and_latest_lines() {
     assert!(rendered.iter().any(|line| line.contains("latest 1")));
     assert!(rendered.iter().any(|line| line.contains("latest 2")));
     assert!(!rendered.iter().any(|line| line.contains("middle 1")));
+}
+
+#[test]
+fn context_overlay_snapshot_with_typical_budget() {
+    use crate::context::ContextAssemblyEntry;
+    use crate::tui::context_display::render_context_lines;
+
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot = RuntimeSnapshot {
+        cwd: "/workspace/rara".into(),
+        branch: "main".into(),
+        session_id: "session-abc".into(),
+        history_len: 42,
+        estimated_history_tokens: 12_000,
+        context_window_tokens: Some(200_000),
+        compact_threshold_tokens: 180_000,
+        reserved_output_tokens: 8_192,
+        stable_instructions_budget: 1_200,
+        workspace_prompt_budget: 320,
+        active_turn_budget: 280,
+        compacted_history_budget: 140,
+        retrieved_memory_budget: 96,
+        remaining_input_budget: Some(189_772),
+        compaction_count: 1,
+        last_compaction_before_tokens: Some(12_000),
+        last_compaction_after_tokens: Some(4_500),
+        plan_steps: vec![("pending".into(), "Implement /context".into())],
+        plan_explanation: Some("Adding Claude Code-style context display".into()),
+        assembly_entries: vec![
+            ContextAssemblyEntry {
+                cache_status: None,
+                order: 1,
+                layer: "stable_instructions".into(),
+                kind: "project_instruction".into(),
+                label: "AGENTS.md".into(),
+                source_path: Some("AGENTS.md".into()),
+                injected: true,
+                inclusion_reason: "workspace instruction discovery".into(),
+                budget_impact_tokens: Some(240),
+                dropped_reason: None,
+            },
+            ContextAssemblyEntry {
+                cache_status: None,
+                order: 2,
+                layer: "active_memory_inputs".into(),
+                kind: "workspace_memory".into(),
+                label: "Project Memory".into(),
+                source_path: Some(".rara/memory.md".into()),
+                injected: true,
+                inclusion_reason: "effective prompt includes memory".into(),
+                budget_impact_tokens: Some(64),
+                dropped_reason: None,
+            },
+        ],
+        ..Default::default()
+    };
+    app.config
+        .set_model(Some("anthropic/claude-sonnet-4".to_string()));
+
+    let lines = render_context_lines(&app, 78);
+    let rendered = lines
+        .into_iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_snapshot!("context_overlay_typical_budget", rendered);
 }


### PR DESCRIPTION
## Summary
Follow-up improvements to the `/context` overlay (from #159).

## Changes
- **Visual budget bar**: `░` for used / `□` for free — Claude Code style
- **Color-coded usage percentage**: green <50%, yellow 50-80%, red >80%, bold
- **Assembly entry details**: shows actual entries in each layer (Stable Instructions, Workspace Prompt Sources, Memory Inputs, History, Turn State, Retrieval-ready)
- Removed multi-color legend — simpler, cleaner bar

## Validation
- `cargo check` — passes
- `cargo test render` — 152 passed