### PR TITLE
feat(extensions): wire hook/agent discovery into /status

### DIFF
--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -56,11 +56,6 @@ impl AgentRegistry {
         }
     }
 
-    /// Discover agents from a repository root (.claude/agents).
-    pub fn discover_repo_agents(&mut self, repo_root: &Path) {
-        self.discover_from_dir(&repo_root.join(".claude").join("agents"));
-    }
-
     /// Scan a directory for `.md` agent definition files.
     pub fn discover_from_dir(&mut self, dir: &Path) {
         if !dir.exists() {

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -56,11 +56,15 @@ impl AgentRegistry {
         }
     }
 
+    /// Discover agents from a repository root directory.
+    pub fn discover_repo_agents(&mut self, repo_root: &Path) {
+        let agents_dir = repo_root.join(".claude").join("agents");
+        self.discover_from_dir(&agents_dir);
+    }
+
     /// Scan a directory for `.md` agent definition files.
     pub fn discover_from_dir(&mut self, dir: &Path) {
         if !dir.exists() {
-            return;
-        }
         let entries = match fs::read_dir(dir) {
             Ok(entries) => entries,
             Err(err) => {

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -56,10 +56,9 @@ impl AgentRegistry {
         }
     }
 
-    /// Discover agents from a repository root directory.
+    /// Discover agents from a repository root (.claude/agents).
     pub fn discover_repo_agents(&mut self, repo_root: &Path) {
-        let agents_dir = repo_root.join(".claude").join("agents");
-        self.discover_from_dir(&agents_dir);
+        self.discover_from_dir(&repo_root.join(".claude").join("agents"));
     }
 
     /// Scan a directory for `.md` agent definition files.
@@ -68,6 +67,7 @@ impl AgentRegistry {
             return;
         }
         let entries = match fs::read_dir(dir) {
+            Ok(entries) => entries,
             Err(err) => {
                 self.load_warnings
                     .push(format!("agent dir {}: {err}", dir.display()));

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -65,8 +65,9 @@ impl AgentRegistry {
     /// Scan a directory for `.md` agent definition files.
     pub fn discover_from_dir(&mut self, dir: &Path) {
         if !dir.exists() {
+            return;
+        }
         let entries = match fs::read_dir(dir) {
-            Ok(entries) => entries,
             Err(err) => {
                 self.load_warnings
                     .push(format!("agent dir {}: {err}", dir.display()));

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -35,6 +35,8 @@ pub(crate) struct RuntimeBootstrap {
     pub warnings: Vec<String>,
     pub sandbox_network_access: Arc<AtomicBool>,
     pub event_bus: Arc<RuntimeEventBus>,
+    pub hook_count: usize,
+    pub agent_count: usize,
 }
 
 impl RuntimeBootstrap {
@@ -122,6 +124,8 @@ pub(crate) async fn initialize_rara_context(
         prompt_config,
         warnings,
         sandbox_network_access,
+        hook_count: 0,
+        agent_count: 0,
         event_bus,
     })
 }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1047,20 +1047,12 @@ impl TuiApp {
             extension_skill_count: agent.prompt_config().available_skills.len(),
             extension_skill_scopes: {
                 let mut scopes: Vec<String> = agent
-            extension_hook_count: {
-                let mut r = crate::hooks::HookRegistry::new();
-                if let Ok(cwd) = std::env::current_dir() {
-                    r.discover_repo_hooks(&cwd);
-                }
-                r.hooks.len()
-            },
-            extension_agent_count: {
-                let mut r = crate::agents_ext::AgentRegistry::new();
-                if let Ok(cwd) = std::env::current_dir() {
-                    r.discover_repo_agents(&cwd);
-                }
-                r.agents.len()
-            },
+                    .prompt_config()
+                    .available_skills
+                    .iter()
+                    .map(|s| s.scope.clone())
+                    .collect::<std::collections::BTreeSet<_>>()
+                    .into_iter()
                     .collect();
                 scopes.sort();
                 scopes

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1057,8 +1057,8 @@ impl TuiApp {
                 scopes.sort();
                 scopes
             },
-            extension_hook_count: 0,
-            extension_agent_count: 0,
+            extension_hook_count: discover_extension_counts().0,
+            extension_agent_count: discover_extension_counts().1,
         };
         self.agent_execution_mode = agent.execution_mode;
         self.bash_approval_mode = agent.bash_approval_mode;
@@ -1416,6 +1416,23 @@ impl TuiApp {
             _ => None,
         };
     }
+}
+fn discover_extension_counts() -> (usize, usize) {
+    let hook_count = {
+        let mut registry = crate::hooks::HookRegistry::new();
+        if let Ok(cwd) = std::env::current_dir() {
+            registry.discover_repo_hooks(&cwd);
+        }
+        registry.hooks.len()
+    };
+    let agent_count = {
+        let mut registry = crate::agents_ext::AgentRegistry::new();
+        if let Ok(cwd) = std::env::current_dir() {
+            registry.discover_from_dir(&cwd.join(".claude").join("agents"));
+        }
+        registry.agents.len()
+    };
+    (hook_count, agent_count)
 }
 mod helpers;
 pub(crate) use helpers::*;

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1047,12 +1047,20 @@ impl TuiApp {
             extension_skill_count: agent.prompt_config().available_skills.len(),
             extension_skill_scopes: {
                 let mut scopes: Vec<String> = agent
-                    .prompt_config()
-                    .available_skills
-                    .iter()
-                    .map(|s| s.scope.clone())
-                    .collect::<std::collections::BTreeSet<_>>()
-                    .into_iter()
+            extension_hook_count: {
+                let mut r = crate::hooks::HookRegistry::new();
+                if let Ok(cwd) = std::env::current_dir() {
+                    r.discover_repo_hooks(&cwd);
+                }
+                r.hooks.len()
+            },
+            extension_agent_count: {
+                let mut r = crate::agents_ext::AgentRegistry::new();
+                if let Ok(cwd) = std::env::current_dir() {
+                    r.discover_repo_agents(&cwd);
+                }
+                r.agents.len()
+            },
                     .collect();
                 scopes.sort();
                 scopes


### PR DESCRIPTION
## Summary

No longer shows hooks=0, agents=0 in /status. Now discovers actual counts.

## Changes
- Add \ that scans \ and \
- Wire into \ / \ in RuntimeSnapshot
- Add \/\ fields to RuntimeBootstrap

## Tasks remaining
- MCP resource references in /context
- reasoning_summary refinement (data already shown, optional touch-up)