### PR TITLE
feat: persist memory records with thread provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8633,6 +8633,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "eventsource-stream",
+ "fs2",
  "futures",
  "glob",
  "hf-hub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ dirs = "6.0"
 open = "5.0"
 rand = "0.10"
 libc = "0.2"
+fs2 = "0.4"
 base64 = "0.22"
 sha2 = "0.11"
 secrecy = { version = "0.10", features = ["serde"] }

--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -58,6 +58,7 @@ pub struct MemoryRecord {
     pub content: String,       // Markdown
     pub labels: Vec<MemoryLabel>,
     pub importance: f32,       // 0.1–1.0
+    pub pinned: bool,
     pub source: MemorySource,
     pub created_at: DateTime,
     pub embedding: Option<Vec<f32>>,
@@ -78,6 +79,8 @@ Each memory owns:
 - `content`: Markdown body containing the durable knowledge.
 - `labels`: reusable classification tags for filtering and routing.
 - `importance`: ranking signal from `0.1` to `1.0`.
+- `pinned`: explicit retention guard for durable facts that must not be removed
+  by automatic cleanup.
 - `created_at` and `updated_at`: temporal search and evolution metadata.
 - `source`: provenance such as user-created, agent turn, thread distillation,
   file import, or protocol write.
@@ -113,6 +116,7 @@ Importance scale:
 | Memory search | Hybrid semantic + keyword search with metadata filters and explainable scores. | Partial. LanceDB vector, FTS, and hybrid helpers exist; `MemoryStore::search` rehydrates full persisted records before returning hits. |
 | Memory update | Existing records can be edited without creating duplicates. | Not implemented as a public memory capability. |
 | Memory delete | User or control-plane request can delete records with audit-safe semantics. | Not implemented as a public memory capability. |
+| Memory retention | Pinned, user-created, and high-importance memories are protected from automatic cleanup; explicit delete remains possible with provenance. | Spec only. No automatic cleanup path exists yet. |
 | Thread distillation | Thread history can be distilled into 2-8 durable memory records. | Partial. `ThreadStore::distill_thread_summary` can persist one thread-linked summary record; LLM extraction and deduplication remain future work. |
 | Context injection | Ranked memory candidates pass through `MemorySelection` before prompt injection. | Partial. `MemorySelection` exists, but LanceDB search results are not yet direct ranked candidates. |
 | Graph retrieval | Entity and relationship traversal complements vector recall. | Future work. |
@@ -163,7 +167,14 @@ not the final session-storage contract.
 - `update(id, patch) -> MemoryRecord`
 - `get(id) -> Option<MemoryRecord>`
 - `delete(id) -> ()`
+- `set_pinned(id, pinned) -> MemoryRecord`
 - `list_labels(scope?) -> Vec<(MemoryLabel, usize)>`
+
+Search ranking should not rely on LanceDB score alone. The final memory ranking
+layer should combine hybrid search score, `importance`, exact keyword/path
+matches, recency where appropriate, and duplicate suppression. `/context` should
+show the selected/dropped reason for memory candidates, including whether
+`importance` or `pinned` status affected the decision.
 
 Storage:
 
@@ -243,15 +254,17 @@ Current implementation checkpoint:
 6. Persist full `MemoryRecord` records separately from the LanceDB search index.
    Done.
 7. Wire `MemorySelection` to ranked memory candidates.
-8. Add update/delete/list-label control-plane scaffolding without exposing
+8. Add pinned/retention policy so pinned, user-created, and high-importance
+   memories are excluded from automatic cleanup.
+9. Add update/delete/list-label control-plane scaffolding without exposing
    storage internals.
-9. Add thread distillation into `MemoryRecord`. Partial: summary distillation is
+10. Add thread distillation into `MemoryRecord`. Partial: summary distillation is
    implemented; multi-record LLM extraction and deduplication remain open.
-10. Move raw session checkpoints out of the global `conversations` LanceDB table
+11. Move raw session checkpoints out of the global `conversations` LanceDB table
    into per-session append shards.
-11. Add periodic promotion from session shards into global `MemoryRecord`s.
-12. Deprecate `VectorDB`.
-13. Remove `VectorDB`.
+12. Add periodic promotion from session shards into global `MemoryRecord`s.
+13. Deprecate `VectorDB`.
+14. Remove `VectorDB`.
 
 ## Source Journals
 

--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -82,6 +82,8 @@ Each memory owns:
 - `source`: provenance such as user-created, agent turn, thread distillation,
   file import, or protocol write.
 - `scope`: user, workspace, project, thread, or session visibility boundary.
+- `session_id`, `thread_id`, and `source_span`: optional provenance linking the
+  memory back to the session/thread and turn range that produced it.
 - `embedding`: optional vector representation for semantic retrieval.
 
 Standard labels:
@@ -106,12 +108,12 @@ Importance scale:
 
 | Capability | Target Behavior | Current Runtime Status |
 |------------|-----------------|------------------------|
-| Memory record anatomy | Title, Markdown content, labels, importance, timestamps, source, scope, embedding. | Partial. `MemoryRecord` exists at the runtime facade; LanceDB rows still store the compact index shape. |
+| Memory record anatomy | Title, Markdown content, labels, importance, timestamps, source, scope, embedding, and provenance. | Partial. `MemoryRecord` is now persisted as the domain record; LanceDB rows still store the compact search index shape. |
 | Memory creation | Agent or user creates a durable `MemoryRecord`; title, labels, and importance can be generated or explicit. | Partial. `remember_experience` is now a compatibility adapter over `MemoryStore::insert`. |
-| Memory search | Hybrid semantic + keyword search with metadata filters and explainable scores. | Partial. LanceDB vector, FTS, and hybrid helpers exist behind the current `VectorDB` façade. |
+| Memory search | Hybrid semantic + keyword search with metadata filters and explainable scores. | Partial. LanceDB vector, FTS, and hybrid helpers exist; `MemoryStore::search` rehydrates full persisted records before returning hits. |
 | Memory update | Existing records can be edited without creating duplicates. | Not implemented as a public memory capability. |
 | Memory delete | User or control-plane request can delete records with audit-safe semantics. | Not implemented as a public memory capability. |
-| Thread distillation | Thread history can be distilled into 2-8 durable memory records. | Spec only. |
+| Thread distillation | Thread history can be distilled into 2-8 durable memory records. | Partial. `ThreadStore::distill_thread_summary` can persist one thread-linked summary record; LLM extraction and deduplication remain future work. |
 | Context injection | Ranked memory candidates pass through `MemorySelection` before prompt injection. | Partial. `MemorySelection` exists, but LanceDB search results are not yet direct ranked candidates. |
 | Graph retrieval | Entity and relationship traversal complements vector recall. | Future work. |
 | Working memory | Daily or session briefing summarizes recent and important memories. | Future work. |
@@ -163,13 +165,19 @@ not the final session-storage contract.
 - `delete(id) -> ()`
 - `list_labels(scope?) -> Vec<(MemoryLabel, usize)>`
 
-Storage: `~/.rara/lancedb/` (LanceDB).
+Storage:
+
+- `~/.rara/memories/records.json`: durable `MemoryRecord` domain records.
+- `~/.rara/lancedb/`: compact search index with text, vector, and source keys.
 
 Local write coordination: RARA uses an adjacent advisory lock file
 (`~/.rara/lancedb.lock`) for LanceDB mutations. Reads remain lock-free, while
 table creation, index creation, upsert, and future update/delete paths must
 serialize through this lock so multiple RARA processes can share the same
-workspace memory directory without racing initialization or commits.
+workspace memory directory without racing initialization or commits. Domain
+record writes use their own adjacent lock file next to `records.json`, so the
+record truth and the search index can evolve independently without depending on
+LanceDB schema migrations.
 
 ## LanceDB Index Contract
 
@@ -210,9 +218,15 @@ Current implementation checkpoint:
 
 - `MemoryStore` owns the memory-domain runtime facade over the LanceDB-backed
   index.
+- `MemoryStore` persists full domain records in `records.json`; search uses
+  LanceDB for recall and then rehydrates the full record by id.
 - `remember_experience` writes through `MemoryStore::insert`.
 - `retrieve_experience` searches through `MemoryStore::search` and returns both
   `relevant_experiences` and memory diagnostics.
+- `retrieve_session_context` searches the `conversations` LanceDB table instead
+  of returning a stub response.
+- `ThreadStore::distill_thread_summary` can promote a loaded thread summary into
+  a thread-linked `MemoryRecord` with `session_id`, `thread_id`, and source span.
 - Agent turn checkpoints continue writing to the `conversations` table.
 - `MemorySelection` is not yet switched to direct ranked memory candidates;
   retrieved memories still enter through retrieval-tool results.
@@ -226,17 +240,21 @@ Current implementation checkpoint:
 4. Add the `MemoryStore` domain façade over `VectorDB`. Done.
 5. Make `remember_experience` and `retrieve_experience` compatibility adapters
    over `MemoryStore`. Done.
-6. Wire `MemorySelection` to ranked memory candidates.
-7. Add update/delete/list-label control-plane scaffolding without exposing
+6. Persist full `MemoryRecord` records separately from the LanceDB search index.
+   Done.
+7. Wire `MemorySelection` to ranked memory candidates.
+8. Add update/delete/list-label control-plane scaffolding without exposing
    storage internals.
-8. Add thread distillation into `MemoryRecord`.
-9. Move raw session checkpoints out of the global `conversations` LanceDB table
+9. Add thread distillation into `MemoryRecord`. Partial: summary distillation is
+   implemented; multi-record LLM extraction and deduplication remain open.
+10. Move raw session checkpoints out of the global `conversations` LanceDB table
    into per-session append shards.
-10. Add periodic promotion from session shards into global `MemoryRecord`s.
-11. Deprecate `VectorDB`.
-12. Remove `VectorDB`.
+11. Add periodic promotion from session shards into global `MemoryRecord`s.
+12. Deprecate `VectorDB`.
+13. Remove `VectorDB`.
 
 ## Source Journals
 
 - 2026-05-03-memory-records-and-threads-spec.md
 - 2026-05-03-lancedb-memory-index.md
+- 2026-05-03-memory-record-persistence-and-thread-export.md

--- a/docs/features/threads.md
+++ b/docs/features/threads.md
@@ -72,6 +72,21 @@ Thread stored (LanceDB)
 
 Storage: `~/.rara/threads/`.
 
+Current backend slice:
+
+- `load_thread(session_id) -> ThreadSnapshot` materializes canonical history,
+  state-db metadata, plan state, interactions, turns, and compaction events.
+- `fork_thread(session_id) -> String` copies the materialized state into a new
+  session id and records lineage.
+- `export_thread_markdown(session_id) -> String` renders a portable markdown
+  transcript with frontmatter, summary, and message sections.
+- `distill_thread_summary(memory_store, session_id) -> Option<MemoryRecord>`
+  persists one summary-style `MemoryRecord` linked to the source session/thread.
+
+The current implementation still stores thread metadata in `StateDb` and
+history/rollout artifacts through `SessionManager`; it is a structured backend
+contract, not yet a dedicated LanceDB thread table.
+
 ## Conversation Markdown Format
 
 ```markdown
@@ -121,6 +136,14 @@ Distillation rules:
 - Use `MemorySelection` for any immediate context carry-over; do not inject
   distilled memories directly into prompts.
 
+Runtime status:
+
+- Implemented: summary distillation for a loaded thread into one
+  `ThreadDistill` memory record with `session_id`, `thread_id`, and source span.
+- Open: LLM-assisted extraction of 2-8 independently useful records,
+  duplicate detection against existing memories, and long-thread chunking.
+
 ## Source Journals
 
 - 2026-05-03-memory-records-and-threads-spec.md
+- 2026-05-03-memory-record-persistence-and-thread-export.md

--- a/docs/journal/2026-05-03-memory-record-persistence-and-thread-export.md
+++ b/docs/journal/2026-05-03-memory-record-persistence-and-thread-export.md
@@ -1,0 +1,61 @@
+# Memory Record Persistence and Thread Export Checkpoint
+
+## Summary
+
+This checkpoint advances the backend-only Memory & Retrieval stream without
+touching the TUI.
+
+RARA now keeps `MemoryRecord` as a durable domain object instead of reconstructing
+records entirely from compact LanceDB rows. LanceDB remains the recall index for
+FTS/vector/hybrid search, while `~/.rara/memories/records.json` stores the full
+record payload: title, Markdown content, labels, importance, source, scope,
+timestamps, `session_id`, `thread_id`, and source turn span.
+
+## Design Notes
+
+The storage split is intentional:
+
+- LanceDB owns recall performance and score diagnostics.
+- `MemoryStore` owns the memory product contract.
+- `MemorySelection` remains the future prompt-injection policy boundary.
+
+This avoids coupling public memory records to the current LanceDB table schema.
+Existing compact rows can still be searched, and new records can add provenance
+without forcing a table migration.
+
+Both storage paths use local advisory locks. LanceDB writes keep the existing
+index lock, and domain record writes use an adjacent lock next to
+`records.json`.
+
+## Runtime Wiring
+
+- `MemoryStore::insert` writes the LanceDB index row and then persists the full
+  domain record.
+- `MemoryStore::search` runs hybrid LanceDB retrieval and rehydrates full records
+  by id when sidecar records exist.
+- `MemoryStore::get` reads a durable record by id.
+- `retrieve_session_context` now searches the `conversations` LanceDB table
+  instead of returning a stub response.
+- `ThreadStore::export_thread_markdown` renders a portable markdown transcript.
+- `ThreadStore::distill_thread_summary` persists one thread-linked
+  `ThreadDistill` memory record through `MemoryStore`.
+
+## Source References
+
+Codex keeps thread metadata and memory-stage outputs separate, with thread rows
+feeding later memory jobs. Claude Code uses memory hooks and background
+extraction after main-thread turns, while keeping direct memory file loading
+separate from the live prompt assembly path.
+
+RARA follows the same separation at this stage: thread lifecycle state,
+retrieval index rows, durable memory records, and prompt selection policy remain
+separate components.
+
+## Follow-Up
+
+- Add update/delete/list-label operations to `MemoryStore`.
+- Promote search hits into ranked `MemorySelection` candidates.
+- Replace summary-only distillation with LLM-assisted 2-8 memory extraction and
+  duplicate detection.
+- Move raw conversation checkpoints from the global `conversations` table into
+  per-session append shards.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -53,9 +53,12 @@ Active backlog only. Keep this file small and current.
 - [x] Add `MemoryRecord` runtime model with title, Markdown content, labels, importance, timestamps, source, and scope.
 - [x] Introduce `MemoryStore` as the memory-domain façade over the current LanceDB-backed `VectorDB`.
 - [x] Turn `remember_experience` and `retrieve_experience` into compatibility adapters over `MemoryStore`.
+- [x] Persist full `MemoryRecord` domain records with session id, thread id, and source span provenance.
+- [x] Replace `retrieve_session_context` stub with LanceDB hybrid search over conversation checkpoints.
+- [x] Add backend `ThreadStore` APIs for markdown export and summary-to-memory distillation.
 - [ ] Promote LanceDB-backed retrieval from `MemoryStore` into ranked `MemorySelection` candidates.
 - [ ] Add memory update/delete/list-label control-plane scaffolding for ACP/Wire without exposing LanceDB APIs.
-- [ ] Add thread distillation into deduplicated `MemoryRecord`s with source message spans.
+- [ ] Upgrade thread distillation from summary capture to LLM-assisted 2-8 record extraction with deduplication.
 - [ ] Move raw session checkpoints into per-session append shards instead of the global LanceDB `conversations` table.
 - [ ] Add periodic promotion from session shards into global `MemoryRecord`s.
 - [ ] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -57,6 +57,7 @@ Active backlog only. Keep this file small and current.
 - [x] Replace `retrieve_session_context` stub with LanceDB hybrid search over conversation checkpoints.
 - [x] Add backend `ThreadStore` APIs for markdown export and summary-to-memory distillation.
 - [ ] Promote LanceDB-backed retrieval from `MemoryStore` into ranked `MemorySelection` candidates.
+- [ ] Add pinned/retention policy so pinned, user-created, and high-importance memories are excluded from automatic cleanup.
 - [ ] Add memory update/delete/list-label control-plane scaffolding for ACP/Wire without exposing LanceDB APIs.
 - [ ] Upgrade thread distillation from summary capture to LLM-assisted 2-8 record extraction with deduplication.
 - [ ] Move raw session checkpoints into per-session append shards instead of the global LanceDB `conversations` table.

--- a/src/file_lock.rs
+++ b/src/file_lock.rs
@@ -1,0 +1,38 @@
+use std::fs::{File, OpenOptions};
+use std::os::fd::AsRawFd;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+pub struct AdvisoryFileLock {
+    file: File,
+}
+
+impl AdvisoryFileLock {
+    pub fn acquire(path: PathBuf) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create lock directory {}", parent.display()))?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .with_context(|| format!("open lock file {}", path.display()))?;
+        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("lock file {}", path.display()));
+        }
+        Ok(Self { file })
+    }
+}
+
+impl Drop for AdvisoryFileLock {
+    fn drop(&mut self) {
+        unsafe {
+            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}

--- a/src/file_lock.rs
+++ b/src/file_lock.rs
@@ -1,8 +1,8 @@
 use std::fs::{File, OpenOptions};
-use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use fs2::FileExt;
 
 pub struct AdvisoryFileLock {
     file: File,
@@ -20,19 +20,14 @@ impl AdvisoryFileLock {
             .write(true)
             .open(&path)
             .with_context(|| format!("open lock file {}", path.display()))?;
-        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-        if rc != 0 {
-            return Err(std::io::Error::last_os_error())
-                .with_context(|| format!("lock file {}", path.display()));
-        }
+        file.lock_exclusive()
+            .with_context(|| format!("lock file {}", path.display()))?;
         Ok(Self { file })
     }
 }
 
 impl Drop for AdvisoryFileLock {
     fn drop(&mut self) {
-        unsafe {
-            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
-        }
+        let _ = self.file.unlock();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod app_cli;
 mod codex_model_catalog;
 mod config;
 mod context;
+mod file_lock;
 mod llm;
 mod local_backend;
 mod memory_store;

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
@@ -242,6 +243,7 @@ impl From<MemoryMetadata> for MemoryRecord {
 struct MemoryRecordFileStore {
     path: PathBuf,
     lock_path: PathBuf,
+    cache: Arc<Mutex<MemoryRecordCache>>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -259,11 +261,34 @@ impl Default for PersistedMemoryRecordFile {
     }
 }
 
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+enum PersistedMemoryRecordEnvelope {
+    Versioned(PersistedMemoryRecordFile),
+    Legacy(Vec<MemoryRecord>),
+}
+
+#[derive(Debug, Default)]
+struct MemoryRecordCache {
+    state: Option<MemoryRecordFileState>,
+    records: HashMap<String, MemoryRecord>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MemoryRecordFileState {
+    Missing,
+    Present {
+        modified_at: Option<SystemTime>,
+        len: u64,
+    },
+}
+
 impl MemoryRecordFileStore {
     fn new(path: PathBuf) -> Self {
         Self {
             lock_path: path.with_extension("json.lock"),
             path,
+            cache: Arc::new(Mutex::new(MemoryRecordCache::default())),
         }
     }
 
@@ -274,28 +299,28 @@ impl MemoryRecordFileStore {
     async fn upsert(&self, record: &MemoryRecord) -> Result<()> {
         let path = self.path.clone();
         let lock_path = self.lock_path.clone();
+        let cache = self.cache.clone();
         let record = record.clone();
-        tokio::task::spawn_blocking(move || upsert_record_sync(path, lock_path, record))
+        tokio::task::spawn_blocking(move || upsert_record_sync(path, lock_path, cache, record))
             .await
             .context("join memory record persistence task")?
     }
 
     async fn load_map(&self) -> Result<HashMap<String, MemoryRecord>> {
         let path = self.path.clone();
-        tokio::task::spawn_blocking(move || load_records_sync(&path))
+        let cache = self.cache.clone();
+        tokio::task::spawn_blocking(move || load_record_map_cached_sync(&path, &cache))
             .await
             .context("join memory record load task")?
-            .map(|records| {
-                records
-                    .into_iter()
-                    .map(|record| (record.id.clone(), record))
-                    .collect()
-            })
     }
 
     async fn get(&self, id: &str) -> Result<Option<MemoryRecord>> {
+        let path = self.path.clone();
+        let cache = self.cache.clone();
         let id = id.to_string();
-        Ok(self.load_map().await?.remove(&id))
+        tokio::task::spawn_blocking(move || get_record_cached_sync(&path, &cache, &id))
+            .await
+            .context("join memory record get task")?
     }
 }
 
@@ -311,7 +336,12 @@ fn default_record_path_for_vdb_uri(uri: &str) -> PathBuf {
     db_path.join("memory_records.json")
 }
 
-fn upsert_record_sync(path: PathBuf, lock_path: PathBuf, record: MemoryRecord) -> Result<()> {
+fn upsert_record_sync(
+    path: PathBuf,
+    lock_path: PathBuf,
+    cache: Arc<Mutex<MemoryRecordCache>>,
+    record: MemoryRecord,
+) -> Result<()> {
     let _lock = AdvisoryFileLock::acquire(lock_path)?;
     let mut file = PersistedMemoryRecordFile {
         records: load_records_sync(&path)?,
@@ -322,24 +352,83 @@ fn upsert_record_sync(path: PathBuf, lock_path: PathBuf, record: MemoryRecord) -
     } else {
         file.records.push(record);
     }
-    write_record_file_sync(&path, &file)
+    write_record_file_sync(&path, &file)?;
+    let records = record_map_from_records(file.records);
+    let state = record_file_state(&path)?;
+    update_record_cache(&cache, state, records);
+    Ok(())
+}
+
+fn load_record_map_cached_sync(
+    path: &Path,
+    cache: &Arc<Mutex<MemoryRecordCache>>,
+) -> Result<HashMap<String, MemoryRecord>> {
+    let state = record_file_state(path)?;
+    {
+        let cache = cache.lock().expect("memory record cache lock poisoned");
+        if cache.state == Some(state) {
+            return Ok(cache.records.clone());
+        }
+    }
+
+    let records = record_map_from_records(load_records_sync(path)?);
+    update_record_cache(cache, state, records.clone());
+    Ok(records)
+}
+
+fn get_record_cached_sync(
+    path: &Path,
+    cache: &Arc<Mutex<MemoryRecordCache>>,
+    id: &str,
+) -> Result<Option<MemoryRecord>> {
+    Ok(load_record_map_cached_sync(path, cache)?.get(id).cloned())
+}
+
+fn update_record_cache(
+    cache: &Arc<Mutex<MemoryRecordCache>>,
+    state: MemoryRecordFileState,
+    records: HashMap<String, MemoryRecord>,
+) {
+    let mut cache = cache.lock().expect("memory record cache lock poisoned");
+    cache.state = Some(state);
+    cache.records = records;
+}
+
+fn record_map_from_records(records: Vec<MemoryRecord>) -> HashMap<String, MemoryRecord> {
+    records
+        .into_iter()
+        .map(|record| (record.id.clone(), record))
+        .collect()
+}
+
+fn record_file_state(path: &Path) -> Result<MemoryRecordFileState> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(MemoryRecordFileState::Present {
+            modified_at: metadata.modified().ok(),
+            len: metadata.len(),
+        }),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            Ok(MemoryRecordFileState::Missing)
+        }
+        Err(err) => Err(err).with_context(|| format!("stat memory records {}", path.display())),
+    }
 }
 
 fn load_records_sync(path: &Path) -> Result<Vec<MemoryRecord>> {
-    let content = match fs::read_to_string(path) {
-        Ok(content) => content,
+    let file = match File::open(path) {
+        Ok(file) => file,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => {
             return Err(err).with_context(|| format!("read memory records {}", path.display()));
         }
     };
-    if content.trim().is_empty() {
-        return Ok(Vec::new());
+    let reader = BufReader::new(file);
+    match serde_json::from_reader::<_, PersistedMemoryRecordEnvelope>(reader) {
+        Ok(PersistedMemoryRecordEnvelope::Versioned(file)) => Ok(file.records),
+        Ok(PersistedMemoryRecordEnvelope::Legacy(records)) => Ok(records),
+        Err(err) if err.is_eof() => Ok(Vec::new()),
+        Err(err) => Err(err).with_context(|| format!("parse memory records {}", path.display())),
     }
-    serde_json::from_str::<PersistedMemoryRecordFile>(&content)
-        .map(|file| file.records)
-        .or_else(|_| serde_json::from_str::<Vec<MemoryRecord>>(&content))
-        .with_context(|| format!("parse memory records {}", path.display()))
 }
 
 fn write_record_file_sync(path: &Path, file: &PersistedMemoryRecordFile) -> Result<()> {
@@ -348,13 +437,29 @@ fn write_record_file_sync(path: &Path, file: &PersistedMemoryRecordFile) -> Resu
             .with_context(|| format!("create memory records dir {}", parent.display()))?;
     }
     let tmp_path = path.with_extension(format!("json.tmp-{}", uuid::Uuid::new_v4()));
-    fs::write(&tmp_path, serde_json::to_string_pretty(file)?)
-        .with_context(|| format!("write memory records temp file {}", tmp_path.display()))?;
-    if let Err(err) = fs::rename(&tmp_path, path) {
+    let tmp_file = File::create(&tmp_path)
+        .with_context(|| format!("create memory records temp file {}", tmp_path.display()))?;
+    let mut writer = BufWriter::new(tmp_file);
+    serde_json::to_writer(&mut writer, file)
+        .with_context(|| format!("serialize memory records {}", tmp_path.display()))?;
+    writer
+        .flush()
+        .with_context(|| format!("flush memory records temp file {}", tmp_path.display()))?;
+    if let Err(err) = replace_record_file_sync(&tmp_path, path) {
         let _ = fs::remove_file(&tmp_path);
         return Err(err).with_context(|| format!("replace memory records {}", path.display()));
     }
     Ok(())
+}
+
+fn replace_record_file_sync(tmp_path: &Path, path: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err),
+    }
+    fs::rename(tmp_path, path)
 }
 
 fn memory_record_for_hit(
@@ -443,6 +548,88 @@ fn unix_timestamp_seconds() -> u64 {
 mod tests {
     use super::*;
     use crate::llm::MockLlm;
+
+    fn test_memory_record(id: &str, content: &str) -> MemoryRecord {
+        MemoryRecord {
+            id: id.to_string(),
+            title: title_from_content(content),
+            content: content.to_string(),
+            labels: vec![MemoryLabel::Fact],
+            importance: DEFAULT_IMPORTANCE,
+            source: MemorySource::UserCreated,
+            scope: MemoryScope::Project,
+            session_id: None,
+            thread_id: None,
+            source_span: None,
+            created_at_unix_seconds: 1,
+            updated_at_unix_seconds: 1,
+        }
+    }
+
+    #[test]
+    fn memory_record_file_store_writes_compact_json_and_reads_legacy_records() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("records.json");
+        let legacy_path = temp.path().join("legacy_records.json");
+        let record = test_memory_record("memory-test-1", "Compact storage should stay readable.");
+        let file = PersistedMemoryRecordFile {
+            version: MEMORY_RECORDS_FILE_VERSION,
+            records: vec![record.clone()],
+        };
+
+        write_record_file_sync(&path, &file).expect("write compact record file");
+        let content = fs::read_to_string(&path).expect("read compact record file");
+        assert!(!content.contains('\n'));
+        assert_eq!(
+            load_records_sync(&path).expect("load compact records"),
+            vec![record.clone()]
+        );
+
+        fs::write(
+            &legacy_path,
+            serde_json::to_string(&vec![record.clone()]).expect("serialize legacy records"),
+        )
+        .expect("write legacy record file");
+        assert_eq!(
+            load_records_sync(&legacy_path).expect("load legacy records"),
+            vec![record]
+        );
+    }
+
+    #[test]
+    fn memory_record_file_store_refreshes_cache_when_file_changes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("records.json");
+        let cache = Arc::new(Mutex::new(MemoryRecordCache::default()));
+        let first = test_memory_record("memory-cache-1", "First cached record.");
+        let second = test_memory_record(
+            "memory-cache-2",
+            "Second cached record with a longer payload.",
+        );
+
+        write_record_file_sync(
+            &path,
+            &PersistedMemoryRecordFile {
+                version: MEMORY_RECORDS_FILE_VERSION,
+                records: vec![first.clone()],
+            },
+        )
+        .expect("write first record file");
+        let first_map = load_record_map_cached_sync(&path, &cache).expect("load first cache");
+        assert_eq!(first_map.get(&first.id), Some(&first));
+
+        write_record_file_sync(
+            &path,
+            &PersistedMemoryRecordFile {
+                version: MEMORY_RECORDS_FILE_VERSION,
+                records: vec![second.clone()],
+            },
+        )
+        .expect("write second record file");
+        let second_map = load_record_map_cached_sync(&path, &cache).expect("refresh cache");
+        assert_eq!(second_map.get(&second.id), Some(&second));
+        assert!(!second_map.contains_key(&first.id));
+    }
 
     #[tokio::test]
     async fn memory_store_inserts_and_searches_memory_records() {

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -1,14 +1,19 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 
+use crate::file_lock::AdvisoryFileLock;
 use crate::llm::LlmBackend;
 use crate::vectordb::{MemoryMetadata, VectorDB};
 
 const EXPERIENCES_TABLE: &str = "experiences";
 const DEFAULT_IMPORTANCE: f32 = 0.5;
 const MEMORY_RECORD_INDEX_PLACEHOLDER: u32 = 0;
+const MEMORY_RECORDS_FILE_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -40,6 +45,12 @@ pub enum MemoryScope {
     Session,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct MemorySourceSpan {
+    pub start_turn_index: u32,
+    pub end_turn_index: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct MemoryRecord {
     pub id: String,
@@ -49,6 +60,12 @@ pub struct MemoryRecord {
     pub importance: f32,
     pub source: MemorySource,
     pub scope: MemoryScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_span: Option<MemorySourceSpan>,
     pub created_at_unix_seconds: u64,
     pub updated_at_unix_seconds: u64,
 }
@@ -61,6 +78,9 @@ pub struct NewMemoryRecord {
     pub importance: f32,
     pub source: MemorySource,
     pub scope: MemoryScope,
+    pub session_id: Option<String>,
+    pub thread_id: Option<String>,
+    pub source_span: Option<MemorySourceSpan>,
 }
 
 impl NewMemoryRecord {
@@ -72,6 +92,9 @@ impl NewMemoryRecord {
             importance: DEFAULT_IMPORTANCE,
             source: MemorySource::AgentTurn,
             scope: MemoryScope::Project,
+            session_id: None,
+            thread_id: None,
+            source_span: None,
         }
     }
 }
@@ -87,11 +110,29 @@ pub struct MemoryRecordSearchHit {
 pub struct MemoryStore {
     backend: Arc<dyn LlmBackend>,
     vdb: Arc<VectorDB>,
+    records: MemoryRecordFileStore,
 }
 
 impl MemoryStore {
     pub fn new(backend: Arc<dyn LlmBackend>, vdb: Arc<VectorDB>) -> Self {
-        Self { backend, vdb }
+        let records = MemoryRecordFileStore::for_vdb_uri(vdb.uri());
+        Self {
+            backend,
+            vdb,
+            records,
+        }
+    }
+
+    pub fn new_with_record_path(
+        backend: Arc<dyn LlmBackend>,
+        vdb: Arc<VectorDB>,
+        record_path: PathBuf,
+    ) -> Self {
+        Self {
+            backend,
+            vdb,
+            records: MemoryRecordFileStore::new(record_path),
+        }
     }
 
     pub async fn insert(&self, input: NewMemoryRecord) -> Result<MemoryRecord> {
@@ -112,6 +153,9 @@ impl MemoryStore {
             importance,
             source: input.source,
             scope: input.scope,
+            session_id: normalized_optional_id(input.session_id),
+            thread_id: normalized_optional_id(input.thread_id),
+            source_span: input.source_span,
             created_at_unix_seconds: now,
             updated_at_unix_seconds: now,
         };
@@ -121,13 +165,14 @@ impl MemoryStore {
                 EXPERIENCES_TABLE,
                 MemoryMetadata {
                     id: Some(record.id.clone()),
-                    session_id: memory_scope_key(&record.scope).to_string(),
+                    session_id: record.index_scope_key(),
                     turn_index: MEMORY_RECORD_INDEX_PLACEHOLDER,
                     text: record.content.clone(),
                 },
                 vector,
             )
             .await?;
+        self.records.upsert(&record).await?;
         Ok(record)
     }
 
@@ -140,20 +185,36 @@ impl MemoryStore {
             .vdb
             .hybrid_search_with_metadata(EXPERIENCES_TABLE, query, query_vector, limit)
             .await?;
+        let records = self.records.load_map().await?;
         Ok(hits
             .into_iter()
             .map(|hit| MemoryRecordSearchHit {
-                record: MemoryRecord::from(hit.metadata),
+                record: memory_record_for_hit(&records, &hit.metadata),
                 score: hit.score,
                 vector_distance: hit.vector_distance,
                 fts_score: hit.fts_score,
             })
             .collect())
     }
+
+    pub async fn get(&self, id: &str) -> Result<Option<MemoryRecord>> {
+        self.records.get(id).await
+    }
+}
+
+impl MemoryRecord {
+    fn index_scope_key(&self) -> String {
+        self.session_id
+            .clone()
+            .or_else(|| self.thread_id.clone())
+            .unwrap_or_else(|| memory_scope_key(&self.scope).to_string())
+    }
 }
 
 impl From<MemoryMetadata> for MemoryRecord {
     fn from(metadata: MemoryMetadata) -> Self {
+        let session_id = metadata.session_id.clone();
+        let turn_index = metadata.turn_index;
         let now = unix_timestamp_seconds();
         Self {
             id: metadata.id.unwrap_or_else(|| {
@@ -165,10 +226,147 @@ impl From<MemoryMetadata> for MemoryRecord {
             importance: DEFAULT_IMPORTANCE,
             source: MemorySource::AgentTurn,
             scope: memory_scope_from_key(&metadata.session_id),
+            session_id: Some(session_id),
+            thread_id: None,
+            source_span: Some(MemorySourceSpan {
+                start_turn_index: turn_index,
+                end_turn_index: turn_index,
+            }),
             created_at_unix_seconds: now,
             updated_at_unix_seconds: now,
         }
     }
+}
+
+#[derive(Debug, Clone)]
+struct MemoryRecordFileStore {
+    path: PathBuf,
+    lock_path: PathBuf,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct PersistedMemoryRecordFile {
+    version: u32,
+    records: Vec<MemoryRecord>,
+}
+
+impl Default for PersistedMemoryRecordFile {
+    fn default() -> Self {
+        Self {
+            version: MEMORY_RECORDS_FILE_VERSION,
+            records: Vec::new(),
+        }
+    }
+}
+
+impl MemoryRecordFileStore {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            lock_path: path.with_extension("json.lock"),
+            path,
+        }
+    }
+
+    fn for_vdb_uri(uri: &str) -> Self {
+        Self::new(default_record_path_for_vdb_uri(uri))
+    }
+
+    async fn upsert(&self, record: &MemoryRecord) -> Result<()> {
+        let path = self.path.clone();
+        let lock_path = self.lock_path.clone();
+        let record = record.clone();
+        tokio::task::spawn_blocking(move || upsert_record_sync(path, lock_path, record))
+            .await
+            .context("join memory record persistence task")?
+    }
+
+    async fn load_map(&self) -> Result<HashMap<String, MemoryRecord>> {
+        let path = self.path.clone();
+        tokio::task::spawn_blocking(move || load_records_sync(&path))
+            .await
+            .context("join memory record load task")?
+            .map(|records| {
+                records
+                    .into_iter()
+                    .map(|record| (record.id.clone(), record))
+                    .collect()
+            })
+    }
+
+    async fn get(&self, id: &str) -> Result<Option<MemoryRecord>> {
+        let id = id.to_string();
+        Ok(self.load_map().await?.remove(&id))
+    }
+}
+
+fn default_record_path_for_vdb_uri(uri: &str) -> PathBuf {
+    let db_path = PathBuf::from(uri);
+    if db_path.file_name().and_then(|value| value.to_str()) == Some("lancedb") {
+        return db_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("memories")
+            .join("records.json");
+    }
+    db_path.join("memory_records.json")
+}
+
+fn upsert_record_sync(path: PathBuf, lock_path: PathBuf, record: MemoryRecord) -> Result<()> {
+    let _lock = AdvisoryFileLock::acquire(lock_path)?;
+    let mut file = PersistedMemoryRecordFile {
+        records: load_records_sync(&path)?,
+        ..Default::default()
+    };
+    if let Some(existing) = file.records.iter_mut().find(|item| item.id == record.id) {
+        *existing = record;
+    } else {
+        file.records.push(record);
+    }
+    write_record_file_sync(&path, &file)
+}
+
+fn load_records_sync(path: &Path) -> Result<Vec<MemoryRecord>> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(err).with_context(|| format!("read memory records {}", path.display()));
+        }
+    };
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str::<PersistedMemoryRecordFile>(&content)
+        .map(|file| file.records)
+        .or_else(|_| serde_json::from_str::<Vec<MemoryRecord>>(&content))
+        .with_context(|| format!("parse memory records {}", path.display()))
+}
+
+fn write_record_file_sync(path: &Path, file: &PersistedMemoryRecordFile) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create memory records dir {}", parent.display()))?;
+    }
+    let tmp_path = path.with_extension(format!("json.tmp-{}", uuid::Uuid::new_v4()));
+    fs::write(&tmp_path, serde_json::to_string_pretty(file)?)
+        .with_context(|| format!("write memory records temp file {}", tmp_path.display()))?;
+    if let Err(err) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(err).with_context(|| format!("replace memory records {}", path.display()));
+    }
+    Ok(())
+}
+
+fn memory_record_for_hit(
+    records: &HashMap<String, MemoryRecord>,
+    metadata: &MemoryMetadata,
+) -> MemoryRecord {
+    metadata
+        .id
+        .as_ref()
+        .and_then(|id| records.get(id))
+        .cloned()
+        .unwrap_or_else(|| MemoryRecord::from(metadata.clone()))
 }
 
 fn normalized_labels(labels: Vec<MemoryLabel>) -> Vec<MemoryLabel> {
@@ -176,6 +374,12 @@ fn normalized_labels(labels: Vec<MemoryLabel>) -> Vec<MemoryLabel> {
         return vec![MemoryLabel::Experience];
     }
     labels
+}
+
+fn normalized_optional_id(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 fn clamp_importance(importance: f32) -> f32 {
@@ -268,6 +472,10 @@ mod tests {
             hits[0].record.content,
             "DeepSeek DSML requires a structured parser."
         );
+        assert_eq!(
+            store.get(&saved.id).await.expect("get saved memory"),
+            Some(saved)
+        );
     }
 
     #[tokio::test]
@@ -286,6 +494,9 @@ mod tests {
                 importance: 4.0,
                 source: MemorySource::UserCreated,
                 scope: MemoryScope::Workspace,
+                session_id: None,
+                thread_id: None,
+                source_span: None,
             })
             .await
             .expect("insert memory");
@@ -293,5 +504,55 @@ mod tests {
         assert_eq!(saved.importance, 1.0);
         assert_eq!(saved.labels, vec![MemoryLabel::Experience]);
         assert_eq!(saved.scope, MemoryScope::Workspace);
+    }
+
+    #[tokio::test]
+    async fn memory_store_persists_thread_provenance_across_instances() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("lancedb");
+        let record_path = temp.path().join("memories").join("records.json");
+        let backend = Arc::new(MockLlm);
+        let vdb = Arc::new(VectorDB::new(db_path.to_str().expect("utf8 path")));
+        let store =
+            MemoryStore::new_with_record_path(backend.clone(), vdb.clone(), record_path.clone());
+
+        let saved = store
+            .insert(NewMemoryRecord {
+                title: Some("Thread decision".to_string()),
+                content: "Keep memory retrieval behind MemoryStore.".to_string(),
+                labels: vec![MemoryLabel::Decision],
+                importance: 0.9,
+                source: MemorySource::ThreadDistill,
+                scope: MemoryScope::Thread,
+                session_id: Some("session-123".to_string()),
+                thread_id: Some("thread-123".to_string()),
+                source_span: Some(MemorySourceSpan {
+                    start_turn_index: 2,
+                    end_turn_index: 4,
+                }),
+            })
+            .await
+            .expect("insert memory");
+
+        let reloaded = MemoryStore::new_with_record_path(backend, vdb, record_path);
+        let hits = reloaded
+            .search("memory retrieval", 5)
+            .await
+            .expect("search memories");
+        assert_eq!(hits[0].record.id, saved.id);
+        assert_eq!(hits[0].record.title, "Thread decision");
+        assert_eq!(hits[0].record.labels, vec![MemoryLabel::Decision]);
+        assert_eq!(hits[0].record.importance, 0.9);
+        assert_eq!(hits[0].record.source, MemorySource::ThreadDistill);
+        assert_eq!(hits[0].record.scope, MemoryScope::Thread);
+        assert_eq!(hits[0].record.session_id.as_deref(), Some("session-123"));
+        assert_eq!(hits[0].record.thread_id.as_deref(), Some("thread-123"));
+        assert_eq!(
+            hits[0].record.source_span,
+            Some(MemorySourceSpan {
+                start_turn_index: 2,
+                end_turn_index: 4,
+            })
+        );
     }
 }

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -2,6 +2,10 @@ use anyhow::Result;
 use uuid::Uuid;
 
 use crate::agent::Message;
+use crate::memory_store::{
+    MemoryLabel, MemoryRecord, MemoryScope, MemorySource, MemorySourceSpan, MemoryStore,
+    NewMemoryRecord,
+};
 use crate::session::{
     PersistedCompactionEvent, PersistedCompactionEventsSource, PersistedThreadHistorySource,
     SessionManager,
@@ -314,6 +318,22 @@ impl<'a> ThreadStore<'a> {
             interactions: materialized.interactions,
             rollout_items: materialized.rollout_items,
         })
+    }
+
+    pub fn export_thread_markdown(&self, session_id: &str) -> Result<String> {
+        Ok(format_thread_markdown(&self.load_thread(session_id)?))
+    }
+
+    pub async fn distill_thread_summary(
+        &self,
+        memory_store: &MemoryStore,
+        session_id: &str,
+    ) -> Result<Option<MemoryRecord>> {
+        let snapshot = self.load_thread(session_id)?;
+        let Some(input) = thread_summary_memory_record(&snapshot) else {
+            return Ok(None);
+        };
+        Ok(Some(memory_store.insert(input).await?))
     }
 
     pub fn fork_thread(&self, source_thread_id: &str) -> Result<String> {
@@ -870,6 +890,175 @@ impl<'a> ThreadRecorder<'a> {
         entries: &[PersistedTurnEntry],
     ) -> Result<PersistedTurnSummary> {
         self.state_db.persist_turn(session_id, ordinal, entries)
+    }
+}
+
+fn format_thread_markdown(thread: &ThreadSnapshot) -> String {
+    let title = thread_title(thread);
+    let mut lines = vec![
+        "---".to_string(),
+        format!("title: {}", yaml_scalar(&title)),
+        "source: rara".to_string(),
+        format!("session_id: {}", yaml_scalar(&thread.metadata.session_id)),
+        format!("workspace: {}", yaml_scalar(&thread.metadata.cwd)),
+        format!("model: {}", yaml_scalar(&thread.metadata.model)),
+        format!("created_at: {}", thread.metadata.created_at),
+        format!("updated_at: {}", thread.metadata.updated_at),
+        "---".to_string(),
+        String::new(),
+        format!("# {title}"),
+        String::new(),
+    ];
+
+    if let Some(summary) = thread
+        .compaction
+        .summary
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        lines.push("## Summary".to_string());
+        lines.push(summary.trim().to_string());
+        lines.push(String::new());
+    }
+
+    for message in &thread.history {
+        lines.push(format!("## {}", role_heading(&message.role)));
+        lines.push(render_message_content(&message.content));
+        lines.push(String::new());
+    }
+
+    lines.join("\n")
+}
+
+fn thread_summary_memory_record(thread: &ThreadSnapshot) -> Option<NewMemoryRecord> {
+    let summary = thread
+        .compaction
+        .summary
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| first_user_message(thread));
+    let summary = summary?;
+    let title = thread_title(thread);
+    let end_turn_index = thread.history.len().saturating_sub(1) as u32;
+    Some(NewMemoryRecord {
+        title: Some(title),
+        content: format!(
+            concat!(
+                "## Summary\n",
+                "{summary}\n\n",
+                "## Provenance\n",
+                "- session_id: {session_id}\n",
+                "- thread_id: {thread_id}\n",
+                "- workspace: {workspace}\n",
+                "- provider: {provider}\n",
+                "- model: {model}\n"
+            ),
+            summary = summary.as_str(),
+            session_id = thread.metadata.session_id.as_str(),
+            thread_id = thread.metadata.session_id.as_str(),
+            workspace = thread.metadata.cwd.as_str(),
+            provider = thread.metadata.provider.as_str(),
+            model = thread.metadata.model.as_str(),
+        ),
+        labels: vec![MemoryLabel::Experience],
+        importance: 0.6,
+        source: MemorySource::ThreadDistill,
+        scope: MemoryScope::Thread,
+        session_id: Some(thread.metadata.session_id.clone()),
+        thread_id: Some(thread.metadata.session_id.clone()),
+        source_span: Some(MemorySourceSpan {
+            start_turn_index: 0,
+            end_turn_index,
+        }),
+    })
+}
+
+fn thread_title(thread: &ThreadSnapshot) -> String {
+    first_user_message(thread)
+        .map(|value| truncate_chars(&collapse_whitespace(&value), 80))
+        .unwrap_or_else(|| format!("Thread {}", thread.metadata.session_id))
+}
+
+fn first_user_message(thread: &ThreadSnapshot) -> Option<String> {
+    thread
+        .history
+        .iter()
+        .find(|message| message.role == "user")
+        .map(|message| render_message_content(&message.content))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn role_heading(role: &str) -> &str {
+    match role {
+        "assistant" => "Assistant",
+        "system" => "System",
+        "tool" => "Tool",
+        "user" => "User",
+        _ => "Message",
+    }
+}
+
+fn render_message_content(content: &serde_json::Value) -> String {
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    if let Some(items) = content.as_array() {
+        let rendered = items
+            .iter()
+            .filter_map(render_content_item)
+            .collect::<Vec<_>>();
+        if !rendered.is_empty() {
+            return rendered.join("\n\n");
+        }
+    }
+    serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string())
+}
+
+fn render_content_item(item: &serde_json::Value) -> Option<String> {
+    match item.get("type").and_then(serde_json::Value::as_str) {
+        Some("text") => item
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        Some("tool_use") => {
+            let name = item
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("tool");
+            let input = item
+                .get("input")
+                .map(|value| {
+                    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+                })
+                .unwrap_or_else(|| "{}".to_string());
+            Some(format!("Tool use: {name}\n\n```json\n{input}\n```"))
+        }
+        Some("tool_result") => item
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        _ => Some(serde_json::to_string_pretty(item).unwrap_or_else(|_| item.to_string())),
+    }
+}
+
+fn yaml_scalar(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
     }
 }
 

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -4,11 +4,14 @@ use std::time::Duration;
 use tempfile::tempdir;
 
 use crate::agent::Message;
+use crate::llm::MockLlm;
+use crate::memory_store::{MemoryScope, MemorySource, MemoryStore};
 use crate::session::{PersistedCompactionEvent, SessionManager};
 use crate::state_db::{
     PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
     PersistedRuntimeRolloutItem, PersistedStructuredRolloutEvent, PersistedTurnEntry, StateDb,
 };
+use crate::vectordb::VectorDB;
 
 use super::{
     RolloutItem, ThreadHistorySource, ThreadMetadataSource, ThreadNonTurnRolloutSource,
@@ -943,6 +946,136 @@ fn latest_thread_summary_uses_thread_summary_contract() -> Result<()> {
     );
     assert_eq!(latest.preview, "Agent: Newer preview");
     assert_eq!(latest.compaction.compaction_count, 2);
+    Ok(())
+}
+
+#[test]
+fn export_thread_markdown_renders_metadata_summary_and_messages() -> Result<()> {
+    let temp = tempdir()?;
+    let rara_dir = temp.path().join(".rara");
+    let session_manager = SessionManager::new_for_rara_dir(rara_dir.clone())?;
+    let state_db = StateDb::new_for_root_dir(rara_dir)?;
+    session_manager.save_session(
+        "thread-export",
+        &[
+            Message {
+                role: "user".to_string(),
+                content: serde_json::json!([{"type": "text", "text": "How should\nmemory work?"}]),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: serde_json::json!("Keep durable memory separate from raw threads."),
+            },
+        ],
+    )?;
+    state_db.upsert_session(
+        "thread-export",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "execute",
+        "always",
+        None,
+        &PersistedPromptRuntimeState::default(),
+        2,
+        2,
+        &PersistedCompactState::default(),
+    )?;
+    session_manager.save_compaction_event(
+        "thread-export",
+        &PersistedCompactionEvent {
+            event_index: 1,
+            before_tokens: 3000,
+            after_tokens: 900,
+            boundary_version: 1,
+            recent_files: vec!["src/memory_store.rs".to_string()],
+            summary: "Memory records are durable; threads are source material.".to_string(),
+        },
+    )?;
+
+    let store = ThreadStore::new(&session_manager, &state_db);
+    let markdown = store.export_thread_markdown("thread-export")?;
+
+    assert!(markdown.contains("session_id: \"thread-export\""));
+    assert!(markdown.contains("# How should memory work?"));
+    assert!(markdown.contains("## Summary"));
+    assert!(markdown.contains("Memory records are durable"));
+    assert!(markdown.contains("## User"));
+    assert!(markdown.contains("How should\nmemory work?"));
+    assert!(markdown.contains("## Assistant"));
+    assert!(markdown.contains("Keep durable memory separate"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn distill_thread_summary_persists_thread_linked_memory_record() -> Result<()> {
+    let temp = tempdir()?;
+    let rara_dir = temp.path().join(".rara");
+    let session_manager = SessionManager::new_for_rara_dir(rara_dir.clone())?;
+    let state_db = StateDb::new_for_root_dir(rara_dir.clone())?;
+    session_manager.save_session(
+        "thread-distill",
+        &[Message {
+            role: "user".to_string(),
+            content: serde_json::json!("Continue memory backend implementation"),
+        }],
+    )?;
+    state_db.upsert_session(
+        "thread-distill",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "execute",
+        "always",
+        None,
+        &PersistedPromptRuntimeState::default(),
+        1,
+        1,
+        &PersistedCompactState::default(),
+    )?;
+    session_manager.save_compaction_event(
+        "thread-distill",
+        &PersistedCompactionEvent {
+            event_index: 1,
+            before_tokens: 4000,
+            after_tokens: 1200,
+            boundary_version: 1,
+            recent_files: vec!["src/thread_store.rs".to_string()],
+            summary: "Thread lifecycle APIs should export markdown and distill durable memory."
+                .to_string(),
+        },
+    )?;
+    let memory_store = MemoryStore::new(
+        std::sync::Arc::new(MockLlm),
+        std::sync::Arc::new(VectorDB::new(
+            rara_dir.join("lancedb").to_str().expect("utf8 path"),
+        )),
+    );
+    let store = ThreadStore::new(&session_manager, &state_db);
+
+    let memory = store
+        .distill_thread_summary(&memory_store, "thread-distill")
+        .await?
+        .expect("distilled memory");
+
+    assert_eq!(memory.source, MemorySource::ThreadDistill);
+    assert_eq!(memory.scope, MemoryScope::Thread);
+    assert_eq!(memory.session_id.as_deref(), Some("thread-distill"));
+    assert_eq!(memory.thread_id.as_deref(), Some("thread-distill"));
+    assert!(
+        memory
+            .content
+            .contains("Thread lifecycle APIs should export markdown")
+    );
+    let reloaded = memory_store
+        .get(&memory.id)
+        .await?
+        .expect("persisted memory record");
+    assert_eq!(reloaded.thread_id.as_deref(), Some("thread-distill"));
     Ok(())
 }
 

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -22,7 +22,90 @@ impl Tool for RetrieveSessionContextTool {
     fn input_schema(&self) -> Value {
         json!({ "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] })
     }
-    async fn call(&self, _: Value) -> Result<Value, ToolError> {
-        Ok(json!({ "status": "no_context_found" }))
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let query = input["query"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("query".into()))?;
+        if query.trim().is_empty() {
+            return Ok(json!({ "status": "no_context_found", "matches": [] }));
+        }
+        let vector = self
+            .backend
+            .embed(query)
+            .await
+            .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
+        let hits = self
+            .vdb
+            .hybrid_search_with_metadata("conversations", query, vector, 8)
+            .await
+            .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
+        if hits.is_empty() {
+            return Ok(json!({ "status": "no_context_found", "matches": [] }));
+        }
+        let matches = hits
+            .into_iter()
+            .map(|hit| {
+                json!({
+                    "session_id": hit.metadata.session_id,
+                    "turn_index": hit.metadata.turn_index,
+                    "text": hit.metadata.text,
+                    "score": hit.score,
+                    "vector_distance": hit.vector_distance,
+                    "fts_score": hit.fts_score,
+                })
+            })
+            .collect::<Vec<_>>();
+        Ok(json!({
+            "status": "ok",
+            "matches": matches,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::MockLlm;
+    use crate::vectordb::MemoryMetadata;
+
+    #[tokio::test]
+    async fn retrieve_session_context_searches_conversation_index() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let vdb = Arc::new(VectorDB::new(temp.path().to_str().expect("utf8 path")));
+        vdb.upsert_turn(
+            "conversations",
+            MemoryMetadata {
+                id: None,
+                session_id: "session-a".to_string(),
+                turn_index: 3,
+                text: "The approval denial should be recorded as an errored tool result."
+                    .to_string(),
+            },
+            vec![1.0; 128],
+        )
+        .await
+        .expect("upsert conversation memory");
+        let tool = RetrieveSessionContextTool {
+            backend: Arc::new(MockLlm),
+            vdb,
+            session_manager: Arc::new(
+                SessionManager::new_for_rara_dir(temp.path().join(".rara"))
+                    .expect("session manager"),
+            ),
+        };
+
+        let result = tool
+            .call(json!({ "query": "approval denial errored result" }))
+            .await
+            .expect("retrieve session context");
+
+        assert_eq!(result["status"], "ok");
+        assert_eq!(result["matches"][0]["session_id"], "session-a");
+        assert_eq!(result["matches"][0]["turn_index"], 3);
+        assert!(
+            result["matches"][0]["text"]
+                .as_str()
+                .is_some_and(|text| text.contains("approval denial"))
+        );
     }
 }

--- a/src/vectordb.rs
+++ b/src/vectordb.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::fs::{File, OpenOptions};
-use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -19,6 +17,8 @@ use lancedb::index::scalar::FtsIndexBuilder;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use lancedb::{Connection, Error as LanceDbError, Table, connect};
 use tokio::sync::{Mutex, OnceCell};
+
+use crate::file_lock::AdvisoryFileLock;
 
 const MEMORY_ID_COLUMN: &str = "id";
 const SESSION_ID_COLUMN: &str = "session_id";
@@ -186,9 +186,9 @@ impl VectorDB {
         Ok(())
     }
 
-    async fn acquire_write_lock(&self) -> Result<VectorDbWriteLock> {
+    async fn acquire_write_lock(&self) -> Result<AdvisoryFileLock> {
         let path = self.write_lock_path.clone();
-        tokio::task::spawn_blocking(move || VectorDbWriteLock::acquire(path))
+        tokio::task::spawn_blocking(move || AdvisoryFileLock::acquire(path))
             .await
             .context("join LanceDB write lock task")?
     }
@@ -257,39 +257,6 @@ impl VectorDB {
             })
             .await
             .map(|_| ())
-    }
-}
-
-struct VectorDbWriteLock {
-    file: File,
-}
-
-impl VectorDbWriteLock {
-    fn acquire(path: PathBuf) -> Result<Self> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("create LanceDB lock directory {}", parent.display()))?;
-        }
-        let file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .write(true)
-            .open(&path)
-            .with_context(|| format!("open LanceDB write lock {}", path.display()))?;
-        let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
-        if rc != 0 {
-            return Err(std::io::Error::last_os_error())
-                .with_context(|| format!("lock LanceDB write lock {}", path.display()));
-        }
-        Ok(Self { file })
-    }
-}
-
-impl Drop for VectorDbWriteLock {
-    fn drop(&mut self) {
-        unsafe {
-            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

- persist full `MemoryRecord` domain records in a sidecar store with `session_id`, `thread_id`, and source turn span provenance
- keep LanceDB as the compact FTS/vector/hybrid recall index and rehydrate search hits through `MemoryStore`
- implement backend thread markdown export and summary-to-memory distillation without touching TUI surfaces
- replace the `retrieve_session_context` stub with LanceDB hybrid search over conversation checkpoints
- document the current checkpoint and remaining Phase A1 follow-up work

## Purpose

This advances the backend-only Memory & Retrieval stream toward a usable durable memory layer while keeping prompt injection policy and TUI work separate. The design keeps thread lifecycle state, durable memory records, retrieval index rows, and future `MemorySelection` policy as separate components.

## Tests

- `cargo test memory_store -- --nocapture`
- `cargo test retrieve_session_context_searches_conversation_index -- --nocapture`
- `cargo test tools::vector -- --nocapture`
- `cargo test thread_store::tests -- --nocapture`
- `cargo check`

Note: the repository still emits existing unused-code/import warnings during `cargo check`; compilation succeeds.
