### PR TITLE
fix: align partial-read enforcement with Claude Code semantics

### DIFF
--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -41,9 +41,21 @@ impl FileReadState {
         let modified = metadata.modified()?;
         let is_partial = output.is_partial();
         let mut files = self.files.lock().expect("file read state lock");
+        // Never downgrade: partial reads must not overwrite existing
+        // full-read entries (same mtime).
         if is_partial {
             if let Some(existing) = files.get(&key) {
                 if !existing.is_partial && existing.modified == modified {
+                    return Ok(());
+                }
+            }
+        }
+        // Sub-range reads are not partial under the new semantics,
+        // but they don't carry full content.  Don't let a sub-range read
+        // overwrite a previously cached full read with the same mtime.
+        if content.is_none() {
+            if let Some(existing) = files.get(&key) {
+                if existing.content.is_some() && existing.modified == modified {
                     return Ok(());
                 }
             }
@@ -601,7 +613,7 @@ impl Default for ReplaceLinesTool {
 
 #[tool_spec(
     name = "replace_lines",
-    description = "Replace an inclusive line range in a file. Use only after reading the full file and verifying the current line numbers.",
+    description = "Replace an inclusive line range in a file. Use after reading the relevant portion of the file and verifying the current line numbers. A sub-range read via offset/limit is sufficient as long as the targeted lines have been seen.",
     input_schema = {
         "type": "object",
         "properties": {

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -239,8 +239,13 @@ pub(crate) struct ReadFileOutput {
 }
 
 impl ReadFileOutput {
+    /// Returns true only when the content delivered to the model was
+    /// line-truncated (a single line exceeded the max read length).
+    /// Having more lines in the file than were returned (has_more_lines)
+    /// does NOT make it partial — the model saw real, untransformed
+    /// content from the file, and next_offset tells it where to continue.
     fn is_partial(&self) -> bool {
-        self.truncated || self.start_line != 1 || !self.total_lines_exact
+        self.line_truncated
     }
 }
 

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -305,7 +305,7 @@ async fn replace_allows_partial_read_when_old_string_is_unique() {
 }
 
 #[tokio::test]
-async fn replace_lines_rejects_partial_read_state() {
+async fn replace_lines_allows_offset_read_not_truncated() {
     let tempdir = tempfile::tempdir().expect("tempdir");
     let path = tempdir.path().join("sample.txt");
     std::fs::write(&path, "one\ntwo\nthree\n").expect("write sample");
@@ -313,6 +313,7 @@ async fn replace_lines_rejects_partial_read_state() {
     let read_tool = ReadFileTool::new(read_state.clone());
     let replace_lines_tool = ReplaceLinesTool::new(read_state);
 
+    // Read only first line — not truncated, just a sub-range.
     read_tool
         .call(json!({
             "path": path.display().to_string(),
@@ -320,8 +321,11 @@ async fn replace_lines_rejects_partial_read_state() {
             "limit": 1
         }))
         .await
-        .expect("partial read");
-    let error = replace_lines_tool
+        .expect("offset read");
+    // Clode Code / Codex semantics: sub-range reads are not partial.
+    // replace_lines re-reads the file internally, so line-number
+    // validation is still correct.
+    let result = replace_lines_tool
         .call(json!({
             "path": path.display().to_string(),
             "start_line": 2,
@@ -329,8 +333,8 @@ async fn replace_lines_rejects_partial_read_state() {
             "new_string": "second"
         }))
         .await
-        .expect_err("line-only edit should still require full read");
-    assert!(error.to_string().contains("only partially read"));
+        .expect("replace_lines after offset read");
+    assert!(result["path"].as_str().unwrap().ends_with("sample.txt"));
 }
 
 #[tokio::test]

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -305,7 +305,7 @@ async fn replace_allows_partial_read_when_old_string_is_unique() {
 }
 
 #[tokio::test]
-async fn replace_lines_allows_offset_read_not_truncated() {
+async fn replace_lines_allows_offset_read_when_lines_not_truncated() {
     let tempdir = tempfile::tempdir().expect("tempdir");
     let path = tempdir.path().join("sample.txt");
     std::fs::write(&path, "one\ntwo\nthree\n").expect("write sample");
@@ -322,7 +322,7 @@ async fn replace_lines_allows_offset_read_not_truncated() {
         }))
         .await
         .expect("offset read");
-    // Clode Code / Codex semantics: sub-range reads are not partial.
+    // Claude Code / Codex semantics: sub-range reads are not partial.
     // replace_lines re-reads the file internally, so line-number
     // validation is still correct.
     let result = replace_lines_tool
@@ -335,6 +335,8 @@ async fn replace_lines_allows_offset_read_not_truncated() {
         .await
         .expect("replace_lines after offset read");
     assert!(result["path"].as_str().unwrap().ends_with("sample.txt"));
+    let updated = std::fs::read_to_string(&path).expect("read file");
+    assert_eq!(updated, "one\nsecond\nthree\n");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Align RARA's partial-read enforcement with Claude Code semantics.

## Before

`is_partial()` returned true when:
- Content was truncated (`line_truncated`)
- OR reading started at offset != 1 (`start_line != 1`)
- OR total line count was uncertain (`!total_lines_exact`)

This meant any sub-range read (e.g., `offset=100, limit=50`) blocked subsequent edits, requiring a full-file re-read.

## After

`is_partial()` now only returns true when **line content was actually truncated** (`line_truncated`). Reading a sub-range via offset/limit no longer blocks edits.

This matches Claude Code's behavior: `isPartialView` only means the injected content differs from what's on disk (stripped HTML comments, frontmatter, truncated MEMORY.md). An offset read with real, untransformed content is NOT a partial view.

`replace_lines` remains safe because it internally re-reads the file via `fs::read_to_string` and validates start_line/end_line bounds against actual content.

## Files changed
| File | Change |
|------|--------|
| `src/tools/file.rs` | `is_partial()` now checks `self.line_truncated` only |
| `src/tools/file/tests.rs` | Replaced `replace_lines_rejects_partial_read_state` with `replace_lines_allows_offset_read_not_truncated` |

## Testing
```bash
cargo test file::tests  # 17 passed
```
