### PR TITLE
feat: add runtime event subscribers

### DIFF
--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -177,6 +177,20 @@ The event stream should remain richer than a plain text stream. Plain text can
 be derived from it, but protocol adapters should not be the only owner of
 structured output.
 
+Runtime subscribers receive `RuntimeControlEvent` objects, not raw TUI text.
+Each event carries:
+
+- a stable event id;
+- a monotonically increasing sequence number from the shared runtime bus;
+- source provenance;
+- the structured `RuntimeEvent` payload derived from the internal `AgentEvent`.
+
+The local TUI may still consume raw `AgentEvent` values for compatibility and
+presentation-specific state, but ACP, Wire, appserver, and future protocol
+adapters should use the structured subscription surface. Slow subscribers must
+treat missed broadcast events as a reconnect/resync boundary rather than
+silently continuing with a partial stream.
+
 ### Prompt Source Registration
 
 External applications may register prompt sources through structured objects:

--- a/docs/journal/2026-05-05-runtime-event-subscribers.md
+++ b/docs/journal/2026-05-05-runtime-event-subscribers.md
@@ -1,0 +1,32 @@
+# Runtime Event Subscribers Checkpoint
+
+## Summary
+
+This checkpoint turns the existing `AgentEvent` bridge into a protocol-ready
+subscription surface.
+
+## Implemented
+
+- Added structured runtime-control subscriptions to `RuntimeEventBus`.
+- Kept raw `AgentEvent` subscriptions for local compatibility.
+- Assigned event ids and monotonic sequence numbers at the shared bus boundary.
+- Wrapped events as `RuntimeControlEvent` with provenance before delivery to
+  protocol subscribers.
+- Routed TUI agent-turn, compact, review, approval-resume, plan-resume, and MCP
+  status events through the provenance-aware send path.
+
+## References
+
+- Codex-style app-server thread event subscriptions and typed notifications.
+- Claude-style session WebSocket subscription with SDK/control message
+  separation.
+
+## Boundary
+
+This does not implement ACP or Wire adapters. It provides the common subscriber
+surface those adapters should consume.
+
+## Validation
+
+- Runtime event bus tests cover structured subscription wrapping, sequence
+  assignment, raw compatibility, and provenance.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -18,7 +18,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add Claude-style `todo_write` runtime state with session persistence, TUI update cards, and structured Wire/ACP-ready events.
 - [x] Add source-aware MCP config registry for user `config.toml` and project `.mcp.json` with duplicate-name conflict failure.
 - [ ] Route ACP prompt/cancel/session handling through the normal RARA runtime path instead of the current stub.
-- [ ] Add protocol subscriber plumbing on top of the structured `AgentEvent` runtime-control bridge.
+- [x] Add protocol subscriber plumbing on top of the structured `AgentEvent` runtime-control bridge.
 - [x] Add MCP connection manager status model (`configured`, `connecting`, `connected`, `refreshing`, `reconnecting`, `failed`, `disabled`) from `McpRegistry`.
 - [x] Add `/mcp` status surface grouped by scope and source path.
 - [x] Publish `/mcp` status snapshots as structured runtime events for future ACP/Wire/appserver subscribers.

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -59,6 +59,17 @@ impl RuntimeProvenance {
         }
     }
 
+    pub fn runtime(session_id: Option<String>) -> Self {
+        Self {
+            controller: RuntimeControllerKind::Runtime,
+            adapter: None,
+            session_id,
+            source_id: None,
+            trust: RuntimeSourceTrust::Trusted,
+            authorship: RuntimeSourceAuthorship::Runtime,
+        }
+    }
+
     pub fn protocol(
         controller: RuntimeControllerKind,
         adapter: impl Into<String>,

--- a/src/runtime_event_bus.rs
+++ b/src/runtime_event_bus.rs
@@ -1,10 +1,16 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
 use tokio::sync::broadcast;
 
 use crate::agent::AgentEvent;
+use crate::runtime_control::{RuntimeControlEvent, RuntimeProvenance, wrap_agent_event};
 
-/// Shared runtime event bus that mirrors `AgentEvent` for non-TUI
-/// subscribers (ACP, Wire, rollout log).  The TUI continues to receive
-/// events through the separate `convert_agent_event → mpsc` path.
+/// Shared runtime event bus for raw agent events and structured protocol
+/// subscribers. The TUI continues to receive events through the separate
+/// `convert_agent_event → mpsc` path.
 ///
 /// Built on a `tokio::sync::broadcast` channel so subscribers receive every
 /// event without the bus needing to know about them ahead of time.  Slow
@@ -12,31 +18,153 @@ use crate::agent::AgentEvent;
 /// to catch up or reconnect.
 #[derive(Clone, Debug)]
 pub struct RuntimeEventBus {
-    sender: broadcast::Sender<AgentEvent>,
+    raw_sender: broadcast::Sender<AgentEvent>,
+    control_sender: broadcast::Sender<RuntimeControlEvent>,
+    next_sequence: Arc<AtomicU64>,
 }
 
 impl RuntimeEventBus {
     /// Create a new bus with a fixed ring-buffer capacity.  When the buffer
     /// is full the oldest event is dropped for the slowest subscriber.
     pub fn new(capacity: usize) -> Self {
-        let (sender, _) = broadcast::channel(capacity);
-        Self { sender }
+        let (raw_sender, _) = broadcast::channel(capacity);
+        let (control_sender, _) = broadcast::channel(capacity);
+        Self {
+            raw_sender,
+            control_sender,
+            next_sequence: Arc::new(AtomicU64::new(0)),
+        }
     }
 
-    /// Push an event to all active subscribers.  Returns the number of
-    /// subscribers that received the event (may be 0).
+    /// Push an event to all active subscribers with runtime provenance.
+    /// Returns the number of raw and structured subscribers that received the
+    /// event (may be 0).
     pub fn send(&self, event: AgentEvent) -> usize {
-        self.sender.send(event).unwrap_or(0)
+        self.send_with_provenance(event, RuntimeProvenance::runtime(None))
+    }
+
+    /// Push an event with explicit provenance for protocol-ready subscribers.
+    pub fn send_with_provenance(&self, event: AgentEvent, provenance: RuntimeProvenance) -> usize {
+        let raw_receivers = self.raw_sender.receiver_count();
+        let control_receivers = self.control_sender.receiver_count();
+
+        match (raw_receivers > 0, control_receivers > 0) {
+            (false, false) => 0,
+            (true, false) => self.raw_sender.send(event).unwrap_or(0),
+            (false, true) => {
+                let sequence = self.next_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                let event_id = format!("evt-{sequence:016x}");
+                let control_event = wrap_agent_event(event_id, sequence, provenance, event);
+                self.control_sender.send(control_event).unwrap_or(0)
+            }
+            (true, true) => {
+                let sequence = self.next_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+                let event_id = format!("evt-{sequence:016x}");
+                let control_event = wrap_agent_event(event_id, sequence, provenance, event.clone());
+                let raw_count = self.raw_sender.send(event).unwrap_or(0);
+                let control_count = self.control_sender.send(control_event).unwrap_or(0);
+                raw_count + control_count
+            }
+        }
     }
 
     /// Create a new receiver that will see all future events.  Past events
     /// are not replayed.
     pub fn subscribe(&self) -> broadcast::Receiver<AgentEvent> {
-        self.sender.subscribe()
+        self.raw_sender.subscribe()
+    }
+
+    /// Create a structured receiver for ACP/Wire/appserver adapters.
+    ///
+    /// Past events are not replayed. Use the embedded sequence and event id to
+    /// preserve stream order and adapter acknowledgements.
+    pub fn subscribe_control(&self) -> broadcast::Receiver<RuntimeControlEvent> {
+        self.control_sender.subscribe()
     }
 
     /// Return the number of active subscribers.
     pub fn receiver_count(&self) -> usize {
-        self.sender.receiver_count()
+        self.raw_sender.receiver_count() + self.control_sender.receiver_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn control_subscriber_receives_wrapped_runtime_events() {
+        let bus = RuntimeEventBus::new(8);
+        let mut control = bus.subscribe_control();
+
+        assert_eq!(
+            bus.send_with_provenance(
+                AgentEvent::Status("ready".to_string()),
+                RuntimeProvenance::local_tui("session-1"),
+            ),
+            1
+        );
+
+        let event = control.try_recv().expect("control event");
+        assert_eq!(event.event_id, "evt-0000000000000001");
+        assert_eq!(event.sequence, 1);
+        assert_eq!(event.provenance.session_id.as_deref(), Some("session-1"));
+        assert_eq!(
+            serde_json::to_value(event.event).unwrap(),
+            json!({
+                "type": "session",
+                "payload": {
+                    "type": "status",
+                    "payload": {
+                        "message": "ready"
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn raw_and_control_subscribers_share_sequence_source() {
+        let bus = RuntimeEventBus::new(8);
+        let mut raw = bus.subscribe();
+        let mut control = bus.subscribe_control();
+
+        assert_eq!(bus.receiver_count(), 2);
+        assert_eq!(bus.send(AgentEvent::AssistantDelta("hello".to_string())), 2);
+
+        assert!(matches!(
+            raw.try_recv().expect("raw event"),
+            AgentEvent::AssistantDelta(delta) if delta == "hello"
+        ));
+        let event = control.try_recv().expect("control event");
+        assert_eq!(event.sequence, 1);
+        assert_eq!(
+            event.provenance.controller,
+            crate::runtime_control::RuntimeControllerKind::Runtime
+        );
+    }
+
+    #[test]
+    fn unsubscribed_events_do_not_advance_control_sequence() {
+        let bus = RuntimeEventBus::new(8);
+
+        assert_eq!(bus.send(AgentEvent::Status("ignored".to_string())), 0);
+
+        let mut raw = bus.subscribe();
+        assert_eq!(bus.send(AgentEvent::Status("raw only".to_string())), 1);
+        assert!(matches!(
+            raw.try_recv().expect("raw event"),
+            AgentEvent::Status(message) if message == "raw only"
+        ));
+        drop(raw);
+
+        let mut control = bus.subscribe_control();
+        assert_eq!(bus.send(AgentEvent::Status("first control".to_string())), 1);
+
+        let event = control.try_recv().expect("control event");
+        assert_eq!(event.sequence, 1);
+        assert_eq!(event.event_id, "evt-0000000000000001");
     }
 }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -9,6 +9,7 @@ use super::tasks::{start_compact_task, start_rebuild_task, start_review_task};
 use crate::agent::{Agent, AgentEvent, AgentExecutionMode, BashApprovalMode};
 use crate::mcp_status::{McpStatusSnapshot, format_mcp_status};
 use crate::oauth::OAuthManager;
+use crate::runtime_control::RuntimeProvenance;
 
 pub(super) async fn execute_local_command(
     command: LocalCommand,
@@ -232,9 +233,12 @@ fn handle_mcp_command(app: &mut TuiApp) {
 fn publish_mcp_status_load_failed_event(app: &TuiApp, message: &str) {
     if let Some(bus) = app.event_bus.as_ref() {
         if bus.receiver_count() > 0 {
-            bus.send(AgentEvent::McpStatusLoadFailed {
-                message: message.to_string(),
-            });
+            bus.send_with_provenance(
+                AgentEvent::McpStatusLoadFailed {
+                    message: message.to_string(),
+                },
+                RuntimeProvenance::local_tui(app.snapshot.session_id.clone()),
+            );
         }
     }
 }
@@ -242,7 +246,10 @@ fn publish_mcp_status_load_failed_event(app: &TuiApp, message: &str) {
 fn publish_mcp_status_event(app: &TuiApp, snapshot: &McpStatusSnapshot) {
     if let Some(bus) = app.event_bus.as_ref() {
         if bus.receiver_count() > 0 {
-            bus.send(AgentEvent::McpStatusUpdated(snapshot.clone()));
+            bus.send_with_provenance(
+                AgentEvent::McpStatusUpdated(snapshot.clone()),
+                RuntimeProvenance::local_tui(app.snapshot.session_id.clone()),
+            );
         }
     }
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -22,14 +22,23 @@ use super::super::state::{
 use super::events::{apply_tui_event, convert_agent_event, format_error_chain};
 use crate::agent::{Agent, AgentOutputMode, BashApprovalDecision};
 use crate::redaction::sanitize_url_for_display;
+use crate::runtime_control::RuntimeProvenance;
 use crate::runtime_event_bus::RuntimeEventBus;
+
+fn local_tui_event_provenance(session_id: &str) -> RuntimeProvenance {
+    RuntimeProvenance::local_tui(session_id.to_string())
+}
 
 /// Forward `event` to the broadcast bus when there are active subscribers.
 /// Avoids the clone cost when nobody is listening (the common TUI-only case).
-fn forward_event_to_bus(bus: &Option<Arc<RuntimeEventBus>>, event: &crate::agent::AgentEvent) {
+fn forward_event_to_bus(
+    bus: &Option<Arc<RuntimeEventBus>>,
+    event: &crate::agent::AgentEvent,
+    provenance: &RuntimeProvenance,
+) {
     if let Some(bus) = bus.as_ref() {
         if bus.receiver_count() > 0 {
-            bus.send(event.clone());
+            bus.send_with_provenance(event.clone(), provenance.clone());
         }
     }
 }
@@ -121,6 +130,7 @@ pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agen
     let (sender, receiver) = mpsc::unbounded_channel();
     let cancellation_token = Arc::new(AtomicBool::new(false));
     let bus = app.event_bus.clone();
+    let event_provenance = local_tui_event_provenance(&agent.session_id);
     app.clear_pending_planning_suggestion();
     app.clear_active_live_sections();
     app.begin_running_turn();
@@ -136,7 +146,7 @@ pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agen
         let tx = sender.clone();
         let result = agent
             .query_with_mode_and_events(prompt, AgentOutputMode::Silent, move |event| {
-                forward_event_to_bus(&bus, &event);
+                forward_event_to_bus(&bus, &event, &event_provenance);
                 if let Some(tui_event) = convert_agent_event(event) {
                     let _ = tx.send(tui_event);
                 }
@@ -159,6 +169,7 @@ pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agen
 pub(super) fn start_compact_task(app: &mut TuiApp, mut agent: Agent) {
     let (sender, receiver) = mpsc::unbounded_channel();
     let bus = app.event_bus.clone();
+    let event_provenance = local_tui_event_provenance(&agent.session_id);
     agent.set_execution_mode(app.agent_execution_mode);
     agent.set_bash_approval_mode(app.bash_approval_mode);
     app.notice = Some("Compacting conversation history.".into());
@@ -172,7 +183,7 @@ pub(super) fn start_compact_task(app: &mut TuiApp, mut agent: Agent) {
         let tx = sender.clone();
         let result = agent
             .compact_now_with_reporter(move |event| {
-                forward_event_to_bus(&bus, &event);
+                forward_event_to_bus(&bus, &event, &event_provenance);
                 if let Some(tui_event) = convert_agent_event(event) {
                     let _ = tx.send(tui_event);
                 }
@@ -196,6 +207,7 @@ pub(super) fn start_review_task(app: &mut TuiApp, prompt: String, mut agent: Age
     use crate::agent::{AgentExecutionMode, BashApprovalMode};
     let (sender, receiver) = mpsc::unbounded_channel();
     let bus = app.event_bus.clone();
+    let event_provenance = local_tui_event_provenance(&agent.session_id);
     agent.set_execution_mode(AgentExecutionMode::Review);
     agent.set_bash_approval_mode(BashApprovalMode::Always);
     app.notice = Some("Running code review.".into());
@@ -209,7 +221,7 @@ pub(super) fn start_review_task(app: &mut TuiApp, prompt: String, mut agent: Age
         let tx = sender.clone();
         let result = agent
             .query_with_mode_and_events(prompt, AgentOutputMode::Silent, move |event| {
-                forward_event_to_bus(&bus, &event);
+                forward_event_to_bus(&bus, &event, &event_provenance);
                 if let Some(tui_event) = convert_agent_event(event) {
                     let _ = tx.send(tui_event);
                 }
@@ -237,6 +249,7 @@ pub(super) fn start_pending_approval_task(
     let (sender, receiver) = mpsc::unbounded_channel();
     let cancellation_token = Arc::new(AtomicBool::new(false));
     let bus = app.event_bus.clone();
+    let event_provenance = local_tui_event_provenance(&agent.session_id);
     let selection_label = match selection {
         BashApprovalDecision::Once => "run once",
         BashApprovalDecision::Prefix => "allow matching prefix",
@@ -256,7 +269,7 @@ pub(super) fn start_pending_approval_task(
         let tx = sender.clone();
         let result = agent
             .answer_pending_approval_with_events(selection, AgentOutputMode::Silent, move |event| {
-                forward_event_to_bus(&bus, &event);
+                forward_event_to_bus(&bus, &event, &event_provenance);
                 if let Some(tui_event) = convert_agent_event(event) {
                     let _ = tx.send(tui_event);
                 }
@@ -308,6 +321,7 @@ fn start_plan_resume_task(
     let (sender, receiver) = mpsc::unbounded_channel();
     let cancellation_token = Arc::new(AtomicBool::new(false));
     let bus = app.event_bus.clone();
+    let event_provenance = local_tui_event_provenance(&agent.session_id);
     app.clear_active_live_sections();
     app.set_pending_plan_approval(false);
     app.notice = Some(notice);
@@ -335,7 +349,7 @@ fn start_plan_resume_task(
                 continue_planning,
                 AgentOutputMode::Silent,
                 move |event| {
-                    forward_event_to_bus(&bus, &event);
+                    forward_event_to_bus(&bus, &event, &event_provenance);
                     if let Some(tui_event) = convert_agent_event(event) {
                         let _ = tx.send(tui_event);
                     }


### PR DESCRIPTION
## Summary

- add structured `RuntimeControlEvent` subscriptions on `RuntimeEventBus`
- keep raw `AgentEvent` subscriptions for local compatibility
- attach event ids, monotonic sequence numbers, and provenance at the shared bus boundary
- route TUI agent, compact, review, approval, plan-resume, and MCP status events through provenance-aware publishing
- document the subscriber contract and checkpoint

## Tests

- `cargo fmt --check`
- `cargo test runtime_event_bus -- --nocapture`
- `cargo test mcp_command_publishes_structured_status_event -- --nocapture`
- `cargo check`
