### PR TITLE
fix: add Custom variant to PermissionMode for individual settings tweaks

### DIFF
--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -40,7 +40,7 @@ pub(super) async fn execute_local_command(
                 BashApprovalMode::Always => BashApprovalMode::Suggestion,
             };
             app.bash_approval_mode = next_mode;
-            app.permission_mode = PermissionMode::Auto;
+            app.permission_mode = PermissionMode::Custom;
             if let Some(agent) = agent_slot.as_mut() {
                 agent.set_bash_approval_mode(next_mode);
             }
@@ -109,7 +109,7 @@ pub(super) async fn execute_local_command(
                 Some("entering planning mode".into()),
             );
             app.set_pending_plan_approval(false);
-            app.permission_mode = PermissionMode::Auto;
+            app.permission_mode = PermissionMode::Custom;
             app.set_agent_execution_mode(AgentExecutionMode::Plan);
             if let Some(agent) = agent_slot.as_mut() {
                 agent.set_execution_mode(AgentExecutionMode::Plan);
@@ -251,6 +251,7 @@ fn apply_permission_mode(app: &mut TuiApp, agent_slot: &mut Option<Agent>, mode:
             false,
         ),
         PermissionMode::FullAccess => (AgentExecutionMode::Execute, BashApprovalMode::Always, true),
+        PermissionMode::Custom => return,
     };
 
     app.set_agent_execution_mode(execution);

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -78,6 +78,7 @@ pub enum PermissionMode {
     ReadOnly,
     AcceptEdits,
     FullAccess,
+    Custom,
 }
 
 impl PermissionMode {
@@ -86,6 +87,7 @@ impl PermissionMode {
             Self::Auto => Self::AcceptEdits,
             Self::AcceptEdits => Self::ReadOnly,
             Self::ReadOnly => Self::FullAccess,
+            Self::Custom => Self::Auto,
             Self::FullAccess => Self::Auto,
         }
     }
@@ -95,6 +97,7 @@ impl PermissionMode {
             Self::Auto => "auto",
             Self::AcceptEdits => "accept-edits",
             Self::ReadOnly => "read-only",
+            Self::Custom => "custom",
             Self::FullAccess => "full-access",
         }
     }


### PR DESCRIPTION
## Summary

When `/approval` or `/plan` are used individually, `permission_mode` now becomes `Custom` instead of `Auto`. This prevents the `/status` line and bottom-pane badge from reporting inaccurate presets, and ensures the next `/permissions` cycle starts from the correct position.

### Changes

- Add `Custom` variant to `PermissionMode` enum
- `/approval` and `/plan` handlers set `permission_mode = Custom` instead of `Auto`
- `Custom` cycles back to `Auto` in `/permissions` cycle
- `Custom` label displays as "custom" in status/bottom-pane
- `Custom` is a no-op in `apply_permission_mode`