### PR TITLE
chore: add reusable tool spec macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8654,6 +8654,7 @@ dependencies = [
  "rara-provider-catalog",
  "rara-sandbox",
  "rara-skills",
+ "rara-tool-macros",
  "ratatui",
  "regex",
  "regex-lite",
@@ -8733,6 +8734,15 @@ dependencies = [
  "dirs",
  "serde",
  "tempfile",
+]
+
+[[package]]
+name = "rara-tool-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/provider-catalog",
     "crates/sandbox",
     "crates/skills",
+    "crates/tool-macros",
 ]
 resolver = "2"
 
@@ -54,6 +55,7 @@ rara-instructions = { path = "crates/instructions" }
 rara-provider-catalog = { path = "crates/provider-catalog" }
 rara-sandbox = { path = "crates/sandbox" }
 rara-skills = { path = "crates/skills" }
+rara-tool-macros = { path = "crates/tool-macros" }
 urlencoding = "2.1"
 url = "2.5"
 ratatui = "0.30"

--- a/crates/tool-macros/Cargo.toml
+++ b/crates/tool-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rara-tool-macros"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }

--- a/crates/tool-macros/src/lib.rs
+++ b/crates/tool-macros/src/lib.rs
@@ -1,0 +1,85 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::{Expr, Ident, ItemImpl, Result, Token, braced, parse_macro_input, parse_quote};
+
+struct ToolSpecArgs {
+    name: Expr,
+    description: Expr,
+    input_schema: TokenStream2,
+}
+
+impl Parse for ToolSpecArgs {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let mut name = None;
+        let mut description = None;
+        let mut input_schema = None;
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+            match key.to_string().as_str() {
+                "name" => name = Some(input.parse()?),
+                "description" => description = Some(input.parse()?),
+                "input_schema" => {
+                    let content;
+                    braced!(content in input);
+                    input_schema = Some(content.parse()?);
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!("unknown tool_spec key `{other}`"),
+                    ));
+                }
+            }
+
+            if input.peek(Token![,]) {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(Self {
+            name: name.ok_or_else(|| input.error("missing `name`"))?,
+            description: description.ok_or_else(|| input.error("missing `description`"))?,
+            input_schema: input_schema.ok_or_else(|| input.error("missing `input_schema`"))?,
+        })
+    }
+}
+
+#[proc_macro_attribute]
+pub fn tool_spec(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(attr as ToolSpecArgs);
+    let mut item = parse_macro_input!(item as ItemImpl);
+    let name = args.name;
+    let description = args.description;
+    let input_schema = args.input_schema;
+
+    item.items.insert(
+        0,
+        parse_quote! {
+            fn input_schema(&self) -> serde_json::Value {
+                serde_json::json!({ #input_schema })
+            }
+        },
+    );
+    item.items.insert(
+        0,
+        parse_quote! {
+            fn description(&self) -> &str {
+                #description
+            }
+        },
+    );
+    item.items.insert(
+        0,
+        parse_quote! {
+            fn name(&self) -> &str {
+                #name
+            }
+        },
+    );
+
+    quote!(#item).into()
+}

--- a/crates/tool-macros/src/lib.rs
+++ b/crates/tool-macros/src/lib.rs
@@ -20,9 +20,16 @@ impl Parse for ToolSpecArgs {
             let key: Ident = input.parse()?;
             input.parse::<Token![=]>()?;
             match key.to_string().as_str() {
-                "name" => name = Some(input.parse()?),
-                "description" => description = Some(input.parse()?),
+                "name" => {
+                    reject_duplicate(&name, &key)?;
+                    name = Some(input.parse()?);
+                }
+                "description" => {
+                    reject_duplicate(&description, &key)?;
+                    description = Some(input.parse()?);
+                }
                 "input_schema" => {
+                    reject_duplicate(&input_schema, &key)?;
                     let content;
                     braced!(content in input);
                     input_schema = Some(content.parse()?);
@@ -35,7 +42,7 @@ impl Parse for ToolSpecArgs {
                 }
             }
 
-            if input.peek(Token![,]) {
+            if !input.is_empty() {
                 input.parse::<Token![,]>()?;
             }
         }
@@ -45,6 +52,17 @@ impl Parse for ToolSpecArgs {
             description: description.ok_or_else(|| input.error("missing `description`"))?,
             input_schema: input_schema.ok_or_else(|| input.error("missing `input_schema`"))?,
         })
+    }
+}
+
+fn reject_duplicate<T>(slot: &Option<T>, key: &Ident) -> Result<()> {
+    if slot.is_some() {
+        Err(syn::Error::new(
+            key.span(),
+            format!("duplicate `{}` key", key),
+        ))
+    } else {
+        Ok(())
     }
 }
 
@@ -82,4 +100,33 @@ pub fn tool_spec(attr: TokenStream, item: TokenStream) -> TokenStream {
     );
 
     quote!(#item).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ToolSpecArgs;
+
+    #[test]
+    fn rejects_duplicate_keys() {
+        let error = match syn::parse_str::<ToolSpecArgs>(
+            r#"name = "first", name = "second", description = "desc", input_schema = {}"#,
+        ) {
+            Ok(_) => panic!("duplicate name should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("duplicate `name` key"));
+    }
+
+    #[test]
+    fn rejects_missing_commas_between_keys() {
+        let error = match syn::parse_str::<ToolSpecArgs>(
+            r#"name = "tool" description = "desc", input_schema = {}"#,
+        ) {
+            Ok(_) => panic!("missing comma should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("expected `,`"));
+    }
 }

--- a/src/agent/tests/support.rs
+++ b/src/agent/tests/support.rs
@@ -2,6 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
@@ -16,33 +17,25 @@ use crate::workspace::WorkspaceMemory;
 pub(super) struct StubTool;
 pub(super) struct StubBashTool;
 
+#[tool_spec(
+    name = "stub_tool",
+    description = "Return a simple structured result",
+    input_schema = { "type": "object" }
+)]
 #[async_trait]
 impl Tool for StubTool {
-    fn name(&self) -> &str {
-        "stub_tool"
-    }
-    fn description(&self) -> &str {
-        "Return a simple structured result"
-    }
-    fn input_schema(&self) -> Value {
-        json!({"type":"object"})
-    }
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({ "status": "ok", "value": 42 }))
     }
 }
 
+#[tool_spec(
+    name = "bash",
+    description = "Return a simple bash result",
+    input_schema = { "type": "object" }
+)]
 #[async_trait]
 impl Tool for StubBashTool {
-    fn name(&self) -> &str {
-        "bash"
-    }
-    fn description(&self) -> &str {
-        "Return a simple bash result"
-    }
-    fn input_schema(&self) -> Value {
-        json!({"type":"object"})
-    }
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({ "stdout": "ok\n", "stderr": "", "exit_code": 0 }))
     }
@@ -50,17 +43,13 @@ impl Tool for StubBashTool {
 
 pub(super) struct ListFilesStub;
 
+#[tool_spec(
+    name = "list_files",
+    description = "Return a simple list result",
+    input_schema = { "type": "object" }
+)]
 #[async_trait]
 impl Tool for ListFilesStub {
-    fn name(&self) -> &str {
-        "list_files"
-    }
-    fn description(&self) -> &str {
-        "Return a simple list result"
-    }
-    fn input_schema(&self) -> Value {
-        json!({"type":"object"})
-    }
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({ "path": ".", "entries": [] }))
     }
@@ -68,17 +57,13 @@ impl Tool for ListFilesStub {
 
 pub(super) struct PlanAgentStub;
 
+#[tool_spec(
+    name = "plan_agent",
+    description = "Return a delegated planning result",
+    input_schema = { "type": "object" }
+)]
 #[async_trait]
 impl Tool for PlanAgentStub {
-    fn name(&self) -> &str {
-        "plan_agent"
-    }
-    fn description(&self) -> &str {
-        "Return a delegated planning result"
-    }
-    fn input_schema(&self) -> Value {
-        json!({"type":"object"})
-    }
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({ "status": "ok", "summary": "delegated inspection complete" }))
     }

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 
 use crate::agent::{Agent, AgentExecutionMode, Message, PendingUserInput, PlanStep};
@@ -118,27 +119,20 @@ pub struct AgentTool {
     pub prompt_config: PromptRuntimeConfig,
 }
 
+#[tool_spec(
+    name = "spawn_agent",
+    description = "Spawn a no-tool reasoning sub-agent. It cannot inspect files, run shell commands, edit files, or spawn other agents; use explore_agent or plan_agent for read-only repository inspection.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "instruction": { "type": "string" }
+        },
+        "required": ["name", "instruction"]
+    }
+)]
 #[async_trait]
 impl Tool for AgentTool {
-    fn name(&self) -> &str {
-        "spawn_agent"
-    }
-
-    fn description(&self) -> &str {
-        "Spawn a no-tool reasoning sub-agent. It cannot inspect files, run shell commands, edit files, or spawn other agents; use explore_agent or plan_agent for read-only repository inspection."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "name": { "type": "string" },
-                "instruction": { "type": "string" }
-            },
-            "required": ["name", "instruction"]
-        })
-    }
-
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let name = i["name"].as_str().unwrap_or("worker");
         let instruction = i["instruction"]
@@ -174,26 +168,19 @@ pub struct ExploreAgentTool {
     pub prompt_config: PromptRuntimeConfig,
 }
 
+#[tool_spec(
+    name = "explore_agent",
+    description = "Spawn a read-only exploration sub-agent for bounded independent sidecar repository inspection. The instruction must be self-contained and include all user constraints.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "instruction": { "type": "string" }
+        },
+        "required": ["instruction"]
+    }
+)]
 #[async_trait]
 impl Tool for ExploreAgentTool {
-    fn name(&self) -> &str {
-        "explore_agent"
-    }
-
-    fn description(&self) -> &str {
-        "Spawn a read-only exploration sub-agent for bounded independent sidecar repository inspection. The instruction must be self-contained and include all user constraints."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "instruction": { "type": "string" }
-            },
-            "required": ["instruction"]
-        })
-    }
-
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let instruction = i["instruction"]
             .as_str()
@@ -227,26 +214,19 @@ pub struct PlanAgentTool {
     pub prompt_config: PromptRuntimeConfig,
 }
 
+#[tool_spec(
+    name = "plan_agent",
+    description = "Spawn a read-only planning sub-agent for bounded independent sidecar plan refinement. The instruction must be self-contained and include all user constraints.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "instruction": { "type": "string" }
+        },
+        "required": ["instruction"]
+    }
+)]
 #[async_trait]
 impl Tool for PlanAgentTool {
-    fn name(&self) -> &str {
-        "plan_agent"
-    }
-
-    fn description(&self) -> &str {
-        "Spawn a read-only planning sub-agent for bounded independent sidecar plan refinement. The instruction must be self-contained and include all user constraints."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "instruction": { "type": "string" }
-            },
-            "required": ["instruction"]
-        })
-    }
-
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let instruction = i["instruction"]
             .as_str()
@@ -284,24 +264,17 @@ pub struct TeamCreateTool {
     pub workspace: Arc<WorkspaceMemory>,
 }
 
+#[tool_spec(
+    name = "team_create",
+    description = "Launch parallel sub-agents",
+    input_schema = {
+        "type": "object",
+        "properties": { "tasks": { "type": "array" } },
+        "required": ["tasks"]
+    }
+)]
 #[async_trait]
 impl Tool for TeamCreateTool {
-    fn name(&self) -> &str {
-        "team_create"
-    }
-
-    fn description(&self) -> &str {
-        "Launch parallel sub-agents"
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": { "tasks": { "type": "array" } },
-            "required": ["tasks"]
-        })
-    }
-
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let tasks = i["tasks"]
             .as_array()

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
@@ -740,72 +741,68 @@ fn command_env_for_wrapped(
     }
 }
 
+#[tool_spec(
+    name = "bash",
+    description = "Run a shell command in the sandbox for commands that need process execution. Prefer dedicated RARA tools for file search, file reads, and file edits; do not use shell redirection, sed, awk, perl, or ad-hoc scripts to edit files when apply_patch or direct file tools can do the job. Use the cwd field instead of prepending cd. Avoid newline-separated command chaining. If commands are independent and can run in parallel, make multiple bash tool calls in one assistant turn instead of joining them with &&, ;, or pipelines. Do not add 2>&1, head, tail, or grep only to reduce displayed output; RARA preserves stdout/stderr and provides bounded model-facing previews. Commands must be non-interactive: do not start editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, always supply the message with git commit -m or git commit -F; never run bare git commit and wait for an editor. Keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "string",
+                "description": "Legacy shell command string. Prefer program+args for new calls. Avoid newline-separated command chaining. Do not join independent validation commands with &&, ;, or pipelines just to run them together; make multiple bash tool calls instead. Do not add 2>&1, head, tail, or grep only to trim output for the model. Do not run interactive editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, use git commit -m or git commit -F, never bare git commit. Do not use this field for file edits when apply_patch or direct file tools can do the job."
+            },
+            "program": {
+                "type": "string",
+                "description": "Executable to run directly without a shell. Prefer this with args for ordinary commands."
+            },
+            "args": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Arguments for program."
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Optional working directory override. Defaults to the current turn cwd; prefer this over prepending cd to a command."
+            },
+            "env": {
+                "type": "object",
+                "additionalProperties": { "type": "string" },
+                "description": "Optional environment overrides."
+            },
+            "allow_net": {
+                "type": "boolean",
+                "default": false,
+                "description": "Request network access for this command. Commands already have network access when sandbox_workspace_write.network_access is enabled in config."
+            },
+            "run_in_background": {
+                "type": "boolean",
+                "default": false,
+                "description": "Run a long-running non-interactive command as a background task and return a task id immediately. Use background_task_status to inspect output later, background_task_list to find tasks, and background_task_stop to stop them."
+            },
+            "sandbox_permissions": {
+                "type": "string",
+                "enum": ["use_default", "require_escalated"],
+                "default": "use_default",
+                "description": "Sandbox permissions for the command. Defaults to use_default. Set to require_escalated only when the user asked for it or sandbox failure evidence shows the command cannot work inside the sandbox."
+            },
+            "justification": {
+                "type": "string",
+                "description": "Only set if sandbox_permissions is require_escalated. Ask the user a short question explaining why this command needs to run outside the sandbox."
+            },
+            "prefix_rule": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Only set if sandbox_permissions is require_escalated. Suggested scoped command prefix to approve for similar future commands, for example [\"git\", \"push\"] or [\"cargo\", \"test\"]. Do not suggest broad prefixes."
+            }
+        },
+        "anyOf": [
+            { "required": ["command"] },
+            { "required": ["program"] }
+        ]
+    }
+)]
 #[async_trait]
 impl Tool for BashTool {
-    fn name(&self) -> &str {
-        "bash"
-    }
-    fn description(&self) -> &str {
-        "Run a shell command in the sandbox for commands that need process execution. Prefer dedicated RARA tools for file search, file reads, and file edits; do not use shell redirection, sed, awk, perl, or ad-hoc scripts to edit files when apply_patch or direct file tools can do the job. Use the cwd field instead of prepending cd. Avoid newline-separated command chaining. If commands are independent and can run in parallel, make multiple bash tool calls in one assistant turn instead of joining them with &&, ;, or pipelines. Do not add 2>&1, head, tail, or grep only to reduce displayed output; RARA preserves stdout/stderr and provides bounded model-facing previews. Commands must be non-interactive: do not start editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, always supply the message with git commit -m or git commit -F; never run bare git commit and wait for an editor. Keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop."
-    }
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "command": {
-                    "type": "string",
-                    "description": "Legacy shell command string. Prefer program+args for new calls. Avoid newline-separated command chaining. Do not join independent validation commands with &&, ;, or pipelines just to run them together; make multiple bash tool calls instead. Do not add 2>&1, head, tail, or grep only to trim output for the model. Do not run interactive editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, use git commit -m or git commit -F, never bare git commit. Do not use this field for file edits when apply_patch or direct file tools can do the job."
-                },
-                "program": {
-                    "type": "string",
-                    "description": "Executable to run directly without a shell. Prefer this with args for ordinary commands."
-                },
-                "args": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Arguments for program."
-                },
-                "cwd": {
-                    "type": "string",
-                    "description": "Optional working directory override. Defaults to the current turn cwd; prefer this over prepending cd to a command."
-                },
-                "env": {
-                    "type": "object",
-                    "additionalProperties": { "type": "string" },
-                    "description": "Optional environment overrides."
-                },
-                "allow_net": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Request network access for this command. Commands already have network access when sandbox_workspace_write.network_access is enabled in config."
-                },
-                "run_in_background": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Run a long-running non-interactive command as a background task and return a task id immediately. Use background_task_status to inspect output later, background_task_list to find tasks, and background_task_stop to stop them."
-                },
-                "sandbox_permissions": {
-                    "type": "string",
-                    "enum": ["use_default", "require_escalated"],
-                    "default": "use_default",
-                    "description": "Sandbox permissions for the command. Defaults to use_default. Set to require_escalated only when the user asked for it or sandbox failure evidence shows the command cannot work inside the sandbox."
-                },
-                "justification": {
-                    "type": "string",
-                    "description": "Only set if sandbox_permissions is require_escalated. Ask the user a short question explaining why this command needs to run outside the sandbox."
-                },
-                "prefix_rule": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Only set if sandbox_permissions is require_escalated. Suggested scoped command prefix to approve for similar future commands, for example [\"git\", \"push\"] or [\"cargo\", \"test\"]. Do not suggest broad prefixes."
-                }
-            },
-            "anyOf": [
-                { "required": ["command"] },
-                { "required": ["program"] }
-            ]
-        })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         self.call_with_events(i, &mut |_| {}).await
     }
@@ -1070,23 +1067,16 @@ impl Tool for BashTool {
     }
 }
 
+#[tool_spec(
+    name = "background_task_list",
+    description = "List background bash tasks started with bash run_in_background. Use this before starting duplicate long-running work when task state is unclear.",
+    input_schema = {
+        "type": "object",
+        "properties": {}
+    }
+)]
 #[async_trait]
 impl Tool for BackgroundTaskListTool {
-    fn name(&self) -> &str {
-        "background_task_list"
-    }
-
-    fn description(&self) -> &str {
-        "List background bash tasks started with bash run_in_background. Use this before starting duplicate long-running work when task state is unclear."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {}
-        })
-    }
-
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({
             "tasks": self.background_tasks.list(),
@@ -1094,35 +1084,28 @@ impl Tool for BackgroundTaskListTool {
     }
 }
 
+#[tool_spec(
+    name = "background_task_status",
+    description = "Inspect a background bash task started with bash run_in_background and read the tail of its output.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Background task id returned by bash run_in_background."
+            },
+            "tail_bytes": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 12000,
+                "description": "Maximum number of output bytes to return from the end of the task log."
+            }
+        },
+        "required": ["task_id"]
+    }
+)]
 #[async_trait]
 impl Tool for BackgroundTaskStatusTool {
-    fn name(&self) -> &str {
-        "background_task_status"
-    }
-
-    fn description(&self) -> &str {
-        "Inspect a background bash task started with bash run_in_background and read the tail of its output."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "task_id": {
-                    "type": "string",
-                    "description": "Background task id returned by bash run_in_background."
-                },
-                "tail_bytes": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "default": 12000,
-                    "description": "Maximum number of output bytes to return from the end of the task log."
-                }
-            },
-            "required": ["task_id"]
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let task_id = input["task_id"]
             .as_str()
@@ -1152,28 +1135,21 @@ impl Tool for BackgroundTaskStatusTool {
     }
 }
 
+#[tool_spec(
+    name = "background_task_stop",
+    description = "Stop one background bash task, or all running background bash tasks when task_id is omitted.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Background task id returned by bash run_in_background. Omit to stop all running background bash tasks."
+            }
+        }
+    }
+)]
 #[async_trait]
 impl Tool for BackgroundTaskStopTool {
-    fn name(&self) -> &str {
-        "background_task_stop"
-    }
-
-    fn description(&self) -> &str {
-        "Stop one background bash task, or all running background bash tasks when task_id is omitted."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "task_id": {
-                    "type": "string",
-                    "description": "Background task id returned by bash run_in_background. Omit to stop all running background bash tasks."
-                }
-            }
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         if let Some(task_id) = input.get("task_id").and_then(Value::as_str) {
             let task = self.background_tasks.stop(task_id)?;

--- a/src/tools/context.rs
+++ b/src/tools/context.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 
 use crate::llm::LlmBackend;
@@ -13,17 +14,13 @@ pub struct RetrieveSessionContextTool {
     pub vdb: Arc<VectorDB>,
     pub session_manager: Arc<SessionManager>,
 }
+#[tool_spec(
+    name = "retrieve_session_context",
+    description = "Recall past context",
+    input_schema = { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
+)]
 #[async_trait]
 impl Tool for RetrieveSessionContextTool {
-    fn name(&self) -> &str {
-        "retrieve_session_context"
-    }
-    fn description(&self) -> &str {
-        "Recall past context"
-    }
-    fn input_schema(&self) -> Value {
-        json!({ "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] })
-    }
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let query = input["query"]
             .as_str()

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader as AsyncBufReader};
 use walkdir::WalkDir;
@@ -166,27 +167,23 @@ impl Default for ReadFileTool {
     }
 }
 
+#[tool_spec(
+    name = "read_file",
+    description = "Read a file with Codex-style 1-based offset/limit windows. Defaults to the first 2000 lines and reports next_offset when more content remains.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "path": { "type": "string", "description": "Path to read." },
+            "offset": { "type": "integer", "minimum": 1, "description": "Optional 1-based first line to include. Use next_offset from a truncated result to continue." },
+            "limit": { "type": "integer", "minimum": 1, "description": "Optional maximum number of lines to return. Defaults to 2000." },
+            "start_line": { "type": "integer", "minimum": 1, "description": "Legacy alias for offset." },
+            "end_line": { "type": "integer", "minimum": 1, "description": "Legacy 1-based inclusive last line. Prefer offset/limit for new calls." }
+        },
+        "required": ["path"]
+    }
+)]
 #[async_trait]
 impl Tool for ReadFileTool {
-    fn name(&self) -> &str {
-        "read_file"
-    }
-    fn description(&self) -> &str {
-        "Read a file with Codex-style 1-based offset/limit windows. Defaults to the first 2000 lines and reports next_offset when more content remains."
-    }
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Path to read." },
-                "offset": { "type": "integer", "minimum": 1, "description": "Optional 1-based first line to include. Use next_offset from a truncated result to continue." },
-                "limit": { "type": "integer", "minimum": 1, "description": "Optional maximum number of lines to return. Defaults to 2000." },
-                "start_line": { "type": "integer", "minimum": 1, "description": "Legacy alias for offset." },
-                "end_line": { "type": "integer", "minimum": 1, "description": "Legacy 1-based inclusive last line. Prefer offset/limit for new calls." }
-            },
-            "required": ["path"]
-        })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let p = i["path"]
             .as_str()
@@ -463,24 +460,20 @@ impl Default for WriteFileTool {
     }
 }
 
+#[tool_spec(
+    name = "write_file",
+    description = "Create a new file or intentionally rewrite one whole file. For existing files, read the full file first and prefer apply_patch for partial edits. If a large write fails or appears truncated, retry with direct edit tools or report the tool failure; do not fall back to shell heredocs or redirection to write files.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "path": { "type": "string", "description": "Path to create or fully rewrite." },
+            "content": { "type": "string", "description": "Complete new file contents for exactly this path. Do not use for small edits to existing files or shell heredoc fallbacks." }
+        },
+        "required": ["path", "content"]
+    }
+)]
 #[async_trait]
 impl Tool for WriteFileTool {
-    fn name(&self) -> &str {
-        "write_file"
-    }
-    fn description(&self) -> &str {
-        "Create a new file or intentionally rewrite one whole file. For existing files, read the full file first and prefer apply_patch for partial edits. If a large write fails or appears truncated, retry with direct edit tools or report the tool failure; do not fall back to shell heredocs or redirection to write files."
-    }
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Path to create or fully rewrite." },
-                "content": { "type": "string", "description": "Complete new file contents for exactly this path. Do not use for small edits to existing files or shell heredoc fallbacks." }
-            },
-            "required": ["path", "content"]
-        })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let p = i["path"]
             .as_str()
@@ -533,25 +526,21 @@ impl Default for ReplaceTool {
     }
 }
 
+#[tool_spec(
+    name = "replace",
+    description = "Replace one exact, unique string in a file. Read the relevant file content first and prefer apply_patch for structured multi-line edits.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "path": { "type": "string", "description": "Path to edit." },
+            "old_string": { "type": "string", "description": "Exact text to replace. It must appear exactly once in the file." },
+            "new_string": { "type": "string", "description": "Replacement text." }
+        },
+        "required": ["path", "old_string", "new_string"]
+    }
+)]
 #[async_trait]
 impl Tool for ReplaceTool {
-    fn name(&self) -> &str {
-        "replace"
-    }
-    fn description(&self) -> &str {
-        "Replace one exact, unique string in a file. Read the relevant file content first and prefer apply_patch for structured multi-line edits."
-    }
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Path to edit." },
-                "old_string": { "type": "string", "description": "Exact text to replace. It must appear exactly once in the file." },
-                "new_string": { "type": "string", "description": "Replacement text." }
-            },
-            "required": ["path", "old_string", "new_string"]
-        })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let p = i["path"]
             .as_str()
@@ -605,29 +594,25 @@ impl Default for ReplaceLinesTool {
     }
 }
 
+#[tool_spec(
+    name = "replace_lines",
+    description = "Replace an inclusive line range in a file. Use only after reading the full file and verifying the current line numbers.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "path": { "type": "string", "description": "Path to edit." },
+            "start_line": { "type": "integer", "minimum": 1, "description": "1-based first line to replace." },
+            "end_line": { "type": "integer", "minimum": 1, "description": "1-based last line to replace, inclusive." },
+            "new_string": {
+                "type": "string",
+                "description": "Replacement text for the inclusive line range. Use an empty string to delete the range."
+            }
+        },
+        "required": ["path", "start_line", "end_line", "new_string"]
+    }
+)]
 #[async_trait]
 impl Tool for ReplaceLinesTool {
-    fn name(&self) -> &str {
-        "replace_lines"
-    }
-    fn description(&self) -> &str {
-        "Replace an inclusive line range in a file. Use only after reading the full file and verifying the current line numbers."
-    }
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string", "description": "Path to edit." },
-                "start_line": { "type": "integer", "minimum": 1, "description": "1-based first line to replace." },
-                "end_line": { "type": "integer", "minimum": 1, "description": "1-based last line to replace, inclusive." },
-                "new_string": {
-                    "type": "string",
-                    "description": "Replacement text for the inclusive line range. Use an empty string to delete the range."
-                }
-            },
-            "required": ["path", "start_line", "end_line", "new_string"]
-        })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let path = i["path"]
             .as_str()
@@ -708,24 +693,20 @@ impl Tool for ReplaceLinesTool {
 }
 
 pub struct ListFilesTool;
+#[tool_spec(
+    name = "list_files",
+    description = "Recursively list files",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "path": { "type": "string" },
+            "include_ignored": { "type": "boolean" }
+        },
+        "required": ["path"]
+    }
+)]
 #[async_trait]
 impl Tool for ListFilesTool {
-    fn name(&self) -> &str {
-        "list_files"
-    }
-    fn description(&self) -> &str {
-        "Recursively list files"
-    }
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "path": { "type": "string" },
-                "include_ignored": { "type": "boolean" }
-            },
-            "required": ["path"]
-        })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let p = i["path"]
             .as_str()

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 
 use crate::tool::{Tool, ToolError};
@@ -79,33 +80,26 @@ struct PatchStats {
     removed_lines: usize,
 }
 
+#[tool_spec(
+    name = "apply_patch",
+    description = "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files. Update operations verify hunks against current file contents.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "patch": {
+                "type": "string",
+                "description": "Patch text using *** Begin Patch / *** End Patch syntax."
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "Validate and preview without writing files."
+            }
+        },
+        "required": ["patch"]
+    }
+)]
 #[async_trait]
 impl Tool for ApplyPatchTool {
-    fn name(&self) -> &str {
-        "apply_patch"
-    }
-
-    fn description(&self) -> &str {
-        "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files. Update operations verify hunks against current file contents."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "patch": {
-                    "type": "string",
-                    "description": "Patch text using *** Begin Patch / *** End Patch syntax."
-                },
-                "dry_run": {
-                    "type": "boolean",
-                    "description": "Validate and preview without writing files."
-                }
-            },
-            "required": ["patch"]
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let patch = input
             .get("patch")

--- a/src/tools/planning.rs
+++ b/src/tools/planning.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 
 use crate::tool::{Tool, ToolError};
@@ -9,23 +10,16 @@ pub const EXIT_PLAN_MODE_TOOL_NAME: &str = "exit_plan_mode";
 pub struct EnterPlanModeTool;
 pub struct ExitPlanModeTool;
 
+#[tool_spec(
+    name = ENTER_PLAN_MODE_TOOL_NAME,
+    description = "Enter read-only planning mode when the task needs repository exploration and design before implementation",
+    input_schema = {
+        "type": "object",
+        "properties": {},
+    }
+)]
 #[async_trait]
 impl Tool for EnterPlanModeTool {
-    fn name(&self) -> &str {
-        ENTER_PLAN_MODE_TOOL_NAME
-    }
-
-    fn description(&self) -> &str {
-        "Enter read-only planning mode when the task needs repository exploration and design before implementation"
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {},
-        })
-    }
-
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({
             "status": "entered_plan_mode",
@@ -65,63 +59,56 @@ mod tests {
     }
 }
 
-#[async_trait]
-impl Tool for ExitPlanModeTool {
-    fn name(&self) -> &str {
-        EXIT_PLAN_MODE_TOOL_NAME
-    }
-
-    fn description(&self) -> &str {
-        "Submit a concrete implementation plan for structured user approval. Prefer passing the plan in the proposed_plan argument. If structured tool arguments are unavailable, this same assistant response must emit a complete <proposed_plan>...</proposed_plan> block before calling this tool."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "proposed_plan": {
-                    "type": "object",
-                    "description": "Structured implementation plan to submit for approval.",
-                    "properties": {
-                        "summary": {
-                            "type": "string",
-                            "description": "One concise sentence describing the implementation goal."
-                        },
-                        "steps": {
-                            "type": "array",
-                            "description": "Concrete implementation steps. Runtime treats only this array as executable plan state.",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "step": {
-                                        "type": "string",
-                                        "description": "One concrete implementation step."
-                                    },
-                                    "status": {
-                                        "type": "string",
-                                        "enum": ["pending", "in_progress", "completed"],
-                                        "description": "Current step status. Use pending for new plans unless a step is already complete."
-                                    }
+#[tool_spec(
+    name = EXIT_PLAN_MODE_TOOL_NAME,
+    description = "Submit a concrete implementation plan for structured user approval. Prefer passing the plan in the proposed_plan argument. If structured tool arguments are unavailable, this same assistant response must emit a complete <proposed_plan>...</proposed_plan> block before calling this tool.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "proposed_plan": {
+                "type": "object",
+                "description": "Structured implementation plan to submit for approval.",
+                "properties": {
+                    "summary": {
+                        "type": "string",
+                        "description": "One concise sentence describing the implementation goal."
+                    },
+                    "steps": {
+                        "type": "array",
+                        "description": "Concrete implementation steps. Runtime treats only this array as executable plan state.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "step": {
+                                    "type": "string",
+                                    "description": "One concrete implementation step."
                                 },
-                                "required": ["step", "status"],
-                                "additionalProperties": false
-                            }
-                        },
-                        "validation": {
-                            "type": "array",
-                            "description": "Focused tests or commands that should validate the implementation.",
-                            "items": { "type": "string" }
+                                "status": {
+                                    "type": "string",
+                                    "enum": ["pending", "in_progress", "completed"],
+                                    "description": "Current step status. Use pending for new plans unless a step is already complete."
+                                }
+                            },
+                            "required": ["step", "status"],
+                            "additionalProperties": false
                         }
                     },
-                    "required": ["summary", "steps", "validation"],
-                    "additionalProperties": false
-                }
-            },
-            "required": ["proposed_plan"],
-            "additionalProperties": false,
-        })
+                    "validation": {
+                        "type": "array",
+                        "description": "Focused tests or commands that should validate the implementation.",
+                        "items": { "type": "string" }
+                    }
+                },
+                "required": ["summary", "steps", "validation"],
+                "additionalProperties": false
+            }
+        },
+        "required": ["proposed_plan"],
+        "additionalProperties": false,
     }
-
+)]
+#[async_trait]
+impl Tool for ExitPlanModeTool {
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({
             "status": "exited_plan_mode",

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use uuid::Uuid;
@@ -363,45 +364,38 @@ impl PtySessionSnapshot {
     }
 }
 
+#[tool_spec(
+    name = "pty_start",
+    description = "Start an interactive PTY session only for commands that need terminal input, terminal control, or an interactive program. For ordinary non-interactive commands, use bash instead. Prefer dedicated RARA tools for file search, file reads, and file edits. Use the cwd field instead of prepending cd. PTY sandboxing is platform-dependent and best-effort; with the macOS seatbelt backend, PTY commands currently run directly because sandbox-exec does not preserve interactive PTY stdin reliably. Treat allow_net as a network-access toggle, not a sandbox guarantee. Inspect or stop sessions with pty_status, pty_list, and pty_stop.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "string",
+                "description": "Shell command to run inside a PTY. Use PTY only for interactive commands; use bash for ordinary non-interactive commands."
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Optional working directory. Defaults to the current turn cwd; prefer this over prepending cd to a command."
+            },
+            "env": {
+                "type": "object",
+                "additionalProperties": { "type": "string" },
+                "description": "Optional environment overrides."
+            },
+            "allow_net": {
+                "type": "boolean",
+                "default": false,
+                "description": "Request network access for this PTY session. PTY sessions already have network access when sandbox_workspace_write.network_access is enabled in config."
+            },
+            "rows": { "type": "integer", "default": 24, "minimum": 1, "maximum": 65535 },
+            "cols": { "type": "integer", "default": 120, "minimum": 1, "maximum": 65535 }
+        },
+        "required": ["command"]
+    }
+)]
 #[async_trait]
 impl Tool for PtyStartTool {
-    fn name(&self) -> &str {
-        "pty_start"
-    }
-
-    fn description(&self) -> &str {
-        "Start an interactive PTY session only for commands that need terminal input, terminal control, or an interactive program. For ordinary non-interactive commands, use bash instead. Prefer dedicated RARA tools for file search, file reads, and file edits. Use the cwd field instead of prepending cd. PTY sandboxing is platform-dependent and best-effort; with the macOS seatbelt backend, PTY commands currently run directly because sandbox-exec does not preserve interactive PTY stdin reliably. Treat allow_net as a network-access toggle, not a sandbox guarantee. Inspect or stop sessions with pty_status, pty_list, and pty_stop."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "command": {
-                    "type": "string",
-                    "description": "Shell command to run inside a PTY. Use PTY only for interactive commands; use bash for ordinary non-interactive commands."
-                },
-                "cwd": {
-                    "type": "string",
-                    "description": "Optional working directory. Defaults to the current turn cwd; prefer this over prepending cd to a command."
-                },
-                "env": {
-                    "type": "object",
-                    "additionalProperties": { "type": "string" },
-                    "description": "Optional environment overrides."
-                },
-                "allow_net": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Request network access for this PTY session. PTY sessions already have network access when sandbox_workspace_write.network_access is enabled in config."
-                },
-                "rows": { "type": "integer", "default": 24, "minimum": 1, "maximum": 65535 },
-                "cols": { "type": "integer", "default": 120, "minimum": 1, "maximum": 65535 }
-            },
-            "required": ["command"]
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let command = input["command"]
             .as_str()
@@ -443,27 +437,20 @@ impl Tool for PtyStartTool {
     }
 }
 
+#[tool_spec(
+    name = "pty_read",
+    description = "Read recent output from a PTY session started with pty_start.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "session_id": { "type": "string" },
+            "tail_bytes": { "type": "integer", "default": 12000, "minimum": 1 }
+        },
+        "required": ["session_id"]
+    }
+)]
 #[async_trait]
 impl Tool for PtyReadTool {
-    fn name(&self) -> &str {
-        "pty_read"
-    }
-
-    fn description(&self) -> &str {
-        "Read recent output from a PTY session started with pty_start."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "session_id": { "type": "string" },
-                "tail_bytes": { "type": "integer", "default": 12000, "minimum": 1 }
-            },
-            "required": ["session_id"]
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let session_id = input["session_id"]
             .as_str()
@@ -483,23 +470,16 @@ impl Tool for PtyReadTool {
     }
 }
 
+#[tool_spec(
+    name = "pty_list",
+    description = "List PTY sessions started with pty_start. Use this before starting duplicate interactive work when session state is unclear.",
+    input_schema = {
+        "type": "object",
+        "properties": {}
+    }
+)]
 #[async_trait]
 impl Tool for PtyListTool {
-    fn name(&self) -> &str {
-        "pty_list"
-    }
-
-    fn description(&self) -> &str {
-        "List PTY sessions started with pty_start. Use this before starting duplicate interactive work when session state is unclear."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {}
-        })
-    }
-
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         let sessions = self
             .sessions
@@ -511,27 +491,20 @@ impl Tool for PtyListTool {
     }
 }
 
+#[tool_spec(
+    name = "pty_status",
+    description = "Inspect a PTY session started with pty_start and read the tail of its output.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "session_id": { "type": "string" },
+            "tail_bytes": { "type": "integer", "default": 12000, "minimum": 1 }
+        },
+        "required": ["session_id"]
+    }
+)]
 #[async_trait]
 impl Tool for PtyStatusTool {
-    fn name(&self) -> &str {
-        "pty_status"
-    }
-
-    fn description(&self) -> &str {
-        "Inspect a PTY session started with pty_start and read the tail of its output."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "session_id": { "type": "string" },
-                "tail_bytes": { "type": "integer", "default": 12000, "minimum": 1 }
-            },
-            "required": ["session_id"]
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         PtyReadTool {
             sessions: self.sessions.clone(),
@@ -541,27 +514,20 @@ impl Tool for PtyStatusTool {
     }
 }
 
+#[tool_spec(
+    name = "pty_write",
+    description = "Write input to a running PTY session started with pty_start.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "session_id": { "type": "string" },
+            "input": { "type": "string", "description": "Text to write, including newlines or control characters when needed." }
+        },
+        "required": ["session_id", "input"]
+    }
+)]
 #[async_trait]
 impl Tool for PtyWriteTool {
-    fn name(&self) -> &str {
-        "pty_write"
-    }
-
-    fn description(&self) -> &str {
-        "Write input to a running PTY session started with pty_start."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "session_id": { "type": "string" },
-                "input": { "type": "string", "description": "Text to write, including newlines or control characters when needed." }
-            },
-            "required": ["session_id", "input"]
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let session_id = input["session_id"]
             .as_str()
@@ -576,26 +542,19 @@ impl Tool for PtyWriteTool {
     }
 }
 
+#[tool_spec(
+    name = "pty_kill",
+    description = "Kill a PTY session started with pty_start.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "session_id": { "type": "string" }
+        },
+        "required": ["session_id"]
+    }
+)]
 #[async_trait]
 impl Tool for PtyKillTool {
-    fn name(&self) -> &str {
-        "pty_kill"
-    }
-
-    fn description(&self) -> &str {
-        "Kill a PTY session started with pty_start."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "session_id": { "type": "string" }
-            },
-            "required": ["session_id"]
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let session_id = input["session_id"]
             .as_str()
@@ -604,28 +563,21 @@ impl Tool for PtyKillTool {
     }
 }
 
+#[tool_spec(
+    name = "pty_stop",
+    description = "Stop one PTY session, or all running PTY sessions when session_id is omitted.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "description": "PTY session id returned by pty_start. Omit to stop all running PTY sessions."
+            }
+        }
+    }
+)]
 #[async_trait]
 impl Tool for PtyStopTool {
-    fn name(&self) -> &str {
-        "pty_stop"
-    }
-
-    fn description(&self) -> &str {
-        "Stop one PTY session, or all running PTY sessions when session_id is omitted."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "session_id": {
-                    "type": "string",
-                    "description": "PTY session id returned by pty_start. Omit to stop all running PTY sessions."
-                }
-            }
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         if let Some(session_id) = input.get("session_id").and_then(Value::as_str) {
             let session = self.sessions.kill(session_id)?;

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -3,27 +3,24 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use glob::glob;
+use rara_tool_macros::tool_spec;
 use regex::Regex;
 use serde_json::{Value, json};
 
 use crate::tool::{Tool, ToolError};
 
 pub struct GlobTool;
+#[tool_spec(
+    name = "glob",
+    description = "Find files matching glob pattern",
+    input_schema = {
+        "type": "object",
+        "properties": { "pattern": { "type": "string" } },
+        "required": ["pattern"]
+    }
+)]
 #[async_trait]
 impl Tool for GlobTool {
-    fn name(&self) -> &str {
-        "glob"
-    }
-    fn description(&self) -> &str {
-        "Find files matching glob pattern"
-    }
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": { "pattern": { "type": "string" } },
-            "required": ["pattern"]
-        })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let p = i["pattern"]
             .as_str()
@@ -39,25 +36,21 @@ impl Tool for GlobTool {
 }
 
 pub struct GrepTool;
+#[tool_spec(
+    name = "grep",
+    description = "Regex search in files",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "pattern": { "type": "string" },
+            "path": { "type": "string", "default": "." },
+            "include_ignored": { "type": "boolean", "default": false }
+        },
+        "required": ["pattern"]
+    }
+)]
 #[async_trait]
 impl Tool for GrepTool {
-    fn name(&self) -> &str {
-        "grep"
-    }
-    fn description(&self) -> &str {
-        "Regex search in files"
-    }
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "pattern": { "type": "string" },
-                "path": { "type": "string", "default": "." },
-                "include_ignored": { "type": "boolean", "default": false }
-            },
-            "required": ["pattern"]
-        })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let p = i["pattern"]
             .as_str()

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 
 use crate::skill::SkillManager;
@@ -9,24 +10,20 @@ use crate::tool::{Tool, ToolError};
 pub struct SkillTool {
     pub skill_manager: Arc<SkillManager>,
 }
+#[tool_spec(
+    name = "skill",
+    description = "Manage and invoke reusable skills",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "action": { "type": "string", "enum": ["list", "invoke"] },
+            "skill_name": { "type": "string" }
+        },
+        "required": ["action"]
+    }
+)]
 #[async_trait]
 impl Tool for SkillTool {
-    fn name(&self) -> &str {
-        "skill"
-    }
-    fn description(&self) -> &str {
-        "Manage and invoke reusable skills"
-    }
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "action": { "type": "string", "enum": ["list", "invoke"] },
-                "skill_name": { "type": "string" }
-            },
-            "required": ["action"]
-        })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let action = i["action"]
             .as_str()

--- a/src/tools/todo.rs
+++ b/src/tools/todo.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
-use serde_json::{Value, json};
+use rara_tool_macros::tool_spec;
+use serde_json::Value;
 
 use crate::todo::normalize_todo_write_input;
 use crate::tool::{Tool, ToolError};
@@ -8,50 +9,43 @@ pub const TODO_WRITE_TOOL_NAME: &str = "todo_write";
 
 pub struct TodoWriteTool;
 
+#[tool_spec(
+    name = "todo_write",
+    description = "Create or replace the session todo list for complex multi-step execution. Use this to track mutable execution progress, not to request plan approval.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "todos": {
+                "type": "array",
+                "description": "Complete replacement list of todo items for the current session.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "Optional stable id. If omitted, RARA assigns todo-1, todo-2, and so on."
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Imperative description of the task."
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": ["pending", "in_progress", "completed", "cancelled"],
+                            "description": "Current task status. Keep at most one item in_progress."
+                        }
+                    },
+                    "required": ["content", "status"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["todos"],
+        "additionalProperties": false
+    }
+)]
 #[async_trait]
 impl Tool for TodoWriteTool {
-    fn name(&self) -> &str {
-        TODO_WRITE_TOOL_NAME
-    }
-
-    fn description(&self) -> &str {
-        "Create or replace the session todo list for complex multi-step execution. Use this to track mutable execution progress, not to request plan approval."
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "todos": {
-                    "type": "array",
-                    "description": "Complete replacement list of todo items for the current session.",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "string",
-                                "description": "Optional stable id. If omitted, RARA assigns todo-1, todo-2, and so on."
-                            },
-                            "content": {
-                                "type": "string",
-                                "description": "Imperative description of the task."
-                            },
-                            "status": {
-                                "type": "string",
-                                "enum": ["pending", "in_progress", "completed", "cancelled"],
-                                "description": "Current task status. Keep at most one item in_progress."
-                            }
-                        },
-                        "required": ["content", "status"],
-                        "additionalProperties": false
-                    }
-                }
-            },
-            "required": ["todos"],
-            "additionalProperties": false
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let state = normalize_todo_write_input(&input)
             .map_err(|err| ToolError::InvalidInput(err.to_string()))?;
@@ -61,6 +55,8 @@ impl Tool for TodoWriteTool {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
     use crate::todo::TodoStatus;
 

--- a/src/tools/vector.rs
+++ b/src/tools/vector.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 
 use crate::llm::LlmBackend;
@@ -13,17 +14,13 @@ pub struct RememberExperienceTool {
     pub vdb: Arc<VectorDB>,
     pub db_uri: String,
 }
+#[tool_spec(
+    name = "remember_experience",
+    description = "Save insight",
+    input_schema = { "type": "object", "properties": { "experience": { "type": "string" } }, "required": ["experience"] }
+)]
 #[async_trait]
 impl Tool for RememberExperienceTool {
-    fn name(&self) -> &str {
-        "remember_experience"
-    }
-    fn description(&self) -> &str {
-        "Save insight"
-    }
-    fn input_schema(&self) -> Value {
-        json!({ "type": "object", "properties": { "experience": { "type": "string" } }, "required": ["experience"] })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let text = i["experience"]
             .as_str()
@@ -44,17 +41,13 @@ pub struct RetrieveExperienceTool {
     pub vdb: Arc<VectorDB>,
     pub db_uri: String,
 }
+#[tool_spec(
+    name = "retrieve_experience",
+    description = "Retrieve past insights",
+    input_schema = { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
+)]
 #[async_trait]
 impl Tool for RetrieveExperienceTool {
-    fn name(&self) -> &str {
-        "retrieve_experience"
-    }
-    fn description(&self) -> &str {
-        "Retrieve past insights"
-    }
-    fn input_schema(&self) -> Value {
-        json!({ "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] })
-    }
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let query = input["query"]
             .as_str()

--- a/src/tools/web/fetch.rs
+++ b/src/tools/web/fetch.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use backon::{ExponentialBuilder, Retryable};
 use futures::StreamExt;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 use url::Url;
 
@@ -53,47 +54,40 @@ struct FetchRequest {
     max_bytes: u64,
 }
 
+#[tool_spec(
+    name = "web_fetch",
+    description = "Fetch a URL as markdown, text, or HTML with timeout and size limits",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "HTTP or HTTPS URL to fetch."
+            },
+            "format": {
+                "type": "string",
+                "enum": ["markdown", "text", "html"],
+                "default": "markdown",
+                "description": "Output format."
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": MAX_TIMEOUT_SECS,
+                "default": DEFAULT_TIMEOUT_SECS
+            },
+            "max_bytes": {
+                "type": "integer",
+                "minimum": 1024,
+                "maximum": HARD_MAX_BYTES,
+                "default": DEFAULT_MAX_BYTES
+            }
+        },
+        "required": ["url"]
+    }
+)]
 #[async_trait]
 impl Tool for WebFetchTool {
-    fn name(&self) -> &str {
-        "web_fetch"
-    }
-
-    fn description(&self) -> &str {
-        "Fetch a URL as markdown, text, or HTML with timeout and size limits"
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "url": {
-                    "type": "string",
-                    "description": "HTTP or HTTPS URL to fetch."
-                },
-                "format": {
-                    "type": "string",
-                    "enum": ["markdown", "text", "html"],
-                    "default": "markdown",
-                    "description": "Output format."
-                },
-                "timeout_seconds": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": MAX_TIMEOUT_SECS,
-                    "default": DEFAULT_TIMEOUT_SECS
-                },
-                "max_bytes": {
-                    "type": "integer",
-                    "minimum": 1024,
-                    "maximum": HARD_MAX_BYTES,
-                    "default": DEFAULT_MAX_BYTES
-                }
-            },
-            "required": ["url"]
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let request = FetchRequest::parse(&input)?;
         let client = reqwest::Client::builder()

--- a/src/tools/web/search.rs
+++ b/src/tools/web/search.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde::Serialize;
 use serde_json::{Value, json};
 
@@ -33,54 +34,47 @@ impl WebSearchTool {
     }
 }
 
+#[tool_spec(
+    name = "web_search",
+    description = "Search the web using Exa MCP for current or external information",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query."
+            },
+            "num_results": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 20,
+                "default": DEFAULT_NUM_RESULTS,
+                "description": "Maximum number of search results to return."
+            },
+            "livecrawl": {
+                "type": "string",
+                "enum": ["fallback", "preferred"],
+                "default": DEFAULT_LIVECRAWL,
+                "description": "Whether Exa should live-crawl result pages when cached content is missing or preferred."
+            },
+            "type": {
+                "type": "string",
+                "enum": ["auto", "fast", "deep"],
+                "default": DEFAULT_SEARCH_TYPE,
+                "description": "Exa search depth."
+            },
+            "context_max_characters": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 100000,
+                "description": "Optional maximum result context size."
+            }
+        },
+        "required": ["query"]
+    }
+)]
 #[async_trait]
 impl Tool for WebSearchTool {
-    fn name(&self) -> &str {
-        "web_search"
-    }
-
-    fn description(&self) -> &str {
-        "Search the web using Exa MCP for current or external information"
-    }
-
-    fn input_schema(&self) -> Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "Search query."
-                },
-                "num_results": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 20,
-                    "default": DEFAULT_NUM_RESULTS,
-                    "description": "Maximum number of search results to return."
-                },
-                "livecrawl": {
-                    "type": "string",
-                    "enum": ["fallback", "preferred"],
-                    "default": DEFAULT_LIVECRAWL,
-                    "description": "Whether Exa should live-crawl result pages when cached content is missing or preferred."
-                },
-                "type": {
-                    "type": "string",
-                    "enum": ["auto", "fast", "deep"],
-                    "default": DEFAULT_SEARCH_TYPE,
-                    "description": "Exa search depth."
-                },
-                "context_max_characters": {
-                    "type": "integer",
-                    "minimum": 1000,
-                    "maximum": 100000,
-                    "description": "Optional maximum result context size."
-                }
-            },
-            "required": ["query"]
-        })
-    }
-
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let args = parse_search_args(&input)?;
         let query = args.query.clone();

--- a/src/tools/workspace.rs
+++ b/src/tools/workspace.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 
 use crate::tool::{Tool, ToolError};
@@ -9,17 +10,20 @@ use crate::workspace::WorkspaceMemory;
 pub struct UpdateProjectMemoryTool {
     pub workspace: Arc<WorkspaceMemory>,
 }
+#[tool_spec(
+    name = "update_project_memory",
+    description = "Update memory.md",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "content": { "type": "string" },
+            "append": { "type": "boolean", "default": true }
+        },
+        "required": ["content"]
+    }
+)]
 #[async_trait]
 impl Tool for UpdateProjectMemoryTool {
-    fn name(&self) -> &str {
-        "update_project_memory"
-    }
-    fn description(&self) -> &str {
-        "Update memory.md"
-    }
-    fn input_schema(&self) -> Value {
-        json!({ "type": "object", "properties": { "content": { "type": "string" }, "append": { "type": "boolean", "default": true } }, "required": ["content"] })
-    }
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
         let content = i["content"]
             .as_str()


### PR DESCRIPTION
## Summary

- add a reusable `#[tool_spec(...)]` proc macro for static RARA tool metadata
- move repeated `name`, `description`, and `input_schema` implementations into semantic attributes across tool implementations
- keep Codex official API handling and OpenAI-compatible provider handling untouched; this PR only refactors RARA local tool metadata

## Why

Tool metadata was repeated as three boilerplate trait methods in many implementations. The new macro keeps each tool's contract near the impl while leaving the actual `call` logic unchanged.

The final diff is net smaller: 698 added lines and 772 removed lines.

## Testing

- `RUSTUP_TOOLCHAIN=nightly cargo fmt --check`
- `RUSTUP_TOOLCHAIN=nightly cargo check`
- `RUSTUP_TOOLCHAIN=nightly cargo check --tests` attempted, but the environment ran out of disk space while writing `target/debug/incremental/.../query-cache.bin`
- `RUSTUP_TOOLCHAIN=nightly cargo test tools::todo::tests -- --nocapture` attempted, but the environment ran out of disk space while building Lance test dependencies

## Notes

- Cleaned local `target` build artifacts with `RUSTUP_TOOLCHAIN=nightly cargo clean` after the filesystem reached 100% capacity.
