### PR TITLE
feat: publish mcp status events

### DIFF
--- a/docs/features/mcp-runtime.md
+++ b/docs/features/mcp-runtime.md
@@ -178,6 +178,17 @@ large dynamic surfaces should be searched or referenced, not eagerly appended.
 - `/mcp` renders the registry-derived status grouped by scope and source path.
 - `/mcp` must report parse/conflict failures instead of silently ignoring broken
   config.
+- `/mcp` publishes the registry-derived status as a structured runtime event so
+  ACP, Wire, and future appserver subscribers do not need to parse TUI text.
+- `/mcp` publishes a structured `status_load_failed` event when registry loading
+  fails so subscribers can drop stale status.
+- MCP runtime-control requests use the `mcp` request family with
+  `query_status`, `refresh { server_name? }`, and
+  `reconnect { server_name }` variants. These request names are part of the
+  external control-plane contract.
+- MCP status snapshots must carry display-safe targets only. Stdio command
+  targets and HTTP URLs are redacted before entering either TUI text or
+  structured runtime events.
 - MCP tools, resources, prompts, and status changes must later enter the
   runtime control plane as structured events.
 
@@ -193,6 +204,10 @@ large dynamic surfaces should be searched or referenced, not eagerly appended.
 | invalid TOML or JSON | load fails with parse path |
 | `/mcp` with configured servers | grouped status includes scope, source path, transport, state, and tool filters |
 | `/mcp` with no servers | status says no MCP servers are configured |
+| `/mcp` with runtime subscribers | emits an `mcp.status_updated` runtime event with the same snapshot |
+| `/mcp` load failure with runtime subscribers | emits an `mcp.status_load_failed` runtime event |
+| MCP control request serde | locks `query_status`, `refresh`, and `reconnect` wire shapes |
+| MCP server target contains secrets | status snapshot stores only redacted display text |
 
 ## Open Risks
 
@@ -207,3 +222,4 @@ large dynamic surfaces should be searched or referenced, not eagerly appended.
 
 - `docs/journal/2026-05-05-mcp-config-registry.md`
 - `docs/journal/2026-05-05-mcp-status-surface.md`
+- `docs/journal/2026-05-05-mcp-runtime-events.md`

--- a/docs/journal/2026-05-05-mcp-runtime-events.md
+++ b/docs/journal/2026-05-05-mcp-runtime-events.md
@@ -1,0 +1,40 @@
+# MCP Runtime Events Checkpoint
+
+## Summary
+
+This checkpoint moves MCP status from a TUI-only surface toward the shared
+runtime control plane.
+
+## Implemented
+
+- Added `AgentEvent::McpStatusUpdated`.
+- Added `RuntimeEvent::Mcp` with `McpEvent::StatusUpdated`.
+- Added MCP control request scaffolding for `query_status`, `refresh`, and
+  `reconnect`.
+- Made `McpStatusSnapshot` and nested status types serializable.
+- Published the `/mcp` registry-derived snapshot to `RuntimeEventBus` when
+  subscribers exist.
+- Published `/mcp` registry load failures as structured MCP events so runtime
+  subscribers can clear stale status.
+- Kept serialized MCP server targets display-safe by redacting stdio arguments
+  and HTTP URL secrets before they enter the snapshot.
+
+## Boundary
+
+This does not start MCP servers or discover MCP tools/resources/prompts. It only
+establishes the structured event path that later connection and refresh logic
+will reuse.
+
+## References
+
+- Claude-style SDK control path: `mcp_status` request/response.
+- Codex-style app-server path: `mcpServerStatus/list` and
+  `mcpServer/startupStatus/updated`.
+
+## Validation
+
+- Runtime event serialization test covers the stable wire shape.
+- TUI command test verifies `/mcp` publishes a structured status event.
+- Runtime-control request serialization tests cover `query_status`, `refresh`,
+  and `reconnect`.
+- Status derivation tests cover redacted stdio and HTTP display targets.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,6 +21,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Add protocol subscriber plumbing on top of the structured `AgentEvent` runtime-control bridge.
 - [x] Add MCP connection manager status model (`configured`, `connecting`, `connected`, `refreshing`, `reconnecting`, `failed`, `disabled`) from `McpRegistry`.
 - [x] Add `/mcp` status surface grouped by scope and source path.
+- [x] Publish `/mcp` status snapshots as structured runtime events for future ACP/Wire/appserver subscribers.
 - [ ] Add dynamic MCP tool/resource/prompt refresh through structured runtime events.
 - [ ] Add bounded MCP auto-reconnect with manual reconnect command.
 - [ ] Add MCP resource references as source objects visible in `/context`.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::context::RetrievedMemoryCandidate;
 use crate::control_tokens::scrub_internal_control_tokens;
 use crate::llm::{ContentBlock, LlmBackend, LlmStreamEvent, LlmTurnMetadata};
+use crate::mcp_status::McpStatusSnapshot;
 use crate::memory_store::MemoryStore;
 use crate::prompt::{self, PromptMode, PromptRuntimeConfig};
 use crate::redaction::redact_secrets;
@@ -95,6 +96,10 @@ pub enum AgentEvent {
         name: String,
         stream: ToolOutputStream,
         chunk: String,
+    },
+    McpStatusUpdated(McpStatusSnapshot),
+    McpStatusLoadFailed {
+        message: String,
     },
     TodoUpdated(TodoState),
 }

--- a/src/mcp_status.rs
+++ b/src/mcp_status.rs
@@ -1,12 +1,15 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
+
 use crate::config::{
     McpRegistry, McpServerConfig, McpServerScope, McpServerTransport, SourcedMcpServerConfig,
 };
-use crate::redaction::sanitize_url_for_display;
+use crate::redaction::{redact_secrets, sanitize_url_for_display};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[allow(dead_code)]
 pub enum McpConnectionState {
     Configured,
@@ -34,7 +37,8 @@ impl McpConnectionState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum McpTransportKind {
     Stdio,
     StreamableHttp,
@@ -49,7 +53,7 @@ impl McpTransportKind {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpServerStatus {
     pub name: String,
     pub scope: McpServerScope,
@@ -64,7 +68,7 @@ pub struct McpServerStatus {
     pub last_error: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct McpStatusSnapshot {
     pub servers: Vec<McpServerStatus>,
 }
@@ -154,7 +158,7 @@ fn transport_display(config: &McpServerConfig) -> (McpTransportKind, String) {
         McpServerTransport::Stdio { command, args, .. } => {
             let mut parts = vec![quote_stdio_display_part(command)];
             parts.extend(args.iter().map(|arg| quote_stdio_display_part(arg)));
-            (McpTransportKind::Stdio, parts.join(" "))
+            (McpTransportKind::Stdio, redact_secrets(parts.join(" ")))
         }
         McpServerTransport::StreamableHttp { url, .. } => (
             McpTransportKind::StreamableHttp,
@@ -224,6 +228,10 @@ args = ["--stdio"]
 enabled_tools = ["search", "fetch"]
 disabled_tools = ["delete"]
 
+[mcp_servers.secret]
+command = "secret-server"
+args = ["--token=supersecretvalue"]
+
 [mcp_servers.remote]
 url = "https://example.com/mcp?token=secret"
 enabled = false
@@ -255,7 +263,7 @@ enabled = false
             .expect("registry");
         let snapshot = McpStatusSnapshot::from_registry(&registry);
 
-        assert_eq!(snapshot.servers.len(), 3);
+        assert_eq!(snapshot.servers.len(), 4);
         let repo = snapshot
             .servers
             .iter()
@@ -276,6 +284,17 @@ enabled = false
             remote.display_target,
             "https://example.com/mcp?token=%3Credacted%3E"
         );
+
+        let secret = snapshot
+            .servers
+            .iter()
+            .find(|server| server.name == "secret")
+            .expect("secret server");
+        assert_eq!(
+            secret.display_target,
+            "secret-server --token=[REDACTED_SECRET]"
+        );
+        assert!(!secret.display_target.contains("supersecretvalue"));
 
         assert_eq!(manager.config_toml_path(), user_config);
     }

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::agent::{AgentEvent, BashApprovalDecision};
+use crate::mcp_status::McpStatusSnapshot;
 use crate::todo::TodoState;
 use crate::tool::ToolOutputStream;
 
@@ -84,6 +85,7 @@ pub enum RuntimeControlRequest {
     Output(OutputSubscriptionRequest),
     PromptSource(PromptSourceControlRequest),
     SkillSource(SkillSourceControlRequest),
+    Mcp(McpControlRequest),
     Memory(MemoryControlRequest),
     Hook(HookControlRequest),
     Approval(ApprovalControlRequest),
@@ -233,6 +235,15 @@ pub enum SkillSourceControlRequest {
 }
 
 #[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
+pub enum McpControlRequest {
+    QueryStatus,
+    Refresh { server_name: Option<String> },
+    Reconnect { server_name: String },
+}
+
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum MemoryControlRequest {
@@ -307,6 +318,7 @@ pub enum RuntimeEvent {
     Plan(PlanEvent),
     PromptSource(PromptSourceEvent),
     Skill(SkillEvent),
+    Mcp(McpEvent),
     Memory(MemoryEvent),
     Hook(HookEvent),
     Context(ContextEvent),
@@ -421,6 +433,14 @@ pub enum SkillEvent {
 #[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
+pub enum McpEvent {
+    StatusUpdated { snapshot: McpStatusSnapshot },
+    StatusLoadFailed { message: String },
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum MemoryEvent {
     RecordAdded { memory_id: String },
     SelectionUpdated,
@@ -498,6 +518,12 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
             stream: stream.into(),
             chunk,
         }),
+        AgentEvent::McpStatusUpdated(snapshot) => {
+            RuntimeEvent::Mcp(McpEvent::StatusUpdated { snapshot })
+        }
+        AgentEvent::McpStatusLoadFailed { message } => {
+            RuntimeEvent::Mcp(McpEvent::StatusLoadFailed { message })
+        }
         AgentEvent::TodoUpdated(state) => RuntimeEvent::Todo(TodoEvent::Updated { state }),
     }
 }
@@ -671,6 +697,98 @@ mod tests {
                             ],
                             "updated_at": value["payload"]["payload"]["state"]["updated_at"]
                         }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn mcp_status_update_event_uses_structured_wire_shape() {
+        let value = serde_json::to_value(agent_event_to_runtime_event(
+            AgentEvent::McpStatusUpdated(McpStatusSnapshot { servers: vec![] }),
+        ))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "type": "mcp",
+                "payload": {
+                    "type": "status_updated",
+                    "payload": {
+                        "snapshot": {
+                            "servers": []
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn mcp_status_load_failed_event_uses_structured_wire_shape() {
+        let value = serde_json::to_value(agent_event_to_runtime_event(
+            AgentEvent::McpStatusLoadFailed {
+                message: "invalid config".to_string(),
+            },
+        ))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "type": "mcp",
+                "payload": {
+                    "type": "status_load_failed",
+                    "payload": {
+                        "message": "invalid config"
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn mcp_control_requests_use_structured_wire_shape() {
+        let query = RuntimeControlRequest::Mcp(McpControlRequest::QueryStatus);
+        assert_eq!(
+            serde_json::to_value(query).unwrap(),
+            json!({
+                "type": "mcp",
+                "payload": {
+                    "type": "query_status"
+                }
+            })
+        );
+
+        let refresh = RuntimeControlRequest::Mcp(McpControlRequest::Refresh {
+            server_name: Some("docs".to_string()),
+        });
+        assert_eq!(
+            serde_json::to_value(refresh).unwrap(),
+            json!({
+                "type": "mcp",
+                "payload": {
+                    "type": "refresh",
+                    "payload": {
+                        "server_name": "docs"
+                    }
+                }
+            })
+        );
+
+        let reconnect = RuntimeControlRequest::Mcp(McpControlRequest::Reconnect {
+            server_name: "docs".to_string(),
+        });
+        assert_eq!(
+            serde_json::to_value(reconnect).unwrap(),
+            json!({
+                "type": "mcp",
+                "payload": {
+                    "type": "reconnect",
+                    "payload": {
+                        "server_name": "docs"
                     }
                 }
             })

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -6,7 +6,7 @@ use super::super::state::{
     TuiApp,
 };
 use super::tasks::{start_compact_task, start_rebuild_task, start_review_task};
-use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
+use crate::agent::{Agent, AgentEvent, AgentExecutionMode, BashApprovalMode};
 use crate::mcp_status::{McpStatusSnapshot, format_mcp_status};
 use crate::oauth::OAuthManager;
 
@@ -214,15 +214,35 @@ fn handle_mcp_command(app: &mut TuiApp) {
     {
         Ok(registry) => {
             let snapshot = McpStatusSnapshot::from_registry(&registry);
+            publish_mcp_status_event(app, &snapshot);
             app.push_entry("System", format_mcp_status(&snapshot));
             app.notice = Some("MCP status updated.".into());
         }
         Err(err) => {
+            publish_mcp_status_load_failed_event(app, &format!("{err:#}"));
             app.push_entry(
                 "System",
                 format!("MCP Servers\n\nFailed to load MCP configuration:\n{err:#}"),
             );
             app.notice = Some("MCP status failed.".into());
+        }
+    }
+}
+
+fn publish_mcp_status_load_failed_event(app: &TuiApp, message: &str) {
+    if let Some(bus) = app.event_bus.as_ref() {
+        if bus.receiver_count() > 0 {
+            bus.send(AgentEvent::McpStatusLoadFailed {
+                message: message.to_string(),
+            });
+        }
+    }
+}
+
+fn publish_mcp_status_event(app: &TuiApp, snapshot: &McpStatusSnapshot) {
+    if let Some(bus) = app.event_bus.as_ref() {
+        if bus.receiver_count() > 0 {
+            bus.send(AgentEvent::McpStatusUpdated(snapshot.clone()));
         }
     }
 }
@@ -321,8 +341,13 @@ fn apply_permission_mode(app: &mut TuiApp, agent_slot: &mut Option<Agent>, mode:
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::Arc;
 
-    use super::mcp_project_root_from_cwd;
+    use super::{handle_mcp_command, mcp_project_root_from_cwd};
+    use crate::agent::AgentEvent;
+    use crate::config::ConfigManager;
+    use crate::runtime_event_bus::RuntimeEventBus;
+    use crate::tui::state::TuiApp;
 
     #[test]
     fn mcp_project_root_walks_up_to_project_config() {
@@ -342,5 +367,63 @@ mod tests {
         fs::create_dir_all(&cwd).expect("cwd");
 
         assert_eq!(mcp_project_root_from_cwd(cwd.clone()), cwd);
+    }
+
+    #[test]
+    fn mcp_command_publishes_structured_status_event() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("config.toml"),
+            r#"
+[mcp_servers.docs]
+command = "docs-server"
+"#,
+        )
+        .expect("user config");
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).expect("project");
+
+        let mut app = TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app");
+        app.snapshot.cwd = project.to_string_lossy().to_string();
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let mut receiver = bus.subscribe();
+        app.event_bus = Some(bus);
+
+        handle_mcp_command(&mut app);
+
+        let event = receiver.try_recv().expect("mcp status event");
+        let AgentEvent::McpStatusUpdated(snapshot) = event else {
+            panic!("expected mcp status event");
+        };
+        assert_eq!(snapshot.servers.len(), 1);
+        assert_eq!(snapshot.servers[0].name, "docs");
+    }
+
+    #[test]
+    fn mcp_command_publishes_structured_load_failure_event() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(dir.path().join("config.toml"), "[mcp_servers.docs\n").expect("user config");
+        let project = dir.path().join("project");
+        fs::create_dir_all(&project).expect("project");
+
+        let mut app = TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app");
+        app.snapshot.cwd = project.to_string_lossy().to_string();
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let mut receiver = bus.subscribe();
+        app.event_bus = Some(bus);
+
+        handle_mcp_command(&mut app);
+
+        let event = receiver.try_recv().expect("mcp failure event");
+        let AgentEvent::McpStatusLoadFailed { message } = event else {
+            panic!("expected mcp load failure event");
+        };
+        assert!(message.contains("config.toml"));
     }
 }

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -315,6 +315,8 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
             role: "Todo",
             message: format_todo_update(&state),
         }),
+        AgentEvent::McpStatusUpdated(_) => None,
+        AgentEvent::McpStatusLoadFailed { .. } => None,
     }
 }
 

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -869,6 +869,21 @@ fn todo_write_events_render_as_compact_todo_transcript() {
 }
 
 #[test]
+fn mcp_status_update_events_stay_off_tui_transcript() {
+    let event = convert_agent_event(AgentEvent::McpStatusUpdated(
+        crate::mcp_status::McpStatusSnapshot { servers: vec![] },
+    ));
+
+    assert!(event.is_none());
+
+    let event = convert_agent_event(AgentEvent::McpStatusLoadFailed {
+        message: "invalid config".to_string(),
+    });
+
+    assert!(event.is_none());
+}
+
+#[test]
 fn applies_terminal_begin_event_as_running_action() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {


### PR DESCRIPTION
## Summary

- publish `/mcp` registry snapshots as structured runtime events
- add MCP runtime control/event scaffolding for status, refresh, and reconnect
- document the event boundary and add focused regression coverage

## Tests

- `cargo fmt --check`
- `cargo test mcp -- --nocapture`
- `cargo check`
