### PR TITLE
feat(tui): implement ralph loop autonomous goal system

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -150,6 +150,7 @@ pub struct Agent {
     pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
     inspection_progress: InspectionProgress,
     last_query_plan_updated: bool,
+    last_turn_had_tool_calls: bool,
     pending_plan_exit_tool_id: Option<String>,
     prompt_config: PromptRuntimeConfig,
     cancellation_token: Option<Arc<AtomicBool>>,
@@ -195,6 +196,7 @@ impl Agent {
             retrieved_memory_candidates: Vec::new(),
             inspection_progress: InspectionProgress::default(),
             last_query_plan_updated: false,
+            last_turn_had_tool_calls: false,
             pending_plan_exit_tool_id: None,
             prompt_config: PromptRuntimeConfig::default(),
             cancellation_token: None,
@@ -500,6 +502,7 @@ impl Agent {
             self.ensure_active_plan_step();
             let mut turn_output = self.run_model_turn(output_mode, report).await?;
             self.last_query_plan_updated = turn_output.plan_updated;
+            self.last_turn_had_tool_calls = !turn_output.tool_calls.is_empty();
             if turn_output
                 .tool_calls
                 .iter()

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -142,6 +142,10 @@ impl Agent {
         self.last_query_plan_updated
     }
 
+    pub fn last_turn_had_tool_calls(&self) -> bool {
+        self.last_turn_had_tool_calls
+    }
+
     pub fn has_pending_plan_exit_approval(&self) -> bool {
         self.pending_plan_exit_tool_id.is_some()
     }

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -169,9 +169,10 @@ async fn run_tui_command(
     emit_bootstrap_warnings(&bootstrap.warnings);
     let sandbox_network_access = bootstrap.sandbox_network_access.clone();
     let event_bus = bootstrap.event_bus.clone();
-    let agent = bootstrap.into_agent();
+    let (agent, _warnings, _network, goal_handle) = bootstrap.into_parts();
     let resumed_thread_id = crate::tui::run_tui(
         agent,
+        goal_handle,
         oauth_manager,
         startup_resume,
         sandbox_network_access,

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -642,12 +642,12 @@ pub(crate) fn infer_openai_compatible_auxiliary_model(
 fn infer_deepseek_lite_model(model: &str) -> Option<Cow<'_, str>> {
     let trimmed = model.trim();
     let lower = trimmed.to_ascii_lowercase();
-    if !lower.contains("deepseek") || lower.contains("lite") {
+    if !lower.contains("deepseek") || lower.contains("flash") {
         return None;
     }
     if lower.contains("v4") && lower.ends_with("-pro") {
         let prefix = &trimmed[..trimmed.len().saturating_sub("-pro".len())];
-        return Some(Cow::Owned(format!("{prefix}-lite")));
+        return Some(Cow::Owned(format!("{prefix}-flash")));
     }
     None
 }

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -492,19 +492,19 @@ fn deepseek_reasoner_defaults_preserve_standard_body() {
 }
 
 #[test]
-fn deepseek_v4_pro_infers_lite_auxiliary_model() {
+fn deepseek_v4_pro_infers_flash_auxiliary_model() {
     assert_eq!(
         infer_openai_compatible_auxiliary_model("deepseek-v4-pro", OpenAiEndpointKind::Deepseek)
             .as_deref(),
-        Some("deepseek-v4-lite")
+        Some("deepseek-v4-flash")
     );
     assert_eq!(
         infer_openai_compatible_auxiliary_model("DeepSeek-V4-PRO", OpenAiEndpointKind::Deepseek)
             .as_deref(),
-        Some("DeepSeek-V4-lite")
+        Some("DeepSeek-V4-flash")
     );
     assert_eq!(
-        infer_openai_compatible_auxiliary_model("deepseek-v4-lite", OpenAiEndpointKind::Deepseek),
+        infer_openai_compatible_auxiliary_model("deepseek-v4-flash", OpenAiEndpointKind::Deepseek),
         None
     );
     assert_eq!(

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -4,8 +4,6 @@ use std::sync::{Arc, atomic::AtomicBool};
 
 use anyhow::{Context, Result, bail};
 
-use crate::tui::state::GoalHandle;
-
 use self::tooling::{create_full_tool_manager, load_skill_manager, vector_db_uri_for_workspace};
 use crate::agent::Agent;
 use crate::config::{
@@ -24,6 +22,7 @@ use crate::session::SessionManager;
 use crate::shell_env::capture_shell_environment_snapshot;
 use crate::skill::SkillScope;
 use crate::tool::ToolManager;
+use crate::tui::state::GoalHandle;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
 
@@ -55,7 +54,12 @@ impl RuntimeBootstrap {
             self.workspace,
         );
         agent.set_prompt_config(self.prompt_config);
-        (agent, self.warnings, self.sandbox_network_access, self.goal_handle)
+        (
+            agent,
+            self.warnings,
+            self.sandbox_network_access,
+            self.goal_handle,
+        )
     }
 }
 

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -4,6 +4,8 @@ use std::sync::{Arc, atomic::AtomicBool};
 
 use anyhow::{Context, Result, bail};
 
+use crate::tui::state::GoalHandle;
+
 use self::tooling::{create_full_tool_manager, load_skill_manager, vector_db_uri_for_workspace};
 use crate::agent::Agent;
 use crate::config::{
@@ -35,15 +37,16 @@ pub(crate) struct RuntimeBootstrap {
     pub warnings: Vec<String>,
     pub sandbox_network_access: Arc<AtomicBool>,
     pub event_bus: Arc<RuntimeEventBus>,
+    pub goal_handle: GoalHandle,
 }
 
 impl RuntimeBootstrap {
     pub(crate) fn into_agent(self) -> Agent {
-        let (agent, _, _) = self.into_parts();
+        let (agent, _, _, _) = self.into_parts();
         agent
     }
 
-    pub(crate) fn into_parts(self) -> (Agent, Vec<String>, Arc<AtomicBool>) {
+    pub(crate) fn into_parts(self) -> (Agent, Vec<String>, Arc<AtomicBool>, GoalHandle) {
         let mut agent = Agent::new(
             self.tool_manager,
             self.backend,
@@ -52,7 +55,7 @@ impl RuntimeBootstrap {
             self.workspace,
         );
         agent.set_prompt_config(self.prompt_config);
-        (agent, self.warnings, self.sandbox_network_access)
+        (agent, self.warnings, self.sandbox_network_access, self.goal_handle)
     }
 }
 
@@ -99,17 +102,19 @@ pub(crate) async fn initialize_rara_context(
     ));
 
     let event_bus = Arc::new(RuntimeEventBus::new(256));
+    let goal_handle: GoalHandle = Arc::new(std::sync::RwLock::new(None));
 
     let tool_manager = create_full_tool_manager(
         backend.clone(),
         vdb.clone(),
         session_manager.clone(),
         workspace.clone(),
-        sandbox_manager,
+        sandbox_manager.clone(),
         skill_manager,
         prompt_config.clone(),
         Arc::new(shell_env.env),
         sandbox_network_access.clone(),
+        goal_handle.clone(),
     );
     let warnings = prompt_config.warnings.clone();
 
@@ -123,6 +128,7 @@ pub(crate) async fn initialize_rara_context(
         warnings,
         sandbox_network_access,
         event_bus,
+        goal_handle,
     })
 }
 

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -1,4 +1,3 @@
-use crate::tui::state::GoalHandle;
 use std::collections::HashMap;
 use std::sync::{Arc, atomic::AtomicBool};
 
@@ -17,6 +16,7 @@ use crate::tools::context::RetrieveSessionContextTool;
 use crate::tools::file::{
     FileReadState, ListFilesTool, ReadFileTool, ReplaceLinesTool, ReplaceTool, WriteFileTool,
 };
+use crate::tools::goal::{CreateGoalTool, GetGoalTool, UpdateGoalTool};
 use crate::tools::patch::ApplyPatchTool;
 use crate::tools::planning::{EnterPlanModeTool, ExitPlanModeTool};
 use crate::tools::pty::{
@@ -28,8 +28,8 @@ use crate::tools::skill::SkillTool;
 use crate::tools::todo::TodoWriteTool;
 use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
 use crate::tools::web::{WebFetchTool, WebSearchTool};
-use crate::tools::goal::{CreateGoalTool, GetGoalTool, UpdateGoalTool};
 use crate::tools::workspace::UpdateProjectMemoryTool;
+use crate::tui::state::GoalHandle;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
 
@@ -154,8 +154,12 @@ pub(super) fn create_full_tool_manager(
         session_manager,
         workspace,
     }));
-    tm.register(Box::new(GetGoalTool { store: goal_handle.clone() }));
-    tm.register(Box::new(CreateGoalTool { store: goal_handle.clone() }));
+    tm.register(Box::new(GetGoalTool {
+        store: goal_handle.clone(),
+    }));
+    tm.register(Box::new(CreateGoalTool {
+        store: goal_handle.clone(),
+    }));
     tm.register(Box::new(UpdateGoalTool { store: goal_handle }));
     tm
 }

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -1,3 +1,4 @@
+use crate::tui::state::GoalHandle;
 use std::collections::HashMap;
 use std::sync::{Arc, atomic::AtomicBool};
 
@@ -27,6 +28,7 @@ use crate::tools::skill::SkillTool;
 use crate::tools::todo::TodoWriteTool;
 use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
 use crate::tools::web::{WebFetchTool, WebSearchTool};
+use crate::tools::goal::{CreateGoalTool, GetGoalTool, UpdateGoalTool};
 use crate::tools::workspace::UpdateProjectMemoryTool;
 use crate::vectordb::VectorDB;
 use crate::workspace::WorkspaceMemory;
@@ -41,6 +43,7 @@ pub(super) fn create_full_tool_manager(
     prompt_config: PromptRuntimeConfig,
     shell_env: Arc<HashMap<String, String>>,
     sandbox_network_access: Arc<AtomicBool>,
+    goal_handle: GoalHandle,
 ) -> ToolManager {
     let mut tm = ToolManager::new();
     let vector_db_uri = vector_db_uri_for_workspace(&workspace);
@@ -151,6 +154,9 @@ pub(super) fn create_full_tool_manager(
         session_manager,
         workspace,
     }));
+    tm.register(Box::new(GetGoalTool { store: goal_handle.clone() }));
+    tm.register(Box::new(CreateGoalTool { store: goal_handle.clone() }));
+    tm.register(Box::new(UpdateGoalTool { store: goal_handle }));
     tm
 }
 

--- a/src/tools/goal.rs
+++ b/src/tools/goal.rs
@@ -171,9 +171,10 @@ impl Tool for UpdateGoalTool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::tool::Tool;
-    use std::sync::Arc;
 
     fn goal_handle() -> GoalHandle {
         Arc::new(std::sync::RwLock::new(None))
@@ -182,7 +183,13 @@ mod tests {
     #[test]
     fn goal_tools_expose_correct_names() {
         let store = goal_handle();
-        assert_eq!(GetGoalTool { store: store.clone() }.name(), GET_GOAL_TOOL_NAME);
+        assert_eq!(
+            GetGoalTool {
+                store: store.clone()
+            }
+            .name(),
+            GET_GOAL_TOOL_NAME
+        );
         assert_eq!(
             CreateGoalTool {
                 store: store.clone()

--- a/src/tools/goal.rs
+++ b/src/tools/goal.rs
@@ -88,7 +88,20 @@ impl Tool for CreateGoalTool {
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("objective must be a string".into()))?
             .to_string();
-        let token_budget = input["token_budget"].as_u64().map(|v| v as u32);
+        if objective.trim().is_empty() {
+            return Err(ToolError::InvalidInput(
+                "objective must not be empty".into(),
+            ));
+        }
+        let token_budget = match input["token_budget"].as_u64() {
+            None => None,
+            Some(v) if v > u32::MAX as u64 => {
+                return Err(ToolError::InvalidInput(format!(
+                    "token_budget {v} exceeds maximum u32 value"
+                )));
+            }
+            Some(v) => Some(v as u32),
+        };
 
         let goal = RalphGoal {
             objective: objective.clone(),
@@ -180,45 +193,152 @@ mod tests {
         Arc::new(std::sync::RwLock::new(None))
     }
 
-    #[test]
-    fn goal_tools_expose_correct_names() {
-        let store = goal_handle();
-        assert_eq!(
-            GetGoalTool {
-                store: store.clone()
-            }
-            .name(),
-            GET_GOAL_TOOL_NAME
-        );
-        assert_eq!(
-            CreateGoalTool {
-                store: store.clone()
-            }
-            .name(),
-            CREATE_GOAL_TOOL_NAME
-        );
-        assert_eq!(
-            UpdateGoalTool {
-                store: store.clone()
-            }
-            .name(),
-            UPDATE_GOAL_TOOL_NAME
-        );
+    fn block<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+            .block_on(f)
     }
 
     #[test]
-    fn create_goal_schema_requires_objective() {
+    fn create_and_read_goal_roundtrip() {
         let store = goal_handle();
-        let tool = CreateGoalTool { store };
-        let schema = tool.input_schema();
-        assert_eq!(schema["required"][0], "objective");
+        let create = CreateGoalTool {
+            store: store.clone(),
+        };
+        let get = GetGoalTool {
+            store: store.clone(),
+        };
+
+        let result =
+            block(create.call(serde_json::json!({"objective": "Fix the build", "token_budget": 50000})))
+                .unwrap();
+        assert_eq!(result["objective"], "Fix the build");
+        assert_eq!(result["status"], "pursuing");
+        assert_eq!(result["token_budget"], 50000);
+        assert_eq!(result["turns_completed"], 0);
+
+        let state = block(get.call(serde_json::json!({}))).unwrap();
+        assert_eq!(state["objective"], "Fix the build");
+        assert_eq!(state["status"], "pursuing");
+        assert_eq!(state["token_budget"], 50000);
+        assert_eq!(state["tokens_used"], 0);
     }
 
     #[test]
-    fn update_goal_schema_requires_status() {
+    fn create_goal_fails_when_goal_exists() {
         let store = goal_handle();
-        let tool = UpdateGoalTool { store };
-        let schema = tool.input_schema();
-        assert_eq!(schema["required"][0], "status");
+        *store.write().unwrap() = Some(RalphGoal {
+            objective: "existing".into(),
+            status: GoalStatus::Pursuing,
+            token_budget: None,
+            tokens_used: 0,
+            turns_completed: 0,
+        });
+
+        let create = CreateGoalTool {
+            store: store.clone(),
+        };
+        let err = block(create.call(serde_json::json!({"objective": "new"}))).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn create_goal_rejects_empty_objective() {
+        let store = goal_handle();
+        let create = CreateGoalTool { store };
+        let err = block(create.call(serde_json::json!({"objective": ""}))).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn create_goal_rejects_whitespace_only_objective() {
+        let store = goal_handle();
+        let create = CreateGoalTool { store };
+        let err = block(create.call(serde_json::json!({"objective": "   "}))).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn create_goal_rejects_oversized_token_budget() {
+        let store = goal_handle();
+        let create = CreateGoalTool { store };
+        let err = block(create.call(serde_json::json!({"objective": "x", "token_budget": 5_000_000_000u64})))
+            .unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum u32 value"));
+    }
+
+    #[test]
+    fn update_goal_mark_achieved() {
+        let store = goal_handle();
+        *store.write().unwrap() = Some(RalphGoal {
+            objective: "test".into(),
+            status: GoalStatus::Pursuing,
+            token_budget: None,
+            tokens_used: 1000,
+            turns_completed: 3,
+        });
+
+        let update = UpdateGoalTool {
+            store: store.clone(),
+        };
+        let result = block(update.call(serde_json::json!({"status": "achieved"}))).unwrap();
+        assert_eq!(result["status"], "achieved");
+        assert_eq!(result["objective"], "test");
+        assert_eq!(result["tokens_used"], 1000);
+        assert_eq!(result["turns_completed"], 3);
+    }
+
+    #[test]
+    fn update_goal_mark_unmet() {
+        let store = goal_handle();
+        *store.write().unwrap() = Some(RalphGoal {
+            objective: "blocked task".into(),
+            status: GoalStatus::Pursuing,
+            token_budget: None,
+            tokens_used: 0,
+            turns_completed: 0,
+        });
+
+        let update = UpdateGoalTool { store };
+        let result = block(update.call(serde_json::json!({"status": "unmet"}))).unwrap();
+        assert_eq!(result["status"], "unmet");
+    }
+
+    #[test]
+    fn update_goal_rejects_invalid_status() {
+        let store = goal_handle();
+        *store.write().unwrap() = Some(RalphGoal {
+            objective: "test".into(),
+            status: GoalStatus::Pursuing,
+            token_budget: None,
+            tokens_used: 0,
+            turns_completed: 0,
+        });
+
+        let update = UpdateGoalTool { store };
+        let err =
+            block(update.call(serde_json::json!({"status": "pursuing"}))).unwrap_err();
+        assert!(err.to_string().contains("Invalid status"));
+    }
+
+    #[test]
+    fn update_goal_fails_without_existing_goal() {
+        let store = goal_handle();
+        let update = UpdateGoalTool { store };
+        let err =
+            block(update.call(serde_json::json!({"status": "achieved"}))).unwrap_err();
+        assert!(err.to_string().contains("No active goal"));
+    }
+
+    #[test]
+    fn get_goal_returns_nulls_when_empty() {
+        let store = goal_handle();
+        let get = GetGoalTool { store };
+        let result = block(get.call(serde_json::json!({}))).unwrap();
+        assert_eq!(result["objective"], serde_json::Value::Null);
+        assert_eq!(result["status"], serde_json::Value::Null);
+        assert_eq!(result["tokens_used"], 0);
     }
 }

--- a/src/tools/goal.rs
+++ b/src/tools/goal.rs
@@ -80,7 +80,7 @@ impl Tool for CreateGoalTool {
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         if self.store.read().unwrap().is_some() {
             return Err(ToolError::InvalidInput(
-                "A goal already exists. Use update_goal to modify it, or clear it first.".into(),
+                "A goal already exists. Use update_goal to mark it achieved or unmet, or clear it first to set a new one.".into(),
             ));
         }
 

--- a/src/tools/goal.rs
+++ b/src/tools/goal.rs
@@ -1,0 +1,217 @@
+use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
+use serde_json::{Value, json};
+
+use crate::tool::{Tool, ToolError};
+use crate::tui::state::{GoalHandle, GoalStatus, RalphGoal};
+
+pub const CREATE_GOAL_TOOL_NAME: &str = "create_goal";
+pub const GET_GOAL_TOOL_NAME: &str = "get_goal";
+pub const UPDATE_GOAL_TOOL_NAME: &str = "update_goal";
+
+pub struct GetGoalTool {
+    pub store: GoalHandle,
+}
+
+#[tool_spec(
+    name = GET_GOAL_TOOL_NAME,
+    description = "Retrieve the current active goal state (objective, status, budget, usage).",
+    input_schema = {
+        "type": "object",
+        "properties": {},
+    }
+)]
+#[async_trait]
+impl Tool for GetGoalTool {
+    async fn call(&self, _input: Value) -> Result<Value, ToolError> {
+        let guard = self.store.read().unwrap();
+        match guard.as_ref() {
+            None => Ok(json!({
+                "objective": null,
+                "status": null,
+                "token_budget": null,
+                "tokens_used": 0,
+                "turns_completed": 0,
+            })),
+            Some(g) => {
+                let status = match g.status {
+                    GoalStatus::Pursuing => "pursuing",
+                    GoalStatus::Paused => "paused",
+                    GoalStatus::Achieved => "achieved",
+                    GoalStatus::Unmet => "unmet",
+                    GoalStatus::BudgetLimited => "budget_limited",
+                };
+                Ok(json!({
+                    "objective": g.objective,
+                    "status": status,
+                    "token_budget": g.token_budget,
+                    "tokens_used": g.tokens_used,
+                    "turns_completed": g.turns_completed,
+                }))
+            }
+        }
+    }
+}
+
+pub struct CreateGoalTool {
+    pub store: GoalHandle,
+}
+
+#[tool_spec(
+    name = CREATE_GOAL_TOOL_NAME,
+    description = "Create a new goal only when no goal exists. Goals define a long-running objective the agent works toward across turns. Include an optional token_budget to limit total token consumption.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "objective": {
+                "type": "string",
+                "description": "The goal objective text. Keep it focused and actionable."
+            },
+            "token_budget": {
+                "type": "integer",
+                "description": "Optional maximum input tokens for this goal. Omit for unlimited."
+            }
+        },
+        "required": ["objective"]
+    }
+)]
+#[async_trait]
+impl Tool for CreateGoalTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        if self.store.read().unwrap().is_some() {
+            return Err(ToolError::InvalidInput(
+                "A goal already exists. Use update_goal to modify it, or clear it first.".into(),
+            ));
+        }
+
+        let objective = input["objective"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("objective must be a string".into()))?
+            .to_string();
+        let token_budget = input["token_budget"].as_u64().map(|v| v as u32);
+
+        let goal = RalphGoal {
+            objective: objective.clone(),
+            status: GoalStatus::Pursuing,
+            token_budget,
+            tokens_used: 0,
+            turns_completed: 0,
+        };
+        *self.store.write().unwrap() = Some(goal);
+
+        Ok(json!({
+            "objective": objective,
+            "status": "pursuing",
+            "token_budget": token_budget,
+            "tokens_used": 0,
+            "turns_completed": 0,
+        }))
+    }
+}
+
+pub struct UpdateGoalTool {
+    pub store: GoalHandle,
+}
+
+#[tool_spec(
+    name = UPDATE_GOAL_TOOL_NAME,
+    description = "Update the current goal status. Use this to mark a goal as achieved or unmet. Do not set pursuing/paused/budget_limited — those are managed by the runtime.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string",
+                "enum": ["achieved", "unmet"],
+                "description": "New goal status. Only achieved or unmet — the runtime owns the other states."
+            }
+        },
+        "required": ["status"]
+    }
+)]
+#[async_trait]
+impl Tool for UpdateGoalTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let new_status = input["status"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("status must be a string".into()))?;
+
+        let new_status = match new_status {
+            "achieved" => GoalStatus::Achieved,
+            "unmet" => GoalStatus::Unmet,
+            other => {
+                return Err(ToolError::InvalidInput(format!(
+                    "Invalid status '{other}'. The model may only set achieved or unmet. \
+                     Use the runtime to set pursuing, paused, or budget_limited."
+                )));
+            }
+        };
+
+        let mut guard = self.store.write().unwrap();
+        let goal = guard
+            .as_mut()
+            .ok_or_else(|| ToolError::InvalidInput("No active goal to update.".into()))?;
+
+        goal.status = new_status;
+
+        let status_str = match new_status {
+            GoalStatus::Achieved => "achieved",
+            GoalStatus::Unmet => "unmet",
+            _ => unreachable!(),
+        };
+
+        Ok(json!({
+            "objective": goal.objective,
+            "status": status_str,
+            "token_budget": goal.token_budget,
+            "tokens_used": goal.tokens_used,
+            "turns_completed": goal.turns_completed,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::Tool;
+    use std::sync::Arc;
+
+    fn goal_handle() -> GoalHandle {
+        Arc::new(std::sync::RwLock::new(None))
+    }
+
+    #[test]
+    fn goal_tools_expose_correct_names() {
+        let store = goal_handle();
+        assert_eq!(GetGoalTool { store: store.clone() }.name(), GET_GOAL_TOOL_NAME);
+        assert_eq!(
+            CreateGoalTool {
+                store: store.clone()
+            }
+            .name(),
+            CREATE_GOAL_TOOL_NAME
+        );
+        assert_eq!(
+            UpdateGoalTool {
+                store: store.clone()
+            }
+            .name(),
+            UPDATE_GOAL_TOOL_NAME
+        );
+    }
+
+    #[test]
+    fn create_goal_schema_requires_objective() {
+        let store = goal_handle();
+        let tool = CreateGoalTool { store };
+        let schema = tool.input_schema();
+        assert_eq!(schema["required"][0], "objective");
+    }
+
+    #[test]
+    fn update_goal_schema_requires_status() {
+        let store = goal_handle();
+        let tool = UpdateGoalTool { store };
+        let schema = tool.input_schema();
+        assert_eq!(schema["required"][0], "status");
+    }
+}

--- a/src/tools/goal.rs
+++ b/src/tools/goal.rs
@@ -211,9 +211,10 @@ mod tests {
             store: store.clone(),
         };
 
-        let result =
-            block(create.call(serde_json::json!({"objective": "Fix the build", "token_budget": 50000})))
-                .unwrap();
+        let result = block(
+            create.call(serde_json::json!({"objective": "Fix the build", "token_budget": 50000})),
+        )
+        .unwrap();
         assert_eq!(result["objective"], "Fix the build");
         assert_eq!(result["status"], "pursuing");
         assert_eq!(result["token_budget"], 50000);
@@ -264,8 +265,10 @@ mod tests {
     fn create_goal_rejects_oversized_token_budget() {
         let store = goal_handle();
         let create = CreateGoalTool { store };
-        let err = block(create.call(serde_json::json!({"objective": "x", "token_budget": 5_000_000_000u64})))
-            .unwrap_err();
+        let err = block(
+            create.call(serde_json::json!({"objective": "x", "token_budget": 5_000_000_000u64})),
+        )
+        .unwrap_err();
         assert!(err.to_string().contains("exceeds maximum u32 value"));
     }
 
@@ -318,8 +321,7 @@ mod tests {
         });
 
         let update = UpdateGoalTool { store };
-        let err =
-            block(update.call(serde_json::json!({"status": "pursuing"}))).unwrap_err();
+        let err = block(update.call(serde_json::json!({"status": "pursuing"}))).unwrap_err();
         assert!(err.to_string().contains("Invalid status"));
     }
 
@@ -327,8 +329,7 @@ mod tests {
     fn update_goal_fails_without_existing_goal() {
         let store = goal_handle();
         let update = UpdateGoalTool { store };
-        let err =
-            block(update.call(serde_json::json!({"status": "achieved"}))).unwrap_err();
+        let err = block(update.call(serde_json::json!({"status": "achieved"}))).unwrap_err();
         assert!(err.to_string().contains("No active goal"));
     }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -2,6 +2,7 @@ pub mod agent;
 pub mod bash;
 pub mod context;
 pub mod file;
+pub mod goal;
 pub mod patch;
 pub mod planning;
 pub mod pty;

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -1,6 +1,6 @@
 use crate::tui::state::{CommandSpec, LocalCommand, LocalCommandKind, TuiApp};
 
-pub const COMMAND_SPECS: [CommandSpec; 22] = [
+pub const COMMAND_SPECS: [CommandSpec; 23] = [
     CommandSpec {
         category: "Session",
         name: "permissions",
@@ -155,6 +155,13 @@ pub const COMMAND_SPECS: [CommandSpec; 22] = [
         summary: "View and toggle loaded skills.",
         detail: "Open a skills picker that shows all loaded skills grouped by scope. Use space to toggle enable/disable. Changes take effect on next turn context assembly.",
     },
+    CommandSpec {
+        category: "Session",
+        name: "goal",
+        usage: "/goal [<objective> | pause | resume | clear]",
+        summary: "Set a long-running goal for autonomous cross-turn work.",
+        detail: "Set a persistent objective that the agent keeps working toward across turns.\n\n/goal <objective>     start a new goal\n/goal <N> <objective>  start with a token budget\n/goal                  show current goal status\n/goal pause            pause an active goal\n/goal resume           resume a paused goal\n/goal clear            clear the current goal",
+    },
 ];
 
 pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
@@ -186,6 +193,7 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
         "mcp" => LocalCommandKind::Mcp,
         "skills" => LocalCommandKind::Skills,
         "permissions" | "permission" => LocalCommandKind::Permissions,
+        "goal" => LocalCommandKind::Goal,
         _ => return None,
     };
 

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -158,9 +158,9 @@ pub const COMMAND_SPECS: [CommandSpec; 23] = [
     CommandSpec {
         category: "Session",
         name: "goal",
-        usage: "/goal [<objective> | pause | resume | clear]",
+        usage: "/goal [<N> <objective> | <objective> | pause | resume | clear]",
         summary: "Set a long-running goal for autonomous cross-turn work.",
-        detail: "Set a persistent objective that the agent keeps working toward across turns.\n\n/goal <objective>     start a new goal\n/goal <N> <objective>  start with a token budget\n/goal                  show current goal status\n/goal pause            pause an active goal\n/goal resume           resume a paused goal\n/goal clear            clear the current goal",
+        detail: "Set a persistent objective that the agent keeps working toward across turns.\n\n/goal                  show current goal status\n/goal <N> <objective>  start goal with token budget N\n/goal <objective>      start goal with no budget\n/goal pause            pause an active goal\n/goal resume           resume a paused goal\n/goal clear            clear the current goal",
     },
 ];
 

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -705,8 +705,12 @@ fn goal_command_spec_is_registered() {
         .iter()
         .find(|s| s.name == "goal")
         .expect("goal should be in COMMAND_SPECS");
-    assert_eq!(spec.usage, "/goal [<objective> | pause | resume | clear]");
+    assert_eq!(
+        spec.usage,
+        "/goal [<N> <objective> | <objective> | pause | resume | clear]"
+    );
     assert!(spec.summary.contains("goal"));
+    assert!(spec.detail.contains("/goal <N>"));
     assert!(spec.detail.contains("/goal <objective>"));
     assert!(spec.detail.contains("/goal pause"));
     assert!(spec.detail.contains("/goal resume"));

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -677,3 +677,49 @@ fn skills_picker_render_shows_entries() {
     assert!(app.skill_picker_entries[1].disable_model_invocation);
     assert!(app.skill_picker_entries[0].enabled);
 }
+
+#[test]
+fn parses_goal_command_with_objective() {
+    let command = parse_local_command("/goal fix the build").expect("/goal should parse");
+    assert!(matches!(command.kind, LocalCommandKind::Goal));
+    assert_eq!(command.arg.as_deref(), Some("fix the build"));
+}
+
+#[test]
+fn parses_goal_command_with_subcommand() {
+    let command = parse_local_command("/goal pause").expect("/goal should parse");
+    assert!(matches!(command.kind, LocalCommandKind::Goal));
+    assert_eq!(command.arg.as_deref(), Some("pause"));
+}
+
+#[test]
+fn parses_goal_bare_command_without_argument() {
+    let command = parse_local_command("/goal").expect("/goal should parse");
+    assert!(matches!(command.kind, LocalCommandKind::Goal));
+    assert!(command.arg.is_none());
+}
+
+#[test]
+fn goal_command_spec_is_registered() {
+    let spec = COMMAND_SPECS
+        .iter()
+        .find(|s| s.name == "goal")
+        .expect("goal should be in COMMAND_SPECS");
+    assert_eq!(spec.usage, "/goal [<objective> | pause | resume | clear]");
+    assert!(spec.summary.contains("goal"));
+    assert!(spec.detail.contains("/goal <objective>"));
+    assert!(spec.detail.contains("/goal pause"));
+    assert!(spec.detail.contains("/goal resume"));
+    assert!(spec.detail.contains("/goal clear"));
+}
+
+#[test]
+fn goal_appears_in_palette_commands() {
+    let temp = tempdir().expect("tempdir");
+    let app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build app");
+    let results = palette_commands(&app, "goal");
+    assert!(results.iter().any(|s| s.name == "goal"));
+}

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -10,9 +10,9 @@ use super::event_stream::{UiEvent, translate_event};
 use super::render::{desired_viewport_height, render};
 use super::runtime::finish_running_task_if_ready;
 use super::session_restore::{restore_latest_thread, restore_thread_by_id};
+use super::state::GoalHandle;
 use super::state::Overlay;
 use super::state::TuiApp;
-use super::state::GoalHandle;
 use super::submit::clamp_command_palette_selection;
 use super::terminal_ui::{
     build_terminal, flush_committed_history, handle_paste, teardown_terminal,

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -12,6 +12,7 @@ use super::runtime::finish_running_task_if_ready;
 use super::session_restore::{restore_latest_thread, restore_thread_by_id};
 use super::state::Overlay;
 use super::state::TuiApp;
+use super::state::GoalHandle;
 use super::submit::clamp_command_palette_selection;
 use super::terminal_ui::{
     build_terminal, flush_committed_history, handle_paste, teardown_terminal,
@@ -32,6 +33,7 @@ pub enum StartupResumeTarget {
 
 pub async fn run_tui(
     agent: Agent,
+    goal_handle: GoalHandle,
     oauth_manager: OAuthManager,
     startup_resume: StartupResumeTarget,
     sandbox_network_access: Arc<AtomicBool>,
@@ -40,6 +42,8 @@ pub async fn run_tui(
     enable_raw_mode()?;
     let initial_size = terminal_size()?;
     let mut app = TuiApp::new(crate::config::ConfigManager::new()?)?;
+    app.goal_handle = goal_handle;
+    app.goal = app.goal_handle.read().unwrap().clone();
     app.sandbox_network_access = sandbox_network_access;
     app.event_bus = Some(event_bus);
     // Sync the AtomicBool to match the default Auto preset (network off).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -24,7 +24,7 @@ mod queued_input;
 mod render;
 mod runtime;
 mod session_restore;
-mod state;
+pub(crate) mod state;
 mod status_display;
 mod sub_agent_display;
 mod submit;

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -90,7 +90,7 @@ fn render_activity_bar(f: &mut Frame, app: &TuiApp, area: Rect) {
             GoalStatus::Pursuing => ("pursuing", STATUS_INFO),
             GoalStatus::Paused => ("paused", STATUS_WARNING),
             GoalStatus::Achieved => ("done", STATUS_SUCCESS),
-            GoalStatus::Unmet => ("unmet", Color::Red),
+            GoalStatus::Unmet => ("unmet", STATUS_ERROR),
             GoalStatus::BudgetLimited => ("budget", STATUS_WARNING),
         };
         spans.push(badge("goal", goal_label, goal_color));

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -10,7 +10,7 @@ use super::super::custom_terminal::Frame;
 use super::super::interaction_text::pending_interaction_hint_text;
 use super::super::queued_input::{pending_follow_up_hint, queued_follow_up_hint};
 use super::super::state::char_offset_to_byte_index;
-use super::super::state::{ActivePendingInteractionKind, TaskKind, TuiApp};
+use super::super::state::{ActivePendingInteractionKind, GoalStatus, TaskKind, TuiApp};
 use super::badge;
 use crate::tui::format::cache_hit_rate_label;
 use crate::tui::theme::*;
@@ -83,6 +83,32 @@ fn render_activity_bar(f: &mut Frame, app: &TuiApp, area: Rect) {
     if app.permission_mode_label() != "auto" {
         spans.push(Span::raw("  "));
         spans.push(badge("perm", app.permission_mode_label(), STATUS_INFO));
+    }
+    if let Some(goal) = app.goal.as_ref() {
+        spans.push(Span::raw("  "));
+        let (goal_label, goal_color) = match goal.status {
+            GoalStatus::Pursuing => ("pursuing", STATUS_INFO),
+            GoalStatus::Paused => ("paused", STATUS_WARNING),
+            GoalStatus::Achieved => ("done", STATUS_SUCCESS),
+            GoalStatus::Unmet => ("unmet", Color::Red),
+            GoalStatus::BudgetLimited => ("budget", STATUS_WARNING),
+        };
+        spans.push(badge("goal", goal_label, goal_color));
+        let goal_detail = if let Some(budget) = goal.token_budget {
+            format!(
+                "t{}/{} · {}tk",
+                goal.turns_completed,
+                goal.tokens_used,
+                budget
+            )
+        } else {
+            format!("t{} · {}tk", goal.turns_completed, goal.tokens_used)
+        };
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            goal_detail,
+            Style::default().fg(TEXT_MUTED),
+        ));
     }
     if !detail.is_empty() {
         spans.push(Span::raw("  "));

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -97,18 +97,13 @@ fn render_activity_bar(f: &mut Frame, app: &TuiApp, area: Rect) {
         let goal_detail = if let Some(budget) = goal.token_budget {
             format!(
                 "t{}/{} · {}tk",
-                goal.turns_completed,
-                goal.tokens_used,
-                budget
+                goal.turns_completed, goal.tokens_used, budget
             )
         } else {
             format!("t{} · {}tk", goal.turns_completed, goal.tokens_used)
         };
         spans.push(Span::raw(" "));
-        spans.push(Span::styled(
-            goal_detail,
-            Style::default().fg(TEXT_MUTED),
-        ));
+        spans.push(Span::styled(goal_detail, Style::default().fg(TEXT_MUTED)));
     }
     if !detail.is_empty() {
         spans.push(Span::raw("  "));

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -355,32 +355,31 @@ fn bottom_pane_style() -> Style {
 }
 
 fn footer_summary_text(app: &TuiApp) -> String {
-    let prefix = app
-        .repo_context_hint()
-        .unwrap_or_default();
+    let mut parts: Vec<String> = Vec::new();
 
-    let cache_summary = cache_hit_rate_label(
+    if let Some(hint) = app.repo_context_hint() {
+        parts.push(hint);
+    }
+
+    if shows_live_task_stats(app) {
+        parts.push(format!(
+            "tokens={} in / {} out",
+            app.snapshot.total_input_tokens, app.snapshot.total_output_tokens,
+        ));
+    }
+
+    if let Some(rate) = cache_hit_rate_label(
         app.snapshot.total_cache_hit_tokens,
         app.snapshot.total_cache_miss_tokens,
-    )
-    .map(|rate| format!("  cache_hit={rate}"))
-    .unwrap_or_default();
-    if shows_live_task_stats(app) {
-        format!(
-            "{}  tokens={} in / {} out{}",
-            prefix,
-            app.snapshot.total_input_tokens,
-            app.snapshot.total_output_tokens,
-            cache_summary
-        )
-    } else if app.snapshot.compaction_count > 0 {
-        format!(
-            "{}  compactions={}{}",
-            prefix, app.snapshot.compaction_count, cache_summary
-        )
-    } else {
-        format!("{prefix}{cache_summary}")
+    ) {
+        parts.push(format!("cache_hit={rate}"));
     }
+
+    if !shows_live_task_stats(app) && app.snapshot.compaction_count > 0 {
+        parts.push(format!("compactions={}", app.snapshot.compaction_count));
+    }
+
+    parts.join("  ")
 }
 
 fn shows_live_task_stats(app: &TuiApp) -> bool {

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -96,7 +96,7 @@ fn render_activity_bar(f: &mut Frame, app: &TuiApp, area: Rect) {
         spans.push(badge("goal", goal_label, goal_color));
         let goal_detail = if let Some(budget) = goal.token_budget {
             format!(
-                "t{}/{} · {}tk",
+                "t{} · {}/{}tk",
                 goal.turns_completed, goal.tokens_used, budget
             )
         } else {

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -355,17 +355,9 @@ fn bottom_pane_style() -> Style {
 }
 
 fn footer_summary_text(app: &TuiApp) -> String {
-    let context = match app.snapshot.context_window_tokens {
-        Some(window) => format!("ctx~={}/{}", app.snapshot.estimated_history_tokens, window),
-        None => format!("ctx~={}", app.snapshot.estimated_history_tokens),
-    };
-
-    let repo_part = app
+    let prefix = app
         .repo_context_hint()
-        .map(|hint| format!("{hint}  "))
         .unwrap_or_default();
-
-    let prefix = format!("{repo_part}{context}");
 
     let cache_summary = cache_hit_rate_label(
         app.snapshot.total_cache_hit_tokens,

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -15,7 +15,7 @@ use crate::tui::state::{
 };
 
 #[test]
-fn footer_summary_text_prefers_minimal_idle_context() {
+fn footer_summary_text_is_empty_when_idle_and_no_repo_context() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -28,7 +28,7 @@ fn footer_summary_text_prefers_minimal_idle_context() {
     };
 
     let rendered = footer_summary_text(&app);
-    assert_eq!(rendered, "ctx~=1234/32768");
+    assert_eq!(rendered, "");
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn footer_summary_text_shows_tokens_only_while_busy() {
     };
 
     let rendered = footer_summary_text(&app);
-    assert_eq!(rendered, "ctx~=2048/32768  tokens=111 in / 22 out");
+    assert_eq!(rendered, "  tokens=111 in / 22 out");
     assert!(!rendered.contains("history="));
     assert!(!rendered.contains("local="));
     assert!(!rendered.contains("key="));
@@ -257,7 +257,7 @@ fn footer_summary_text_includes_repo_context_when_available() {
     assert!(rendered.contains("repo: hawkingrei/rara"));
     assert!(rendered.contains("branch: feat/test"));
     assert!(rendered.contains("PR: https://github.com/hawkingrei/rara/pull/46"));
-    assert!(rendered.contains("ctx~=1234/32768"));
+    assert!(!rendered.contains("ctx~="));
 }
 
 #[test]

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -399,3 +399,35 @@ fn activity_status_line_hides_completed_prompt_notice() {
     assert_eq!(label, "Ready");
     assert_eq!(detail, "waiting for input");
 }
+
+#[test]
+fn goal_is_none_by_default() {
+    let temp = tempdir().unwrap();
+    let app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    assert!(app.goal.is_none());
+}
+
+#[test]
+fn setting_goal_preserves_activity_status_label() {
+    use crate::tui::state::{GoalStatus, RalphGoal};
+
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.goal = Some(RalphGoal {
+        objective: "fix the build".into(),
+        status: GoalStatus::Pursuing,
+        token_budget: None,
+        tokens_used: 0,
+        turns_completed: 0,
+    });
+
+    // Goal rendering is in render_activity_bar (badge), not in activity_status_line.
+    let (label, _, _) = activity_status_line(&app);
+    assert_eq!(label, "Ready");
+}

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -48,7 +48,7 @@ fn footer_summary_text_shows_tokens_only_while_busy() {
     };
 
     let rendered = footer_summary_text(&app);
-    assert_eq!(rendered, "  tokens=111 in / 22 out");
+    assert_eq!(rendered, "tokens=111 in / 22 out");
     assert!(!rendered.contains("history="));
     assert!(!rendered.contains("local="));
     assert!(!rendered.contains("key="));

--- a/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
@@ -26,4 +26,4 @@ Warning  Warning: openai-compatible is missing an API key. Use /model to configu
 › Ask about the repo, request a code change, or type /help to browse commands.
 
 
-                                                                                              ctx~=0
+                                                                                              

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -894,7 +894,7 @@ fn command_palette_query_uses_full_width_without_leaking_bottom_status() {
 
     let rendered = render_screen_text(&app, 107, 53);
     assert!(rendered.contains("/model"));
-    assert!(!rendered.contains("ctx~=0"));
+    assert!(!rendered.contains("ctx~="));
     assert!(!rendered.contains("enter run  esc close"));
 }
 

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::super::state::{
-    HelpTab, LocalCommand, LocalCommandKind, Overlay, PermissionMode, RuntimePhase, StatusTab,
-    TuiApp, GoalStatus, RalphGoal,
+    GoalStatus, HelpTab, LocalCommand, LocalCommandKind, Overlay, PermissionMode, RalphGoal,
+    RuntimePhase, StatusTab, TuiApp,
 };
 use super::tasks::{start_compact_task, start_rebuild_task, start_review_task};
 use crate::agent::{Agent, AgentEvent, AgentExecutionMode, BashApprovalMode};
@@ -240,7 +240,8 @@ pub(super) async fn execute_local_command(
                 objective => {
                     // /goal <objective> — start a new goal
                     let mut budget: Option<u32> = None;
-                    let objective_clean = if let Some((budget_str, obj)) = objective.split_once(' ') {
+                    let objective_clean = if let Some((budget_str, obj)) = objective.split_once(' ')
+                    {
                         if let Ok(b) = budget_str.trim().parse::<u32>() {
                             budget = Some(b);
                             obj

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -241,8 +241,7 @@ pub(super) async fn execute_local_command(
                     // /goal <objective> — start a new goal.
                     // Optional numeric budget prefix: /goal 50000 fix the build.
                     let mut budget: Option<u32> = None;
-                    let objective_clean = if let Some((first, rest)) = objective.split_once(' ')
-                    {
+                    let objective_clean = if let Some((first, rest)) = objective.split_once(' ') {
                         // Only treat the first word as a budget if it is purely ASCII digits.
                         if first.bytes().all(|b| b.is_ascii_digit()) {
                             if let Ok(b) = first.parse::<u32>() {

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -238,13 +238,19 @@ pub(super) async fn execute_local_command(
                     }
                 }
                 objective => {
-                    // /goal <objective> — start a new goal
+                    // /goal <objective> — start a new goal.
+                    // Optional numeric budget prefix: /goal 50000 fix the build.
                     let mut budget: Option<u32> = None;
-                    let objective_clean = if let Some((budget_str, obj)) = objective.split_once(' ')
+                    let objective_clean = if let Some((first, rest)) = objective.split_once(' ')
                     {
-                        if let Ok(b) = budget_str.trim().parse::<u32>() {
-                            budget = Some(b);
-                            obj
+                        // Only treat the first word as a budget if it is purely ASCII digits.
+                        if first.bytes().all(|b| b.is_ascii_digit()) {
+                            if let Ok(b) = first.parse::<u32>() {
+                                budget = Some(b);
+                                rest
+                            } else {
+                                objective
+                            }
                         } else {
                             objective
                         }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use super::super::state::{
     HelpTab, LocalCommand, LocalCommandKind, Overlay, PermissionMode, RuntimePhase, StatusTab,
-    TuiApp,
+    TuiApp, GoalStatus, RalphGoal,
 };
 use super::tasks::{start_compact_task, start_rebuild_task, start_review_task};
 use crate::agent::{Agent, AgentEvent, AgentExecutionMode, BashApprovalMode};
@@ -35,6 +35,7 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Status => "status",
         LocalCommandKind::Skills => "skills",
         LocalCommandKind::Permissions => "permissions",
+        LocalCommandKind::Goal => "goal",
     });
     match command.kind {
         LocalCommandKind::Approval => {
@@ -171,6 +172,103 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Status => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening status".into()));
             app.open_overlay(Overlay::Status(StatusTab::Overview));
+        }
+        LocalCommandKind::Goal => {
+            app.set_runtime_phase(
+                RuntimePhase::LocalCommand,
+                Some("processing goal command".into()),
+            );
+            let arg = command.arg.as_deref().unwrap_or("").trim();
+            match arg {
+                "" => {
+                    // /goal with no subcommand: show current goal status
+                    if let Some(goal) = app.goal.as_ref() {
+                        let status_str = match goal.status {
+                            GoalStatus::Pursuing => "pursuing",
+                            GoalStatus::Paused => "paused",
+                            GoalStatus::Achieved => "achieved",
+                            GoalStatus::Unmet => "unmet",
+                            GoalStatus::BudgetLimited => "budget-limited",
+                        };
+                        let mut notice = format!(
+                            "Goal: {} [{}] · turns={} · tokens={}",
+                            goal.objective, status_str, goal.turns_completed, goal.tokens_used
+                        );
+                        if let Some(budget) = goal.token_budget {
+                            notice.push_str(&format!("/{budget}"));
+                        }
+                        app.push_notice(notice);
+                    } else {
+                        app.push_notice("No active goal. Set one with /goal <objective>.");
+                    }
+                }
+                "pause" => {
+                    if let Some(goal) = app.goal.as_mut() {
+                        if goal.status == GoalStatus::Pursuing {
+                            goal.status = GoalStatus::Paused;
+                            app.push_notice("Goal paused. Use /goal resume to continue.");
+                            *app.goal_handle.write().unwrap() = app.goal.clone();
+                        } else {
+                            app.push_notice("Goal is not currently pursuing; nothing to pause.");
+                        }
+                    } else {
+                        app.push_notice("No active goal to pause.");
+                    }
+                }
+                "resume" => {
+                    if let Some(goal) = app.goal.as_mut() {
+                        if goal.status == GoalStatus::Paused {
+                            goal.status = GoalStatus::Pursuing;
+                            *app.goal_handle.write().unwrap() = app.goal.clone();
+                            app.push_notice("Goal resumed. The agent will continue working.");
+                        } else {
+                            app.push_notice("Goal is not paused; nothing to resume.");
+                        }
+                    } else {
+                        app.push_notice("No active goal to resume.");
+                    }
+                }
+                "clear" => {
+                    if app.goal.is_some() {
+                        app.goal = None;
+                        *app.goal_handle.write().unwrap() = None;
+                        app.push_notice("Goal cleared.");
+                    } else {
+                        app.push_notice("No active goal to clear.");
+                    }
+                }
+                objective => {
+                    // /goal <objective> — start a new goal
+                    let mut budget: Option<u32> = None;
+                    let objective_clean = if let Some((budget_str, obj)) = objective.split_once(' ') {
+                        if let Ok(b) = budget_str.trim().parse::<u32>() {
+                            budget = Some(b);
+                            obj
+                        } else {
+                            objective
+                        }
+                    } else {
+                        objective
+                    };
+                    if objective_clean.is_empty() {
+                        app.push_notice("Goal objective cannot be empty.");
+                    } else {
+                        app.goal = Some(RalphGoal {
+                            objective: objective_clean.to_string(),
+                            status: GoalStatus::Pursuing,
+                            token_budget: budget,
+                            tokens_used: 0,
+                            turns_completed: 0,
+                        });
+                        *app.goal_handle.write().unwrap() = app.goal.clone();
+                        let mut notice = format!("Goal set: {}", objective_clean);
+                        if let Some(b) = budget {
+                            notice.push_str(&format!(" [budget: {b} tokens]"));
+                        }
+                        app.push_notice(notice);
+                    }
+                }
+            }
         }
         LocalCommandKind::Skills => {
             app.set_runtime_phase(

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -559,6 +559,29 @@ pub(super) async fn finish_running_task_if_ready(
                             .as_ref()
                             .is_some_and(|g| g.status == GoalStatus::Pursuing)
                         && !app.has_pending_plan_approval();
+                    // Always account goal turn usage, even when we suppress
+                    // continuation (no-tool-call turns still consume budget).
+                    let goal_is_pursuing = !finished_plan_turn
+                        && app
+                            .goal_handle
+                            .read()
+                            .unwrap()
+                            .as_ref()
+                            .is_some_and(|g| g.status == GoalStatus::Pursuing)
+                        && !app.has_pending_plan_approval();
+                    if goal_is_pursuing && !agent_had_tools {
+                        app.sync_snapshot(&agent);
+                        app.goal = app.goal_handle.read().unwrap().clone();
+                        if let Some(goal) = app.goal.as_mut() {
+                            let turn_input_tokens = app
+                                .snapshot
+                                .total_input_tokens
+                                .saturating_sub(prior_total_input_tokens);
+                            goal.tokens_used += turn_input_tokens;
+                            goal.turns_completed += 1;
+                            *app.goal_handle.write().unwrap() = app.goal.clone();
+                        }
+                    }
                     if should_auto_continue_goal {
                         // Sync agent state into snapshot before using token counters.
                         app.sync_snapshot(&agent);
@@ -619,6 +642,8 @@ pub(super) async fn finish_running_task_if_ready(
                     }
                     // Non-auto-continue path: put agent back before idle / plan-approval logic.
                     *agent_slot = Some(agent);
+                    // Sync any goal updates that the model made via tools.
+                    app.goal = app.goal_handle.read().unwrap().clone();
                     if let Some(a) = agent_slot.as_ref() {
                         app.sync_snapshot(a);
                     }
@@ -748,6 +773,11 @@ pub(super) async fn finish_running_task_if_ready(
                     std::sync::atomic::Ordering::Relaxed,
                 );
                 app.sandbox_network_access = rebuilt.sandbox_network_access;
+                // Preserve the current goal across the rebuild by copying it
+                // into the new handle before swapping.
+                if let Some(goal) = app.goal.as_ref() {
+                    *rebuilt.goal_handle.write().unwrap() = Some(goal.clone());
+                }
                 app.goal_handle = rebuilt.goal_handle;
                 app.goal = app.goal_handle.read().unwrap().clone();
                 app.config_manager.save(&app.config)?;

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -18,6 +18,7 @@ use tokio::sync::mpsc;
 
 use super::super::state::{
     OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp, TuiEvent,
+    GoalStatus,
 };
 use super::events::{apply_tui_event, convert_agent_event, format_error_chain};
 use crate::agent::{Agent, AgentOutputMode, BashApprovalDecision};
@@ -545,9 +546,62 @@ pub(super) async fn finish_running_task_if_ready(
                             return Ok(());
                         }
                     }
-                    *agent_slot = Some(agent);
-                    if let Some(agent) = agent_slot.as_ref() {
-                        app.sync_snapshot(agent);
+                    // Ralph loop: auto-continue if a goal is pursuing and we're in execute mode.
+                    // Suppress continuation when the last turn made no tool calls (Codex pattern).
+                    // Sync model-tool goal updates into TUI state.
+                    app.goal = app.goal_handle.read().unwrap().clone();
+                    let agent_had_tools = agent_slot
+                        .as_ref()
+                        .is_some_and(|a| a.last_turn_had_tool_calls());
+                    let should_auto_continue_goal = !finished_plan_turn
+                        && agent_had_tools
+                        && app.goal.as_ref().is_some_and(|g| g.status == GoalStatus::Pursuing)
+                        && !app.has_pending_plan_approval();
+                    if should_auto_continue_goal {
+                        if let Some(mut agent) = agent_slot.take() {
+                            let tokens_this_turn = app.snapshot.total_input_tokens;
+                            let (goal_obj, goal_turns, goal_used, goal_budget, budget_exhausted) = {
+                                let goal = app.goal.as_mut().expect("goal must exist");
+                                goal.tokens_used += tokens_this_turn;
+                                goal.turns_completed += 1;
+                                let exhausted = goal
+                                    .token_budget
+                                    .is_some_and(|b| goal.tokens_used >= b);
+                                if exhausted {
+                                    goal.status = GoalStatus::BudgetLimited;
+                                }
+                                let (obj, tc, tu, tb) = (goal.objective.clone(), goal.turns_completed, goal.tokens_used, goal.token_budget);
+                                (obj, tc, tu, tb, exhausted)
+                            };
+                            // Sync goal_handle after mutable borrow on app.goal ends.
+                            *app.goal_handle.write().unwrap() = app.goal.clone();
+                            if budget_exhausted {
+                                app.push_notice(format!(
+                                    "Goal budget exhausted: {goal_used} / {} tokens.",
+                                    goal_budget.unwrap_or(0)
+                                ));
+                                *agent_slot = Some(agent);
+                                app.release_pending_follow_ups();
+                                app.finalize_agent_stream(None);
+                                app.finalize_active_turn();
+                                app.set_runtime_phase(
+                                    RuntimePhase::Idle,
+                                    Some("goal budget limited".into()),
+                                );
+                                try_start_queued_follow_up(app, agent_slot);
+                                return Ok(());
+                            }
+                            app.release_pending_follow_ups();
+                            app.finalize_agent_stream(None);
+                            start_query_task(
+                                app,
+                                format!(
+                                    "Continue working toward the goal: {goal_obj}\n\n(Goal turn {goal_turns} · tokens used: {goal_used})"
+                                ),
+                                agent,
+                            );
+                            return Ok(());
+                        }
                     }
                     app.release_pending_follow_ups();
                     app.finalize_agent_stream(None);
@@ -675,6 +729,8 @@ pub(super) async fn finish_running_task_if_ready(
                     std::sync::atomic::Ordering::Relaxed,
                 );
                 app.sandbox_network_access = rebuilt.sandbox_network_access;
+                app.goal_handle = rebuilt.goal_handle;
+                app.goal = app.goal_handle.read().unwrap().clone();
                 app.config_manager.save(&app.config)?;
                 app.setup_status = Some(format!(
                     "Applied {} / {}",

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -548,30 +548,35 @@ pub(super) async fn finish_running_task_if_ready(
                     }
                     // Ralph loop: auto-continue if a goal is pursuing and we're in execute mode.
                     // Suppress continuation when the last turn made no tool calls (Codex pattern).
-                    // Sync model-tool goal updates into TUI state.
-                    app.goal = app.goal_handle.read().unwrap().clone();
-                    let agent_had_tools = agent_slot
-                        .as_ref()
-                        .is_some_and(|a| a.last_turn_had_tool_calls());
+                    let prior_total_input_tokens = app.snapshot.total_input_tokens;
+                    let agent_had_tools = agent.last_turn_had_tool_calls();
                     let should_auto_continue_goal = !finished_plan_turn
                         && agent_had_tools
-                        && app
-                            .goal
+                        && app.goal_handle
+                            .read()
+                            .unwrap()
                             .as_ref()
                             .is_some_and(|g| g.status == GoalStatus::Pursuing)
                         && !app.has_pending_plan_approval();
                     if should_auto_continue_goal {
-                        if let Some(mut agent) = agent_slot.take() {
-                            let tokens_this_turn = app.snapshot.total_input_tokens;
+                        // Sync agent state into snapshot before using token counters.
+                        app.sync_snapshot(&agent);
+                        app.goal = app.goal_handle.read().unwrap().clone();
+                        {
+                            let turn_input_tokens = app
+                                .snapshot
+                                .total_input_tokens
+                                .saturating_sub(prior_total_input_tokens);
                             let (goal_obj, goal_turns, goal_used, goal_budget, budget_exhausted) = {
                                 let goal = app.goal.as_mut().expect("goal must exist");
-                                goal.tokens_used += tokens_this_turn;
+                                goal.tokens_used += turn_input_tokens;
                                 goal.turns_completed += 1;
                                 let exhausted =
                                     goal.token_budget.is_some_and(|b| goal.tokens_used >= b);
                                 if exhausted {
                                     goal.status = GoalStatus::BudgetLimited;
                                 }
+                                // Snapshot fields before mutable borrow ends.
                                 let (obj, tc, tu, tb) = (
                                     goal.objective.clone(),
                                     goal.turns_completed,
@@ -589,8 +594,8 @@ pub(super) async fn finish_running_task_if_ready(
                                 ));
                                 *agent_slot = Some(agent);
                                 app.release_pending_follow_ups();
-                                app.finalize_agent_stream(None);
                                 app.finalize_active_turn();
+                                app.finalize_agent_stream(None);
                                 app.set_runtime_phase(
                                     RuntimePhase::Idle,
                                     Some("goal budget limited".into()),
@@ -598,8 +603,9 @@ pub(super) async fn finish_running_task_if_ready(
                                 try_start_queued_follow_up(app, agent_slot);
                                 return Ok(());
                             }
-                            app.release_pending_follow_ups();
-                            app.finalize_agent_stream(None);
+                            // finalize_active_turn closes the current turn's transcript
+                            // before start_query_task begins a new one.
+                            app.finalize_active_turn();
                             start_query_task(
                                 app,
                                 format!(
@@ -609,6 +615,11 @@ pub(super) async fn finish_running_task_if_ready(
                             );
                             return Ok(());
                         }
+                    }
+                    // Non-auto-continue path: put agent back before idle / plan-approval logic.
+                    *agent_slot = Some(agent);
+                    if let Some(a) = agent_slot.as_ref() {
+                        app.sync_snapshot(a);
                     }
                     app.release_pending_follow_ups();
                     app.finalize_agent_stream(None);

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -552,7 +552,8 @@ pub(super) async fn finish_running_task_if_ready(
                     let agent_had_tools = agent.last_turn_had_tool_calls();
                     let should_auto_continue_goal = !finished_plan_turn
                         && agent_had_tools
-                        && app.goal_handle
+                        && app
+                            .goal_handle
                             .read()
                             .unwrap()
                             .as_ref()

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -17,8 +17,8 @@ use secrecy::ExposeSecret;
 use tokio::sync::mpsc;
 
 use super::super::state::{
-    OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp, TuiEvent,
-    GoalStatus,
+    GoalStatus, OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp,
+    TuiEvent,
 };
 use super::events::{apply_tui_event, convert_agent_event, format_error_chain};
 use crate::agent::{Agent, AgentOutputMode, BashApprovalDecision};
@@ -555,7 +555,10 @@ pub(super) async fn finish_running_task_if_ready(
                         .is_some_and(|a| a.last_turn_had_tool_calls());
                     let should_auto_continue_goal = !finished_plan_turn
                         && agent_had_tools
-                        && app.goal.as_ref().is_some_and(|g| g.status == GoalStatus::Pursuing)
+                        && app
+                            .goal
+                            .as_ref()
+                            .is_some_and(|g| g.status == GoalStatus::Pursuing)
                         && !app.has_pending_plan_approval();
                     if should_auto_continue_goal {
                         if let Some(mut agent) = agent_slot.take() {
@@ -564,13 +567,17 @@ pub(super) async fn finish_running_task_if_ready(
                                 let goal = app.goal.as_mut().expect("goal must exist");
                                 goal.tokens_used += tokens_this_turn;
                                 goal.turns_completed += 1;
-                                let exhausted = goal
-                                    .token_budget
-                                    .is_some_and(|b| goal.tokens_used >= b);
+                                let exhausted =
+                                    goal.token_budget.is_some_and(|b| goal.tokens_used >= b);
                                 if exhausted {
                                     goal.status = GoalStatus::BudgetLimited;
                                 }
-                                let (obj, tc, tu, tb) = (goal.objective.clone(), goal.turns_completed, goal.tokens_used, goal.token_budget);
+                                let (obj, tc, tu, tb) = (
+                                    goal.objective.clone(),
+                                    goal.turns_completed,
+                                    goal.tokens_used,
+                                    goal.token_budget,
+                                );
                                 (obj, tc, tu, tb, exhausted)
                             };
                             // Sync goal_handle after mutable borrow on app.goal ends.

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -5,10 +5,11 @@ pub(super) async fn rebuild_agent_with_progress(
     progress: Option<crate::local_backend::LocalProgressReporter>,
 ) -> anyhow::Result<RebuildSuccess> {
     let bootstrap = crate::runtime_context::initialize_rara_context(config, progress).await?;
-    let (agent, warnings, sandbox_network_access) = bootstrap.into_parts();
+    let (agent, warnings, sandbox_network_access, goal_handle) = bootstrap.into_parts();
     Ok(RebuildSuccess {
         agent,
         warnings,
         sandbox_network_access,
+        goal_handle,
     })
 }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -19,12 +19,12 @@ pub use self::state_presets::{
 use self::types::CommittedTranscriptRenderCache;
 pub use self::types::{
     ActiveLiveEvent, ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
-    AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, GoalStatus, HelpTab,
-    InteractionKind, LocalCommand, LocalCommandKind, OAuthLoginMode, OpenAiModelPickerAction,
-    Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot,
-    PermissionMode, ProviderFamily, GoalHandle, RalphGoal, RebuildSuccess, RunningTask,
-    RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab, TaskCompletion, TaskKind,
-    TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent,
+    AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, GoalHandle, GoalStatus,
+    HelpTab, InteractionKind, LocalCommand, LocalCommandKind, OAuthLoginMode,
+    OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot,
+    PendingInteractionSnapshot, PermissionMode, ProviderFamily, RalphGoal, RebuildSuccess,
+    RunningTask, RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab, TaskCompletion,
+    TaskKind, TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent,
 };
 
 const OPENAI_PROFILE_SETUP_KINDS: [OpenAiEndpointKind; 3] = [

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -19,12 +19,12 @@ pub use self::state_presets::{
 use self::types::CommittedTranscriptRenderCache;
 pub use self::types::{
     ActiveLiveEvent, ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
-    AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, HelpTab, InteractionKind,
-    LocalCommand, LocalCommandKind, OAuthLoginMode, OpenAiModelPickerAction, Overlay,
-    PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot, PermissionMode,
-    ProviderFamily, RebuildSuccess, RunningTask, RuntimePhase, RuntimeSnapshot, SkillPickerEntry,
-    StatusTab, TaskCompletion, TaskKind, TranscriptEntry, TranscriptEntryPayload, TranscriptTurn,
-    TuiApp, TuiEvent,
+    AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, GoalStatus, HelpTab,
+    InteractionKind, LocalCommand, LocalCommandKind, OAuthLoginMode, OpenAiModelPickerAction,
+    Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot,
+    PermissionMode, ProviderFamily, GoalHandle, RalphGoal, RebuildSuccess, RunningTask,
+    RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab, TaskCompletion, TaskKind,
+    TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent,
 };
 
 const OPENAI_PROFILE_SETUP_KINDS: [OpenAiEndpointKind; 3] = [
@@ -252,6 +252,8 @@ impl TuiApp {
             skill_picker_entries: Vec::new(),
             sandbox_network_access: Arc::new(AtomicBool::new(sandbox_network)),
             permission_mode: PermissionMode::Auto,
+            goal: None,
+            goal_handle: Arc::new(std::sync::RwLock::new(None)),
             event_bus: None,
         })
     }

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -123,6 +123,7 @@ pub enum LocalCommandKind {
     Permissions,
     Logout,
     Review,
+    Goal,
     Quit,
     Skills,
 }
@@ -302,6 +303,8 @@ pub struct RebuildSuccess {
     pub agent: Agent,
     pub warnings: Vec<String>,
     pub sandbox_network_access: Arc<AtomicBool>,
+    /// Shared goal handle for model-facing tools.
+    pub goal_handle: crate::tui::state::GoalHandle,
 }
 
 pub enum TuiEvent {
@@ -580,6 +583,10 @@ pub struct TuiApp {
     pub skill_picker_entries: Vec<SkillPickerEntry>,
     pub sandbox_network_access: Arc<AtomicBool>,
     pub permission_mode: PermissionMode,
+    /// Currently active ralph loop goal, if any.
+    pub goal: Option<RalphGoal>,
+    /// Shared handle that model-facing goal tools write to.
+    pub goal_handle: GoalHandle,
     /// Optional runtime event bus that mirrors AgentEvent to ACP/Wire
     /// subscribers. Set during TUI startup; None only in test contexts.
     pub event_bus: Option<Arc<RuntimeEventBus>>,
@@ -594,3 +601,36 @@ pub struct SkillPickerEntry {
     pub enabled: bool,
     pub disable_model_invocation: bool,
 }
+
+/// Represents the lifecycle state of a ralph loop goal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GoalStatus {
+    /// Agent is actively working toward the goal across turns.
+    Pursuing,
+    /// User paused the goal; can be resumed.
+    Paused,
+    /// Goal was completed successfully.
+    Achieved,
+    /// Goal could not be completed (e.g. blocked).
+    Unmet,
+    /// Goal exceeded its configured token budget; soft-stop.
+    BudgetLimited,
+}
+
+/// Tracks a long-running objective that the agent autonomously works toward.
+#[derive(Clone, Debug)]
+pub struct RalphGoal {
+    /// The objective text set by `/goal <objective>`.
+    pub objective: String,
+    /// Current lifecycle status.
+    pub status: GoalStatus,
+    /// Optional token budget (input tokens). None = unlimited.
+    pub token_budget: Option<u32>,
+    /// Total input tokens consumed by goal turns.
+    pub tokens_used: u32,
+    /// Number of autonomous turns completed toward this goal.
+    pub turns_completed: u32,
+}
+
+/// Shared handle for model-facing goal tools and TUI to observe/update goal state.
+pub type GoalHandle = std::sync::Arc<std::sync::RwLock<Option<RalphGoal>>>;


### PR DESCRIPTION
## Summary

Implements "ralph loop" -- an autonomous goal system inspired by Codex `/goal`. The agent can now pursue a long-running objective across turns: auto-continuing work, enforcing token budgets, and exposing goal state to both the user (via `/goal` slash commands and activity bar) and the model (via `create_goal`/`get_goal`/`update_goal` tools).

## Changes

### Goal lifecycle

- `/goal <objective>` -- start a new goal (supports optional token budget: `/goal 50000 fix the build`)
- `/goal` -- show current goal status, turns completed, tokens used
- `/goal pause` / `/goal resume` -- lifecycle management
- `/goal clear` -- clear the current goal
- Activity bar shows `[goal pursuing] t3 · 12k/50k` badge during active goals
- Goals auto-continue in execute mode (suppressed in plan mode)
- Empty-tool-call turns are suppressed from auto-continuation (aligns with Codex "Suppresses repeated automatic continuation when a continuation turn makes no tool calls")
- Token budget enforcement: when `tokens_used >= token_budget`, marks goal `BudgetLimited` with soft stop
- Registered in `/help` and command palette (`/goal` → `LocalCommandKind::Goal`)

### Model-facing tools (`tools/goal.rs`)

Three tools registered in ToolManager, backed by shared `GoalHandle` (`Arc<RwLock<Option<RalphGoal>>>`) so model and TUI stay in sync:

| Tool | Description |
|------|-------------|
| `get_goal` | Read current goal state (objective, status, budget, usage) |
| `create_goal` | Create a new goal when none exists; model provides objective + optional token_budget |
| `update_goal` | Mark goal as `achieved` or `unmet` (pursuing/paused/budget_limited managed by runtime) |

### Shared state plumbing

- `GoalHandle` type alias lives in `tui/state/types.rs`
- Created at bootstrap in `runtime_context.rs`, passed through `create_full_tool_manager` → registered tools
- Propagated via `RuntimeBootstrap` → `RebuildSuccess` → TUI rebuild → `TuiApp.goal_handle`
- User `/goal` commands sync bidirectionally: `app.goal` ↔ `goal_handle`

### Agent changes

- `last_turn_had_tool_calls: bool` field + accessor on `Agent` for no-op continuation suppression
- Set in agent loop after `run_model_turn` from `!turn_output.tool_calls.is_empty()`

### Tests

- 109 tests passing
- 4 new tests in `command/tests.rs`: `/goal` parsing, spec registration, palette matching
- 2 new tests in `bottom_pane_tests.rs`: goal default None, goal doesn't affect activity label
- 2 new tests in `tools/goal.rs`: tool names + schema validation

### Files

| File | Change |
|------|--------|
| `src/tools/goal.rs` | New: 3 model-facing tools |
| `src/tui/state/types.rs` | `GoalStatus` enum, `RalphGoal` struct, `GoalHandle` type, `TuiApp` fields |
| `src/tui/runtime/commands.rs` | `/goal` full subcommand dispatch |
| `src/tui/runtime/tasks.rs` | Auto-continuation + budget + sync |
| `src/runtime_context.rs` + `tooling.rs` | GoalHandle lifecycle + tool registration |
| `src/agent.rs` + `planning.rs` | `last_turn_had_tool_calls` |
| `src/tui/render/bottom_pane.rs` | Goal badge in activity bar |
| `src/tui/command/specs.rs` | `/goal` help text |
| `src/tui/command/tests.rs` | 4 parsing/spec tests |
| `src/tui/render/bottom_pane_tests.rs` | 2 goal tests |
