### PR TITLE
feat: add mcp config registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8705,6 +8705,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ dirs = "6.0"
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.9.12"
 tempfile = "3.17"
 codex-execpolicy = { git = "https://github.com/openai/codex", package = "codex-execpolicy", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -11,6 +11,7 @@ dirs.workspace = true
 secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,4 +1,5 @@
 mod defaults;
+mod mcp;
 mod migration;
 mod model;
 mod provider_surface;
@@ -13,6 +14,10 @@ pub use self::defaults::{
     LEGACY_CODEX_BASE_URL, LEGACY_CODEX_MODEL, LEGACY_CODEX_MODEL_V1, LEGACY_CODEX_MODEL_V1_MINI,
     REASONING_SUMMARY_DETAILED, REASONING_SUMMARY_NONE, should_apply_codex_base_url,
     should_reset_codex_base_url, should_reset_codex_model,
+};
+pub use self::mcp::{
+    McpRegistry, McpServerConfig, McpServerScope, McpServerSource, McpServerTransport,
+    SourcedMcpServerConfig,
 };
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{

--- a/crates/config/src/mcp.rs
+++ b/crates/config/src/mcp.rs
@@ -1,0 +1,282 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpServerScope {
+    Project,
+    Local,
+    User,
+    Enterprise,
+    Builtin,
+}
+
+impl McpServerScope {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Project => "project",
+            Self::Local => "local",
+            Self::User => "user",
+            Self::Enterprise => "enterprise",
+            Self::Builtin => "builtin",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpServerSource {
+    pub scope: McpServerScope,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpRegistry {
+    pub servers: BTreeMap<String, SourcedMcpServerConfig>,
+}
+
+impl McpRegistry {
+    pub fn empty() -> Self {
+        Self {
+            servers: BTreeMap::new(),
+        }
+    }
+
+    fn insert_source(
+        &mut self,
+        source: McpServerSource,
+        servers: BTreeMap<String, McpServerConfig>,
+    ) -> Result<()> {
+        for (name, config) in servers {
+            if let Some(existing) = self.servers.get(&name) {
+                bail!(
+                    "MCP server `{name}` is defined in both {} ({}) and {} ({}); remove one definition",
+                    existing.source.scope.label(),
+                    existing.source.path.display(),
+                    source.scope.label(),
+                    source.path.display()
+                );
+            }
+            self.servers.insert(
+                name,
+                SourcedMcpServerConfig {
+                    config,
+                    source: source.clone(),
+                },
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourcedMcpServerConfig {
+    pub config: McpServerConfig,
+    pub source: McpServerSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct McpServerConfig {
+    #[serde(flatten)]
+    pub transport: McpServerTransport,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub supports_parallel_tool_calls: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_timeout_sec: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_timeout_sec: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled_tools: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disabled_tools: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged, deny_unknown_fields)]
+pub enum McpServerTransport {
+    Stdio {
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        env: Option<BTreeMap<String, String>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd: Option<PathBuf>,
+    },
+    StreamableHttp {
+        url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        bearer_token_env_var: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        http_headers: Option<BTreeMap<String, String>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        env_http_headers: Option<BTreeMap<String, String>>,
+    },
+}
+
+const fn default_enabled() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+struct TomlMcpConfig {
+    #[serde(default)]
+    mcp_servers: BTreeMap<String, McpServerConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectMcpConfig {
+    #[serde(default, rename = "mcpServers")]
+    mcp_servers: BTreeMap<String, McpServerConfig>,
+}
+
+pub fn load_mcp_registry(user_config_toml: &Path, project_root: &Path) -> Result<McpRegistry> {
+    let mut registry = McpRegistry::empty();
+    let project_config = project_root.join(".mcp.json");
+
+    append_servers_from_path(
+        &mut registry,
+        user_config_toml,
+        McpServerScope::User,
+        |content| toml::from_str::<TomlMcpConfig>(content).map(|config| config.mcp_servers),
+    )?;
+    append_servers_from_path(
+        &mut registry,
+        &project_config,
+        McpServerScope::Project,
+        |content| {
+            serde_json::from_str::<ProjectMcpConfig>(content).map(|config| config.mcp_servers)
+        },
+    )?;
+
+    Ok(registry)
+}
+
+fn append_servers_from_path<E>(
+    registry: &mut McpRegistry,
+    path: &Path,
+    scope: McpServerScope,
+    parse: impl FnOnce(&str) -> std::result::Result<BTreeMap<String, McpServerConfig>, E>,
+) -> Result<()>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err).with_context(|| format!("read {}", path.display())),
+    };
+    let servers = parse(&content).with_context(|| format!("parse {}", path.display()))?;
+    registry.insert_source(
+        McpServerSource {
+            scope,
+            path: path.to_path_buf(),
+        },
+        servers,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loads_user_config_toml_and_project_mcp_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let user_config = dir.path().join("config.toml");
+        fs::write(
+            &user_config,
+            r#"
+[mcp_servers.docs]
+command = "docs-server"
+args = ["--stdio"]
+enabled_tools = ["search"]
+
+[mcp_servers.remote]
+url = "https://example.com/mcp"
+bearer_token_env_var = "MCP_TOKEN"
+"#,
+        )
+        .expect("write config.toml");
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+        fs::write(
+            project.join(".mcp.json"),
+            r#"{
+  "mcpServers": {
+    "repo": {
+      "command": "repo-mcp",
+      "args": ["--root", "."],
+      "required": true
+    }
+  }
+}"#,
+        )
+        .expect("write .mcp.json");
+
+        let registry = load_mcp_registry(&user_config, &project).expect("registry");
+
+        assert_eq!(registry.servers.len(), 3);
+        assert_eq!(registry.servers["docs"].source.scope, McpServerScope::User);
+        assert_eq!(
+            registry.servers["repo"].source.scope,
+            McpServerScope::Project
+        );
+        assert!(registry.servers["repo"].config.required);
+        assert_eq!(
+            registry.servers["docs"].config.enabled_tools.as_deref(),
+            Some(&["search".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn duplicate_server_names_across_sources_fail() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let user_config = dir.path().join("config.toml");
+        fs::write(
+            &user_config,
+            r#"
+[mcp_servers.docs]
+command = "docs-server"
+"#,
+        )
+        .expect("write config.toml");
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+        fs::write(
+            project.join(".mcp.json"),
+            r#"{
+  "mcpServers": {
+    "docs": {
+      "command": "other-docs-server"
+    }
+  }
+}"#,
+        )
+        .expect("write .mcp.json");
+
+        let err = load_mcp_registry(&user_config, &project).expect_err("conflict");
+
+        let message = err.to_string();
+        assert!(message.contains("MCP server `docs` is defined in both user"));
+        assert!(message.contains("project"));
+    }
+
+    #[test]
+    fn missing_config_files_produce_empty_registry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let registry =
+            load_mcp_registry(&dir.path().join("config.toml"), dir.path()).expect("registry");
+
+        assert!(registry.servers.is_empty());
+    }
+}

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -15,6 +15,7 @@ use crate::defaults::{
     DEFAULT_OPENAI_COMPATIBLE_MODEL, DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OPENROUTER_MODEL,
     DEFAULT_REASONING_SUMMARY, should_apply_codex_base_url, should_reset_codex_model,
 };
+use crate::mcp::{McpRegistry, load_mcp_registry};
 use crate::migration::migrate_reasoning_summary;
 use crate::provider_surface::{ConfigValueSource, EffectiveProviderSurface, ResolvedProviderValue};
 use crate::secrets::{deserialize_secret_option, serialize_secret_option};
@@ -763,6 +764,17 @@ impl ConfigManager {
         let content = serde_json::to_string_pretty(config)?;
         fs::write(&self.path, content)?;
         Ok(())
+    }
+
+    pub fn load_mcp_registry_for_project(&self, project_root: &Path) -> Result<McpRegistry> {
+        load_mcp_registry(&self.config_toml_path(), project_root)
+    }
+
+    pub fn config_toml_path(&self) -> PathBuf {
+        self.path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("config.toml")
     }
 
     pub fn rules_path(&self) -> PathBuf {
@@ -1527,6 +1539,33 @@ prefix_rule(pattern=["rm", "-rf"], decision="prompt")
         let manager =
             ConfigManager::new_for_rara_home(dir.path().join(".rara")).expect("config manager");
         assert_eq!(manager.path, dir.path().join(".rara").join("config.json"));
+    }
+
+    #[test]
+    fn config_toml_path_lives_next_to_config_json() {
+        let dir = tempdir().expect("tempdir");
+        let manager =
+            ConfigManager::new_for_rara_home(dir.path().join(".rara")).expect("config manager");
+
+        assert_eq!(
+            manager.config_toml_path(),
+            dir.path().join(".rara").join("config.toml")
+        );
+    }
+
+    #[test]
+    fn load_mcp_registry_for_project_returns_empty_when_configs_are_missing() {
+        let dir = tempdir().expect("tempdir");
+        let manager =
+            ConfigManager::new_for_rara_home(dir.path().join(".rara")).expect("config manager");
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+
+        let registry = manager
+            .load_mcp_registry_for_project(&project)
+            .expect("mcp registry");
+
+        assert!(registry.servers.is_empty());
     }
 
     #[test]

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -38,3 +38,8 @@ future appserver integrations can use.
 
 - `shell-approval-policy.md`: bash read-only classification and reusable prefix
   approval boundaries.
+
+## Runtime Extension Specs
+
+- `mcp-runtime.md`: source-aware MCP configuration, registry, status, refresh,
+  reconnect, resource, and Tool Search contracts.

--- a/docs/features/mcp-runtime.md
+++ b/docs/features/mcp-runtime.md
@@ -1,0 +1,197 @@
+# MCP Runtime
+
+## Problem
+
+RARA needs a Claude-style MCP integration surface that can be configured from
+both user-level settings and project-level files without silently changing tool
+availability. MCP servers affect tools, resources, prompts, approvals, context
+budget, and future ACP/Wire adapters, so the integration must start with a
+source-aware registry instead of ad hoc tool injection.
+
+## Scope
+
+This spec covers:
+
+- user MCP configuration in `~/.rara/config.toml` under `[mcp_servers.*]`;
+- project MCP configuration in `<workspace>/.mcp.json` under `mcpServers`;
+- source and scope tracking for every configured server;
+- hard failure when the same server name appears in multiple sources;
+- future status, refresh, reconnect, resource, and Tool Search contracts.
+
+## Non-Goals
+
+- Starting MCP server processes in the first slice.
+- OAuth login for MCP servers.
+- Enterprise-managed MCP policies.
+- Project approval UI for newly discovered `.mcp.json` servers.
+- Letting MCP tools bypass RARA approval, sandbox, or transcript policy.
+
+## Architecture
+
+### Source Scopes
+
+RARA tracks MCP definitions with explicit scope provenance:
+
+- `user`: `~/.rara/config.toml`;
+- `project`: `<workspace>/.mcp.json`;
+- `local`: reserved for machine-local project settings;
+- `enterprise`: reserved for managed policy;
+- `builtin`: reserved for RARA-provided MCP surfaces.
+
+Claude Code groups MCP servers by scope in its management UI. RARA should keep
+the same source clarity, but it must not silently override conflicting server
+names across `config.toml` and `.mcp.json`. A duplicate name is a configuration
+error and startup/status refresh should fail with both source paths.
+
+### Configuration Shapes
+
+User config follows the Codex-style TOML shape:
+
+```toml
+[mcp_servers.docs]
+command = "docs-server"
+args = ["--stdio"]
+
+[mcp_servers.remote]
+url = "https://example.com/mcp"
+bearer_token_env_var = "MCP_TOKEN"
+```
+
+Project config follows the Claude-compatible JSON shape:
+
+```json
+{
+  "mcpServers": {
+    "repo": {
+      "command": "repo-mcp",
+      "args": ["--root", "."]
+    }
+  }
+}
+```
+
+Supported transports:
+
+- stdio: `command`, optional `args`, `env`, and `cwd`;
+- streamable HTTP: `url`, optional bearer-token environment variable and
+  headers.
+
+### Registry Boundary
+
+`McpRegistry` is the stable configuration boundary. It owns the effective map of
+server name to:
+
+- transport config;
+- enablement and required flags;
+- startup/tool timeout hints;
+- enabled/disabled tool filters;
+- source scope and path.
+
+Runtime connection managers, `/mcp`, `/status`, `/context`, ACP, and Wire should
+read from the registry instead of reparsing files.
+
+### Status Model
+
+The runtime connection layer should later expose one structured status per MCP
+server:
+
+- `configured`;
+- `connecting`;
+- `connected`;
+- `disconnected`;
+- `refreshing`;
+- `reconnecting`;
+- `failed`;
+- `disabled`.
+
+The status event must include server name, scope, source path, transport kind,
+last error, discovered tools count, discovered resources count, and whether the
+server is required.
+
+### Dynamic Refresh
+
+MCP tool/resource/prompt lists can change after startup. RARA should support:
+
+- manual refresh through `/mcp refresh`;
+- automatic refresh when a server emits list-changed notifications;
+- structured runtime events so TUI, ACP, Wire, and future appserver clients see
+  the same refreshed state.
+
+Refresh must preserve prompt-cache stability. Newly discovered tools should not
+be appended directly to the core prompt unless the Tool Search policy chooses to
+expose them.
+
+### Auto Reconnect
+
+Disconnected HTTP streams or crashed stdio servers should move through:
+
+```text
+connected -> disconnected -> reconnecting -> connected | failed
+```
+
+Reconnect should use bounded exponential backoff and should stop retrying for
+non-retryable config errors. Users should also be able to trigger reconnect
+manually.
+
+### Resource References
+
+MCP resources should be first-class context sources rather than copied into the
+system prompt by default. A future resource reference should carry:
+
+- server name;
+- resource URI;
+- title or display label;
+- MIME type when known;
+- token estimate;
+- scope and source path.
+
+`/context` should show selected and available MCP resources with the same
+provenance rules used for files, memory, skills, and prompt sources.
+
+### Tool Search
+
+RARA should not inject every MCP tool schema into every turn. Large MCP
+installations make context unstable and consume budget. The target model is:
+
+1. inject a small, stable MCP Tool Search entrypoint;
+2. index discovered MCP tool names, descriptions, schemas, and server scopes;
+3. let the model search for relevant tools when needed;
+4. expose or call only the selected tool set for the turn.
+
+This follows the same cache-prefix principle used by prompt sources and memory:
+large dynamic surfaces should be searched or referenced, not eagerly appended.
+
+## Contracts
+
+- Loading user `config.toml` and project `.mcp.json` is deterministic.
+- Missing config files produce an empty registry.
+- Duplicate server names across sources fail loudly.
+- Source scope and path are preserved for every server.
+- Registry parsing is independent from TUI rendering and future connection
+  startup.
+- MCP tools, resources, prompts, and status changes must later enter the
+  runtime control plane as structured events.
+
+## Validation Matrix
+
+| Case | Expected result |
+| --- | --- |
+| only `~/.rara/config.toml` has MCP servers | registry contains user-scoped servers |
+| only `.mcp.json` has MCP servers | registry contains project-scoped servers |
+| both files define distinct server names | registry contains both with source paths |
+| both files define the same server name | load fails with both source paths |
+| neither file exists | empty registry |
+| invalid TOML or JSON | load fails with parse path |
+
+## Open Risks
+
+- Project `.mcp.json` can start arbitrary stdio commands once connection startup
+  exists. RARA should add project trust or per-server approval before spawning.
+- HTTP MCP auth and OAuth state need a separate credential policy.
+- Tool Search needs careful prompt design so tools remain discoverable without
+  bloating the system prompt.
+- Dynamic refresh and reconnect need bounded retry policy to avoid noisy loops.
+
+## Source Journals
+
+- `docs/journal/2026-05-05-mcp-config-registry.md`

--- a/docs/journal/2026-05-05-mcp-config-registry.md
+++ b/docs/journal/2026-05-05-mcp-config-registry.md
@@ -1,0 +1,31 @@
+# MCP Config Registry Checkpoint
+
+## Summary
+
+Added the first MCP runtime slice: a source-aware configuration registry that
+loads user `config.toml` and project `.mcp.json` definitions without starting
+servers.
+
+## Implemented
+
+- Added `McpRegistry` in `rara-config`.
+- Added user-scope TOML loading from `[mcp_servers.*]`.
+- Added project-scope JSON loading from `.mcp.json` / `mcpServers`.
+- Added explicit source scope and source path on every server.
+- Added hard duplicate-name failure across sources.
+- Added focused tests for mixed sources, duplicate conflicts, and missing files.
+
+## Design Notes
+
+- RARA borrows Codex's TOML shape for user configuration and Claude Code's
+  project `.mcp.json` shape.
+- RARA intentionally rejects same-name conflicts instead of applying silent
+  precedence. Scope remains useful for display, diagnostics, and future
+  permissions.
+- Runtime startup, refresh, reconnect, resources, and Tool Search remain behind
+  the registry boundary for later phases.
+
+## Validation
+
+- `cargo test -p rara-config mcp -- --nocapture`
+- `cargo check`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -16,8 +16,15 @@ Active backlog only. Keep this file small and current.
 
 - [x] Define adapter-neutral runtime control request/event types for ACP, Wire, TUI, CLI, and future appserver entrypoints (see `docs/features/runtime-control-plane.md`).
 - [x] Add Claude-style `todo_write` runtime state with session persistence, TUI update cards, and structured Wire/ACP-ready events.
+- [x] Add source-aware MCP config registry for user `config.toml` and project `.mcp.json` with duplicate-name conflict failure.
 - [ ] Route ACP prompt/cancel/session handling through the normal RARA runtime path instead of the current stub.
 - [ ] Add protocol subscriber plumbing on top of the structured `AgentEvent` runtime-control bridge.
+- [ ] Add MCP connection manager status model (`configured`, `connecting`, `connected`, `refreshing`, `reconnecting`, `failed`, `disabled`) from `McpRegistry`.
+- [ ] Add `/mcp` status surface grouped by scope and source path.
+- [ ] Add dynamic MCP tool/resource/prompt refresh through structured runtime events.
+- [ ] Add bounded MCP auto-reconnect with manual reconnect command.
+- [ ] Add MCP resource references as source objects visible in `/context`.
+- [ ] Add MCP Tool Search so large MCP tool sets are discovered on demand instead of injected into every prompt.
 - [ ] Support protocol-registered prompt sources with provenance, scope, budget hints, and `/context` visibility.
 - [ ] Support protocol-registered skill sources through the same `SkillRegistry` precedence and override reporting as local skills.
 - [ ] Add protocol-safe memory mutation/query scaffolding that creates memory records and selection views without bypassing `MemorySelection`.


### PR DESCRIPTION
## Summary

- add a source-aware MCP registry in `rara-config`
- support user `~/.rara/config.toml` `[mcp_servers.*]` and project `.mcp.json` `mcpServers`
- fail loudly when the same MCP server name appears in multiple sources
- document the MCP runtime roadmap and add follow-up TODOs for status, refresh, reconnect, resources, and Tool Search

## Purpose

This is the first MCP runtime slice. It creates the stable configuration boundary before adding server startup, `/mcp`, dynamic refresh, reconnect, resource references, or Tool Search.

## Related Issues

None.

## Testing

- `cargo fmt --check`
- `cargo test -p rara-config mcp -- --nocapture`
- `cargo check`
