### PR TITLE
feat: add session transcript foundation

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -22,6 +22,10 @@ Each active feature spec should include:
 - `docs/journal/`: date-prefixed implementation records
 - When a feature evolves, update the canonical feature doc and add or append a journal note.
 
+## Current Persistence Specs
+
+- `session-transcript.md`: typed session and sub-agent transcript storage.
+
 ## Control-Plane Readiness
 
 Features that affect skills, memory, prompt sources, hooks, planning, approvals,

--- a/docs/features/session-transcript.md
+++ b/docs/features/session-transcript.md
@@ -1,0 +1,175 @@
+# Session Transcript
+
+## Problem
+
+RARA currently persists model history, TUI transcript artifacts, runtime rollout
+events, plan state, and todo state through separate files. The separation is
+useful, but the primary model history is still a full JSON snapshot
+(`rollouts/<session_id>/history.json`) while runtime events are JSONL and turn
+artifacts are per-turn JSON arrays.
+
+That mixed shape makes the resume boundary harder to reason about:
+
+- model-visible messages can be confused with TUI-only transcript artifacts;
+- sub-agent output has no first-class sidechain identity;
+- fork/resume work has no stable typed event stream to filter by semantic role;
+- future ACP/Wire subscribers cannot follow one ordered transcript contract.
+
+## Scope
+
+This spec defines a typed session transcript format for RARA sessions and
+sub-agent sidechains.
+
+It covers:
+
+- the local file layout;
+- typed JSONL entries;
+- model-visible vs sidechain filtering;
+- parent/child agent relationships;
+- the migration path from `history.json`.
+
+## Non-Goals
+
+- Replacing `history.json` in the first implementation slice.
+- Replacing `StateDb`; SQLite remains the listing/index surface.
+- Storing full sub-agent output inline in the parent session transcript.
+- Persisting TUI rendering cells as model-visible messages.
+- Designing the full remote/appserver thread store.
+
+## Architecture
+
+RARA should converge on a Claude-style transcript layout with Codex-style typed
+events:
+
+```text
+rollouts/<session_id>/
+  history.json              # compatibility snapshot, not the long-term source
+  transcript.jsonl          # typed main-session transcript
+  events.jsonl              # non-turn runtime events
+  000000.json               # TUI turn artifact snapshots
+  subagents/
+    agent-<agent_id>.jsonl  # typed sidechain transcript
+```
+
+The first implementation keeps `history.json` as the resume source and writes
+`transcript.jsonl` as a typed compatibility mirror. This is intentionally
+additive: existing session restore behavior stays unchanged while tests start
+locking down the model-visible transcript boundary.
+
+The long-term target is:
+
+- `transcript.jsonl` becomes the canonical model-history stream;
+- `history.json` becomes an optional acceleration snapshot or disappears;
+- `StateDb` indexes sessions, turns, plan state, and parent/child edges;
+- sidechain transcripts remain separate files and are never replayed into the
+  parent model context unless an explicit fork/context operation selects a
+  filtered subset.
+
+## Contracts
+
+### Entry Types
+
+All transcript files are JSONL: one typed JSON object per line.
+
+Current schema:
+
+```rust
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionTranscriptEntry {
+    SessionMeta {
+        schema_version: u32,
+        session_id: String,
+        parent_session_id: Option<String>,
+        agent_id: Option<String>,
+        is_sidechain: bool,
+    },
+    Message {
+        message_id: String,
+        parent_message_id: Option<String>,
+        session_id: String,
+        agent_id: Option<String>,
+        is_sidechain: bool,
+        role: String,
+        content: serde_json::Value,
+    },
+    SpawnAgent {
+        event_id: String,
+        session_id: String,
+        child_session_id: Option<String>,
+        agent_id: Option<String>,
+        name: Option<String>,
+        status: String,
+        summary: Option<String>,
+    },
+}
+```
+
+### Model Visibility
+
+Only `Message` entries with `is_sidechain == false` may be projected into the
+parent model context.
+
+Sidechain entries are durable and inspectable, but they are not parent context.
+The parent session may store a `SpawnAgent` summary event, but it must not
+inline the child transcript.
+
+### Parent Links
+
+`parent_message_id` is a local transcript chain link. It gives the future
+resume path a stable ordered chain without requiring the TUI turn artifacts to
+be replayed as text.
+
+### Sub-Agent Sidechains
+
+Sub-agent transcripts use:
+
+```text
+rollouts/<parent_session_id>/subagents/agent-<agent_id>.jsonl
+```
+
+Each sidechain entry carries:
+
+- `parent_session_id`;
+- `agent_id`;
+- `is_sidechain = true`;
+- its own `session_id` when the sub-agent runtime has one.
+
+### Fork Context
+
+Forking a child agent from parent context should use a filtered transcript
+projection:
+
+- keep system/developer/user messages and assistant final answers;
+- drop reasoning, raw tool calls, tool results, TUI progress, approval UI, and
+  runtime-control metadata;
+- preserve prefix stability by avoiding parent runtime-event reinjection before
+  stable prompt sources.
+
+This mirrors Codex's fork filtering while keeping Claude-style sidechain files.
+
+## Validation Matrix
+
+| Case | Expected behavior |
+| ---- | ----------------- |
+| Save ordinary session history | `history.json` and `transcript.jsonl` both exist. |
+| Load transcript with malformed line | Valid lines load; parse error count increments. |
+| Project model-visible messages | Only non-sidechain `Message` entries are returned. |
+| Write sub-agent sidechain | File is under `subagents/`; entries carry `is_sidechain = true`. |
+| Legacy history backfill | `history.json` and `transcript.jsonl` are both backfilled. |
+| Future resume migration | Resume can switch from `history.json` to transcript projection without reading TUI artifacts. |
+
+## Open Risks
+
+- The first implementation rewrites the transcript mirror from `history.json`.
+  The canonical target is append-only, but the compatibility bridge must stay
+  consistent with the existing snapshot source until resume migrates.
+- Existing sub-agent tools create independent `Agent` sessions. They need a
+  follow-up wiring step to write sidechain transcripts under the parent session.
+- `StateDb` still stores parent/child relationships only indirectly. A durable
+  spawn-edge table is needed before cross-session sub-agent resume is complete.
+- Context compaction must preserve transcript boundaries and avoid injecting
+  summaries before stable prompt-prefix sources.
+
+## Source Journals
+
+- 2026-05-04-session-transcript-foundation.md

--- a/docs/journal/2026-05-04-session-transcript-foundation.md
+++ b/docs/journal/2026-05-04-session-transcript-foundation.md
@@ -1,0 +1,44 @@
+# Session Transcript Foundation
+
+## Context
+
+RARA had three relevant persistence surfaces:
+
+- `rollouts/<session_id>/history.json` for model history;
+- `rollouts/<session_id>/events.jsonl` for structured non-turn runtime events;
+- `rollouts/<session_id>/<ordinal>.json` for TUI turn artifacts.
+
+Codex and Claude Code both use typed transcript/rollout streams as the durable
+conversation surface. Claude Code keeps sub-agent sidechains in separate
+agent-scoped JSONL files, while Codex keeps spawned agents as separate threads
+with typed spawn edges and filtered fork history.
+
+## Change
+
+Added a typed transcript foundation:
+
+- `src/session_transcript.rs` defines `SessionTranscriptEntry`.
+- Main session transcripts write to `rollouts/<session_id>/transcript.jsonl`.
+- Sub-agent sidechain paths are defined as
+  `rollouts/<parent_session_id>/subagents/agent-<agent_id>.jsonl`.
+- `SessionManager::save_session` now writes the existing `history.json`
+  snapshot and a typed transcript mirror.
+- Legacy history backfill also writes the typed transcript mirror.
+- Transcript loading is tolerant of malformed lines and reports a parse-error
+  count.
+- `model_visible_messages` projects only non-sidechain message entries.
+
+## Boundary
+
+This is an additive compatibility bridge. `history.json` remains the active
+resume source for this slice. The new transcript file gives later work a tested
+typed target without changing session restore semantics in the same PR.
+
+## Follow-Up
+
+- Promote `transcript.jsonl` from mirror to canonical model-history source.
+- Wire existing `spawn_agent`, `explore_agent`, and `plan_agent` tools to write
+  parent-scoped sidechain transcripts.
+- Add durable spawn-edge metadata in `StateDb`.
+- Add fork-context filtering that drops tool/runtime/reasoning entries before
+  handing parent context to a child agent.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -61,6 +61,9 @@ Active backlog only. Keep this file small and current.
 - [ ] Add memory update/delete/list-label control-plane scaffolding for ACP/Wire without exposing LanceDB APIs.
 - [ ] Upgrade thread distillation from summary capture to LLM-assisted 2-8 record extraction with deduplication.
 - [ ] Move raw session checkpoints into per-session append shards instead of the global LanceDB `conversations` table.
+- [ ] Promote `rollouts/<session_id>/transcript.jsonl` from compatibility mirror to canonical model-history source.
+- [ ] Wire sub-agent tools to write parent-scoped sidechain transcripts under `rollouts/<parent_session_id>/subagents/`.
+- [ ] Add durable parent/child spawn-edge metadata in `StateDb`.
 - [ ] Add periodic promotion from session shards into global `MemoryRecord`s.
 - [ ] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.
 - [ ] Define background task restart/reattach semantics.

--- a/src/atomic_file.rs
+++ b/src/atomic_file.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+
+pub fn replace_file(src: &Path, dst: &Path) -> Result<()> {
+    replace_file_impl(src, dst)?;
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_file_impl(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::rename(src, dst)
+}
+
+#[cfg(windows)]
+fn replace_file_impl(src: &Path, dst: &Path) -> std::io::Result<()> {
+    match fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists && dst.exists() => {
+            fs::remove_file(dst)?;
+            fs::rename(src, dst)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use tempfile::tempdir;
+
+    use super::replace_file;
+
+    #[test]
+    fn replace_file_replaces_existing_destination() -> Result<()> {
+        let temp = tempdir()?;
+        let src = temp.path().join("value.tmp");
+        let dst = temp.path().join("value.txt");
+        std::fs::write(&dst, "old")?;
+        std::fs::write(&src, "new")?;
+
+        replace_file(&src, &dst)?;
+
+        assert_eq!(std::fs::read_to_string(&dst)?, "new");
+        assert!(!src.exists());
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod runtime_context;
 mod runtime_control;
 mod sandbox;
 mod session;
+mod session_transcript;
 mod shell_env;
 mod skill;
 mod state_db;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod acp;
 mod agent;
 mod app_cli;
+mod atomic_file;
 mod codex_model_catalog;
 mod config;
 mod context;

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -7,6 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 
+use crate::atomic_file;
 use crate::file_lock::AdvisoryFileLock;
 use crate::llm::LlmBackend;
 use crate::vectordb::{MemoryMetadata, VectorDB};
@@ -445,21 +446,11 @@ fn write_record_file_sync(path: &Path, file: &PersistedMemoryRecordFile) -> Resu
     writer
         .flush()
         .with_context(|| format!("flush memory records temp file {}", tmp_path.display()))?;
-    if let Err(err) = replace_record_file_sync(&tmp_path, path) {
+    if let Err(err) = atomic_file::replace_file(&tmp_path, path) {
         let _ = fs::remove_file(&tmp_path);
         return Err(err).with_context(|| format!("replace memory records {}", path.display()));
     }
     Ok(())
-}
-
-fn replace_record_file_sync(tmp_path: &Path, path: &Path) -> std::io::Result<()> {
-    #[cfg(windows)]
-    match fs::remove_file(path) {
-        Ok(()) => {}
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-        Err(err) => return Err(err),
-    }
-    fs::rename(tmp_path, path)
 }
 
 fn memory_record_for_hit(

--- a/src/session.rs
+++ b/src/session.rs
@@ -302,8 +302,8 @@ impl SessionManager {
             let _ = fs::remove_file(&temp_path);
             return Err(err);
         }
-        session_transcript::write_history_snapshot(&self.storage_dir, thread_id, history)
-            .context("write legacy session transcript snapshot")?;
+        // Legacy restore should remain available even if the additive transcript mirror fails.
+        let _ = session_transcript::write_history_snapshot(&self.storage_dir, thread_id, history);
         Ok(())
     }
 
@@ -439,6 +439,36 @@ mod tests {
             model_visible_messages(&transcript.entries),
             canonical_messages
         );
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_history_restore_survives_transcript_backfill_failure() -> Result<()> {
+        let temp = tempdir()?;
+        let session_manager = SessionManager::new_for_rara_dir(temp.path().join(".rara"))?;
+        let legacy_path = session_manager.legacy_session_history_path("thread-transcript-blocked");
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: serde_json::json!("legacy restore should win"),
+        }];
+        fs::write(&legacy_path, serde_json::to_string(&history)?)?;
+        fs::create_dir_all(main_transcript_path(
+            &session_manager.storage_dir,
+            "thread-transcript-blocked",
+        ))?;
+
+        let migration =
+            session_manager.load_thread_history_migration("thread-transcript-blocked")?;
+
+        assert_eq!(migration.history, history);
+        assert_eq!(
+            migration.source,
+            PersistedThreadHistorySource::LegacyBackfilled
+        );
+        let canonical_history =
+            fs::read_to_string(session_manager.session_history_path("thread-transcript-blocked"))?;
+        let canonical_messages: Vec<Message> = serde_json::from_str(&canonical_history)?;
+        assert_eq!(canonical_messages, history);
         Ok(())
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,10 +2,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 
 use crate::agent::Message;
+use crate::session_transcript;
 use crate::state_db::PersistedStructuredRolloutEvent;
 use crate::thread_rollout_log;
 use crate::todo::TodoState;
@@ -90,6 +91,8 @@ impl SessionManager {
             let _ = fs::remove_file(&tmp_path);
             return Err(err);
         }
+        session_transcript::write_history_snapshot(&self.storage_dir, session_id, history)
+            .context("write session transcript snapshot")?;
         Ok(())
     }
 
@@ -314,6 +317,8 @@ impl SessionManager {
         let temp_path = path.with_extension("json.tmp");
         fs::write(&temp_path, serde_json::to_string(history)?)?;
         fs::rename(temp_path, path)?;
+        session_transcript::write_history_snapshot(&self.storage_dir, thread_id, history)
+            .context("write legacy session transcript snapshot")?;
         Ok(())
     }
 
@@ -376,6 +381,9 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::session_transcript::{
+        SessionTranscriptEntry, load_transcript, main_transcript_path, model_visible_messages,
+    };
 
     #[test]
     fn save_compaction_event_appends_jsonl_lines() -> Result<()> {
@@ -438,6 +446,14 @@ mod tests {
         let canonical_messages: Vec<Message> = serde_json::from_str(&canonical_history)?;
         assert_eq!(canonical_messages.len(), 1);
         assert_eq!(canonical_messages[0].role, "user");
+        let transcript = load_transcript(&main_transcript_path(
+            &session_manager.storage_dir,
+            "thread-legacy-history",
+        ))?;
+        assert_eq!(
+            model_visible_messages(&transcript.entries),
+            canonical_messages
+        );
         Ok(())
     }
 
@@ -455,6 +471,19 @@ mod tests {
         let path = session_manager.session_history_path("thread-atomic-history");
         let persisted: Vec<Message> = serde_json::from_str(&fs::read_to_string(&path)?)?;
         assert_eq!(persisted, history);
+        let transcript_path =
+            main_transcript_path(&session_manager.storage_dir, "thread-atomic-history");
+        let transcript = load_transcript(&transcript_path)?;
+        assert_eq!(transcript.parse_errors, 0);
+        assert_eq!(model_visible_messages(&transcript.entries), history);
+        assert!(matches!(
+            &transcript.entries[0],
+            SessionTranscriptEntry::SessionMeta {
+                session_id,
+                is_sidechain: false,
+                ..
+            } if session_id == "thread-atomic-history"
+        ));
         let leftovers = fs::read_dir(path.parent().expect("history parent"))?
             .filter_map(std::result::Result::ok)
             .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp-"))

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,11 +1,12 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, anyhow};
 use serde::{Deserialize, Serialize};
 
 use crate::agent::Message;
+use crate::atomic_file;
 use crate::session_transcript;
 use crate::state_db::PersistedStructuredRolloutEvent;
 use crate::thread_rollout_log;
@@ -87,7 +88,7 @@ impl SessionManager {
         let content = serde_json::to_string(history)?;
         let tmp_path = path.with_extension(format!("json.tmp-{}", uuid::Uuid::new_v4()));
         fs::write(&tmp_path, content)?;
-        if let Err(err) = Self::replace_file(&tmp_path, &path) {
+        if let Err(err) = atomic_file::replace_file(&tmp_path, &path) {
             let _ = fs::remove_file(&tmp_path);
             return Err(err);
         }
@@ -111,7 +112,7 @@ impl SessionManager {
         }
         let tmp_path = path.with_extension(format!("md.tmp-{}", uuid::Uuid::new_v4()));
         fs::write(&tmp_path, plan)?;
-        if let Err(err) = Self::replace_file(&tmp_path, &path) {
+        if let Err(err) = atomic_file::replace_file(&tmp_path, &path) {
             let _ = fs::remove_file(&tmp_path);
             return Err(err);
         }
@@ -126,7 +127,7 @@ impl SessionManager {
         let content = serde_json::to_string_pretty(state)?;
         let tmp_path = path.with_extension(format!("json.tmp-{}", uuid::Uuid::new_v4()));
         fs::write(&tmp_path, content)?;
-        if let Err(err) = Self::replace_file(&tmp_path, &path) {
+        if let Err(err) = atomic_file::replace_file(&tmp_path, &path) {
             let _ = fs::remove_file(&tmp_path);
             return Err(err);
         }
@@ -138,25 +139,6 @@ impl SessionManager {
         match fs::read_to_string(path) {
             Ok(content) => Ok(Some(serde_json::from_str(&content)?)),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(err) => Err(err.into()),
-        }
-    }
-
-    #[cfg(not(windows))]
-    fn replace_file(src: &Path, dst: &Path) -> Result<()> {
-        fs::rename(src, dst)?;
-        Ok(())
-    }
-
-    #[cfg(windows)]
-    fn replace_file(src: &Path, dst: &Path) -> Result<()> {
-        match fs::rename(src, dst) {
-            Ok(()) => Ok(()),
-            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists && dst.exists() => {
-                fs::remove_file(dst)?;
-                fs::rename(src, dst)?;
-                Ok(())
-            }
             Err(err) => Err(err.into()),
         }
     }
@@ -316,7 +298,7 @@ impl SessionManager {
         }
         let temp_path = path.with_extension(format!("json.tmp-{}", uuid::Uuid::new_v4()));
         fs::write(&temp_path, serde_json::to_string(history)?)?;
-        if let Err(err) = Self::replace_file(&temp_path, &path) {
+        if let Err(err) = atomic_file::replace_file(&temp_path, &path) {
             let _ = fs::remove_file(&temp_path);
             return Err(err);
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -314,9 +314,12 @@ impl SessionManager {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let temp_path = path.with_extension("json.tmp");
+        let temp_path = path.with_extension(format!("json.tmp-{}", uuid::Uuid::new_v4()));
         fs::write(&temp_path, serde_json::to_string(history)?)?;
-        fs::rename(temp_path, path)?;
+        if let Err(err) = Self::replace_file(&temp_path, &path) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(err);
+        }
         session_transcript::write_history_snapshot(&self.storage_dir, thread_id, history)
             .context("write legacy session transcript snapshot")?;
         Ok(())

--- a/src/session_transcript.rs
+++ b/src/session_transcript.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::Write;
+use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -83,9 +83,13 @@ pub fn main_transcript_path(root_dir: &Path, session_id: &str) -> PathBuf {
     root_dir.join(session_id).join(TRANSCRIPT_FILE_NAME)
 }
 
-pub fn subagent_transcript_path(root_dir: &Path, session_id: &str, agent_id: &str) -> PathBuf {
+pub fn subagent_transcript_path(
+    root_dir: &Path,
+    parent_session_id: &str,
+    agent_id: &str,
+) -> PathBuf {
     root_dir
-        .join(session_id)
+        .join(parent_session_id)
         .join("subagents")
         .join(format!("agent-{}.jsonl", sanitize_path_component(agent_id)))
 }
@@ -112,12 +116,15 @@ pub fn append_entry(path: &Path, entry: &SessionTranscriptEntry) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let mut file = fs::OpenOptions::new()
+    let file = fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)?;
-    serde_json::to_writer(&mut file, entry)?;
-    file.write_all(b"\n")?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer(&mut writer, entry)?;
+    writer.write_all(b"\n")?;
+    writer.flush()?;
+    writer.into_inner()?.sync_all()?;
     Ok(())
 }
 
@@ -125,10 +132,16 @@ pub fn load_transcript(path: &Path) -> Result<SessionTranscriptLoad> {
     if !path.exists() {
         return Ok(SessionTranscriptLoad::default());
     }
-    let content = fs::read_to_string(path)?;
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
     let mut entries = Vec::new();
     let mut parse_errors = 0usize;
-    for line in content.lines() {
+    for line in reader.lines() {
+        let line = match line {
+            Ok(line) => line,
+            Err(err) if err.kind() == ErrorKind::Interrupted => continue,
+            Err(err) => return Err(err.into()),
+        };
         let line = line.trim();
         if line.is_empty() {
             continue;
@@ -193,14 +206,19 @@ fn write_entries_atomic(path: &Path, entries: &[SessionTranscriptEntry]) -> Resu
         fs::create_dir_all(parent)?;
     }
     let tmp_path = path.with_extension(format!("jsonl.tmp-{}", uuid::Uuid::new_v4()));
-    {
-        let mut file = fs::File::create(&tmp_path)?;
+    let result = (|| -> Result<()> {
+        let file = fs::File::create(&tmp_path)?;
+        let mut writer = BufWriter::new(file);
         for entry in entries {
-            serde_json::to_writer(&mut file, entry)?;
-            file.write_all(b"\n")?;
+            serde_json::to_writer(&mut writer, entry)?;
+            writer.write_all(b"\n")?;
         }
-    }
-    if let Err(err) = replace_file(&tmp_path, path) {
+        writer.flush()?;
+        writer.into_inner()?.sync_all()?;
+        replace_file(&tmp_path, path)?;
+        Ok(())
+    })();
+    if let Err(err) = result {
         let _ = fs::remove_file(&tmp_path);
         return Err(err);
     }
@@ -231,21 +249,10 @@ fn message_id(idx: usize) -> String {
 }
 
 fn sanitize_path_component(value: &str) -> String {
-    let sanitized = value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
-                ch
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
-    let trimmed = sanitized.trim_matches('_');
-    if trimmed.is_empty() {
+    if value.is_empty() {
         "agent".to_string()
     } else {
-        trimmed.to_string()
+        urlencoding::encode(value).into_owned()
     }
 }
 
@@ -377,5 +384,16 @@ mod tests {
         assert_eq!(load.entries.len(), 1);
         assert_eq!(load.parse_errors, 1);
         Ok(())
+    }
+
+    #[test]
+    fn subagent_paths_preserve_distinct_agent_ids() {
+        let temp = tempdir().expect("tempdir");
+        let slash_path = subagent_transcript_path(temp.path(), "session-1", "review/worker");
+        let colon_path = subagent_transcript_path(temp.path(), "session-1", "review:worker");
+
+        assert_ne!(slash_path, colon_path);
+        assert!(slash_path.ends_with("subagents/agent-review%2Fworker.jsonl"));
+        assert!(colon_path.ends_with("subagents/agent-review%3Aworker.jsonl"));
     }
 }

--- a/src/session_transcript.rs
+++ b/src/session_transcript.rs
@@ -134,7 +134,7 @@ pub fn load_transcript(path: &Path) -> Result<SessionTranscriptLoad> {
         return Ok(SessionTranscriptLoad::default());
     }
     let file = fs::File::open(path)?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
     let mut entries = Vec::new();
     let mut parse_errors = 0usize;
     let mut line_bytes = Vec::new();

--- a/src/session_transcript.rs
+++ b/src/session_transcript.rs
@@ -1,0 +1,381 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::agent::Message;
+
+const TRANSCRIPT_FILE_NAME: &str = "transcript.jsonl";
+const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SessionTranscriptEntry {
+    SessionMeta {
+        schema_version: u32,
+        session_id: String,
+        parent_session_id: Option<String>,
+        agent_id: Option<String>,
+        is_sidechain: bool,
+    },
+    Message {
+        message_id: String,
+        parent_message_id: Option<String>,
+        session_id: String,
+        agent_id: Option<String>,
+        is_sidechain: bool,
+        role: String,
+        content: Value,
+    },
+    SpawnAgent {
+        event_id: String,
+        session_id: String,
+        child_session_id: Option<String>,
+        agent_id: Option<String>,
+        name: Option<String>,
+        status: String,
+        summary: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SessionTranscriptLoad {
+    pub entries: Vec<SessionTranscriptEntry>,
+    pub parse_errors: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptScope {
+    pub session_id: String,
+    pub parent_session_id: Option<String>,
+    pub agent_id: Option<String>,
+    pub is_sidechain: bool,
+}
+
+impl TranscriptScope {
+    pub fn main(session_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            parent_session_id: None,
+            agent_id: None,
+            is_sidechain: false,
+        }
+    }
+
+    pub fn sidechain(
+        parent_session_id: impl Into<String>,
+        agent_id: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            parent_session_id: Some(parent_session_id.into()),
+            agent_id: Some(agent_id.into()),
+            is_sidechain: true,
+        }
+    }
+}
+
+pub fn main_transcript_path(root_dir: &Path, session_id: &str) -> PathBuf {
+    root_dir.join(session_id).join(TRANSCRIPT_FILE_NAME)
+}
+
+pub fn subagent_transcript_path(root_dir: &Path, session_id: &str, agent_id: &str) -> PathBuf {
+    root_dir
+        .join(session_id)
+        .join("subagents")
+        .join(format!("agent-{}.jsonl", sanitize_path_component(agent_id)))
+}
+
+pub fn write_history_snapshot(
+    root_dir: &Path,
+    session_id: &str,
+    history: &[Message],
+) -> Result<()> {
+    let scope = TranscriptScope::main(session_id);
+    write_message_snapshot(&main_transcript_path(root_dir, session_id), &scope, history)
+}
+
+pub fn write_message_snapshot(
+    path: &Path,
+    scope: &TranscriptScope,
+    messages: &[Message],
+) -> Result<()> {
+    let entries = entries_for_messages(scope, messages);
+    write_entries_atomic(path, &entries)
+}
+
+pub fn append_entry(path: &Path, entry: &SessionTranscriptEntry) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    serde_json::to_writer(&mut file, entry)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+pub fn load_transcript(path: &Path) -> Result<SessionTranscriptLoad> {
+    if !path.exists() {
+        return Ok(SessionTranscriptLoad::default());
+    }
+    let content = fs::read_to_string(path)?;
+    let mut entries = Vec::new();
+    let mut parse_errors = 0usize;
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<SessionTranscriptEntry>(line) {
+            Ok(entry) => entries.push(entry),
+            Err(_) => parse_errors = parse_errors.saturating_add(1),
+        }
+    }
+    Ok(SessionTranscriptLoad {
+        entries,
+        parse_errors,
+    })
+}
+
+pub fn model_visible_messages(entries: &[SessionTranscriptEntry]) -> Vec<Message> {
+    entries
+        .iter()
+        .filter_map(|entry| match entry {
+            SessionTranscriptEntry::Message {
+                is_sidechain: false,
+                role,
+                content,
+                ..
+            } => Some(Message {
+                role: role.clone(),
+                content: content.clone(),
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+fn entries_for_messages(
+    scope: &TranscriptScope,
+    messages: &[Message],
+) -> Vec<SessionTranscriptEntry> {
+    let mut entries = Vec::with_capacity(messages.len().saturating_add(1));
+    entries.push(SessionTranscriptEntry::SessionMeta {
+        schema_version: TRANSCRIPT_SCHEMA_VERSION,
+        session_id: scope.session_id.clone(),
+        parent_session_id: scope.parent_session_id.clone(),
+        agent_id: scope.agent_id.clone(),
+        is_sidechain: scope.is_sidechain,
+    });
+    for (idx, message) in messages.iter().enumerate() {
+        entries.push(SessionTranscriptEntry::Message {
+            message_id: message_id(idx),
+            parent_message_id: idx.checked_sub(1).map(message_id),
+            session_id: scope.session_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            is_sidechain: scope.is_sidechain,
+            role: message.role.clone(),
+            content: message.content.clone(),
+        });
+    }
+    entries
+}
+
+fn write_entries_atomic(path: &Path, entries: &[SessionTranscriptEntry]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let tmp_path = path.with_extension(format!("jsonl.tmp-{}", uuid::Uuid::new_v4()));
+    {
+        let mut file = fs::File::create(&tmp_path)?;
+        for entry in entries {
+            serde_json::to_writer(&mut file, entry)?;
+            file.write_all(b"\n")?;
+        }
+    }
+    if let Err(err) = replace_file(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(err);
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_file(src: &Path, dst: &Path) -> Result<()> {
+    fs::rename(src, dst)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn replace_file(src: &Path, dst: &Path) -> Result<()> {
+    match fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists && dst.exists() => {
+            fs::remove_file(dst)?;
+            fs::rename(src, dst)?;
+            Ok(())
+        }
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn message_id(idx: usize) -> String {
+    format!("msg-{idx:06}")
+}
+
+fn sanitize_path_component(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    let trimmed = sanitized.trim_matches('_');
+    if trimmed.is_empty() {
+        "agent".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use anyhow::Result;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::{
+        SessionTranscriptEntry, TranscriptScope, append_entry, load_transcript,
+        main_transcript_path, model_visible_messages, subagent_transcript_path,
+        write_history_snapshot, write_message_snapshot,
+    };
+    use crate::agent::Message;
+
+    #[test]
+    fn history_snapshot_writes_typed_jsonl_with_parent_links() -> Result<()> {
+        let temp = tempdir()?;
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!([{"type": "text", "text": "hello"}]),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!([{"type": "text", "text": "hi"}]),
+            },
+        ];
+
+        write_history_snapshot(temp.path(), "session-1", &history)?;
+
+        let load = load_transcript(&main_transcript_path(temp.path(), "session-1"))?;
+        assert_eq!(load.parse_errors, 0);
+        assert_eq!(load.entries.len(), 3);
+        assert!(matches!(
+            &load.entries[0],
+            SessionTranscriptEntry::SessionMeta {
+                session_id,
+                is_sidechain: false,
+                ..
+            } if session_id == "session-1"
+        ));
+        assert!(matches!(
+            &load.entries[1],
+            SessionTranscriptEntry::Message {
+                message_id,
+                parent_message_id: None,
+                role,
+                ..
+            } if message_id == "msg-000000" && role == "user"
+        ));
+        assert!(matches!(
+            &load.entries[2],
+            SessionTranscriptEntry::Message {
+                message_id,
+                parent_message_id: Some(parent),
+                role,
+                ..
+            } if message_id == "msg-000001" && parent == "msg-000000" && role == "assistant"
+        ));
+        assert_eq!(model_visible_messages(&load.entries), history);
+        Ok(())
+    }
+
+    #[test]
+    fn sidechain_messages_are_not_model_visible_in_parent_context() -> Result<()> {
+        let temp = tempdir()?;
+        let main_history = vec![Message {
+            role: "user".to_string(),
+            content: json!("parent"),
+        }];
+        let sidechain_history = vec![Message {
+            role: "assistant".to_string(),
+            content: json!("sidechain details"),
+        }];
+
+        write_history_snapshot(temp.path(), "session-1", &main_history)?;
+        write_message_snapshot(
+            &subagent_transcript_path(temp.path(), "session-1", "review/worker"),
+            &TranscriptScope::sidechain("session-1", "review/worker", "child-session"),
+            &sidechain_history,
+        )?;
+
+        let main = load_transcript(&main_transcript_path(temp.path(), "session-1"))?;
+        let sidechain = load_transcript(&subagent_transcript_path(
+            temp.path(),
+            "session-1",
+            "review/worker",
+        ))?;
+        assert_eq!(model_visible_messages(&main.entries), main_history);
+        assert!(model_visible_messages(&sidechain.entries).is_empty());
+        assert!(matches!(
+            &sidechain.entries[0],
+            SessionTranscriptEntry::SessionMeta {
+                parent_session_id: Some(parent),
+                agent_id: Some(agent_id),
+                is_sidechain: true,
+                ..
+            } if parent == "session-1" && agent_id == "review/worker"
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn append_entry_keeps_malformed_lines_non_fatal_on_load() -> Result<()> {
+        let temp = tempdir()?;
+        let path = main_transcript_path(temp.path(), "session-1");
+        append_entry(
+            &path,
+            &SessionTranscriptEntry::SpawnAgent {
+                event_id: "spawn-1".to_string(),
+                session_id: "session-1".to_string(),
+                child_session_id: Some("child-1".to_string()),
+                agent_id: Some("worker".to_string()),
+                name: Some("worker".to_string()),
+                status: "completed".to_string(),
+                summary: Some("done".to_string()),
+            },
+        )?;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)?
+            .write_all(b"not json\n")?;
+
+        let load = load_transcript(&path)?;
+        assert_eq!(load.entries.len(), 1);
+        assert_eq!(load.parse_errors, 1);
+        Ok(())
+    }
+}

--- a/src/session_transcript.rs
+++ b/src/session_transcript.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::agent::Message;
+use crate::atomic_file;
 
 const TRANSCRIPT_FILE_NAME: &str = "transcript.jsonl";
 const TRANSCRIPT_SCHEMA_VERSION: u32 = 1;
@@ -136,11 +137,21 @@ pub fn load_transcript(path: &Path) -> Result<SessionTranscriptLoad> {
     let reader = BufReader::new(file);
     let mut entries = Vec::new();
     let mut parse_errors = 0usize;
-    for line in reader.lines() {
-        let line = match line {
-            Ok(line) => line,
+    let mut line_bytes = Vec::new();
+    loop {
+        line_bytes.clear();
+        match reader.read_until(b'\n', &mut line_bytes) {
+            Ok(0) => break,
+            Ok(_) => {}
             Err(err) if err.kind() == ErrorKind::Interrupted => continue,
             Err(err) => return Err(err.into()),
+        }
+        let line = match std::str::from_utf8(&line_bytes) {
+            Ok(line) => line,
+            Err(_) => {
+                parse_errors = parse_errors.saturating_add(1);
+                continue;
+            }
         };
         let line = line.trim();
         if line.is_empty() {
@@ -215,7 +226,7 @@ fn write_entries_atomic(path: &Path, entries: &[SessionTranscriptEntry]) -> Resu
         }
         writer.flush()?;
         writer.into_inner()?.sync_all()?;
-        replace_file(&tmp_path, path)?;
+        atomic_file::replace_file(&tmp_path, path)?;
         Ok(())
     })();
     if let Err(err) = result {
@@ -223,25 +234,6 @@ fn write_entries_atomic(path: &Path, entries: &[SessionTranscriptEntry]) -> Resu
         return Err(err);
     }
     Ok(())
-}
-
-#[cfg(not(windows))]
-fn replace_file(src: &Path, dst: &Path) -> Result<()> {
-    fs::rename(src, dst)?;
-    Ok(())
-}
-
-#[cfg(windows)]
-fn replace_file(src: &Path, dst: &Path) -> Result<()> {
-    match fs::rename(src, dst) {
-        Ok(()) => Ok(()),
-        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists && dst.exists() => {
-            fs::remove_file(dst)?;
-            fs::rename(src, dst)?;
-            Ok(())
-        }
-        Err(err) => Err(err.into()),
-    }
 }
 
 fn message_id(idx: usize) -> String {
@@ -382,6 +374,46 @@ mod tests {
 
         let load = load_transcript(&path)?;
         assert_eq!(load.entries.len(), 1);
+        assert_eq!(load.parse_errors, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn load_transcript_counts_non_utf8_lines_as_parse_errors() -> Result<()> {
+        let temp = tempdir()?;
+        let path = main_transcript_path(temp.path(), "session-1");
+        append_entry(
+            &path,
+            &SessionTranscriptEntry::SpawnAgent {
+                event_id: "spawn-1".to_string(),
+                session_id: "session-1".to_string(),
+                child_session_id: Some("child-1".to_string()),
+                agent_id: Some("worker".to_string()),
+                name: Some("worker".to_string()),
+                status: "completed".to_string(),
+                summary: Some("done".to_string()),
+            },
+        )?;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)?
+            .write_all(b"\xff\xfe\xfd\n")?;
+        append_entry(
+            &path,
+            &SessionTranscriptEntry::SpawnAgent {
+                event_id: "spawn-2".to_string(),
+                session_id: "session-1".to_string(),
+                child_session_id: Some("child-2".to_string()),
+                agent_id: Some("worker".to_string()),
+                name: Some("worker".to_string()),
+                status: "completed".to_string(),
+                summary: Some("done again".to_string()),
+            },
+        )?;
+
+        let load = load_transcript(&path)?;
+
+        assert_eq!(load.entries.len(), 2);
         assert_eq!(load.parse_errors, 1);
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Add a session transcript spec for typed JSONL main-session and sub-agent sidechain storage.
- Add a `session_transcript` module with typed entries, atomic snapshot writing, tolerant JSONL loading, and model-visible filtering.
- Mirror existing `history.json` writes into `rollouts/<session_id>/transcript.jsonl` while keeping `history.json` as the active resume source.
- Record follow-up work for canonical transcript resume, sub-agent sidechain wiring, and durable spawn edges.

## Purpose

This creates an additive transcript foundation for future context, resume, fork, and sub-agent work without changing the current session restore path.

## Related Issues

None.

## Tests

- `cargo fmt --check`
- `cargo test session_transcript -- --nocapture`
- `cargo test session::tests -- --nocapture`
- `cargo check`

Note: `cargo check` passed with existing unused/dead-code warnings in the repository.
