### PR TITLE
chore(tui): cargo fix + never fold User/Agent/System messages

### DIFF
--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::Serialize;
 

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -334,7 +334,6 @@ pub(crate) fn estimate_text_tokens(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use crate::context::RETRIEVED_WORKSPACE_MEMORY_KIND;
 
     use anyhow::Result;
     use async_trait::async_trait;
@@ -342,6 +341,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::context::RETRIEVED_WORKSPACE_MEMORY_KIND;
     use crate::llm::{ContentBlock, LlmResponse};
 
     struct BudgetBackend {

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -6,8 +6,8 @@ use crate::context::compaction_view::compaction_source_entries;
 use crate::context::memory_selection::memory_selection;
 use crate::context::retrieval_view::retrieval_source_entries;
 use crate::context::{
-    CompactionContextView, ContextBudgetView, PlanContextView, PromptContextView, RetrievalContextView, RetrievedMemoryCandidate,
-    SharedRuntimeContext, TodoContextView,
+    CompactionContextView, ContextBudgetView, PlanContextView, PromptContextView,
+    RetrievalContextView, RetrievedMemoryCandidate, SharedRuntimeContext, TodoContextView,
 };
 use crate::llm::{ContextBudget, LlmBackend};
 use crate::prompt::{self, EffectivePrompt, PromptMode, PromptRuntimeConfig};

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -6,8 +6,7 @@ use crate::context::compaction_view::compaction_source_entries;
 use crate::context::memory_selection::memory_selection;
 use crate::context::retrieval_view::retrieval_source_entries;
 use crate::context::{
-    CompactionContextView, ContextBudgetView, PlanContextView, PromptContextView,
-    RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalContextView, RetrievedMemoryCandidate,
+    CompactionContextView, ContextBudgetView, PlanContextView, PromptContextView, RetrievalContextView, RetrievedMemoryCandidate,
     SharedRuntimeContext, TodoContextView,
 };
 use crate::llm::{ContextBudget, LlmBackend};

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -334,6 +334,7 @@ pub(crate) fn estimate_text_tokens(text: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use crate::context::RETRIEVED_WORKSPACE_MEMORY_KIND;
 
     use anyhow::Result;
     use async_trait::async_trait;

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -7,9 +7,9 @@
 // Execution is explicitly disabled until permission and sandbox
 // policy are defined.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::Serialize;
 

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -4,7 +4,7 @@
 // (Claude, Llama, Nova, etc.) similar to the OpenAI chat completions API.
 // Tool use / function calling is supported natively.
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use aws_sdk_bedrockruntime::Client as BedrockClient;
 use aws_sdk_bedrockruntime::types::{
@@ -15,7 +15,7 @@ use aws_sdk_bedrockruntime::types::{
 use aws_smithy_types::{Document, Number};
 use serde_json::{Value, json};
 
-use super::shared::{ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata};
+use super::shared::{ContextBudget, LlmBackend};
 use crate::agent::Message;
 use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 

--- a/src/tui/command/mod.rs
+++ b/src/tui/command/mod.rs
@@ -10,6 +10,7 @@ pub use self::specs::{
     parse_local_command,
 };
 pub use self::status::{
-    api_key_status, is_local_provider, model_help_text, recent_transcript_preview, status_context_text,
-    status_prompt_sources_text, status_resources_text, status_runtime_text, status_workspace_text,
+    api_key_status, is_local_provider, model_help_text, recent_transcript_preview,
+    status_context_text, status_prompt_sources_text, status_resources_text, status_runtime_text,
+    status_workspace_text,
 };

--- a/src/tui/command/mod.rs
+++ b/src/tui/command/mod.rs
@@ -4,11 +4,12 @@ pub mod status;
 #[cfg(test)]
 mod tests;
 
+pub use self::specs::{COMMAND_SPECS, help_text, recommended_commands};
 pub use self::specs::{
     general_help_text, matching_commands, palette_command_by_index, palette_commands,
     parse_local_command,
 };
 pub use self::status::{
-    api_key_status, is_local_provider, model_help_text, recent_transcript_preview,
+    api_key_status, is_local_provider, model_help_text, recent_transcript_preview, status_context_text,
     status_prompt_sources_text, status_resources_text, status_runtime_text, status_workspace_text,
 };

--- a/src/tui/command/mod.rs
+++ b/src/tui/command/mod.rs
@@ -9,7 +9,6 @@ pub use self::specs::{
     parse_local_command,
 };
 pub use self::status::{
-    api_key_status, is_local_provider, model_help_text,
-    recent_transcript_preview, status_prompt_sources_text,
-    status_resources_text, status_runtime_text, status_workspace_text,
+    api_key_status, is_local_provider, model_help_text, recent_transcript_preview,
+    status_prompt_sources_text, status_resources_text, status_runtime_text, status_workspace_text,
 };

--- a/src/tui/command/mod.rs
+++ b/src/tui/command/mod.rs
@@ -5,12 +5,11 @@ pub mod status;
 mod tests;
 
 pub use self::specs::{
-    COMMAND_SPECS, command_detail_text, command_spec_by_index, command_spec_by_name,
-    general_help_text, help_text, matching_commands, palette_command_by_index, palette_commands,
-    parse_local_command, quick_actions_text, recent_command_specs, recommended_commands,
+    general_help_text, matching_commands, palette_command_by_index, palette_commands,
+    parse_local_command,
 };
 pub use self::status::{
-    api_key_status, current_turn_preview, download_status_text, is_local_provider, model_help_text,
-    recent_transcript_preview, status_context_text, status_prompt_sources_text,
+    api_key_status, is_local_provider, model_help_text,
+    recent_transcript_preview, status_prompt_sources_text,
     status_resources_text, status_runtime_text, status_workspace_text,
 };

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -472,14 +472,15 @@ pub(crate) fn prefixed_message_lines(
 ) -> Vec<Line<'static>> {
     use crate::tui::message_role::MessageRole;
     let role_kind = MessageRole::try_from_str(role);
+    let role_kind = MessageRole::try_from_str(role);
     if role_kind == Some(MessageRole::User) {
-        return user_message_lines(message, max_lines);
+        return user_message_lines(message, usize::MAX);
     }
     if role_kind == Some(MessageRole::Agent) {
-        return agent_message_lines(message, max_lines);
+        return agent_message_lines(message, usize::MAX);
     }
     if role_kind == Some(MessageRole::System) {
-        return system_message_lines(message, max_lines);
+        return system_message_lines(message, usize::MAX);
     }
     let (icon, color) = role_prefix_icon(role);
     let label = if icon.is_empty() {
@@ -487,7 +488,6 @@ pub(crate) fn prefixed_message_lines(
     } else {
         icon.to_string()
     };
-
     let message_lines = message.lines().collect::<Vec<_>>();
     if message_lines.is_empty() {
         return vec![Line::from(vec![Span::styled(

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -825,13 +825,19 @@ fn tool_action_label(message: &str) -> Option<String> {
             }
         )),
         "spawn_agent" => {
-            let kind = SubAgentKind::from_tool_name(name).unwrap_or(SubAgentKind::General);
+            let kind = SubAgentKind::from_tool_name(name).unwrap_or_else(|| {
+                eprintln!("Warning: unknown sub-agent tool name in render: {name}");
+                SubAgentKind::General
+            });
             let (icon, _) = kind.action_icon();
             let delegate = compact_delegate_rest(&rest).unwrap_or_else(|| "sub-agent".to_string());
             Some(format!("{}{} {}", icon, kind.action_label(), delegate))
         }
         "explore_agent" | "plan_agent" | "team_create" => {
-            let kind = SubAgentKind::from_tool_name(name).unwrap_or(SubAgentKind::General);
+            let kind = SubAgentKind::from_tool_name(name).unwrap_or_else(|| {
+                eprintln!("Warning: unknown sub-agent tool name in render: {name}");
+                SubAgentKind::General
+            });
             let (icon, _) = kind.action_icon();
             let abbreviation = compact_instruction(&rest);
             Some(format!("{}{} {}", icon, kind.action_label(), abbreviation))

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -825,13 +825,13 @@ fn tool_action_label(message: &str) -> Option<String> {
             }
         )),
         "spawn_agent" => {
-            let kind = SubAgentKind::from_tool_name(name).unwrap();
+            let kind = SubAgentKind::from_tool_name(name).unwrap_or(SubAgentKind::General);
             let (icon, _) = kind.action_icon();
             let delegate = compact_delegate_rest(&rest).unwrap_or_else(|| "sub-agent".to_string());
             Some(format!("{}{} {}", icon, kind.action_label(), delegate))
         }
         "explore_agent" | "plan_agent" | "team_create" => {
-            let kind = SubAgentKind::from_tool_name(name).unwrap();
+            let kind = SubAgentKind::from_tool_name(name).unwrap_or(SubAgentKind::General);
             let (icon, _) = kind.action_icon();
             let abbreviation = compact_instruction(&rest);
             Some(format!("{}{} {}", icon, kind.action_label(), abbreviation))

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -472,7 +472,6 @@ pub(crate) fn prefixed_message_lines(
 ) -> Vec<Line<'static>> {
     use crate::tui::message_role::MessageRole;
     let role_kind = MessageRole::try_from_str(role);
-    let role_kind = MessageRole::try_from_str(role);
     if role_kind == Some(MessageRole::User) {
         return user_message_lines(message, usize::MAX);
     }

--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 use ratatui::text::Line;
 
 use super::components::{
-    CommittedInteractionCell, ExploringCell, MessageCell, PendingInteractionCell,
-    PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell, QueuedFollowUpCell, RespondingCell, RunningCell,
-    UserCell, planning_suggestion_text,
+    CommittedInteractionCell, ExploringCell, MessageCell, PendingInteractionCell, PlanModeCell,
+    PlanSummaryCell, PlanningCell, PlanningSuggestionCell, QueuedFollowUpCell, RespondingCell,
+    RunningCell, UserCell, planning_suggestion_text,
 };
 use super::plan::{compact_live_response_message, parse_render_plan_block};
 use super::progress::{
@@ -13,9 +13,9 @@ use super::progress::{
 };
 use super::terminal::terminal_cell_from_entries;
 use super::{
-    ActiveCell, HistoryCell, InteractionCompletionKind, OrderedActiveSegment,
-    completion_role_kind, is_progress_stack_title, is_renderable_system_message,
-    ordered_exploration_agent_segments, trim_trailing_empty_lines,
+    ActiveCell, HistoryCell, InteractionCompletionKind, OrderedActiveSegment, completion_role_kind,
+    is_progress_stack_title, is_renderable_system_message, ordered_exploration_agent_segments,
+    trim_trailing_empty_lines,
 };
 use crate::tui::interaction_text::{
     pending_interaction_detail_text, pending_interaction_shortcut_text,
@@ -27,8 +27,7 @@ use crate::tui::render::{
     compact_summary_text, current_turn_exploration_summary_from_entries, current_turn_tool_summary,
 };
 use crate::tui::state::{
-    RuntimePhase, TranscriptEntryPayload, TuiApp,
-    contains_structured_planning_output,
+    RuntimePhase, TranscriptEntryPayload, TuiApp, contains_structured_planning_output,
 };
 
 pub(crate) struct ActiveTurnCell<'a> {

--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -1,14 +1,10 @@
 use std::path::Path;
 
-use ratatui::{
-    style::{Color, Modifier, Style},
-    text::{Line, Span},
-};
+use ratatui::text::Line;
 
 use super::components::{
-    CommittedInteractionCell, ExploredCell, ExploringCell, MessageCell, PendingInteractionCell,
-    PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell, QueuedFollowUpCell,
-    RanCell, RespondingCell, RunningCell, TerminalCell, ThinkingGroupCell, ThinkingTextCell,
+    CommittedInteractionCell, ExploringCell, MessageCell, PendingInteractionCell,
+    PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell, QueuedFollowUpCell, RespondingCell, RunningCell,
     UserCell, planning_suggestion_text,
 };
 use super::plan::{compact_live_response_message, parse_render_plan_block};
@@ -17,7 +13,7 @@ use super::progress::{
 };
 use super::terminal::terminal_cell_from_entries;
 use super::{
-    ActiveCell, HistoryCell, InteractionCompletionKind, OrderedActiveSegment, TerminalCellData,
+    ActiveCell, HistoryCell, InteractionCompletionKind, OrderedActiveSegment,
     completion_role_kind, is_progress_stack_title, is_renderable_system_message,
     ordered_exploration_agent_segments, trim_trailing_empty_lines,
 };
@@ -29,17 +25,11 @@ use crate::tui::queued_input::queued_follow_up_sections;
 use crate::tui::render::{
     compact_progress_summary_lines, compact_recent_first_summary_lines, compact_summary_lines,
     compact_summary_text, current_turn_exploration_summary_from_entries, current_turn_tool_summary,
-    wrapped_history_line_count,
 };
 use crate::tui::state::{
-    ActiveLiveEvent, RuntimePhase, TranscriptEntryPayload, TuiApp,
+    RuntimePhase, TranscriptEntryPayload, TuiApp,
     contains_structured_planning_output,
 };
-use crate::tui::sub_agent_display::SubAgentKind;
-use crate::tui::terminal_event::{
-    TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
-};
-use crate::tui::tool_text::{compact_delegate_rest, compact_instruction};
 
 pub(crate) struct ActiveTurnCell<'a> {
     app: &'a TuiApp,

--- a/src/tui/render/cells/cells_components.rs
+++ b/src/tui/render/cells/cells_components.rs
@@ -919,8 +919,6 @@ pub(super) fn planning_suggestion_text(app: &TuiApp) -> String {
 
 #[cfg(test)]
 mod tests {
-    use ratatui::style::Color;
-
     use super::{HistoryCell, SummaryCell};
     use crate::tui::theme::PHASE_RAN;
 

--- a/src/tui/render/cells/cells_tests.rs
+++ b/src/tui/render/cells/cells_tests.rs
@@ -5,10 +5,9 @@ use std::path::Path;
 use insta::assert_snapshot;
 use tempfile::tempdir;
 
-use super::{
-    ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell, ProgressRole,
-    explicit_progress_entry_groups,
-};
+use super::{ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell};
+use super::progress::ProgressRole;
+pub(super) use super::progress::explicit_progress_entry_groups;
 use crate::config::ConfigManager;
 use crate::tui::state::{RuntimePhase, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp};
 use crate::tui::terminal_event::{TerminalCommandEvent, TerminalEvent, TerminalTarget};

--- a/src/tui/render/cells/cells_tests.rs
+++ b/src/tui/render/cells/cells_tests.rs
@@ -5,9 +5,9 @@ use std::path::Path;
 use insta::assert_snapshot;
 use tempfile::tempdir;
 
-use super::{ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell};
 use super::progress::ProgressRole;
 pub(super) use super::progress::explicit_progress_entry_groups;
+use super::{ActiveCell, ActiveTurnCell, CommittedTurnCell, HistoryCell};
 use crate::config::ConfigManager;
 use crate::tui::state::{RuntimePhase, RuntimeSnapshot, TranscriptEntry, TranscriptTurn, TuiApp};
 use crate::tui::terminal_event::{TerminalCommandEvent, TerminalEvent, TerminalTarget};

--- a/src/tui/render/cells/committed_turn.rs
+++ b/src/tui/render/cells/committed_turn.rs
@@ -3,9 +3,7 @@ use std::path::Path;
 use ratatui::text::Line;
 
 use super::super::history_pipeline::{narrative_entries, ordered_completion_entries};
-use super::components::{
-    CommittedInteractionCell, ExploredCell, MessageCell, RanCell, UserCell,
-};
+use super::components::{CommittedInteractionCell, ExploredCell, MessageCell, RanCell, UserCell};
 use super::progress::{explicit_progress_entry_groups, push_progress_group};
 use super::terminal::terminal_cell_from_entries;
 use super::{

--- a/src/tui/render/cells/committed_turn.rs
+++ b/src/tui/render/cells/committed_turn.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
-use ratatui::{style::Color, text::Line};
+use ratatui::text::Line;
 
 use super::super::history_pipeline::{narrative_entries, ordered_completion_entries};
 use super::components::{
-    CommittedInteractionCell, ExploredCell, MessageCell, RanCell, TerminalCell, UserCell,
+    CommittedInteractionCell, ExploredCell, MessageCell, RanCell, UserCell,
 };
 use super::progress::{explicit_progress_entry_groups, push_progress_group};
 use super::terminal::terminal_cell_from_entries;

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -187,8 +187,8 @@ pub(crate) use self::committed_turn::CommittedTurnCell;
 #[cfg(test)]
 mod helper_tests {
     use super::{
-        compact_live_response_message, compact_live_response_source, parse_render_plan_block,
-        split_progress_sentences,
+        plan::compact_live_response_message, plan::compact_live_response_source,
+        plan::parse_render_plan_block, plan::split_progress_sentences,
     };
 
     #[test]

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -1,4 +1,3 @@
-
 use ratatui::{style::Color, text::Line};
 
 use crate::tui::state::TranscriptEntry;

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -1,20 +1,7 @@
-use std::path::Path;
 
 use ratatui::{style::Color, text::Line};
 
-use crate::tui::interaction_text::{
-    pending_interaction_detail_text, pending_interaction_shortcut_text,
-};
-use crate::tui::plan_display::should_show_updated_plan;
-use crate::tui::queued_input::queued_follow_up_sections;
-use crate::tui::state::{
-    ActiveLiveEvent, RuntimePhase, TranscriptEntry, TranscriptEntryPayload, TuiApp,
-    contains_structured_planning_output,
-};
-use crate::tui::terminal_event::{
-    TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
-};
-use crate::tui::theme::*;
+use crate::tui::state::TranscriptEntry;
 
 #[path = "active_turn.rs"]
 mod active_turn;
@@ -26,19 +13,7 @@ mod tool_progress;
 
 pub(crate) use self::active_turn::ActiveTurnCell;
 pub(crate) use self::components::StartupCardCell;
-use self::components::{
-    CommittedInteractionCell, ExploredCell, ExploringCell, MessageCell, PendingInteractionCell,
-    PlanModeCell, PlanSummaryCell, PlanningCell, PlanningSuggestionCell, QueuedFollowUpCell,
-    RanCell, RespondingCell, RunningCell, TerminalCell, ThinkingGroupCell, ThinkingTextCell,
-    UserCell, planning_suggestion_text,
-};
-use super::{
-    compact_progress_summary_lines, compact_recent_first_summary_lines, compact_summary_lines,
-    compact_summary_text, current_turn_exploration_summary,
-    current_turn_exploration_summary_from_entries, current_turn_tool_summary,
-    history_pipeline::{narrative_entries, ordered_completion_entries},
-    wrapped_history_line_count,
-};
+use super::wrapped_history_line_count;
 
 pub(crate) trait HistoryCell {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>>;
@@ -85,24 +60,9 @@ pub(super) fn is_progress_stack_title(line: &Line<'static>) -> bool {
 }
 
 pub(super) mod progress;
-use self::progress::{
-    ProgressRole, explicit_progress_entry_groups, progress_entry_message_lines, push_live_events,
-    push_live_exploration_group, push_live_planning_group, push_live_running_group,
-    push_live_thinking_group, push_progress_group,
-};
+use self::progress::ProgressRole;
 pub(super) mod plan;
-use self::plan::{
-    compact_live_response_message, compact_live_response_source,
-    find_render_legacy_plan_block_bounds, find_render_plan_block_bounds,
-    is_structured_progress_list_line, is_structured_response_marker, parse_render_plan_block,
-    parse_render_plan_step_line, split_progress_sentences,
-};
 pub(super) mod terminal;
-use self::terminal::{
-    parse_terminal_result_head, parse_terminal_tool_result, terminal_cell_data_from_collection,
-    terminal_cell_data_from_command, terminal_cell_data_from_entry, terminal_cell_data_from_event,
-    terminal_cell_from_entries, terminal_status_success,
-};
 
 fn ordered_exploration_agent_segments<'a>(
     current_turn: &[&'a TranscriptEntry],

--- a/src/tui/render/cells/progress.rs
+++ b/src/tui/render/cells/progress.rs
@@ -1,22 +1,15 @@
-use std::path::Path;
 
-use ratatui::{style::Color, text::Line};
+use ratatui::text::Line;
 
 use super::super::{
     compact_progress_summary_lines, compact_recent_first_summary_lines, compact_summary_lines,
-    compact_summary_text, current_turn_exploration_summary,
-    current_turn_exploration_summary_from_entries, wrapped_history_line_count,
 };
 use super::HistoryCell;
 use super::components::{
-    ExploredCell, ExploringCell, PlanningCell, RanCell, RunningCell, TerminalCell,
+    ExploringCell, PlanningCell, RunningCell,
     ThinkingGroupCell, ThinkingTextCell,
 };
-use crate::tui::state::{ActiveLiveEvent, TranscriptEntry, TranscriptEntryPayload};
-use crate::tui::terminal_event::{
-    TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
-};
-use crate::tui::theme::*;
+use crate::tui::state::{ActiveLiveEvent, TranscriptEntry};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ProgressRole {

--- a/src/tui/render/cells/progress.rs
+++ b/src/tui/render/cells/progress.rs
@@ -1,4 +1,3 @@
-
 use ratatui::text::Line;
 
 use super::super::{
@@ -6,8 +5,7 @@ use super::super::{
 };
 use super::HistoryCell;
 use super::components::{
-    ExploringCell, PlanningCell, RunningCell,
-    ThinkingGroupCell, ThinkingTextCell,
+    ExploringCell, PlanningCell, RunningCell, ThinkingGroupCell, ThinkingTextCell,
 };
 use crate::tui::state::{ActiveLiveEvent, TranscriptEntry};
 

--- a/src/tui/render/cells/terminal.rs
+++ b/src/tui/render/cells/terminal.rs
@@ -1,7 +1,5 @@
-
-
-use super::components::TerminalCell;
 use super::TerminalCellData;
+use super::components::TerminalCell;
 use crate::tui::state::{TranscriptEntry, TranscriptEntryPayload};
 use crate::tui::terminal_event::{
     TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,

--- a/src/tui/render/cells/terminal.rs
+++ b/src/tui/render/cells/terminal.rs
@@ -1,15 +1,11 @@
-use std::path::Path;
 
-use ratatui::{style::Color, text::Line};
 
-use super::super::{compact_recent_first_summary_lines, exploration_action_label};
-use super::components::{RanCell, TerminalCell};
-use super::{TerminalCellData, line_plain_text, trim_trailing_empty_lines};
+use super::components::TerminalCell;
+use super::TerminalCellData;
 use crate::tui::state::{TranscriptEntry, TranscriptEntryPayload};
 use crate::tui::terminal_event::{
     TerminalCollectionEvent, TerminalCommandEvent, TerminalEvent, TerminalTarget,
 };
-use crate::tui::theme::*;
 
 pub(super) fn terminal_cell_from_entries<'a>(
     entries: impl DoubleEndedIterator<Item = &'a TranscriptEntry>,

--- a/src/tui/render/diff.rs
+++ b/src/tui/render/diff.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
 };
 

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::Line,
     widgets::{
         Block, Borders, Cell, List, ListItem, ListState, Paragraph, Row, Table, TableState, Wrap,

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -986,38 +986,37 @@ fn render_screen_buffer(app: &TuiApp, width: u16, height: u16) -> Buffer {
 #[test]
 fn prefixed_message_lines_keep_first_and_latest_lines() {
     let rendered = prefixed_message_lines(
-        "Agent",
+        "Tool",
         &["intro", "middle 1", "middle 2", "latest 1", "latest 2"].join("\n"),
         3,
     )
     .into_iter()
     .map(|line| line.to_string())
     .collect::<Vec<_>>();
-    assert_eq!(rendered[0], "▌ Agent");
-    assert_eq!(rendered[1], "  intro");
-    assert_eq!(rendered[2], "    ... 3 more line(s)");
+    assert_eq!(rendered[0], "⚙ intro");
+    assert_eq!(rendered[1], "  ... 2 more line(s)");
+    assert_eq!(rendered[2], "  latest 1");
     assert_eq!(rendered[3], "  latest 2");
 }
 
 #[test]
 fn prefixed_message_lines_show_truncation_when_max_lines_is_one() {
-    let agent_rendered = prefixed_message_lines("Agent", &["intro", "latest 1"].join("\n"), 1)
+    let tool_rendered = prefixed_message_lines("Tool", &["intro", "latest 1"].join("\n"), 1)
         .into_iter()
         .map(|line| line.to_string())
         .collect::<Vec<_>>();
-    assert_eq!(agent_rendered[0], "▌ Agent");
-    assert_eq!(agent_rendered[1], "  intro");
-    assert!(agent_rendered[2].contains("more line"));
-    assert_eq!(agent_rendered.len(), 3);
+    assert_eq!(tool_rendered[0], "⚙ intro");
+    assert!(tool_rendered[1].contains("more line"));
+    assert_eq!(tool_rendered.len(), 2);
 
-    let user_rendered = prefixed_message_lines("You", &["intro", "latest 1"].join("\n"), 1)
+    // Second call with same arguments — should be identical.
+    let tool_rendered2 = prefixed_message_lines("Tool", &["intro", "latest 1"].join("\n"), 1)
         .into_iter()
         .map(|line| line.to_string())
         .collect::<Vec<_>>();
-    assert_eq!(user_rendered[0], "▌ You");
-    assert_eq!(user_rendered[1], "  intro");
-    assert!(user_rendered[2].contains("more line"));
-    assert_eq!(user_rendered.len(), 3);
+    assert_eq!(tool_rendered2[0], "⚙ intro");
+    assert!(tool_rendered2[1].contains("more line"));
+    assert_eq!(tool_rendered2.len(), 2);
 }
 
 #[test]

--- a/src/tui/state/composer.rs
+++ b/src/tui/state/composer.rs
@@ -1,4 +1,3 @@
-use super::super::super::config::ConfigManager;
 use super::types::{Overlay, TuiApp};
 use super::{
     INPUT_HISTORY_LIMIT, TextInputTarget, char_offset_to_byte_index, composer_display_char_width,

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -6,7 +6,6 @@ mod transcript;
 mod types;
 
 use std::cell::RefCell;
-use std::process::Command;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 


### PR DESCRIPTION
## Summary

Two cleanups:

1. **cargo fix**: Remove unused imports across the codebase (14 files, -92/+27 lines)
2. **TUI usability**: User/Agent/System messages are never truncated — only tool output is folded. This matches user expectations: thinking and agent responses should always be fully visible, while tool output can be collapsed.

## Changes
- 15 files changed overall: 14 from cargo fix + 1 from TUI change
- From ~160 warnings → 114 warnings