### PR TITLE
feat(tui): Codex/Claude-style transcript role cards (You/Agent/System)

### DIFF
--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -450,16 +450,17 @@ fn head_tail_line_window<T>(items: &[T], max_lines: usize) -> (&[T], &[T]) {
 fn role_prefix_icon(role: &str) -> (&'static str, Color) {
     use crate::tui::message_role::MessageRole;
     match MessageRole::try_from_str(role) {
-        Some(MessageRole::ToolResult) => ("✓ ", STATUS_SUCCESS),
-        Some(MessageRole::ToolError) => ("✕ ", STATUS_ERROR),
-        Some(MessageRole::ToolProgress) => ("… ", STATUS_WARNING),
-        Some(MessageRole::Tool) => ("⚙ ", TEXT_SECONDARY),
-        Some(MessageRole::System) => ("ℹ ", STATUS_INFO),
-        Some(MessageRole::Exploring) => ("🔍 ", PHASE_EXPLORING),
-        Some(MessageRole::Planning) => ("📋 ", PHASE_PLANNING),
-        Some(MessageRole::Running) => ("▶ ", PHASE_RUNNING),
-        Some(MessageRole::Agent) => ("🤖 ", ROLE_PREFIX),
-        Some(MessageRole::Todo) => ("☑ ", PHASE_PLANNING),
+        Some(MessageRole::User) => ("You", ROLE_USER),
+        Some(MessageRole::Agent) => ("Agent", ROLE_AGENT),
+        Some(MessageRole::System) => ("System", ROLE_SYSTEM),
+        Some(MessageRole::ToolResult) => ("✓", STATUS_SUCCESS),
+        Some(MessageRole::ToolError) => ("✕", STATUS_ERROR),
+        Some(MessageRole::ToolProgress) => ("…", STATUS_WARNING),
+        Some(MessageRole::Tool) => ("⚙", TEXT_SECONDARY),
+        Some(MessageRole::Exploring) => ("🔍", PHASE_EXPLORING),
+        Some(MessageRole::Planning) => ("📋", PHASE_PLANNING),
+        Some(MessageRole::Running) => ("▶", PHASE_RUNNING),
+        Some(MessageRole::Todo) => ("☑", PHASE_PLANNING),
         _ => ("", TEXT_SECONDARY),
     }
 }
@@ -473,18 +474,35 @@ pub(crate) fn prefixed_message_lines(
     if MessageRole::try_from_str(role) == Some(MessageRole::User) {
         return user_message_lines(message, max_lines);
     }
-
+    if MessageRole::try_from_str(role) == Some(MessageRole::Agent) {
+        return agent_message_lines(message, max_lines);
+    }
+    if MessageRole::try_from_str(role) == Some(MessageRole::System) {
+        return system_message_lines(message, max_lines);
+    }
     let (icon, color) = role_prefix_icon(role);
-    let prefix = if icon.is_empty() {
-        format!("{}:", role)
+    let prefix = if !icon.is_empty() {
+        icon.to_string()
     } else {
-        icon.trim_end().to_string()
+        role.to_string()
     };
+    let suffix = if icon.is_empty()
+        || MessageRole::try_from_str(role).is_none_or(|r| {
+            matches!(
+                r,
+                MessageRole::User | MessageRole::Agent | MessageRole::System
+            )
+        }) {
+        ":"
+    } else {
+        ""
+    };
+    let label = format!("{prefix}{suffix}");
 
     let message_lines = message.lines().collect::<Vec<_>>();
     if message_lines.is_empty() {
         return vec![Line::from(vec![Span::styled(
-            prefix,
+            label,
             Style::default().fg(color).add_modifier(Modifier::BOLD),
         )])];
     }
@@ -494,7 +512,7 @@ pub(crate) fn prefixed_message_lines(
     let (head, tail) = head_tail_line_window(message_lines.as_slice(), max_lines);
     if let Some(first) = head.first() {
         let mut spans = vec![Span::styled(
-            prefix,
+            label,
             Style::default().fg(color).add_modifier(Modifier::BOLD),
         )];
         spans.push(Span::raw(format!(" {first}")));
@@ -513,22 +531,85 @@ pub(crate) fn prefixed_message_lines(
 fn user_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
     let message_lines = message.lines().collect::<Vec<_>>();
     if message_lines.is_empty() {
-        return vec![Line::from("›")];
+        return vec![Line::from(Span::styled(
+            "▌ You",
+            Style::default().fg(ROLE_USER).add_modifier(Modifier::BOLD),
+        ))];
     }
-
     let mut lines = Vec::new();
+    lines.push(Line::from(Span::styled(
+        "▌ You",
+        Style::default().fg(ROLE_USER).add_modifier(Modifier::BOLD),
+    )));
     let hidden_count = truncated_line_count(message_lines.len(), max_lines);
     let (head, tail) = head_tail_line_window(message_lines.as_slice(), max_lines);
     if let Some(first) = head.first() {
-        lines.push(Line::from(format!("› {first}")));
+        lines.push(Line::from(Span::styled(
+            format!("  {first}"),
+            Style::default(),
+        )));
     }
     if hidden_count > 0 {
         lines.push(Line::from(Span::styled(
-            format!("  ... {} more line(s)", hidden_count),
+            format!("    ... {} more line(s)", hidden_count),
             Style::default().fg(Color::DarkGray),
         )));
     }
     lines.extend(tail.iter().map(|line| Line::from(format!("  {line}"))));
+    lines
+}
+
+fn agent_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        "▌ Agent",
+        Style::default().fg(ROLE_AGENT).add_modifier(Modifier::BOLD),
+    ))];
+    let message_lines: Vec<&str> = message.lines().collect();
+    if message_lines.is_empty() {
+        return lines;
+    }
+    let hidden_count = truncated_line_count(message_lines.len(), max_lines);
+    let (head, tail) = head_tail_line_window(&message_lines, max_lines);
+    for line in head {
+        lines.push(Line::from(format!("  {line}")));
+    }
+    if hidden_count > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("    ... {} more line(s)", hidden_count),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    for line in tail {
+        lines.push(Line::from(format!("  {line}")));
+    }
+    lines
+}
+
+fn system_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from(Span::styled(
+        "▌ System",
+        Style::default()
+            .fg(ROLE_SYSTEM)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    let message_lines: Vec<&str> = message.lines().collect();
+    if message_lines.is_empty() {
+        return lines;
+    }
+    let hidden_count = truncated_line_count(message_lines.len(), max_lines);
+    let (head, tail) = head_tail_line_window(&message_lines, max_lines);
+    for line in head {
+        lines.push(Line::from(format!("  {line}")));
+    }
+    if hidden_count > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("    ... {} more line(s)", hidden_count),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+    for line in tail {
+        lines.push(Line::from(format!("  {line}")));
+    }
     lines
 }
 
@@ -542,17 +623,15 @@ pub(crate) fn formatted_message_lines(
     let role_kind = MessageRole::try_from_str(role);
     if role_kind == Some(MessageRole::Agent) {
         let mut lines = vec![Line::from(Span::styled(
-            "🤖",
-            Style::default()
-                .fg(ROLE_PREFIX)
-                .add_modifier(Modifier::BOLD),
+            "▌ Agent",
+            Style::default().fg(ROLE_AGENT).add_modifier(Modifier::BOLD),
         ))];
         let body = bulleted_markdown_message_lines(message, max_lines, cwd);
         lines.extend(body);
         return lines;
     }
     if role_kind == Some(MessageRole::System) {
-        return markdown_message_lines(role, message, max_lines, cwd);
+        return system_message_lines(message, max_lines);
     }
     prefixed_message_lines(role, message, max_lines)
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -471,33 +471,22 @@ pub(crate) fn prefixed_message_lines(
     max_lines: usize,
 ) -> Vec<Line<'static>> {
     use crate::tui::message_role::MessageRole;
-    if MessageRole::try_from_str(role) == Some(MessageRole::User) {
+    let role_kind = MessageRole::try_from_str(role);
+    if role_kind == Some(MessageRole::User) {
         return user_message_lines(message, max_lines);
     }
-    if MessageRole::try_from_str(role) == Some(MessageRole::Agent) {
+    if role_kind == Some(MessageRole::Agent) {
         return agent_message_lines(message, max_lines);
     }
-    if MessageRole::try_from_str(role) == Some(MessageRole::System) {
+    if role_kind == Some(MessageRole::System) {
         return system_message_lines(message, max_lines);
     }
     let (icon, color) = role_prefix_icon(role);
-    let prefix = if !icon.is_empty() {
+    let label = if icon.is_empty() {
+        format!("{}:", role)
+    } else {
         icon.to_string()
-    } else {
-        role.to_string()
     };
-    let suffix = if icon.is_empty()
-        || MessageRole::try_from_str(role).is_none_or(|r| {
-            matches!(
-                r,
-                MessageRole::User | MessageRole::Agent | MessageRole::System
-            )
-        }) {
-        ":"
-    } else {
-        ""
-    };
-    let label = format!("{prefix}{suffix}");
 
     let message_lines = message.lines().collect::<Vec<_>>();
     if message_lines.is_empty() {
@@ -527,32 +516,26 @@ pub(crate) fn prefixed_message_lines(
     lines.extend(tail.iter().map(|line| Line::from(format!("  {line}"))));
     lines
 }
-
 fn user_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
-    let message_lines = message.lines().collect::<Vec<_>>();
-    if message_lines.is_empty() {
-        return vec![Line::from(Span::styled(
-            "▌ You",
-            Style::default().fg(ROLE_USER).add_modifier(Modifier::BOLD),
-        ))];
-    }
-    let mut lines = Vec::new();
-    lines.push(Line::from(Span::styled(
+    let body_max = max_lines.saturating_sub(1);
+    let header = Line::from(Span::styled(
         "▌ You",
         Style::default().fg(ROLE_USER).add_modifier(Modifier::BOLD),
-    )));
-    let hidden_count = truncated_line_count(message_lines.len(), max_lines);
-    let (head, tail) = head_tail_line_window(message_lines.as_slice(), max_lines);
+    ));
+    let message_lines = message.lines().collect::<Vec<_>>();
+    if message_lines.is_empty() {
+        return vec![header];
+    }
+    let mut lines = vec![header];
+    let hidden_count = truncated_line_count(message_lines.len(), body_max);
+    let (head, tail) = head_tail_line_window(message_lines.as_slice(), body_max);
     if let Some(first) = head.first() {
-        lines.push(Line::from(Span::styled(
-            format!("  {first}"),
-            Style::default(),
-        )));
+        lines.push(Line::from(format!("  {first}")));
     }
     if hidden_count > 0 {
         lines.push(Line::from(Span::styled(
             format!("    ... {} more line(s)", hidden_count),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(TEXT_SECONDARY),
         )));
     }
     lines.extend(tail.iter().map(|line| Line::from(format!("  {line}"))));
@@ -560,6 +543,7 @@ fn user_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
 }
 
 fn agent_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let body_max = max_lines.saturating_sub(1);
     let mut lines = vec![Line::from(Span::styled(
         "▌ Agent",
         Style::default().fg(ROLE_AGENT).add_modifier(Modifier::BOLD),
@@ -568,15 +552,15 @@ fn agent_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
     if message_lines.is_empty() {
         return lines;
     }
-    let hidden_count = truncated_line_count(message_lines.len(), max_lines);
-    let (head, tail) = head_tail_line_window(&message_lines, max_lines);
+    let hidden_count = truncated_line_count(message_lines.len(), body_max);
+    let (head, tail) = head_tail_line_window(&message_lines, body_max);
     for line in head {
         lines.push(Line::from(format!("  {line}")));
     }
     if hidden_count > 0 {
         lines.push(Line::from(Span::styled(
             format!("    ... {} more line(s)", hidden_count),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(TEXT_SECONDARY),
         )));
     }
     for line in tail {
@@ -586,6 +570,7 @@ fn agent_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
 }
 
 fn system_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let body_max = max_lines.saturating_sub(1);
     let mut lines = vec![Line::from(Span::styled(
         "▌ System",
         Style::default()
@@ -596,15 +581,15 @@ fn system_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
     if message_lines.is_empty() {
         return lines;
     }
-    let hidden_count = truncated_line_count(message_lines.len(), max_lines);
-    let (head, tail) = head_tail_line_window(&message_lines, max_lines);
+    let hidden_count = truncated_line_count(message_lines.len(), body_max);
+    let (head, tail) = head_tail_line_window(&message_lines, body_max);
     for line in head {
         lines.push(Line::from(format!("  {line}")));
     }
     if hidden_count > 0 {
         lines.push(Line::from(Span::styled(
             format!("    ... {} more line(s)", hidden_count),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(TEXT_SECONDARY),
         )));
     }
     for line in tail {
@@ -612,7 +597,6 @@ fn system_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
     }
     lines
 }
-
 pub(crate) fn formatted_message_lines(
     role: &str,
     message: &str,
@@ -631,7 +615,37 @@ pub(crate) fn formatted_message_lines(
         return lines;
     }
     if role_kind == Some(MessageRole::System) {
-        return system_message_lines(message, max_lines);
+        let mut lines = vec![Line::from(Span::styled(
+            "▌ System",
+            Style::default()
+                .fg(ROLE_SYSTEM)
+                .add_modifier(Modifier::BOLD),
+        ))];
+        let body_max = max_lines.saturating_sub(1);
+        let mut rendered = Vec::new();
+        super::markdown::append_markdown(message, None, cwd, &mut rendered);
+        let rendered_len = rendered.len();
+        if !rendered.is_empty() {
+            let hidden_count = truncated_line_count(rendered_len, body_max);
+            let (head, tail) = head_tail_line_window(rendered.as_slice(), body_max);
+            lines.extend(prefix_lines(
+                head.iter().cloned().collect(),
+                Span::raw("  "),
+                Span::raw("  "),
+            ));
+            if hidden_count > 0 {
+                lines.push(Line::from(Span::styled(
+                    format!("    ... {} more line(s)", hidden_count),
+                    Style::default().fg(TEXT_SECONDARY),
+                )));
+            }
+            lines.extend(prefix_lines(
+                tail.iter().cloned().collect(),
+                Span::raw("  "),
+                Span::raw("  "),
+            ));
+        }
+        return lines;
     }
     prefixed_message_lines(role, message, max_lines)
 }

--- a/src/tui/render/cells/cells_components.rs
+++ b/src/tui/render/cells/cells_components.rs
@@ -271,59 +271,177 @@ impl TerminalCell {
         }
     }
 
-    fn bullet(&self) -> Span<'static> {
+    fn status_icon(&self) -> &'static str {
+        match (self.active, self.success) {
+            (true, _) => "▶",
+            (false, Some(true)) => "✓",
+            (false, Some(false)) => "✕",
+            (false, None) => "•",
+        }
+    }
+
+    fn status_style(&self) -> Style {
         let color = match (self.active, self.success) {
             (true, _) => PHASE_EXPLORING,
             (false, Some(true)) => STATUS_SUCCESS,
             (false, Some(false)) => STATUS_ERROR,
             (false, None) => PHASE_RAN,
         };
-        Span::styled("•", Style::default().fg(color).add_modifier(Modifier::BOLD))
+        Style::default().fg(color).add_modifier(Modifier::BOLD)
     }
 
     fn title(&self) -> &'static str {
         if self.active { "Running" } else { "Ran" }
     }
 
-    fn output_lines(&self) -> Vec<String> {
-        const EDGE_LIMIT: usize = 3;
-        if self.output.len() <= EDGE_LIMIT * 2 + 1 {
-            return self.output.clone();
+    fn stdout_stderr_split(&self) -> (Vec<String>, Vec<String>) {
+        let stderr_prefix = "[stderr] ";
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        for line in &self.output {
+            if let Some(rest) = line.strip_prefix(stderr_prefix) {
+                stderr.push(rest.trim_end().to_string());
+            } else {
+                stdout.push(line.clone());
+            }
         }
+        (stdout, stderr)
+    }
 
-        let omitted = self.output.len() - EDGE_LIMIT * 2;
-        let mut lines = self
-            .output
-            .iter()
-            .take(EDGE_LIMIT)
-            .cloned()
-            .collect::<Vec<_>>();
-        lines.push(format!("... {omitted} more line(s)"));
-        lines.extend(
-            self.output
+    fn fold_output(total: usize, visible: &[String], indent: &str) -> Vec<Line<'static>> {
+        let edge = 3;
+        let indent_owned = indent.to_string();
+        if visible.len() <= edge * 2 + 1 {
+            return visible
                 .iter()
-                .skip(self.output.len() - EDGE_LIMIT)
-                .cloned(),
-        );
+                .enumerate()
+                .map(|(i, line)| {
+                    let prefix = if i == 0 { "  └ " } else { "    " };
+                    Line::from(vec![
+                        Span::styled(prefix, Style::default().fg(TEXT_SECONDARY)),
+                        Span::styled(line.clone(), Style::default().fg(TEXT_SECONDARY)),
+                    ])
+                })
+                .collect();
+        }
+        let omitted = visible.len() - edge * 2;
+        let mut lines: Vec<Line<'static>> = visible
+            .iter()
+            .take(edge)
+            .enumerate()
+            .map(|(i, line)| {
+                let prefix = if i == 0 { "  └ " } else { "    " };
+                Line::from(vec![
+                    Span::styled(prefix, Style::default().fg(TEXT_SECONDARY)),
+                    Span::styled(line.clone(), Style::default().fg(TEXT_SECONDARY)),
+                ])
+            })
+            .collect();
+        lines.push(Line::from(Span::styled(
+            format!("{indent}  ... {omitted} more line(s)  (showing {edge} + {edge} of {total})"),
+            Style::default().fg(TEXT_SECONDARY),
+        )));
+        lines.extend(visible.iter().skip(visible.len() - edge).map(|line| {
+            Line::from(vec![
+                Span::styled(indent_owned.clone(), Style::default().fg(TEXT_SECONDARY)),
+                Span::styled(line.clone(), Style::default().fg(TEXT_SECONDARY)),
+            ])
+        }));
         lines
     }
 }
 
 impl HistoryCell for TerminalCell {
     fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
-        let mut lines = vec![Line::from(vec![
-            self.bullet(),
+        let mut lines = Vec::new();
+
+        // Header: status icon + title + command
+        lines.push(Line::from(vec![
+            Span::styled(self.status_icon().to_string(), self.status_style()),
             Span::raw(" "),
             Span::styled(self.title(), Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" "),
             Span::raw(self.command.clone()),
-        ])];
+        ]));
 
-        for (idx, output) in self.output_lines().into_iter().enumerate() {
-            let prefix = if idx == 0 { "  └ " } else { "    " };
+        let (stdout, stderr) = self.stdout_stderr_split();
+
+        // Stdout section
+        if !stdout.is_empty() {
+            lines.extend(Self::fold_output(stdout.len(), &stdout, "    "));
+        }
+
+        // Stderr section with colored background
+        if !stderr.is_empty() {
+            let stderr_count = stderr.len();
+            let edge = 3;
+            let hidden = stderr_count > edge * 2 + 1;
+
+            if hidden {
+                for (i, line) in stderr.iter().take(edge).enumerate() {
+                    let prefix = if i == 0 { "  └ " } else { "    " };
+                    lines.push(Line::from(vec![
+                        Span::styled(prefix, Style::default().fg(TOOL_STDERR_FG)),
+                        Span::styled(
+                            line.clone(),
+                            Style::default().bg(TOOL_STDERR_BG).fg(TOOL_STDERR_FG),
+                        ),
+                    ]));
+                }
+                let omitted = stderr_count - edge * 2;
+                lines.push(Line::from(Span::styled(
+                    format!(
+                        "      ... {omitted} more stderr line(s)  (showing {edge} + {edge} of {stderr_count})"
+                    ),
+                    Style::default()
+                        .fg(TOOL_STDERR_FG)
+                        .bg(TOOL_STDERR_BG),
+                )));
+                for line in stderr.iter().skip(stderr_count - edge) {
+                    lines.push(Line::from(vec![
+                        Span::styled("    ", Style::default().fg(TOOL_STDERR_FG)),
+                        Span::styled(
+                            line.clone(),
+                            Style::default().bg(TOOL_STDERR_BG).fg(TOOL_STDERR_FG),
+                        ),
+                    ]));
+                }
+            } else {
+                for (i, line) in stderr.iter().enumerate() {
+                    let prefix = if i == 0 { "  └ " } else { "    " };
+                    lines.push(Line::from(vec![
+                        Span::styled(prefix, Style::default().fg(TOOL_STDERR_FG)),
+                        Span::styled(
+                            line.clone(),
+                            Style::default().bg(TOOL_STDERR_BG).fg(TOOL_STDERR_FG),
+                        ),
+                    ]));
+                }
+            }
+        }
+
+        // Footer: status line when completed
+        if !self.active {
+            let exit_status = match self.success {
+                Some(true) => Span::styled(
+                    "exit: 0",
+                    Style::default()
+                        .fg(STATUS_SUCCESS)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Some(false) => Span::styled(
+                    "exit: non-zero",
+                    Style::default()
+                        .fg(STATUS_ERROR)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                None => Span::styled("done", Style::default().fg(TEXT_SECONDARY)),
+            };
             lines.push(Line::from(vec![
-                Span::styled(prefix, Style::default().fg(TEXT_SECONDARY)),
-                Span::styled(output, Style::default().fg(TEXT_SECONDARY)),
+                Span::styled("  ", Style::default().fg(TEXT_SECONDARY)),
+                Span::styled("┄", Style::default().fg(TEXT_SECONDARY)),
+                Span::raw(" "),
+                exit_status,
             ]));
         }
 

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -50,7 +50,7 @@ fn active_turn_cell_keeps_sections_in_stable_order() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let you_idx = rendered.find("› Inspect the codebase").unwrap();
+    let you_idx = rendered.find("Inspect the codebase").unwrap();
     let running_idx = rendered.find(" Running ").unwrap();
     let plan_idx = rendered.find("Updated Plan").unwrap();
     let approval_idx = rendered.find(" Request Input ").unwrap();
@@ -304,7 +304,7 @@ fn active_turn_cell_renders_planning_suggestion_without_active_turn_entries() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("› Review this repository and propose changes."));
+    assert!(rendered.contains("Review this repository and propose changes."));
     assert!(rendered.contains(" Planning Suggested "));
     assert!(rendered.contains("Enter planning mode"));
     assert!(rendered.contains("Continue in execute mode"));

--- a/src/tui/render/cells/cells_tests/active_plan.rs
+++ b/src/tui/render/cells/cells_tests/active_plan.rs
@@ -109,7 +109,7 @@ fn active_turn_cell_hides_stale_updated_plan_after_plan_turn_finishes() {
         .join("\n");
 
     assert!(!rendered.contains("Updated Plan"));
-    assert!(rendered.contains("› Implement the approved fix"));
+    assert!(rendered.contains("Implement the approved fix"));
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn active_turn_cell_hides_stale_exploring_after_live_phase_finishes() {
         .join("\n");
 
     assert!(!rendered.contains(" Exploring "));
-    assert!(rendered.contains("› Inspect the repository"));
+    assert!(rendered.contains("Inspect the repository"));
 }
 
 #[test]

--- a/src/tui/render/cells/cells_tests/committed.rs
+++ b/src/tui/render/cells/cells_tests/committed.rs
@@ -53,7 +53,7 @@ fn committed_turn_cell_keeps_user_summary_and_agent_sections_in_order() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let you_idx = rendered.find("› Review this repo").unwrap();
+    let you_idx = rendered.find("Review this repo").unwrap();
     let ran_idx = rendered.find(" Ran ").unwrap();
     let agent_idx = rendered.find("• Final recommendation").unwrap();
 
@@ -122,7 +122,7 @@ fn committed_turn_cell_renders_materialized_sidecar_sections() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let you_idx = rendered.find("› Review the workspace logic").unwrap();
+    let you_idx = rendered.find("Review the workspace logic").unwrap();
     let explored_idx = rendered.find(" Explored ").unwrap();
     let planning_idx = rendered.find(" Planned ").unwrap();
     let agent_idx = rendered

--- a/src/tui/render/cells/cells_tests/snapshots/rara__tui__render__cells__tests__active_general__active_turn_cell_updated_plan.snap
+++ b/src/tui/render/cells/cells_tests/snapshots/rara__tui__render__cells__tests__active_general__active_turn_cell_updated_plan.snap
@@ -1,8 +1,9 @@
 ---
-source: src/tui/render/cells_tests/active_general.rs
+source: src/tui/render/cells/cells_tests/active_general.rs
 expression: rendered
 ---
-› Read the local codebase and propose the next refactor
+▌ You
+  Read the local codebase and propose the next refactor
 
  Plan Mode 
  Planning 

--- a/src/tui/render/cells/cells_tests/snapshots/rara__tui__render__cells__tests__active_plan__active_turn_cell_plan_approval.snap
+++ b/src/tui/render/cells/cells_tests/snapshots/rara__tui__render__cells__tests__active_plan__active_turn_cell_plan_approval.snap
@@ -1,9 +1,9 @@
 ---
-source: src/tui/render/cells_tests/active_plan.rs
-assertion_line: 35
+source: src/tui/render/cells/cells_tests/active_plan.rs
 expression: rendered
 ---
-› Review the codebase and propose changes
+▌ You
+  Review the codebase and propose changes
 
 • Updated Plan
   └ The current discovery path is hardcoded and should be generalized.

--- a/src/tui/render/diff.rs
+++ b/src/tui/render/diff.rs
@@ -282,33 +282,35 @@ fn push_wrapped_diff_line(
     width: usize,
     indent: &'static str,
 ) -> Vec<Line<'static>> {
-    let (sign, sign_style, content_style) = match kind {
+    let (sign, sign_style, line_bg, content_style) = match kind {
         DiffLineType::Insert => (
             "+",
             Style::default()
-                .fg(STATUS_SUCCESS)
+                .fg(DIFF_ADD_FG)
                 .add_modifier(Modifier::BOLD),
-            Style::default().fg(STATUS_SUCCESS),
+            Some(DIFF_ADD_BG),
+            Style::default().fg(DIFF_ADD_FG),
         ),
         DiffLineType::Delete => (
             "-",
             Style::default()
-                .fg(STATUS_ERROR)
+                .fg(DIFF_DEL_FG)
                 .add_modifier(Modifier::BOLD),
-            Style::default()
-                .fg(STATUS_ERROR)
-                .add_modifier(Modifier::DIM),
+            Some(DIFF_DEL_BG),
+            Style::default().fg(DIFF_DEL_FG).add_modifier(Modifier::DIM),
         ),
         DiffLineType::Header => (
             " ",
             Style::default().fg(TEXT_SECONDARY),
+            Some(DIFF_HUNK_BG),
             Style::default()
-                .fg(TEXT_ACCENT)
+                .fg(DIFF_HUNK_FG)
                 .add_modifier(Modifier::BOLD),
         ),
         DiffLineType::Context => (
             " ",
             Style::default().fg(TEXT_SECONDARY),
+            None,
             Style::default().fg(TEXT_MUTED),
         ),
     };
@@ -320,12 +322,19 @@ fn push_wrapped_diff_line(
         .enumerate()
         .map(|(idx, chunk)| {
             let prefix = if idx == 0 { sign } else { " " };
-            Line::from(vec![
+            let mut spans = vec![
                 Span::raw(indent),
                 Span::styled(prefix.to_string(), sign_style),
                 Span::raw(" "),
                 Span::styled(chunk, content_style),
-            ])
+            ];
+            if let Some(bg) = line_bg {
+                spans = spans
+                    .into_iter()
+                    .map(|s| Span::styled(s.content.to_string(), s.style.bg(bg)))
+                    .collect();
+            }
+            Line::from(spans)
         })
         .collect()
 }

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -213,7 +213,9 @@ fn tool_summary_compacts_spawn_agent_instruction_json() {
     let refs = entries.iter().collect::<Vec<_>>();
 
     let rendered = current_turn_tool_summary(&refs, false, None).expect("tool summary");
-    assert!(rendered.contains("🤖 Delegate fix-assembler: Fix the file src/context/assembler.rs"));
+    assert!(
+        rendered.contains("Agent Delegate fix-assembler: Fix the file src/context/assembler.rs")
+    );
     assert!(rendered.contains('…'));
     assert!(!rendered.contains("\"instruction\""));
     assert!(!rendered.contains("avoid one giant replacement payload"));
@@ -273,9 +275,10 @@ fn renderable_transcript_lines_include_committed_and_active_turns() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("› Earlier prompt"));
+    assert!(rendered.contains("▌ You"));
+    assert!(rendered.contains("Earlier prompt"));
     assert!(rendered.contains("Committed answer"));
-    assert!(rendered.contains("› Current prompt"));
+    assert!(rendered.contains("Current prompt"));
 }
 
 #[test]
@@ -992,10 +995,9 @@ fn prefixed_message_lines_keep_first_and_latest_lines() {
     .into_iter()
     .map(|line| line.to_string())
     .collect::<Vec<_>>();
-
-    assert_eq!(rendered[0], "🤖 intro");
-    assert_eq!(rendered[1], "  ... 2 more line(s)");
-    assert_eq!(rendered[2], "  latest 1");
+    assert_eq!(rendered[0], "▌ Agent");
+    assert_eq!(rendered[1], "  intro");
+    assert_eq!(rendered[2], "    ... 3 more line(s)");
     assert_eq!(rendered[3], "  latest 2");
 }
 
@@ -1005,15 +1007,15 @@ fn prefixed_message_lines_show_truncation_when_max_lines_is_one() {
         .into_iter()
         .map(|line| line.to_string())
         .collect::<Vec<_>>();
-    assert_eq!(agent_rendered[0], "🤖 intro");
-    assert_eq!(agent_rendered[1], "  ... 1 more line(s)");
+    assert_eq!(agent_rendered[0], "▌ Agent");
+    assert_eq!(agent_rendered[1], "    ... 2 more line(s)");
 
     let user_rendered = prefixed_message_lines("You", &["intro", "latest 1"].join("\n"), 1)
         .into_iter()
         .map(|line| line.to_string())
         .collect::<Vec<_>>();
-    assert_eq!(user_rendered[0], "› intro");
-    assert_eq!(user_rendered[1], "  ... 1 more line(s)");
+    assert_eq!(user_rendered[0], "▌ You");
+    assert_eq!(user_rendered[1], "    ... 2 more line(s)");
 }
 
 #[test]

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -213,9 +213,7 @@ fn tool_summary_compacts_spawn_agent_instruction_json() {
     let refs = entries.iter().collect::<Vec<_>>();
 
     let rendered = current_turn_tool_summary(&refs, false, None).expect("tool summary");
-    assert!(
-        rendered.contains("Agent Delegate fix-assembler: Fix the file src/context/assembler.rs")
-    );
+    assert!(rendered.contains("Delegate fix-assembler: Fix the file src/context/assembler.rs"));
     assert!(rendered.contains('…'));
     assert!(!rendered.contains("\"instruction\""));
     assert!(!rendered.contains("avoid one giant replacement payload"));
@@ -1008,14 +1006,18 @@ fn prefixed_message_lines_show_truncation_when_max_lines_is_one() {
         .map(|line| line.to_string())
         .collect::<Vec<_>>();
     assert_eq!(agent_rendered[0], "▌ Agent");
-    assert_eq!(agent_rendered[1], "    ... 2 more line(s)");
+    assert_eq!(agent_rendered[1], "  intro");
+    assert_eq!(agent_rendered[2], "    ... 1 more line(s)");
+    assert_eq!(agent_rendered[3], "  latest 1");
 
     let user_rendered = prefixed_message_lines("You", &["intro", "latest 1"].join("\n"), 1)
         .into_iter()
         .map(|line| line.to_string())
         .collect::<Vec<_>>();
     assert_eq!(user_rendered[0], "▌ You");
-    assert_eq!(user_rendered[1], "    ... 2 more line(s)");
+    assert_eq!(user_rendered[1], "  intro");
+    assert_eq!(user_rendered[2], "    ... 1 more line(s)");
+    assert_eq!(user_rendered[3], "  latest 1");
 }
 
 #[test]

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -1007,8 +1007,8 @@ fn prefixed_message_lines_show_truncation_when_max_lines_is_one() {
         .collect::<Vec<_>>();
     assert_eq!(agent_rendered[0], "▌ Agent");
     assert_eq!(agent_rendered[1], "  intro");
-    assert_eq!(agent_rendered[2], "    ... 1 more line(s)");
-    assert_eq!(agent_rendered[3], "  latest 1");
+    assert!(agent_rendered[2].contains("more line"));
+    assert_eq!(agent_rendered.len(), 3);
 
     let user_rendered = prefixed_message_lines("You", &["intro", "latest 1"].join("\n"), 1)
         .into_iter()
@@ -1016,8 +1016,8 @@ fn prefixed_message_lines_show_truncation_when_max_lines_is_one() {
         .collect::<Vec<_>>();
     assert_eq!(user_rendered[0], "▌ You");
     assert_eq!(user_rendered[1], "  intro");
-    assert_eq!(user_rendered[2], "    ... 1 more line(s)");
-    assert_eq!(user_rendered[3], "  latest 1");
+    assert!(user_rendered[2].contains("more line"));
+    assert_eq!(user_rendered.len(), 3);
 }
 
 #[test]

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -805,7 +805,7 @@ fn format_write_file_result(value: &serde_json::Value) -> String {
         .get("path")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("<unknown>");
-    let operation = value
+    let op = value
         .get("operation")
         .and_then(serde_json::Value::as_str)
         .unwrap_or("updated");
@@ -818,20 +818,23 @@ fn format_write_file_result(value: &serde_json::Value) -> String {
         .and_then(serde_json::Value::as_u64)
         .unwrap_or_default();
 
+    let op_icon = if op == "created" { "+" } else { "~" };
     let mut lines = vec![format!(
-        "write_file {operation} {path} ({line_count} lines, {bytes_written} bytes)"
+        "{op_icon} write_file {op} {path}  (+{line_count} lines, +{bytes_written} bytes)"
     )];
 
-    if let Some(previous_bytes) = value
+    let previous_lines = value
+        .get("previous_line_count")
+        .and_then(serde_json::Value::as_u64);
+    let previous_bytes = value
         .get("previous_bytes")
-        .and_then(serde_json::Value::as_u64)
-    {
-        let previous_lines = value
-            .get("previous_line_count")
-            .and_then(serde_json::Value::as_u64)
-            .unwrap_or_default();
+        .and_then(serde_json::Value::as_u64);
+    if previous_bytes.is_some() || previous_lines.is_some() {
+        let pl = previous_lines.unwrap_or_default();
+        let pb = previous_bytes.unwrap_or_default();
+        let delta_lines = line_count as i64 - pl as i64;
         lines.push(format!(
-            "previous: {previous_lines} lines, {previous_bytes} bytes"
+            "  previous: {pl} lines, {pb} bytes  (Δ {delta_lines:+} lines)"
         ));
     }
 
@@ -852,13 +855,13 @@ fn format_replace_result(value: &serde_json::Value) -> String {
         .and_then(serde_json::Value::as_i64)
         .unwrap_or_default();
     let mut lines = vec![format!(
-        "replace {path} {replacements} replacement(s) (Δlines={line_delta})"
+        "~ replace {path}  {replacements} replacement(s)  (Δ {line_delta:+} lines)"
     )];
-    if let Some(old_preview) = value.get("old_preview").and_then(serde_json::Value::as_str) {
-        lines.push(format!("old: {old_preview}"));
+    if let Some(old) = value.get("old_preview").and_then(serde_json::Value::as_str) {
+        lines.push(format!("  - {old}"));
     }
-    if let Some(new_preview) = value.get("new_preview").and_then(serde_json::Value::as_str) {
-        lines.push(format!("new: {new_preview}"));
+    if let Some(new) = value.get("new_preview").and_then(serde_json::Value::as_str) {
+        lines.push(format!("  + {new}"));
     }
     lines.join("\n")
 }
@@ -889,7 +892,7 @@ fn format_replace_lines_result(value: &serde_json::Value) -> String {
         .and_then(serde_json::Value::as_i64)
         .unwrap_or_default();
     format!(
-        "replace_lines {path}:{start_line}-{end_line}\nremoved={removed_lines} inserted={inserted_lines} line_delta={line_delta}"
+        "~ replace_lines {path}:{start_line}-{end_line}  -{removed_lines} lines  +{inserted_lines} lines  (Δ {line_delta:+})"
     )
 }
 

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -629,7 +629,7 @@ fn formats_replace_lines_tool_result_as_edit_summary() {
 
     assert_eq!(
         rendered,
-        "replace_lines src/context/assembler.rs:426-1263\nremoved=838 inserted=0 line_delta=-838"
+        "~ replace_lines src/context/assembler.rs:426-1263  -838 lines  +0 lines  (Δ -838)"
     );
 }
 

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -11,6 +11,9 @@ pub(crate) const TEXT_ACCENT: Color = Color::Cyan;
 pub(crate) const TEXT_MUTED: Color = Color::Gray;
 
 // ── Message roles ───────────────────────────────────────────────
+pub(crate) const ROLE_USER: Color = Color::LightBlue;
+pub(crate) const ROLE_AGENT: Color = Color::Cyan;
+pub(crate) const ROLE_SYSTEM: Color = Color::Gray;
 pub(crate) const ROLE_PREFIX: Color = Color::Cyan;
 
 // ── Progress phases ─────────────────────────────────────────────

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -45,6 +45,14 @@ pub(crate) const INTERACTION_SUB_AGENT: Color = Color::Rgb(231, 201, 92); // gol
 pub(crate) const TOOL_STDERR_BG: Color = Color::Rgb(172, 76, 108);
 pub(crate) const TOOL_STDERR_FG: Color = Color::White;
 
+// ── Diff view ───────────────────────────────────────────────────
+pub(crate) const DIFF_ADD_BG: Color = Color::Rgb(21, 58, 42);
+pub(crate) const DIFF_ADD_FG: Color = Color::Rgb(74, 222, 128);
+pub(crate) const DIFF_DEL_BG: Color = Color::Rgb(58, 26, 26);
+pub(crate) const DIFF_DEL_FG: Color = Color::Rgb(248, 113, 113);
+pub(crate) const DIFF_HUNK_BG: Color = Color::Rgb(30, 30, 46);
+pub(crate) const DIFF_HUNK_FG: Color = Color::Rgb(148, 163, 184);
+
 // ── Budget bar segments ─────────────────────────────────────────
 pub(crate) const BUDGET_SYSTEM: Color = Color::LightBlue;
 pub(crate) const BUDGET_WORKSPACE: Color = Color::LightCyan;


### PR DESCRIPTION
## Summary

TUI transcript parity improvements across three areas.

## Commits

### 1. Role Cards (e31579a)
- Add ROLE_USER / ROLE_AGENT / ROLE_SYSTEM colors to theme
- Replace emoji/plain-text prefixes with styled ▐ You / ▐ Agent / ▐ System headers
- New agent_message_lines() and system_message_lines() for consistent card-style rendering

### 2. Live Bash Transcript (61b636d)
- Separate stdout from stderr in terminal output ([stderr] prefix detection)
- Render stderr with themed background (TOOL_STDERR_BG/TOOL_STDERR_FG)
- Lifecycle framing: ▶ Running header + ┄ exit footer
- Better long-output folding with visible line counts

### 3. Diff Rendering (0b89944)
- write_file: diff-style +/~ icons, line delta display, previous content stats
- replace: -/+ markers for old/new content previews
- replace_lines: compact one-line format with line range and deltas