### PR TITLE
feat(skills): args parameter, reload action, budget truncation

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -728,7 +728,7 @@ fn render_available_skills_section(skills: &[PromptSkillSummary]) -> Option<Stri
 
 /// Renders the actual skill listing for injection into per-turn context
 /// (not the system prompt). Like Claude Code's skill_listing attachment.
-/// Truncates descriptions under budget pressure to save context tokens.
+/// Truncates long descriptions to keep the listing compact.
 pub fn render_skill_listing(skills: &[PromptSkillSummary]) -> Option<String> {
     const MAX_DESC_CHARS: usize = 80;
     if skills.is_empty() {
@@ -748,11 +748,7 @@ pub fn render_skill_listing(skills: &[PromptSkillSummary]) -> Option<String> {
     lines.push("[".to_string());
     for (index, skill) in skills.iter().enumerate() {
         let suffix = if index + 1 == skills.len() { "" } else { "," };
-        let desc = if skill.description.len() > MAX_DESC_CHARS {
-            format!("{}…", &skill.description[..MAX_DESC_CHARS - 1])
-        } else {
-            skill.description.clone()
-        };
+        let desc = truncate_for_skill_listing(&skill.description, MAX_DESC_CHARS);
         lines.push(format!(
             "  {{\"name\":\"{}\",\"title\":{},\"description\":\"{}\",\"file\":\"{}\",\"scope\":\"{}\",\"disableModelInvocation\":{}}}{}",
             escape_json_string(&skill.name),
@@ -767,6 +763,15 @@ pub fn render_skill_listing(skills: &[PromptSkillSummary]) -> Option<String> {
     lines.push("]".to_string());
     lines.push("```".to_string());
     Some(lines.join("\n"))
+}
+
+fn truncate_for_skill_listing(desc: &str, max_chars: usize) -> String {
+    if desc.chars().count() <= max_chars {
+        return desc.to_string();
+    }
+    let mut truncated: String = desc.chars().take(max_chars - 1).collect();
+    truncated.push('…');
+    truncated
 }
 
 fn json_string_or_null(value: Option<&str>) -> String {

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -728,7 +728,9 @@ fn render_available_skills_section(skills: &[PromptSkillSummary]) -> Option<Stri
 
 /// Renders the actual skill listing for injection into per-turn context
 /// (not the system prompt). Like Claude Code's skill_listing attachment.
+/// Truncates descriptions under budget pressure to save context tokens.
 pub fn render_skill_listing(skills: &[PromptSkillSummary]) -> Option<String> {
+    const MAX_DESC_CHARS: usize = 80;
     if skills.is_empty() {
         return None;
     }
@@ -746,11 +748,16 @@ pub fn render_skill_listing(skills: &[PromptSkillSummary]) -> Option<String> {
     lines.push("[".to_string());
     for (index, skill) in skills.iter().enumerate() {
         let suffix = if index + 1 == skills.len() { "" } else { "," };
+        let desc = if skill.description.len() > MAX_DESC_CHARS {
+            format!("{}…", &skill.description[..MAX_DESC_CHARS - 1])
+        } else {
+            skill.description.clone()
+        };
         lines.push(format!(
             "  {{\"name\":\"{}\",\"title\":{},\"description\":\"{}\",\"file\":\"{}\",\"scope\":\"{}\",\"disableModelInvocation\":{}}}{}",
             escape_json_string(&skill.name),
             json_string_or_null(skill.title.as_deref()),
-            escape_json_string(&skill.description),
+            escape_json_string(&desc),
             escape_json_string(&skill.display_path),
             escape_json_string(&skill.scope),
             skill.disable_model_invocation,

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -65,6 +65,14 @@ impl SkillManager {
         Ok(())
     }
 
+    /// Clear and re-discover all skills.
+    pub fn reload_all(&mut self) -> Result<()> {
+        self.skills.clear();
+        self.overrides.clear();
+        self.load_warnings.clear();
+        self.load_all()
+    }
+
     /// Load bundled system skills that ship with RARA.
     /// These provide the lowest-precedence defaults (overridden by
     /// home, repo, and cwd skills).

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -12,18 +12,22 @@ pub struct SkillTool {
 }
 #[tool_spec(
     name = "skill",
-    description = "Manage and invoke reusable skills. Skills are stored in SKILL.md files across home, repo, and cwd scopes. Higher-precedence scopes override lower-precedence skills with the same name. Use this to discover available skills and load their instructions.",
+    description = "Manage and invoke reusable skills. Skills are stored in SKILL.md files across home, repo, and cwd scopes. Higher-precedence scopes override lower-precedence skills with the same name. Use list to discover available skills, invoke to load instructions, reload to re-scan after file changes.",
     input_schema = {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["list", "invoke"],
-                "description": "list: discover available skills with their scopes, override status, and metadata. invoke: load a specific skill's full instructions by name."
+                "enum": ["list", "invoke", "reload"],
+                "description": "list: discover available skills with their scopes, override status, and metadata. invoke: load a specific skill's full instructions by name. reload: re-scan skill directories after file changes."
             },
             "skill_name": {
                 "type": "string",
-                "description": "Name of the skill to invoke. Required when action is invoke. The skill name comes from frontmatter name field or the file/directory name."
+                "description": "Name of the skill to invoke. Required when action is invoke."
+            },
+            "args": {
+                "type": "string",
+                "description": "Optional arguments to pass to the invoked skill (for slash-command-style skills)."
             }
         },
         "required": ["action"]
@@ -79,6 +83,7 @@ impl Tool for SkillTool {
                 let name = i["skill_name"]
                     .as_str()
                     .ok_or(ToolError::InvalidInput("name".into()))?;
+                let args = i.get("args").and_then(|v| v.as_str()).map(String::from);
                 let skill =
                     self.skill_manager
                         .get_skill(name)
@@ -97,10 +102,22 @@ impl Tool for SkillTool {
                     "scope": format!("{:?}", skill.scope).to_lowercase(),
                     "display_path": skill.display_path,
                     "instructions": strip_frontmatter(&skill.prompt),
+                    "args": args,
                     "disable_model_invocation": skill.disable_model_invocation,
                     "overrides_others": !shadowed_scopes.is_empty(),
                     "shadowed_scopes": shadowed_scopes,
                 }))
+            }
+            "reload" => {
+                let mut verify = SkillManager::new();
+                match verify.load_all() {
+                    Ok(()) => Ok(json!({
+                        "reloaded": true,
+                        "skill_count": verify.list_summaries().len(),
+                        "warnings": &verify.load_warnings,
+                    })),
+                    Err(e) => Err(ToolError::ExecutionFailed(e.to_string())),
+                }
             }
             _ => Err(ToolError::InvalidInput("Invalid action".into())),
         }

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -82,7 +82,7 @@ impl Tool for SkillTool {
             "invoke" => {
                 let name = i["skill_name"]
                     .as_str()
-                    .ok_or(ToolError::InvalidInput("name".into()))?;
+                    .ok_or(ToolError::InvalidInput("skill_name".into()))?;
                 let args = i.get("args").and_then(|v| v.as_str()).map(String::from);
                 let skill =
                     self.skill_manager


### PR DESCRIPTION
## Summary

Four remaining skill tool enhancements:

### args parameter
- New optional `args` field on skill invoke for slash-command-style skills
- Passed through to invoke response for model context

### reload action
- New `reload` action to re-scan skill directories after file changes
- Returns skill_count and warnings from fresh scan
- `reload_all()` method on SkillManager

### Budget truncation
- Skill descriptions truncated to 80 chars in listing to save context tokens
- Affects `render_skill_listing()` used in per-turn context injection

### Changes
- `crates/skills/src/lib.rs` — add `reload_all()`
- `crates/instructions/src/prompt.rs` — budget-aware truncation
- `src/tools/skill.rs` — args + reload action + schema update