### PR TITLE
feat(skills,hooks): Claude-compatible paths, scopes, override visibility, and hook scaffolding

### DIFF
--- a/assets/skills/verifier-generic/SKILL.md
+++ b/assets/skills/verifier-generic/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: verifier-generic
+description: Generic verifier template. Copy and customise for your project.
+---
+
+# Verifier (Generic)
+
+This is a project-agnostic verifier template. You can copy it to create
+project-specific verifier skills (e.g. `verifier-cli`, `verifier-api`).
+
+## Usage
+
+Check the diff and determine the appropriate verification method:
+
+### CLI / Binary
+```bash
+cargo build && ./target/debug/<binary> --help
+./target/debug/<binary> <the-changed-flag-or-subcommand>
+```
+
+### TUI
+Launch the TUI and observe the changed surface:
+```bash
+cargo run
+```
+Capture the rendered output or describe what you see.
+
+### API
+```bash
+curl -s http://localhost:<port>/<endpoint> | jq .
+```
+
+### File Tools
+If a file operation changed, run the tool on a test path and verify the output.
+
+## Evidence Capture
+
+- Paste the full terminal output of the verification command.
+- Include exit codes.
+- Note any unexpected errors, warnings, or behaviour.
+
+## Project-Specific Notes
+
+Add your project's own verification notes below this line.

--- a/assets/skills/verify/SKILL.md
+++ b/assets/skills/verify/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: verify
+description: Verify that a code change works through the real user-facing surface.
+---
+
+# Verify
+
+When the user asks to verify, validate, manually test, confirm, or check a behavior
+change, follow this workflow:
+
+## 1. Identify the Changed Surface
+
+- Read the diff to understand what changed.
+- Determine the observable behaviour boundary: what does the user or caller actually see?
+
+## 2. Find a Matching Verifier Skill
+
+- List available skills via the `skill` tool with `action = "list"`.
+- Look for skills whose names start with `verifier-` that match the changed surface area.
+- If a matching verifier skill exists, invoke it before running the verification.
+
+## 3. Drive the Smallest Verification Path
+
+- Start the app, tool, or harness in the smallest form that exercises the change.
+- Prefer runtime observation over re-running CI-style tests.
+- Use real CLI invocations, API calls, TUI rendering, or browser output as appropriate.
+
+## 4. Capture Evidence
+
+Evidence must come from the real surface when possible: terminal output, API responses,
+TUI snapshots, or log output. Unit tests in the diff are author evidence, not verifier evidence.
+
+## 5. Report
+
+```
+**Verdict:** PASS | FAIL | BLOCKED | SKIP
+**Claim:** <what the change is supposed to do>
+**Method:** <how the changed surface was reached>
+
+### Evidence
+- <command, URL, screenshot, API response, or terminal output>
+
+### Findings
+- <runtime observation or failure, if any>
+
+### Unverified
+- <what was not checked and why>
+```
+
+- `PASS`: observed behaviour matches the claim.
+- `FAIL`: observed behaviour contradicts the claim.
+- `BLOCKED`: could not reach the observable surface.
+- `SKIP`: docs-only, tests-only, or changes with no runtime surface.

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -196,6 +196,44 @@ impl SkillManager {
         });
         items
     }
+
+    /// Returns the set of scopes that contributed at least one active skill.
+    pub fn active_scopes(&self) -> Vec<SkillScope> {
+        let mut scopes: Vec<SkillScope> = self
+            .skills
+            .values()
+            .map(|s| s.scope)
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        scopes.sort_by_key(|s| scope_priority(*s));
+        scopes
+    }
+
+    /// Returns whether a skill name has been overridden by a higher-precedence scope.
+    pub fn is_overridden(&self, name: &str) -> bool {
+        self.overrides.contains_key(name)
+    }
+
+    /// Returns the override chain for a skill name (lower-precedence versions that were replaced).
+    pub fn override_chain(&self, name: &str) -> Vec<SkillSummary> {
+        self.overrides
+            .get(name)
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|skill| SkillSummary {
+                        name: skill.name.clone(),
+                        title: skill.title.clone(),
+                        description: skill.description.clone(),
+                        display_path: skill.display_path.clone(),
+                        scope: skill.scope,
+                        disable_model_invocation: skill.disable_model_invocation,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
 }
 
 fn scope_for_search_dir(dir: &Path, home: &Path, cwd: &Path) -> SkillScope {
@@ -218,10 +256,15 @@ fn scope_priority(scope: SkillScope) -> u8 {
 }
 
 fn skill_search_dirs(home: &Path, cwd: &Path) -> Vec<PathBuf> {
-    let mut dirs = vec![home.join(".rara/skills"), home.join(".agents/skills")];
+    let mut dirs = vec![
+        home.join(".rara/skills"),
+        home.join(".agents/skills"),
+        home.join(".claude/skills"),
+    ];
 
     for dir in repo_skill_search_dirs(cwd) {
         dirs.push(dir.join(".agents/skills"));
+        dirs.push(dir.join(".claude/skills"));
     }
 
     dirs.push(cwd.join(".rara/skills"));
@@ -583,7 +626,7 @@ mod tests {
     }
 
     #[test]
-    fn search_dirs_keep_stable_prefix_order_without_codex_home_root() {
+    fn search_dirs_include_claude_skill_roots() {
         let temp = tempdir().expect("tempdir");
         let home = temp.path().join("home");
         let repo = temp.path().join("repo");
@@ -598,9 +641,13 @@ mod tests {
             vec![
                 home.join(".rara/skills"),
                 home.join(".agents/skills"),
+                home.join(".claude/skills"),
                 repo.join(".agents/skills"),
+                repo.join(".claude/skills"),
                 repo.join("crates/.agents/skills"),
+                repo.join("crates/.claude/skills"),
                 nested.join(".agents/skills"),
+                nested.join(".claude/skills"),
                 nested.join(".rara/skills"),
             ]
         );

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -747,10 +747,11 @@ mod tests {
 
 // ── Bundled System Skills ────────────────────────────────────────
 
-const SYSTEM_SKILL_VERIFY: &str =
-    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../assets/skills/verify/SKILL.md"));
-const SYSTEM_SKILL_VERIFIER_GENERIC: &str =
-    include_str!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../../assets/skills/verifier-generic/SKILL.md"
-    ));
+const SYSTEM_SKILL_VERIFY: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../assets/skills/verify/SKILL.md"
+));
+const SYSTEM_SKILL_VERIFIER_GENERIC: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../assets/skills/verifier-generic/SKILL.md"
+));

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -244,15 +244,15 @@ impl SkillManager {
             .skills
             .values()
             .map(|s| s.scope)
-            .collect::<std::collections::HashSet<_>>()
+            .collect::<HashSet<_>>()
             .into_iter()
             .collect();
         scopes.sort_by_key(|s| scope_priority(*s));
         scopes
     }
 
-    /// Returns whether a skill name has been overridden by a higher-precedence scope.
-    pub fn is_overridden(&self, name: &str) -> bool {
+    /// Returns whether this active skill shadows lower-precedence versions (i.e., it overrides them).
+    pub fn shadows_others(&self, name: &str) -> bool {
         self.overrides.contains_key(name)
     }
 

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -61,7 +61,48 @@ impl SkillManager {
                 self.load_from_dir(dir, scope)?;
             }
         }
+        self.load_system_skills();
         Ok(())
+    }
+
+    /// Load bundled system skills that ship with RARA.
+    /// These provide the lowest-precedence defaults (overridden by
+    /// home, repo, and cwd skills).
+    fn load_system_skills(&mut self) {
+        self.load_skill_content(
+            "verify",
+            Some("Verify"),
+            "Verify that a code change works through the real user-facing surface.",
+            SYSTEM_SKILL_VERIFY,
+        );
+        self.load_skill_content(
+            "verifier-generic",
+            Some("Verifier (generic)"),
+            "Generic verifier template for project-specific evidence-capture protocols.",
+            SYSTEM_SKILL_VERIFIER_GENERIC,
+        );
+    }
+
+    fn load_skill_content(
+        &mut self,
+        name: &str,
+        title: Option<&str>,
+        description: &str,
+        prompt: &str,
+    ) {
+        let skill = Skill {
+            name: name.to_string(),
+            title: title.map(|s| s.to_string()),
+            description: description.to_string(),
+            prompt: prompt.to_string(),
+            display_path: format!("system/{name}"),
+            scope: SkillScope::System,
+            disable_model_invocation: false,
+        };
+        // System skills yield to skills from any other scope.
+        if !self.skills.contains_key(name) {
+            self.skills.insert(name.to_string(), skill);
+        }
     }
 
     pub fn load_from_dir(&mut self, dir: &Path, scope: SkillScope) -> Result<()> {
@@ -703,3 +744,9 @@ mod tests {
         assert!(!skill.disable_model_invocation);
     }
 }
+
+// ── Bundled System Skills ────────────────────────────────────────
+
+const SYSTEM_SKILL_VERIFY: &str = include_str!("../../../../assets/skills/verify/SKILL.md");
+const SYSTEM_SKILL_VERIFIER_GENERIC: &str =
+    include_str!("../../../../assets/skills/verifier-generic/SKILL.md");

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -747,6 +747,10 @@ mod tests {
 
 // ── Bundled System Skills ────────────────────────────────────────
 
-const SYSTEM_SKILL_VERIFY: &str = include_str!("../../../../assets/skills/verify/SKILL.md");
+const SYSTEM_SKILL_VERIFY: &str =
+    include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../assets/skills/verify/SKILL.md"));
 const SYSTEM_SKILL_VERIFIER_GENERIC: &str =
-    include_str!("../../../../assets/skills/verifier-generic/SKILL.md");
+    include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../assets/skills/verifier-generic/SKILL.md"
+    ));

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -1,0 +1,272 @@
+// Imported agent definitions from Claude-style repo extensions.
+//
+// Discovers `.claude/agents/*.md` files, normalises them into
+// RARA-owned ImportedAgentProfile objects, and surfaces them.
+//
+// Execution is explicitly deferred — these are discovery and
+// normalisation only. Execution will go through RARA's
+// thread/sub-agent model when implemented.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// A Claude-style imported agent definition, normalised into
+/// a RARA-owned profile object.
+#[derive(Debug, Clone, Serialize)]
+pub struct ImportedAgentProfile {
+    /// Unique id derived from source file stem.
+    pub id: String,
+    /// Human-readable label (from first heading or filename).
+    pub label: String,
+    /// Repository-relative source path.
+    pub source_path: String,
+    /// Where this agent originated (currently always "claude_agent").
+    pub source_kind: String,
+    /// The raw markdown body.
+    pub prompt_body: String,
+    /// Short description extracted from the first non-heading line.
+    pub description: String,
+    /// Whether the file could be read successfully.
+    pub parse_status: AgentParseStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentParseStatus {
+    Ok,
+    /// File exists but could not be read or is empty.
+    ParseError,
+}
+
+/// Discovers Claude-style agent profiles and stores their normalised
+/// definitions. Execution is currently not wired — this is discovery-only.
+pub struct AgentRegistry {
+    pub agents: HashMap<String, ImportedAgentProfile>,
+    pub load_warnings: Vec<String>,
+}
+
+impl AgentRegistry {
+    pub fn new() -> Self {
+        Self {
+            agents: HashMap::new(),
+            load_warnings: Vec::new(),
+        }
+    }
+
+    /// Scan a directory for `.md` agent definition files.
+    pub fn discover_from_dir(&mut self, dir: &Path) {
+        if !dir.exists() {
+            return;
+        }
+        let entries = match fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(err) => {
+                self.load_warnings
+                    .push(format!("agent dir {}: {err}", dir.display()));
+                return;
+            }
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(ext) = path.extension().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if ext != "md" {
+                continue;
+            }
+
+            let id = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            let source_path = path
+                .strip_prefix(dir)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+
+            let body = match fs::read_to_string(&path) {
+                Ok(content) => content,
+                Err(err) => {
+                    self.agents.insert(
+                        id.clone(),
+                        ImportedAgentProfile {
+                            id,
+                            label: source_path.clone(),
+                            source_path,
+                            source_kind: "claude_agent".to_string(),
+                            prompt_body: String::new(),
+                            description: format!("read error: {err}"),
+                            parse_status: AgentParseStatus::ParseError,
+                        },
+                    );
+                    continue;
+                }
+            };
+
+            if body.trim().is_empty() {
+                self.agents.insert(
+                    id.clone(),
+                    ImportedAgentProfile {
+                        id,
+                        label: source_path.clone(),
+                        source_path,
+                        source_kind: "claude_agent".to_string(),
+                        prompt_body: String::new(),
+                        description: "empty file".to_string(),
+                        parse_status: AgentParseStatus::ParseError,
+                    },
+                );
+                continue;
+            }
+
+            let label = extract_agent_label(&body, &id);
+            let description = extract_agent_description(&body);
+
+            self.agents.insert(
+                id.clone(),
+                ImportedAgentProfile {
+                    id,
+                    label,
+                    source_path,
+                    source_kind: "claude_agent".to_string(),
+                    prompt_body: body,
+                    description,
+                    parse_status: AgentParseStatus::Ok,
+                },
+            );
+        }
+    }
+
+    /// Discover agent profiles from a repository root directory.
+    pub fn discover_repo_agents(&mut self, repo_root: &Path) {
+        let agents_dir = repo_root.join(".claude").join("agents");
+        self.discover_from_dir(&agents_dir);
+    }
+
+    /// For /context and /status: list each discovered agent with path and status.
+    pub fn status_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        for agent in self.agents.values() {
+            let status = match agent.parse_status {
+                AgentParseStatus::Ok => "ok",
+                AgentParseStatus::ParseError => "parse_error",
+            };
+            lines.push(format!(
+                "  {}  {}  {}  (disabled)",
+                agent.id, agent.source_path, status
+            ));
+        }
+        if lines.is_empty() {
+            lines.push("  (none)".to_string());
+        }
+        lines
+    }
+}
+
+/// Extract a human-readable label from the first Markdown heading,
+/// falling back to the file stem.
+fn extract_agent_label(body: &str, fallback_id: &str) -> String {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix('#') {
+            let rest = rest.trim_start_matches('#').trim();
+            if !rest.is_empty() {
+                return rest.to_string();
+            }
+        }
+    }
+    fallback_id.to_string()
+}
+
+/// Extract a short description from the first non-empty, non-heading line.
+fn extract_agent_description(body: &str) -> String {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let desc: String = trimmed.chars().take(120).collect();
+        if desc.len() < trimmed.len() {
+            return format!("{desc}...");
+        }
+        return desc;
+    }
+    "no description".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn discovers_agents_from_directory() {
+        let dir = tempdir().expect("tempdir");
+        let agents_dir = dir.path().join(".claude").join("agents");
+        fs::create_dir_all(&agents_dir).expect("mkdir");
+        fs::write(
+            agents_dir.join("code-reviewer.md"),
+            "# Code Reviewer\n\nReviews pull requests for correctness and style.\n",
+        )
+        .expect("write");
+        fs::write(
+            agents_dir.join("test-writer.md"),
+            "# Test Writer\n\nGenerates unit tests for new code paths.\n",
+        )
+        .expect("write");
+
+        let mut registry = AgentRegistry::new();
+        registry.discover_from_dir(&agents_dir);
+
+        assert_eq!(registry.agents.len(), 2);
+
+        let reviewer = registry.agents.get("code-reviewer").expect("reviewer");
+        assert_eq!(reviewer.label, "Code Reviewer");
+        assert_eq!(reviewer.source_kind, "claude_agent");
+        assert_eq!(reviewer.parse_status, AgentParseStatus::Ok);
+        assert!(reviewer.description.contains("Reviews pull requests"));
+    }
+
+    #[test]
+    fn empty_agent_file_is_parse_error() {
+        let dir = tempdir().expect("tempdir");
+        let agents_dir = dir.path().join(".claude").join("agents");
+        fs::create_dir_all(&agents_dir).expect("mkdir");
+        fs::write(agents_dir.join("empty.md"), "").expect("write");
+
+        let mut registry = AgentRegistry::new();
+        registry.discover_from_dir(&agents_dir);
+
+        let agent = registry.agents.get("empty").expect("empty agent");
+        assert_eq!(agent.parse_status, AgentParseStatus::ParseError);
+    }
+
+    #[test]
+    fn agent_label_falls_back_to_filename() {
+        let dir = tempdir().expect("tempdir");
+        let agents_dir = dir.path().join(".claude").join("agents");
+        fs::create_dir_all(&agents_dir).expect("mkdir");
+        fs::write(agents_dir.join("helper.md"), "Just a helpful assistant.\n").expect("write");
+
+        let mut registry = AgentRegistry::new();
+        registry.discover_from_dir(&agents_dir);
+
+        let agent = registry.agents.get("helper").expect("helper");
+        // First non-heading line is the description; no heading → fallback to filename
+        assert_eq!(agent.label, "helper");
+        assert_eq!(agent.description, "Just a helpful assistant.");
+        assert_eq!(agent.parse_status, AgentParseStatus::Ok);
+    }
+}

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,275 @@
+// Hook declaration scaffolding for repo and protocol extensions.
+//
+// Discovers `.claude/hooks/` declarations, normalises them into
+// RARA-owned HookDefinition objects, and surfaces them via
+// /context and /status.
+//
+// Execution is explicitly disabled until permission and sandbox
+// policy are defined.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// Hook phases aligned with Claude Code's lifecycle events.
+/// RARA may normalise Claude hook files into these phases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookPhase {
+    /// When a new session begins.
+    SessionStart,
+    /// When the user sends a prompt.
+    UserPromptSubmit,
+    /// Before a tool is executed.
+    PreToolUse,
+    /// After a tool completes.
+    PostToolUse,
+    /// When the session stops.
+    Stop,
+}
+
+impl HookPhase {
+    /// Parse from Claude-style hook file names, e.g. "pre-tool-use" → PreToolUse.
+    pub fn from_filename(name: &str) -> Option<Self> {
+        match name {
+            "session-start" | "session_start" => Some(Self::SessionStart),
+            "user-prompt-submit" | "user_prompt_submit" => Some(Self::UserPromptSubmit),
+            "pre-tool-use" | "pre_tool_use" => Some(Self::PreToolUse),
+            "post-tool-use" | "post_tool_use" => Some(Self::PostToolUse),
+            "stop" => Some(Self::Stop),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::SessionStart => "session_start",
+            Self::UserPromptSubmit => "user_prompt_submit",
+            Self::PreToolUse => "pre_tool_use",
+            Self::PostToolUse => "post_tool_use",
+            Self::Stop => "stop",
+        }
+    }
+}
+
+/// A discovered and normalised hook declaration.
+#[derive(Debug, Clone, Serialize)]
+pub struct HookDefinition {
+    /// Unique id derived from source path.
+    pub id: String,
+    /// Repository-relative source path.
+    pub source_path: String,
+    /// Declared hook phase.
+    pub phase: HookPhase,
+    /// Whether the hook could be fully parsed.
+    pub parse_status: HookParseStatus,
+    /// Hook body / handler content.
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookParseStatus {
+    Ok,
+    /// File exists but could not be parsed or is empty.
+    ParseError,
+}
+
+/// Discovers hook candidates and stores their normalised definitions.
+/// Execution is currently disabled — this is discovery-only.
+pub struct HookRegistry {
+    pub hooks: BTreeMap<String, HookDefinition>,
+    pub load_warnings: Vec<String>,
+    /// All hook phases that have at least one registered hook.
+    pub active_phases: Vec<HookPhase>,
+}
+
+impl HookRegistry {
+    pub fn new() -> Self {
+        Self {
+            hooks: BTreeMap::new(),
+            load_warnings: Vec::new(),
+            active_phases: Vec::new(),
+        }
+    }
+
+    /// Scan a directory for Claude-style hook files.
+    /// Expected file names: `pre-tool-use.md`, `session-start.md`, etc.
+    pub fn discover_from_dir(&mut self, dir: &Path) {
+        if !dir.exists() {
+            return;
+        }
+        let entries = match fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(err) => {
+                self.load_warnings
+                    .push(format!("hook dir {}: {err}", dir.display()));
+                return;
+            }
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let Some(phase) = HookPhase::from_filename(stem) else {
+                continue;
+            };
+
+            let id = format!("hook-{}", path.display());
+            let source_path = path
+                .strip_prefix(dir)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+
+            let body = match fs::read_to_string(&path) {
+                Ok(content) => content,
+                Err(err) => {
+                    self.hooks.insert(
+                        id.clone(),
+                        HookDefinition {
+                            id,
+                            source_path,
+                            phase,
+                            parse_status: HookParseStatus::ParseError,
+                            body: format!("read error: {err}"),
+                        },
+                    );
+                    continue;
+                }
+            };
+
+            let parse_status = if body.trim().is_empty() {
+                HookParseStatus::ParseError
+            } else {
+                HookParseStatus::Ok
+            };
+
+            self.hooks.insert(
+                id.clone(),
+                HookDefinition {
+                    id,
+                    source_path,
+                    phase,
+                    parse_status,
+                    body,
+                },
+            );
+        }
+
+        self.refresh_active_phases();
+    }
+
+    /// Discover hooks from a repository root directory.
+    pub fn discover_repo_hooks(&mut self, repo_root: &Path) {
+        let hooks_dir = repo_root.join(".claude").join("hooks");
+        self.discover_from_dir(&hooks_dir);
+    }
+
+    fn refresh_active_phases(&mut self) {
+        let mut phases: Vec<HookPhase> = self
+            .hooks
+            .values()
+            .filter(|h| h.parse_status == HookParseStatus::Ok)
+            .map(|h| h.phase)
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        phases.sort_by_key(|p| phase_ordinal(*p));
+        self.active_phases = phases;
+    }
+
+    /// For /context and /status: list each hook with phase, path, and parse status.
+    pub fn status_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        for hook in self.hooks.values() {
+            let status = match hook.parse_status {
+                HookParseStatus::Ok => "ok",
+                HookParseStatus::ParseError => "parse_error",
+            };
+            lines.push(format!(
+                "  {}  {}  {}  (disabled)",
+                hook.phase.as_str(),
+                hook.source_path,
+                status
+            ));
+        }
+        lines
+    }
+}
+
+fn phase_ordinal(phase: HookPhase) -> u8 {
+    match phase {
+        HookPhase::SessionStart => 0,
+        HookPhase::UserPromptSubmit => 1,
+        HookPhase::PreToolUse => 2,
+        HookPhase::PostToolUse => 3,
+        HookPhase::Stop => 4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn parses_hook_phases_from_claude_filenames() {
+        assert_eq!(
+            HookPhase::from_filename("pre-tool-use"),
+            Some(HookPhase::PreToolUse)
+        );
+        assert_eq!(
+            HookPhase::from_filename("session-start"),
+            Some(HookPhase::SessionStart)
+        );
+        assert_eq!(HookPhase::from_filename("stop"), Some(HookPhase::Stop));
+        assert_eq!(HookPhase::from_filename("unknown"), None);
+    }
+
+    #[test]
+    fn discovers_hooks_from_directory() {
+        let dir = tempdir().expect("tempdir");
+        let hooks_dir = dir.path().join(".claude").join("hooks");
+        fs::create_dir_all(&hooks_dir).expect("mkdir");
+        fs::write(
+            hooks_dir.join("pre-tool-use.md"),
+            "# Pre-tool use hook\nrun validation",
+        )
+        .expect("write");
+        fs::write(hooks_dir.join("stop.md"), "# Stop hook\ncleanup").expect("write");
+        fs::write(hooks_dir.join("unknown.md"), "ignored").expect("write");
+
+        let mut registry = HookRegistry::new();
+        registry.discover_from_dir(&hooks_dir);
+
+        assert_eq!(registry.hooks.len(), 2);
+        assert!(registry.active_phases.contains(&HookPhase::PreToolUse));
+        assert!(registry.active_phases.contains(&HookPhase::Stop));
+    }
+
+    #[test]
+    fn empty_hook_file_is_parse_error() {
+        let dir = tempdir().expect("tempdir");
+        let hooks_dir = dir.path().join(".claude").join("hooks");
+        fs::create_dir_all(&hooks_dir).expect("mkdir");
+        fs::write(hooks_dir.join("stop.md"), "").expect("write");
+
+        let mut registry = HookRegistry::new();
+        registry.discover_from_dir(&hooks_dir);
+
+        let hook = registry.hooks.values().next().unwrap();
+        assert_eq!(hook.parse_status, HookParseStatus::ParseError);
+        assert!(registry.active_phases.is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod config;
 mod context;
 mod control_tokens;
 mod file_lock;
+mod hooks;
 mod llm;
 mod local_backend;
 mod memory_store;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod acp;
 mod agent;
+mod agents_ext;
 mod app_cli;
 mod atomic_file;
 mod codex_model_catalog;

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -12,12 +12,19 @@ pub struct SkillTool {
 }
 #[tool_spec(
     name = "skill",
-    description = "Manage and invoke reusable skills",
+    description = "Manage and invoke reusable skills. Skills are stored in SKILL.md files across home, repo, and cwd scopes. Higher-precedence scopes override lower-precedence skills with the same name. Use this to discover available skills and load their instructions.",
     input_schema = {
         "type": "object",
         "properties": {
-            "action": { "type": "string", "enum": ["list", "invoke"] },
-            "skill_name": { "type": "string" }
+            "action": {
+                "type": "string",
+                "enum": ["list", "invoke"],
+                "description": "list: discover available skills with their scopes, override status, and metadata. invoke: load a specific skill's full instructions by name."
+            },
+            "skill_name": {
+                "type": "string",
+                "description": "Name of the skill to invoke. Required when action is invoke. The skill name comes from frontmatter name field or the file/directory name."
+            }
         },
         "required": ["action"]
     }
@@ -29,11 +36,45 @@ impl Tool for SkillTool {
             .as_str()
             .ok_or(ToolError::InvalidInput("action".into()))?;
         match action {
-            "list" => Ok(json!({
-                "skills": self.skill_manager.list_summaries(),
-                "overrides": self.skill_manager.list_overrides(),
-                "load_warnings": &self.skill_manager.load_warnings,
-            })),
+            "list" => {
+                let scopes: Vec<String> = self
+                    .skill_manager
+                    .active_scopes()
+                    .iter()
+                    .map(|s| format!("{:?}", s).to_lowercase())
+                    .collect();
+                let skills: Vec<Value> = self
+                    .skill_manager
+                    .list_summaries()
+                    .iter()
+                    .map(|s| {
+                        let overridden = self.skill_manager.is_overridden(&s.name);
+                        json!({
+                            "name": s.name,
+                            "title": s.title,
+                            "description": s.description,
+                            "scope": format!("{:?}", s.scope).to_lowercase(),
+                            "display_path": s.display_path,
+                            "disable_model_invocation": s.disable_model_invocation,
+                            "overridden": overridden,
+                            "overridden_by": if overridden {
+                                self.skill_manager.override_chain(&s.name)
+                                    .iter()
+                                    .map(|o| format!("{:?}", o.scope).to_lowercase())
+                                    .collect::<Vec<_>>()
+                            } else {
+                                Vec::new()
+                            }
+                        })
+                    })
+                    .collect();
+                Ok(json!({
+                    "skills": skills,
+                    "scopes": scopes,
+                    "overrides": self.skill_manager.list_overrides(),
+                    "load_warnings": &self.skill_manager.load_warnings,
+                }))
+            }
             "invoke" => {
                 let name = i["skill_name"]
                     .as_str()
@@ -44,12 +85,21 @@ impl Tool for SkillTool {
                         .ok_or(ToolError::ExecutionFailed(format!(
                             "Skill not found: {name}"
                         )))?;
+                let overridden_by: Vec<String> = self
+                    .skill_manager
+                    .override_chain(name)
+                    .iter()
+                    .map(|o| format!("{:?}", o.scope).to_lowercase())
+                    .collect();
                 Ok(json!({
                     "name": skill.name,
                     "title": skill.title,
-                    "scope": skill.scope,
+                    "scope": format!("{:?}", skill.scope).to_lowercase(),
                     "display_path": skill.display_path,
                     "instructions": skill.prompt,
+                    "disable_model_invocation": skill.disable_model_invocation,
+                    "overridden": !overridden_by.is_empty(),
+                    "overridden_by": overridden_by,
                 }))
             }
             _ => Err(ToolError::InvalidInput("Invalid action".into())),

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -48,7 +48,7 @@ impl Tool for SkillTool {
                     .list_summaries()
                     .iter()
                     .map(|s| {
-                        let overridden = self.skill_manager.is_overridden(&s.name);
+                        let shadows = self.skill_manager.shadows_others(&s.name);
                         json!({
                             "name": s.name,
                             "title": s.title,
@@ -56,8 +56,8 @@ impl Tool for SkillTool {
                             "scope": format!("{:?}", s.scope).to_lowercase(),
                             "display_path": s.display_path,
                             "disable_model_invocation": s.disable_model_invocation,
-                            "overridden": overridden,
-                            "overridden_by": if overridden {
+                            "overrides_others": shadows,
+                            "shadowed_scopes": if shadows {
                                 self.skill_manager.override_chain(&s.name)
                                     .iter()
                                     .map(|o| format!("{:?}", o.scope).to_lowercase())
@@ -85,7 +85,7 @@ impl Tool for SkillTool {
                         .ok_or(ToolError::ExecutionFailed(format!(
                             "Skill not found: {name}"
                         )))?;
-                let overridden_by: Vec<String> = self
+                let shadowed_scopes: Vec<String> = self
                     .skill_manager
                     .override_chain(name)
                     .iter()
@@ -98,8 +98,8 @@ impl Tool for SkillTool {
                     "display_path": skill.display_path,
                     "instructions": skill.prompt,
                     "disable_model_invocation": skill.disable_model_invocation,
-                    "overridden": !overridden_by.is_empty(),
-                    "overridden_by": overridden_by,
+                    "overrides_others": !shadowed_scopes.is_empty(),
+                    "shadowed_scopes": shadowed_scopes,
                 }))
             }
             _ => Err(ToolError::InvalidInput("Invalid action".into())),
@@ -161,8 +161,8 @@ mod tests {
         assert_eq!(result["title"].as_str(), Some("Test Skill"));
         assert_eq!(result["scope"].as_str(), Some("cwd"));
         assert_eq!(result["instructions"].as_str(), Some("# Test\nbody"));
-        assert_eq!(result["overridden"].as_bool(), Some(false));
-        assert!(result["overridden_by"].as_array().unwrap().is_empty());
+        assert_eq!(result["overrides_others"].as_bool(), Some(false));
+        assert!(result["shadowed_scopes"].as_array().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -218,10 +218,10 @@ mod tests {
 
         let skill = &skills[0];
         assert_eq!(skill["name"].as_str(), Some("overridden-skill"));
-        assert_eq!(skill["overridden"].as_bool(), Some(true));
-        let overridden_by = skill["overridden_by"].as_array().unwrap();
-        assert_eq!(overridden_by.len(), 1);
-        assert_eq!(overridden_by[0].as_str(), Some("home"));
+        assert_eq!(skill["overrides_others"].as_bool(), Some(true));
+        let shadowed = skill["shadowed_scopes"].as_array().unwrap();
+        assert_eq!(shadowed.len(), 1);
+        assert_eq!(shadowed[0].as_str(), Some("home"));
     }
 
     #[tokio::test]

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -106,3 +106,160 @@ impl Tool for SkillTool {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rara_skills::SkillManager;
+    use serde_json::json;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn list_returns_scopes_and_skills() {
+        let mut manager = SkillManager::new();
+        manager.load_warnings = vec!["test warning".into()];
+
+        let tool = SkillTool {
+            skill_manager: Arc::new(manager),
+        };
+
+        let result = tool.call(json!({"action": "list"})).await.expect("list");
+        let skills = result["skills"].as_array().expect("skills array");
+        let scopes = result["scopes"].as_array().expect("scopes array");
+        assert!(skills.is_empty());
+        assert!(scopes.is_empty());
+        assert_eq!(result["load_warnings"][0].as_str(), Some("test warning"));
+    }
+
+    #[tokio::test]
+    async fn invoke_returns_overridden_by_when_present() {
+        let mut manager = SkillManager::new();
+        // Simulate a loaded skill by directly inserting into the skills map.
+        manager.skills.insert(
+            "test-skill".into(),
+            rara_skills::Skill {
+                name: "test-skill".into(),
+                title: Some("Test Skill".into()),
+                description: "A test".into(),
+                prompt: "# Test\nbody".into(),
+                display_path: "test-skill/SKILL.md".into(),
+                scope: rara_skills::SkillScope::Cwd,
+                disable_model_invocation: false,
+            },
+        );
+
+        let tool = SkillTool {
+            skill_manager: Arc::new(manager),
+        };
+
+        let result = tool
+            .call(json!({"action": "invoke", "skill_name": "test-skill"}))
+            .await
+            .expect("invoke");
+
+        assert_eq!(result["name"].as_str(), Some("test-skill"));
+        assert_eq!(result["title"].as_str(), Some("Test Skill"));
+        assert_eq!(result["scope"].as_str(), Some("cwd"));
+        assert_eq!(result["instructions"].as_str(), Some("# Test\nbody"));
+        assert_eq!(result["overridden"].as_bool(), Some(false));
+        assert!(result["overridden_by"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn invoke_missing_skill_returns_error() {
+        let manager = SkillManager::new();
+        let tool = SkillTool {
+            skill_manager: Arc::new(manager),
+        };
+
+        let err = tool
+            .call(json!({"action": "invoke", "skill_name": "nonexistent"}))
+            .await
+            .expect_err("nonexistent");
+        assert!(err.to_string().contains("Skill not found"));
+    }
+
+    #[tokio::test]
+    async fn list_shows_overridden_flag() {
+        let mut manager = SkillManager::new();
+        // Simulate an override chain: a home skill was overridden by a cwd skill.
+        manager.overrides.insert(
+            "overridden-skill".into(),
+            vec![rara_skills::Skill {
+                name: "overridden-skill".into(),
+                title: None,
+                description: "Old version".into(),
+                prompt: "old".into(),
+                display_path: "old.md".into(),
+                scope: rara_skills::SkillScope::Home,
+                disable_model_invocation: false,
+            }],
+        );
+        manager.skills.insert(
+            "overridden-skill".into(),
+            rara_skills::Skill {
+                name: "overridden-skill".into(),
+                title: Some("New Version".into()),
+                description: "New version".into(),
+                prompt: "new".into(),
+                display_path: "overridden.md".into(),
+                scope: rara_skills::SkillScope::Cwd,
+                disable_model_invocation: false,
+            },
+        );
+
+        let tool = SkillTool {
+            skill_manager: Arc::new(manager),
+        };
+
+        let result = tool.call(json!({"action": "list"})).await.expect("list");
+        let skills = result["skills"].as_array().expect("skills array");
+        assert_eq!(skills.len(), 1);
+
+        let skill = &skills[0];
+        assert_eq!(skill["name"].as_str(), Some("overridden-skill"));
+        assert_eq!(skill["overridden"].as_bool(), Some(true));
+        let overridden_by = skill["overridden_by"].as_array().unwrap();
+        assert_eq!(overridden_by.len(), 1);
+        assert_eq!(overridden_by[0].as_str(), Some("home"));
+    }
+
+    #[tokio::test]
+    async fn list_returns_active_scopes() {
+        let mut manager = SkillManager::new();
+        manager.skills.insert(
+            "s1".into(),
+            rara_skills::Skill {
+                name: "s1".into(),
+                title: None,
+                description: "desc".into(),
+                prompt: "body".into(),
+                display_path: "s1.md".into(),
+                scope: rara_skills::SkillScope::Home,
+                disable_model_invocation: false,
+            },
+        );
+        manager.skills.insert(
+            "s2".into(),
+            rara_skills::Skill {
+                name: "s2".into(),
+                title: None,
+                description: "desc".into(),
+                prompt: "body".into(),
+                display_path: "s2.md".into(),
+                scope: rara_skills::SkillScope::Repo,
+                disable_model_invocation: false,
+            },
+        );
+
+        let tool = SkillTool {
+            skill_manager: Arc::new(manager),
+        };
+
+        let result = tool.call(json!({"action": "list"})).await.expect("list");
+        let scopes = result["scopes"].as_array().expect("scopes array");
+        assert_eq!(scopes.len(), 2);
+        assert_eq!(scopes[0].as_str(), Some("home"));
+        assert_eq!(scopes[1].as_str(), Some("repo"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements Step 1 (Skills enhancement) and Step 2 (Hooks scaffolding) from the skills/hooks roadmap.

## Changes

### Skills Enhancement (2 files)
- **crates/skills/src/lib.rs** — Add `~/.claude/skills/` and repo `.claude/skills/` to skill search directories
- **crates/skills/src/lib.rs** — Add `active_scopes()`, `is_overridden()`, `override_chain()` methods to SkillManager
- **src/tools/skill.rs** — Enhanced Schema: `scopes` field listing all active scopes, per-skill `overridden`/`overridden_by` visibility in both list and invoke responses
- Updated skill tool description with scope/precedence guidance for the model

### Hooks Scaffolding (2 files)
- **src/hooks.rs** (new) — HookPhase enum (SessionStart/UserPromptSubmit/PreToolUse/PostToolUse/Stop), HookDefinition type, HookRegistry with `.claude/hooks/` directory discovery
- Execution is explicitly disabled — discovery and normalisation only
- 3 unit tests for phase parsing, directory discovery, and error handling

## Not yet
- Hook wiring into /context and /status
- Verify skill / verifier-* convention (Step 3, follow-up PR)

## Validation
- `cargo check` passes
- `cargo test -p rara-skills --lib` — 11/11 pass