### PR TITLE
fix: compact background task progress labels

### DIFF
--- a/src/tui/render/cells/cells_components.rs
+++ b/src/tui/render/cells/cells_components.rs
@@ -5,6 +5,7 @@ use ratatui::{
     text::{Line, Span},
 };
 
+use super::tool_progress::tool_progress_lines;
 use super::{HistoryCell, InteractionCompletionKind};
 use crate::tui::interaction_text::{
     pending_interaction_card_title, status_planning_suggestion_text,
@@ -588,7 +589,7 @@ impl<'a> RespondingCell<'a> {
 }
 
 impl HistoryCell for RespondingCell<'_> {
-    fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
         match &self.content {
             RespondingCellContent::Stream { lines, max_lines } => {
                 lightweight_stream_lines(lines, *max_lines)
@@ -608,6 +609,11 @@ impl HistoryCell for RespondingCell<'_> {
                 max_lines,
                 cwd,
             } => formatted_message_lines(role, message, *max_lines, *cwd),
+            RespondingCellContent::ToolResult {
+                role,
+                message,
+                max_lines,
+            } if *role == "Tool Progress" => tool_progress_lines(message, *max_lines, width),
             RespondingCellContent::ToolResult {
                 role,
                 message,

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -148,6 +148,64 @@ fn active_turn_cell_renders_progress_sections_as_compact_stack() {
 }
 
 #[test]
+fn active_turn_cell_hides_background_stdout_label_and_pins_stderr() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Run the formatter".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool Progress".into(),
+                message: [
+                    "background task stdout:",
+                    "info: downloading 6 components",
+                    "background task stderr:",
+                    "warning: retrying download",
+                    "background task stdout:",
+                    "info: installing rustfmt",
+                ]
+                .join("\n"),
+                payload: None,
+            },
+        ],
+    };
+
+    let rendered_lines = ActiveTurnCell::new(&app, Some(Path::new("."))).display_lines(100);
+    let rendered = rendered_lines
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(!rendered.contains("background task stdout:"));
+    assert!(!rendered.contains("background task stderr:"));
+    assert!(rendered.contains("info: downloading 6 components"));
+    assert!(rendered.contains("info: installing rustfmt"));
+    assert!(rendered.contains("warning: retrying download"));
+
+    let install_idx = rendered.find("info: installing rustfmt").unwrap();
+    let stderr_idx = rendered.find("warning: retrying download").unwrap();
+    assert!(install_idx < stderr_idx);
+
+    let stderr_line = rendered_lines
+        .iter()
+        .find(|line| line.to_string().contains("warning: retrying download"))
+        .expect("stderr line should render");
+    assert!(stderr_line.spans.iter().any(|span| {
+        span.style.fg == Some(crate::tui::theme::TOOL_STDERR_FG)
+            && span.style.bg == Some(crate::tui::theme::TOOL_STDERR_BG)
+    }));
+}
+
+#[test]
 fn active_turn_cell_renders_terminal_result_as_terminal_cell() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -18,6 +18,7 @@ use crate::tui::theme::*;
 
 #[path = "cells_components.rs"]
 mod components;
+mod tool_progress;
 
 pub(crate) use self::components::StartupCardCell;
 use self::components::{

--- a/src/tui/render/cells/tool_progress.rs
+++ b/src/tui/render/cells/tool_progress.rs
@@ -1,0 +1,332 @@
+use ratatui::{
+    style::{Modifier, Style},
+    text::{Line, Span},
+};
+
+use crate::tui::render::display_width;
+use crate::tui::theme::{STATUS_WARNING, TEXT_SECONDARY, TOOL_STDERR_BG, TOOL_STDERR_FG};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ToolProgressStream {
+    Stdout,
+    Stderr,
+}
+
+struct ToolProgressMarker {
+    stream: ToolProgressStream,
+    label: Option<String>,
+}
+
+pub(super) fn tool_progress_lines(
+    message: &str,
+    max_lines: usize,
+    width: u16,
+) -> Vec<Line<'static>> {
+    let (stdout_lines, stderr_lines) = split_tool_progress_streams(message);
+    if stderr_lines.is_empty() {
+        return stdout_progress_lines(&stdout_lines, max_lines);
+    }
+
+    let stderr_budget = tool_progress_stderr_budget(!stdout_lines.is_empty(), max_lines);
+    let stderr_rendered = stderr_progress_lines(&stderr_lines, stderr_budget, width);
+    let stdout_budget = max_lines.saturating_sub(stderr_rendered.len());
+    let mut lines = if stdout_lines.is_empty() || stdout_budget == 0 {
+        Vec::new()
+    } else {
+        stdout_progress_lines(&stdout_lines, stdout_budget)
+    };
+
+    lines.extend(stderr_rendered);
+    lines
+}
+
+fn stdout_progress_lines(stdout_lines: &[String], max_lines: usize) -> Vec<Line<'static>> {
+    if max_lines == 0 {
+        return Vec::new();
+    }
+    if stdout_lines.is_empty() {
+        return vec![Line::from(Span::styled(
+            "…",
+            Style::default()
+                .fg(STATUS_WARNING)
+                .add_modifier(Modifier::BOLD),
+        ))];
+    }
+
+    if max_lines == usize::MAX || stdout_lines.len() <= max_lines {
+        let mut lines = Vec::new();
+        let mut visible = stdout_lines.iter().map(String::as_str);
+        if let Some(first) = visible.next() {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "…",
+                    Style::default()
+                        .fg(STATUS_WARNING)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(format!(" {first}")),
+            ]));
+        }
+        lines.extend(visible.map(|line| Line::from(format!("  {line}"))));
+        return lines;
+    }
+
+    if max_lines == 1 {
+        return vec![Line::from(vec![
+            Span::styled(
+                "…",
+                Style::default()
+                    .fg(STATUS_WARNING)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!(" ... {} more line(s)", stdout_lines.len()),
+                Style::default().fg(TEXT_SECONDARY),
+            ),
+        ])];
+    }
+
+    let content_budget = max_lines - 1;
+    let hidden_count = stdout_lines.len().saturating_sub(content_budget);
+    let mut visible = Vec::new();
+    if content_budget == 1 {
+        visible.push(stdout_lines[0].as_str());
+    } else {
+        visible.push(stdout_lines[0].as_str());
+        visible.extend(
+            stdout_lines[stdout_lines
+                .len()
+                .saturating_sub(content_budget.saturating_sub(1))..]
+                .iter()
+                .map(String::as_str),
+        );
+    }
+
+    let mut lines = Vec::new();
+    if let Some(first) = visible.first() {
+        lines.push(Line::from(vec![
+            Span::styled(
+                "…",
+                Style::default()
+                    .fg(STATUS_WARNING)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(" {first}")),
+        ]));
+    }
+    if hidden_count > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("  ... {hidden_count} more line(s)"),
+            Style::default().fg(TEXT_SECONDARY),
+        )));
+    }
+    lines.extend(
+        visible
+            .iter()
+            .skip(1)
+            .map(|line| Line::from(format!("  {line}"))),
+    );
+    lines
+}
+
+fn split_tool_progress_streams(message: &str) -> (Vec<String>, Vec<String>) {
+    let mut current_stream = ToolProgressStream::Stdout;
+    let mut stdout_lines = Vec::new();
+    let mut stderr_lines = Vec::new();
+
+    for line in message.lines() {
+        if let Some(marker) = tool_progress_stream_marker(line) {
+            current_stream = marker.stream;
+            if let Some(label) = marker.label {
+                match marker.stream {
+                    ToolProgressStream::Stdout => stdout_lines.push(label),
+                    ToolProgressStream::Stderr => stderr_lines.push(label),
+                }
+            }
+            continue;
+        }
+
+        match current_stream {
+            ToolProgressStream::Stdout => stdout_lines.push(line.to_string()),
+            ToolProgressStream::Stderr => stderr_lines.push(line.to_string()),
+        }
+    }
+
+    (stdout_lines, stderr_lines)
+}
+
+fn tool_progress_stream_marker(line: &str) -> Option<ToolProgressMarker> {
+    let trimmed = line.trim();
+    if trimmed == "background task stdout:" {
+        return Some(ToolProgressMarker {
+            stream: ToolProgressStream::Stdout,
+            label: None,
+        });
+    }
+    if trimmed == "background task stderr:" {
+        return Some(ToolProgressMarker {
+            stream: ToolProgressStream::Stderr,
+            label: None,
+        });
+    }
+    if trimmed.ends_with(" stdout:") {
+        return Some(ToolProgressMarker {
+            stream: ToolProgressStream::Stdout,
+            label: Some(line.to_string()),
+        });
+    }
+    if trimmed.ends_with(" stderr:") {
+        return Some(ToolProgressMarker {
+            stream: ToolProgressStream::Stderr,
+            label: Some(line.to_string()),
+        });
+    }
+    None
+}
+
+fn tool_progress_stderr_budget(has_stdout: bool, max_lines: usize) -> usize {
+    if max_lines == 0 {
+        return 0;
+    }
+    if !has_stdout || max_lines == 1 {
+        return max_lines;
+    }
+    max_lines - 1
+}
+
+fn stderr_progress_lines(
+    stderr_lines: &[String],
+    max_lines: usize,
+    width: u16,
+) -> Vec<Line<'static>> {
+    if max_lines == 0 {
+        return Vec::new();
+    }
+
+    if max_lines == usize::MAX || stderr_lines.len() <= max_lines {
+        return stderr_lines
+            .iter()
+            .map(|line| styled_stderr_progress_line(line, width))
+            .collect();
+    }
+
+    if max_lines == 1 {
+        return vec![styled_stderr_progress_line(
+            &format!("... {} more stderr line(s)", stderr_lines.len()),
+            width,
+        )];
+    }
+
+    let visible_count = max_lines - 1;
+    let hidden_count = stderr_lines.len().saturating_sub(visible_count);
+    let mut rendered = vec![styled_stderr_progress_line(
+        &format!("... {hidden_count} more stderr line(s)"),
+        width,
+    )];
+    rendered.extend(
+        stderr_lines[stderr_lines.len().saturating_sub(visible_count)..]
+            .iter()
+            .map(|line| styled_stderr_progress_line(line, width)),
+    );
+    rendered
+}
+
+fn styled_stderr_progress_line(text: &str, width: u16) -> Line<'static> {
+    let text = format!("  {text}");
+    let target_width = usize::from(width.saturating_sub(2)).max(display_width(&text));
+    let padding = target_width.saturating_sub(display_width(&text));
+    Line::from(Span::styled(
+        format!("{text}{}", " ".repeat(padding)),
+        Style::default().fg(TOOL_STDERR_FG).bg(TOOL_STDERR_BG),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plain(lines: &[Line<'static>]) -> String {
+        lines
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn stdout_progress_respects_line_budget_when_truncated() {
+        let rendered = tool_progress_lines(
+            [
+                "background task stdout:",
+                "line 1",
+                "line 2",
+                "line 3",
+                "line 4",
+                "line 5",
+            ]
+            .join("\n")
+            .as_str(),
+            3,
+            80,
+        );
+        let rendered_text = plain(&rendered);
+
+        assert_eq!(rendered.len(), 3);
+        assert!(!rendered_text.contains("background task stdout:"));
+        assert!(rendered_text.contains("line 1"));
+        assert!(rendered_text.contains("... 3 more line(s)"));
+        assert!(rendered_text.contains("line 5"));
+    }
+
+    #[test]
+    fn stderr_progress_uses_full_budget_without_stdout_and_marks_truncation() {
+        let rendered = tool_progress_lines(
+            [
+                "background task stderr:",
+                "err 1",
+                "err 2",
+                "err 3",
+                "err 4",
+            ]
+            .join("\n")
+            .as_str(),
+            3,
+            80,
+        );
+        let rendered_text = plain(&rendered);
+
+        assert_eq!(rendered.len(), 3);
+        assert!(rendered_text.contains("... 2 more stderr line(s)"));
+        assert!(rendered_text.contains("err 3"));
+        assert!(rendered_text.contains("err 4"));
+        assert!(rendered.iter().all(|line| {
+            line.spans.iter().any(|span| {
+                span.style.fg == Some(TOOL_STDERR_FG) && span.style.bg == Some(TOOL_STDERR_BG)
+            })
+        }));
+    }
+
+    #[test]
+    fn custom_stderr_label_is_preserved_in_stderr_card() {
+        let rendered = tool_progress_lines(
+            [
+                "compiler stderr:",
+                "warning: unused import",
+                "background task stdout:",
+                "done",
+            ]
+            .join("\n")
+            .as_str(),
+            4,
+            80,
+        );
+        let rendered_text = plain(&rendered);
+
+        assert!(!rendered_text.contains("background task stdout:"));
+        assert!(rendered_text.contains("compiler stderr:"));
+        assert!(rendered_text.contains("warning: unused import"));
+        assert!(
+            rendered_text.find("done").unwrap() < rendered_text.find("compiler stderr:").unwrap()
+        );
+    }
+}

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -38,6 +38,10 @@ pub(crate) const BADGE_FG_LIGHT: Color = Color::Black;
 // ── Interaction ─────────────────────────────────────────────────
 pub(crate) const INTERACTION_SUB_AGENT: Color = Color::Rgb(231, 201, 92); // gold distinct from green RequestInput
 
+// ── Tool output ─────────────────────────────────────────────────
+pub(crate) const TOOL_STDERR_BG: Color = Color::Rgb(172, 76, 108);
+pub(crate) const TOOL_STDERR_FG: Color = Color::White;
+
 // ── Budget bar segments ─────────────────────────────────────────
 pub(crate) const BUDGET_SYSTEM: Color = Color::LightBlue;
 pub(crate) const BUDGET_WORKSPACE: Color = Color::LightCyan;


### PR DESCRIPTION
## Summary

- Hide redundant `background task stdout:` and `background task stderr:` markers from live tool progress rendering.
- Keep stdout content in the normal progress flow while pinning stderr content to the bottom with a dedicated stderr style.
- Split Tool Progress stream rendering into a small dedicated TUI module and cover the behavior with a focused active-turn test.

## Testing

- `cargo test active_turn_cell_hides_background_stdout_label_and_pins_stderr -- --nocapture`
- `cargo check`

## Related Issue

- None.
