### PR TITLE
feat: add /permissions command with permission mode presets

### DIFF
--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -167,7 +167,8 @@ async fn run_tui_command(
     emit_bootstrap_warnings(&bootstrap.warnings);
     let sandbox_network_access = bootstrap.sandbox_network_access.clone();
     let agent = bootstrap.into_agent();
-    let resumed_thread_id = crate::tui::run_tui(agent, oauth_manager, startup_resume, sandbox_network_access).await?;
+    let resumed_thread_id =
+        crate::tui::run_tui(agent, oauth_manager, startup_resume, sandbox_network_access).await?;
     if let Some(thread_id) = resumed_thread_id {
         print!("{}", rendered_resume_hint(&thread_id));
     }

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -165,8 +165,9 @@ async fn run_tui_command(
 ) -> Result<()> {
     let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
     emit_bootstrap_warnings(&bootstrap.warnings);
+    let sandbox_network_access = bootstrap.sandbox_network_access.clone();
     let agent = bootstrap.into_agent();
-    let resumed_thread_id = crate::tui::run_tui(agent, oauth_manager, startup_resume).await?;
+    let resumed_thread_id = crate::tui::run_tui(agent, oauth_manager, startup_resume, sandbox_network_access).await?;
     if let Some(thread_id) = resumed_thread_id {
         print!("{}", rendered_resume_hint(&thread_id));
     }

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -1,6 +1,9 @@
 mod tooling;
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::AtomicBool,
+};
 
 use anyhow::{Context, Result, bail};
 
@@ -32,6 +35,7 @@ pub(crate) struct RuntimeBootstrap {
     pub tool_manager: ToolManager,
     pub prompt_config: PromptRuntimeConfig,
     pub warnings: Vec<String>,
+    pub sandbox_network_access: Arc<AtomicBool>,
 }
 
 impl RuntimeBootstrap {
@@ -91,6 +95,10 @@ pub(crate) async fn initialize_rara_context(
         })
         .collect();
 
+    let sandbox_network_access = Arc::new(AtomicBool::new(
+        config.sandbox_workspace_write.network_access,
+    ));
+
     let tool_manager = create_full_tool_manager(
         backend.clone(),
         vdb.clone(),
@@ -100,7 +108,7 @@ pub(crate) async fn initialize_rara_context(
         skill_manager,
         prompt_config.clone(),
         Arc::new(shell_env.env),
-        config.sandbox_workspace_write.network_access,
+        sandbox_network_access.clone(),
     );
     let warnings = prompt_config.warnings.clone();
 
@@ -112,6 +120,7 @@ pub(crate) async fn initialize_rara_context(
         tool_manager,
         prompt_config,
         warnings,
+        sandbox_network_access,
     })
 }
 

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -37,11 +37,11 @@ pub(crate) struct RuntimeBootstrap {
 
 impl RuntimeBootstrap {
     pub(crate) fn into_agent(self) -> Agent {
-        let (agent, _) = self.into_parts();
+        let (agent, _, _) = self.into_parts();
         agent
     }
 
-    pub(crate) fn into_parts(self) -> (Agent, Vec<String>) {
+    pub(crate) fn into_parts(self) -> (Agent, Vec<String>, Arc<AtomicBool>) {
         let mut agent = Agent::new(
             self.tool_manager,
             self.backend,
@@ -50,7 +50,7 @@ impl RuntimeBootstrap {
             self.workspace,
         );
         agent.set_prompt_config(self.prompt_config);
-        (agent, self.warnings)
+        (agent, self.warnings, self.sandbox_network_access)
     }
 }
 

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -1,9 +1,6 @@
 mod tooling;
 
-use std::sync::{
-    Arc,
-    atomic::AtomicBool,
-};
+use std::sync::{Arc, atomic::AtomicBool};
 
 use anyhow::{Context, Result, bail};
 

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::AtomicBool,
+};
 
 use crate::llm::LlmBackend;
 use crate::prompt::PromptRuntimeConfig;
@@ -40,7 +43,7 @@ pub(super) fn create_full_tool_manager(
     skill_manager: Arc<SkillManager>,
     prompt_config: PromptRuntimeConfig,
     shell_env: Arc<HashMap<String, String>>,
-    sandbox_network_access: bool,
+    sandbox_network_access: Arc<AtomicBool>,
 ) -> ToolManager {
     let mut tm = ToolManager::new();
     let vector_db_uri = vector_db_uri_for_workspace(&workspace);
@@ -57,7 +60,7 @@ pub(super) fn create_full_tool_manager(
         sandbox: sandbox.clone(),
         background_tasks: background_tasks.clone(),
         base_env: shell_env.clone(),
-        sandbox_network_access,
+        sandbox_network_access: sandbox_network_access.clone(),
     }));
     tm.register(Box::new(BackgroundTaskListTool {
         background_tasks: background_tasks.clone(),
@@ -70,7 +73,7 @@ pub(super) fn create_full_tool_manager(
         sessions: pty_sessions.clone(),
         sandbox: sandbox.clone(),
         base_env: shell_env.clone(),
-        sandbox_network_access,
+        sandbox_network_access: sandbox_network_access.clone(),
     }));
     tm.register(Box::new(PtyReadTool {
         sessions: pty_sessions.clone(),

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -1,8 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{
-    Arc,
-    atomic::AtomicBool,
-};
+use std::sync::{Arc, atomic::AtomicBool};
 
 use crate::llm::LlmBackend;
 use crate::prompt::PromptRuntimeConfig;

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -4,9 +4,9 @@ use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::time::Instant;
 

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -4,6 +4,7 @@ use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -28,7 +29,7 @@ pub struct BashTool {
     pub sandbox: Arc<SandboxManager>,
     pub background_tasks: Arc<BackgroundTaskStore>,
     pub base_env: Arc<HashMap<String, String>>,
-    pub sandbox_network_access: bool,
+    pub sandbox_network_access: Arc<AtomicBool>,
 }
 
 pub struct BackgroundTaskStatusTool {
@@ -827,7 +828,7 @@ impl Tool for BashTool {
     ) -> Result<Value, ToolError> {
         let request = BashCommandInput::from_value(i)?;
         let cwd = request.working_dir()?;
-        let allow_net = self.sandbox_network_access || request.allow_net;
+        let allow_net = self.sandbox_network_access.load(Ordering::Relaxed) || request.allow_net;
         let wrapped = if let Some(command) = request.command.as_deref() {
             if request.sandbox_permissions == BashSandboxPermissions::RequireEscalated {
                 self.sandbox.wrap_unsandboxed_shell_command(command)
@@ -1557,7 +1558,7 @@ mod tests {
                     .expect("background task store"),
             ),
             base_env: Arc::new(HashMap::new()),
-            sandbox_network_access: false,
+            sandbox_network_access: Arc::new(AtomicBool::new(false)),
         };
 
         let description = tool.description();
@@ -1871,7 +1872,7 @@ mod tests {
                     .expect("background task store"),
             ),
             base_env: Arc::new(HashMap::new()),
-            sandbox_network_access: false,
+            sandbox_network_access: Arc::new(AtomicBool::new(false)),
         };
 
         let result = tool
@@ -1938,7 +1939,7 @@ mod tests {
                     .expect("background task store"),
             ),
             base_env: Arc::new(HashMap::new()),
-            sandbox_network_access: false,
+            sandbox_network_access: Arc::new(AtomicBool::new(false)),
         };
         let mut events = Vec::new();
         let result = tool
@@ -2001,7 +2002,7 @@ mod tests {
                     .expect("background task store"),
             ),
             base_env: Arc::new(HashMap::new()),
-            sandbox_network_access: false,
+            sandbox_network_access: Arc::new(AtomicBool::new(false)),
         };
         let cancellation = Arc::new(AtomicBool::new(false));
         let cancellation_for_task = cancellation.clone();
@@ -2115,7 +2116,7 @@ mod tests {
             sandbox: Arc::new(sandbox),
             background_tasks: background_tasks.clone(),
             base_env: Arc::new(HashMap::new()),
-            sandbox_network_access: false,
+            sandbox_network_access: Arc::new(AtomicBool::new(false)),
         };
         let status_tool = BackgroundTaskStatusTool {
             background_tasks: background_tasks.clone(),
@@ -2190,7 +2191,7 @@ mod tests {
             sandbox: Arc::new(sandbox),
             background_tasks: background_tasks.clone(),
             base_env: Arc::new(HashMap::new()),
-            sandbox_network_access: false,
+            sandbox_network_access: Arc::new(AtomicBool::new(false)),
         };
         let list_tool = BackgroundTaskListTool {
             background_tasks: background_tasks.clone(),

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::fs::OpenOptions;
 use std::io::{Read, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -23,7 +24,7 @@ pub struct PtyStartTool {
     pub sessions: Arc<PtySessionStore>,
     pub sandbox: Arc<SandboxManager>,
     pub base_env: Arc<HashMap<String, String>>,
-    pub sandbox_network_access: bool,
+    pub sandbox_network_access: Arc<AtomicBool>,
 }
 
 pub struct PtyReadTool {
@@ -423,7 +424,7 @@ impl Tool for PtyStartTool {
             .get("allow_net")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        let allow_net = self.sandbox_network_access || allow_net;
+        let allow_net = self.sandbox_network_access.load(Ordering::Relaxed) || allow_net;
         let wrapped = self
             .sandbox
             .wrap_pty_shell_command(&command, &cwd, allow_net)
@@ -787,7 +788,7 @@ mod tests {
                 SandboxManager::new_for_rara_dir(temp.path().join(".rara")).expect("sandbox"),
             ),
             base_env: Arc::new(HashMap::new()),
-            sandbox_network_access: false,
+            sandbox_network_access: Arc::new(AtomicBool::new(false)),
         };
         let list = PtyListTool {
             sessions: sessions.clone(),

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -6,7 +6,7 @@ pub const COMMAND_SPECS: [CommandSpec; 21] = [
         name: "permissions",
         usage: "/permissions",
         summary: "Cycle permission mode (Auto → AcceptEdits → ReadOnly → FullAccess).",
-        detail: "Set what RARA can do without asking first. Cycles through Auto (sandbox workspace-write, bash always-approve), AcceptEdits (auto-approve file edits, suggestion bash), ReadOnly (plan mode, no edits), and FullAccess (danger-full-access with network, no approvals).",
+        detail: "Set what RARA can do without asking first. Cycles through Auto (sandbox workspace-write, bash always-approve), AcceptEdits (auto-approve file edits, suggestion bash), ReadOnly (plan mode, no edits), and FullAccess (network access, bash always-approve).",
     },
     CommandSpec {
         category: "Session",

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -1,6 +1,13 @@
 use crate::tui::state::{CommandSpec, LocalCommand, LocalCommandKind, TuiApp};
 
-pub const COMMAND_SPECS: [CommandSpec; 21] = [
+pub const COMMAND_SPECS: [CommandSpec; 22] = [
+    CommandSpec {
+        category: "Session",
+        name: "permissions",
+        usage: "/permissions",
+        summary: "Cycle permission mode (Auto → AcceptEdits → ReadOnly → FullAccess).",
+        detail: "Set what RARA can do without asking first. Cycles through Auto (sandbox workspace-write, bash always-approve), AcceptEdits (auto-approve file edits, suggestion bash), ReadOnly (plan mode, no edits), and FullAccess (danger-full-access with network, no approvals).",
+    },
     CommandSpec {
         category: "Session",
         name: "help",
@@ -178,6 +185,7 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
         "logout" => LocalCommandKind::Logout,
         "review" => LocalCommandKind::Review,
         "skills" => LocalCommandKind::Skills,
+        "permissions" | "permission" => LocalCommandKind::Permissions,
         _ => return None,
     };
 
@@ -248,7 +256,7 @@ pub fn command_detail_text(spec: &CommandSpec) -> String {
 }
 
 pub fn general_help_text() -> &'static str {
-    "RARA uses a single composer as the control surface.\n\nNormal input goes to the current agent.\nSlash commands stay local and open overlays or update runtime state.\n\nCompaction:\n  /compact forces one history compaction pass\n\nContext:\n  /context shows the effective runtime context for the current turn\n\nModes:\n  /plan enters planning mode for the current task\n  The agent may call enter_plan_mode for non-trivial repository work\n  /approval toggles bash approval between suggestion and always\n\nAuth:\n  /login opens the provider auth picker\n  /logout clears the saved provider credential\n\nEditing:\n  apply_patch is the default tool for updating existing files\n  replace_lines is for verified large line-range edits\n  write_file is for new files or full rewrites\n  replace is only a simple fallback for unique string swaps\n\nKeyboard:\n  Enter submit current composer input\n  Shift+Enter insert a newline in the composer\n  Esc close the current overlay only\n  Up/Down or j/k move inside lists\n  1/2/3 switch help tabs or choose guided model options\n\nExit:\n  /quit or /exit leave the TUI."
+    "RARA uses a single composer as the control surface.\n\nNormal input goes to the current agent.\nSlash commands stay local and open overlays or update runtime state.\n\nCompaction:\n  /compact forces one history compaction pass\n\nContext:\n  /context shows the effective runtime context for the current turn\n\nModes:\n  /permissions cycles through permission presets (auto, accept-edits, read-only, full-access)\n  /plan enters planning mode for the current task\n  The agent may call enter_plan_mode for non-trivial repository work\n  /approval toggles bash approval between suggestion and always\n\nAuth:\n  /login opens the provider auth picker\n  /logout clears the saved provider credential\n\nEditing:\n  apply_patch is the default tool for updating existing files\n  replace_lines is for verified large line-range edits\n  write_file is for new files or full rewrites\n  replace is only a simple fallback for unique string swaps\n\nKeyboard:\n  Enter submit current composer input\n  Shift+Enter insert a newline in the composer\n  Esc close the current overlay only\n  Up/Down or j/k move inside lists\n  1/2/3 switch help tabs or choose guided model options\n\nExit:\n  /quit or /exit leave the TUI."
 }
 
 fn command_score(spec: &CommandSpec, query: &str) -> Option<u8> {
@@ -296,21 +304,22 @@ pub fn help_text() -> String {
         .collect::<Vec<_>>()
         .join("\n");
     format!(
-        "Built-in commands:\n{}\n\nCompaction:\n  /compact   summarize older conversation history now\n\nThreads:\n  /resume    reopen a recent local thread\n\nModes:\n  /plan      enter planning mode for the current task\n  Agent may call enter_plan_mode automatically\n  /approval  toggle bash approval mode\n\nAuth:\n  /login     open the provider auth picker\n  /logout    clear the saved provider credential\n\nEditing:\n  apply_patch    preferred for editing existing files\n  replace_lines  use for verified large line-range edits\n  write_file     use for new files or full rewrites\n  replace        simple fallback for unique string replacement\n\nKeyboard:\n  Enter submit\n  Shift+Enter insert newline\n  Esc close current overlay\n\nExit:\n  /quit\n  /exit\n\nModel switching:\n  /model\n\nProvider URL:\n  /base-url",
+        "Built-in commands:\n{}\n\nCompaction:\n  /compact   summarize older conversation history now\n\nThreads:\n  /resume    reopen a recent local thread\n\nModes:\n  /permissions   cycle permission presets (auto, accept-edits, read-only, full-access)\n  /plan      enter planning mode for the current task\n  Agent may call enter_plan_mode automatically\n  /approval  toggle bash approval mode\n\nAuth:\n  /login     open the provider auth picker\n  /logout    clear the saved provider credential\n\nEditing:\n  apply_patch    preferred for editing existing files\n  replace_lines  use for verified large line-range edits\n  write_file     use for new files or full rewrites\n  replace        simple fallback for unique string replacement\n\nKeyboard:\n  Enter submit\n  Shift+Enter insert newline\n  Esc close current overlay\n\nExit:\n  /quit\n  /exit\n\nModel switching:\n  /model\n\nProvider URL:\n  /base-url",
         commands
     )
 }
 
 pub fn quick_actions_text() -> &'static str {
-    "/approval  toggle bash approval mode\n\
-     /base-url  open the provider URL editor\n\
-     /clear     reset the visible transcript\n\
-     /context   inspect effective runtime context\n\
-     /help      browse commands and keyboard hints\n\
-     /model     open guided model switching\n\
-     /plan      enter planning mode for the current task\n\
-     /status    inspect runtime and workspace\n\
-     /quit      leave the TUI"
+    "/permissions  cycle permission presets\n\
+     /approval    toggle bash approval mode\n\
+     /base-url    open the provider URL editor\n\
+     /clear       reset the visible transcript\n\
+     /context     inspect effective runtime context\n\
+     /help        browse commands and keyboard hints\n\
+     /model       open guided model switching\n\
+     /plan        enter planning mode for the current task\n\
+     /status      inspect runtime and workspace\n\
+     /quit        leave the TUI"
 }
 
 #[cfg(test)]

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -1,6 +1,6 @@
 use crate::tui::state::{CommandSpec, LocalCommand, LocalCommandKind, TuiApp};
 
-pub const COMMAND_SPECS: [CommandSpec; 22] = [
+pub const COMMAND_SPECS: [CommandSpec; 21] = [
     CommandSpec {
         category: "Session",
         name: "permissions",
@@ -94,13 +94,6 @@ pub const COMMAND_SPECS: [CommandSpec; 22] = [
     },
     CommandSpec {
         category: "Setup",
-        name: "model-name",
-        usage: "/model-name",
-        summary: "Open the model name editor.",
-        detail: "Open the interactive model name editor. Type a model identifier to override the default for the active provider. This accepts arbitrary provider model IDs.",
-    },
-    CommandSpec {
-        category: "Setup",
         name: "base-url",
         usage: "/base-url",
         summary: "Open the provider base URL editor.",
@@ -179,7 +172,6 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
         "approval" => LocalCommandKind::Approval,
         "compact" => LocalCommandKind::Compact,
         "model" | "models" => LocalCommandKind::Model,
-        "model-name" => LocalCommandKind::ModelName,
         "base-url" => LocalCommandKind::BaseUrl,
         "login" | "auth" => LocalCommandKind::Login,
         "logout" => LocalCommandKind::Logout,

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -19,12 +19,6 @@ fn parses_model_command_argument() {
     assert_eq!(command.arg.as_deref(), Some("anything"));
 }
 
-#[test]
-fn parses_model_name_command_separately_from_model_picker() {
-    let command = parse_local_command("/model-name").expect("command should parse");
-    assert!(matches!(command.kind, LocalCommandKind::ModelName));
-    assert!(command.arg.is_none());
-}
 
 #[test]
 fn model_help_text_labels_deepseek_as_openai_compatible_endpoint() {

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -19,7 +19,6 @@ fn parses_model_command_argument() {
     assert_eq!(command.arg.as_deref(), Some("anything"));
 }
 
-
 #[test]
 fn model_help_text_labels_deepseek_as_openai_compatible_endpoint() {
     let dir = tempdir().expect("tempdir");
@@ -100,6 +99,17 @@ fn parses_plan_command() {
 fn parses_approval_command() {
     let approval = parse_local_command("/approval").expect("approval should parse");
     assert!(matches!(approval.kind, LocalCommandKind::Approval));
+}
+
+#[test]
+fn parses_permissions_command() {
+    let cmd = parse_local_command("/permissions").expect("/permissions should parse");
+    assert!(matches!(cmd.kind, LocalCommandKind::Permissions));
+    assert!(cmd.arg.is_none());
+
+    let alias = parse_local_command("/permission").expect("/permission should parse");
+    assert!(matches!(alias.kind, LocalCommandKind::Permissions));
+    assert!(alias.arg.is_none());
 }
 
 #[test]

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -39,6 +39,9 @@ pub async fn run_tui(
     let initial_size = terminal_size()?;
     let mut app = TuiApp::new(crate::config::ConfigManager::new()?)?;
     app.sandbox_network_access = sandbox_network_access;
+    // Sync the AtomicBool to match the default Auto preset (network off).
+    app.sandbox_network_access
+        .store(false, std::sync::atomic::Ordering::Relaxed);
     app.terminal_width = initial_size.0;
     let viewport_height = desired_viewport_height(&app, initial_size.0, initial_size.1);
     let mut terminal = build_terminal(viewport_height)?;

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use crossterm::{event::EventStream, terminal::enable_raw_mode, terminal::size as terminal_size};
 use futures::StreamExt;
@@ -32,10 +33,12 @@ pub async fn run_tui(
     agent: Agent,
     oauth_manager: OAuthManager,
     startup_resume: StartupResumeTarget,
+    sandbox_network_access: Arc<AtomicBool>,
 ) -> anyhow::Result<Option<String>> {
     enable_raw_mode()?;
     let initial_size = terminal_size()?;
     let mut app = TuiApp::new(crate::config::ConfigManager::new()?)?;
+    app.sandbox_network_access = sandbox_network_access;
     app.terminal_width = initial_size.0;
     let viewport_height = desired_viewport_height(&app, initial_size.0, initial_size.1);
     let mut terminal = build_terminal(viewport_height)?;

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -80,6 +80,10 @@ fn render_activity_bar(f: &mut Frame, app: &TuiApp, area: Rect) {
         spans.push(Span::raw("  "));
         spans.push(badge("mode", "plan", TEXT_ACCENT));
     }
+    if app.permission_mode_label() != "auto" {
+        spans.push(Span::raw("  "));
+        spans.push(badge("perm", app.permission_mode_label(), STATUS_INFO));
+    }
     if !detail.is_empty() {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(detail, Style::default().fg(TEXT_SECONDARY)));

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use super::super::state::{
-    HelpTab, LocalCommand, LocalCommandKind, Overlay, PermissionMode, RuntimePhase, StatusTab, TuiApp,
+    HelpTab, LocalCommand, LocalCommandKind, Overlay, PermissionMode, RuntimePhase, StatusTab,
+    TuiApp,
 };
 use super::tasks::{start_compact_task, start_rebuild_task, start_review_task};
 use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
@@ -243,19 +244,11 @@ fn capture_git_diff(cwd: &str) -> String {
     }
 }
 
-fn apply_permission_mode(
-    app: &mut TuiApp,
-    agent_slot: &mut Option<Agent>,
-    mode: PermissionMode,
-) {
+fn apply_permission_mode(app: &mut TuiApp, agent_slot: &mut Option<Agent>, mode: PermissionMode) {
     use std::sync::atomic::Ordering;
 
     let (execution, approval, allow_net) = match mode {
-        PermissionMode::Auto => (
-            AgentExecutionMode::Execute,
-            BashApprovalMode::Always,
-            false,
-        ),
+        PermissionMode::Auto => (AgentExecutionMode::Execute, BashApprovalMode::Always, false),
         PermissionMode::AcceptEdits => (
             AgentExecutionMode::Execute,
             BashApprovalMode::Suggestion,
@@ -275,12 +268,16 @@ fn apply_permission_mode(
 
     app.set_agent_execution_mode(execution);
     app.bash_approval_mode = approval;
-    app.sandbox_network_access.store(allow_net, Ordering::Relaxed);
+    app.sandbox_network_access
+        .store(allow_net, Ordering::Relaxed);
 
     if let Some(agent) = agent_slot.as_mut() {
         agent.set_execution_mode(execution);
         agent.set_bash_approval_mode(approval);
     }
 
-    app.set_runtime_phase(RuntimePhase::LocalCommand, Some("updating permissions".into()));
+    app.set_runtime_phase(
+        RuntimePhase::LocalCommand,
+        Some("updating permissions".into()),
+    );
 }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::super::state::{
-    HelpTab, LocalCommand, LocalCommandKind, Overlay, RuntimePhase, StatusTab, TuiApp,
+    HelpTab, LocalCommand, LocalCommandKind, Overlay, PermissionMode, RuntimePhase, StatusTab, TuiApp,
 };
 use super::tasks::{start_compact_task, start_rebuild_task, start_review_task};
 use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
@@ -30,6 +30,7 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Review => "review",
         LocalCommandKind::Status => "status",
         LocalCommandKind::Skills => "skills",
+        LocalCommandKind::Permissions => "permissions",
     });
     match command.kind {
         LocalCommandKind::Approval => {
@@ -140,6 +141,16 @@ pub(super) async fn execute_local_command(
                 start_review_task(app, prompt, agent);
             }
         }
+        LocalCommandKind::Permissions => {
+            let next_mode = app.permission_mode.cycle();
+            app.permission_mode = next_mode;
+            apply_permission_mode(app, agent_slot, next_mode);
+            let notice = format!(
+                "Permission mode: {label}.",
+                label = app.permission_mode_label()
+            );
+            app.push_notice(notice);
+        }
         LocalCommandKind::Quit => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("quitting".into()));
             return Ok(true);
@@ -230,4 +241,46 @@ fn capture_git_diff(cwd: &str) -> String {
         (None, Some(u)) => u,
         (None, None) => String::new(),
     }
+}
+
+fn apply_permission_mode(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    mode: PermissionMode,
+) {
+    use std::sync::atomic::Ordering;
+
+    let (execution, approval, allow_net) = match mode {
+        PermissionMode::Auto => (
+            AgentExecutionMode::Execute,
+            BashApprovalMode::Always,
+            false,
+        ),
+        PermissionMode::AcceptEdits => (
+            AgentExecutionMode::Execute,
+            BashApprovalMode::Suggestion,
+            false,
+        ),
+        PermissionMode::ReadOnly => (
+            AgentExecutionMode::Plan,
+            BashApprovalMode::Suggestion,
+            false,
+        ),
+        PermissionMode::FullAccess => (
+            AgentExecutionMode::Execute,
+            BashApprovalMode::Suggestion,
+            true,
+        ),
+    };
+
+    app.set_agent_execution_mode(execution);
+    app.bash_approval_mode = approval;
+    app.sandbox_network_access.store(allow_net, Ordering::Relaxed);
+
+    if let Some(agent) = agent_slot.as_mut() {
+        agent.set_execution_mode(execution);
+        agent.set_bash_approval_mode(approval);
+    }
+
+    app.set_runtime_phase(RuntimePhase::LocalCommand, Some("updating permissions".into()));
 }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -40,6 +40,7 @@ pub(super) async fn execute_local_command(
                 BashApprovalMode::Always => BashApprovalMode::Suggestion,
             };
             app.bash_approval_mode = next_mode;
+            app.permission_mode = PermissionMode::Auto;
             if let Some(agent) = agent_slot.as_mut() {
                 agent.set_bash_approval_mode(next_mode);
             }
@@ -108,6 +109,7 @@ pub(super) async fn execute_local_command(
                 Some("entering planning mode".into()),
             );
             app.set_pending_plan_approval(false);
+            app.permission_mode = PermissionMode::Auto;
             app.set_agent_execution_mode(AgentExecutionMode::Plan);
             if let Some(agent) = agent_slot.as_mut() {
                 agent.set_execution_mode(AgentExecutionMode::Plan);
@@ -188,7 +190,6 @@ fn handle_model_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Result<(
     Ok(())
 }
 
-
 fn handle_base_url_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Result<()> {
     if arg.map(str::trim).filter(|arg| !arg.is_empty()).is_some() {
         app.push_notice("/base-url does not accept arguments. Edit the value in the TUI.");
@@ -249,11 +250,7 @@ fn apply_permission_mode(app: &mut TuiApp, agent_slot: &mut Option<Agent>, mode:
             BashApprovalMode::Suggestion,
             false,
         ),
-        PermissionMode::FullAccess => (
-            AgentExecutionMode::Execute,
-            BashApprovalMode::Suggestion,
-            true,
-        ),
+        PermissionMode::FullAccess => (AgentExecutionMode::Execute, BashApprovalMode::Always, true),
     };
 
     app.set_agent_execution_mode(execution);
@@ -270,4 +267,5 @@ fn apply_permission_mode(app: &mut TuiApp, agent_slot: &mut Option<Agent>, mode:
         RuntimePhase::LocalCommand,
         Some("updating permissions".into()),
     );
+    app.set_pending_plan_approval(false);
 }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -24,7 +24,6 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Login => "login",
         LocalCommandKind::Logout => "logout",
         LocalCommandKind::Model => "model",
-        LocalCommandKind::ModelName => "model-name",
         LocalCommandKind::Plan => "plan",
         LocalCommandKind::Quit => "quit",
         LocalCommandKind::Resume => "resume",
@@ -103,7 +102,6 @@ pub(super) async fn execute_local_command(
             }
         }
         LocalCommandKind::Model => handle_model_command(command.arg.as_deref(), app)?,
-        LocalCommandKind::ModelName => handle_model_name_command(command.arg.as_deref(), app)?,
         LocalCommandKind::Plan => {
             app.set_runtime_phase(
                 RuntimePhase::LocalCommand,
@@ -190,14 +188,6 @@ fn handle_model_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Result<(
     Ok(())
 }
 
-fn handle_model_name_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Result<()> {
-    if arg.map(str::trim).filter(|arg| !arg.is_empty()).is_some() {
-        app.push_notice("/model-name does not accept arguments. Edit the value in the TUI.");
-    }
-    app.open_overlay(Overlay::ModelNameEditor);
-    app.push_notice("Opened model name editor.");
-    Ok(())
-}
 
 fn handle_base_url_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Result<()> {
     if arg.map(str::trim).filter(|arg| !arg.is_empty()).is_some() {

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -633,6 +633,12 @@ pub(super) async fn finish_running_task_if_ready(
                 }
                 agent.set_execution_mode(app.agent_execution_mode);
                 agent.set_bash_approval_mode(app.bash_approval_mode);
+                // Preserve any runtime /permissions override across rebuilds.
+                rebuilt.sandbox_network_access.store(
+                    app.sandbox_network_access
+                        .load(std::sync::atomic::Ordering::Relaxed),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
                 app.sandbox_network_access = rebuilt.sandbox_network_access;
                 app.config_manager.save(&app.config)?;
                 app.setup_status = Some(format!(

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -633,6 +633,7 @@ pub(super) async fn finish_running_task_if_ready(
                 }
                 agent.set_execution_mode(app.agent_execution_mode);
                 agent.set_bash_approval_mode(app.bash_approval_mode);
+                app.sandbox_network_access = rebuilt.sandbox_network_access;
                 app.config_manager.save(&app.config)?;
                 app.setup_status = Some(format!(
                     "Applied {} / {}",

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -5,6 +5,10 @@ pub(super) async fn rebuild_agent_with_progress(
     progress: Option<crate::local_backend::LocalProgressReporter>,
 ) -> anyhow::Result<RebuildSuccess> {
     let bootstrap = crate::runtime_context::initialize_rara_context(config, progress).await?;
-    let (agent, warnings) = bootstrap.into_parts();
-    Ok(RebuildSuccess { agent, warnings })
+    let (agent, warnings, sandbox_network_access) = bootstrap.into_parts();
+    Ok(RebuildSuccess {
+        agent,
+        warnings,
+        sandbox_network_access,
+    })
 }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -22,9 +22,9 @@ pub use self::types::{
     AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, HelpTab, InteractionKind,
     LocalCommand, LocalCommandKind, OAuthLoginMode, OpenAiModelPickerAction, Overlay,
     PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot, PermissionMode,
-    ProviderFamily, RebuildSuccess, RunningTask, RuntimePhase, RuntimeSnapshot,
-    SkillPickerEntry, StatusTab, TaskCompletion, TaskKind, TranscriptEntry, TranscriptEntryPayload,
-    TranscriptTurn, TuiApp, TuiEvent,
+    ProviderFamily, RebuildSuccess, RunningTask, RuntimePhase, RuntimeSnapshot, SkillPickerEntry,
+    StatusTab, TaskCompletion, TaskKind, TranscriptEntry, TranscriptEntryPayload, TranscriptTurn,
+    TuiApp, TuiEvent,
 };
 
 const OPENAI_PROFILE_SETUP_KINDS: [OpenAiEndpointKind; 3] = [

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -455,6 +455,9 @@ impl TuiApp {
 
     fn selected_model_preset(&self) -> (&'static str, &'static str, &'static str) {
         let presets = current_model_presets(self.provider_picker_idx);
+        if presets.is_empty() {
+            return ("", "", "");
+        }
         presets[self.model_picker_idx.min(presets.len().saturating_sub(1))]
     }
 

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -185,6 +185,7 @@ impl TuiApp {
         let startup_notice = startup_warning_for_config(&cfg);
         let provider_picker_idx = selected_provider_family_idx_for_config(&cfg);
         let model_picker_idx = selected_preset_idx_for_config(&cfg, provider_picker_idx);
+        let sandbox_network = cfg.sandbox_workspace_write.network_access;
         Ok(Self {
             input: String::new(),
             input_cursor_offset: None,
@@ -248,7 +249,7 @@ impl TuiApp {
             codex_auth_mode: None,
             skill_picker_idx: 0,
             skill_picker_entries: Vec::new(),
-            sandbox_network_access: Arc::new(AtomicBool::new(false)),
+            sandbox_network_access: Arc::new(AtomicBool::new(sandbox_network)),
             permission_mode: PermissionMode::Auto,
         })
     }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -941,7 +941,9 @@ impl TuiApp {
                 approval: Some(PendingApprovalSnapshot {
                     tool_use_id: pending.tool_use_id.clone(),
                     command: pending.request.summary(),
-                    allow_net: self.config.sandbox_workspace_write.network_access
+                    allow_net: self
+                        .sandbox_network_access
+                        .load(std::sync::atomic::Ordering::Relaxed)
                         || pending.request.allow_net,
                     payload: pending.request.clone(),
                 }),

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -7,6 +7,8 @@ mod types;
 
 use std::cell::RefCell;
 use std::process::Command;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 
 use unicode_width::UnicodeWidthChar;
 
@@ -19,10 +21,10 @@ pub use self::types::{
     ActiveLiveEvent, ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
     AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, HelpTab, InteractionKind,
     LocalCommand, LocalCommandKind, OAuthLoginMode, OpenAiModelPickerAction, Overlay,
-    PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot, ProviderFamily,
-    RebuildSuccess, RunningTask, RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab,
-    TaskCompletion, TaskKind, TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp,
-    TuiEvent,
+    PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot, PermissionMode,
+    ProviderFamily, RebuildSuccess, RunningTask, RuntimePhase, RuntimeSnapshot,
+    SkillPickerEntry, StatusTab, TaskCompletion, TaskKind, TranscriptEntry, TranscriptEntryPayload,
+    TranscriptTurn, TuiApp, TuiEvent,
 };
 
 const OPENAI_PROFILE_SETUP_KINDS: [OpenAiEndpointKind; 3] = [
@@ -246,6 +248,8 @@ impl TuiApp {
             codex_auth_mode: None,
             skill_picker_idx: 0,
             skill_picker_entries: Vec::new(),
+            sandbox_network_access: Arc::new(AtomicBool::new(false)),
+            permission_mode: PermissionMode::Auto,
         })
     }
 
@@ -1171,6 +1175,10 @@ impl TuiApp {
             AgentExecutionMode::Plan => "plan",
             AgentExecutionMode::Review => "review",
         }
+    }
+
+    pub fn permission_mode_label(&self) -> &'static str {
+        self.permission_mode.label()
     }
 
     pub fn bash_approval_mode_label(&self) -> &'static str {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -72,6 +72,34 @@ pub enum OpenAiModelPickerAction {
     DeleteProfile,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PermissionMode {
+    Auto,
+    ReadOnly,
+    AcceptEdits,
+    FullAccess,
+}
+
+impl PermissionMode {
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Auto => Self::AcceptEdits,
+            Self::AcceptEdits => Self::ReadOnly,
+            Self::ReadOnly => Self::FullAccess,
+            Self::FullAccess => Self::Auto,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::AcceptEdits => "accept-edits",
+            Self::ReadOnly => "read-only",
+            Self::FullAccess => "full-access",
+        }
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum LocalCommandKind {
     Help,
@@ -86,6 +114,7 @@ pub enum LocalCommandKind {
     ModelName,
     BaseUrl,
     Login,
+    Permissions,
     Logout,
     Review,
     Quit,
@@ -492,6 +521,8 @@ pub struct TuiApp {
     pub codex_auth_mode: Option<SavedCodexAuthMode>,
     pub skill_picker_idx: usize,
     pub skill_picker_entries: Vec<SkillPickerEntry>,
+    pub sandbox_network_access: Arc<AtomicBool>,
+    pub permission_mode: PermissionMode,
 }
 
 #[derive(Debug, Clone)]

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -289,6 +289,7 @@ pub enum TaskCompletion {
 pub struct RebuildSuccess {
     pub agent: Agent,
     pub warnings: Vec<String>,
+    pub sandbox_network_access: Arc<AtomicBool>,
 }
 
 pub enum TuiEvent {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -111,7 +111,6 @@ pub enum LocalCommandKind {
     Approval,
     Compact,
     Model,
-    ModelName,
     BaseUrl,
     Login,
     Permissions,

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -2,9 +2,10 @@
 //
 // Each line is a ratatui Line with Span-styled values so colors
 // actually render in the TUI, not just plain text.
+use std::sync::atomic::Ordering;
+
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use std::sync::atomic::Ordering;
 
 use crate::tui::state::{StatusTab, TuiApp};
 

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -4,6 +4,7 @@
 // actually render in the TUI, not just plain text.
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
+use std::sync::atomic::Ordering;
 
 use crate::tui::state::{StatusTab, TuiApp};
 
@@ -38,6 +39,12 @@ fn render_overview_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
         lines,
         "mode",
         app.agent_execution_mode_label(),
+        Color::LightBlue,
+    );
+    kv(
+        lines,
+        "permissions",
+        app.permission_mode_label(),
         Color::LightBlue,
     );
     kv(lines, "phase", app.runtime_phase_label(), Color::DarkGray);
@@ -95,12 +102,12 @@ fn render_config_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
     kv(
         lines,
         "network",
-        if app.config.sandbox_workspace_write.network_access {
+        if app.sandbox_network_access.load(Ordering::Relaxed) {
             "permitted"
         } else {
             "restricted"
         },
-        if app.config.sandbox_workspace_write.network_access {
+        if app.sandbox_network_access.load(Ordering::Relaxed) {
             Color::Yellow
         } else {
             Color::LightGreen


### PR DESCRIPTION
## Summary

Adds a `/permissions` slash command that cycles through four permission mode presets, modeled after Codex CLI's `/permissions` and Claude Code's `/permissions`.

### Permission presets

| Preset | Execution | Bash Approval | Network |
|---|---|---|---|
| **Auto** (default) | Execute | Always | off |
| **AcceptEdits** | Execute | Suggestion | off |
| **ReadOnly** | Plan | Suggestion | off |
| **FullAccess** | Execute | Suggestion | **on** |

Input `/permissions` to cycle Auto → AcceptEdits → ReadOnly → FullAccess → Auto.

### Arc\<AtomicBool\> refactor

`sandbox_network_access` is now `Arc\<AtomicBool\>` shared across `BashTool`, `PtyStartTool`, and `TuiApp`. Switching permission modes is instant — no backend rebuild needed.

### Status display

- `/status` Execution section shows current `permissions` line
- `/status` Network line reads the live `AtomicBool` instead of config
- Bottom pane shows `perm` badge when not in `auto` mode

### Verification

- `cargo check` ✅
- `cargo test -- tui::command::tests`: 32 passed
- `cargo test -- tools::bash::tests tools::pty::tests`: 38 passed