### PR TITLE
feat(memory): route retrieval through selection

### DIFF
--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -118,7 +118,7 @@ Importance scale:
 | Memory delete | User or control-plane request can delete records with audit-safe semantics. | Not implemented as a public memory capability. |
 | Memory retention | Pinned, user-created, and high-importance memories are protected from automatic cleanup; explicit delete remains possible with provenance. | Spec only. No automatic cleanup path exists yet. |
 | Thread distillation | Thread history can be distilled into 2-8 durable memory records. | Partial. `ThreadStore::distill_thread_summary` can persist one thread-linked summary record; LLM extraction and deduplication remain future work. |
-| Context injection | Ranked memory candidates pass through `MemorySelection` before prompt injection. | Partial. `MemorySelection` exists, but LanceDB search results are not yet direct ranked candidates. |
+| Context injection | Ranked memory candidates pass through `MemorySelection` before prompt injection. | Partial. LanceDB-backed memory and session search now produce direct ranked `MemorySelection` candidates; retention, deduplication, and protocol mutation remain future work. |
 | Graph retrieval | Entity and relationship traversal complements vector recall. | Future work. |
 | Working memory | Daily or session briefing summarizes recent and important memories. | Future work. |
 | MCP / ACP / Wire memory APIs | Protocol clients can query and mutate memory through the runtime control plane. | Future work over the `MemoryStore` boundary. |
@@ -239,8 +239,11 @@ Current implementation checkpoint:
 - `ThreadStore::distill_thread_summary` can promote a loaded thread summary into
   a thread-linked `MemoryRecord` with `session_id`, `thread_id`, and source span.
 - Agent turn checkpoints continue writing to the `conversations` table.
-- `MemorySelection` is not yet switched to direct ranked memory candidates;
-  retrieved memories still enter through retrieval-tool results.
+- `MemoryRetrievalOrchestrator` promotes LanceDB-backed workspace memories and
+  session-context hits into direct ranked `MemorySelection` candidates.
+- Selected retrieval candidates are rendered as a per-turn internal context
+  block prepended to the current user request. They are not persisted into
+  thread history and do not change the stable system prompt prefix.
 
 ## Migration
 
@@ -253,7 +256,7 @@ Current implementation checkpoint:
    over `MemoryStore`. Done.
 6. Persist full `MemoryRecord` records separately from the LanceDB search index.
    Done.
-7. Wire `MemorySelection` to ranked memory candidates.
+7. Wire `MemorySelection` to ranked memory candidates. Done.
 8. Add pinned/retention policy so pinned, user-created, and high-importance
    memories are excluded from automatic cleanup.
 9. Add update/delete/list-label control-plane scaffolding without exposing

--- a/docs/features/memory-selection.md
+++ b/docs/features/memory-selection.md
@@ -219,6 +219,13 @@ consume the remaining discretionary retrieval budget inside `MemorySelection`.
 Overall model-window budgeting stays owned by the broader context assembly and
 compaction layers.
 
+Retrieved memory candidates should charge budget against the same rendered
+context block that is injected into the next model turn. The shared
+header/footer/instruction overhead is charged once per selected retrieved-memory
+block, and each later retrieved item only charges its incremental rendered
+cost. Multi-line labels and details are normalized before rendering so one
+memory candidate cannot break the injected list shape.
+
 ### Dedupe
 
 The selector should avoid injecting redundant views of the same source.
@@ -243,6 +250,61 @@ Ownership boundaries:
 - retrieval backends own candidate discovery;
 - `MemorySelection` owns per-turn classification, ordering, reasons, and budget
   outcome.
+
+Direct retrieval candidates are injected only after selection. RARA follows the
+same reference-agent shape here: stable base instructions remain fixed, while
+turn-specific recall is attached as separate contextual material. Selected
+retrieval candidates must therefore be rendered as a per-turn internal context
+block before the current user request content, not appended to the base system
+prompt or persisted as conversation history. The block must not create an extra
+user-role message before the request because some providers require strict role
+alternation. Retrieval runs once after the user request is accepted, then the
+selected candidates are reused for tool-followup model turns until the next
+user request.
+
+### Reference Implementation Alignment
+
+RARA should keep the following alignment points with mature coding-agent memory
+systems:
+
+- Stable base instructions and prompt-file sources should remain ordered and
+  byte-stable. Per-turn recall must be injected as contextual material after
+  selection instead of being appended to the base system prompt.
+- Recall should run once for a user turn, then be reused for tool-followup model
+  turns. Re-running retrieval inside every model-loop iteration wastes
+  embedding/search work and can create inconsistent context inside one user
+  request.
+- Retrieved memory must not become ordinary conversation history. It is an input
+  artifact for the current model request and should be regenerated or reused by
+  the runtime contract, not checkpointed as if the user had said it.
+- The injection shape must preserve provider role constraints. If the transport
+  requires strict user/assistant alternation, contextual recall should be merged
+  into the current user request content or represented as a provider-safe
+  attachment-like input, not inserted as an extra adjacent user message.
+- Recall output should be inspectable as structured state. The runtime should be
+  able to explain what was selected, what was available, what was dropped, why it
+  happened, and how much budget was consumed.
+
+The main architectural difference is storage and selection. File-memory
+reference agents commonly keep durable memories as markdown files with a compact
+index, scan file headers, then use a side-query selector to choose a small number
+of relevant files. RARA instead routes durable workspace memory and thread
+context through retrieval backends first, then lets `MemorySelection` make the
+final per-turn decision. This keeps RARA compatible with LanceDB-backed full-text,
+vector, and later graph retrieval while preserving the same cache-safe injection
+boundary.
+
+Future work can borrow three additional ideas without changing this PR's core
+contract:
+
+- add a lightweight selector/reranker over retrieval candidates using structured
+  output, so the model can choose from a manifest-like view before injection;
+- add cumulative surfaced-memory accounting and per-item truncation limits so a
+  long session cannot repeatedly surface large recall blocks;
+- add a unified attachment-like context carrier for retrieved memory, skills,
+  queued input, hook output, and post-compaction restoration. Until that carrier
+  exists, prepending an internal context block to the latest user text request is
+  the provider-safe bridge.
 
 ### `/context` Priority
 

--- a/docs/journal/2026-05-03-lancedb-memory-index.md
+++ b/docs/journal/2026-05-03-lancedb-memory-index.md
@@ -49,8 +49,6 @@ updated through explicit memory writes or periodic promotion and distillation.
 
 ## Follow-Up
 
-- Feed ranked memory candidates into `MemorySelection` directly instead of only
-  through retrieval tool results.
 - Move raw session checkpoints into per-session append shards.
 - Add periodic promotion from session shards into global `MemoryRecord`s.
 - Extend records with provenance, source scope, trust level, labels, and path

--- a/docs/journal/2026-05-04-memory-retrieval-selection.md
+++ b/docs/journal/2026-05-04-memory-retrieval-selection.md
@@ -1,0 +1,44 @@
+# Memory Retrieval Selection Checkpoint
+
+## Summary
+
+M1 and M2 are now wired as one runtime slice:
+
+- `MemoryRetrievalOrchestrator` searches the session-context LanceDB table and
+  the durable `MemoryStore`.
+- Search hits become direct `RetrievedMemoryCandidate` values.
+- `MemorySelection` ranks those candidates against the discretionary retrieval
+  budget and reports selected, available, and dropped outcomes.
+- Selected retrieval candidates are sent to the model as a per-turn internal
+  context block prepended to the current user request content, not as part of
+  the stable system prompt and not as persisted conversation history.
+
+## Reference Pattern
+
+The injection shape follows the reference-agent boundary:
+
+- Codex keeps base instructions separate from contextual user fragments such as
+  `AGENTS.md` and environment updates.
+- Peer agent runtimes render memory as contextual attachments and keep
+  prompt-cache-sensitive text stable when possible.
+
+RARA should keep the same invariant for future memory work: retrieval may change
+per turn, but stable prompt sources should keep their ordering and bytes.
+
+## Validation
+
+Focused coverage was added for:
+
+- direct retrieved candidates selected when budget allows;
+- retrieved candidates dropped when the budget is exhausted;
+- `/context` assembly showing selected retrieval under `active_memory_inputs`;
+- agent model input receiving internal memory context without persisting it into
+  `history` or creating consecutive user-role messages.
+- tool-result follow-up turns reusing the same retrieval candidates without
+  prepending memory context to tool-result messages.
+
+## Remaining Work
+
+- Move raw session checkpoints into per-session append shards.
+- Add periodic promotion from session shards into global `MemoryRecord`s.
+- Add retention and pinning policy before any automatic cleanup path exists.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,7 +56,7 @@ Active backlog only. Keep this file small and current.
 - [x] Persist full `MemoryRecord` domain records with session id, thread id, and source span provenance.
 - [x] Replace `retrieve_session_context` stub with LanceDB hybrid search over conversation checkpoints.
 - [x] Add backend `ThreadStore` APIs for markdown export and summary-to-memory distillation.
-- [ ] Promote LanceDB-backed retrieval from `MemoryStore` into ranked `MemorySelection` candidates.
+- [x] Promote LanceDB-backed retrieval from `MemoryStore` into ranked `MemorySelection` candidates.
 - [ ] Add pinned/retention policy so pinned, user-created, and high-importance memories are excluded from automatic cleanup.
 - [ ] Add memory update/delete/list-label control-plane scaffolding for ACP/Wire without exposing LanceDB APIs.
 - [ ] Upgrade thread distillation from summary capture to LLM-assisted 2-8 record extraction with deduplication.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,5 +1,6 @@
 mod compact;
 mod context_view;
+mod memory_retrieval;
 mod planning;
 mod prompting;
 #[cfg(test)]
@@ -12,8 +13,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
+use crate::context::RetrievedMemoryCandidate;
 use crate::control_tokens::scrub_internal_control_tokens;
 use crate::llm::{ContentBlock, LlmBackend, LlmStreamEvent, LlmTurnMetadata};
+use crate::memory_store::MemoryStore;
 use crate::prompt::{self, PromptMode, PromptRuntimeConfig};
 use crate::redaction::redact_secrets;
 use crate::session::SessionManager;
@@ -118,6 +121,7 @@ pub struct Agent {
     pub tool_manager: ToolManager,
     pub llm_backend: Arc<dyn LlmBackend>,
     pub vdb: Arc<VectorDB>,
+    pub memory_store: Arc<MemoryStore>,
     pub session_manager: Arc<SessionManager>,
     pub workspace: Arc<WorkspaceMemory>,
     pub history: Vec<Message>,
@@ -138,6 +142,7 @@ pub struct Agent {
     pub completed_approval: Option<CompletedInteraction>,
     pub approved_bash_prefixes: Vec<String>,
     pub compact_state: CompactState,
+    pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
     inspection_progress: InspectionProgress,
     last_query_plan_updated: bool,
     pending_plan_exit_tool_id: Option<String>,
@@ -153,10 +158,12 @@ impl Agent {
         session_manager: Arc<SessionManager>,
         workspace: Arc<WorkspaceMemory>,
     ) -> Self {
+        let memory_store = Arc::new(MemoryStore::new(llm_backend.clone(), vdb.clone()));
         Self {
             tool_manager,
             llm_backend,
             vdb,
+            memory_store,
             session_manager,
             workspace,
             history: Vec::new(),
@@ -180,6 +187,7 @@ impl Agent {
             completed_approval: None,
             approved_bash_prefixes: Vec::new(),
             compact_state: CompactState::default(),
+            retrieved_memory_candidates: Vec::new(),
             inspection_progress: InspectionProgress::default(),
             last_query_plan_updated: false,
             pending_plan_exit_tool_id: None,
@@ -230,6 +238,7 @@ impl Agent {
             content: json!([{"type": "text", "text": prompt.clone()}]),
         });
         self.checkpoint_session()?;
+        self.refresh_memory_retrieval_candidates().await;
 
         match self
             .run_agent_loop_with_limit(output_mode, &mut report, &mut agentic_turns)
@@ -311,6 +320,7 @@ impl Agent {
         report(AgentEvent::Status("Sending prompt to model.".to_string()));
         let turn_metadata = self.llm_turn_metadata();
         turn_metadata.ensure_not_cancelled()?;
+        let assembled = self.assemble_turn_context();
         let mut messages = self
             .history
             .iter()
@@ -321,9 +331,12 @@ impl Agent {
             0,
             Message {
                 role: "system".to_string(),
-                content: json!(self.build_system_prompt()),
+                content: json!(assembled.prompt.effective_prompt.text),
             },
         );
+        if let Some(memory_context) = Agent::selected_memory_context_text(&assembled.runtime) {
+            Agent::prepend_memory_context_to_latest_user_message(&mut messages, memory_context);
+        }
 
         let mut streamed_any_text_delta = false;
         let mut streamed_any_reasoning_delta = false;

--- a/src/agent/memory_retrieval.rs
+++ b/src/agent/memory_retrieval.rs
@@ -1,0 +1,98 @@
+use serde_json::{Value, json};
+
+use super::{Agent, Message};
+use crate::context::{
+    MemoryRetrievalOrchestrator, MemorySelectionItemContextEntry, RetrievedMemoryRenderItem,
+    SharedRuntimeContext, is_retrieved_memory_kind, render_retrieved_memory_context,
+};
+
+impl Agent {
+    pub(super) async fn refresh_memory_retrieval_candidates(&mut self) {
+        self.retrieved_memory_candidates = MemoryRetrievalOrchestrator::new(
+            self.llm_backend.clone(),
+            self.vdb.clone(),
+            self.memory_store.clone(),
+        )
+        .retrieve_for_history(&self.history)
+        .await;
+    }
+
+    pub(super) fn selected_memory_context_text(
+        runtime_context: &SharedRuntimeContext,
+    ) -> Option<String> {
+        let selected = runtime_context
+            .retrieval
+            .memory_selection
+            .selected_items
+            .iter()
+            .filter(|item| is_retrieved_memory_kind(item.kind.as_str()))
+            .collect::<Vec<_>>();
+
+        render_selected_memory_context(selected.as_slice())
+    }
+
+    pub(super) fn prepend_memory_context_to_latest_user_message(
+        messages: &mut Vec<Message>,
+        memory_context: String,
+    ) {
+        let Some(message) = messages
+            .iter_mut()
+            .rfind(|message| message.role == "user" && is_user_text_request(message))
+        else {
+            return;
+        };
+
+        prepend_text_to_message(message, memory_context);
+    }
+}
+
+fn prepend_text_to_message(message: &mut Message, text: String) {
+    match &mut message.content {
+        Value::Array(items) => items.insert(0, memory_text_block(text)),
+        Value::String(existing) => {
+            let original = std::mem::take(existing);
+            *existing = format!("{text}\n\n{original}");
+        }
+        other => {
+            let original = other.take();
+            *other = json!([
+                memory_text_block(text),
+                {"type": "text", "text": original.to_string()}
+            ]);
+        }
+    }
+}
+
+fn is_user_text_request(message: &Message) -> bool {
+    if message
+        .content
+        .as_str()
+        .is_some_and(|text| !text.trim().is_empty())
+    {
+        return true;
+    }
+    message.content.as_array().is_some_and(|items| {
+        items.iter().any(|item| {
+            item.get("type").and_then(Value::as_str) == Some("text")
+                && item
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .is_some_and(|text| !text.trim().is_empty())
+        })
+    })
+}
+
+fn memory_text_block(text: String) -> Value {
+    json!({"type": "text", "text": text})
+}
+
+fn render_selected_memory_context(items: &[&MemorySelectionItemContextEntry]) -> Option<String> {
+    let render_items = items
+        .iter()
+        .map(|item| RetrievedMemoryRenderItem {
+            label: item.label.as_str(),
+            detail: item.detail.as_str(),
+        })
+        .collect::<Vec<_>>();
+    render_retrieved_memory_context(render_items.as_slice())
+}

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -63,6 +63,7 @@ impl Agent {
             vdb_uri: self.vdb.uri(),
             pending_interactions: self.pending_runtime_interactions(),
             skill_listing: prompt::render_skill_listing(&self.prompt_config.available_skills),
+            retrieved_memory_candidates: self.retrieved_memory_candidates.clone(),
         }
     }
 

--- a/src/agent/tests/context_view.rs
+++ b/src/agent/tests/context_view.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use super::support::{SequencedBackend, test_runtime_storage};
 use crate::agent::{Agent, AgentExecutionMode, Message, PlanStep, PlanStepStatus};
 use crate::llm::{ContentBlock, LlmResponse};
+use crate::memory_store::{MemoryLabel, MemoryScope, MemorySource, MemoryStore, NewMemoryRecord};
 use crate::prompt::PromptRuntimeConfig;
 use crate::tool::ToolManager;
 use crate::vectordb::VectorDB;
@@ -386,4 +387,192 @@ fn assemble_turn_context_matches_prompt_and_runtime_views() {
         Some("appendix")
     );
     assert_eq!(assembled.runtime.plan.execution_mode, "plan");
+}
+
+#[tokio::test]
+async fn query_injects_selected_memory_context_without_persisting_it_to_history() {
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::Text {
+            text: "ok".to_string(),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: None,
+    }]));
+    let vdb = Arc::new(VectorDB::new(
+        &rara_dir.join("lancedb").display().to_string(),
+    ));
+    let store = MemoryStore::new(backend.clone(), vdb.clone());
+    store
+        .insert(NewMemoryRecord {
+            title: Some("Reference project path".to_string()),
+            content: "Reference project source lives at /Users/example/reference-project."
+                .to_string(),
+            labels: vec![MemoryLabel::Fact],
+            importance: 0.9,
+            source: MemorySource::UserCreated,
+            scope: MemoryScope::Workspace,
+            session_id: None,
+            thread_id: None,
+            source_span: None,
+        })
+        .await
+        .expect("insert memory");
+
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        vdb,
+        session_manager,
+        workspace,
+    );
+
+    agent
+        .query_with_mode(
+            "Where is the reference project source path?".to_string(),
+            crate::agent::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("query");
+
+    let observed = backend.observed_messages();
+    let first_turn = observed.first().expect("model call");
+    assert_eq!(first_turn[0].role, "system");
+    assert!(
+        !first_turn
+            .windows(2)
+            .any(|pair| pair[0].role == "user" && pair[1].role == "user")
+    );
+    let user_index = first_turn
+        .iter()
+        .position(|message| {
+            message
+                .content
+                .to_string()
+                .contains("Where is the reference project source path?")
+        })
+        .expect("user request");
+    let user_message = &first_turn[user_index];
+    assert_eq!(user_message.role, "user");
+    let user_content = user_message.content.to_string();
+    let memory_position = user_content
+        .find("<rara_internal_history_context>")
+        .expect("memory context");
+    let request_position = user_content
+        .find("Where is the reference project source path?")
+        .expect("user request");
+    assert!(memory_position < request_position);
+    assert!(user_content.contains("reference-project"));
+    assert!(!first_turn.iter().enumerate().any(|(idx, message)| {
+        idx != user_index
+            && message
+                .content
+                .to_string()
+                .contains("<rara_internal_history_context>")
+    }));
+    assert!(!agent.history.iter().any(|message| {
+        message
+            .content
+            .to_string()
+            .contains("<rara_internal_history_context>")
+    }));
+    assert!(
+        agent
+            .shared_runtime_context()
+            .retrieval
+            .memory_selection
+            .selected_items
+            .iter()
+            .any(|item| item.kind == crate::context::RETRIEVED_WORKSPACE_MEMORY_KIND)
+    );
+}
+
+#[test]
+fn memory_context_prepends_to_existing_user_message_without_adding_user_turn() {
+    let mut messages = vec![
+        Message {
+            role: "system".to_string(),
+            content: json!("system"),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"current request"}]),
+        },
+    ];
+
+    Agent::prepend_memory_context_to_latest_user_message(
+        &mut messages,
+        "<rara_internal_history_context>\nrecall\n</rara_internal_history_context>".to_string(),
+    );
+
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[1].role, "user");
+    let text = messages[1].content.to_string();
+    assert!(text.contains("<rara_internal_history_context>"));
+    assert!(text.find("recall").expect("recall") < text.find("current request").expect("request"));
+    assert!(
+        !messages
+            .windows(2)
+            .any(|pair| pair[0].role == "user" && pair[1].role == "user")
+    );
+}
+
+#[test]
+fn memory_context_noops_without_user_text_request() {
+    let mut messages = vec![
+        Message {
+            role: "system".to_string(),
+            content: json!("system"),
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: json!([{"type":"tool_use","id":"tool-1","name":"list_files","input":{}}]),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([{"type":"tool_result","tool_use_id":"tool-1","content":"ok"}]),
+        },
+    ];
+
+    Agent::prepend_memory_context_to_latest_user_message(
+        &mut messages,
+        "<rara_internal_history_context>\nrecall\n</rara_internal_history_context>".to_string(),
+    );
+
+    assert_eq!(messages.len(), 3);
+    assert!(
+        !messages
+            .iter()
+            .any(|message| message.content.to_string().contains("recall"))
+    );
+}
+
+#[test]
+fn memory_context_skips_tool_result_user_messages() {
+    let mut messages = vec![
+        Message {
+            role: "system".to_string(),
+            content: json!("system"),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"current request"}]),
+        },
+        Message {
+            role: "assistant".to_string(),
+            content: json!([{"type":"tool_use","id":"tool-1","name":"list_files","input":{}}]),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([{"type":"tool_result","tool_use_id":"tool-1","content":"ok"}]),
+        },
+    ];
+
+    Agent::prepend_memory_context_to_latest_user_message(
+        &mut messages,
+        "<rara_internal_history_context>\nrecall\n</rara_internal_history_context>".to_string(),
+    );
+
+    assert!(messages[1].content.to_string().contains("recall"));
+    assert!(!messages[3].content.to_string().contains("recall"));
 }

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -7,7 +7,8 @@ use crate::context::memory_selection::memory_selection;
 use crate::context::retrieval_view::retrieval_source_entries;
 use crate::context::{
     CompactionContextView, ContextBudgetView, PlanContextView, PromptContextView,
-    RetrievalContextView, SharedRuntimeContext, TodoContextView,
+    RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalContextView, RetrievedMemoryCandidate,
+    SharedRuntimeContext, TodoContextView,
 };
 use crate::llm::{ContextBudget, LlmBackend};
 use crate::prompt::{self, EffectivePrompt, PromptMode, PromptRuntimeConfig};
@@ -45,6 +46,7 @@ pub struct RuntimeContextInputs<'a> {
     pub vdb_uri: &'a str,
     pub pending_interactions: Vec<RuntimeInteractionInput>,
     pub skill_listing: Option<String>,
+    pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
 }
 
 #[derive(Debug, Clone)]
@@ -162,6 +164,7 @@ impl<'a> ContextAssembler<'a> {
                 inputs.history,
                 inputs.session_id.as_str(),
                 inputs.vdb_uri,
+                inputs.retrieved_memory_candidates.as_slice(),
                 selection_budget,
             ),
         };
@@ -435,6 +438,7 @@ mod tests {
                 vdb_uri: "memory://vdb",
                 pending_interactions: Vec::new(),
                 skill_listing: None,
+                retrieved_memory_candidates: Vec::new(),
             },
         );
 
@@ -494,6 +498,7 @@ mod tests {
                 vdb_uri: "memory://vdb",
                 pending_interactions: Vec::new(),
                 skill_listing: None,
+                retrieved_memory_candidates: Vec::new(),
             },
         );
 
@@ -575,6 +580,7 @@ mod tests {
                 vdb_uri: "memory://vdb",
                 pending_interactions: Vec::new(),
                 skill_listing: None,
+                retrieved_memory_candidates: Vec::new(),
             },
         );
 
@@ -612,6 +618,67 @@ mod tests {
                         .is_some_and(|r| r.reason().contains("memory-selection budget"))
                 })
         );
+    }
+
+    #[test]
+    fn assemble_runtime_places_selected_retrieved_memory_in_active_memory_inputs() {
+        let workspace = test_workspace();
+        let runtime = PromptRuntimeConfig::default();
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"Where is the reference project?"}]),
+        }];
+
+        let runtime_context = ContextAssembler::new(&workspace, &runtime).assemble_runtime(
+            PromptMode::Execute,
+            RuntimeContextInputs {
+                cwd: "repo".to_string(),
+                branch: "main".to_string(),
+                session_id: "session-1".to_string(),
+                history_len: history.len(),
+                total_input_tokens: 0,
+                total_output_tokens: 0,
+                total_cache_hit_tokens: 0,
+                total_cache_miss_tokens: 0,
+                execution_mode: "execute".to_string(),
+                plan_steps: Vec::new(),
+                plan_explanation: None,
+                todo_state: None,
+                compact_state: crate::agent::CompactState {
+                    context_window_tokens: Some(200_000),
+                    compact_threshold_tokens: 190_000,
+                    reserved_output_tokens: 1_024,
+                    ..Default::default()
+                },
+                history: &history,
+                vdb_uri: "memory://vdb",
+                pending_interactions: Vec::new(),
+                skill_listing: None,
+                retrieved_memory_candidates: vec![RetrievedMemoryCandidate {
+                    kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+                    label: "Memory: reference project path".to_string(),
+                    detail: "content: Reference project source lives at /Users/example/reference-project."
+                        .to_string(),
+                    selection_reason: "retrieved as a candidate for the current turn query"
+                        .to_string(),
+                    rank: 1,
+                }],
+            },
+        );
+
+        assert!(
+            runtime_context
+                .retrieval
+                .memory_selection
+                .selected_items
+                .iter()
+                .any(|item| item.kind == RETRIEVED_WORKSPACE_MEMORY_KIND)
+        );
+        assert!(runtime_context.assembly.entries.iter().any(|entry| {
+            entry.layer == "active_memory_inputs"
+                && entry.kind == RETRIEVED_WORKSPACE_MEMORY_KIND
+                && entry.injected
+        }));
     }
 
     #[test]
@@ -665,6 +732,7 @@ mod tests {
                     source: None,
                 }],
                 skill_listing: None,
+                retrieved_memory_candidates: Vec::new(),
             },
         );
 

--- a/src/context/memory_selection.rs
+++ b/src/context/memory_selection.rs
@@ -8,7 +8,10 @@ use crate::context::assembler::{
 };
 use crate::context::{
     CompactionSourceContextEntry, DropReason, MemorySelectionContextView,
-    MemorySelectionItemContextEntry,
+    MemorySelectionItemContextEntry, RETRIEVED_THREAD_CONTEXT_KIND,
+    RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievedMemoryCandidate, RetrievedMemoryRenderItem,
+    is_retrieved_memory_kind, render_retrieved_memory_context,
+    render_retrieved_memory_context_item,
 };
 use crate::prompt::PromptSource;
 
@@ -21,6 +24,7 @@ pub(crate) fn memory_selection(
     history: &[Message],
     session_id: &str,
     vdb_uri: &str,
+    retrieved_memory_candidates: &[RetrievedMemoryCandidate],
     selection_budget_tokens: Option<usize>,
 ) -> MemorySelectionContextView {
     let mut selected_items = fixed_memory_selection_items(
@@ -36,7 +40,7 @@ pub(crate) fn memory_selection(
         .map(|item| item.kind.clone())
         .collect::<Vec<_>>();
     let mut discretionary = select_memory_candidates(
-        retrieval_memory_candidates(history, session_id, vdb_uri),
+        retrieval_memory_candidates(history, session_id, vdb_uri, retrieved_memory_candidates),
         selection_budget_tokens,
         fixed_kinds.as_slice(),
     );
@@ -242,11 +246,50 @@ fn retrieval_memory_candidates(
     history: &[Message],
     session_id: &str,
     vdb_uri: &str,
+    retrieved_memory_candidates: &[RetrievedMemoryCandidate],
 ) -> Vec<MemorySelectionCandidate> {
-    let mut candidates = retrieval_tool_candidates(history);
+    let mut candidates = direct_retrieved_memory_candidates(retrieved_memory_candidates);
+    candidates.extend(retrieval_tool_candidates(history));
     candidates.push(thread_history_candidate(history, session_id));
     candidates.push(vector_memory_candidate(vdb_uri));
     candidates
+}
+
+fn direct_retrieved_memory_candidates(
+    retrieved_memory_candidates: &[RetrievedMemoryCandidate],
+) -> Vec<MemorySelectionCandidate> {
+    retrieved_memory_candidates
+        .iter()
+        .map(|candidate| {
+            let base_priority = match candidate.kind.as_str() {
+                RETRIEVED_THREAD_CONTEXT_KIND => 10,
+                RETRIEVED_WORKSPACE_MEMORY_KIND => 20,
+                _ => 25,
+            };
+            MemorySelectionCandidate {
+                kind: candidate.kind.clone(),
+                label: candidate.label.clone(),
+                detail: candidate.detail.clone(),
+                selection_reason: candidate.selection_reason.clone(),
+                budget_impact_tokens: Some(direct_retrieved_memory_budget_impact(candidate)),
+                priority: base_priority + candidate.rank,
+                selectable: true,
+                dropped_reason: DropReason::NotSelected {
+                    reason:
+                        "not selected after ranking the retrieved memory candidate against the current memory-selection budget"
+                            .to_string(),
+                },
+            }
+        })
+        .collect()
+}
+
+fn direct_retrieved_memory_budget_impact(candidate: &RetrievedMemoryCandidate) -> usize {
+    let item = RetrievedMemoryRenderItem {
+        label: candidate.label.as_str(),
+        detail: candidate.detail.as_str(),
+    };
+    estimate_text_tokens(&render_retrieved_memory_context_item(item))
 }
 
 fn retrieval_tool_candidates(history: &[Message]) -> Vec<MemorySelectionCandidate> {
@@ -345,8 +388,14 @@ fn select_memory_candidates(
     });
     let mut decision = MemorySelectionDecision::default();
     let mut selected_kinds = fixed_selected_kinds.to_vec();
+    let mut selected_retrieved_items: Vec<(String, String)> = Vec::new();
 
     for candidate in candidates {
+        let candidate_budget_impact =
+            candidate_budget_impact_tokens(&candidate, selected_retrieved_items.as_slice());
+        let is_retrieved_memory = is_retrieved_memory_kind(candidate.kind.as_str());
+        let selected_retrieved_item =
+            is_retrieved_memory.then(|| (candidate.label.clone(), candidate.detail.clone()));
         let should_drop: Option<DropReason> = if !candidate.selectable {
             Some(candidate.dropped_reason.clone())
         } else if candidate.kind == "thread_history" && has_compacted_history {
@@ -361,9 +410,7 @@ fn select_memory_candidates(
                 reason:
                     "not selected because a more focused retrieved thread-context candidate already won the current memory selection".to_string(),
             })
-        } else if let (Some(remaining), Some(cost)) =
-            (remaining_budget, candidate.budget_impact_tokens)
-        {
+        } else if let (Some(remaining), Some(cost)) = (remaining_budget, candidate_budget_impact) {
             (cost > remaining).then(|| DropReason::BudgetExceeded {
                 reason: format!(
                     "not selected because it would exceed the remaining memory-selection budget ({cost} > {remaining})"
@@ -381,7 +428,7 @@ fn select_memory_candidates(
                 label: candidate.label,
                 detail: candidate.detail,
                 selection_reason: candidate.selection_reason,
-                budget_impact_tokens: candidate.budget_impact_tokens,
+                budget_impact_tokens: candidate_budget_impact,
                 dropped_reason: Some(dropped_reason),
             };
             if is_budget {
@@ -392,10 +439,12 @@ fn select_memory_candidates(
             continue;
         }
 
-        if let (Some(remaining), Some(cost)) =
-            (remaining_budget.as_mut(), candidate.budget_impact_tokens)
+        if let (Some(remaining), Some(cost)) = (remaining_budget.as_mut(), candidate_budget_impact)
         {
             *remaining = remaining.saturating_sub(cost);
+        }
+        if let Some(item) = selected_retrieved_item {
+            selected_retrieved_items.push(item);
         }
         selected_kinds.push(candidate.kind.clone());
         decision
@@ -406,12 +455,48 @@ fn select_memory_candidates(
                 label: candidate.label,
                 detail: candidate.detail,
                 selection_reason: candidate.selection_reason,
-                budget_impact_tokens: candidate.budget_impact_tokens,
+                budget_impact_tokens: candidate_budget_impact,
                 dropped_reason: None,
             });
     }
 
     decision
+}
+
+fn candidate_budget_impact_tokens(
+    candidate: &MemorySelectionCandidate,
+    selected_retrieved_items: &[(String, String)],
+) -> Option<usize> {
+    if !is_retrieved_memory_kind(candidate.kind.as_str()) {
+        return candidate.budget_impact_tokens;
+    }
+    Some(retrieved_memory_incremental_budget_impact(
+        selected_retrieved_items,
+        candidate,
+    ))
+}
+
+fn retrieved_memory_incremental_budget_impact(
+    selected_items: &[(String, String)],
+    candidate: &MemorySelectionCandidate,
+) -> usize {
+    let current = retrieved_memory_context_budget(selected_items);
+    let mut with_candidate = selected_items.to_vec();
+    with_candidate.push((candidate.label.clone(), candidate.detail.clone()));
+    retrieved_memory_context_budget(with_candidate.as_slice()).saturating_sub(current)
+}
+
+fn retrieved_memory_context_budget(items: &[(String, String)]) -> usize {
+    let render_items = items
+        .iter()
+        .map(|(label, detail)| RetrievedMemoryRenderItem {
+            label: label.as_str(),
+            detail: detail.as_str(),
+        })
+        .collect::<Vec<_>>();
+    render_retrieved_memory_context(render_items.as_slice())
+        .map(|rendered| estimate_text_tokens(&rendered))
+        .unwrap_or_default()
 }
 
 fn workspace_memory_available_item(
@@ -627,6 +712,7 @@ mod tests {
             &history,
             "session-1",
             "",
+            &[],
             Some(10_000),
         );
 
@@ -668,6 +754,7 @@ mod tests {
             &history,
             "session-1",
             "",
+            &[],
             Some(10_000),
         );
 
@@ -703,6 +790,7 @@ mod tests {
             &history,
             "session-1",
             "memory://vdb",
+            &[],
             Some(10_000),
         );
 
@@ -756,7 +844,18 @@ mod tests {
         ];
         // Budget of 1 token forces the retrieval candidate to be dropped,
         // proving it was captured as a candidate.
-        let result = memory_selection(&[], None, &[], &[], &[], &history, "session-1", "", Some(1));
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "",
+            &[],
+            Some(1),
+        );
 
         let dropped_kinds: Vec<&str> = result
             .dropped_items
@@ -820,6 +919,7 @@ mod tests {
             &history,
             "session-1",
             "",
+            &[],
             Some(10_000),
         );
 
@@ -831,6 +931,163 @@ mod tests {
         assert!(
             selected_kinds.contains(&"retrieved_thread_context"),
             "retrieve_session_context results should be selected when budget allows"
+        );
+    }
+
+    #[test]
+    fn direct_retrieved_memory_candidates_are_selected_when_budget_allows() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"Where is the reference project?"}]),
+        }];
+        let retrieved = vec![RetrievedMemoryCandidate {
+            kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+            label: "Memory: reference project path".to_string(),
+            detail: "content: Reference project source lives at /Users/example/reference-project."
+                .to_string(),
+            selection_reason: "retrieved as a candidate for the current turn query".to_string(),
+            rank: 1,
+        }];
+
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "memory://vdb",
+            &retrieved,
+            Some(10_000),
+        );
+
+        let selected = result
+            .selected_items
+            .iter()
+            .find(|item| item.kind == RETRIEVED_WORKSPACE_MEMORY_KIND)
+            .expect("direct retrieved workspace memory should be selected");
+        assert_eq!(selected.label, "Memory: reference project path");
+        assert!(selected.detail.contains("/Users/example/reference-project"));
+        let expected_rendered = render_retrieved_memory_context(&[RetrievedMemoryRenderItem {
+            label: selected.label.as_str(),
+            detail: selected.detail.as_str(),
+        }])
+        .expect("retrieved memory context should render");
+        assert_eq!(
+            selected.budget_impact_tokens,
+            Some(estimate_text_tokens(&expected_rendered))
+        );
+    }
+
+    #[test]
+    fn direct_retrieved_memory_candidates_charge_shared_context_overhead_once() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"Where are the reference project notes?"}]),
+        }];
+        let retrieved = vec![
+            RetrievedMemoryCandidate {
+                kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+                label: "Memory: reference project path".to_string(),
+                detail: "content: Reference project source lives at /Users/example/reference-project."
+                    .to_string(),
+                selection_reason: "retrieved as a candidate for the current turn query".to_string(),
+                rank: 1,
+            },
+            RetrievedMemoryCandidate {
+                kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+                label: "Memory: reference project docs".to_string(),
+                detail: "content: Reference project docs live under /Users/example/reference-project/docs."
+                    .to_string(),
+                selection_reason: "retrieved as a candidate for the current turn query".to_string(),
+                rank: 2,
+            },
+        ];
+        let rendered = render_retrieved_memory_context(
+            retrieved
+                .iter()
+                .map(|candidate| RetrievedMemoryRenderItem {
+                    label: candidate.label.as_str(),
+                    detail: candidate.detail.as_str(),
+                })
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+        .expect("retrieved memory context should render");
+        let exact_budget = estimate_text_tokens(&rendered);
+
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "memory://vdb",
+            &retrieved,
+            Some(exact_budget),
+        );
+
+        let selected = result
+            .selected_items
+            .iter()
+            .filter(|item| item.kind == RETRIEVED_WORKSPACE_MEMORY_KIND)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            selected.len(),
+            2,
+            "shared memory-context overhead should be charged once, not once per candidate"
+        );
+        assert_eq!(
+            selected
+                .iter()
+                .map(|item| item.budget_impact_tokens.unwrap_or_default())
+                .sum::<usize>(),
+            exact_budget
+        );
+    }
+
+    #[test]
+    fn direct_retrieved_memory_candidates_are_dropped_when_budget_is_tight() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"Where is the reference project?"}]),
+        }];
+        let retrieved = vec![RetrievedMemoryCandidate {
+            kind: RETRIEVED_THREAD_CONTEXT_KIND.to_string(),
+            label: "Session Context session-1#3".to_string(),
+            detail:
+                "content: a long prior session observation that will exceed the one-token budget"
+                    .to_string(),
+            selection_reason: "retrieved as a candidate for the current turn query".to_string(),
+            rank: 1,
+        }];
+
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "memory://vdb",
+            &retrieved,
+            Some(1),
+        );
+
+        let dropped = result
+            .dropped_items
+            .iter()
+            .find(|item| item.kind == RETRIEVED_THREAD_CONTEXT_KIND)
+            .expect("direct retrieved thread context should be dropped by budget");
+        assert!(
+            dropped
+                .dropped_reason
+                .as_ref()
+                .is_some_and(|reason| reason.reason().contains("memory-selection budget"))
         );
     }
 
@@ -851,6 +1108,7 @@ mod tests {
             &history,
             "session-1",
             "memory://vdb",
+            &[],
             Some(10_000),
         );
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -8,16 +8,24 @@ mod assembly_view;
 mod compaction_view;
 mod memory_selection;
 mod retrieval_view;
+mod retrieved_memory_render;
+mod retriever;
 mod runtime;
 
 pub use self::assembler::{
     AssembledContext, AssembledTurnContext, ContextAssembler, RuntimeContextInputs,
     RuntimeInteractionInput,
 };
+pub(crate) use self::retrieved_memory_render::{
+    RetrievedMemoryRenderItem, render_retrieved_memory_context,
+    render_retrieved_memory_context_item,
+};
+pub(crate) use self::retriever::MemoryRetrievalOrchestrator;
 pub use self::runtime::{
     CacheStatus, CompactionContextView, CompactionSourceContextEntry, ContextAssemblyEntry,
     ContextAssemblyView, ContextBudgetView, DropReason, MemorySelectionContextView,
     MemorySelectionItemContextEntry, PlanContextView, PromptContextView, PromptSourceContextEntry,
-    RetrievalContextView, RetrievalSourceContextEntry, SharedRuntimeContext, TodoContextView,
+    RETRIEVED_THREAD_CONTEXT_KIND, RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalContextView,
+    RetrievalSourceContextEntry, RetrievedMemoryCandidate, SharedRuntimeContext, TodoContextView,
     is_retrieved_memory_kind,
 };

--- a/src/context/retrieved_memory_render.rs
+++ b/src/context/retrieved_memory_render.rs
@@ -1,0 +1,61 @@
+pub(crate) const MEMORY_CONTEXT_HEADER: &str = "<rara_internal_history_context>";
+pub(crate) const MEMORY_CONTEXT_FOOTER: &str = "</rara_internal_history_context>";
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RetrievedMemoryRenderItem<'a> {
+    pub label: &'a str,
+    pub detail: &'a str,
+}
+
+pub(crate) fn render_retrieved_memory_context(
+    items: &[RetrievedMemoryRenderItem<'_>],
+) -> Option<String> {
+    if items.is_empty() {
+        return None;
+    }
+
+    let mut lines = vec![
+        MEMORY_CONTEXT_HEADER.to_string(),
+        "Relevant memory selected for the current turn:".to_string(),
+    ];
+    for item in items {
+        lines.push(render_retrieved_memory_context_item(*item));
+    }
+    lines.extend([
+        "".to_string(),
+        "Use this as background recall. If it conflicts with the current user request or inspected files, trust the current evidence."
+            .to_string(),
+        MEMORY_CONTEXT_FOOTER.to_string(),
+    ]);
+
+    Some(lines.join("\n"))
+}
+
+pub(crate) fn render_retrieved_memory_context_item(item: RetrievedMemoryRenderItem<'_>) -> String {
+    format!(
+        "- {}: {}",
+        normalize_memory_context_field(item.label),
+        normalize_memory_context_field(item.detail)
+    )
+}
+
+fn normalize_memory_context_field(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_retrieved_memory_context_normalizes_multiline_items() {
+        let rendered = render_retrieved_memory_context(&[RetrievedMemoryRenderItem {
+            label: "Memory:\nReference",
+            detail: "first line\nsecond\tline",
+        }])
+        .expect("retrieved memory context should render");
+
+        assert!(rendered.contains("- Memory: Reference: first line second line"));
+        assert!(!rendered.contains("first line\nsecond"));
+    }
+}

--- a/src/context/retriever.rs
+++ b/src/context/retriever.rs
@@ -1,0 +1,248 @@
+use std::sync::Arc;
+
+use crate::agent::Message;
+use crate::context::assembler::latest_user_request;
+use crate::context::{
+    RETRIEVED_THREAD_CONTEXT_KIND, RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievedMemoryCandidate,
+};
+use crate::llm::LlmBackend;
+use crate::memory_store::{MemoryRecordSearchHit, MemoryStore};
+use crate::vectordb::{MemorySearchHit, VectorDB};
+
+const WORKSPACE_MEMORY_LIMIT: usize = 6;
+const THREAD_CONTEXT_LIMIT: usize = 4;
+const MEMORY_DETAIL_MAX_CHARS: usize = 1_200;
+
+pub(crate) struct MemoryRetrievalOrchestrator {
+    backend: Arc<dyn LlmBackend>,
+    vdb: Arc<VectorDB>,
+    memory_store: Arc<MemoryStore>,
+}
+
+impl MemoryRetrievalOrchestrator {
+    pub(crate) fn new(
+        backend: Arc<dyn LlmBackend>,
+        vdb: Arc<VectorDB>,
+        memory_store: Arc<MemoryStore>,
+    ) -> Self {
+        Self {
+            backend,
+            vdb,
+            memory_store,
+        }
+    }
+
+    pub(crate) async fn retrieve_for_history(
+        &self,
+        history: &[Message],
+    ) -> Vec<RetrievedMemoryCandidate> {
+        let Some(query) = latest_user_request(history) else {
+            return Vec::new();
+        };
+        self.retrieve_for_query(query.as_str()).await
+    }
+
+    async fn retrieve_for_query(&self, query: &str) -> Vec<RetrievedMemoryCandidate> {
+        let query = query.trim();
+        if query.is_empty() {
+            return Vec::new();
+        }
+
+        let Ok(query_vector) = self.backend.embed(query).await else {
+            return Vec::new();
+        };
+        let mut candidates = Vec::new();
+        candidates.extend(
+            self.thread_context_candidates(query, query_vector.clone())
+                .await,
+        );
+        candidates.extend(self.workspace_memory_candidates(query, query_vector).await);
+        candidates
+    }
+
+    async fn workspace_memory_candidates(
+        &self,
+        query: &str,
+        query_vector: Vec<f32>,
+    ) -> Vec<RetrievedMemoryCandidate> {
+        let Ok(mut hits) = self
+            .memory_store
+            .search_with_embedding(query, query_vector, WORKSPACE_MEMORY_LIMIT)
+            .await
+        else {
+            return Vec::new();
+        };
+        hits.sort_by(|a, b| workspace_rank_score(b).total_cmp(&workspace_rank_score(a)));
+        hits.into_iter()
+            .enumerate()
+            .map(|(idx, hit)| workspace_memory_candidate(idx + 1, hit))
+            .collect()
+    }
+
+    async fn thread_context_candidates(
+        &self,
+        query: &str,
+        query_vector: Vec<f32>,
+    ) -> Vec<RetrievedMemoryCandidate> {
+        let Ok(hits) = self
+            .vdb
+            .hybrid_search_with_metadata("conversations", query, query_vector, THREAD_CONTEXT_LIMIT)
+            .await
+        else {
+            return Vec::new();
+        };
+        hits.into_iter()
+            .enumerate()
+            .map(|(idx, hit)| thread_context_candidate(idx + 1, hit))
+            .collect()
+    }
+}
+
+fn workspace_rank_score(hit: &MemoryRecordSearchHit) -> f32 {
+    hit.score + hit.record.importance
+}
+
+fn workspace_memory_candidate(rank: usize, hit: MemoryRecordSearchHit) -> RetrievedMemoryCandidate {
+    let labels = hit
+        .record
+        .labels
+        .iter()
+        .map(|label| format!("{label:?}").to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join(",");
+    RetrievedMemoryCandidate {
+        kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+        label: format!("Memory: {}", hit.record.title),
+        detail: format!(
+            "id={}; scope={:?}; labels={}; importance={:.1}; score={:.3}; content: {}",
+            hit.record.id,
+            hit.record.scope,
+            labels,
+            hit.record.importance,
+            hit.score,
+            truncate_for_memory_context(hit.record.content.as_str(), MEMORY_DETAIL_MAX_CHARS)
+        ),
+        selection_reason:
+            "retrieved as a candidate because LanceDB-backed MemoryStore retrieval matched the current turn query"
+                .to_string(),
+        rank,
+    }
+}
+
+fn thread_context_candidate(rank: usize, hit: MemorySearchHit) -> RetrievedMemoryCandidate {
+    RetrievedMemoryCandidate {
+        kind: RETRIEVED_THREAD_CONTEXT_KIND.to_string(),
+        label: format!(
+            "Session Context {}#{}",
+            hit.metadata.session_id, hit.metadata.turn_index
+        ),
+        detail: format!(
+            "session={}; turn={}; score={:.3}; text: {}",
+            hit.metadata.session_id,
+            hit.metadata.turn_index,
+            hit.score,
+            truncate_for_memory_context(hit.metadata.text.as_str(), MEMORY_DETAIL_MAX_CHARS)
+        ),
+        selection_reason:
+            "retrieved as a candidate because LanceDB-backed session-context retrieval matched the current turn query"
+                .to_string(),
+        rank,
+    }
+}
+
+fn truncate_for_memory_context(value: &str, max_chars: usize) -> String {
+    let value = value.trim();
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use serde_json::Value;
+
+    use super::*;
+    use crate::llm::{ContentBlock, LlmResponse};
+    use crate::memory_store::{MemoryLabel, MemoryScope, MemorySource, NewMemoryRecord};
+
+    #[derive(Default)]
+    struct TestBackend {
+        embed_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmBackend for TestBackend {
+        async fn ask(&self, _messages: &[Message], _tools: &[Value]) -> Result<LlmResponse> {
+            Ok(LlmResponse {
+                content: vec![ContentBlock::Text {
+                    text: "ok".to_string(),
+                }],
+                stop_reason: Some("end_turn".to_string()),
+                usage: None,
+            })
+        }
+
+        async fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+            self.embed_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![1.0; 8])
+        }
+
+        async fn summarize(&self, _messages: &[Message], _instruction: &str) -> Result<String> {
+            Ok("summary".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn retrieves_memory_store_candidates_for_latest_user_request() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let backend = Arc::new(TestBackend::default());
+        let vdb = Arc::new(VectorDB::new(temp.path().to_str().expect("utf8 path")));
+        let store = Arc::new(MemoryStore::new(backend.clone(), vdb.clone()));
+        store
+            .insert(NewMemoryRecord {
+                title: Some("Reference project path".to_string()),
+                content:
+                    "Reference project source lives at /Users/example/devel/opensource/reference-project."
+                        .to_string(),
+                labels: vec![MemoryLabel::Fact],
+                importance: 0.9,
+                source: MemorySource::UserCreated,
+                scope: MemoryScope::Workspace,
+                session_id: None,
+                thread_id: None,
+                source_span: None,
+            })
+            .await
+            .expect("insert memory");
+        backend.embed_calls.store(0, Ordering::SeqCst);
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: serde_json::json!([
+                {"type": "text", "text": "Where is the reference project source path?"}
+            ]),
+        }];
+
+        let candidates = MemoryRetrievalOrchestrator::new(backend.clone(), vdb, store)
+            .retrieve_for_history(&history)
+            .await;
+
+        assert!(candidates.iter().any(|candidate| {
+            candidate.kind == RETRIEVED_WORKSPACE_MEMORY_KIND
+                && candidate.detail.contains("reference-project")
+        }));
+        assert_eq!(
+            backend.embed_calls.load(Ordering::SeqCst),
+            1,
+            "orchestrator should embed the latest user query once and reuse it across retrieval sources"
+        );
+    }
+}

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -292,6 +292,15 @@ pub struct RetrievalSourceContextEntry {
     pub inclusion_reason: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetrievedMemoryCandidate {
+    pub kind: String,
+    pub label: String,
+    pub detail: String,
+    pub selection_reason: String,
+    pub rank: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct MemorySelectionContextView {
     pub selection_budget_tokens: Option<usize>,

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -182,6 +182,18 @@ impl MemoryStore {
             return Ok(Vec::new());
         }
         let query_vector = self.backend.embed(query).await?;
+        self.search_with_embedding(query, query_vector, limit).await
+    }
+
+    pub async fn search_with_embedding(
+        &self,
+        query: &str,
+        query_vector: Vec<f32>,
+        limit: usize,
+    ) -> Result<Vec<MemoryRecordSearchHit>> {
+        if query.trim().is_empty() || query_vector.is_empty() || limit == 0 {
+            return Ok(Vec::new());
+        }
         let hits = self
             .vdb
             .hybrid_search_with_metadata(EXPERIENCES_TABLE, query, query_vector, limit)


### PR DESCRIPTION
## Summary

- add a `MemoryRetrievalOrchestrator` that searches LanceDB-backed session context and durable `MemoryStore` records
- route retrieved memory through `MemorySelection` so `/context` can report selected, available, and dropped candidates
- inject selected memory as per-turn internal context before the current user request, without persisting it into history or changing the stable system prompt prefix
- update memory specs, journal, and TODO checkpoint for the M1/M2 runtime slice

## Tests

- `RUSTUP_TOOLCHAIN=nightly cargo fmt --check`
- `RUSTUP_TOOLCHAIN=nightly cargo test context::memory_selection -- --nocapture`
- `RUSTUP_TOOLCHAIN=nightly cargo test context::retriever -- --nocapture`
- `RUSTUP_TOOLCHAIN=nightly cargo test agent::tests::context_view::query_injects_selected_memory_context_without_persisting_it_to_history -- --nocapture`
- `RUSTUP_TOOLCHAIN=nightly cargo check --tests`
