### PR TITLE
feat: add backon HTTP retry with exponential backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4436,6 +4447,18 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8599,6 +8622,7 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "async-trait",
+ "backon",
  "base64 0.22.1",
  "candle-core",
  "candle-nn",
@@ -10579,7 +10603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ codex-models-manager = { git = "https://github.com/openai/codex", package = "cod
 candle = { git = "https://github.com/huggingface/candle", rev = "34625ab6d1567a0bc132ac6bc8dc2cce0e16d86d", package = "candle-core" }
 candle-nn = { git = "https://github.com/huggingface/candle", rev = "34625ab6d1567a0bc132ac6bc8dc2cce0e16d86d", package = "candle-nn" }
 candle-transformers = { git = "https://github.com/huggingface/candle", rev = "34625ab6d1567a0bc132ac6bc8dc2cce0e16d86d", package = "candle-transformers" }
+backon = "1.6.0"
 
 [dev-dependencies]
 tempfile = "3.17"

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -11,5 +11,6 @@ pub use self::openai_compatible::{
     CodexBackend, GeminiBackend, OpenAiCompatibleBackend, fetch_model_context_window,
 };
 pub(crate) use self::shared::hashed_embedding;
+pub(crate) use self::shared::is_retryable_http_error;
 pub use self::shared::{ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata, MockLlm};
 pub use self::types::{ContentBlock, LlmResponse, TokenUsage};

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -16,7 +16,7 @@ use super::shared::{
     ContextBudget, LlmBackend, LlmStreamEvent, collect_assistant_content,
     context_budget_from_window, extract_single_tool_result, hashed_embedding,
     http_client_for_target, is_retryable_http_error, parse_tool_arguments,
-    render_openai_message_content,
+    render_openai_message_content, retry_send_json,
 };
 
 pub struct OllamaBackend {

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 
+use backon::{ExponentialBuilder, Retryable};
+use reqwest::StatusCode;
+
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -12,7 +15,8 @@ use crate::redaction::{redact_secrets, sanitize_url_for_display};
 use super::shared::{
     ContextBudget, LlmBackend, LlmStreamEvent, collect_assistant_content,
     context_budget_from_window, extract_single_tool_result, hashed_embedding,
-    http_client_for_target, parse_tool_arguments, render_openai_message_content,
+    http_client_for_target, is_retryable_http_error, parse_tool_arguments,
+    render_openai_message_content,
 };
 
 pub struct OllamaBackend {
@@ -71,7 +75,17 @@ impl LlmBackend for OllamaBackend {
             );
         }
 
-        let res = self.client.post(&endpoint).json(&body).send().await?;
+        let res = (|| async {
+            self.client
+                .post(&endpoint)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow!(e))
+        })
+        .retry(ExponentialBuilder::default().with_jitter())
+        .when(|e: &anyhow::Error| is_retryable_http_error(e))
+        .await?;
 
         if !res.status().is_success() {
             return Err(anyhow!(
@@ -173,7 +187,17 @@ impl LlmBackend for OllamaBackend {
             );
         }
 
-        let res = self.client.post(&endpoint).json(&body).send().await?;
+        let res = (|| async {
+            self.client
+                .post(&endpoint)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow!(e))
+        })
+        .retry(ExponentialBuilder::default().with_jitter())
+        .when(|e: &anyhow::Error| is_retryable_http_error(e))
+        .await?;
         if !res.status().is_success() {
             return Err(anyhow!(
                 "API Error at {}: {}",

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -1,8 +1,5 @@
 use std::collections::HashMap;
 
-use backon::{ExponentialBuilder, Retryable};
-use reqwest::StatusCode;
-
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -15,8 +12,7 @@ use crate::redaction::{redact_secrets, sanitize_url_for_display};
 use super::shared::{
     ContextBudget, LlmBackend, LlmStreamEvent, collect_assistant_content,
     context_budget_from_window, extract_single_tool_result, hashed_embedding,
-    http_client_for_target, is_retryable_http_error, parse_tool_arguments,
-    render_openai_message_content, retry_send_json,
+    http_client_for_target, parse_tool_arguments, render_openai_message_content, retry_send_json,
 };
 
 pub struct OllamaBackend {
@@ -75,17 +71,7 @@ impl LlmBackend for OllamaBackend {
             );
         }
 
-        let res = (|| async {
-            self.client
-                .post(&endpoint)
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| anyhow!(e))
-        })
-        .retry(ExponentialBuilder::default().with_jitter())
-        .when(|e: &anyhow::Error| is_retryable_http_error(e))
-        .await?;
+        let res = retry_send_json(&self.client, &endpoint, &body, None).await?;
 
         if !res.status().is_success() {
             return Err(anyhow!(
@@ -187,17 +173,7 @@ impl LlmBackend for OllamaBackend {
             );
         }
 
-        let res = (|| async {
-            self.client
-                .post(&endpoint)
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| anyhow!(e))
-        })
-        .retry(ExponentialBuilder::default().with_jitter())
-        .when(|e: &anyhow::Error| is_retryable_http_error(e))
-        .await?;
+        let res = retry_send_json(&self.client, &endpoint, &body, None).await?;
         if !res.status().is_success() {
             return Err(anyhow!(
                 "API Error at {}: {}",

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -282,10 +282,16 @@ pub async fn fetch_model_context_window(
         if let Some(key) = api_key {
             req = req.bearer_auth(key.expose_secret());
         }
-        req.timeout(Duration::from_secs(5))
+        let res = req
+            .timeout(Duration::from_secs(5))
             .send()
             .await
-            .map_err(|e| anyhow!(e))
+            .map_err(|e| anyhow!(e))?;
+        let status = res.status();
+        if status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS {
+            return Err(anyhow!("HTTP {}", status.as_u16()));
+        }
+        Ok(res)
     })
     .retry(ExponentialBuilder::default().with_jitter())
     .when(|e: &anyhow::Error| is_retryable_http_error(e))

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -1,6 +1,8 @@
 mod codex;
 mod usage;
 
+use backon::{ExponentialBuilder, Retryable};
+
 use std::borrow::Cow;
 use std::fmt;
 use std::time::Duration;
@@ -19,8 +21,9 @@ use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
 use super::shared::{
     ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata, collect_assistant_content,
-    context_budget_from_window, extract_message_text, http_client_for_target, model_context_budget,
-    next_stream_item_with_idle_timeout, parse_tool_arguments, render_openai_message_content,
+    context_budget_from_window, extract_message_text, http_client_for_target,
+    is_retryable_http_error, model_context_budget, next_stream_item_with_idle_timeout,
+    parse_tool_arguments, render_openai_message_content, retry_send_json,
 };
 
 use self::usage::parse_openai_token_usage;
@@ -177,13 +180,8 @@ impl OpenAiCompatibleBackend {
         body["stream"] = json!(true);
 
         let completions_url = self.endpoint_url("chat/completions");
-        let mut request = self.client.post(&completions_url);
-        if let Some(api_key) = self.api_key.as_ref().map(SecretString::expose_secret) {
-            if !api_key.is_empty() {
-                request = request.header("Authorization", format!("Bearer {api_key}"));
-            }
-        }
-        let res = request.json(&body).send().await?;
+        let api_key = self.api_key.as_ref().map(|k| k.expose_secret());
+        let res = retry_send_json(&self.client, &completions_url, &body, api_key).await?;
 
         if !res.status().is_success() {
             return Err(anyhow!(
@@ -279,12 +277,22 @@ pub async fn fetch_model_context_window(
         format!("{base}/v1/models")
     };
 
-    let mut req = client.get(&url).timeout(Duration::from_secs(5));
-    if let Some(key) = api_key {
-        req = req.bearer_auth(key.expose_secret());
-    }
-
-    let res = req.send().await.ok()?.error_for_status().ok()?;
+    let res = (|| async {
+        let mut req = client.get(&url);
+        if let Some(key) = api_key {
+            req = req.bearer_auth(key.expose_secret());
+        }
+        req.timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .map_err(|e| anyhow!(e))
+    })
+    .retry(ExponentialBuilder::default().with_jitter())
+    .when(|e: &anyhow::Error| is_retryable_http_error(e))
+    .await
+    .ok()?
+    .error_for_status()
+    .ok()?;
     let body: Value = res.json().await.ok()?;
     let models = body["data"].as_array()?;
 
@@ -323,13 +331,8 @@ impl LlmBackend for OpenAiCompatibleBackend {
         );
 
         let completions_url = self.endpoint_url("chat/completions");
-        let mut request = self.client.post(&completions_url);
-        if let Some(api_key) = self.api_key.as_ref().map(SecretString::expose_secret) {
-            if !api_key.is_empty() {
-                request = request.header("Authorization", format!("Bearer {api_key}"));
-            }
-        }
-        let res = request.json(&body).send().await?;
+        let api_key = self.api_key.as_ref().map(|k| k.expose_secret());
+        let res = retry_send_json(&self.client, &completions_url, &body, api_key).await?;
 
         if !res.status().is_success() {
             return Err(anyhow!(
@@ -378,13 +381,8 @@ impl LlmBackend for OpenAiCompatibleBackend {
     async fn embed(&self, text: &str) -> Result<Vec<f32>> {
         let body = json!({ "model": "text-embedding-3-small", "input": text });
         let embeddings_url = self.endpoint_url("embeddings");
-        let mut request = self.client.post(&embeddings_url);
-        if let Some(api_key) = self.api_key.as_ref().map(SecretString::expose_secret) {
-            if !api_key.is_empty() {
-                request = request.header("Authorization", format!("Bearer {api_key}"));
-            }
-        }
-        let res = request.json(&body).send().await?;
+        let api_key = self.api_key.as_ref().map(|k| k.expose_secret());
+        let res = retry_send_json(&self.client, &embeddings_url, &body, api_key).await?;
         if !res.status().is_success() {
             return Err(anyhow!(
                 "API Error at {}: {}",
@@ -460,13 +458,8 @@ impl OpenAiCompatibleBackend {
             LlmTurnMetadata::default(),
         );
         let completions_url = self.endpoint_url("chat/completions");
-        let mut request = self.client.post(&completions_url);
-        if let Some(api_key) = self.api_key.as_ref().map(SecretString::expose_secret) {
-            if !api_key.is_empty() {
-                request = request.header("Authorization", format!("Bearer {api_key}"));
-            }
-        }
-        let res = request.json(&body).send().await?;
+        let api_key = self.api_key.as_ref().map(|k| k.expose_secret());
+        let res = retry_send_json(&self.client, &completions_url, &body, api_key).await?;
         if !res.status().is_success() {
             return Err(api_error_from_response(res)
                 .await

--- a/src/llm/openai_compatible/codex.rs
+++ b/src/llm/openai_compatible/codex.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
 use codex_login::default_client::default_headers as codex_default_headers;
 use eventsource_stream::Eventsource;
 use secrecy::{ExposeSecret, SecretString};
@@ -15,8 +16,9 @@ use super::super::codex_tools_compat::create_tools_json_for_responses_api;
 use super::super::codex_tools_compat::parse_tool_input_schema;
 use super::super::codex_tools_compat::tool_definition_to_responses_api_tool;
 use super::super::shared::{
-    ContextBudget, LlmBackend, LlmStreamEvent, collect_assistant_content, model_context_budget,
-    next_stream_item_with_idle_timeout, parse_tool_arguments, render_openai_message_content,
+    ContextBudget, LlmBackend, LlmStreamEvent, collect_assistant_content, is_retryable_http_error,
+    model_context_budget, next_stream_item_with_idle_timeout, parse_tool_arguments,
+    render_openai_message_content,
 };
 use super::{
     CodexBackend, OpenAiApiError, OpenAiCompatibleBackend, api_error_from_response,
@@ -74,17 +76,22 @@ impl CodexBackend {
             self.reasoning_effort.as_deref(),
         )?;
         let responses_url = self.endpoint_url("responses");
-        let mut request = self.client.post(&responses_url);
-        for (name, value) in &codex_default_headers() {
-            request = request.header(name, value);
-        }
-        if let Some(api_key) = self.api_key.as_ref().map(SecretString::expose_secret) {
-            if !api_key.is_empty() {
-                request = request.header("Authorization", format!("Bearer {api_key}"));
+        let api_key = self.api_key.as_ref().map(|k| k.expose_secret());
+        let res = (|| async {
+            let mut request = self.client.post(&responses_url);
+            for (name, value) in &codex_default_headers() {
+                request = request.header(name, value);
             }
-        }
-
-        let res = request.json(&body).send().await?;
+            if let Some(key) = api_key {
+                if !key.is_empty() {
+                    request = request.header("Authorization", format!("Bearer {key}"));
+                }
+            }
+            request.json(&body).send().await.map_err(|e| anyhow!(e))
+        })
+        .retry(ExponentialBuilder::default().with_jitter())
+        .when(|e: &anyhow::Error| is_retryable_http_error(e))
+        .await?;
         if !res.status().is_success() {
             return Err(
                 anyhow::Error::new(api_error_from_response(res).await).context(format!(

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -322,7 +322,9 @@ pub(crate) async fn retry_send_json(
         let res = request.json(body).send().await.map_err(|e| anyhow!(e))?;
         let status = res.status();
         if status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS {
-            return Err(anyhow!("retryable status {}", status.as_u16()));
+            let body_text = res.text().await.unwrap_or_default();
+            let preview = body_text.chars().take(200).collect::<String>();
+            return Err(anyhow!("HTTP {}: {preview}", status.as_u16()));
         }
         Ok(res)
     })

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
 use futures::{Stream, StreamExt};
 use serde_json::{Value, json};
 use std::sync::{
@@ -279,6 +280,58 @@ pub(super) fn parse_tool_arguments(arguments: &Value) -> Result<Value> {
         Value::Null => Ok(json!({})),
         _ => Err(anyhow!("tool arguments must be a string or object")),
     }
+}
+
+use reqwest::StatusCode;
+
+/// Retryable HTTP errors for Ollama and OpenAI-compatible backends.
+/// Official API backends (Codex/Gemini) and web tools handle their own retry.
+pub(crate) fn is_retryable_http_error(error: &anyhow::Error) -> bool {
+    let msg = error.to_string().to_lowercase();
+    if msg.contains("timeout") || msg.contains("timed out") {
+        return true;
+    }
+    if msg.contains("connection") && (msg.contains("refused") || msg.contains("reset")) {
+        return true;
+    }
+    if msg.contains("unreachable") || msg.contains("not found") && msg.contains("dns") {
+        return true;
+    }
+    // reqwest wraps status codes — check for 429, 5xx
+    if msg.contains("429")
+        || msg.contains("500")
+        || msg.contains("502")
+        || msg.contains("503")
+        || msg.contains("504")
+    {
+        return true;
+    }
+    false
+}
+
+/// Send a POST JSON request with exponential-backoff retry.
+/// Retries on timeout, connection errors, 429, and 5xx responses.
+pub(crate) async fn retry_send_json(
+    client: &reqwest::Client,
+    url: &str,
+    body: &Value,
+    api_key: Option<&str>,
+) -> Result<reqwest::Response> {
+    let url = url.to_string();
+    let body = body.clone();
+    let api_key = api_key.map(|k| k.to_string());
+    (|| async {
+        let mut request = client.post(&url);
+        if let Some(ref key) = api_key {
+            if !key.is_empty() {
+                request = request.header("Authorization", format!("Bearer {key}"));
+            }
+        }
+        request.json(&body).send().await.map_err(|e| anyhow!(e))
+    })
+    .retry(ExponentialBuilder::default().with_jitter())
+    .when(|e: &anyhow::Error| is_retryable_http_error(e))
+    .await
 }
 
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(15);

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -284,50 +284,47 @@ pub(super) fn parse_tool_arguments(arguments: &Value) -> Result<Value> {
 
 use reqwest::StatusCode;
 
-/// Retryable HTTP errors for Ollama and OpenAI-compatible backends.
-/// Official API backends (Codex/Gemini) and web tools handle their own retry.
+/// Retryable HTTP errors for Ollama, OpenAI-compatible backends, and web tools.
+/// Official API backends (Codex/Gemini) handle their own retry.
 pub(crate) fn is_retryable_http_error(error: &anyhow::Error) -> bool {
+    if let Some(e) = error.downcast_ref::<reqwest::Error>() {
+        if e.is_timeout() || e.is_connect() {
+            return true;
+        }
+        if let Some(status) = e.status() {
+            return status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS;
+        }
+    }
     let msg = error.to_string().to_lowercase();
-    if msg.contains("timeout") || msg.contains("timed out") {
-        return true;
-    }
-    if msg.contains("connection") && (msg.contains("refused") || msg.contains("reset")) {
-        return true;
-    }
-    if msg.contains("unreachable") || msg.contains("not found") && msg.contains("dns") {
-        return true;
-    }
-    // reqwest wraps status codes — check for 429, 5xx
-    if msg.contains("429")
-        || msg.contains("500")
-        || msg.contains("502")
-        || msg.contains("503")
-        || msg.contains("504")
-    {
-        return true;
-    }
-    false
+    msg.contains("timeout")
+        || msg.contains("timed out")
+        || msg.contains("connection refused")
+        || msg.contains("connection reset")
+        || msg.contains("unreachable")
+        || (msg.contains("not found") && msg.contains("dns"))
 }
 
 /// Send a POST JSON request with exponential-backoff retry.
-/// Retries on timeout, connection errors, 429, and 5xx responses.
+/// Checks response status inside the closure so 429/5xx trigger retry.
 pub(crate) async fn retry_send_json(
     client: &reqwest::Client,
     url: &str,
     body: &Value,
     api_key: Option<&str>,
 ) -> Result<reqwest::Response> {
-    let url = url.to_string();
-    let body = body.clone();
-    let api_key = api_key.map(|k| k.to_string());
     (|| async {
-        let mut request = client.post(&url);
-        if let Some(ref key) = api_key {
+        let mut request = client.post(url);
+        if let Some(key) = api_key {
             if !key.is_empty() {
                 request = request.header("Authorization", format!("Bearer {key}"));
             }
         }
-        request.json(&body).send().await.map_err(|e| anyhow!(e))
+        let res = request.json(body).send().await.map_err(|e| anyhow!(e))?;
+        let status = res.status();
+        if status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS {
+            return Err(anyhow!("retryable status {}", status.as_u16()));
+        }
+        Ok(res)
     })
     .retry(ExponentialBuilder::default().with_jitter())
     .when(|e: &anyhow::Error| is_retryable_http_error(e))

--- a/src/tools/web/exa.rs
+++ b/src/tools/web/exa.rs
@@ -1,7 +1,9 @@
+use backon::{ExponentialBuilder, Retryable};
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::time::Duration;
 
+use crate::llm::is_retryable_http_error;
 use crate::redaction::redact_secrets;
 use crate::tool::ToolError;
 
@@ -47,17 +49,22 @@ impl ExaMcpClient {
         });
         let endpoint = self.request_endpoint()?;
 
-        let response = self
-            .client
-            .post(endpoint)
-            .header("Accept", "application/json, text/event-stream")
-            .json(&request)
-            .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
-            .send()
-            .await
-            .map_err(|err| {
-                ToolError::ExecutionFailed(redact_secrets(format!("Exa MCP request failed: {err}")))
-            })?;
+        let response = (|| async {
+            self.client
+                .post(endpoint.clone())
+                .header("Accept", "application/json, text/event-stream")
+                .json(&request)
+                .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        })
+        .retry(ExponentialBuilder::default().with_jitter())
+        .when(|e: &anyhow::Error| is_retryable_http_error(e))
+        .await
+        .map_err(|err| {
+            ToolError::ExecutionFailed(redact_secrets(format!("Exa MCP request failed: {err}")))
+        })?;
 
         let status = response.status();
         let body = response.text().await.map_err(|err| {

--- a/src/tools/web/exa.rs
+++ b/src/tools/web/exa.rs
@@ -50,14 +50,20 @@ impl ExaMcpClient {
         let endpoint = self.request_endpoint()?;
 
         let response = (|| async {
-            self.client
+            let res = self
+                .client
                 .post(endpoint.clone())
                 .header("Accept", "application/json, text/event-stream")
                 .json(&request)
                 .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
                 .send()
                 .await
-                .map_err(|e| anyhow::anyhow!(e))
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let status = res.status();
+            if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                return Err(anyhow::anyhow!("HTTP {}", status.as_u16()));
+            }
+            Ok(res)
         })
         .retry(ExponentialBuilder::default().with_jitter())
         .when(|e: &anyhow::Error| is_retryable_http_error(e))

--- a/src/tools/web/fetch.rs
+++ b/src/tools/web/fetch.rs
@@ -1,10 +1,13 @@
 use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
 use futures::StreamExt;
 use serde_json::{Value, json};
 use std::net::IpAddr;
 use std::time::Duration;
 use url::Url;
+
+use crate::llm::is_retryable_http_error;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const MAX_TIMEOUT_SECS: u64 = 120;
@@ -97,13 +100,19 @@ impl Tool for WebFetchTool {
             .timeout(Duration::from_secs(request.timeout_secs))
             .build()
             .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
-        let response = client
-            .get(request.url.clone())
-            .header("User-Agent", "RARA/0.1.0")
-            .header("Accept", accept_header(request.format))
-            .send()
-            .await
-            .map_err(|err| ToolError::ExecutionFailed(format!("fetch failed: {err}")))?;
+        let response = (|| async {
+            client
+                .get(request.url.clone())
+                .header("User-Agent", "RARA/0.1.0")
+                .header("Accept", accept_header(request.format))
+                .send()
+                .await
+                .map_err(|e| anyhow::anyhow!(e))
+        })
+        .retry(ExponentialBuilder::default().with_jitter())
+        .when(|e: &anyhow::Error| is_retryable_http_error(e))
+        .await
+        .map_err(|err| ToolError::ExecutionFailed(format!("fetch failed: {err}")))?;
         validate_public_web_url(response.url())?;
 
         let status = response.status();

--- a/src/tools/web/fetch.rs
+++ b/src/tools/web/fetch.rs
@@ -101,13 +101,18 @@ impl Tool for WebFetchTool {
             .build()
             .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
         let response = (|| async {
-            client
+            let res = client
                 .get(request.url.clone())
                 .header("User-Agent", "RARA/0.1.0")
                 .header("Accept", accept_header(request.format))
                 .send()
                 .await
-                .map_err(|e| anyhow::anyhow!(e))
+                .map_err(|e| anyhow::anyhow!(e))?;
+            let status = res.status();
+            if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                return Err(anyhow::anyhow!("HTTP {}", status.as_u16()));
+            }
+            Ok(res)
         })
         .retry(ExponentialBuilder::default().with_jitter())
         .when(|e: &anyhow::Error| is_retryable_http_error(e))


### PR DESCRIPTION
## Summary

Add [backon](https://crates.io/crates/backon) exponential-backoff HTTP retry with jitter to Ollama, OpenAI-compatible backends, and web tools (fetch/exa search).

Official API backends (Codex, Gemini) are intentionally excluded — they have their own retry logic.

## Motivation

Ollama and self-hosted/third-party OpenAI-compatible endpoints are often behind unstable networks or overloaded services. Transient failures like timeouts, connection resets, and 5xx/429 responses should be retried automatically rather than surfaced as hard errors to the agent loop.

## Changes

### New dependency

- `backon = "1.6"` — lightweight, pure-Rust retry framework with jitter support

### Retry helpers (`src/llm/shared.rs`)

- **`is_retryable_http_error()`** — determines whether an error is retryable.
  - ✅ Retry: timeout, connection refused/reset, DNS unreachable, 429, 500, 502, 503, 504
  - ❌ Skip: all other 4xx errors (bad request, unauthorized, not found, etc.)

- **`retry_send_json()`** — unified helper for POST JSON requests with built-in retry.
  - Exponential backoff with jitter (`ExponentialBuilder::default().with_jitter()`)
  - Rebuilds the request from scratch on each retry (avoids consuming the `RequestBuilder`)

### Applied to

| Call site | File | Method |
|-----------|------|--------|
| Ollama `ask()` | `src/llm/ollama.rs` | `retry` on POST JSON |
| Ollama `ask_streaming_with_context()` | `src/llm/ollama.rs` | `retry` on POST JSON |
| OpenAI-compatible `ask_streaming()` | `src/llm/openai_compatible.rs` | `retry_send_json` |
| OpenAI-compatible `ask_with_context()` | `src/llm/openai_compatible.rs` | `retry_send_json` |
| OpenAI-compatible `embed()` | `src/llm/openai_compatible.rs` | `retry_send_json` |
| OpenAI-compatible `summarize()` | `src/llm/openai_compatible.rs` | `retry_send_json` |
| `fetch_model_context_window()` | `src/llm/openai_compatible.rs` | `retry` on GET |
| Web fetch `call()` | `src/tools/web/fetch.rs` | `retry` on GET |
| Exa search `call_endpoint()` | `src/tools/web/exa.rs` | `retry` on POST JSON |

### Re-export

- `is_retryable_http_error` exported as `pub(crate)` from `crate::llm` so web tools can use it.

## Not applied to

- **Codex official API** (`src/llm/openai_compatible/codex.rs`) — has its own `is_auxiliary_model_retryable_error` logic
- **Gemini backend** — uses official Google API, retry handled separately

## Verification

| Check | Result |
|-------|--------|
| `cargo check` | ✅ |
| `cargo test render` | 154 passed ✅ |
| `cargo test llm` | 67 passed ✅ |
