### PR TITLE
chore(tui): remove ctx~= from footer status bar

### DIFF
--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -355,32 +355,31 @@ fn bottom_pane_style() -> Style {
 }
 
 fn footer_summary_text(app: &TuiApp) -> String {
-    let prefix = app
-        .repo_context_hint()
-        .unwrap_or_default();
+    let mut parts: Vec<String> = Vec::new();
 
-    let cache_summary = cache_hit_rate_label(
+    if let Some(hint) = app.repo_context_hint() {
+        parts.push(hint);
+    }
+
+    if shows_live_task_stats(app) {
+        parts.push(format!(
+            "tokens={} in / {} out",
+            app.snapshot.total_input_tokens, app.snapshot.total_output_tokens,
+        ));
+    }
+
+    if let Some(rate) = cache_hit_rate_label(
         app.snapshot.total_cache_hit_tokens,
         app.snapshot.total_cache_miss_tokens,
-    )
-    .map(|rate| format!("  cache_hit={rate}"))
-    .unwrap_or_default();
-    if shows_live_task_stats(app) {
-        format!(
-            "{}  tokens={} in / {} out{}",
-            prefix,
-            app.snapshot.total_input_tokens,
-            app.snapshot.total_output_tokens,
-            cache_summary
-        )
-    } else if app.snapshot.compaction_count > 0 {
-        format!(
-            "{}  compactions={}{}",
-            prefix, app.snapshot.compaction_count, cache_summary
-        )
-    } else {
-        format!("{prefix}{cache_summary}")
+    ) {
+        parts.push(format!("cache_hit={rate}"));
     }
+
+    if !shows_live_task_stats(app) && app.snapshot.compaction_count > 0 {
+        parts.push(format!("compactions={}", app.snapshot.compaction_count));
+    }
+
+    parts.join("  ")
 }
 
 fn shows_live_task_stats(app: &TuiApp) -> bool {

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -355,17 +355,9 @@ fn bottom_pane_style() -> Style {
 }
 
 fn footer_summary_text(app: &TuiApp) -> String {
-    let context = match app.snapshot.context_window_tokens {
-        Some(window) => format!("ctx~={}/{}", app.snapshot.estimated_history_tokens, window),
-        None => format!("ctx~={}", app.snapshot.estimated_history_tokens),
-    };
-
-    let repo_part = app
+    let prefix = app
         .repo_context_hint()
-        .map(|hint| format!("{hint}  "))
         .unwrap_or_default();
-
-    let prefix = format!("{repo_part}{context}");
 
     let cache_summary = cache_hit_rate_label(
         app.snapshot.total_cache_hit_tokens,

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -15,7 +15,7 @@ use crate::tui::state::{
 };
 
 #[test]
-fn footer_summary_text_prefers_minimal_idle_context() {
+fn footer_summary_text_is_empty_when_idle_and_no_repo_context() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -28,7 +28,7 @@ fn footer_summary_text_prefers_minimal_idle_context() {
     };
 
     let rendered = footer_summary_text(&app);
-    assert_eq!(rendered, "ctx~=1234/32768");
+    assert_eq!(rendered, "");
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn footer_summary_text_shows_tokens_only_while_busy() {
     };
 
     let rendered = footer_summary_text(&app);
-    assert_eq!(rendered, "ctx~=2048/32768  tokens=111 in / 22 out");
+    assert_eq!(rendered, "  tokens=111 in / 22 out");
     assert!(!rendered.contains("history="));
     assert!(!rendered.contains("local="));
     assert!(!rendered.contains("key="));
@@ -257,7 +257,7 @@ fn footer_summary_text_includes_repo_context_when_available() {
     assert!(rendered.contains("repo: hawkingrei/rara"));
     assert!(rendered.contains("branch: feat/test"));
     assert!(rendered.contains("PR: https://github.com/hawkingrei/rara/pull/46"));
-    assert!(rendered.contains("ctx~=1234/32768"));
+    assert!(!rendered.contains("ctx~="));
 }
 
 #[test]

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -48,7 +48,7 @@ fn footer_summary_text_shows_tokens_only_while_busy() {
     };
 
     let rendered = footer_summary_text(&app);
-    assert_eq!(rendered, "  tokens=111 in / 22 out");
+    assert_eq!(rendered, "tokens=111 in / 22 out");
     assert!(!rendered.contains("history="));
     assert!(!rendered.contains("local="));
     assert!(!rendered.contains("key="));

--- a/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
@@ -26,4 +26,4 @@ Warning  Warning: openai-compatible is missing an API key. Use /model to configu
 › Ask about the repo, request a code change, or type /help to browse commands.
 
 
-                                                                                              ctx~=0
+                                                                                              

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -894,7 +894,7 @@ fn command_palette_query_uses_full_width_without_leaking_bottom_status() {
 
     let rendered = render_screen_text(&app, 107, 53);
     assert!(rendered.contains("/model"));
-    assert!(!rendered.contains("ctx~=0"));
+    assert!(!rendered.contains("ctx~="));
     assert!(!rendered.contains("enter run  esc close"));
 }
 


### PR DESCRIPTION
The `/context` command already provides full runtime context details, so the footer no longer needs to repeat `ctx~=` information.

## Changes
- Removed context token display from footer summary text
- Updated 3 tests to no longer expect `ctx~=` in footer
- Updated SSH startup warning screen snapshot
- Strengthened command palette test assertion to check no `ctx~=` at all