### PR TITLE
fix: enforce bash approval segment boundaries

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -33,3 +33,8 @@ tool output, `/context`, or `/status` must describe how the behavior can be
 driven through the runtime control plane. Local TUI behavior should be one
 adapter over the same structured request/event contract that ACP, Wire, and
 future appserver integrations can use.
+
+## Security And Approval Specs
+
+- `shell-approval-policy.md`: bash read-only classification and reusable prefix
+  approval boundaries.

--- a/docs/features/shell-approval-policy.md
+++ b/docs/features/shell-approval-policy.md
@@ -1,0 +1,110 @@
+# Shell Approval Policy
+
+## Problem
+
+RARA allows users to approve reusable bash command prefixes. A reusable prefix is
+useful for repeated commands such as `cargo test` or `git push`, but it is also a
+safety boundary. A prefix approved for one command segment must not implicitly
+approve unrelated segments joined with shell control operators.
+
+## Scope
+
+- Bash tool approval in suggestion mode.
+- Reusable command-prefix approvals persisted in RARA config.
+- Legacy shell command strings and structured `program` plus `args` calls.
+- Read-only command auto-allow classification.
+
+## Non-Goals
+
+- Replacing the current approval UI.
+- Implementing a full shell parser.
+- Granting external protocol adapters direct approval authority.
+- Completing the larger auditable permission and sandbox-bypass rule system.
+
+## Architecture
+
+RARA evaluates bash approval in three layers:
+
+1. Tool input parsing produces a `BashCommandInput`.
+2. The agent loop checks plan-mode read-only rules and suggestion-mode approval.
+3. The bash tool executes only after the agent loop has allowed the request.
+
+For legacy shell command strings, approval-prefix reuse follows a Codex-style
+segment boundary:
+
+- split the command at shell control operators such as `|`, `&&`, `||`, and `;`;
+- evaluate each segment independently;
+- allow the whole command only when every segment is either read-only or matches
+  an approved prefix;
+- reject prefix reuse for syntax outside the conservative matcher, including
+  redirection, command substitution, environment expansion, wildcard expansion,
+  subshell grouping, and leading environment assignments.
+
+Structured `program` plus `args` calls do not need shell segmentation. They use
+the normalized program and subcommand prefix directly.
+
+When RARA cannot derive a reusable prefix for a shell command, a user approval
+may still be stored as the exact command summary. Exact-command approvals are
+replayed only for the same normalized summary. They do not become starts-with
+prefix rules and do not cover additional shell segments.
+
+## Control-Plane Readiness
+
+Shell approval remains a runtime policy decision, not a TUI-only shortcut. The
+TUI, ACP, Wire, and future protocol adapters should submit structured approval
+decisions to the runtime and consume the resulting approval lifecycle events.
+
+RARA remains the authority for evaluating whether a bash request is allowed:
+
+- adapters may present approval choices, but they must not directly mark a tool
+  call as allowed;
+- prefix and exact-command approvals flow through the same runtime approval
+  state used by the local TUI;
+- persisted approval rules are loaded into the agent runtime before evaluation;
+- reusable prefix matching and exact-command replay are both evaluated by the
+  bash request policy helper;
+- external adapters cannot bypass segment-level approval checks by sending a
+  pre-approved command string.
+
+This keeps future ACP/Wire approval surfaces compatible with the local TUI while
+preserving one centralized approval boundary.
+
+## Contracts
+
+- A read-only multi-segment shell command may run without approval in suggestion
+  mode.
+- A multi-segment command with one approved mutating segment and one read-only
+  segment may reuse the approved prefix.
+- A multi-segment command with any unapproved mutating segment must stop for
+  approval.
+- A single approved prefix must never approve an entire shell string solely
+  because the first segment starts with that prefix.
+- Prefix matching must be conservative. If the command uses syntax that the
+  matcher cannot safely model, it must fall back to explicit approval.
+- Exact-command fallback must only replay the same full command summary.
+- Plan mode remains stricter: non-read-only bash is rejected instead of entering
+  the normal shell approval flow.
+
+## Validation Matrix
+
+- Helper tests cover single-segment prefix matching.
+- Helper tests cover multi-segment commands with read-only and mutating
+  segments.
+- Helper tests cover shell syntax that must not use prefix reuse.
+- Helper tests cover exact-command fallback for shell commands without a
+  reusable prefix.
+- Agent-loop tests cover the real suggestion-mode regression where an approved
+  `git push` prefix must not allow `git push && rm -rf target`.
+
+## Open Risks
+
+- The matcher is intentionally conservative and can request approval for commands
+  that a full shell parser might classify more precisely.
+- The larger approval-policy enum, granular approval families, and auditable
+  rule provenance remain future work.
+- Prefix approvals are still command-prefix based, not full structured command
+  policies.
+
+## Source Journals
+
+- `docs/journal/2026-05-04-shell-approval-segments.md`

--- a/docs/journal/2026-05-04-shell-approval-segments.md
+++ b/docs/journal/2026-05-04-shell-approval-segments.md
@@ -1,0 +1,37 @@
+# Shell Approval Segment Boundaries
+
+## Context
+
+Codex treats shell control operators as approval boundaries. A command string
+joined with `|`, `&&`, `||`, `;`, or a subshell boundary is split into segments,
+and each segment is evaluated independently for sandbox and approval purposes.
+
+RARA already had a segment splitter for read-only classification, but reusable
+prefix approval still checked whether the full normalized shell string started
+with a saved prefix. That allowed an approved prefix such as `git push` to cover
+an unrelated chained segment.
+
+## Change
+
+- Added segment-level reusable-prefix evaluation for legacy shell command
+  strings.
+- Kept read-only multi-segment commands auto-allowable in suggestion mode.
+- Allowed a mixed command only when every segment is read-only or covered by an
+  approved prefix.
+- Rejected prefix reuse for conservative shell syntax gaps: redirection,
+  substitutions, variable expansion, wildcards, subshell grouping, and leading
+  environment assignments.
+- Preserved exact-command replay for shell commands that cannot produce a
+  reusable prefix. The replay key must match the full command summary and does
+  not approve additional segments.
+- Updated the agent loop to call the segment-aware approval helper instead of
+  applying `any(prefix)` to the whole command.
+- Documented the control-plane boundary: TUI, ACP, and Wire adapters may submit
+  approval decisions, but the runtime remains responsible for applying prefix,
+  exact-command, and segment-level policy checks.
+
+## Validation
+
+- `cargo test bash::tests::approval_prefix`
+- `cargo test approved_bash_prefix_does_not_auto_allow_unapproved_shell_segments -- --nocapture`
+- `cargo check`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -105,7 +105,9 @@ Active backlog only. Keep this file small and current.
 
 - [x] Structured command model (`program`, `args`, `cwd`, `allow_net`) in `src/tools/bash.rs` and `crates/sandbox`.
 - [ ] Classifier and routing model from `docs/features/classifier-and-routing.md`.
-- [ ] Auditable permission + sandbox-bypass rules (Codex/Claude-inspired).
+- [ ] Auditable permission + sandbox-bypass rules (Codex/Claude-inspired);
+      segment-level bash prefix reuse is implemented, but typed approval-policy
+      modes and full rule provenance remain open.
 - [ ] Structured auto-permission classifier with compact transcript projection.
 - [ ] Background-task state classifier: `working` / `blocked` / `done` / `failed`.
 - [ ] `secrecy::SecretString` end-to-end for API keys, audit error paths.

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -163,9 +163,7 @@ impl Agent {
     }
 
     pub fn is_bash_prefix_approved(&self, request: &BashCommandInput) -> bool {
-        self.approved_bash_prefixes
-            .iter()
-            .any(|prefix| request.matches_approval_prefix(prefix))
+        request.is_allowed_by_approval_prefixes(&self.approved_bash_prefixes)
     }
 
     pub fn clear_completed_interactions(&mut self) {

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -1233,6 +1233,42 @@ async fn approved_bash_prefix_auto_allows_later_matching_commands() {
 }
 
 #[tokio::test]
+async fn approved_bash_prefix_does_not_auto_allow_unapproved_shell_segments() {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::ToolUse {
+            id: "tool-chained-push-rm".to_string(),
+            name: "bash".to_string(),
+            input: json!({ "command": "git push origin main && rm -rf target" }),
+        }],
+        stop_reason: Some("tool_use".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubBashTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.bash_approval_mode = crate::agent::BashApprovalMode::Suggestion;
+    agent.approved_bash_prefixes.push("git push".to_string());
+
+    agent
+        .query_with_mode(
+            "push and clean".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("query should pause on the unapproved chained segment");
+
+    assert!(agent.pending_approval.is_some());
+    assert_eq!(backend.observed_messages().len(), 1);
+}
+
+#[tokio::test]
 async fn checkpoints_user_message_before_first_model_turn() {
     let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
     let session_id = "checkpoint-before-model".to_string();

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -222,12 +222,11 @@ impl BashCommandInput {
             .map(|value| value.trim())
             .filter(|value| !value.is_empty())
         {
-            let segments = split_shell_segments(command)?;
+            let segments = shell_command_prefix_segments(command)?;
             if segments.len() != 1 {
                 return None;
             }
-            let tokens = tokenize_shell_segment(&segments[0])?;
-            return prefix_from_tokens(&tokens);
+            return prefix_from_tokens(&segments[0]);
         }
 
         let program = self
@@ -241,11 +240,55 @@ impl BashCommandInput {
     }
 
     pub fn matches_approval_prefix(&self, prefix: &str) -> bool {
+        if let Some(command) = self
+            .command
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+        {
+            return shell_command_matches_single_approval_prefix(command, prefix);
+        }
+
         let normalized = self.normalized_approval_summary();
-        normalized == prefix
-            || normalized
-                .strip_prefix(prefix)
-                .is_some_and(|suffix| suffix.starts_with(char::is_whitespace))
+        normalized_summary_matches_prefix(&normalized, prefix)
+    }
+
+    pub fn is_allowed_by_approval_prefixes(&self, prefixes: &[String]) -> bool {
+        if prefixes.is_empty() {
+            return false;
+        }
+        if prefixes
+            .iter()
+            .any(|prefix| summary_matches_exact_approval(&self.summary(), prefix))
+        {
+            return true;
+        }
+
+        if let Some(command) = self
+            .command
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+        {
+            return shell_command_allowed_by_approval_prefixes(
+                command,
+                prefixes,
+                self.can_use_read_only_segment_bypass(),
+            );
+        }
+
+        prefixes
+            .iter()
+            .any(|prefix| self.matches_approval_prefix(prefix))
+    }
+
+    fn can_use_read_only_segment_bypass(&self) -> bool {
+        !self.allow_net
+            && !self.run_in_background
+            && self.env.is_empty()
+            && self.sandbox_permissions == BashSandboxPermissions::UseDefault
+            && self.justification.is_none()
+            && self.prefix_rule.is_empty()
     }
 
     fn normalized_approval_summary(&self) -> String {
@@ -458,6 +501,106 @@ fn git_args_are_read_only(args: &[String]) -> bool {
 fn docker_args_are_read_only(args: &[String]) -> bool {
     args.first()
         .is_some_and(|value| matches!(value.as_str(), "ps" | "images" | "logs" | "inspect"))
+}
+
+fn shell_command_matches_single_approval_prefix(command: &str, prefix: &str) -> bool {
+    let Some(segments) = shell_command_prefix_segments(command) else {
+        return false;
+    };
+    if segments.len() != 1 {
+        return false;
+    }
+    tokens_match_approval_prefix(&segments[0], prefix)
+}
+
+fn shell_command_allowed_by_approval_prefixes(
+    command: &str,
+    prefixes: &[String],
+    allow_read_only_segments: bool,
+) -> bool {
+    let Some(segments) = shell_command_prefix_segments(command) else {
+        return false;
+    };
+    if segments.is_empty() {
+        return false;
+    }
+
+    segments.iter().all(|tokens| {
+        if tokens.is_empty() {
+            return false;
+        }
+        if allow_read_only_segments && argv_is_read_only(&tokens[0], &tokens[1..]) {
+            return true;
+        }
+        prefixes
+            .iter()
+            .any(|prefix| tokens_match_approval_prefix(tokens, prefix))
+    })
+}
+
+fn shell_command_prefix_segments(command: &str) -> Option<Vec<Vec<String>>> {
+    if command_has_prefix_rule_unsafe_syntax(command) {
+        return None;
+    }
+    split_shell_segments(command).and_then(|segments| {
+        segments
+            .into_iter()
+            .map(|segment| {
+                let tokens = tokenize_shell_segment(&segment)?;
+                if tokens_have_env_assignment_prefix(&tokens) {
+                    return None;
+                }
+                Some(tokens)
+            })
+            .collect()
+    })
+}
+
+fn command_has_prefix_rule_unsafe_syntax(command: &str) -> bool {
+    command.contains('\n')
+        || command.contains('`')
+        || command.contains('$')
+        || command.contains('>')
+        || command.contains('<')
+        || command.contains('*')
+        || command.contains('?')
+        || command.contains('(')
+        || command.contains(')')
+}
+
+fn tokens_have_env_assignment_prefix(tokens: &[String]) -> bool {
+    tokens.first().is_some_and(|token| is_env_assignment(token))
+}
+
+fn is_env_assignment(token: &str) -> bool {
+    let Some((name, _)) = token.split_once('=') else {
+        return false;
+    };
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn tokens_match_approval_prefix(tokens: &[String], prefix: &str) -> bool {
+    let normalized = normalized_tokens_summary(tokens);
+    normalized_summary_matches_prefix(&normalized, prefix)
+}
+
+fn summary_matches_exact_approval(summary: &str, prefix: &str) -> bool {
+    let prefix = prefix.trim();
+    !prefix.is_empty() && summary.trim() == prefix
+}
+
+fn normalized_summary_matches_prefix(normalized: &str, prefix: &str) -> bool {
+    let prefix = prefix.trim();
+    !prefix.is_empty()
+        && (normalized == prefix
+            || normalized
+                .strip_prefix(prefix)
+                .is_some_and(|suffix| suffix.starts_with(char::is_whitespace)))
 }
 
 fn split_shell_segments(command: &str) -> Option<Vec<String>> {
@@ -1707,6 +1850,83 @@ mod tests {
 
         assert_eq!(input.approval_prefix().as_deref(), Some("git push"));
         assert!(input.matches_approval_prefix("git push"));
+    }
+
+    #[test]
+    fn approval_prefix_does_not_match_multi_segment_command_by_first_segment() {
+        let input = BashCommandInput::from_value(json!({
+            "command": "git push origin main && rm -rf target"
+        }))
+        .expect("shell payload");
+
+        assert_eq!(input.approval_prefix(), None);
+        assert!(!input.matches_approval_prefix("git push"));
+        assert!(!input.is_allowed_by_approval_prefixes(&["git push".to_string()]));
+    }
+
+    #[test]
+    fn approval_prefixes_evaluate_every_shell_segment() {
+        let push_then_status = BashCommandInput::from_value(json!({
+            "command": "git push origin main && git status --short"
+        }))
+        .expect("shell payload");
+        assert!(
+            push_then_status.is_allowed_by_approval_prefixes(&["git push".to_string()]),
+            "approved write segment plus read-only segment should be allowed"
+        );
+
+        let push_then_test = BashCommandInput::from_value(json!({
+            "command": "git push origin main && cargo test"
+        }))
+        .expect("shell payload");
+        assert!(!push_then_test.is_allowed_by_approval_prefixes(&["git push".to_string()]));
+        assert!(
+            push_then_test.is_allowed_by_approval_prefixes(&[
+                "git push".to_string(),
+                "cargo test".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn approval_prefix_fallback_allows_only_exact_multi_segment_command() {
+        let input = BashCommandInput::from_value(json!({
+            "command": "git push origin main && git status --short"
+        }))
+        .expect("shell payload");
+        let exact_approval = "git push origin main && git status --short".to_string();
+
+        assert_eq!(input.approval_prefix(), None);
+        assert!(input.is_allowed_by_approval_prefixes(std::slice::from_ref(&exact_approval)));
+
+        let extra_segment = BashCommandInput::from_value(json!({
+            "command": "git push origin main && git status --short && rm -rf target"
+        }))
+        .expect("shell payload");
+        assert!(!extra_segment.is_allowed_by_approval_prefixes(&[exact_approval]));
+    }
+
+    #[test]
+    fn approval_prefixes_reject_shell_features_outside_rule_matching() {
+        for command in [
+            "git push origin main > /tmp/out",
+            "git push origin $BRANCH",
+            "git push origin main && rm -rf *",
+            "FOO=bar git push origin main",
+            "(git push origin main)",
+        ] {
+            let input =
+                BashCommandInput::from_value(json!({ "command": command })).expect("shell payload");
+            assert_eq!(
+                input.approval_prefix(),
+                None,
+                "{command} should not suggest a reusable prefix"
+            );
+            assert!(
+                !input.is_allowed_by_approval_prefixes(&["git push".to_string()]),
+                "{command} should not be allowed by a simple prefix"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Enforce reusable bash prefix approvals at shell segment boundaries.
- Reject prefix reuse for conservative shell syntax gaps such as redirection,
  substitutions, wildcards, subshell grouping, and leading env assignments.
- Document the shell approval policy and record the implementation checkpoint.

## Why

An approved prefix like `git push` should not implicitly approve unrelated
segments in a chained command such as `git push ... && rm -rf target`.

## Validation

- `cargo fmt`
- `cargo test bash::tests::approval_prefix -- --nocapture`
- `cargo test approved_bash_prefix_does_not_auto_allow_unapproved_shell_segments -- --nocapture`
- `git diff --check`
- `cargo check` (passes; existing unused/dead-code warnings remain)
