### PR TITLE
feat: add mcp status surface

### DIFF
--- a/docs/features/mcp-runtime.md
+++ b/docs/features/mcp-runtime.md
@@ -108,6 +108,12 @@ The status event must include server name, scope, source path, transport kind,
 last error, discovered tools count, discovered resources count, and whether the
 server is required.
 
+The first implemented status slice is read-only. It derives `configured` and
+`disabled` from `McpRegistry`, preserves scope/source provenance, redacts URL
+secrets, and reports load failures through `/mcp` without starting any server
+process. Later connection-manager work should update the same status objects
+instead of adding a second representation.
+
 ### Dynamic Refresh
 
 MCP tool/resource/prompt lists can change after startup. RARA should support:
@@ -169,6 +175,9 @@ large dynamic surfaces should be searched or referenced, not eagerly appended.
 - Source scope and path are preserved for every server.
 - Registry parsing is independent from TUI rendering and future connection
   startup.
+- `/mcp` renders the registry-derived status grouped by scope and source path.
+- `/mcp` must report parse/conflict failures instead of silently ignoring broken
+  config.
 - MCP tools, resources, prompts, and status changes must later enter the
   runtime control plane as structured events.
 
@@ -182,6 +191,8 @@ large dynamic surfaces should be searched or referenced, not eagerly appended.
 | both files define the same server name | load fails with both source paths |
 | neither file exists | empty registry |
 | invalid TOML or JSON | load fails with parse path |
+| `/mcp` with configured servers | grouped status includes scope, source path, transport, state, and tool filters |
+| `/mcp` with no servers | status says no MCP servers are configured |
 
 ## Open Risks
 
@@ -195,3 +206,4 @@ large dynamic surfaces should be searched or referenced, not eagerly appended.
 ## Source Journals
 
 - `docs/journal/2026-05-05-mcp-config-registry.md`
+- `docs/journal/2026-05-05-mcp-status-surface.md`

--- a/docs/journal/2026-05-05-mcp-status-surface.md
+++ b/docs/journal/2026-05-05-mcp-status-surface.md
@@ -1,0 +1,36 @@
+# MCP Status Surface Checkpoint
+
+## Summary
+
+This checkpoint adds the first runtime-facing MCP status slice on top of the
+source-aware registry.
+
+## Implemented
+
+- Added a read-only `McpStatusSnapshot` that derives per-server status from
+  `McpRegistry`.
+- Added status fields for server name, scope, source path, transport kind,
+  display target, enablement, required flag, tool-filter counts, and last error.
+- Added `/mcp` as a local TUI command.
+- Rendered `/mcp` output grouped by scope and source path.
+- Kept the first slice non-spawning: configured servers are reported as
+  `configured`, disabled servers as `disabled`, and configuration load failures
+  are shown as failures in the transcript.
+- Redacted URL query secrets before showing HTTP MCP targets.
+
+## Boundary
+
+This does not start MCP processes, connect HTTP clients, discover tools,
+subscribe to resource updates, or auto-reconnect. Those behaviors should update
+the same status snapshot shape instead of introducing another model.
+
+## Validation
+
+- Unit tests cover snapshot derivation and grouped `/mcp` text formatting.
+- Command tests cover `/mcp` parsing.
+
+## Follow-Up
+
+- Wire the status snapshot into a real connection manager.
+- Publish MCP status changes through runtime control events.
+- Extend `/mcp` with refresh/reconnect actions after server startup exists.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -19,8 +19,8 @@ Active backlog only. Keep this file small and current.
 - [x] Add source-aware MCP config registry for user `config.toml` and project `.mcp.json` with duplicate-name conflict failure.
 - [ ] Route ACP prompt/cancel/session handling through the normal RARA runtime path instead of the current stub.
 - [ ] Add protocol subscriber plumbing on top of the structured `AgentEvent` runtime-control bridge.
-- [ ] Add MCP connection manager status model (`configured`, `connecting`, `connected`, `refreshing`, `reconnecting`, `failed`, `disabled`) from `McpRegistry`.
-- [ ] Add `/mcp` status surface grouped by scope and source path.
+- [x] Add MCP connection manager status model (`configured`, `connecting`, `connected`, `refreshing`, `reconnecting`, `failed`, `disabled`) from `McpRegistry`.
+- [x] Add `/mcp` status surface grouped by scope and source path.
 - [ ] Add dynamic MCP tool/resource/prompt refresh through structured runtime events.
 - [ ] Add bounded MCP auto-reconnect with manual reconnect command.
 - [ ] Add MCP resource references as source objects visible in `/context`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod file_lock;
 mod hooks;
 mod llm;
 mod local_backend;
+mod mcp_status;
 mod memory_store;
 mod oauth;
 mod prompt;

--- a/src/mcp_status.rs
+++ b/src/mcp_status.rs
@@ -115,12 +115,9 @@ pub fn format_mcp_status(snapshot: &McpStatusSnapshot) -> String {
                 server.display_target,
                 status_flags(server)
             ));
-            if server.allowed_tools_count.is_some() || server.disabled_tools_count.is_some() {
-                lines.push(format!(
-                    "  tools: allow {}, deny {}",
-                    server.allowed_tools_count.unwrap_or(0),
-                    server.disabled_tools_count.unwrap_or(0)
-                ));
+            let tool_filters = tool_filter_parts(server);
+            if !tool_filters.is_empty() {
+                lines.push(format!("  tools: {}", tool_filters.join(", ")));
             }
             if let Some(error) = &server.last_error {
                 lines.push(format!("  error: {error}"));
@@ -155,8 +152,8 @@ fn server_status(name: &str, sourced: &SourcedMcpServerConfig) -> McpServerStatu
 fn transport_display(config: &McpServerConfig) -> (McpTransportKind, String) {
     match &config.transport {
         McpServerTransport::Stdio { command, args, .. } => {
-            let mut parts = vec![command.clone()];
-            parts.extend(args.iter().cloned());
+            let mut parts = vec![quote_stdio_display_part(command)];
+            parts.extend(args.iter().map(|arg| quote_stdio_display_part(arg)));
             (McpTransportKind::Stdio, parts.join(" "))
         }
         McpServerTransport::StreamableHttp { url, .. } => (
@@ -177,11 +174,33 @@ fn scope_heading(scope: McpServerScope) -> &'static str {
 }
 
 fn status_flags(server: &McpServerStatus) -> String {
-    match (server.required, server.enabled) {
-        (true, true) => " (required)".to_string(),
-        (true, false) => " (required, disabled)".to_string(),
-        (false, false) => " (disabled)".to_string(),
-        (false, true) => String::new(),
+    if server.required {
+        " (required)".to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn tool_filter_parts(server: &McpServerStatus) -> Vec<String> {
+    let mut parts = Vec::new();
+    if let Some(count) = server.allowed_tools_count {
+        parts.push(format!("allow {count}"));
+    }
+    if let Some(count) = server.disabled_tools_count {
+        parts.push(format!("deny {count}"));
+    }
+    parts
+}
+
+fn quote_stdio_display_part(value: &str) -> String {
+    if value.is_empty()
+        || value
+            .chars()
+            .any(|ch| ch.is_whitespace() || matches!(ch, '\'' | '"' | '\\'))
+    {
+        format!("'{}'", value.replace('\'', r"'\''"))
+    } else {
+        value.to_string()
     }
 }
 
@@ -220,7 +239,7 @@ enabled = false
   "mcpServers": {
     "repo": {
       "command": "repo-mcp",
-      "args": ["--root", "."],
+      "args": ["--root", ".", "--label", "my repo"],
       "required": true
     }
   }
@@ -245,7 +264,7 @@ enabled = false
         assert_eq!(repo.scope, McpServerScope::Project);
         assert_eq!(repo.state, McpConnectionState::Configured);
         assert!(repo.required);
-        assert_eq!(repo.display_target, "repo-mcp --root .");
+        assert_eq!(repo.display_target, "repo-mcp --root . --label 'my repo'");
 
         let remote = snapshot
             .servers
@@ -272,6 +291,10 @@ enabled = false
 command = "docs-server"
 args = ["--stdio"]
 enabled_tools = ["search"]
+
+[mcp_servers.deny]
+command = "deny-server"
+disabled_tools = ["delete"]
 
 [mcp_servers.remote]
 url = "https://example.com/mcp?token=secret"
@@ -307,10 +330,13 @@ enabled = false
         assert!(rendered.contains("User ("));
         assert!(rendered.contains("- repo [configured] stdio: repo-mcp (required)"));
         assert!(rendered.contains("- docs [configured] stdio: docs-server --stdio"));
-        assert!(rendered.contains("tools: allow 1, deny 0"));
+        assert!(rendered.contains("tools: allow 1"));
+        assert!(rendered.contains("tools: deny 1"));
+        assert!(!rendered.contains("allow 0"));
         assert!(rendered.contains(
-            "- remote [disabled] streamable-http: https://example.com/mcp?token=%3Credacted%3E (disabled)"
+            "- remote [disabled] streamable-http: https://example.com/mcp?token=%3Credacted%3E"
         ));
+        assert!(!rendered.contains("(disabled)"));
     }
 
     #[test]

--- a/src/mcp_status.rs
+++ b/src/mcp_status.rs
@@ -1,0 +1,322 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::config::{
+    McpRegistry, McpServerConfig, McpServerScope, McpServerTransport, SourcedMcpServerConfig,
+};
+use crate::redaction::sanitize_url_for_display;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum McpConnectionState {
+    Configured,
+    Connecting,
+    Connected,
+    Disconnected,
+    Refreshing,
+    Reconnecting,
+    Failed,
+    Disabled,
+}
+
+impl McpConnectionState {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Configured => "configured",
+            Self::Connecting => "connecting",
+            Self::Connected => "connected",
+            Self::Disconnected => "disconnected",
+            Self::Refreshing => "refreshing",
+            Self::Reconnecting => "reconnecting",
+            Self::Failed => "failed",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpTransportKind {
+    Stdio,
+    StreamableHttp,
+}
+
+impl McpTransportKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Stdio => "stdio",
+            Self::StreamableHttp => "streamable-http",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpServerStatus {
+    pub name: String,
+    pub scope: McpServerScope,
+    pub source_path: PathBuf,
+    pub state: McpConnectionState,
+    pub transport: McpTransportKind,
+    pub display_target: String,
+    pub required: bool,
+    pub enabled: bool,
+    pub allowed_tools_count: Option<usize>,
+    pub disabled_tools_count: Option<usize>,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpStatusSnapshot {
+    pub servers: Vec<McpServerStatus>,
+}
+
+impl McpStatusSnapshot {
+    pub fn from_registry(registry: &McpRegistry) -> Self {
+        let servers = registry
+            .servers
+            .iter()
+            .map(|(name, sourced)| server_status(name, sourced))
+            .collect();
+
+        Self { servers }
+    }
+}
+
+pub fn format_mcp_status(snapshot: &McpStatusSnapshot) -> String {
+    let mut lines = vec!["MCP Servers".to_string()];
+
+    if snapshot.servers.is_empty() {
+        lines.push(String::new());
+        lines.push("No MCP servers configured.".to_string());
+        return lines.join("\n");
+    }
+
+    let mut groups: BTreeMap<(McpServerScope, PathBuf), Vec<&McpServerStatus>> = BTreeMap::new();
+    for server in &snapshot.servers {
+        groups
+            .entry((server.scope, server.source_path.clone()))
+            .or_default()
+            .push(server);
+    }
+
+    for ((scope, path), mut servers) in groups {
+        servers.sort_by(|left, right| left.name.cmp(&right.name));
+        lines.push(String::new());
+        lines.push(format!(
+            "{} ({})",
+            scope_heading(scope),
+            path.to_string_lossy()
+        ));
+        for server in servers {
+            lines.push(format!(
+                "- {} [{}] {}: {}{}",
+                server.name,
+                server.state.label(),
+                server.transport.label(),
+                server.display_target,
+                status_flags(server)
+            ));
+            if server.allowed_tools_count.is_some() || server.disabled_tools_count.is_some() {
+                lines.push(format!(
+                    "  tools: allow {}, deny {}",
+                    server.allowed_tools_count.unwrap_or(0),
+                    server.disabled_tools_count.unwrap_or(0)
+                ));
+            }
+            if let Some(error) = &server.last_error {
+                lines.push(format!("  error: {error}"));
+            }
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn server_status(name: &str, sourced: &SourcedMcpServerConfig) -> McpServerStatus {
+    let (transport, display_target) = transport_display(&sourced.config);
+    McpServerStatus {
+        name: name.to_string(),
+        scope: sourced.source.scope,
+        source_path: sourced.source.path.clone(),
+        state: if sourced.config.enabled {
+            McpConnectionState::Configured
+        } else {
+            McpConnectionState::Disabled
+        },
+        transport,
+        display_target,
+        required: sourced.config.required,
+        enabled: sourced.config.enabled,
+        allowed_tools_count: sourced.config.enabled_tools.as_ref().map(Vec::len),
+        disabled_tools_count: sourced.config.disabled_tools.as_ref().map(Vec::len),
+        last_error: None,
+    }
+}
+
+fn transport_display(config: &McpServerConfig) -> (McpTransportKind, String) {
+    match &config.transport {
+        McpServerTransport::Stdio { command, args, .. } => {
+            let mut parts = vec![command.clone()];
+            parts.extend(args.iter().cloned());
+            (McpTransportKind::Stdio, parts.join(" "))
+        }
+        McpServerTransport::StreamableHttp { url, .. } => (
+            McpTransportKind::StreamableHttp,
+            sanitize_url_for_display(url),
+        ),
+    }
+}
+
+fn scope_heading(scope: McpServerScope) -> &'static str {
+    match scope {
+        McpServerScope::Project => "Project",
+        McpServerScope::Local => "Local",
+        McpServerScope::User => "User",
+        McpServerScope::Enterprise => "Enterprise",
+        McpServerScope::Builtin => "Builtin",
+    }
+}
+
+fn status_flags(server: &McpServerStatus) -> String {
+    match (server.required, server.enabled) {
+        (true, true) => " (required)".to_string(),
+        (true, false) => " (required, disabled)".to_string(),
+        (false, false) => " (disabled)".to_string(),
+        (false, true) => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::{McpConnectionState, McpStatusSnapshot, format_mcp_status};
+    use crate::config::{ConfigManager, McpServerScope};
+
+    #[test]
+    fn derives_status_snapshot_from_user_and_project_registry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let user_config = dir.path().join("config.toml");
+        fs::write(
+            &user_config,
+            r#"
+[mcp_servers.docs]
+command = "docs-server"
+args = ["--stdio"]
+enabled_tools = ["search", "fetch"]
+disabled_tools = ["delete"]
+
+[mcp_servers.remote]
+url = "https://example.com/mcp?token=secret"
+enabled = false
+"#,
+        )
+        .expect("write user config");
+
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+        fs::write(
+            project.join(".mcp.json"),
+            r#"{
+  "mcpServers": {
+    "repo": {
+      "command": "repo-mcp",
+      "args": ["--root", "."],
+      "required": true
+    }
+  }
+}"#,
+        )
+        .expect("write project config");
+
+        let manager = ConfigManager {
+            path: dir.path().join("config.json"),
+        };
+        let registry = manager
+            .load_mcp_registry_for_project(&project)
+            .expect("registry");
+        let snapshot = McpStatusSnapshot::from_registry(&registry);
+
+        assert_eq!(snapshot.servers.len(), 3);
+        let repo = snapshot
+            .servers
+            .iter()
+            .find(|server| server.name == "repo")
+            .expect("repo server");
+        assert_eq!(repo.scope, McpServerScope::Project);
+        assert_eq!(repo.state, McpConnectionState::Configured);
+        assert!(repo.required);
+        assert_eq!(repo.display_target, "repo-mcp --root .");
+
+        let remote = snapshot
+            .servers
+            .iter()
+            .find(|server| server.name == "remote")
+            .expect("remote server");
+        assert_eq!(remote.state, McpConnectionState::Disabled);
+        assert_eq!(
+            remote.display_target,
+            "https://example.com/mcp?token=%3Credacted%3E"
+        );
+
+        assert_eq!(manager.config_toml_path(), user_config);
+    }
+
+    #[test]
+    fn formats_status_grouped_by_scope_and_source_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let user_config = dir.path().join("config.toml");
+        fs::write(
+            &user_config,
+            r#"
+[mcp_servers.docs]
+command = "docs-server"
+args = ["--stdio"]
+enabled_tools = ["search"]
+
+[mcp_servers.remote]
+url = "https://example.com/mcp?token=secret"
+enabled = false
+"#,
+        )
+        .expect("write user config");
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).expect("project dir");
+        fs::write(
+            project.join(".mcp.json"),
+            r#"{
+  "mcpServers": {
+    "repo": {
+      "command": "repo-mcp",
+      "required": true
+    }
+  }
+}"#,
+        )
+        .expect("write project config");
+
+        let manager = ConfigManager {
+            path: dir.path().join("config.json"),
+        };
+        let registry = manager
+            .load_mcp_registry_for_project(&project)
+            .expect("registry");
+        let rendered = format_mcp_status(&McpStatusSnapshot::from_registry(&registry));
+
+        assert!(rendered.contains("MCP Servers"));
+        assert!(rendered.contains("Project ("));
+        assert!(rendered.contains("User ("));
+        assert!(rendered.contains("- repo [configured] stdio: repo-mcp (required)"));
+        assert!(rendered.contains("- docs [configured] stdio: docs-server --stdio"));
+        assert!(rendered.contains("tools: allow 1, deny 0"));
+        assert!(rendered.contains(
+            "- remote [disabled] streamable-http: https://example.com/mcp?token=%3Credacted%3E (disabled)"
+        ));
+    }
+
+    #[test]
+    fn formats_empty_status() {
+        let rendered = format_mcp_status(&McpStatusSnapshot { servers: vec![] });
+
+        assert_eq!(rendered, "MCP Servers\n\nNo MCP servers configured.");
+    }
+}

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -89,8 +89,8 @@ pub const COMMAND_SPECS: [CommandSpec; 22] = [
         category: "Session",
         name: "mcp",
         usage: "/mcp",
-        summary: "Show configured MCP servers and current connection state.",
-        detail: "Load user config.toml and project .mcp.json, then show MCP servers grouped by scope and source path. This status surface reports configured, disabled, and configuration failures without starting servers yet.",
+        summary: "Show configured MCP servers from the effective registry.",
+        detail: "Load user config.toml and project .mcp.json, then show MCP servers grouped by scope and source path. This read-only status surface reports configured, disabled, and configuration failures without starting servers yet.",
     },
     CommandSpec {
         category: "Setup",

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -1,6 +1,6 @@
 use crate::tui::state::{CommandSpec, LocalCommand, LocalCommandKind, TuiApp};
 
-pub const COMMAND_SPECS: [CommandSpec; 21] = [
+pub const COMMAND_SPECS: [CommandSpec; 22] = [
     CommandSpec {
         category: "Session",
         name: "permissions",
@@ -84,6 +84,13 @@ pub const COMMAND_SPECS: [CommandSpec; 21] = [
         usage: "/compact",
         summary: "Compact the current conversation history immediately.",
         detail: "Force one explicit history compaction pass. Compaction summarizes older turns into a structured summary so the model can continue a long conversation without losing early context. Compaction runs on every message and tool-result batch, but /compact lets you trigger one on demand.",
+    },
+    CommandSpec {
+        category: "Session",
+        name: "mcp",
+        usage: "/mcp",
+        summary: "Show configured MCP servers and current connection state.",
+        detail: "Load user config.toml and project .mcp.json, then show MCP servers grouped by scope and source path. This status surface reports configured, disabled, and configuration failures without starting servers yet.",
     },
     CommandSpec {
         category: "Setup",
@@ -176,6 +183,7 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
         "login" | "auth" => LocalCommandKind::Login,
         "logout" => LocalCommandKind::Logout,
         "review" => LocalCommandKind::Review,
+        "mcp" => LocalCommandKind::Mcp,
         "skills" => LocalCommandKind::Skills,
         "permissions" | "permission" => LocalCommandKind::Permissions,
         _ => return None,

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -113,6 +113,13 @@ fn parses_permissions_command() {
 }
 
 #[test]
+fn parses_mcp_command() {
+    let command = parse_local_command("/mcp").expect("/mcp should parse");
+    assert!(matches!(command.kind, LocalCommandKind::Mcp));
+    assert!(command.arg.is_none());
+}
+
+#[test]
 fn parses_compact_command() {
     let command = parse_local_command("/compact").expect("compact should parse");
     assert!(matches!(command.kind, LocalCommandKind::Compact));

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -220,7 +220,7 @@ fn handle_mcp_command(app: &mut TuiApp) {
         Err(err) => {
             app.push_entry(
                 "System",
-                format!("MCP Servers\n\nFailed to load MCP configuration:\n{err}"),
+                format!("MCP Servers\n\nFailed to load MCP configuration:\n{err:#}"),
             );
             app.notice = Some("MCP status failed.".into());
         }
@@ -228,11 +228,21 @@ fn handle_mcp_command(app: &mut TuiApp) {
 }
 
 fn command_project_root(app: &TuiApp) -> PathBuf {
-    if app.snapshot.cwd.is_empty() {
+    let cwd = if app.snapshot.cwd.is_empty() {
         std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
     } else {
         PathBuf::from(&app.snapshot.cwd)
+    };
+    mcp_project_root_from_cwd(cwd)
+}
+
+fn mcp_project_root_from_cwd(cwd: PathBuf) -> PathBuf {
+    for ancestor in cwd.ancestors() {
+        if ancestor.join(".mcp.json").is_file() {
+            return ancestor.to_path_buf();
+        }
     }
+    cwd
 }
 
 fn capture_git_diff(cwd: &str) -> String {
@@ -306,4 +316,31 @@ fn apply_permission_mode(app: &mut TuiApp, agent_slot: &mut Option<Agent>, mode:
         Some("updating permissions".into()),
     );
     app.set_pending_plan_approval(false);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::mcp_project_root_from_cwd;
+
+    #[test]
+    fn mcp_project_root_walks_up_to_project_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path().join("project");
+        let nested = project.join("src").join("bin");
+        fs::create_dir_all(&nested).expect("nested dirs");
+        fs::write(project.join(".mcp.json"), r#"{"mcpServers":{}}"#).expect("project config");
+
+        assert_eq!(mcp_project_root_from_cwd(nested), project);
+    }
+
+    #[test]
+    fn mcp_project_root_keeps_cwd_when_no_project_config_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cwd = dir.path().join("project").join("src");
+        fs::create_dir_all(&cwd).expect("cwd");
+
+        assert_eq!(mcp_project_root_from_cwd(cwd.clone()), cwd);
+    }
 }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::super::state::{
@@ -6,6 +7,7 @@ use super::super::state::{
 };
 use super::tasks::{start_compact_task, start_rebuild_task, start_review_task};
 use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
+use crate::mcp_status::{McpStatusSnapshot, format_mcp_status};
 use crate::oauth::OAuthManager;
 
 pub(super) async fn execute_local_command(
@@ -23,6 +25,7 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Help => "help",
         LocalCommandKind::Login => "login",
         LocalCommandKind::Logout => "logout",
+        LocalCommandKind::Mcp => "mcp",
         LocalCommandKind::Model => "model",
         LocalCommandKind::Plan => "plan",
         LocalCommandKind::Quit => "quit",
@@ -103,6 +106,7 @@ pub(super) async fn execute_local_command(
             }
         }
         LocalCommandKind::Model => handle_model_command(command.arg.as_deref(), app)?,
+        LocalCommandKind::Mcp => handle_mcp_command(app),
         LocalCommandKind::Plan => {
             app.set_runtime_phase(
                 RuntimePhase::LocalCommand,
@@ -196,6 +200,39 @@ fn handle_base_url_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Resul
     }
     app.open_overlay(Overlay::BaseUrlEditor);
     Ok(())
+}
+
+fn handle_mcp_command(app: &mut TuiApp) {
+    app.set_runtime_phase(
+        RuntimePhase::LocalCommand,
+        Some("showing mcp status".into()),
+    );
+    let project_root = command_project_root(app);
+    match app
+        .config_manager
+        .load_mcp_registry_for_project(&project_root)
+    {
+        Ok(registry) => {
+            let snapshot = McpStatusSnapshot::from_registry(&registry);
+            app.push_entry("System", format_mcp_status(&snapshot));
+            app.notice = Some("MCP status updated.".into());
+        }
+        Err(err) => {
+            app.push_entry(
+                "System",
+                format!("MCP Servers\n\nFailed to load MCP configuration:\n{err}"),
+            );
+            app.notice = Some("MCP status failed.".into());
+        }
+    }
+}
+
+fn command_project_root(app: &TuiApp) -> PathBuf {
+    if app.snapshot.cwd.is_empty() {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    } else {
+        PathBuf::from(&app.snapshot.cwd)
+    }
 }
 
 fn capture_git_diff(cwd: &str) -> String {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -118,6 +118,7 @@ pub enum LocalCommandKind {
     Model,
     BaseUrl,
     Login,
+    Mcp,
     Permissions,
     Logout,
     Review,


### PR DESCRIPTION
## Summary

- add a read-only MCP status snapshot derived from `McpRegistry`
- add `/mcp` to show configured MCP servers grouped by scope and source path
- document the implemented status slice and update the MCP rollout todo

## Testing

- `cargo fmt --check`
- `cargo test mcp_status -- --nocapture`
- `cargo test parses_mcp_command -- --nocapture`
- `cargo check`

## Notes

This slice does not start MCP servers. It only reports registry-derived
`configured` and `disabled` states plus configuration load failures. Future
connection-manager work should update the same status model.
