### PR TITLE
feat(memory): add retention metadata

### DIFF
--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -14,10 +14,11 @@ LanceDB as a unified local memory index: raw text, metadata, full-text search,
 and vector search live in one table, while context assembly still goes through
 `MemorySelection`.
 
-This spec describes the target product contract. The first implementation
-slices provide the LanceDB-backed index, retrieval tools, and a runtime
-`MemoryStore` facade; update/delete, filtering, distillation, and direct
-`MemorySelection` integration remain follow-up work.
+This spec describes the target product contract. The current implementation
+slices provide the LanceDB-backed index, retrieval tools, a runtime
+`MemoryStore` facade, ranked `MemorySelection` candidates, and pinned retention
+metadata. Update/delete, filtering, and multi-record distillation remain
+follow-up work.
 
 ## Six Design Laws (Cross-Industry Consensus)
 
@@ -111,12 +112,12 @@ Importance scale:
 
 | Capability | Target Behavior | Current Runtime Status |
 |------------|-----------------|------------------------|
-| Memory record anatomy | Title, Markdown content, labels, importance, timestamps, source, scope, embedding, and provenance. | Partial. `MemoryRecord` is now persisted as the domain record; LanceDB rows still store the compact search index shape. |
+| Memory record anatomy | Title, Markdown content, labels, importance, pinned status, timestamps, source, scope, embedding, and provenance. | Partial. `MemoryRecord` is now persisted as the domain record; LanceDB rows still store the compact search index shape. |
 | Memory creation | Agent or user creates a durable `MemoryRecord`; title, labels, and importance can be generated or explicit. | Partial. `remember_experience` is now a compatibility adapter over `MemoryStore::insert`. |
 | Memory search | Hybrid semantic + keyword search with metadata filters and explainable scores. | Partial. LanceDB vector, FTS, and hybrid helpers exist; `MemoryStore::search` rehydrates full persisted records before returning hits. |
-| Memory update | Existing records can be edited without creating duplicates. | Not implemented as a public memory capability. |
+| Memory update | Existing records can be edited without creating duplicates. | Partial. `MemoryStore::set_pinned` updates retention metadata; general content/title/label updates remain future work. |
 | Memory delete | User or control-plane request can delete records with audit-safe semantics. | Not implemented as a public memory capability. |
-| Memory retention | Pinned, user-created, and high-importance memories are protected from automatic cleanup; explicit delete remains possible with provenance. | Spec only. No automatic cleanup path exists yet. |
+| Memory retention | Pinned, user-created, and high-importance memories are protected from automatic cleanup; explicit delete remains possible with provenance. | Implemented as a domain guard on `MemoryRecord`; no automatic cleanup path exists yet. |
 | Thread distillation | Thread history can be distilled into 2-8 durable memory records. | Partial. `ThreadStore::distill_thread_summary` can persist one thread-linked summary record; LLM extraction and deduplication remain future work. |
 | Context injection | Ranked memory candidates pass through `MemorySelection` before prompt injection. | Partial. LanceDB-backed memory and session search now produce direct ranked `MemorySelection` candidates; retention, deduplication, and protocol mutation remain future work. |
 | Graph retrieval | Entity and relationship traversal complements vector recall. | Future work. |
@@ -231,6 +232,10 @@ Current implementation checkpoint:
   index.
 - `MemoryStore` persists full domain records in `records.json`; search uses
   LanceDB for recall and then rehydrates the full record by id.
+- `MemoryStore::set_pinned` updates persistent retention metadata without
+  touching the LanceDB search row.
+- `MemoryRecord::is_protected_from_automatic_cleanup` protects pinned,
+  user-created, and high-importance records from future automatic cleanup paths.
 - `remember_experience` writes through `MemoryStore::insert`.
 - `retrieve_experience` searches through `MemoryStore::search` and returns both
   `relevant_experiences` and memory diagnostics.
@@ -258,7 +263,7 @@ Current implementation checkpoint:
    Done.
 7. Wire `MemorySelection` to ranked memory candidates. Done.
 8. Add pinned/retention policy so pinned, user-created, and high-importance
-   memories are excluded from automatic cleanup.
+   memories are excluded from automatic cleanup. Done.
 9. Add update/delete/list-label control-plane scaffolding without exposing
    storage internals.
 10. Add thread distillation into `MemoryRecord`. Partial: summary distillation is

--- a/docs/journal/2026-05-05-memory-retention.md
+++ b/docs/journal/2026-05-05-memory-retention.md
@@ -1,0 +1,34 @@
+# Memory Retention Checkpoint
+
+## Summary
+
+RARA now persists explicit retention metadata on durable memory records:
+
+- `MemoryRecord.pinned` is part of the domain record and defaults to `false`
+  when older record files are loaded.
+- `NewMemoryRecord.pinned` lets memory creation callers mark records as pinned
+  without bypassing `MemoryStore`.
+- `MemoryStore::set_pinned` updates the durable record file and leaves the
+  LanceDB search row unchanged because pinning does not alter searchable text or
+  embeddings.
+- `MemoryRecord::is_protected_from_automatic_cleanup` centralizes the retention
+  rule: pinned records, user-created records, and records with importance `0.8`
+  or higher are protected from future automatic cleanup paths.
+
+## Design Boundary
+
+This slice does not add automatic cleanup. It intentionally lands the retention
+contract first so later cleanup, promotion, and protocol memory mutation code
+must call the same domain guard instead of re-implementing policy at the edge.
+
+The shape follows the existing memory/context boundary: LanceDB remains the
+retrieval index, while durable memory policy lives in `MemoryStore` and
+`MemoryRecord`.
+
+## Validation
+
+Focused coverage was added for:
+
+- retention protection across pinned, user-created, and high-importance records;
+- persisted pin updates through `MemoryStore::set_pinned`;
+- existing record persistence/search tests now preserving pinned metadata.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -72,7 +72,7 @@ Active backlog only. Keep this file small and current.
 - [x] Replace `retrieve_session_context` stub with LanceDB hybrid search over conversation checkpoints.
 - [x] Add backend `ThreadStore` APIs for markdown export and summary-to-memory distillation.
 - [x] Promote LanceDB-backed retrieval from `MemoryStore` into ranked `MemorySelection` candidates.
-- [ ] Add pinned/retention policy so pinned, user-created, and high-importance memories are excluded from automatic cleanup.
+- [x] Add pinned/retention policy so pinned, user-created, and high-importance memories are excluded from automatic cleanup.
 - [ ] Add memory update/delete/list-label control-plane scaffolding for ACP/Wire without exposing LanceDB APIs.
 - [ ] Upgrade thread distillation from summary capture to LLM-assisted 2-8 record extraction with deduplication.
 - [ ] Move raw session checkpoints into per-session append shards instead of the global LanceDB `conversations` table.

--- a/src/agent/tests/context_view.rs
+++ b/src/agent/tests/context_view.rs
@@ -410,6 +410,7 @@ async fn query_injects_selected_memory_context_without_persisting_it_to_history(
                 .to_string(),
             labels: vec![MemoryLabel::Fact],
             importance: 0.9,
+            pinned: false,
             source: MemorySource::UserCreated,
             scope: MemoryScope::Workspace,
             session_id: None,

--- a/src/context/retriever.rs
+++ b/src/context/retriever.rs
@@ -215,6 +215,7 @@ mod tests {
                         .to_string(),
                 labels: vec![MemoryLabel::Fact],
                 importance: 0.9,
+                pinned: false,
                 source: MemorySource::UserCreated,
                 scope: MemoryScope::Workspace,
                 session_id: None,

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -14,6 +14,7 @@ use crate::vectordb::{MemoryMetadata, VectorDB};
 
 const EXPERIENCES_TABLE: &str = "experiences";
 const DEFAULT_IMPORTANCE: f32 = 0.5;
+const HIGH_IMPORTANCE_RETENTION_THRESHOLD: f32 = 0.8;
 const MEMORY_RECORD_INDEX_PLACEHOLDER: u32 = 0;
 const MEMORY_RECORDS_FILE_VERSION: u32 = 1;
 
@@ -60,6 +61,8 @@ pub struct MemoryRecord {
     pub content: String,
     pub labels: Vec<MemoryLabel>,
     pub importance: f32,
+    #[serde(default)]
+    pub pinned: bool,
     pub source: MemorySource,
     pub scope: MemoryScope,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -78,6 +81,7 @@ pub struct NewMemoryRecord {
     pub content: String,
     pub labels: Vec<MemoryLabel>,
     pub importance: f32,
+    pub pinned: bool,
     pub source: MemorySource,
     pub scope: MemoryScope,
     pub session_id: Option<String>,
@@ -92,6 +96,7 @@ impl NewMemoryRecord {
             content: content.into(),
             labels: vec![MemoryLabel::Experience],
             importance: DEFAULT_IMPORTANCE,
+            pinned: false,
             source: MemorySource::AgentTurn,
             scope: MemoryScope::Project,
             session_id: None,
@@ -153,6 +158,7 @@ impl MemoryStore {
             content: content.to_string(),
             labels: normalized_labels(input.labels),
             importance,
+            pinned: input.pinned,
             source: input.source,
             scope: input.scope,
             session_id: normalized_optional_id(input.session_id),
@@ -214,6 +220,10 @@ impl MemoryStore {
     pub async fn get(&self, id: &str) -> Result<Option<MemoryRecord>> {
         self.records.get(id).await
     }
+
+    pub async fn set_pinned(&self, id: &str, pinned: bool) -> Result<MemoryRecord> {
+        self.records.set_pinned(id, pinned).await
+    }
 }
 
 impl MemoryRecord {
@@ -222,6 +232,12 @@ impl MemoryRecord {
             .clone()
             .or_else(|| self.thread_id.clone())
             .unwrap_or_else(|| memory_scope_key(&self.scope).to_string())
+    }
+
+    pub fn is_protected_from_automatic_cleanup(&self) -> bool {
+        self.pinned
+            || self.source == MemorySource::UserCreated
+            || self.importance >= HIGH_IMPORTANCE_RETENTION_THRESHOLD
     }
 }
 
@@ -238,6 +254,7 @@ impl From<MemoryMetadata> for MemoryRecord {
             content: metadata.text,
             labels: vec![MemoryLabel::Experience],
             importance: DEFAULT_IMPORTANCE,
+            pinned: false,
             source: MemorySource::AgentTurn,
             scope: memory_scope_from_key(&metadata.session_id),
             session_id: Some(session_id),
@@ -335,6 +352,26 @@ impl MemoryRecordFileStore {
             .await
             .context("join memory record get task")?
     }
+
+    async fn set_pinned(&self, id: &str, pinned: bool) -> Result<MemoryRecord> {
+        let path = self.path.clone();
+        let lock_path = self.lock_path.clone();
+        let cache = self.cache.clone();
+        let id = id.to_string();
+        tokio::task::spawn_blocking(move || {
+            update_record_sync(path, lock_path, cache, &id, |record| {
+                if record.pinned != pinned {
+                    record.pinned = pinned;
+                    record.updated_at_unix_seconds = unix_timestamp_seconds();
+                    true
+                } else {
+                    false
+                }
+            })
+        })
+        .await
+        .context("join memory record pin update task")?
+    }
 }
 
 fn default_record_path_for_vdb_uri(uri: &str) -> PathBuf {
@@ -370,6 +407,35 @@ fn upsert_record_sync(
     let state = record_file_state(&path)?;
     update_record_cache(&cache, state, records);
     Ok(())
+}
+
+fn update_record_sync<F>(
+    path: PathBuf,
+    lock_path: PathBuf,
+    cache: Arc<Mutex<MemoryRecordCache>>,
+    id: &str,
+    update: F,
+) -> Result<MemoryRecord>
+where
+    F: FnOnce(&mut MemoryRecord) -> bool,
+{
+    let _lock = AdvisoryFileLock::acquire(lock_path)?;
+    let mut file = PersistedMemoryRecordFile {
+        records: load_records_sync(&path)?,
+        ..Default::default()
+    };
+    let Some(record) = file.records.iter_mut().find(|item| item.id == id) else {
+        bail!("memory record not found: {id}");
+    };
+    let changed = update(record);
+    let updated = record.clone();
+    if changed {
+        write_record_file_sync(&path, &file)?;
+        let records = record_map_from_records(file.records);
+        let state = record_file_state(&path)?;
+        update_record_cache(&cache, state, records);
+    }
+    Ok(updated)
 }
 
 fn load_record_map_cached_sync(
@@ -559,6 +625,7 @@ mod tests {
             content: content.to_string(),
             labels: vec![MemoryLabel::Fact],
             importance: DEFAULT_IMPORTANCE,
+            pinned: false,
             source: MemorySource::UserCreated,
             scope: MemoryScope::Project,
             session_id: None,
@@ -682,6 +749,7 @@ mod tests {
                 content: "A durable fact".to_string(),
                 labels: Vec::new(),
                 importance: 4.0,
+                pinned: false,
                 source: MemorySource::UserCreated,
                 scope: MemoryScope::Workspace,
                 session_id: None,
@@ -712,6 +780,7 @@ mod tests {
                 content: "Keep memory retrieval behind MemoryStore.".to_string(),
                 labels: vec![MemoryLabel::Decision],
                 importance: 0.9,
+                pinned: true,
                 source: MemorySource::ThreadDistill,
                 scope: MemoryScope::Thread,
                 session_id: Some("session-123".to_string()),
@@ -733,6 +802,7 @@ mod tests {
         assert_eq!(hits[0].record.title, "Thread decision");
         assert_eq!(hits[0].record.labels, vec![MemoryLabel::Decision]);
         assert_eq!(hits[0].record.importance, 0.9);
+        assert!(hits[0].record.pinned);
         assert_eq!(hits[0].record.source, MemorySource::ThreadDistill);
         assert_eq!(hits[0].record.scope, MemoryScope::Thread);
         assert_eq!(hits[0].record.session_id.as_deref(), Some("session-123"));
@@ -744,5 +814,54 @@ mod tests {
                 end_turn_index: 4,
             })
         );
+    }
+
+    #[test]
+    fn memory_record_retention_protects_pinned_user_created_and_high_importance_records() {
+        let mut record = test_memory_record("memory-retention-1", "Durable user note.");
+        assert!(record.is_protected_from_automatic_cleanup());
+
+        record.source = MemorySource::AgentTurn;
+        assert!(!record.is_protected_from_automatic_cleanup());
+
+        record.importance = HIGH_IMPORTANCE_RETENTION_THRESHOLD;
+        assert!(record.is_protected_from_automatic_cleanup());
+
+        record.importance = DEFAULT_IMPORTANCE;
+        record.pinned = true;
+        assert!(record.is_protected_from_automatic_cleanup());
+    }
+
+    #[tokio::test]
+    async fn memory_store_set_pinned_updates_and_persists_record_metadata() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("lancedb");
+        let record_path = temp.path().join("memories").join("records.json");
+        let backend = Arc::new(MockLlm);
+        let vdb = Arc::new(VectorDB::new(db_path.to_str().expect("utf8 path")));
+        let store =
+            MemoryStore::new_with_record_path(backend.clone(), vdb.clone(), record_path.clone());
+
+        let saved = store
+            .insert(NewMemoryRecord::experience(
+                "Pinned records survive automatic cleanup.",
+            ))
+            .await
+            .expect("insert memory");
+        assert!(!saved.pinned);
+        assert!(!saved.is_protected_from_automatic_cleanup());
+
+        let pinned = store.set_pinned(&saved.id, true).await.expect("pin memory");
+        assert!(pinned.pinned);
+        assert!(pinned.is_protected_from_automatic_cleanup());
+
+        let reloaded = MemoryStore::new_with_record_path(backend, vdb, record_path);
+        let persisted = reloaded
+            .get(&saved.id)
+            .await
+            .expect("get memory")
+            .expect("persisted memory");
+        assert!(persisted.pinned);
+        assert!(persisted.is_protected_from_automatic_cleanup());
     }
 }

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -964,6 +964,7 @@ fn thread_summary_memory_record(thread: &ThreadSnapshot) -> Option<NewMemoryReco
         ),
         labels: vec![MemoryLabel::Experience],
         importance: 0.6,
+        pinned: false,
         source: MemorySource::ThreadDistill,
         scope: MemoryScope::Thread,
         session_id: Some(thread.metadata.session_id.clone()),


### PR DESCRIPTION
## Summary

- add persistent `pinned` metadata to `MemoryRecord` and memory creation inputs
- add `MemoryStore::set_pinned` plus a centralized automatic-cleanup retention guard
- update the memory records spec, todo, and journal checkpoint for the completed retention slice

## Tests

- `cargo fmt`
- `cargo test memory_store -- --nocapture`
- `cargo check`
