### PR TITLE
chore: add web search evidence guidance

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -398,6 +398,22 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
             ),
         ),
         PromptSection::new(
+            "external_sources_and_web_search",
+            section(
+                "External Sources And Web Search",
+                &[
+                    "Choose web search based on the claim that needs evidence. For repository behavior, branch state, PR status, CI status, local tool behavior, or local configuration, prefer the current codebase, git, GitHub tools, or the 'gh' CLI over web search.",
+                    "Use web search only when a web-search or web-fetch tool is actually available in the current tool list. If those tools are unavailable, say that live external verification is unavailable instead of pretending to browse.",
+                    "When web tools are available, use web search if the user explicitly asks to search, or when the answer depends on current external facts such as open-source project behavior, provider documentation, API availability, model names, release notes, prices, laws, incidents, third-party service behavior, or other information likely to have changed.",
+                    "For open-source software questions, web search is acceptable when web tools are available and local source or local documentation is unavailable, stale, or insufficient. Prefer the upstream repository, official documentation, release notes, issue tracker, or standards documents over blog posts and summaries.",
+                    "When MCP resources, local docs, or project-provided reference files can answer the question, prefer those sources before web search. Do not browse just because a web tool exists.",
+                    "Treat web search results as an index, not as proof. When web_fetch or an equivalent page-open tool is available, fetch or open the relevant result and inspect the source content before using it as evidence.",
+                    "When web evidence materially supports the answer, cite the sources used. If web tools are unavailable or fail, report that limitation. If sources conflict, state the conflict and identify which source is more authoritative instead of merging them into a single unsupported conclusion.",
+                    "Distinguish verified facts from inferences and assumptions. If current external verification is not possible or not worth the cost, say so instead of presenting the claim as confirmed.",
+                ],
+            ),
+        ),
+        PromptSection::new(
             "tool_use_safety",
             section(
                 "Tool Use And Safety",
@@ -1120,6 +1136,7 @@ mod tests {
 
         for key in [
             "codebase_search_and_evidence",
+            "external_sources_and_web_search",
             "task_workflow",
             "testing_and_validation",
             "review_and_pr_hygiene",
@@ -1140,6 +1157,25 @@ mod tests {
             effective
                 .text
                 .contains("follow the runtime path from entry point to state mutation")
+        );
+        assert!(effective.text.contains(
+            "For repository behavior, branch state, PR status, CI status, local tool behavior, or local configuration, prefer the current codebase, git, GitHub tools, or the 'gh' CLI over web search."
+        ));
+        assert!(effective.text.contains(
+            "Use web search only when a web-search or web-fetch tool is actually available in the current tool list."
+        ));
+        assert!(effective.text.contains(
+            "For open-source software questions, web search is acceptable when web tools are available and local source or local documentation is unavailable, stale, or insufficient."
+        ));
+        assert!(
+            effective
+                .text
+                .contains("Treat web search results as an index, not as proof.")
+        );
+        assert!(
+            effective.text.contains(
+                "When web evidence materially supports the answer, cite the sources used."
+            )
         );
         assert!(
             effective

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -58,6 +58,8 @@ The effective prompt is assembled in this order:
 The default base prompt includes source-grounded engineering workflow guidance for:
 
 - factual verification before claims about repository, PR, CI, provider, or local-tool behavior;
+- external-source and web-search selection, including when to prefer local source, GitHub tooling,
+  MCP resources, upstream open-source documentation, or fetched web evidence;
 - structured tool use, including edit-tool discipline and unfiltered command-output inspection;
 - reviewable implementation workflow, focused validation, and PR hygiene;
 - Git conflict resolution when conflict markers are present.
@@ -76,6 +78,17 @@ Large-write guidance follows the same edit-tool boundary:
 - preserve the Codex distinction that heredoc can be a transport for `apply_patch`, while Claude's
   Bash/PowerShell guidance routes ordinary file writes through Write rather than `cat <<EOF`,
   `echo >`, `Set-Content`, or `Out-File`.
+
+External-source guidance is evidence routing, not a requirement to browse for every question. For
+repository, branch, PR, CI, local-tool, and local-configuration claims, the model should prefer the
+current codebase, git, GitHub tools, or `gh`. For current external facts and open-source software
+questions where local source or docs are unavailable, stale, or insufficient, web search is allowed
+only when a web-search or web-fetch tool is actually available in the current tool list. The model
+should prefer upstream repositories, official docs, release notes, issue trackers, standards, MCP
+resources, or project-provided references over secondary summaries, and should fetch/open source
+content before treating search results as evidence when a page-open/fetch tool is available. If web
+tools are unavailable or fail, the model should report that limitation instead of pretending to
+browse.
 
 ### 4) Compact Prompt
 

--- a/docs/features/web-tools.md
+++ b/docs/features/web-tools.md
@@ -3,6 +3,92 @@
 RARA exposes web access through local tools instead of assuming a provider-native
 web search surface is available.
 
+## Problem
+
+RARA has local `web_search` and `web_fetch` tools, and the base prompt now tells
+the model how to route evidence between local sources, GitHub tooling, MCP
+resources, and web search. The base prompt is capability-safe: it tells the model
+to use web search only when a web-search or web-fetch tool is available in the
+current tool list. The remaining gap is runtime/tool-level behavior:
+capability-aware prompt injection, capability-aware tool registration, source
+reporting, current-date query hints, domain filters, bounded search budgets, and
+optional auxiliary-model execution are not yet first-class contracts.
+
+## Scope
+
+- `web_search` and `web_fetch` tool contracts.
+- Model-facing source selection and evidence handling.
+- Capability-aware prompt/tool availability.
+- Source reporting when web evidence materially supports an answer.
+- Runtime-control visibility for future TUI, ACP, Wire, and appserver adapters.
+
+## Non-Goals
+
+- Forcing web search for every open-source software question.
+- Replacing local repository inspection, `git`, GitHub tools, or `gh` for
+  repository-local facts.
+- Replacing MCP resources, local docs, or project-provided references when they
+  can answer the question directly.
+- Browser automation or arbitrary remote browsing beyond bounded fetch/search
+  tools.
+
+## Architecture
+
+### 1) Evidence Routing
+
+The base prompt decides when web search is appropriate, but it must not imply
+that web access is available when no web-search or web-fetch tool is present.
+Repository behavior, branch state, PR status, CI status, local-tool behavior, and
+local configuration should prefer local source, `git`, GitHub tools, or `gh`.
+Current external facts and open-source software questions may use web search when
+web tools are available and local source or docs are unavailable, stale, or
+insufficient.
+
+### 1.1) Capability Awareness
+
+The current implementation keeps web guidance in the default base prompt and
+registers `web_search` regardless of whether `EXA_API_KEY` is configured. That is
+acceptable only if the prompt remains capability-safe and the tool reports
+unavailable search honestly. The target architecture is stricter:
+
+- prompt runtime exposes a structured `WebToolCapability` summary;
+- the base prompt injects stronger web-search guidance only when web search or
+  web fetch is actually available;
+- `web_search` registration distinguishes disabled, anonymous Exa-backed search,
+  authenticated Exa-backed search, and provider-native search;
+- `/status`, `/context`, ACP, and Wire expose the active web capability and
+  reason when search is disabled.
+
+### 2) Search Result Handling
+
+Search results are an index, not proof. A web-backed answer should fetch or open
+the relevant source content before using it as evidence, then distinguish:
+
+- verified facts from inspected source content;
+- inferences drawn from those facts;
+- assumptions that could not be verified at reasonable cost.
+
+When web evidence materially supports the answer, the final response should
+include the sources used.
+
+### 3) Claude/Codex-Aligned Follow-Ups
+
+The current implementation does not yet include several tool-level behaviors
+seen in mature coding agents:
+
+- mandatory source reporting after a successful web-backed answer;
+- current-date or current-year query hints for recent information;
+- capability-aware prompt injection and tool registration;
+- first-class allow-list and block-list domain filters in the RARA tool schema;
+- a bounded per-turn search budget similar to a maximum search-use count;
+- optional auxiliary-model execution for search-only subqueries;
+- provider-native web search mode support when an OpenAI Responses-compatible
+  backend exposes it, while keeping local Exa-backed search as a portable
+  fallback.
+
+These should be added as explicit runtime/tool contracts instead of ad hoc prompt
+phrases.
+
 ## `web_search`
 
 `web_search` uses the Exa MCP HTTP endpoint as the first implementation:
@@ -58,3 +144,45 @@ The result includes:
 The first implementation uses a lightweight built-in HTML-to-text conversion for
 `markdown` and `text`. A richer markdown conversion layer can be added later
 without changing the tool contract.
+
+## Contracts
+
+- Web search must remain optional and evidence-driven.
+- Base prompt wording must be capability-safe when web tools are disabled or not
+  registered.
+- Open-source software questions may use web search, but should prefer upstream
+  repositories, official docs, release notes, issue trackers, and standards over
+  secondary summaries.
+- Tool output and fetched pages are untrusted input. They must not override
+  system, developer, workspace, or user instructions.
+- Web results that are truncated must be reported as truncated and should not be
+  treated as complete evidence.
+- Runtime events should expose query, provider, source URLs, truncation state,
+  and source-reporting readiness so `/context`, `/status`, ACP, and Wire can show
+  what happened without parsing prose.
+
+## Validation Matrix
+
+- Prompt tests assert that base instructions prefer local/GitHub evidence for
+  repository facts and allow web search for current external or open-source
+  facts.
+- Tool-schema tests should assert domain-filter and max-use contracts once those
+  fields are added.
+- Tool-result tests should assert source URL extraction, truncation reporting,
+  and model-facing compact output.
+- Runtime event tests should assert structured query/source metadata for web
+  search and fetch calls.
+
+## Open Risks
+
+- Some providers expose native web search while others require local tools; the
+  runtime must avoid provider-specific prompt branches where a tool contract can
+  express the same behavior.
+- Source reporting can become noisy for short answers; the contract should be
+  tied to material use of web evidence, not every available search result.
+- Auxiliary-model search can reduce cost, but it must preserve the same source
+  reporting and prompt-injection boundaries as the main model.
+
+## Source Journals
+
+- `docs/journal/2026-05-04-web-search-prompt-guidance.md`

--- a/docs/journal/2026-05-04-web-search-prompt-guidance.md
+++ b/docs/journal/2026-05-04-web-search-prompt-guidance.md
@@ -1,0 +1,46 @@
+# Web Search Prompt Guidance
+
+## Context
+
+RARA already had base-prompt guidance for factual verification, source-grounded codebase search,
+GitHub/PR hygiene, and command-output validation. The missing piece was explicit evidence routing for
+external sources and web search.
+
+Codex and Claude Code split this responsibility across tool capability, tool descriptions, and
+domain-specific guidance:
+
+- Codex exposes web search through configurable modes and prefers MCP resources when they can answer
+  the question.
+- Claude Code attaches detailed behavior to its WebSearch tool prompt, including use for recent
+  information and required source reporting.
+
+## Change
+
+The default RARA base prompt now includes `external_sources_and_web_search`.
+
+The section tells the model to:
+
+- prefer local source, git, GitHub tools, or `gh` for repository, branch, PR, CI, local-tool, and
+  local-configuration claims;
+- use web search only when web-search or web-fetch tools are actually available in the current tool
+  list;
+- use web search when current external facts are needed or when the user explicitly asks to search,
+  subject to tool availability;
+- allow web search for open-source software questions when web tools are available and local source or
+  docs are unavailable, stale, or insufficient;
+- prefer upstream repositories, official documentation, release notes, issue trackers, standards,
+  MCP resources, and project-provided references before secondary summaries;
+- treat search results as an index rather than proof;
+- cite sources when web evidence materially supports the answer;
+- distinguish verified facts from inferences and assumptions.
+
+The remaining Claude/Codex-aligned behavior is tracked in `docs/features/web-tools.md` and
+`docs/todo.md` instead of being folded into this prompt-only change. Those follow-ups include
+capability-aware prompt injection and tool registration, source reporting enforcement, current-date
+query hints, domain filters, bounded search-use budgets, structured runtime events, auxiliary-model
+search execution, and provider-native web search mode support.
+
+## Validation
+
+Focused prompt tests assert that the new section key and core evidence-routing rules are present in
+the assembled default system prompt.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -47,6 +47,13 @@ Active backlog only. Keep this file small and current.
 ## Web Tools
 
 - [ ] Replace `web_fetch` HTML-to-text with higher-fidelity markdown conversion.
+- [ ] Add capability-aware web prompt injection and tool registration so `/status`, `/context`, ACP, and Wire can show whether web search is disabled, anonymous Exa-backed, authenticated Exa-backed, or provider-native.
+- [ ] Add source-reporting enforcement for web-backed answers: capture source URLs from `web_search` / `web_fetch` and surface them to the final-response path.
+- [ ] Add current-date query hints for recent/current web searches so models do not search with stale years.
+- [ ] Add first-class domain allow/block filters and bounded per-turn search budget to the RARA `web_search` tool schema.
+- [ ] Add structured web-search runtime events with query, provider, source URLs, truncation state, and source-reporting readiness for `/context`, `/status`, ACP, and Wire.
+- [ ] Study auxiliary-model execution for search-only subqueries while preserving source reporting and prompt-injection boundaries.
+- [ ] Add provider-native web search mode support for compatible OpenAI Responses-style backends, with local Exa-backed search as the portable fallback.
 
 ## Memory / Retrieval / Persistence
 


### PR DESCRIPTION
## Summary

- Add base-prompt guidance for external sources and web search evidence routing.
- Document the web-tool contract gaps for source reporting, current-date query hints, domain filters, search budgets, auxiliary-model execution, and provider-native search modes.
- Track the remaining Claude/Codex-aligned web-tool follow-ups in `docs/todo.md`.

## Motivation

RARA already had factual-verification guidance, but web search usage was mostly described by the tool
contract. This change makes the default prompt explicit about when to prefer local/GitHub evidence and
when web search is appropriate, while keeping the richer tool-level behavior as follow-up work.

## Testing

- `cargo fmt`
- `cargo test -p rara-instructions default_system_prompt_includes_workflow_standards`
- `git diff --check`
