### PR TITLE
fix: handle deepseek dsml tool call fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8641,6 +8641,7 @@ dependencies = [
  "lance-index",
  "lancedb",
  "libc",
+ "nom 8.0.0",
  "open",
  "owo-colors",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ rusqlite = "0.39"
 pulldown-cmark = "0.13"
 textwrap = "0.16.2"
 unicode-width = "0.2"
+nom = "8.0"
 syntect = "5"
 portable-pty = "0.9"
 two-face = { version = "0.5", default-features = false, features = ["syntect-default-onig"] }

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -116,6 +116,14 @@ The transcript should move toward Codex/Claude-style tool visibility:
   DeepSeek thinking mode is explicitly enabled; the default DeepSeek request body
   must preserve assistant tool calls and adjacent tool results so the model can
   continue after approval.
+- If one assistant turn contains visible text followed by tool calls, render the
+  visible text first and then execute the tool calls. Visible text is progress
+  output, not an end-of-turn signal, while structured tool calls are still
+  pending.
+- DeepSeek V4 DSML is a fallback parser path, not the primary official API
+  contract. Official DeepSeek API responses should prefer protocol-level
+  `tool_calls`; if a compatible endpoint leaks DSML text, RARA should parse it
+  with one shared DeepSeek V4 DSML parser and scrub the same blocks from the TUI.
 - The default TUI terminal mode should preserve native terminal text selection.
   Mouse capture may be added later only behind an explicit opt-in, because
   terminal mouse reporting steals drag and wheel events from the host terminal.

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -179,6 +179,106 @@ async fn appends_continuation_after_tool_result() {
 }
 
 #[tokio::test]
+async fn visible_text_before_tool_call_does_not_end_agent_turn() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![
+                ContentBlock::Text {
+                    text: "I will inspect the file first.".to_string(),
+                },
+                ContentBlock::ToolUse {
+                    id: "tool-1".to_string(),
+                    name: "stub_tool".to_string(),
+                    input: json!({}),
+                },
+            ],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "The tool result is handled.".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured_events = events.clone();
+
+    agent
+        .query_with_mode_and_events(
+            "continue".to_string(),
+            super::super::AgentOutputMode::Silent,
+            move |event| captured_events.lock().expect("events").push(event),
+        )
+        .await
+        .expect("query should continue through tool call");
+
+    let events = events.lock().expect("events");
+    let text_idx = events
+        .iter()
+        .position(|event| {
+            matches!(
+                event,
+                AgentEvent::AssistantText(text) if text.contains("inspect the file")
+            )
+        })
+        .expect("visible text event");
+    let tool_idx = events
+        .iter()
+        .position(|event| {
+            matches!(
+                event,
+                AgentEvent::ToolUse { name, .. } if name == "stub_tool"
+            )
+        })
+        .expect("tool use event");
+    assert!(
+        text_idx < tool_idx,
+        "visible assistant text should render before the tool call is executed"
+    );
+    assert!(
+        events.iter().any(|event| {
+            matches!(
+                event,
+                AgentEvent::ToolResult {
+                    name,
+                    is_error: false,
+                    ..
+                } if name == "stub_tool"
+            )
+        }),
+        "tool call should still execute after visible text"
+    );
+    drop(events);
+
+    let observed = backend.observed_messages();
+    assert_eq!(
+        observed.len(),
+        2,
+        "tool result should trigger a follow-up model turn"
+    );
+    assert!(
+        observed[1]
+            .iter()
+            .any(|message| message.content.to_string().contains("tool_result")),
+        "follow-up model turn should receive the tool result"
+    );
+}
+
+#[tokio::test]
 async fn todo_write_updates_session_state_and_emits_event() {
     let backend = Arc::new(SequencedBackend::new(vec![
         LlmResponse {

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,4 +1,5 @@
 mod codex_tools_compat;
+pub(crate) mod deepseek_dsml;
 mod ollama;
 mod openai_compatible;
 mod shared;

--- a/src/llm/deepseek_dsml.rs
+++ b/src/llm/deepseek_dsml.rs
@@ -1,0 +1,244 @@
+use std::borrow::Cow;
+
+use nom::bytes::complete::{tag, take_until};
+use nom::character::complete::multispace0;
+use nom::error::{Error, ErrorKind};
+use nom::{Err as NomErr, IResult, Parser};
+use serde_json::Value;
+
+const DSML_TOKENS: [&str; 2] = ["｜DSML｜", "|DSML|"];
+const TOOL_CALLS_BLOCK_NAME: &str = "tool_calls";
+const INVOKE_TAG_NAME: &str = "invoke";
+const PARAMETER_TAG_NAME: &str = "parameter";
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DeepSeekDsmlToolCall {
+    pub(crate) name: String,
+    pub(crate) input: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DeepSeekDsmlExtraction {
+    pub(crate) visible_text: String,
+    pub(crate) tool_calls: Vec<DeepSeekDsmlToolCall>,
+}
+
+pub(crate) fn contains_dsml(text: &str) -> bool {
+    DSML_TOKENS.iter().any(|token| text.contains(token))
+}
+
+pub(crate) fn extract_tool_calls_from_text(text: &str) -> DeepSeekDsmlExtraction {
+    let mut visible_text = String::new();
+    let mut tool_calls = Vec::new();
+    let mut rest = text;
+
+    while let Some(open) = find_next_open_tag(rest, TOOL_CALLS_BLOCK_NAME) {
+        visible_text.push_str(&rest[..open.start]);
+        let after_open = &rest[open.start + open.tag.len()..];
+        let close_tag = close_tag(open.token, TOOL_CALLS_BLOCK_NAME);
+        let Some(close_start) = after_open.find(&close_tag) else {
+            visible_text.push_str(&rest[open.start..]);
+            rest = "";
+            break;
+        };
+
+        let block_body = &after_open[..close_start];
+        let candidate =
+            &rest[open.start..open.start + open.tag.len() + close_start + close_tag.len()];
+        match parse_tool_call_block(block_body, open.token) {
+            Some(mut calls) => tool_calls.append(&mut calls),
+            None => visible_text.push_str(candidate),
+        }
+        rest = &after_open[close_start + close_tag.len()..];
+    }
+
+    visible_text.push_str(rest);
+    DeepSeekDsmlExtraction {
+        visible_text,
+        tool_calls,
+    }
+}
+
+pub(crate) fn strip_tool_call_blocks(text: &str) -> Cow<'_, str> {
+    let extraction = extract_tool_calls_from_text(text);
+    if extraction.tool_calls.is_empty() || extraction.visible_text == text {
+        Cow::Borrowed(text)
+    } else {
+        Cow::Owned(extraction.visible_text)
+    }
+}
+
+type NomResult<'a, T> = IResult<&'a str, T>;
+
+fn parse_tool_call_block(block: &str, token: &'static str) -> Option<Vec<DeepSeekDsmlToolCall>> {
+    let (rest, calls) = parse_tool_call_block_nom(block, token).ok()?;
+    if !rest.trim().is_empty() || calls.is_empty() {
+        return None;
+    }
+    Some(calls)
+}
+
+fn parse_tool_call_block_nom<'a>(
+    input: &'a str,
+    token: &'static str,
+) -> NomResult<'a, Vec<DeepSeekDsmlToolCall>> {
+    let mut calls = Vec::new();
+    let (mut rest, _) = multispace0.parse(input)?;
+    while !rest.is_empty() {
+        let (next, call) = parse_invoke_nom(rest, token)?;
+        calls.push(call);
+        let (next, _) = multispace0.parse(next)?;
+        rest = next;
+    }
+    Ok((rest, calls))
+}
+
+fn parse_invoke_nom<'a>(
+    input: &'a str,
+    token: &'static str,
+) -> NomResult<'a, DeepSeekDsmlToolCall> {
+    let input = input.trim_start();
+    let open_tag = open_tag(token, INVOKE_TAG_NAME);
+    let (input, _) = tag(open_tag.as_str()).parse(input)?;
+    let (input, attrs) = take_until(">").parse(input)?;
+    let (input, _) = tag(">").parse(input)?;
+    let name = quoted_attr(attrs, "name").ok_or_else(|| nom_error(input, ErrorKind::Tag))?;
+    if name.is_empty() {
+        return Err(nom_error(input, ErrorKind::Tag));
+    }
+
+    let close_tag = close_tag(token, INVOKE_TAG_NAME);
+    let (input, body) = take_until(close_tag.as_str()).parse(input)?;
+    let (input, _) = tag(close_tag.as_str()).parse(input)?;
+    let (_, parameters) = parse_parameters_nom(body, token)?;
+    Ok((
+        input,
+        DeepSeekDsmlToolCall {
+            name: name.to_string(),
+            input: parameters,
+        },
+    ))
+}
+
+fn parse_parameters_nom<'a>(body: &'a str, token: &'static str) -> NomResult<'a, Value> {
+    let mut params = serde_json::Map::new();
+    let (mut rest, _) = multispace0.parse(body)?;
+
+    while !rest.is_empty() {
+        let (next, (name, value)) = parse_parameter_nom(rest, token)?;
+        params.insert(name, value);
+        let (next, _) = multispace0.parse(next)?;
+        rest = next;
+    }
+
+    Ok((rest, Value::Object(params)))
+}
+
+fn parse_parameter_nom<'a>(input: &'a str, token: &'static str) -> NomResult<'a, (String, Value)> {
+    let open_tag = open_tag(token, PARAMETER_TAG_NAME);
+    let close_tag = close_tag(token, PARAMETER_TAG_NAME);
+
+    let (input, _) = tag(open_tag.as_str()).parse(input)?;
+    let (input, attrs) = take_until(">").parse(input)?;
+    let (input, _) = tag(">").parse(input)?;
+
+    let name = quoted_attr(attrs, "name").ok_or_else(|| nom_error(input, ErrorKind::Tag))?;
+    if name.is_empty() {
+        return Err(nom_error(input, ErrorKind::Tag));
+    }
+    let is_string = match quoted_attr(attrs, "string") {
+        Some("true") => true,
+        Some("false") | None => false,
+        Some(_) => return Err(nom_error(input, ErrorKind::Tag)),
+    };
+
+    let (input, raw_value) = take_until(close_tag.as_str()).parse(input)?;
+    let (input, _) = tag(close_tag.as_str()).parse(input)?;
+    let value = if is_string {
+        Value::String(raw_value.to_string())
+    } else {
+        serde_json::from_str(raw_value.trim())
+            .unwrap_or_else(|_| Value::String(raw_value.trim().to_string()))
+    };
+    Ok((input, (name.to_string(), value)))
+}
+
+#[derive(Debug)]
+struct OpenTag {
+    start: usize,
+    token: &'static str,
+    tag: String,
+}
+
+fn find_next_open_tag(input: &str, name: &str) -> Option<OpenTag> {
+    DSML_TOKENS
+        .into_iter()
+        .filter_map(|token| {
+            let tag = exact_open_tag(token, name);
+            input.find(&tag).map(|start| OpenTag { start, token, tag })
+        })
+        .min_by_key(|found| found.start)
+}
+
+fn exact_open_tag(token: &str, name: &str) -> String {
+    format!("<{token}{name}>")
+}
+
+fn open_tag(token: &str, name: &str) -> String {
+    format!("<{token}{name}")
+}
+
+fn close_tag(token: &str, name: &str) -> String {
+    format!("</{token}{name}>")
+}
+
+fn quoted_attr<'a>(tag: &'a str, name: &str) -> Option<&'a str> {
+    let needle = format!("{name}=\"");
+    let start = tag.find(&needle)? + needle.len();
+    let rest = &tag[start..];
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}
+
+fn nom_error(input: &str, kind: ErrorKind) -> NomErr<Error<&str>> {
+    NomErr::Error(Error::new(input, kind))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_fullwidth_dsml_tool_call_and_preserves_visible_text() {
+        let extraction = extract_tool_calls_from_text(
+            "Before\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read_file\">\n<｜DSML｜parameter name=\"path\" string=\"true\">src/lib.rs</｜DSML｜parameter>\n<｜DSML｜parameter name=\"options\" string=\"false\">{\"limit\":20}</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nAfter",
+        );
+
+        assert_eq!(extraction.visible_text, "Before\n\nAfter");
+        assert_eq!(extraction.tool_calls.len(), 1);
+        assert_eq!(extraction.tool_calls[0].name, "read_file");
+        assert_eq!(extraction.tool_calls[0].input["path"], "src/lib.rs");
+        assert_eq!(extraction.tool_calls[0].input["options"]["limit"], 20);
+    }
+
+    #[test]
+    fn extracts_ascii_pipe_dsml_tool_call_as_pdf_compatibility_fallback() {
+        let extraction = extract_tool_calls_from_text(
+            "Before\n<|DSML|tool_calls>\n<|DSML|invoke name=\"list_files\">\n<|DSML|parameter name=\"path\" string=\"true\">src</|DSML|parameter>\n</|DSML|invoke>\n</|DSML|tool_calls>\nAfter",
+        );
+
+        assert_eq!(extraction.visible_text, "Before\n\nAfter");
+        assert_eq!(extraction.tool_calls.len(), 1);
+        assert_eq!(extraction.tool_calls[0].name, "list_files");
+        assert_eq!(extraction.tool_calls[0].input["path"], "src");
+    }
+
+    #[test]
+    fn preserves_malformed_dsml_without_closing_block() {
+        let input = "Before\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read_file\">\nAfter";
+        let extraction = extract_tool_calls_from_text(input);
+
+        assert_eq!(extraction.visible_text, input);
+        assert!(extraction.tool_calls.is_empty());
+    }
+}

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -14,6 +14,7 @@ use secrecy::{ExposeSecret, SecretString};
 use serde_json::{Value, json};
 
 use self::usage::parse_openai_token_usage;
+use super::deepseek_dsml;
 use super::shared::{
     ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata, collect_assistant_content,
     context_budget_from_window, extract_message_text, http_client_for_target,
@@ -1080,10 +1081,13 @@ pub(super) fn parse_chat_completion_response(
     let mut parsed_dsml_tool_calls = Vec::new();
     if let Some(text) = extract_message_text(choice.get("content")) {
         if endpoint_kind == OpenAiEndpointKind::Deepseek {
-            let (visible_text, dsml_tool_calls) = extract_dsml_tool_calls_from_text(&text);
-            parsed_dsml_tool_calls = dsml_tool_calls;
-            if !visible_text.trim().is_empty() {
-                content.push(ContentBlock::Text { text: visible_text });
+            let extraction = deepseek_dsml::extract_tool_calls_from_text(&text);
+            parsed_dsml_tool_calls =
+                deepseek_dsml_tool_calls_to_content_blocks(extraction.tool_calls);
+            if !extraction.visible_text.trim().is_empty() {
+                content.push(ContentBlock::Text {
+                    text: extraction.visible_text,
+                });
             }
         } else if !text.trim().is_empty() {
             content.push(ContentBlock::Text { text });
@@ -1150,102 +1154,6 @@ pub(super) fn parse_chat_completion_response(
     })
 }
 
-fn extract_dsml_tool_calls_from_text(text: &str) -> (String, Vec<ContentBlock>) {
-    const TOOL_CALLS_OPEN: &str = "<｜DSML｜tool_calls>";
-    const TOOL_CALLS_CLOSE: &str = "</｜DSML｜tool_calls>";
-
-    let mut visible = String::new();
-    let mut rest = text;
-    let mut tool_calls = Vec::new();
-    while let Some(start) = rest.find(TOOL_CALLS_OPEN) {
-        visible.push_str(&rest[..start]);
-        let block = &rest[start + TOOL_CALLS_OPEN.len()..];
-        let Some(end) = block.find(TOOL_CALLS_CLOSE) else {
-            break;
-        };
-        tool_calls.extend(parse_dsml_tool_call_block(&block[..end], tool_calls.len()));
-        rest = &block[end + TOOL_CALLS_CLOSE.len()..];
-    }
-    visible.push_str(rest);
-
-    if tool_calls.is_empty() {
-        (text.to_string(), tool_calls)
-    } else {
-        (visible, tool_calls)
-    }
-}
-
-fn parse_dsml_tool_call_block(block: &str, start_idx: usize) -> Vec<ContentBlock> {
-    const INVOKE_OPEN: &str = "<｜DSML｜invoke";
-    const INVOKE_CLOSE: &str = "</｜DSML｜invoke>";
-
-    let mut calls = Vec::new();
-    let mut rest = block;
-    while let Some(start) = rest.find(INVOKE_OPEN) {
-        let invoke = &rest[start..];
-        let Some(open_end) = invoke.find('>') else {
-            break;
-        };
-        let tag = &invoke[..=open_end];
-        let Some(name) = extract_dsml_attr(tag, "name") else {
-            rest = &invoke[open_end + 1..];
-            continue;
-        };
-        let body = &invoke[open_end + 1..];
-        let Some(close) = body.find(INVOKE_CLOSE) else {
-            break;
-        };
-        let input = parse_dsml_parameters(&body[..close]);
-        calls.push(ContentBlock::ToolUse {
-            id: format!("dsml-tool-{}", start_idx + calls.len() + 1),
-            name,
-            input,
-        });
-        rest = &body[close + INVOKE_CLOSE.len()..];
-    }
-    calls
-}
-
-fn parse_dsml_parameters(body: &str) -> Value {
-    const PARAM_OPEN: &str = "<｜DSML｜parameter";
-    const PARAM_CLOSE: &str = "</｜DSML｜parameter>";
-
-    let mut params = serde_json::Map::new();
-    let mut rest = body;
-    while let Some(start) = rest.find(PARAM_OPEN) {
-        let param = &rest[start..];
-        let Some(open_end) = param.find('>') else {
-            break;
-        };
-        let tag = &param[..=open_end];
-        let Some(name) = extract_dsml_attr(tag, "name") else {
-            rest = &param[open_end + 1..];
-            continue;
-        };
-        let value_body = &param[open_end + 1..];
-        let Some(close) = value_body.find(PARAM_CLOSE) else {
-            break;
-        };
-        let raw_value = value_body[..close].trim();
-        let value = if tag.contains("string=\"true\"") {
-            Value::String(raw_value.to_string())
-        } else {
-            serde_json::from_str(raw_value).unwrap_or_else(|_| Value::String(raw_value.to_string()))
-        };
-        params.insert(name, value);
-        rest = &value_body[close + PARAM_CLOSE.len()..];
-    }
-    Value::Object(params)
-}
-
-fn extract_dsml_attr(tag: &str, name: &str) -> Option<String> {
-    let needle = format!("{name}=\"");
-    let start = tag.find(&needle)? + needle.len();
-    let value = &tag[start..];
-    let end = value.find('"')?;
-    Some(value[..end].to_string())
-}
-
 pub(super) fn build_streaming_response_content(
     endpoint_kind: OpenAiEndpointKind,
     streamed_text: String,
@@ -1256,10 +1164,12 @@ pub(super) fn build_streaming_response_content(
     let mut parsed_dsml_tool_calls = Vec::new();
 
     if endpoint_kind == OpenAiEndpointKind::Deepseek {
-        let (visible_text, dsml_tool_calls) = extract_dsml_tool_calls_from_text(&streamed_text);
-        parsed_dsml_tool_calls = dsml_tool_calls;
-        if !visible_text.trim().is_empty() {
-            content.push(ContentBlock::Text { text: visible_text });
+        let extraction = deepseek_dsml::extract_tool_calls_from_text(&streamed_text);
+        parsed_dsml_tool_calls = deepseek_dsml_tool_calls_to_content_blocks(extraction.tool_calls);
+        if !extraction.visible_text.trim().is_empty() {
+            content.push(ContentBlock::Text {
+                text: extraction.visible_text,
+            });
         }
     } else if !streamed_text.trim().is_empty() {
         content.push(ContentBlock::Text {
@@ -1309,6 +1219,20 @@ pub(super) fn build_streaming_response_content(
     }
 
     Ok(content)
+}
+
+fn deepseek_dsml_tool_calls_to_content_blocks(
+    tool_calls: Vec<deepseek_dsml::DeepSeekDsmlToolCall>,
+) -> Vec<ContentBlock> {
+    tool_calls
+        .into_iter()
+        .enumerate()
+        .map(|(idx, call)| ContentBlock::ToolUse {
+            id: format!("dsml-tool-{}", idx + 1),
+            name: call.name,
+            input: call.input,
+        })
+        .collect()
 }
 
 pub(super) fn merge_streaming_tool_calls(

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -1075,6 +1075,78 @@ fn parses_dsml_tool_calls_from_text_content() {
 }
 
 #[test]
+fn parses_visible_text_before_dsml_tool_calls_for_deepseek() {
+    let response = parse_chat_completion_response(
+        &json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": concat!(
+                        "I will inspect the file first.\n",
+                        "<｜DSML｜tool_calls>\n",
+                        "<｜DSML｜invoke name=\"read_file\">\n",
+                        "<｜DSML｜parameter name=\"path\" string=\"true\">Cargo.toml</｜DSML｜parameter>\n",
+                        "</｜DSML｜invoke>\n",
+                        "</｜DSML｜tool_calls>"
+                    )
+                },
+                "finish_reason": "stop"
+            }]
+        }),
+        OpenAiEndpointKind::Deepseek,
+    )
+    .expect("parse response");
+
+    assert_eq!(response.content.len(), 2);
+    assert!(matches!(
+        &response.content[0],
+        ContentBlock::Text { text } if text.contains("inspect the file")
+    ));
+    assert!(matches!(
+        &response.content[1],
+        ContentBlock::ToolUse { id, name, input }
+            if id == "dsml-tool-1"
+                && name == "read_file"
+                && input["path"] == "Cargo.toml"
+    ));
+}
+
+#[test]
+fn parses_ascii_pipe_dsml_tool_calls_for_deepseek_pdf_compatibility() {
+    let response = parse_chat_completion_response(
+        &json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": concat!(
+                        "I will inspect the directory first.\n",
+                        "<|DSML|tool_calls>\n",
+                        "<|DSML|invoke name=\"list_files\">\n",
+                        "<|DSML|parameter name=\"path\" string=\"true\">src</|DSML|parameter>\n",
+                        "</|DSML|invoke>\n",
+                        "</|DSML|tool_calls>"
+                    )
+                },
+                "finish_reason": "tool_calls"
+            }]
+        }),
+        OpenAiEndpointKind::Deepseek,
+    )
+    .expect("parse response");
+
+    assert_eq!(response.content.len(), 2);
+    assert!(matches!(
+        &response.content[0],
+        ContentBlock::Text { text } if text.contains("inspect the directory")
+    ));
+    assert!(matches!(
+        &response.content[1],
+        ContentBlock::ToolUse { id, name, input }
+            if id == "dsml-tool-1" && name == "list_files" && input["path"] == "src"
+    ));
+}
+
+#[test]
 fn ignores_dsml_tool_calls_for_generic_openai_compatible_endpoint() {
     let response = parse_chat_completion_response(
         &json!({

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use crate::llm::deepseek_dsml;
 use crate::tool::ToolOutputStream;
 use crate::tools::bash::BashCommandInput;
 use crate::tui::state::TuiApp;
@@ -239,7 +240,7 @@ pub(super) fn planning_note_lines(message: &str) -> Vec<String> {
 }
 
 pub(super) fn scrub_internal_control_tokens(message: &str) -> String {
-    let had_deepseek_dsml = message.contains("｜DSML｜");
+    let had_deepseek_dsml = deepseek_dsml::contains_dsml(message);
     let had_deepseek_eos = message.contains("<｜end▁of▁sentence｜>");
 
     let message = if had_deepseek_dsml {
@@ -314,141 +315,16 @@ fn strip_deepseek_leading_think_block(message: &str) -> Cow<'_, str> {
 }
 
 fn strip_deepseek_v4_dsml_control_blocks(message: &str) -> Cow<'_, str> {
-    const TOOL_CALLS_OPEN: &str = "<｜DSML｜tool_calls>";
-    const TOOL_CALLS_CLOSE: &str = "</｜DSML｜tool_calls>";
-
-    if !message.contains("｜DSML｜") {
+    if !deepseek_dsml::contains_dsml(message) {
         return Cow::Borrowed(message);
     }
 
-    let mut output = String::new();
-    let mut rest = message;
-    while let Some(start) = rest.find(TOOL_CALLS_OPEN) {
-        output.push_str(&rest[..start]);
-        let block = &rest[start..];
-        let Some(close_idx) = block.find(TOOL_CALLS_CLOSE) else {
-            output.push_str(block);
-            rest = "";
-            break;
-        };
-        let skip_len = close_idx + TOOL_CALLS_CLOSE.len();
-        let candidate = &block[..skip_len];
-        if parse_deepseek_v4_dsml_tool_calls_block(candidate).is_none() {
-            output.push_str(candidate);
-            rest = &block[skip_len..];
-            continue;
-        }
-        rest = &block[skip_len..];
-        if !output.ends_with('\n') && !rest.trim_start().is_empty() {
-            output.push('\n');
-        }
-    }
-    output.push_str(rest);
+    let output = deepseek_dsml::strip_tool_call_blocks(message);
     if looks_like_orphaned_deepseek_v4_dsml_payload(output.trim()) {
         Cow::Owned(String::new())
     } else {
-        Cow::Owned(output)
+        output
     }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct DeepSeekV4DsmlToolCall<'a> {
-    name: &'a str,
-    parameters: Vec<DeepSeekV4DsmlParameter<'a>>,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct DeepSeekV4DsmlParameter<'a> {
-    name: &'a str,
-    value: &'a str,
-    is_string: bool,
-}
-
-fn parse_deepseek_v4_dsml_tool_calls_block(block: &str) -> Option<Vec<DeepSeekV4DsmlToolCall<'_>>> {
-    const TOOL_CALLS_OPEN: &str = "<｜DSML｜tool_calls>";
-    const TOOL_CALLS_CLOSE: &str = "</｜DSML｜tool_calls>";
-
-    let body = block
-        .strip_prefix(TOOL_CALLS_OPEN)?
-        .strip_suffix(TOOL_CALLS_CLOSE)?;
-    let mut rest = body.trim();
-    let mut calls = Vec::new();
-    while !rest.is_empty() {
-        let (call, next) = parse_deepseek_v4_dsml_invoke(rest)?;
-        calls.push(call);
-        rest = next.trim_start();
-    }
-    if calls.is_empty() { None } else { Some(calls) }
-}
-
-fn parse_deepseek_v4_dsml_invoke(input: &str) -> Option<(DeepSeekV4DsmlToolCall<'_>, &str)> {
-    const INVOKE_OPEN: &str = "<｜DSML｜invoke";
-    const INVOKE_CLOSE: &str = "</｜DSML｜invoke>";
-
-    let input = input.trim_start();
-    if !input.starts_with(INVOKE_OPEN) {
-        return None;
-    }
-    let open_end = input.find('>')?;
-    let open_tag = &input[..open_end];
-    let name = parse_deepseek_v4_dsml_quoted_attr(open_tag, "name")?;
-    if name.is_empty() {
-        return None;
-    }
-
-    let after_open = &input[open_end + 1..];
-    let close_start = after_open.find(INVOKE_CLOSE)?;
-    let mut body = after_open[..close_start].trim();
-    let mut parameters = Vec::new();
-    while !body.is_empty() {
-        let (parameter, next) = parse_deepseek_v4_dsml_parameter(body)?;
-        parameters.push(parameter);
-        body = next.trim_start();
-    }
-    let after_close = &after_open[close_start + INVOKE_CLOSE.len()..];
-    Some((DeepSeekV4DsmlToolCall { name, parameters }, after_close))
-}
-
-fn parse_deepseek_v4_dsml_parameter(input: &str) -> Option<(DeepSeekV4DsmlParameter<'_>, &str)> {
-    const PARAM_OPEN: &str = "<｜DSML｜parameter";
-    const PARAM_CLOSE: &str = "</｜DSML｜parameter>";
-
-    let input = input.trim_start();
-    if !input.starts_with(PARAM_OPEN) {
-        return None;
-    }
-    let open_end = input.find('>')?;
-    let open_tag = &input[..open_end];
-    let name = parse_deepseek_v4_dsml_quoted_attr(open_tag, "name")?;
-    if name.is_empty() {
-        return None;
-    }
-    let is_string = match parse_deepseek_v4_dsml_quoted_attr(open_tag, "string") {
-        Some("true") => true,
-        Some("false") | None => false,
-        Some(_) => return None,
-    };
-
-    let after_open = &input[open_end + 1..];
-    let close_start = after_open.find(PARAM_CLOSE)?;
-    let value = &after_open[..close_start];
-    let after_close = &after_open[close_start + PARAM_CLOSE.len()..];
-    Some((
-        DeepSeekV4DsmlParameter {
-            name,
-            value,
-            is_string,
-        },
-        after_close,
-    ))
-}
-
-fn parse_deepseek_v4_dsml_quoted_attr<'a>(tag: &'a str, name: &str) -> Option<&'a str> {
-    let needle = format!("{name}=\"");
-    let start = tag.find(&needle)? + needle.len();
-    let rest = &tag[start..];
-    let end = rest.find('"')?;
-    Some(&rest[..end])
 }
 
 fn looks_like_orphaned_deepseek_v4_dsml_payload(text: &str) -> bool {

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -173,6 +173,17 @@ fn scrub_internal_control_tokens_removes_dsml_tool_blocks() {
 }
 
 #[test]
+fn scrub_internal_control_tokens_removes_ascii_pipe_dsml_tool_blocks() {
+    let cleaned = scrub_internal_control_tokens(
+        "Before\n<|DSML|tool_calls>\n<|DSML|invoke name=\"read_file\">\n<|DSML|parameter name=\"path\" string=\"true\">src/lib.rs</|DSML|parameter>\n</|DSML|invoke>\n</|DSML|tool_calls>\nAfter",
+    );
+
+    assert_eq!(cleaned.trim(), "Before\n\nAfter");
+    assert!(!cleaned.contains("DSML"));
+    assert!(!cleaned.contains("read_file"));
+}
+
+#[test]
 fn scrub_internal_control_tokens_removes_structured_dsml_tool_block_with_json_parameter() {
     let cleaned = scrub_internal_control_tokens(
         "Before\n<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read_file\">\n<｜DSML｜parameter name=\"options\" string=\"false\">{\"path\":\"src/lib.rs\",\"limit\":20}</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nAfter",


### PR DESCRIPTION
## Summary

- Add a shared DeepSeek V4 DSML fallback parser backed by `nom`.
- Reuse the same parser from OpenAI-compatible response parsing and TUI control-token scrubbing.
- Keep official DeepSeek API `tool_calls` as the primary path, while parsing leaked DSML text from compatible/raw endpoints.
- Document that visible assistant text before a tool call is progress output, not an end-of-turn signal.
- Add regressions for visible text before tool calls, fullwidth DSML, ASCII-pipe DSML fallback, and TUI DSML scrubbing.

## Tests

- `cargo test deepseek_dsml -- --nocapture`
- `cargo test dsml -- --nocapture`
- `cargo test visible_text_before_tool_call_does_not_end_agent_turn -- --nocapture`
- `cargo check`

`cargo check` passes with existing unused/dead code warnings.
