### PR TITLE
feat(tui): add vertical scroll to /context overlay modal

### DIFF
--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -18,6 +18,7 @@ pub enum AppEvent {
     MoveCursorDown,
     NavigateInputHistory(i32),
     ScrollTranscript(i32),
+    ScrollContext(i32),
     MoveCommandSelection(i32),
     MoveProviderSelection(i32),
     MoveModelSelection(i32),

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -72,6 +72,7 @@ pub(crate) async fn dispatch_event(
             app.navigate_input_history(delta);
         }
         AppEvent::ScrollTranscript(delta) => app.scroll_transcript(delta),
+        AppEvent::ScrollContext(delta) => app.scroll_context(delta),
         AppEvent::MoveCommandSelection(delta) => {
             let len = palette_commands(app, app.command_query()).len();
             if len > 0 {

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -50,6 +50,10 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
         },
         Some(Overlay::Context) => match code {
             KeyCode::Esc | KeyCode::Enter => AppEvent::CloseOverlay,
+            KeyCode::Up | KeyCode::Char('k') => AppEvent::ScrollContext(-1),
+            KeyCode::Down | KeyCode::Char('j') => AppEvent::ScrollContext(1),
+            KeyCode::PageUp => AppEvent::ScrollContext(-5),
+            KeyCode::PageDown => AppEvent::ScrollContext(5),
             _ => AppEvent::Noop,
         },
         Some(Overlay::ProviderPicker) => match code {

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -470,11 +470,13 @@ fn render_context_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_widget(
         Paragraph::new(lines)
             .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
-            .wrap(Wrap { trim: false }),
+            .wrap(Wrap { trim: false })
+            .scroll((app.context_scroll, 0)),
         chunks[0],
     );
     f.render_widget(
-        Paragraph::new("esc close").alignment(Alignment::Center),
+        Paragraph::new("esc close  j/k ↑↓ scroll")
+            .alignment(Alignment::Center),
         chunks[1],
     );
 }

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -475,8 +475,7 @@ fn render_context_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
         chunks[0],
     );
     f.render_widget(
-        Paragraph::new("esc close  j/k ↑↓ scroll")
-            .alignment(Alignment::Center),
+        Paragraph::new("esc close  j/k ↑↓ scroll").alignment(Alignment::Center),
         chunks[1],
     );
 }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -231,6 +231,7 @@ impl TuiApp {
             committed_render_generation: 0,
             committed_render_cache: RefCell::new(CommittedTranscriptRenderCache::default()),
             transcript_scroll: 0,
+            context_scroll: 0,
             terminal_width: 80,
             agent_markdown_stream: None,
             agent_thinking_stream: None,
@@ -1157,6 +1158,9 @@ impl TuiApp {
         }
         if matches!(overlay, Overlay::SkillsPicker) {
             self.skill_picker_idx = 0;
+        }
+        if matches!(overlay, Overlay::Context) {
+            self.context_scroll = 0;
         }
         self.overlay = Some(overlay);
     }

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -217,6 +217,16 @@ impl TuiApp {
         }
     }
 
+    pub fn scroll_context(&mut self, delta: i32) {
+        if delta < 0 {
+            self.context_scroll = self
+                .context_scroll
+                .saturating_add(delta.unsigned_abs() as u16);
+        } else {
+            self.context_scroll = self.context_scroll.saturating_sub(delta as u16);
+        }
+    }
+
     pub fn set_runtime_phase(&mut self, phase: RuntimePhase, detail: Option<String>) {
         self.runtime_phase = phase;
         self.runtime_phase_detail = detail;

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -218,12 +218,12 @@ impl TuiApp {
     }
 
     pub fn scroll_context(&mut self, delta: i32) {
-        if delta < 0 {
+        if delta > 0 {
+            self.context_scroll = self.context_scroll.saturating_add(delta as u16);
+        } else {
             self.context_scroll = self
                 .context_scroll
-                .saturating_add(delta.unsigned_abs() as u16);
-        } else {
-            self.context_scroll = self.context_scroll.saturating_sub(delta as u16);
+                .saturating_sub(delta.unsigned_abs() as u16);
         }
     }
 

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -547,6 +547,7 @@ pub struct TuiApp {
     pub committed_render_generation: u64,
     pub committed_render_cache: RefCell<CommittedTranscriptRenderCache>,
     pub transcript_scroll: usize,
+    pub context_scroll: u16,
     pub terminal_width: u16,
     pub agent_markdown_stream: Option<AgentMarkdownStreamState>,
     pub agent_thinking_stream: Option<AgentMarkdownStreamState>,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -126,6 +126,83 @@ fn status_overlay_shortcuts_switch_tabs() {
     ));
 }
 
+#[test]
+fn context_overlay_scroll_keybindings() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    app.open_overlay(Overlay::Context);
+
+    // j / Down scroll down → positive delta
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Char('j')), &app),
+        AppEvent::ScrollContext(1)
+    ));
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Down), &app),
+        AppEvent::ScrollContext(1)
+    ));
+    // k / Up scroll up → negative delta
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Char('k')), &app),
+        AppEvent::ScrollContext(-1)
+    ));
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Up), &app),
+        AppEvent::ScrollContext(-1)
+    ));
+    // Esc / Enter close
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Esc), &app),
+        AppEvent::CloseOverlay
+    ));
+    assert!(matches!(
+        map_key_to_event(key(KeyCode::Enter), &app),
+        AppEvent::CloseOverlay
+    ));
+}
+
+#[test]
+fn context_scroll_direction_is_top_down() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    app.open_overlay(Overlay::Context);
+    assert_eq!(app.context_scroll, 0);
+
+    // Down / j → scroll away from top, offset increases
+    app.scroll_context(1);
+    assert_eq!(app.context_scroll, 1);
+    app.scroll_context(1);
+    assert_eq!(app.context_scroll, 2);
+
+    // Up / k → scroll back toward top, offset decreases
+    app.scroll_context(-1);
+    assert_eq!(app.context_scroll, 1);
+    app.scroll_context(-1);
+    assert_eq!(app.context_scroll, 0);
+
+    // Cannot go below 0
+    app.scroll_context(-1);
+    assert_eq!(app.context_scroll, 0);
+
+    // PageDown / PageUp
+    app.scroll_context(5);
+    assert_eq!(app.context_scroll, 5);
+    app.scroll_context(-5);
+    assert_eq!(app.context_scroll, 0);
+
+    // Reopen resets scroll
+    app.scroll_context(10);
+    assert_eq!(app.context_scroll, 10);
+    app.open_overlay(Overlay::Context);
+    assert_eq!(app.context_scroll, 0);
+}
+
 #[tokio::test]
 async fn pending_plan_approval_blocks_plain_submit() {
     let temp = tempdir().expect("tempdir");


### PR DESCRIPTION
## What

Add j/k/arrow keyboard scrolling to the `/context` overlay modal. When the terminal window is too small to show all context lines, you can now scroll through the content.

## Why

The /context display has many sections (budget, breakdown, session, compaction, plan, assembly, etc.) that easily overflow a centered modal on smaller windows. Previously there was no way to see the hidden content — no scroll state, no keyboard bindings, just a static `Paragraph` without `.scroll()`.

## Changes

- Add `context_scroll: u16` field to `TuiApp` state, initialized to 0
- New `ScrollContext(i32)` app event + `scroll_context` method (same saturating pattern as `scroll_transcript`)
- Keyboard: `j/k`, `↑/↓` scroll by 1 line; `PageUp/PageDown` scroll by 5
- `ratatui::Paragraph::scroll((app.context_scroll, 0))` in render_context_modal
- Scroll automatically resets to top when reopening `/context`
- Footer hint updated: `"esc close  j/k ↑↓ scroll"`

| File | Change |
|---|---|
| `src/tui/state/types.rs` | +1 field |
| `src/tui/app_event.rs` | +1 variant |
| `src/tui/state/transcript.rs` | +10 method |
| `src/tui/state/mod.rs` | +4 (init + reset) |
| `src/tui/keymap.rs` | +4 key bindings |
| `src/tui/event_dispatch.rs` | +1 dispatch arm |
| `src/tui/render/overlay.rs` | +2 (scroll + footer) |

## Verification

- `cargo build` / `cargo check`
- `cargo test -- keymap`
- `cargo test -- render::tests::context_overlay_snapshot_with_typical_budget`
- Manual: open `/context` in a small terminal window, scroll through content with j/k/arrows, verify content is fully accessible
