### PR TITLE
feat: structured command model across bash, sandbox, and PTY tools

### DIFF
--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -311,6 +311,20 @@ impl SandboxManager {
         }
     }
 
+    pub fn wrap_pty_exec_command(
+        &self,
+        program: &str,
+        args: &[String],
+        cwd: &str,
+        allow_net: bool,
+    ) -> Result<WrappedCommand> {
+        match &self.backend {
+            // macOS sandbox-exec does not preserve interactive PTY stdin reliably.
+            SandboxBackend::MacosSeatbelt => Ok(wrap_direct_exec_command(program, args)),
+            _ => self.wrap_exec_command(program, args, cwd, allow_net),
+        }
+    }
+
     pub fn wrap_unsandboxed_exec_command(&self, program: &str, args: &[String]) -> WrappedCommand {
         wrap_direct_exec_command(program, args)
     }

--- a/crates/sandbox/src/tests.rs
+++ b/crates/sandbox/src/tests.rs
@@ -565,3 +565,128 @@ fn sandbox_profile_string_literal_escapes_control_characters() {
 
     assert_eq!(escaped, "/tmp/a\\nb\\tc");
 }
+
+#[test]
+fn wrap_exec_command_fails_closed_on_unsupported_platform() {
+    let manager = manager(
+        "freebsd",
+        SandboxBackend::Unsupported {
+            platform: "freebsd".to_string(),
+        },
+    );
+
+    let err = manager
+        .wrap_exec_command("cargo", &["check".to_string()], "/tmp", false)
+        .expect_err("unsupported platforms should not fall back to unsandboxed execution");
+
+    assert!(
+        err.to_string()
+            .contains("sandboxed command execution is unsupported on platform freebsd")
+    );
+}
+
+#[test]
+fn wrap_exec_command_unsandboxed_exec_runs_directly() {
+    let manager = manager("macos", SandboxBackend::Direct);
+
+    let wrapped = manager.wrap_unsandboxed_exec_command(
+        "cargo",
+        &["check".to_string(), "--workspace".to_string()],
+    );
+
+    assert_eq!(wrapped.program, "cargo");
+    assert_eq!(wrapped.args, vec!["check", "--workspace"]);
+    assert!(!wrapped.sandboxed);
+    assert_eq!(wrapped.sandbox_backend, "direct");
+}
+
+#[test]
+fn wrap_exec_command_direct_fallback() {
+    let manager = manager("macos", SandboxBackend::Direct);
+
+    let wrapped = manager
+        .wrap_exec_command(
+            "cargo",
+            &["test".to_string()],
+            "/workspace",
+            false,
+        )
+        .expect("direct exec");
+
+    assert_eq!(wrapped.program, "cargo");
+    assert_eq!(wrapped.args, vec!["test"]);
+    assert!(!wrapped.sandboxed);
+    assert_eq!(wrapped.sandbox_backend, "direct");
+    assert!(wrapped.network_access);
+    assert!(wrapped.cleanup_path.is_none());
+}
+
+#[test]
+fn wrap_exec_command_macos_seatbelt() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let manager = SandboxManager {
+        os: "macos".to_string(),
+        profile_dir: tempdir.path().to_path_buf(),
+        sandbox_home: tempdir.path().join("home"),
+        backend: SandboxBackend::MacosSeatbelt,
+        command_install_roots: command_search_install_roots(
+            std::env::var_os("PATH").as_deref(),
+        ),
+    };
+
+    let wrapped = manager
+        .wrap_exec_command(
+            "cargo",
+            &["check".to_string(), "--workspace".to_string()],
+            "/tmp",
+            false,
+        )
+        .expect("macos exec wrapper");
+
+    assert_eq!(wrapped.program, MACOS_SANDBOX_EXEC);
+    assert!(wrapped.sandboxed);
+    assert_eq!(wrapped.sandbox_backend, "macos-seatbelt");
+
+    let cleanup_path = wrapped
+        .cleanup_path
+        .expect("macos wrapper should return cleanup path");
+    assert!(cleanup_path.exists());
+
+    assert!(
+        wrapped.args.contains(&"cargo".to_string()),
+        "wrapped args should contain the program name"
+    );
+    assert!(
+        wrapped.args.iter().any(|arg| arg == "check"),
+        "wrapped args should contain program args"
+    );
+    assert!(
+        wrapped.args.iter().any(|arg| arg == "--workspace"),
+        "wrapped args should contain all program args"
+    );
+}
+
+#[test]
+fn wrap_exec_command_linux_bubblewrap() {
+    let manager = manager("linux", SandboxBackend::LinuxBubblewrap);
+
+    let wrapped = manager
+        .wrap_exec_command(
+            "cargo",
+            &["check".to_string()],
+            "/workspace/project",
+            false,
+        )
+        .expect("linux exec wrapper");
+
+    assert_eq!(wrapped.program, "bwrap");
+    assert!(wrapped.sandboxed);
+    assert_eq!(wrapped.sandbox_backend, "linux-bubblewrap");
+
+    let dash_dash_pos = wrapped.args.iter().position(|a| a == "--");
+    assert!(dash_dash_pos.is_some(), "-- separator should be present");
+    let after_sep = &wrapped.args[dash_dash_pos.unwrap() + 1..];
+    assert_eq!(after_sep[0], "cargo");
+    assert_eq!(after_sep[1], "check");
+    assert_eq!(after_sep.len(), 2);
+}

--- a/crates/sandbox/src/tests.rs
+++ b/crates/sandbox/src/tests.rs
@@ -589,10 +589,8 @@ fn wrap_exec_command_fails_closed_on_unsupported_platform() {
 fn wrap_exec_command_unsandboxed_exec_runs_directly() {
     let manager = manager("macos", SandboxBackend::Direct);
 
-    let wrapped = manager.wrap_unsandboxed_exec_command(
-        "cargo",
-        &["check".to_string(), "--workspace".to_string()],
-    );
+    let wrapped = manager
+        .wrap_unsandboxed_exec_command("cargo", &["check".to_string(), "--workspace".to_string()]);
 
     assert_eq!(wrapped.program, "cargo");
     assert_eq!(wrapped.args, vec!["check", "--workspace"]);
@@ -605,12 +603,7 @@ fn wrap_exec_command_direct_fallback() {
     let manager = manager("macos", SandboxBackend::Direct);
 
     let wrapped = manager
-        .wrap_exec_command(
-            "cargo",
-            &["test".to_string()],
-            "/workspace",
-            false,
-        )
+        .wrap_exec_command("cargo", &["test".to_string()], "/workspace", false)
         .expect("direct exec");
 
     assert_eq!(wrapped.program, "cargo");
@@ -629,9 +622,7 @@ fn wrap_exec_command_macos_seatbelt() {
         profile_dir: tempdir.path().to_path_buf(),
         sandbox_home: tempdir.path().join("home"),
         backend: SandboxBackend::MacosSeatbelt,
-        command_install_roots: command_search_install_roots(
-            std::env::var_os("PATH").as_deref(),
-        ),
+        command_install_roots: command_search_install_roots(std::env::var_os("PATH").as_deref()),
     };
 
     let wrapped = manager
@@ -671,12 +662,7 @@ fn wrap_exec_command_linux_bubblewrap() {
     let manager = manager("linux", SandboxBackend::LinuxBubblewrap);
 
     let wrapped = manager
-        .wrap_exec_command(
-            "cargo",
-            &["check".to_string()],
-            "/workspace/project",
-            false,
-        )
+        .wrap_exec_command("cargo", &["check".to_string()], "/workspace/project", false)
         .expect("linux exec wrapper");
 
     assert_eq!(wrapped.program, "bwrap");

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -93,7 +93,7 @@ Active backlog only. Keep this file small and current.
 
 ## Security / Reliability / Performance
 
-- [ ] Structured command model (`program`, `args`, `cwd`, `allow_net`) in `src/tools/bash.rs` and `crates/sandbox`.
+- [x] Structured command model (`program`, `args`, `cwd`, `allow_net`) in `src/tools/bash.rs` and `crates/sandbox`.
 - [ ] Classifier and routing model from `docs/features/classifier-and-routing.md`.
 - [ ] Auditable permission + sandbox-bypass rules (Codex/Claude-inspired).
 - [ ] Structured auto-permission classifier with compact transcript projection.

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -56,6 +56,12 @@ pub struct BackgroundTaskStore {
 pub struct BackgroundTaskRecord {
     id: String,
     command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    program: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    args: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cwd: Option<String>,
     output_path: PathBuf,
     status: BackgroundTaskStatus,
     exit_code: Option<i32>,
@@ -554,7 +560,7 @@ impl BackgroundTaskStore {
 
     fn start_record(
         &self,
-        command: String,
+        request: &BashCommandInput,
         sandboxed: bool,
         sandbox_backend: String,
         network_access: bool,
@@ -563,7 +569,14 @@ impl BackgroundTaskStore {
         let output_path = self.dir.join(format!("{id}.log"));
         let record = BackgroundTaskRecord {
             id: id.clone(),
-            command,
+            command: request.summary(),
+            program: request
+                .program
+                .as_deref()
+                .filter(|v| !v.trim().is_empty())
+                .map(String::from),
+            args: request.args.clone(),
+            cwd: request.cwd.clone(),
             output_path,
             status: BackgroundTaskStatus::Running,
             exit_code: None,
@@ -892,7 +905,7 @@ impl Tool for BashTool {
 
         if request.run_in_background {
             let (record, stop_rx) = self.background_tasks.start_record(
-                request.summary(),
+                &request,
                 wrapped.sandboxed,
                 wrapped.sandbox_backend.clone(),
                 wrapped.network_access,
@@ -1125,6 +1138,9 @@ impl Tool for BackgroundTaskStatusTool {
         Ok(json!({
             "task_id": record.id,
             "command": record.command,
+            "program": record.program,
+            "args": record.args,
+            "cwd": record.cwd,
             "status": record.status,
             "exit_code": record.exit_code,
             "output_path": record.output_path,

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -576,7 +576,11 @@ impl BackgroundTaskStore {
                 .filter(|v| !v.trim().is_empty())
                 .map(String::from),
             args: request.args.clone(),
-            cwd: request.cwd.clone(),
+            cwd: request
+                .cwd
+                .as_ref()
+                .filter(|d| !d.trim().is_empty())
+                .cloned(),
             output_path,
             status: BackgroundTaskStatus::Running,
             exit_code: None,

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use rara_tool_macros::tool_spec;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use uuid::Uuid;
@@ -365,6 +366,88 @@ impl PtySessionSnapshot {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PtyCommandInput {
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub program: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub allow_net: bool,
+    #[serde(default = "default_rows")]
+    pub rows: u16,
+    #[serde(default = "default_cols")]
+    pub cols: u16,
+}
+
+fn default_rows() -> u16 {
+    24
+}
+fn default_cols() -> u16 {
+    120
+}
+
+impl PtyCommandInput {
+    pub fn from_value(input: Value) -> Result<Self, ToolError> {
+        let parsed: Self = serde_json::from_value(input)
+            .map_err(|err| ToolError::InvalidInput(format!("pty payload: {err}")))?;
+        parsed.validate()?;
+        Ok(parsed)
+    }
+
+    pub fn validate(&self) -> Result<(), ToolError> {
+        let has_command = self
+            .command
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty());
+        let has_program = self
+            .program
+            .as_ref()
+            .is_some_and(|value| !value.trim().is_empty());
+        if !has_command && !has_program {
+            return Err(ToolError::InvalidInput(
+                "pty payload requires either command or program".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn working_dir(&self) -> String {
+        match self.cwd.as_ref() {
+            Some(cwd) if !cwd.trim().is_empty() => cwd.clone(),
+            _ => env::current_dir()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|_| ".".to_string()),
+        }
+    }
+
+    pub fn summary(&self) -> String {
+        if let Some(command) = self
+            .command
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+        {
+            return command.to_string();
+        }
+        let program = self
+            .program
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("<program>");
+        if self.args.is_empty() {
+            program.to_string()
+        } else {
+            format!("{program} {}", self.args.join(" "))
+        }
+    }
+}
 #[tool_spec(
     name = "pty_start",
     description = "Start an interactive PTY session only for commands that need terminal input, terminal control, or an interactive program. For ordinary non-interactive commands, use bash instead. Prefer dedicated RARA tools for file search, file reads, and file edits. Use the cwd field instead of prepending cd. PTY sandboxing is platform-dependent and best-effort; with the macOS seatbelt backend, PTY commands currently run directly because sandbox-exec does not preserve interactive PTY stdin reliably. Treat allow_net as a network-access toggle, not a sandbox guarantee. Inspect or stop sessions with pty_status, pty_list, and pty_stop.",
@@ -410,69 +493,42 @@ impl PtySessionSnapshot {
 #[async_trait]
 impl Tool for PtyStartTool {
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
-        let cwd = input
-            .get("cwd")
-            .and_then(Value::as_str)
-            .filter(|value| !value.trim().is_empty())
-            .map(str::to_string)
-            .unwrap_or_else(|| {
-                env::current_dir()
-                    .map(|path| path.display().to_string())
-                    .unwrap_or_else(|_| ".".to_string())
-            });
-        let env = parse_env(input.get("env"))?;
-        let allow_net = input
-            .get("allow_net")
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        let allow_net = self.sandbox_network_access.load(Ordering::Relaxed) || allow_net;
-        let (command, wrapped) = if let Some(cmd) = input
-            .get("command")
-            .and_then(Value::as_str)
-            .filter(|v| !v.trim().is_empty())
-        {
-            let cmd = cmd.to_string();
+        let request = PtyCommandInput::from_value(input)?;
+        let cwd = request.working_dir();
+        let allow_net = self.sandbox_network_access.load(Ordering::Relaxed) || request.allow_net;
+        let (command, wrapped) = if let Some(cmd) = request.command.as_deref() {
             let wrapped = self
                 .sandbox
-                .wrap_pty_shell_command(&cmd, &cwd, allow_net)
+                .wrap_pty_shell_command(cmd, &cwd, allow_net)
                 .map_err(|err| {
                     ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
                 })?;
-            (cmd, wrapped)
+            (cmd.to_string(), wrapped)
         } else {
-            let program = input
-                .get("program")
-                .and_then(Value::as_str)
+            let program = request
+                .program
+                .as_deref()
                 .filter(|v| !v.trim().is_empty())
                 .ok_or_else(|| ToolError::InvalidInput("program".into()))?
                 .to_string();
-            let args: Vec<String> = input
-                .get("args")
-                .and_then(Value::as_array)
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
-                })
-                .unwrap_or_default();
-            let summary = if args.is_empty() {
-                program.clone()
-            } else {
-                format!("{} {}", program, args.join(" "))
-            };
+            let summary = request.summary();
             let wrapped = self
                 .sandbox
-                .wrap_pty_exec_command(&program, &args, &cwd, allow_net)
+                .wrap_pty_exec_command(&program, &request.args, &cwd, allow_net)
                 .map_err(|err| {
                     ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
                 })?;
             (summary, wrapped)
         };
-        let rows = parse_pty_dimension(input.get("rows"), 24, "rows")?;
-        let cols = parse_pty_dimension(input.get("cols"), 120, "cols")?;
-        let started =
-            self.sessions
-                .start(command, wrapped, cwd, &self.base_env, env, rows, cols)?;
+        let started = self.sessions.start(
+            command,
+            wrapped,
+            cwd,
+            &self.base_env,
+            request.env,
+            request.rows,
+            request.cols,
+        )?;
         self.sessions
             .wait_for_quick_completion(&started.id, PTY_START_QUICK_COMPLETION_TIMEOUT)
             .await
@@ -636,15 +692,6 @@ impl Tool for PtyStopTool {
         Ok(json!({ "stopped": stopped }))
     }
 }
-
-fn parse_env(value: Option<&Value>) -> Result<HashMap<String, String>, ToolError> {
-    let Some(value) = value else {
-        return Ok(HashMap::new());
-    };
-    serde_json::from_value(value.clone())
-        .map_err(|err| ToolError::InvalidInput(format!("env: {err}")))
-}
-
 fn command_env_for_wrapped(
     wrapped: &WrappedCommand,
     base_env: &HashMap<String, String>,

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -502,34 +502,31 @@ impl Tool for PtyStartTool {
         let request = PtyCommandInput::from_value(input)?;
         let cwd = request.working_dir();
         let allow_net = self.sandbox_network_access.load(Ordering::Relaxed) || request.allow_net;
-        let (command, wrapped) = if let Some(cmd) = request
-            .command
-            .as_deref()
-            .filter(|v| !v.trim().is_empty())
-        {
-            let wrapped = self
-                .sandbox
-                .wrap_pty_shell_command(cmd, &cwd, allow_net)
-                .map_err(|err| {
-                    ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
-                })?;
-            (cmd.to_string(), wrapped)
-        } else {
-            let program = request
-                .program
-                .as_deref()
-                .filter(|v| !v.trim().is_empty())
-                .ok_or_else(|| ToolError::InvalidInput("program".into()))?
-                .to_string();
-            let summary = request.summary();
-            let wrapped = self
-                .sandbox
-                .wrap_pty_exec_command(&program, &request.args, &cwd, allow_net)
-                .map_err(|err| {
-                    ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
-                })?;
-            (summary, wrapped)
-        };
+        let (command, wrapped) =
+            if let Some(cmd) = request.command.as_deref().filter(|v| !v.trim().is_empty()) {
+                let wrapped = self
+                    .sandbox
+                    .wrap_pty_shell_command(cmd, &cwd, allow_net)
+                    .map_err(|err| {
+                        ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
+                    })?;
+                (cmd.to_string(), wrapped)
+            } else {
+                let program = request
+                    .program
+                    .as_deref()
+                    .filter(|v| !v.trim().is_empty())
+                    .ok_or_else(|| ToolError::InvalidInput("program".into()))?
+                    .to_string();
+                let summary = request.summary();
+                let wrapped = self
+                    .sandbox
+                    .wrap_pty_exec_command(&program, &request.args, &cwd, allow_net)
+                    .map_err(|err| {
+                        ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
+                    })?;
+                (summary, wrapped)
+            };
         let started = self.sessions.start(
             command,
             wrapped,
@@ -1151,8 +1148,9 @@ mod tests {
 
 #[cfg(test)]
 mod input_tests {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     #[test]
     fn parses_structured_program_payload() {

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -366,7 +366,7 @@ impl PtySessionSnapshot {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PtyCommandInput {
     #[serde(default)]
     pub command: Option<String>,
@@ -414,6 +414,12 @@ impl PtyCommandInput {
             return Err(ToolError::InvalidInput(
                 "pty payload requires either command or program".into(),
             ));
+        }
+        if self.rows == 0 {
+            return Err(ToolError::InvalidInput("rows must be >= 1".into()));
+        }
+        if self.cols == 0 {
+            return Err(ToolError::InvalidInput("cols must be >= 1".into()));
         }
         Ok(())
     }
@@ -496,7 +502,11 @@ impl Tool for PtyStartTool {
         let request = PtyCommandInput::from_value(input)?;
         let cwd = request.working_dir();
         let allow_net = self.sandbox_network_access.load(Ordering::Relaxed) || request.allow_net;
-        let (command, wrapped) = if let Some(cmd) = request.command.as_deref() {
+        let (command, wrapped) = if let Some(cmd) = request
+            .command
+            .as_deref()
+            .filter(|v| !v.trim().is_empty())
+        {
             let wrapped = self
                 .sandbox
                 .wrap_pty_shell_command(cmd, &cwd, allow_net)
@@ -1136,5 +1146,97 @@ mod tests {
                 .and_then(Value::as_bool),
             Some(true)
         );
+    }
+}
+
+#[cfg(test)]
+mod input_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_structured_program_payload() {
+        let input = PtyCommandInput::from_value(json!({
+            "program": "cargo",
+            "args": ["check", "--workspace"],
+            "cwd": "/tmp",
+            "allow_net": true,
+            "rows": 30,
+            "cols": 100,
+        }))
+        .expect("structured pty payload");
+
+        assert_eq!(input.program.as_deref(), Some("cargo"));
+        assert_eq!(
+            input.args,
+            vec!["check".to_string(), "--workspace".to_string()]
+        );
+        assert_eq!(input.cwd.as_deref(), Some("/tmp"));
+        assert!(input.allow_net);
+        assert_eq!(input.rows, 30);
+        assert_eq!(input.cols, 100);
+        assert_eq!(input.summary(), "cargo check --workspace");
+    }
+
+    #[test]
+    fn parses_legacy_command_payload() {
+        let input = PtyCommandInput::from_value(json!({
+            "command": "echo hello",
+        }))
+        .expect("legacy pty payload");
+
+        assert_eq!(input.command.as_deref(), Some("echo hello"));
+        assert_eq!(input.summary(), "echo hello");
+        assert_eq!(input.rows, 24);
+        assert_eq!(input.cols, 120);
+    }
+
+    #[test]
+    fn rejects_missing_command_and_program() {
+        let err = PtyCommandInput::from_value(json!({
+            "rows": 24,
+            "cols": 120,
+        }))
+        .expect_err("no command or program");
+
+        assert!(
+            err.to_string().contains("either command or program"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_zero_rows() {
+        let err = PtyCommandInput::from_value(json!({
+            "command": "echo hi",
+            "rows": 0,
+        }))
+        .expect_err("zero rows");
+
+        assert!(err.to_string().contains("rows must be >= 1"), "{err}");
+    }
+
+    #[test]
+    fn rejects_zero_cols() {
+        let err = PtyCommandInput::from_value(json!({
+            "command": "echo hi",
+            "cols": 0,
+        }))
+        .expect_err("zero cols");
+
+        assert!(err.to_string().contains("cols must be >= 1"), "{err}");
+    }
+
+    #[test]
+    fn whitespace_command_falls_back_to_program() {
+        let input = PtyCommandInput::from_value(json!({
+            "command": "   ",
+            "program": "cargo",
+            "args": ["test"],
+        }))
+        .expect("whitespace command");
+
+        assert_eq!(input.program.as_deref(), Some("cargo"));
+        assert_eq!(input.summary(), "cargo test");
     }
 }

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -375,6 +375,15 @@ impl PtySessionSnapshot {
                 "type": "string",
                 "description": "Shell command to run inside a PTY. Use PTY only for interactive commands; use bash for ordinary non-interactive commands."
             },
+            "program": {
+                "type": "string",
+                "description": "Executable to run directly without a shell. Prefer this with args for ordinary commands."
+            },
+            "args": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Arguments for program."
+            },
             "cwd": {
                 "type": "string",
                 "description": "Optional working directory. Defaults to the current turn cwd; prefer this over prepending cd to a command."
@@ -392,17 +401,15 @@ impl PtySessionSnapshot {
             "rows": { "type": "integer", "default": 24, "minimum": 1, "maximum": 65535 },
             "cols": { "type": "integer", "default": 120, "minimum": 1, "maximum": 65535 }
         },
-        "required": ["command"]
+        "anyOf": [
+            { "required": ["command"] },
+            { "required": ["program"] }
+        ]
     }
 )]
 #[async_trait]
 impl Tool for PtyStartTool {
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
-        let command = input["command"]
-            .as_str()
-            .filter(|value| !value.trim().is_empty())
-            .ok_or_else(|| ToolError::InvalidInput("command".into()))?
-            .to_string();
         let cwd = input
             .get("cwd")
             .and_then(Value::as_str)
@@ -419,12 +426,48 @@ impl Tool for PtyStartTool {
             .and_then(Value::as_bool)
             .unwrap_or(false);
         let allow_net = self.sandbox_network_access.load(Ordering::Relaxed) || allow_net;
-        let wrapped = self
-            .sandbox
-            .wrap_pty_shell_command(&command, &cwd, allow_net)
-            .map_err(|err| {
-                ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
-            })?;
+        let (command, wrapped) = if let Some(cmd) = input
+            .get("command")
+            .and_then(Value::as_str)
+            .filter(|v| !v.trim().is_empty())
+        {
+            let cmd = cmd.to_string();
+            let wrapped = self
+                .sandbox
+                .wrap_pty_shell_command(&cmd, &cwd, allow_net)
+                .map_err(|err| {
+                    ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
+                })?;
+            (cmd, wrapped)
+        } else {
+            let program = input
+                .get("program")
+                .and_then(Value::as_str)
+                .filter(|v| !v.trim().is_empty())
+                .ok_or_else(|| ToolError::InvalidInput("program".into()))?
+                .to_string();
+            let args: Vec<String> = input
+                .get("args")
+                .and_then(Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let summary = if args.is_empty() {
+                program.clone()
+            } else {
+                format!("{} {}", program, args.join(" "))
+            };
+            let wrapped = self
+                .sandbox
+                .wrap_pty_exec_command(&program, &args, &cwd, allow_net)
+                .map_err(|err| {
+                    ToolError::ExecutionFailed(format!("{} {}", err, sandbox_failure_hint()))
+                })?;
+            (summary, wrapped)
+        };
         let rows = parse_pty_dimension(input.get("rows"), 24, "rows")?;
         let cols = parse_pty_dimension(input.get("cols"), 120, "cols")?;
         let started =


### PR DESCRIPTION
## Summary

Completes the structured command model work (`program`, `args`, `cwd`, `allow_net`) across all shell-execution surfaces.

## Changes

- **crates/sandbox** — Add 5 unit tests for `wrap_exec_command` (macOS seatbelt, linux bubblewrap, direct fallback, unsandboxed exec, unsupported platform), closing a test coverage gap.
- **crates/sandbox** — Add `wrap_pty_exec_command` to SandboxManager, mirroring the existing `wrap_pty_shell_command` pattern for structured PTY execution.
- **src/tools/pty.rs** — Extend `pty_start` tool schema to accept `program`/`args` alongside the legacy `command` field, using `anyOf` for schema compatibility.
- **src/tools/bash.rs** — Store `program`/`args`/`cwd` in `BackgroundTaskRecord` for full payload preservation; refactor `start_record` to accept `&BashCommandInput` instead of just a summary string.
- **docs/todo.md** — Mark the structured command model item as complete.

## Validation

- `cargo check` — passes
- `cargo test -p rara-sandbox` — **27/27 tests pass** (including 5 new ones)