### PR TITLE
chore: group rust imports by origin

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
 

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -1,12 +1,13 @@
+use std::collections::{BTreeMap, hash_map::DefaultHasher};
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
 use anyhow::Result;
 use codex_execpolicy::{PolicyParser, blocking_append_allow_prefix_rule};
 use dirs::home_dir;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, hash_map::DefaultHasher};
-use std::fs;
-use std::hash::{Hash, Hasher};
-use std::path::{Path, PathBuf};
 
 use crate::defaults::{
     DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, DEFAULT_DEEPSEEK_BASE_URL, DEFAULT_DEEPSEEK_MODEL,
@@ -918,6 +919,12 @@ fn stable_path_hash(root: &Path) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+
+    use secrecy::ExposeSecret;
+    use tempfile::tempdir;
+
     use super::{
         ConfigManager, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState, RaraConfig,
         workspace_data_dir_for_home,
@@ -928,10 +935,6 @@ mod tests {
         DEFAULT_OPENROUTER_MODEL, DEFAULT_REASONING_SUMMARY, REASONING_SUMMARY_NONE,
     };
     use crate::provider_surface::ConfigValueSource;
-    use secrecy::ExposeSecret;
-    use std::collections::BTreeMap;
-    use std::fs;
-    use tempfile::tempdir;
 
     #[test]
     fn secret_api_key_roundtrips_through_json() {

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -1,8 +1,10 @@
-use crate::workspace::WorkspaceMemory;
-use rara_config::RaraConfig;
 use std::fs;
 use std::path::Path;
 use std::sync::LazyLock;
+
+use rara_config::RaraConfig;
+
+use crate::workspace::WorkspaceMemory;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptMode {
@@ -782,13 +784,14 @@ fn section(title: &str, items: &[&str]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::{
         PromptMode, PromptRuntimeConfig, PromptSkillSummary, PromptSourceKind,
         build_compact_instruction, build_effective_prompt, build_system_prompt,
         discover_prompt_sources,
     };
     use crate::workspace::WorkspaceMemory;
-    use std::fs;
 
     #[test]
     fn prompt_runtime_prefers_inline_override_over_file() {

--- a/crates/instructions/src/workspace.rs
+++ b/crates/instructions/src/workspace.rs
@@ -1,11 +1,13 @@
-use crate::prompt::{PromptSource, PromptSourceKind};
-use anyhow::Result;
-use rara_config::workspace_data_dir_for;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::SystemTime;
+
+use anyhow::Result;
+use rara_config::workspace_data_dir_for;
+
+use crate::prompt::{PromptSource, PromptSourceKind};
 
 const PROJECT_INSTRUCTION_FILES: [&str; 3] = ["CLAUDE.md", "GEMINI.md", "AGENTS.md"];
 const USER_INSTRUCTION_FILE: &str = "AGENTS.md";
@@ -278,13 +280,15 @@ impl WorkspaceMemory {
 
 #[cfg(test)]
 mod tests {
-    use super::WorkspaceMemory;
-    use crate::prompt::PromptSourceKind;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::{Mutex, OnceLock};
     use std::time::Duration;
+
     use tempfile::tempdir;
+
+    use super::WorkspaceMemory;
+    use crate::prompt::PromptSourceKind;
 
     fn cwd_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/crates/sandbox/src/tests.rs
+++ b/crates/sandbox/src/tests.rs
@@ -1,12 +1,14 @@
+use std::env;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tempfile::tempdir;
+
 use super::{
     DEFAULT_SHELL, MACOS_SANDBOX_EXEC, SandboxBackend, SandboxManager, cleanup_profiles_older_than,
     cleanup_stale_profiles, command_search_install_roots, sandbox_profile_string_literal,
     sanitize_shell_program, shell_command_flag, shell_program,
 };
-use std::env;
-use std::path::PathBuf;
-use std::time::Duration;
-use tempfile::tempdir;
 
 fn manager(os: &str, backend: SandboxBackend) -> SandboxManager {
     SandboxManager {

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -1,8 +1,9 @@
-use anyhow::{Result, anyhow};
-use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Skill {
@@ -301,9 +302,11 @@ fn skill_file_sort_key(path: &Path) -> (String, u8, &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::{SkillManager, repo_skill_search_dirs, skill_search_dirs};
     use std::fs;
+
     use tempfile::tempdir;
+
+    use super::{SkillManager, repo_skill_search_dirs, skill_search_dirs};
 
     #[test]
     fn loads_legacy_markdown_skills() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+group_imports = "StdExternalCrate"

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1,11 +1,12 @@
-use crate::llm::LlmBackend;
-use crate::tool::ToolManager;
 use agent_client_protocol::Error;
 use agent_client_protocol::schema::{
     AuthenticateRequest, AuthenticateResponse, CancelNotification, Implementation,
     InitializeRequest, InitializeResponse, NewSessionRequest, NewSessionResponse, PromptRequest,
     PromptResponse, ProtocolVersion, SessionId, StopReason,
 };
+
+use crate::llm::LlmBackend;
+use crate::tool::ToolManager;
 
 pub struct RaraAcpAgent {
     pub tool_manager: ToolManager,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -5,6 +5,13 @@ mod prompting;
 #[cfg(test)]
 mod tests;
 
+use std::sync::{Arc, atomic::AtomicBool};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
 use crate::llm::{ContentBlock, LlmBackend, LlmStreamEvent, LlmTurnMetadata};
 use crate::prompt::{self, PromptMode, PromptRuntimeConfig};
 use crate::redaction::redact_secrets;
@@ -21,11 +28,6 @@ use crate::tools::planning::{ENTER_PLAN_MODE_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME
 use crate::tools::todo::TODO_WRITE_TOOL_NAME;
 use crate::vectordb::{MemoryMetadata, VectorDB};
 use crate::workspace::WorkspaceMemory;
-use anyhow::Result;
-use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
-use std::sync::{Arc, atomic::AtomicBool};
-use uuid::Uuid;
 
 const MAX_RUNTIME_ERROR_RECOVERY_ATTEMPTS: usize = 1;
 const MAX_PLAN_EXIT_REPAIR_ATTEMPTS: usize = 1;

--- a/src/agent/compact.rs
+++ b/src/agent/compact.rs
@@ -1,8 +1,9 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
 use super::*;
 use crate::llm::ContextBudget;
 use crate::session::PersistedCompactionEvent;
-use std::sync::OnceLock;
-use std::time::Duration;
 
 const RECENT_FILE_CARRY_OVER_LIMIT: usize = 5;
 const RECENT_FILE_EXCERPT_LIMIT: usize = 3;
@@ -686,9 +687,10 @@ pub fn latest_compact_boundary_metadata(history: &[Message]) -> Option<CompactBo
 
 #[cfg(test)]
 mod tests {
+    use serde_json::{Map, Value, json};
+
     use super::{build_compact_plan, group_history_by_api_round, read_file_line_range};
     use crate::agent::Message;
-    use serde_json::{Map, Value, json};
 
     fn object(value: Value) -> Map<String, Value> {
         value.as_object().expect("object").clone()

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -1,9 +1,10 @@
+use anyhow::anyhow;
+
 use super::*;
 use crate::tool::ToolProgressEvent;
 use crate::tools::bash::BashCommandInput;
 use crate::tools::planning::{ENTER_PLAN_MODE_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME};
 use crate::tools::todo::TODO_WRITE_TOOL_NAME;
-use anyhow::anyhow;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlanStepStatus {

--- a/src/agent/tests/compaction.rs
+++ b/src/agent/tests/compaction.rs
@@ -4,14 +4,13 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::json;
 
+use super::support::SequencedBackend;
 use crate::agent::{Agent, AgentEvent, CompactState, ContentBlock, Message};
 use crate::llm::{ContextBudget, LlmBackend, LlmResponse, TokenUsage};
 use crate::session::SessionManager;
 use crate::tool::ToolManager;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
-
-use super::support::SequencedBackend;
 
 struct SlowSummarizeBackend;
 

--- a/src/agent/tests/context_view.rs
+++ b/src/agent/tests/context_view.rs
@@ -1,11 +1,13 @@
+use std::sync::Arc;
+
+use serde_json::json;
+
 use super::support::{SequencedBackend, test_runtime_storage};
 use crate::agent::{Agent, AgentExecutionMode, Message, PlanStep, PlanStepStatus};
 use crate::llm::{ContentBlock, LlmResponse};
 use crate::prompt::PromptRuntimeConfig;
 use crate::tool::ToolManager;
 use crate::vectordb::VectorDB;
-use serde_json::json;
-use std::sync::Arc;
 
 #[test]
 fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use serde_json::json;
 use tempfile::tempdir;
 
+use super::support::{SequencedBackend, StubBashTool, StubTool, test_runtime_storage};
 use crate::agent::planning::{
     has_unclosed_proposed_plan_block, parse_exit_plan_tool_input, parse_plan_block,
     parse_request_user_input_block, strip_continue_inspection_control,
@@ -21,8 +22,6 @@ use crate::tools::planning::{EnterPlanModeTool, ExitPlanModeTool};
 use crate::tools::todo::TodoWriteTool;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
-
-use super::support::{SequencedBackend, StubBashTool, StubTool, test_runtime_storage};
 
 struct CheckpointObserverBackend {
     session_manager: Arc<SessionManager>,

--- a/src/agent/tests/support.rs
+++ b/src/agent/tests/support.rs
@@ -1,3 +1,10 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
 use crate::agent::Message;
 use crate::llm::LlmBackend;
 use crate::llm::LlmResponse;
@@ -5,11 +12,6 @@ use crate::session::SessionManager;
 use crate::tool::{Tool, ToolError, ToolManager};
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
-use anyhow::Result;
-use async_trait::async_trait;
-use serde_json::{Value, json};
-use std::sync::{Arc, Mutex};
-use tempfile::tempdir;
 
 pub(super) struct StubTool;
 pub(super) struct StubBashTool;

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -1,3 +1,7 @@
+use anyhow::{Result, bail};
+use clap::{Parser, Subcommand};
+use secrecy::ExposeSecret;
+
 use crate::acp::{RaraAcpAgent, run_acp_stdio};
 use crate::config::{
     ConfigManager, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, RaraConfig,
@@ -8,9 +12,6 @@ use crate::redaction::redact_secrets;
 use crate::runtime_context;
 use crate::thread_cli;
 use crate::tui::StartupResumeTarget;
-use anyhow::{Result, bail};
-use clap::{Parser, Subcommand};
-use secrecy::ExposeSecret;
 
 #[derive(Parser)]
 #[command(name = "rara")]

--- a/src/codex_model_catalog.rs
+++ b/src/codex_model_catalog.rs
@@ -1,10 +1,11 @@
+use std::path::Path;
+use std::sync::Arc;
+
 use anyhow::Result;
 use codex_login::{AuthCredentialsStoreMode, AuthManager};
 use codex_models_manager::bundled_models_response;
 use codex_models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy, StaticModelsManager};
-use std::path::Path;
-use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CodexReasoningOption {

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -1,3 +1,5 @@
+use serde_json::Value;
+
 use crate::agent::{CompactState, Message, PlanStepStatus};
 use crate::context::assembly_view::assemble_context_view;
 use crate::context::compaction_view::compaction_source_entries;
@@ -11,7 +13,6 @@ use crate::llm::{ContextBudget, LlmBackend};
 use crate::prompt::{self, EffectivePrompt, PromptMode, PromptRuntimeConfig};
 use crate::todo::TodoState;
 use crate::workspace::WorkspaceMemory;
-use serde_json::Value;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssembledContext {
@@ -328,13 +329,15 @@ pub(crate) fn estimate_text_tokens(text: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::llm::{ContentBlock, LlmResponse};
+    use std::path::PathBuf;
+
     use anyhow::Result;
     use async_trait::async_trait;
     use rara_config::RaraConfig;
     use serde_json::json;
-    use std::path::PathBuf;
+
+    use super::*;
+    use crate::llm::{ContentBlock, LlmResponse};
 
     struct BudgetBackend {
         budget: Option<ContextBudget>,

--- a/src/context/assembly_view.rs
+++ b/src/context/assembly_view.rs
@@ -1,13 +1,12 @@
 use crate::agent::{Message, PlanStepStatus};
+use crate::context::assembler::{
+    RuntimeInteractionInput, estimate_text_tokens, latest_tool_results, latest_user_request,
+};
 use crate::context::{
     CompactionSourceContextEntry, ContextAssemblyEntry, ContextAssemblyView,
     MemorySelectionItemContextEntry, is_retrieved_memory_kind,
 };
 use crate::prompt::EffectivePrompt;
-
-use crate::context::assembler::{
-    RuntimeInteractionInput, estimate_text_tokens, latest_tool_results, latest_user_request,
-};
 
 pub(crate) fn assemble_context_view(
     effective_prompt: &EffectivePrompt,

--- a/src/context/compaction_view.rs
+++ b/src/context/compaction_view.rs
@@ -1,6 +1,7 @@
+use serde_json::Value;
+
 use crate::agent::Message;
 use crate::context::CompactionSourceContextEntry;
-use serde_json::Value;
 
 pub(crate) fn compaction_source_entries(history: &[Message]) -> Vec<CompactionSourceContextEntry> {
     let mut entries = Vec::new();

--- a/src/context/memory_selection.rs
+++ b/src/context/memory_selection.rs
@@ -1,15 +1,16 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
 use crate::agent::{Message, PlanStepStatus};
+use crate::context::assembler::{
+    RuntimeInteractionInput, estimate_text_tokens, latest_tool_results, latest_user_request,
+};
 use crate::context::{
     CompactionSourceContextEntry, DropReason, MemorySelectionContextView,
     MemorySelectionItemContextEntry,
 };
 use crate::prompt::PromptSource;
-use serde_json::Value;
-use std::collections::HashMap;
-
-use crate::context::assembler::{
-    RuntimeInteractionInput, estimate_text_tokens, latest_tool_results, latest_user_request,
-};
 
 pub(crate) fn memory_selection(
     prompt_sources: &[PromptSource],
@@ -579,8 +580,9 @@ pub(crate) fn extract_tool_result_payload(content: &str) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn extract_tool_result_payload_falls_back_to_plain_json_content() {

--- a/src/llm/codex_tools_compat.rs
+++ b/src/llm/codex_tools_compat.rs
@@ -1,8 +1,9 @@
+use std::collections::BTreeMap;
+
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use serde_json::json;
-use std::collections::BTreeMap;
 
 // Vendored from openai/codex codex-tools (rev 996aa23e4ce900468047ed3ec57d1e7271f8d6de),
 // trimmed to the minimum schema/export path needed by RARA:

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -5,15 +5,14 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use serde_json::{Value, json};
 
-use crate::agent::Message;
-use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
-use crate::redaction::{redact_secrets, sanitize_url_for_display};
-
 use super::shared::{
     ContextBudget, LlmBackend, LlmStreamEvent, collect_assistant_content,
     context_budget_from_window, extract_single_tool_result, hashed_embedding,
     http_client_for_target, parse_tool_arguments, render_openai_message_content, retry_send_json,
 };
+use crate::agent::Message;
+use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
+use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
 pub struct OllamaBackend {
     pub client: reqwest::Client,

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -1,32 +1,29 @@
 mod codex;
 mod usage;
 
-use backon::{ExponentialBuilder, Retryable};
-
 use std::borrow::Cow;
 use std::fmt;
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
 use eventsource_stream::Eventsource;
 use reqwest::{Response, StatusCode};
 use secrecy::{ExposeSecret, SecretString};
 use serde_json::{Value, json};
 
-use crate::agent::Message;
-use crate::config::OpenAiEndpointKind;
-use crate::llm::{ContentBlock, LlmResponse};
-use crate::redaction::{redact_secrets, sanitize_url_for_display};
-
+use self::usage::parse_openai_token_usage;
 use super::shared::{
     ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata, collect_assistant_content,
     context_budget_from_window, extract_message_text, http_client_for_target,
     is_retryable_http_error, model_context_budget, next_stream_item_with_idle_timeout,
     parse_tool_arguments, render_openai_message_content, retry_send_json,
 };
-
-use self::usage::parse_openai_token_usage;
+use crate::agent::Message;
+use crate::config::OpenAiEndpointKind;
+use crate::llm::{ContentBlock, LlmResponse};
+use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
 const STREAM_IDLE_RETRY_ATTEMPTS: usize = 1;
 const STREAM_IDLE_ERROR_FRAGMENT: &str = "stream produced no events";

--- a/src/llm/openai_compatible/codex.rs
+++ b/src/llm/openai_compatible/codex.rs
@@ -6,10 +6,6 @@ use eventsource_stream::Eventsource;
 use secrecy::{ExposeSecret, SecretString};
 use serde_json::{Value, json};
 
-use crate::agent::Message;
-use crate::llm::{ContentBlock, LlmResponse};
-use crate::redaction::sanitize_url_for_display;
-
 use super::super::codex_tools_compat::ToolDefinition;
 use super::super::codex_tools_compat::ToolSpec;
 use super::super::codex_tools_compat::create_tools_json_for_responses_api;
@@ -24,6 +20,9 @@ use super::{
     CodexBackend, OpenAiApiError, OpenAiCompatibleBackend, api_error_from_response,
     is_auxiliary_model_retryable_error,
 };
+use crate::agent::Message;
+use crate::llm::{ContentBlock, LlmResponse};
+use crate::redaction::sanitize_url_for_display;
 
 impl CodexBackend {
     pub fn new(

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -1,13 +1,14 @@
-use anyhow::{Result, anyhow};
-use async_trait::async_trait;
-use backon::{ExponentialBuilder, Retryable};
-use futures::{Stream, StreamExt};
-use serde_json::{Value, json};
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
 use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
+use futures::{Stream, StreamExt};
+use serde_json::{Value, json};
 use url::Url;
 
 use crate::agent::Message;

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -1,12 +1,6 @@
 use reqwest::StatusCode;
 use serde_json::json;
 
-use crate::agent::Message;
-use crate::config::OpenAiEndpointKind;
-use crate::llm::{ContentBlock, LlmStreamEvent, LlmTurnMetadata};
-use crate::tool::Tool;
-use crate::tools::planning::ExitPlanModeTool;
-
 use super::ollama::{
     apply_ollama_stream_event, build_ollama_options, ensure_ollama_stream_completed,
     suggest_ollama_num_ctx, to_ollama_messages,
@@ -22,6 +16,11 @@ use super::openai_compatible::{
 use super::shared::{
     extract_message_text, model_context_budget, parse_tool_arguments, should_bypass_proxy,
 };
+use crate::agent::Message;
+use crate::config::OpenAiEndpointKind;
+use crate::llm::{ContentBlock, LlmStreamEvent, LlmTurnMetadata};
+use crate::tool::Tool;
+use crate::tools::planning::ExitPlanModeTool;
 
 #[test]
 fn converts_assistant_tool_history_to_openai_messages() {

--- a/src/local_backend.rs
+++ b/src/local_backend.rs
@@ -13,18 +13,16 @@ use candle::{DType, Tensor};
 use candle_transformers::generation::{LogitsProcessor, Sampling};
 use serde_json::Value;
 
-use crate::agent::Message;
-use crate::config::RaraConfig;
-use crate::llm::{ContentBlock, LlmBackend, LlmResponse, TokenUsage, hashed_embedding};
-
 use self::model::{
     LocalModelSpec, LocalTextModel, build_hf_api, default_local_model_cache_dir as model_cache_dir,
     load_safetensors, preferred_dtype, select_device,
 };
+pub use self::model::{default_local_model_cache_dir, local_runtime_target};
 use self::parser::parse_tool_aware_reply;
 use self::prompt::{build_agent_prompt, render_messages, scenario_token_cap};
-
-pub use self::model::{default_local_model_cache_dir, local_runtime_target};
+use crate::agent::Message;
+use crate::config::RaraConfig;
+use crate::llm::{ContentBlock, LlmBackend, LlmResponse, TokenUsage, hashed_embedding};
 
 pub type LocalProgressReporter = Arc<dyn Fn(String) + Send + Sync>;
 

--- a/src/local_backend/tests.rs
+++ b/src/local_backend/tests.rs
@@ -1,10 +1,9 @@
 use serde_json::json;
 
-use crate::agent::Message;
-
 use super::model::{LocalModelSpec, default_local_model_cache_dir, extract_context_window};
 use super::parser::{extract_json_object, parse_tool_aware_reply};
 use super::prompt::{render_content, scenario_token_cap};
+use crate::agent::Message;
 
 #[test]
 fn resolves_supported_aliases() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,9 @@ mod tui;
 mod vectordb;
 mod workspace;
 
-use crate::redaction::redact_secrets;
 use anyhow::Result;
+
+use crate::redaction::redact_secrets;
 
 #[tokio::main]
 async fn main() {

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,3 +1,7 @@
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
 use anyhow::{Result, anyhow};
 use codex_login::{
     AuthCredentialsStoreMode, AuthDotJson, CLIENT_ID, DeviceCode as CodexDeviceCode,
@@ -7,9 +11,6 @@ use codex_login::{
     request_device_code as codex_request_device_code, run_login_server as codex_run_login_server,
 };
 use secrecy::SecretString;
-use std::io::Read;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 
 const ISSUER: &str = "https://auth.openai.com";
 
@@ -282,10 +283,12 @@ fn detect_saved_auth_mode(auth: &AuthDotJson) -> Option<SavedCodexAuthMode> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use secrecy::ExposeSecret;
     use std::path::Path;
+
+    use secrecy::ExposeSecret;
     use tempfile::tempdir;
+
+    use super::*;
 
     #[tokio::test]
     async fn browser_login_session_uses_codex_issuer_and_client_id() {

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -1,5 +1,6 @@
-use regex::Regex;
 use std::sync::LazyLock;
+
+use regex::Regex;
 
 const REDACTED_SECRET: &str = "[REDACTED_SECRET]";
 const REDACTED_URL_VALUE: &str = "<redacted>";

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -224,13 +224,14 @@ fn ollama_thinking_enabled(config: &RaraConfig) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use tempfile::tempdir;
+
     use super::{
         build_backend_with_progress, initialize_rara_context, ollama_thinking_enabled,
         vector_db_uri_for_workspace,
     };
     use crate::config::{DEFAULT_REASONING_SUMMARY, REASONING_SUMMARY_NONE, RaraConfig};
     use crate::workspace::WorkspaceMemory;
-    use tempfile::tempdir;
 
     #[test]
     fn vector_db_uri_is_workspace_scoped() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,12 +1,14 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+
 use crate::agent::Message;
 use crate::state_db::PersistedStructuredRolloutEvent;
 use crate::thread_rollout_log;
 use crate::todo::TodoState;
-use anyhow::{Result, anyhow};
-use serde::{Deserialize, Serialize};
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PersistedCompactionEvent {
@@ -371,8 +373,9 @@ fn epoch_seconds() -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use tempfile::tempdir;
+
+    use super::*;
 
     #[test]
     fn save_compaction_event_appends_jsonl_lines() -> Result<()> {

--- a/src/state_db/tests.rs
+++ b/src/state_db/tests.rs
@@ -1,10 +1,11 @@
+use anyhow::Result;
+use rusqlite::Connection;
+use tempfile::tempdir;
+
 use super::{
     PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
     PersistedStructuredRolloutEvent, PersistedTurnEntry, StateDb,
 };
-use anyhow::Result;
-use rusqlite::Connection;
-use tempfile::tempdir;
 
 #[test]
 fn persists_metadata_and_rollout_artifact() -> Result<()> {

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -1,18 +1,18 @@
-use anyhow::Result;
 use std::fs;
 use std::time::Duration;
+
+use anyhow::Result;
 use tempfile::tempdir;
 
+use super::{
+    RolloutItem, ThreadHistorySource, ThreadMetadataSource, ThreadNonTurnRolloutSource,
+    ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeState, ThreadStore,
+};
 use crate::agent::Message;
 use crate::session::{PersistedCompactionEvent, SessionManager};
 use crate::state_db::{
     PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
     PersistedRuntimeRolloutItem, PersistedStructuredRolloutEvent, PersistedTurnEntry, StateDb,
-};
-
-use super::{
-    RolloutItem, ThreadHistorySource, ThreadMetadataSource, ThreadNonTurnRolloutSource,
-    ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeState, ThreadStore,
 };
 
 #[test]

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -1,8 +1,9 @@
+use std::collections::HashSet;
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashSet;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TodoState {
@@ -179,8 +180,9 @@ fn epoch_seconds() -> i64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn normalizes_todo_write_input() {

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1,11 +1,12 @@
-use anyhow::Result;
-use async_trait::async_trait;
-use serde_json::Value;
 use std::collections::BTreeMap;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ToolError {

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -976,13 +976,14 @@ pub fn default_tool_result_store_dir() -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::{
         TOOL_RESULT_BATCH_BUDGET, ToolResultStore, compact_read_file, compact_subagent_result,
         compact_web_search, default_tool_result_store_dir, enforce_tool_result_batch_budget,
         repair_tool_result_history, tool_result_content_candidates,
     };
     use crate::agent::Message;
-    use serde_json::json;
 
     #[test]
     fn repairs_missing_tool_results() {

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1,3 +1,8 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
 use crate::agent::{Agent, AgentExecutionMode, Message, PendingUserInput, PlanStep};
 use crate::llm::LlmBackend;
 use crate::prompt::PromptRuntimeConfig;
@@ -7,9 +12,6 @@ use crate::tools::file::{ListFilesTool, ReadFileTool};
 use crate::tools::search::{GlobTool, GrepTool};
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
-use async_trait::async_trait;
-use serde_json::{Value, json};
-use std::sync::Arc;
 
 #[derive(Clone, Copy)]
 enum SubAgentKind {
@@ -442,13 +444,14 @@ fn serialize_pending_user_input(request: &PendingUserInput) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::{
         SubAgentKind, append_subagent_prompt, build_read_only_tool_manager,
         build_subagent_tool_manager, latest_assistant_text_from_history,
     };
     use crate::agent::Message;
     use crate::prompt::PromptRuntimeConfig;
-    use serde_json::json;
 
     #[test]
     fn read_only_subagent_manager_excludes_mutating_and_agent_tools() {

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -1,9 +1,3 @@
-use crate::sandbox::{SandboxManager, WrappedCommand, sandbox_failure_hint};
-use crate::tool::{Tool, ToolCallContext, ToolError, ToolOutputStream, ToolProgressEvent};
-use crate::tool_result::model_preview_bash_output;
-use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::env;
 use std::io::SeekFrom;
@@ -14,6 +8,10 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
 use tokio::fs;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
@@ -21,6 +19,10 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::time::{Instant as TokioInstant, MissedTickBehavior};
 use uuid::Uuid;
+
+use crate::sandbox::{SandboxManager, WrappedCommand, sandbox_failure_hint};
+use crate::tool::{Tool, ToolCallContext, ToolError, ToolOutputStream, ToolProgressEvent};
+use crate::tool_result::model_preview_bash_output;
 
 pub struct BashTool {
     pub sandbox: Arc<SandboxManager>,
@@ -1449,6 +1451,18 @@ async fn ensure_sandbox_home_dirs(sandbox_home: &Path) -> Result<(), ToolError> 
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::env;
+    use std::path::Path;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    use std::time::Duration;
+
+    use serde_json::{Value, json};
+    use tempfile::tempdir;
+
     use super::{
         BackgroundTaskListTool, BackgroundTaskStatus, BackgroundTaskStatusTool,
         BackgroundTaskStopTool, BackgroundTaskStore, BashCommandInput, BashSandboxPermissions,
@@ -1458,16 +1472,6 @@ mod tests {
     use crate::sandbox::{SandboxManager, WrappedCommand};
     use crate::tool::{Tool, ToolCallContext, ToolOutputStream, ToolProgressEvent};
     use crate::tool_result::model_preview_bash_output;
-    use serde_json::{Value, json};
-    use std::collections::HashMap;
-    use std::env;
-    use std::path::Path;
-    use std::sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    };
-    use std::time::Duration;
-    use tempfile::tempdir;
 
     #[test]
     fn parses_legacy_shell_payload() {

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
 use crate::llm::LlmBackend;
 use crate::session::SessionManager;
 use crate::tool::{Tool, ToolError};
 use crate::vectordb::VectorDB;
-use async_trait::async_trait;
-use serde_json::{Value, json};
-use std::sync::Arc;
 
 pub struct RetrieveSessionContextTool {
     pub backend: Arc<dyn LlmBackend>,

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -1,14 +1,16 @@
-use crate::tool::{Tool, ToolError};
-use async_trait::async_trait;
-use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader as AsyncBufReader};
 use walkdir::WalkDir;
+
+use crate::tool::{Tool, ToolError};
 
 const DEFAULT_READ_LINE_LIMIT: usize = 2_000;
 const MAX_READ_LINE_CHARS: usize = 4_000;

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+
 use super::{
     FileReadState, ListFilesTool, MAX_READ_LINE_BYTES, MAX_READ_LINE_CHARS, ReadFileTool,
     ReplaceLinesTool, ReplaceTool, WriteFileTool,
 };
 use crate::tool::Tool;
-use serde_json::{Value, json};
-use std::sync::Arc;
 
 #[tokio::test]
 async fn read_file_supports_line_ranges() {

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -1,9 +1,11 @@
-use crate::tool::{Tool, ToolError};
-use crate::tools::file::{FileReadState, SharedFileReadState};
-use async_trait::async_trait;
-use serde_json::{Value, json};
 use std::fs;
 use std::path::Path;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tool::{Tool, ToolError};
+use crate::tools::file::{FileReadState, SharedFileReadState};
 
 #[derive(Default)]
 pub struct ApplyPatchTool {
@@ -452,11 +454,13 @@ fn read_lines(path: &str) -> Result<Vec<String>, ToolError> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use serde_json::json;
+
     use super::ApplyPatchTool;
     use crate::tool::Tool;
     use crate::tools::file::{FileReadState, ReadFileTool};
-    use serde_json::json;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn applies_update_patch() {

--- a/src/tools/planning.rs
+++ b/src/tools/planning.rs
@@ -1,6 +1,7 @@
-use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
 use serde_json::{Value, json};
+
+use crate::tool::{Tool, ToolError};
 
 pub const ENTER_PLAN_MODE_TOOL_NAME: &str = "enter_plan_mode";
 pub const EXIT_PLAN_MODE_TOOL_NAME: &str = "exit_plan_mode";

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -1,8 +1,3 @@
-use crate::sandbox::{SandboxManager, WrappedCommand, sandbox_failure_hint};
-use crate::tool::{Tool, ToolError};
-use async_trait::async_trait;
-use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
-use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::env;
 use std::fs::OpenOptions;
@@ -11,8 +6,15 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use uuid::Uuid;
+
+use crate::sandbox::{SandboxManager, WrappedCommand, sandbox_failure_hint};
+use crate::tool::{Tool, ToolError};
 
 const PTY_START_QUICK_COMPLETION_TIMEOUT: Duration = Duration::from_millis(750);
 const PTY_START_QUICK_COMPLETION_POLL: Duration = Duration::from_millis(25);
@@ -748,9 +750,10 @@ fn parse_pty_dimension(value: Option<&Value>, default: u16, name: &str) -> Resul
 
 #[cfg(test)]
 mod tests {
+    use tempfile::tempdir;
+
     use super::*;
     use crate::sandbox::WrappedCommand;
-    use tempfile::tempdir;
 
     #[tokio::test]
     async fn read_output_tail_returns_only_requested_suffix() {

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -1,10 +1,12 @@
-use crate::tool::{Tool, ToolError};
+use std::fs;
+use std::path::Path;
+
 use async_trait::async_trait;
 use glob::glob;
 use regex::Regex;
 use serde_json::{Value, json};
-use std::fs;
-use std::path::Path;
+
+use crate::tool::{Tool, ToolError};
 
 pub struct GlobTool;
 #[async_trait]
@@ -110,9 +112,10 @@ fn is_ignored_path(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::GrepTool;
     use crate::tool::Tool;
-    use serde_json::json;
 
     #[tokio::test]
     async fn grep_skips_build_artifacts_by_default() {

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -1,8 +1,10 @@
-use crate::skill::SkillManager;
-use crate::tool::{Tool, ToolError};
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use serde_json::{Value, json};
-use std::sync::Arc;
+
+use crate::skill::SkillManager;
+use crate::tool::{Tool, ToolError};
 
 pub struct SkillTool {
     pub skill_manager: Arc<SkillManager>,

--- a/src/tools/todo.rs
+++ b/src/tools/todo.rs
@@ -1,7 +1,8 @@
-use crate::todo::normalize_todo_write_input;
-use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
 use serde_json::{Value, json};
+
+use crate::todo::normalize_todo_write_input;
+use crate::tool::{Tool, ToolError};
 
 pub const TODO_WRITE_TOOL_NAME: &str = "todo_write";
 

--- a/src/tools/vector.rs
+++ b/src/tools/vector.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
 use crate::llm::LlmBackend;
 use crate::memory_store::{MemoryStore, NewMemoryRecord};
 use crate::tool::{Tool, ToolError};
 use crate::vectordb::VectorDB;
-use async_trait::async_trait;
-use serde_json::{Value, json};
-use std::sync::Arc;
 
 pub struct RememberExperienceTool {
     pub backend: Arc<dyn LlmBackend>,

--- a/src/tools/web/exa.rs
+++ b/src/tools/web/exa.rs
@@ -1,7 +1,8 @@
+use std::time::Duration;
+
 use backon::{ExponentialBuilder, Retryable};
 use serde::Serialize;
 use serde_json::{Value, json};
-use std::time::Duration;
 
 use crate::llm::is_retryable_http_error;
 use crate::redaction::redact_secrets;

--- a/src/tools/web/fetch.rs
+++ b/src/tools/web/fetch.rs
@@ -1,13 +1,14 @@
-use crate::tool::{Tool, ToolError};
+use std::net::IpAddr;
+use std::time::Duration;
+
 use async_trait::async_trait;
 use backon::{ExponentialBuilder, Retryable};
 use futures::StreamExt;
 use serde_json::{Value, json};
-use std::net::IpAddr;
-use std::time::Duration;
 use url::Url;
 
 use crate::llm::is_retryable_http_error;
+use crate::tool::{Tool, ToolError};
 
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const MAX_TIMEOUT_SECS: u64 = 120;
@@ -373,8 +374,9 @@ fn decode_basic_entities(input: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{FetchFormat, FetchRequest, html_to_text};
     use serde_json::json;
+
+    use super::{FetchFormat, FetchRequest, html_to_text};
 
     #[test]
     fn fetch_request_rejects_non_http_urls() {

--- a/src/tools/web/search.rs
+++ b/src/tools/web/search.rs
@@ -1,8 +1,9 @@
-use super::exa::ExaMcpClient;
-use crate::tool::{Tool, ToolError};
 use async_trait::async_trait;
 use serde::Serialize;
 use serde_json::{Value, json};
+
+use super::exa::ExaMcpClient;
+use crate::tool::{Tool, ToolError};
 
 const DEFAULT_NUM_RESULTS: u64 = 8;
 const DEFAULT_SEARCH_TYPE: &str = "auto";
@@ -157,8 +158,9 @@ fn enum_string(
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_LIVECRAWL, DEFAULT_NUM_RESULTS, DEFAULT_SEARCH_TYPE, parse_search_args};
     use serde_json::json;
+
+    use super::{DEFAULT_LIVECRAWL, DEFAULT_NUM_RESULTS, DEFAULT_SEARCH_TYPE, parse_search_args};
 
     #[test]
     fn search_args_apply_opencode_compatible_defaults() {

--- a/src/tools/workspace.rs
+++ b/src/tools/workspace.rs
@@ -1,8 +1,10 @@
-use crate::tool::{Tool, ToolError};
-use crate::workspace::WorkspaceMemory;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use serde_json::{Value, json};
-use std::sync::Arc;
+
+use crate::tool::{Tool, ToolError};
+use crate::workspace::WorkspaceMemory;
 
 pub struct UpdateProjectMemoryTool {
     pub workspace: Arc<WorkspaceMemory>,

--- a/src/tui/auth_mode_picker.rs
+++ b/src/tui/auth_mode_picker.rs
@@ -68,10 +68,9 @@ mod tests {
     use insta::assert_snapshot;
     use tempfile::tempdir;
 
+    use super::build_auth_mode_picker_view;
     use crate::config::ConfigManager;
     use crate::tui::state::TuiApp;
-
-    use super::build_auth_mode_picker_view;
 
     #[test]
     fn auth_mode_picker_local_snapshot() {

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -1,3 +1,5 @@
+use time::{OffsetDateTime, format_description};
+
 use crate::config::RaraConfig;
 use crate::context::{CacheStatus, DropReason};
 use crate::tui::format::cache_hit_rate_label;
@@ -5,7 +7,6 @@ use crate::tui::session_restore::provider_requires_api_key;
 use crate::tui::state::{
     PROVIDER_FAMILIES, PendingInteractionSnapshot, ProviderFamily, TuiApp, current_model_presets,
 };
-use time::{OffsetDateTime, format_description};
 
 fn format_pending_interaction(snapshot: &PendingInteractionSnapshot) -> String {
     let kind = match snapshot.kind {

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -1,3 +1,5 @@
+use tempfile::tempdir;
+
 use super::specs::normalize_command_token;
 use super::status::truncate_preview;
 use super::{
@@ -9,7 +11,6 @@ use crate::config::{ConfigManager, OpenAiEndpointKind};
 use crate::context::{PromptSourceContextEntry, TodoContextView};
 use crate::todo::TodoSummary;
 use crate::tui::state::{LocalCommandKind, RuntimeSnapshot, TuiApp};
-use tempfile::tempdir;
 
 #[test]
 fn parses_model_command_argument() {

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -1,9 +1,5 @@
 use std::sync::Arc;
 
-use crate::agent::{Agent, BashApprovalDecision};
-use crate::config::DEFAULT_CODEX_BASE_URL;
-use crate::oauth::{OAuthManager, SavedCodexAuthMode};
-
 use super::app_event::AppEvent;
 use super::auth_mode_picker::AUTH_MODE_OPTION_COUNT;
 use super::command::{palette_command_by_index, palette_commands};
@@ -22,6 +18,9 @@ use super::state::{
 };
 use super::submit::{apply_openai_model_picker_action, handle_submit};
 use super::terminal_ui::is_ssh_session;
+use crate::agent::{Agent, BashApprovalDecision};
+use crate::config::DEFAULT_CODEX_BASE_URL;
+use crate::oauth::{OAuthManager, SavedCodexAuthMode};
 
 pub(crate) async fn dispatch_event(
     event: AppEvent,

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -4,10 +4,6 @@ use crossterm::{event::EventStream, terminal::enable_raw_mode, terminal::size as
 use futures::StreamExt;
 use tokio::time::{Duration, interval};
 
-use crate::agent::Agent;
-use crate::oauth::OAuthManager;
-use crate::state_db::StateDb;
-
 use super::event_dispatch::dispatch_event;
 use super::event_stream::{UiEvent, translate_event};
 use super::render::{desired_viewport_height, render};
@@ -20,6 +16,9 @@ use super::terminal_ui::{
     build_terminal, flush_committed_history, handle_paste, teardown_terminal,
     update_terminal_viewport,
 };
+use crate::agent::Agent;
+use crate::oauth::OAuthManager;
+use crate::state_db::StateDb;
 
 #[derive(Debug, Clone)]
 pub enum StartupResumeTarget {

--- a/src/tui/highlight.rs
+++ b/src/tui/highlight.rs
@@ -1,8 +1,9 @@
+use std::sync::{OnceLock, RwLock};
+
 use ratatui::{
     style::{Color as RtColor, Modifier, Style},
     text::{Line, Span},
 };
-use std::sync::{OnceLock, RwLock};
 use syntect::{
     easy::HighlightLines,
     highlighting::{Color as SyntectColor, FontStyle, Style as SyntectStyle, Theme},

--- a/src/tui/interaction_text.rs
+++ b/src/tui/interaction_text.rs
@@ -153,14 +153,13 @@ pub fn status_command_approval_text(app: &TuiApp) -> String {
 mod tests {
     use tempfile::tempdir;
 
+    use super::{
+        pending_interaction_hint_text, status_command_approval_text, status_plan_approval_text,
+    };
     use crate::config::ConfigManager;
     use crate::tools::bash::BashCommandInput;
     use crate::tui::state::{
         InteractionKind, PendingApprovalSnapshot, PendingInteractionSnapshot, TuiApp,
-    };
-
-    use super::{
-        pending_interaction_hint_text, status_command_approval_text, status_plan_approval_text,
     };
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -35,13 +35,11 @@ mod tests;
 mod theme;
 mod tool_text;
 
-pub(crate) use self::keymap::map_key_to_event;
-pub(crate) use self::session_restore::provider_requires_api_key;
-pub(crate) use self::terminal_ui::is_ssh_session;
-
 #[cfg(test)]
 pub(crate) use self::event_dispatch::dispatch_event;
+pub use self::event_loop::{StartupResumeTarget, run_tui};
+pub(crate) use self::keymap::map_key_to_event;
+pub(crate) use self::session_restore::provider_requires_api_key;
 #[cfg(test)]
 pub(crate) use self::submit::handle_submit;
-
-pub use self::event_loop::{StartupResumeTarget, run_tui};
+pub(crate) use self::terminal_ui::is_ssh_session;

--- a/src/tui/plan_display.rs
+++ b/src/tui/plan_display.rs
@@ -126,10 +126,9 @@ pub(crate) fn updated_plan_lines(
 mod tests {
     use tempfile::tempdir;
 
+    use super::{should_show_updated_plan, updated_plan_lines, updated_plan_text};
     use crate::config::ConfigManager;
     use crate::tui::state::TuiApp;
-
-    use super::{should_show_updated_plan, updated_plan_lines, updated_plan_text};
 
     #[test]
     fn updated_plan_text_formats_note_and_checklist() {

--- a/src/tui/provider_flow.rs
+++ b/src/tui/provider_flow.rs
@@ -1,12 +1,11 @@
+use codex_models_manager::manager::RefreshStrategy;
 use secrecy::{ExposeSecret, SecretString};
 
+use super::state::{Overlay, ProviderFamily, TuiApp};
 use crate::agent::Agent;
 use crate::codex_model_catalog::load_codex_model_catalog;
 use crate::config::OpenAiEndpointKind;
 use crate::oauth::OAuthManager;
-
-use super::state::{Overlay, ProviderFamily, TuiApp};
-use codex_models_manager::manager::RefreshStrategy;
 
 pub(super) fn sync_codex_credential_from_auth_store(
     app: &mut TuiApp,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -8,16 +8,15 @@ mod overlay;
 mod tests;
 mod viewport;
 
-pub(crate) use helpers::*;
+use std::path::Path;
 
-use crate::tui::theme::*;
+pub(crate) use helpers::*;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Paragraph, Wrap},
 };
-use std::path::Path;
 
 pub(crate) use self::bottom_pane::desired_viewport_height;
 use self::bottom_pane::{desired_bottom_pane_height, render_bottom_pane};
@@ -30,6 +29,7 @@ use super::line_utils::prefix_lines;
 use super::state::{TranscriptEntry, TuiApp};
 use super::tool_text::{compact_delegate_rest, compact_instruction};
 use crate::tui::sub_agent_display::SubAgentKind;
+use crate::tui::theme::*;
 
 pub fn render(f: &mut Frame, app: &TuiApp) {
     let bottom_pane_height = desired_bottom_pane_height(app, f.area().width, f.area().height);

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -1,4 +1,3 @@
-use crate::tui::theme::*;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -7,14 +6,14 @@ use ratatui::{
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::tui::format::cache_hit_rate_label;
-
 use super::super::custom_terminal::Frame;
 use super::super::interaction_text::pending_interaction_hint_text;
 use super::super::queued_input::{pending_follow_up_hint, queued_follow_up_hint};
 use super::super::state::char_offset_to_byte_index;
 use super::super::state::{ActivePendingInteractionKind, TaskKind, TuiApp};
 use super::badge;
+use crate::tui::format::cache_hit_rate_label;
+use crate::tui::theme::*;
 
 const COMPOSER_TAB_WIDTH: usize = 4;
 const BOTTOM_PANE_BG: Color = SURFACE_BOTTOM_PANE_BG;

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -4,15 +4,14 @@ use ratatui::{layout::Rect, style::Color};
 use tempfile::tempdir;
 use tokio::sync::mpsc;
 
+use super::{
+    activity_status_line, animated_activity_label, composer_hint, composer_hint_line,
+    footer_summary_text, wrapped_text_cursor_position, wrapped_text_rows,
+};
 use crate::config::ConfigManager;
 use crate::tui::state::{
     InteractionKind, PendingInteractionSnapshot, RunningTask, RuntimePhase, RuntimeSnapshot,
     TaskCompletion, TaskKind, TuiApp,
-};
-
-use super::{
-    activity_status_line, animated_activity_label, composer_hint, composer_hint_line,
-    footer_summary_text, wrapped_text_cursor_position, wrapped_text_rows,
 };
 
 #[test]

--- a/src/tui/render/cells/cells_components.rs
+++ b/src/tui/render/cells/cells_components.rs
@@ -1,5 +1,3 @@
-use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;
-use crate::tui::theme::*;
 use std::path::Path;
 
 use ratatui::{
@@ -7,6 +5,7 @@ use ratatui::{
     text::{Line, Span},
 };
 
+use super::{HistoryCell, InteractionCompletionKind};
 use crate::tui::interaction_text::{
     pending_interaction_card_title, status_planning_suggestion_text,
 };
@@ -22,8 +21,8 @@ use crate::tui::render::{
     with_border,
 };
 use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
-
-use super::{HistoryCell, InteractionCompletionKind};
+use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;
+use crate::tui::theme::*;
 
 pub(super) struct UserCell {
     message: String,
@@ -796,9 +795,10 @@ pub(super) fn planning_suggestion_text(app: &TuiApp) -> String {
 
 #[cfg(test)]
 mod tests {
+    use ratatui::style::Color;
+
     use super::{HistoryCell, SummaryCell};
     use crate::tui::theme::PHASE_RAN;
-    use ratatui::style::Color;
 
     #[test]
     fn summary_cell_renders_indented_diff_block_as_patch_preview() {

--- a/src/tui/render/cells/cells_tests.rs
+++ b/src/tui/render/cells/cells_tests.rs
@@ -2,9 +2,6 @@
 
 use std::path::Path;
 
-use crate::config::ConfigManager;
-use crate::tui::state::{RuntimePhase, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp};
-use crate::tui::terminal_event::{TerminalCommandEvent, TerminalEvent, TerminalTarget};
 use insta::assert_snapshot;
 use tempfile::tempdir;
 
@@ -12,6 +9,9 @@ use super::{
     ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell, ProgressRole,
     explicit_progress_entry_groups,
 };
+use crate::config::ConfigManager;
+use crate::tui::state::{RuntimePhase, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp};
+use crate::tui::terminal_event::{TerminalCommandEvent, TerminalEvent, TerminalTarget};
 
 #[path = "cells_tests/active_general.rs"]
 mod active_general;

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -1,4 +1,3 @@
-use crate::tui::theme::*;
 use std::path::Path;
 
 use ratatui::{style::Color, text::Line};
@@ -15,6 +14,7 @@ use crate::tui::state::{
 use crate::tui::terminal_event::{
     TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
 };
+use crate::tui::theme::*;
 
 #[path = "cells_components.rs"]
 mod components;

--- a/src/tui/render/cells/progress.rs
+++ b/src/tui/render/cells/progress.rs
@@ -1,11 +1,6 @@
-use crate::tui::theme::*;
-use ratatui::{style::Color, text::Line};
 use std::path::Path;
 
-use crate::tui::state::{ActiveLiveEvent, TranscriptEntry, TranscriptEntryPayload};
-use crate::tui::terminal_event::{
-    TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
-};
+use ratatui::{style::Color, text::Line};
 
 use super::super::{
     compact_progress_summary_lines, compact_recent_first_summary_lines, compact_summary_lines,
@@ -17,6 +12,11 @@ use super::components::{
     ExploredCell, ExploringCell, PlanningCell, RanCell, RunningCell, TerminalCell,
     ThinkingGroupCell, ThinkingTextCell,
 };
+use crate::tui::state::{ActiveLiveEvent, TranscriptEntry, TranscriptEntryPayload};
+use crate::tui::terminal_event::{
+    TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
+};
+use crate::tui::theme::*;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ProgressRole {

--- a/src/tui/render/cells/terminal.rs
+++ b/src/tui/render/cells/terminal.rs
@@ -1,15 +1,15 @@
-use crate::tui::theme::*;
-use ratatui::{style::Color, text::Line};
 use std::path::Path;
 
-use crate::tui::state::{TranscriptEntry, TranscriptEntryPayload};
-use crate::tui::terminal_event::{
-    TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
-};
+use ratatui::{style::Color, text::Line};
 
 use super::super::{compact_recent_first_summary_lines, exploration_action_label};
 use super::components::{RanCell, TerminalCell};
 use super::{TerminalCellData, line_plain_text, trim_trailing_empty_lines};
+use crate::tui::state::{TranscriptEntry, TranscriptEntryPayload};
+use crate::tui::terminal_event::{
+    TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
+};
+use crate::tui::theme::*;
 
 pub(super) fn terminal_cell_from_entries<'a>(
     entries: impl DoubleEndedIterator<Item = &'a TranscriptEntry>,

--- a/src/tui/render/diff.rs
+++ b/src/tui/render/diff.rs
@@ -1,10 +1,10 @@
-use crate::tui::theme::*;
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
 
 use crate::tui::render::display_width;
+use crate::tui::theme::*;
 
 const MAX_DIFF_LINES: usize = 80;
 

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -1,4 +1,5 @@
-use crate::tui::theme::*;
+use std::path::Path;
+
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -6,7 +7,6 @@ use ratatui::{
     widgets::{Block, Borders, Cell, List, ListItem, Paragraph, Row, Table, TableState, Wrap},
 };
 use secrecy::ExposeSecret;
-use std::path::Path;
 use unicode_width::UnicodeWidthChar;
 
 use super::Frame;
@@ -18,6 +18,7 @@ use crate::tui::render::bottom_pane::editor_cursor_position;
 use crate::tui::state::{
     PROVIDER_FAMILIES, ProviderFamily, TuiApp, current_model_presets, openai_profile_setup_kinds,
 };
+use crate::tui::theme::*;
 
 fn wrapped_text_height(text: &str, area_width: u16) -> u16 {
     let width = area_width.saturating_sub(2).max(1) as usize;

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -7,12 +7,6 @@ use ratatui::{buffer::Buffer, layout::Rect};
 use serde_json::json;
 use tempfile::tempdir;
 
-use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
-use crate::tui::custom_terminal::Frame;
-use crate::tui::state::{
-    Overlay, ProviderFamily, RuntimeSnapshot, StatusTab, TranscriptEntry, TranscriptTurn, TuiApp,
-};
-
 use super::cells::HistoryCell;
 use super::viewport::TranscriptViewport;
 use super::{
@@ -21,6 +15,11 @@ use super::{
     desired_bottom_pane_height, desired_viewport_height, formatted_message_lines,
     prefixed_message_lines, renderable_transcript_lines, tool_action_label,
     transcript_scroll_offset, transcript_viewport, transcript_visual_row_count,
+};
+use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
+use crate::tui::custom_terminal::Frame;
+use crate::tui::state::{
+    Overlay, ProviderFamily, RuntimeSnapshot, StatusTab, TranscriptEntry, TranscriptTurn, TuiApp,
 };
 
 fn provider_family_idx(family: ProviderFamily) -> usize {

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -4,10 +4,9 @@ mod tasks;
 
 use std::sync::Arc;
 
+use super::state::{LocalCommand, OAuthLoginMode, TuiApp};
 use crate::agent::{Agent, BashApprovalDecision};
 use crate::oauth::OAuthManager;
-
-use super::state::{LocalCommand, OAuthLoginMode, TuiApp};
 
 pub async fn execute_local_command(
     command: LocalCommand,

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
-use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
-use crate::oauth::OAuthManager;
-
 use super::super::state::{
     HelpTab, LocalCommand, LocalCommandKind, Overlay, RuntimePhase, StatusTab, TuiApp,
 };
 use super::tasks::{start_compact_task, start_rebuild_task};
+use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
+use crate::oauth::OAuthManager;
 
 pub(super) async fn execute_local_command(
     command: LocalCommand,

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -3,26 +3,25 @@ mod oauth;
 #[cfg(test)]
 mod tests;
 
-use secrecy::ExposeSecret;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
 use std::time::Instant;
 
+use builder::rebuild_agent_with_progress;
 use rara_provider_catalog::{
     ModelCatalogProvider, ModelCatalogRequest, fallback_models, load_model_catalog,
 };
+use secrecy::ExposeSecret;
 use tokio::sync::mpsc;
-
-use crate::agent::{Agent, AgentOutputMode, BashApprovalDecision};
-use crate::redaction::sanitize_url_for_display;
 
 use super::super::state::{
     OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp, TuiEvent,
 };
 use super::events::{apply_tui_event, convert_agent_event, format_error_chain};
-use builder::rebuild_agent_with_progress;
+use crate::agent::{Agent, AgentOutputMode, BashApprovalDecision};
+use crate::redaction::sanitize_url_for_display;
 
 fn merge_rebuilt_agent(mut rebuilt: Agent, previous: Agent) -> Agent {
     let previous_prompt_config = previous.prompt_config().clone();

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -4,9 +4,15 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
+use serde_json::json;
 use tempfile::tempdir;
 use tokio::sync::{Mutex, mpsc};
 
+use super::{
+    emit_query_heartbeat, finish_running_task_if_ready, merge_rebuilt_agent,
+    request_running_task_cancellation, start_oauth_task, start_query_task,
+    try_start_queued_follow_up,
+};
 use crate::agent::{
     Agent, AgentExecutionMode, BashApprovalMode, Message, PlanStep, PlanStepStatus,
 };
@@ -22,13 +28,6 @@ use crate::tui::state::{
 };
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
-use serde_json::json;
-
-use super::{
-    emit_query_heartbeat, finish_running_task_if_ready, merge_rebuilt_agent,
-    request_running_task_cancellation, start_oauth_task, start_query_task,
-    try_start_queued_follow_up,
-};
 
 struct PlainAnswerBackend;
 

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
+use super::state::{TranscriptEntry, TranscriptTurn, TuiApp};
 use crate::agent::{
     Agent, BashApprovalMode, CompactBoundaryMetadata, CompletedInteraction, PendingApproval,
     PendingUserInput, PlanStep, PlanStepStatus, latest_compact_boundary_metadata,
@@ -9,8 +10,6 @@ use crate::agent::{
 use crate::state_db::StateDb;
 use crate::thread_store::{CompactionRecord, RolloutItem, ThreadStore};
 use crate::tools::bash::BashCommandInput;
-
-use super::state::{TranscriptEntry, TranscriptTurn, TuiApp};
 
 pub(super) fn restore_latest_thread(
     state_db: &Arc<StateDb>,
@@ -227,6 +226,11 @@ pub(crate) fn provider_requires_api_key(provider: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
     use super::*;
     use crate::agent::{AgentExecutionMode, Message};
     use crate::config::ConfigManager;
@@ -238,9 +242,6 @@ mod tests {
     use crate::tui::state::TuiApp;
     use crate::vectordb::VectorDB;
     use crate::workspace::WorkspaceMemory;
-    use serde_json::json;
-    use std::fs;
-    use tempfile::tempdir;
 
     #[test]
     fn restore_session_keeps_runtime_context_and_snapshot_aligned() {

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -7,6 +7,7 @@ mod types;
 
 use std::cell::RefCell;
 use std::process::Command;
+
 use unicode_width::UnicodeWidthChar;
 
 pub use self::state_presets::{
@@ -34,6 +35,8 @@ pub fn openai_profile_setup_kinds() -> &'static [OpenAiEndpointKind] {
     &OPENAI_PROFILE_SETUP_KINDS
 }
 
+use rara_provider_catalog::{ModelCatalogProvider, fallback_models};
+
 use super::queued_input::PendingFollowUpMessage;
 use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
@@ -41,7 +44,6 @@ use crate::config::{ConfigManager, DEFAULT_CODEX_BASE_URL, OpenAiEndpointKind};
 use crate::redaction::redact_secrets;
 use crate::state_db::StateDb;
 use crate::tui::is_ssh_session;
-use rara_provider_catalog::{ModelCatalogProvider, fallback_models};
 
 fn completed_interaction_role(kind: InteractionKind, source: Option<&str>) -> &'static str {
     match kind {

--- a/src/tui/state/state_presets.rs
+++ b/src/tui/state/state_presets.rs
@@ -1,6 +1,5 @@
-use crate::config::{OpenAiEndpointKind, RaraConfig};
-
 use super::ProviderFamily;
+use crate::config::{OpenAiEndpointKind, RaraConfig};
 
 pub const CODEX_MODEL_PRESETS: [(&str, &str, &str); 0] = [];
 

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1,3 +1,5 @@
+use tempfile::tempdir;
+
 use super::{
     ActivePendingInteractionKind, InteractionKind, Overlay, PROVIDER_FAMILIES,
     PendingInteractionSnapshot, ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn,
@@ -14,7 +16,6 @@ use crate::tool::ToolManager;
 use crate::tools::bash::BashCommandInput;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
-use tempfile::tempdir;
 
 fn provider_family_idx(family: ProviderFamily) -> usize {
     PROVIDER_FAMILIES

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
-use crate::agent::Agent;
-
 use super::command::{palette_command_by_index, parse_local_command};
 use super::runtime::{execute_local_command, start_query_task};
 use super::state::{LocalCommandKind, OpenAiModelPickerAction, Overlay, TaskKind, TuiApp};
+use crate::agent::Agent;
 
 mod pending;
 

--- a/src/tui/submit/pending.rs
+++ b/src/tui/submit/pending.rs
@@ -1,5 +1,4 @@
 use crate::agent::{Agent, BashApprovalDecision};
-
 use crate::tui::runtime::{
     start_pending_approval_task, start_plan_approval_resume_task, start_query_task,
 };

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -6,16 +6,15 @@ use secrecy::ExposeSecret;
 use tempfile::tempdir;
 use tokio::sync::mpsc;
 
-use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
-use crate::config::{ConfigManager, OpenAiEndpointKind};
-use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL};
-use crate::tui::command::palette_commands;
-
 use super::app_event::AppEvent;
 use super::event_stream::{UiEvent, translate_event};
 use super::provider_flow::{
     codex_auth_is_available, open_provider_family_overlay, sync_codex_credential_from_auth_store,
 };
+use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
+use crate::config::{ConfigManager, OpenAiEndpointKind};
+use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL};
+use crate::tui::command::palette_commands;
 
 fn key(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::NONE)


### PR DESCRIPTION
## Summary
- Add rustfmt configuration to group imports into std/core/alloc, external crates, and local crate imports.
- Run cargo fmt across the workspace with the new import grouping.
- Switch the fmt workflow to nightly rustfmt because group_imports is still an unstable rustfmt option on stable.

## Tests
- cargo +nightly fmt --all --check
- git diff --check