### PR TITLE
feat(llm): add AWS Bedrock provider backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,6 +804,360 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-bedrockruntime"
+version = "1.130.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2f7bca252e3c5c8f0ed12c5501bf8b0fbadb937cd9fdd71a0ebd9d7526540f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body-util",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -792,6 +1188,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -1080,6 +1486,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "candle-core"
 version = "0.10.2"
 source = "git+https://github.com/huggingface/candle?rev=34625ab6d1567a0bc132ac6bc8dc2cce0e16d86d#34625ab6d1567a0bc132ac6bc8dc2cce0e16d86d"
@@ -1358,6 +1774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "cmp_any"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,7 +1818,7 @@ dependencies = [
  "codex-utils-rustls-provider",
  "eventsource-stream",
  "futures",
- "http",
+ "http 1.4.0",
  "regex-lite",
  "reqwest 0.12.28",
  "serde",
@@ -1454,11 +1876,11 @@ dependencies = [
  "codex-utils-rustls-provider",
  "eventsource-stream",
  "futures",
- "http",
+ "http 1.4.0",
  "opentelemetry",
  "rand 0.9.4",
  "reqwest 0.12.28",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -1602,7 +2024,7 @@ dependencies = [
  "codex-api",
  "codex-app-server-protocol",
  "codex-protocol",
- "http",
+ "http 1.4.0",
  "schemars 0.8.22",
  "serde",
 ]
@@ -1670,7 +2092,7 @@ dependencies = [
  "codex-utils-string",
  "eventsource-stream",
  "gethostname",
- "http",
+ "http 1.4.0",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
@@ -1821,7 +2243,7 @@ name = "codex-utils-rustls-provider"
 version = "0.125.0"
 source = "git+https://github.com/openai/codex?rev=637f7dd6d737f3961e6bf32fbb3861c4953269c5#637f7dd6d737f3961e6bf32fbb3861c4953269c5"
 dependencies = [
- "rustls",
+ "rustls 0.23.40",
 ]
 
 [[package]]
@@ -2287,6 +2709,15 @@ checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -3287,6 +3718,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -3391,7 +3823,7 @@ checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
 dependencies = [
  "cfg-if",
  "libc",
- "socket2",
+ "socket2 0.6.3",
  "windows-sys 0.60.2",
 ]
 
@@ -4463,6 +4895,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -4472,7 +4923,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4559,7 +5010,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http",
+ "http 1.4.0",
  "httpdate",
  "mime",
  "sha1",
@@ -4571,7 +5022,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -4600,7 +5051,7 @@ checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
  "futures",
- "http",
+ "http 1.4.0",
  "indicatif",
  "libc",
  "log",
@@ -4668,7 +5119,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4678,6 +5129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4697,6 +5157,17 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -4707,12 +5178,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -4723,8 +5205,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -4763,6 +5245,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -4771,9 +5277,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -4784,17 +5290,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.7",
 ]
@@ -4805,7 +5326,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4820,7 +5341,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4838,14 +5359,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5218,7 +5739,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2",
+ "socket2 0.6.3",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -5883,7 +6404,7 @@ dependencies = [
  "chrono",
  "deepsize",
  "futures",
- "http",
+ "http 1.4.0",
  "lance-arrow",
  "lance-core",
  "lance-namespace",
@@ -7110,7 +7631,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "http",
+ "http 1.4.0",
  "humantime",
  "itertools 0.14.0",
  "parking_lot",
@@ -7313,7 +7834,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.4.0",
  "opentelemetry",
  "reqwest 0.12.28",
 ]
@@ -7324,7 +7845,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "http",
+ "http 1.4.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -7427,6 +7948,12 @@ dependencies = [
  "serde",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "ownedbytes"
@@ -8092,8 +8619,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls",
- "socket2",
+ "rustls 0.23.40",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8113,7 +8640,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -8131,7 +8658,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8239,7 +8766,7 @@ dependencies = [
  "chrono",
  "const_format",
  "csv",
- "http",
+ "http 1.4.0",
  "http-range-header",
  "httpdate",
  "iri-string",
@@ -8268,7 +8795,7 @@ version = "0.3.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3ff6a3c8ae690be8167e43777ba0bf6b0c8c2f6de165c538666affe2a32fd81"
 dependencies = [
- "h2",
+ "h2 0.4.13",
  "pin-project-lite",
  "rama-core",
  "rama-http",
@@ -8339,8 +8866,8 @@ dependencies = [
  "bytes",
  "const_format",
  "fnv",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "memchr",
@@ -8395,7 +8922,7 @@ dependencies = [
  "rama-utils",
  "serde",
  "sha2 0.10.9",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
 ]
 
@@ -8442,11 +8969,11 @@ dependencies = [
  "rama-net",
  "rama-utils",
  "rcgen",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "webpki-roots 1.0.7",
  "x509-parser",
 ]
@@ -8635,6 +9162,9 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "async-trait",
+ "aws-config",
+ "aws-sdk-bedrockruntime",
+ "aws-smithy-types",
  "backon",
  "base64 0.22.1",
  "candle-core",
@@ -9025,12 +9555,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -9041,7 +9571,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -9050,7 +9580,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -9074,12 +9604,12 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
@@ -9087,14 +9617,14 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -9299,6 +9829,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
@@ -9308,7 +9850,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -9346,10 +9888,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -9361,6 +9903,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -9571,6 +10123,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted 0.9.0",
+]
 
 [[package]]
 name = "seccompiler"
@@ -10047,6 +10609,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10971,7 +11543,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -11012,11 +11584,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -11049,11 +11631,11 @@ source = "git+https://github.com/openai-oss-forks/tokio-tungstenite?rev=132f5b39
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tungstenite",
 ]
 
@@ -11194,10 +11776,10 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -11205,7 +11787,7 @@ dependencies = [
  "rustls-native-certs",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -11254,8 +11836,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "iri-string",
  "pin-project-lite",
@@ -11425,11 +12007,11 @@ dependencies = [
  "data-encoding",
  "flate2",
  "headers",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.4",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -11645,7 +12227,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -11666,7 +12248,7 @@ dependencies = [
  "log",
  "native-tls",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -11684,7 +12266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -11768,6 +12350,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vtparse"
@@ -12631,6 +13219,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,10 @@ clap = { version = "4.0", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.13", features = ["json", "stream"] }
+aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+aws-sdk-bedrockruntime = { version = "1.130", features = ["behavior-version-latest"] }
 async-trait = "0.1"
+aws-smithy-types = "1.4"
 anyhow = "1.0"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting"] }

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -162,6 +162,7 @@ pub struct RaraConfig {
     pub revision: Option<String>,
     pub thinking: Option<bool>,
     pub num_ctx: Option<u32>,
+    pub aws_region: Option<String>,
     pub system_prompt: Option<String>,
     pub system_prompt_file: Option<String>,
     pub append_system_prompt: Option<String>,

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,3 +1,4 @@
+mod bedrock;
 mod codex_tools_compat;
 pub(crate) mod deepseek_dsml;
 mod ollama;
@@ -7,6 +8,7 @@ mod shared;
 mod tests;
 mod types;
 
+pub use self::bedrock::BedrockBackend;
 pub use self::ollama::OllamaBackend;
 pub use self::openai_compatible::{
     CodexBackend, GeminiBackend, OpenAiCompatibleBackend, fetch_model_context_window,

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -1,0 +1,369 @@
+// AWS Bedrock backend using the Converse API.
+//
+// Bedrock Converse provides a unified messages API across Bedrock models
+// (Claude, Llama, Nova, etc.) similar to the OpenAI chat completions API.
+// Tool use / function calling is supported natively.
+
+use anyhow::{Context as _, Result, anyhow};
+use async_trait::async_trait;
+use aws_sdk_bedrockruntime::Client as BedrockClient;
+use aws_sdk_bedrockruntime::types::{
+    ContentBlock as BedrockContentBlock, ConversationRole, InferenceConfiguration,
+    Message as BedrockMessage, StopReason, Tool, ToolConfiguration, ToolInputSchema,
+    ToolResultBlock, ToolResultContentBlock, ToolResultStatus, ToolSpecification, ToolUseBlock,
+};
+use aws_smithy_types::{Document, Number};
+use serde_json::{Value, json};
+
+use super::shared::{ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata};
+use crate::agent::Message;
+use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
+
+const DEFAULT_CONTEXT_WINDOW: usize = 200_000;
+const DEFAULT_OUTPUT_TOKENS: i32 = 8_192;
+
+fn model_context_window(model_id: &str) -> Option<(usize, usize)> {
+    let lower = model_id.to_lowercase();
+    if lower.contains("claude-sonnet-4") || lower.contains("claude-3-5-sonnet") {
+        Some((200_000, 8_192))
+    } else if lower.contains("claude-3-opus") {
+        Some((200_000, 4_096))
+    } else if lower.contains("claude-3-haiku") {
+        Some((200_000, 4_096))
+    } else if lower.contains("claude-3") {
+        Some((200_000, 4_096))
+    } else if lower.contains("claude") {
+        Some((200_000, 4_096))
+    } else if lower.contains("llama") {
+        Some((128_000, 2_048))
+    } else if lower.contains("nova-pro") {
+        Some((300_000, 5_000))
+    } else if lower.contains("nova-lite") {
+        Some((300_000, 5_000))
+    } else if lower.contains("nova") {
+        Some((300_000, 5_000))
+    } else if lower.contains("command") {
+        Some((128_000, 4_096))
+    } else if lower.contains("mistral") {
+        Some((128_000, 4_096))
+    } else {
+        None
+    }
+}
+
+pub struct BedrockBackend {
+    client: BedrockClient,
+    model_id: String,
+    region: String,
+}
+
+impl BedrockBackend {
+    pub async fn new(region: Option<String>, model_id: String) -> Result<Self> {
+        let sdk_config = aws_config::load_from_env().await;
+        let client = BedrockClient::new(&sdk_config);
+
+        Ok(Self {
+            client,
+            model_id,
+            region: region.unwrap_or_else(|| "default".to_string()),
+        })
+    }
+}
+
+// ── serde_json::Value ↔ aws_smithy_types::Document ──
+
+fn value_to_document(value: &Value) -> Document {
+    match value {
+        Value::Null => Document::Null,
+        Value::Bool(b) => Document::Bool(*b),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Document::Number(Number::NegInt(i))
+            } else if let Some(u) = n.as_u64() {
+                Document::Number(Number::PosInt(u))
+            } else if let Some(f) = n.as_f64() {
+                Document::Number(Number::Float(f))
+            } else {
+                Document::Null
+            }
+        }
+        Value::String(s) => Document::String(s.clone()),
+        Value::Array(arr) => Document::Array(arr.iter().map(value_to_document).collect()),
+        Value::Object(obj) => {
+            let map: std::collections::HashMap<String, Document> = obj
+                .iter()
+                .map(|(k, v)| (k.clone(), value_to_document(v)))
+                .collect();
+            Document::Object(map)
+        }
+    }
+}
+
+fn document_to_value(doc: &Document) -> Value {
+    match doc {
+        Document::Object(map) => {
+            let mut obj = serde_json::Map::new();
+            for (k, v) in map {
+                obj.insert(k.clone(), document_to_value(v));
+            }
+            Value::Object(obj)
+        }
+        Document::Array(arr) => Value::Array(arr.iter().map(document_to_value).collect()),
+        Document::String(s) => Value::String(s.clone()),
+        Document::Number(n) => match n {
+            Number::PosInt(u) => Value::Number(serde_json::Number::from(*u)),
+            Number::NegInt(i) => Value::Number(serde_json::Number::from(*i)),
+            Number::Float(f) => serde_json::Number::from_f64(*f)
+                .map(Value::Number)
+                .unwrap_or(Value::Null),
+        },
+        Document::Bool(b) => Value::Bool(*b),
+        Document::Null => Value::Null,
+    }
+}
+
+// ── Message conversion ──
+
+fn to_bedrock_messages(messages: &[Message]) -> Result<Vec<BedrockMessage>> {
+    messages
+        .iter()
+        .filter_map(|msg| {
+            let role = match msg.role.as_str() {
+                "user" => ConversationRole::User,
+                "assistant" => ConversationRole::Assistant,
+                _ => return None,
+            };
+            let content = convert_content_to_bedrock(&msg.content);
+            match BedrockMessage::builder()
+                .role(role)
+                .set_content(if content.is_empty() {
+                    None
+                } else {
+                    Some(content)
+                })
+                .build()
+            {
+                Ok(message) => Some(Ok(message)),
+                Err(e) => Some(Err(anyhow!("failed to build Bedrock message: {e}"))),
+            }
+        })
+        .collect()
+}
+
+fn convert_content_to_bedrock(content: &Value) -> Vec<BedrockContentBlock> {
+    let mut blocks = Vec::new();
+
+    if let Some(text) = content.as_str() {
+        if !text.trim().is_empty() {
+            blocks.push(BedrockContentBlock::Text(text.to_string()));
+        }
+        return blocks;
+    }
+
+    let Some(items) = content.as_array() else {
+        return blocks;
+    };
+
+    for item in items {
+        match item.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                    if !text.trim().is_empty() {
+                        blocks.push(BedrockContentBlock::Text(text.to_string()));
+                    }
+                }
+            }
+            Some("tool_use") => {
+                let id = item["id"].as_str().unwrap_or_default().to_string();
+                let name = item["name"].as_str().unwrap_or_default().to_string();
+                let input = item
+                    .get("input")
+                    .map(value_to_document)
+                    .unwrap_or(Document::Null);
+                if let Ok(tool_use) = ToolUseBlock::builder()
+                    .tool_use_id(id)
+                    .name(name)
+                    .input(input)
+                    .build()
+                {
+                    blocks.push(BedrockContentBlock::ToolUse(tool_use));
+                }
+            }
+            Some("tool_result") => {
+                let tool_use_id = item["tool_use_id"].as_str().unwrap_or_default().to_string();
+                let result_content = item["content"].as_str().unwrap_or("");
+                let is_error = item["is_error"].as_bool().unwrap_or(false);
+                if let Ok(tr) = ToolResultBlock::builder()
+                    .tool_use_id(tool_use_id)
+                    .set_content(Some(vec![ToolResultContentBlock::Text(
+                        result_content.to_string(),
+                    )]))
+                    .set_status(if is_error {
+                        Some(ToolResultStatus::Error)
+                    } else {
+                        Some(ToolResultStatus::Success)
+                    })
+                    .build()
+                {
+                    blocks.push(BedrockContentBlock::ToolResult(tr));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    blocks
+}
+
+// ── Tool conversion ──
+
+fn to_bedrock_tools(tools: &[Value]) -> Vec<Tool> {
+    tools
+        .iter()
+        .map(|tool| {
+            let name = tool["name"].as_str().unwrap_or("unknown").to_string();
+            let description = tool["description"].as_str().unwrap_or("").to_string();
+            let schema = value_to_document(&tool["input_schema"]);
+            Tool::ToolSpec(
+                ToolSpecification::builder()
+                    .name(name)
+                    .description(description)
+                    .input_schema(ToolInputSchema::Json(schema))
+                    .build()
+                    .expect("valid tool spec"),
+            )
+        })
+        .collect()
+}
+
+// ── Response conversion ──
+
+fn from_bedrock_response(
+    output: Option<aws_sdk_bedrockruntime::types::ConverseOutput>,
+    stop_reason: StopReason,
+    usage: Option<aws_sdk_bedrockruntime::types::TokenUsage>,
+) -> Result<LlmResponse> {
+    let message = match output {
+        Some(aws_sdk_bedrockruntime::types::ConverseOutput::Message(msg)) => msg,
+        _ => return Err(anyhow!("no message in Bedrock ConverseOutput")),
+    };
+
+    let mut content = Vec::new();
+
+    for block in message.content {
+        match block {
+            BedrockContentBlock::Text(text) => {
+                if !text.trim().is_empty() {
+                    content.push(ContentBlock::Text { text });
+                }
+            }
+            BedrockContentBlock::ToolUse(tool_use) => {
+                let input = document_to_value(&tool_use.input);
+                content.push(ContentBlock::ToolUse {
+                    id: tool_use.tool_use_id,
+                    name: tool_use.name,
+                    input,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let reason_str = format!("{:?}", stop_reason);
+
+    let usage = usage.map(|u| TokenUsage {
+        input_tokens: u.input_tokens as u32,
+        output_tokens: u.output_tokens as u32,
+        cache_hit_tokens: 0,
+        cache_miss_tokens: 0,
+    });
+
+    Ok(LlmResponse {
+        content,
+        stop_reason: Some(reason_str),
+        usage,
+    })
+}
+
+// ── LlmBackend impl ──
+
+#[async_trait]
+impl LlmBackend for BedrockBackend {
+    async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
+        let bedrock_messages = to_bedrock_messages(messages)?;
+
+        let mut builder = self
+            .client
+            .converse()
+            .model_id(&self.model_id)
+            .set_messages(Some(bedrock_messages));
+
+        if !tools.is_empty() {
+            if let Ok(tool_config) = ToolConfiguration::builder()
+                .set_tools(Some(to_bedrock_tools(tools)))
+                .build()
+            {
+                builder = builder.tool_config(tool_config);
+            }
+        }
+
+        builder = builder.inference_config(
+            InferenceConfiguration::builder()
+                .temperature(0.7)
+                .max_tokens(DEFAULT_OUTPUT_TOKENS)
+                .build(),
+        );
+
+        let output = builder.send().await.map_err(|err| {
+            anyhow!(
+                "Bedrock API error (region={}, model={}): {err}",
+                self.region,
+                self.model_id
+            )
+        })?;
+
+        from_bedrock_response(output.output, output.stop_reason, output.usage)
+    }
+
+    async fn ask_streaming(
+        &self,
+        _messages: &[Message],
+        _tools: &[Value],
+        _on_event: &mut (dyn FnMut(LlmStreamEvent) + Send),
+    ) -> Result<LlmResponse> {
+        Err(anyhow!(
+            "Bedrock streaming not yet implemented. Use non-streaming path."
+        ))
+    }
+
+    async fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+        Err(anyhow!(
+            "Bedrock embedding not yet supported. Use a different provider for embeddings."
+        ))
+    }
+
+    async fn summarize(&self, messages: &[Message], instruction: &str) -> Result<String> {
+        let mut all_messages = messages.to_vec();
+        all_messages.push(Message {
+            role: "user".to_string(),
+            content: json!([{ "type": "text", "text": instruction }]),
+        });
+        let response = self.ask(&all_messages, &[]).await?;
+        for block in &response.content {
+            if let ContentBlock::Text { text } = block {
+                return Ok(text.clone());
+            }
+        }
+        Ok(String::new())
+    }
+
+    fn context_budget(&self, _messages: &[Message], _tools: &[Value]) -> Option<ContextBudget> {
+        let (window, max_output) = model_context_window(&self.model_id)
+            .unwrap_or((DEFAULT_CONTEXT_WINDOW, DEFAULT_OUTPUT_TOKENS as usize));
+        Some(ContextBudget {
+            context_window_tokens: window,
+            reserved_output_tokens: max_output,
+            compact_threshold_tokens: window.saturating_sub(max_output),
+        })
+    }
+}

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -59,7 +59,11 @@ pub struct BedrockBackend {
 
 impl BedrockBackend {
     pub async fn new(region: Option<String>, model_id: String) -> Result<Self> {
-        let sdk_config = aws_config::load_from_env().await;
+        let mut config_loader = aws_config::from_env();
+        if let Some(r) = region.as_deref() {
+            config_loader = config_loader.region(aws_config::Region::new(r.to_string()));
+        }
+        let sdk_config = config_loader.load().await;
         let client = BedrockClient::new(&sdk_config);
 
         Ok(Self {
@@ -224,13 +228,14 @@ fn to_bedrock_tools(tools: &[Value]) -> Vec<Tool> {
             let name = tool["name"].as_str().unwrap_or("unknown").to_string();
             let description = tool["description"].as_str().unwrap_or("").to_string();
             let schema = value_to_document(&tool["input_schema"]);
+            let tool_name = name.clone();
             Tool::ToolSpec(
                 ToolSpecification::builder()
                     .name(name)
                     .description(description)
                     .input_schema(ToolInputSchema::Json(schema))
                     .build()
-                    .expect("valid tool spec"),
+                    .unwrap_or_else(|_| panic!("invalid tool spec: {tool_name}")),
             )
         })
         .collect()
@@ -323,17 +328,6 @@ impl LlmBackend for BedrockBackend {
         })?;
 
         from_bedrock_response(output.output, output.stop_reason, output.usage)
-    }
-
-    async fn ask_streaming(
-        &self,
-        _messages: &[Message],
-        _tools: &[Value],
-        _on_event: &mut (dyn FnMut(LlmStreamEvent) + Send),
-    ) -> Result<LlmResponse> {
-        Err(anyhow!(
-            "Bedrock streaming not yet implemented. Use non-streaming path."
-        ))
     }
 
     async fn embed(&self, _text: &str) -> Result<Vec<f32>> {

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -11,8 +11,8 @@ use crate::config::{
     RaraConfig,
 };
 use crate::llm::{
-    CodexBackend, GeminiBackend, LlmBackend, MockLlm, OllamaBackend, OpenAiCompatibleBackend,
-    fetch_model_context_window,
+    BedrockBackend, CodexBackend, GeminiBackend, LlmBackend, MockLlm, OllamaBackend,
+    OpenAiCompatibleBackend, fetch_model_context_window,
 };
 use crate::local_backend::{LocalLlmBackend, LocalProgressReporter};
 use crate::prompt::{PromptRuntimeConfig, PromptSkillSummary};
@@ -232,6 +232,16 @@ pub(crate) async fn build_backend_with_progress(
             .await??;
             Ok(Box::new(backend))
         }
+        "bedrock" => Ok(Box::new(
+            BedrockBackend::new(
+                config.aws_region.clone(),
+                config
+                    .model
+                    .clone()
+                    .context("Model required for Bedrock provider")?,
+            )
+            .await?,
+        )),
         "mock" => Ok(Box::new(MockLlm)),
         other => bail!("Unsupported provider '{other}'"),
     }

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -883,6 +883,7 @@ pub fn model_help_text(app: &TuiApp) -> String {
                             ProviderFamily::OpenAiCompatible => (idx + 1).to_string(),
                             ProviderFamily::CandleLocal => (idx + 1).to_string(),
                             ProviderFamily::Ollama => model.to_string(),
+                            ProviderFamily::Bedrock => model.to_string(),
                         };
                         format!("{marker} {shortcut}. {label} ({provider}/{model})")
                     })

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -878,12 +878,12 @@ pub fn model_help_text(app: &TuiApp) -> String {
                             " "
                         };
                         let shortcut = match family {
-                            ProviderFamily::Codex => (idx + 1).to_string(),
-                            ProviderFamily::DeepSeek => (idx + 1).to_string(),
-                            ProviderFamily::OpenAiCompatible => (idx + 1).to_string(),
-                            ProviderFamily::CandleLocal => (idx + 1).to_string(),
+                            ProviderFamily::Codex
+                            | ProviderFamily::DeepSeek
+                            | ProviderFamily::OpenAiCompatible
+                            | ProviderFamily::CandleLocal
+                            | ProviderFamily::Bedrock => (idx + 1).to_string(),
                             ProviderFamily::Ollama => model.to_string(),
-                            ProviderFamily::Bedrock => model.to_string(),
                         };
                         format!("{marker} {shortcut}. {label} ({provider}/{model})")
                     })

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tui/render/tests.rs
-assertion_line: 570
 expression: rendered
 ---
 ┌ Provider Menu ───────────────────────────────────────────────────────────────────────────────────┐
@@ -16,8 +15,8 @@ expression: rendered
 │  Run local Candle models directly in-process.                                                    │
 │[5] Ollama                                                                                        │
 │  Use an external Ollama server and choose a local tag.                                           │
-│                                                                                                  │
-│                                                                                                  │
+│[6] Bedrock                                                                                       │
+│  Use AWS Bedrock with the Converse API. Credentials from the default AWS chain.                  │
 │                                                                                                  │
 │                                                                                                  │
 │                                                                                                  │

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -220,7 +220,7 @@ fn parse_bash_approval_mode(mode: &str) -> BashApprovalMode {
 pub(crate) fn provider_requires_api_key(provider: &str) -> bool {
     !matches!(
         provider,
-        "mock" | "local" | "local-candle" | "gemma4" | "qwen3" | "qwn3" | "ollama"
+        "mock" | "local" | "local-candle" | "gemma4" | "qwen3" | "qwn3" | "ollama" | "bedrock"
     )
 }
 

--- a/src/tui/state/state_presets.rs
+++ b/src/tui/state/state_presets.rs
@@ -22,6 +22,20 @@ pub const OLLAMA_MODEL_PRESETS: [(&str, &str, &str); 3] = [
     ("Gemma 4 E2B", "ollama", "gemma4:e2b"),
 ];
 
+pub const BEDROCK_MODEL_PRESETS: [(&str, &str, &str); 3] = [
+    (
+        "Claude Sonnet 4",
+        "bedrock",
+        "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    ),
+    (
+        "Claude 3.5 Sonnet v2",
+        "bedrock",
+        "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    ),
+    ("Nova Pro", "bedrock", "us.amazon.nova-pro-v1:0"),
+];
+
 pub fn selected_provider_family_idx_for_config(config: &RaraConfig) -> usize {
     let family = match config.provider.as_str() {
         "codex" => ProviderFamily::Codex,
@@ -35,6 +49,7 @@ pub fn selected_provider_family_idx_for_config(config: &RaraConfig) -> usize {
         }
         "kimi" | "openrouter" => ProviderFamily::OpenAiCompatible,
         "ollama" | "ollama-native" | "ollama-openai" => ProviderFamily::Ollama,
+        "bedrock" => ProviderFamily::Bedrock,
         "gemma4" | "qwn3" | "qwen3" => ProviderFamily::CandleLocal,
         _ => ProviderFamily::Codex,
     };
@@ -57,6 +72,7 @@ pub fn current_model_presets(
         ProviderFamily::OpenAiCompatible => &OPENAI_COMPATIBLE_MODEL_PRESETS,
         ProviderFamily::CandleLocal => &LOCAL_MODEL_PRESETS,
         ProviderFamily::Ollama => &OLLAMA_MODEL_PRESETS,
+        ProviderFamily::Bedrock => &BEDROCK_MODEL_PRESETS,
     }
 }
 

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -66,6 +66,7 @@ pub enum ProviderFamily {
     OpenAiCompatible,
     CandleLocal,
     Ollama,
+    Bedrock,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -320,7 +321,7 @@ pub struct RunningTask {
     pub cancellation_requested: bool,
 }
 
-pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 5] = [
+pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 6] = [
     (
         ProviderFamily::Codex,
         "Codex",
@@ -345,6 +346,11 @@ pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 5] = [
         ProviderFamily::Ollama,
         "Ollama",
         "Use an external Ollama server and choose a local tag.",
+    ),
+    (
+        ProviderFamily::Bedrock,
+        "Bedrock",
+        "Use AWS Bedrock with the Converse API. Credentials from the default AWS chain.",
     ),
 ];
 


### PR DESCRIPTION
## What

Add AWS Bedrock as a provider backend using `aws-sdk-bedrockruntime` Converse API. Supports any Bedrock model (Claude, Llama, Nova, etc.) through a single backend using Converse's unified messages API.

## Why

Users want to call Bedrock-hosted models directly without an OpenAI-compatible proxy. Bedrock's Converse API offers a clean, modern interface with native tool use support.

## Changes

### LLM Backend (`src/llm/bedrock.rs`)
- `BedrockBackend` implements `LlmBackend` trait
- `ask()` via Converse API with full tool use (function calling) support
- `summarize()` and `context_budget()` based on model family
- `serde_json::Value ↔ aws_smithy_types::Document` bi-directional conversion
- Streaming and embedding are stubs (delegates to non-streaming path for now)
- Credentials from the default AWS chain (env vars, ~/.aws/credentials, IAM)

### Config
- `aws_region` field on `RaraConfig` (overridable via `AWS_REGION` env var)
- Provider name: `bedrock`

### TUI
- `ProviderFamily::Bedrock` variant with presets: Claude Sonnet 4, Claude 3.5 Sonnet v2, Nova Pro
- Provider picker: 6 families now (added Bedrock)
- Model presets button: model IDs like `us.anthropic.claude-sonnet-4-20250514-v1:0`

### Dependencies
- `aws-config = "1.1.7"` (behavior-version-latest)
- `aws-sdk-bedrockruntime = "1.130"` (behavior-version-latest)
- `aws-smithy-types = "1.4"`

## Verification

- `cargo check` — compiles cleanly
- `cargo test` — all 761 tests pass (updated 1 snapshot for new provider)
- Manual: `/provider` → pick Bedrock → select model preset → send message