### PR TITLE
feat(subagent): persist sidechain transcripts

### DIFF
--- a/docs/features/context-architecture.md
+++ b/docs/features/context-architecture.md
@@ -1075,9 +1075,11 @@ runtime accepts at most 8 tasks and runs at most 4 sub-agents at once. This
 matches the current foreground delegation boundary, but it is not yet a durable
 background task system.
 
-The next alignment step is to give each sub-agent invocation a stable
-`agent_id`, persist its sidechain transcript under the parent session, and store
-only a structured delegation result in the parent context.
+Foreground sub-agent invocations now generate an `agent_id`, persist completed
+child history as a parent-scoped sidechain transcript, and return only a
+structured delegation result to the parent context. The next alignment step is
+to persist durable spawn-edge metadata and add background resume/stop semantics
+on top of the same sidechain contract.
 
 ### Required Objects
 

--- a/docs/features/context-architecture.md
+++ b/docs/features/context-architecture.md
@@ -1076,10 +1076,11 @@ matches the current foreground delegation boundary, but it is not yet a durable
 background task system.
 
 Foreground sub-agent invocations now generate an `agent_id`, persist completed
-child history as a parent-scoped sidechain transcript, and return only a
-structured delegation result to the parent context. The next alignment step is
-to persist durable spawn-edge metadata and add background resume/stop semantics
-on top of the same sidechain contract.
+child history as a parent-scoped sidechain transcript, append a `SpawnAgent`
+rollout event with parent/child edge metadata, and return only a structured
+delegation result to the parent context. The next alignment step is to index
+those edges for query/resume and add background resume/stop semantics on top of
+the same sidechain contract.
 
 ### Required Objects
 

--- a/docs/features/session-transcript.md
+++ b/docs/features/session-transcript.md
@@ -54,8 +54,16 @@ rollouts/<session_id>/
 The first implementation keeps `history.json` as the resume source and writes
 `transcript.jsonl` as a typed compatibility mirror. Foreground sub-agent tools
 also write parent-scoped sidechain transcripts after each completed invocation.
-This is intentionally additive: existing session restore behavior stays
-unchanged while tests start locking down the model-visible transcript boundary.
+They also append a parent-session `SpawnAgent` rollout event that records the
+generated `agent_id`, child `session_id`, optional display name, status, and summary
+without inlining the child transcript. This is intentionally additive: existing
+session restore behavior stays unchanged while tests start locking down the
+model-visible transcript boundary.
+
+If sidechain or spawn-edge persistence fails after the child agent has already
+completed, the tool call should still return the child result and include a
+structured `persistence_error` field. This keeps foreground delegation useful
+while making the missing sidechain explicit to the parent agent and TUI.
 
 The long-term target is:
 
@@ -156,6 +164,7 @@ This mirrors Codex's fork filtering while keeping Claude-style sidechain files.
 | Load transcript with malformed line | Valid lines load; parse error count increments. |
 | Project model-visible messages | Only non-sidechain `Message` entries are returned. |
 | Write sub-agent sidechain | File is under `subagents/`; entries carry `is_sidechain = true`. |
+| Record sub-agent spawn edge | Parent rollout events include one `spawn_agent` edge summary with child identity. |
 | Legacy history backfill | `history.json` and `transcript.jsonl` are both backfilled. |
 | Future resume migration | Resume can switch from `history.json` to transcript projection without reading TUI artifacts. |
 
@@ -167,8 +176,11 @@ This mirrors Codex's fork filtering while keeping Claude-style sidechain files.
 - Existing foreground sub-agent tools write sidechain transcripts only when
   invoked with parent session context. Direct test calls without parent context
   still return structured results without writing detached sidechain files.
-- `StateDb` still stores parent/child relationships only indirectly. A durable
-  spawn-edge table is needed before cross-session sub-agent resume is complete.
+- Sidechain persistence failures are reported through `persistence_error`; they
+  do not abort an otherwise completed foreground sub-agent call.
+- `StateDb` still stores parent/child relationships only indirectly through
+  rollout events. A queryable spawn-edge table is needed before cross-session
+  sub-agent resume is complete.
 - Context compaction must preserve transcript boundaries and avoid injecting
   summaries before stable prompt-prefix sources.
 - Background sub-agent execution, resume, and stop semantics remain future work.

--- a/docs/features/session-transcript.md
+++ b/docs/features/session-transcript.md
@@ -11,7 +11,7 @@ artifacts are per-turn JSON arrays.
 That mixed shape makes the resume boundary harder to reason about:
 
 - model-visible messages can be confused with TUI-only transcript artifacts;
-- sub-agent output has no first-class sidechain identity;
+- sub-agent output needs first-class sidechain identity;
 - fork/resume work has no stable typed event stream to filter by semantic role;
 - future ACP/Wire subscribers cannot follow one ordered transcript contract.
 
@@ -52,9 +52,10 @@ rollouts/<session_id>/
 ```
 
 The first implementation keeps `history.json` as the resume source and writes
-`transcript.jsonl` as a typed compatibility mirror. This is intentionally
-additive: existing session restore behavior stays unchanged while tests start
-locking down the model-visible transcript boundary.
+`transcript.jsonl` as a typed compatibility mirror. Foreground sub-agent tools
+also write parent-scoped sidechain transcripts after each completed invocation.
+This is intentionally additive: existing session restore behavior stays
+unchanged while tests start locking down the model-visible transcript boundary.
 
 The long-term target is:
 
@@ -163,13 +164,16 @@ This mirrors Codex's fork filtering while keeping Claude-style sidechain files.
 - The first implementation rewrites the transcript mirror from `history.json`.
   The canonical target is append-only, but the compatibility bridge must stay
   consistent with the existing snapshot source until resume migrates.
-- Existing sub-agent tools create independent `Agent` sessions. They need a
-  follow-up wiring step to write sidechain transcripts under the parent session.
+- Existing foreground sub-agent tools write sidechain transcripts only when
+  invoked with parent session context. Direct test calls without parent context
+  still return structured results without writing detached sidechain files.
 - `StateDb` still stores parent/child relationships only indirectly. A durable
   spawn-edge table is needed before cross-session sub-agent resume is complete.
 - Context compaction must preserve transcript boundaries and avoid injecting
   summaries before stable prompt-prefix sources.
+- Background sub-agent execution, resume, and stop semantics remain future work.
 
 ## Source Journals
 
 - 2026-05-04-session-transcript-foundation.md
+- 2026-05-05-subagent-sidechain-transcripts.md

--- a/docs/features/session-transcript.md
+++ b/docs/features/session-transcript.md
@@ -60,6 +60,12 @@ without inlining the child transcript. This is intentionally additive: existing
 session restore behavior stays unchanged while tests start locking down the
 model-visible transcript boundary.
 
+Parent-scoped sub-agent calls also register a child `StateDb` session row with
+`origin_kind = subagent` and `forked_from_thread_id = <parent_session_id>`.
+Plan steps, plan explanation, and pending request-input state are copied into
+the child row so `ThreadStore` does not need to fabricate metadata from
+history-only files.
+
 If sidechain or spawn-edge persistence fails after the child agent has already
 completed, the tool call should still return the child result and include a
 structured `persistence_error` field. This keeps foreground delegation useful

--- a/docs/journal/2026-05-05-subagent-sidechain-transcripts.md
+++ b/docs/journal/2026-05-05-subagent-sidechain-transcripts.md
@@ -15,6 +15,17 @@ The parent receives only the structured tool result summary; the child history
 stays in the sidechain file and is not projected into parent model-visible
 messages.
 
+Foreground calls also append a parent-session `SpawnAgent` rollout event. The
+event stores the parent/child edge metadata needed by later resume and stop
+work: generated `agent_id`, child `session_id`, optional display name, status, and
+summary. The edge is intentionally stored as rollout metadata instead of parent
+model-visible text, preserving the context prefix boundary.
+
+If persistence fails after the child agent completes, the foreground tool result
+now includes `persistence_error` instead of failing the whole tool call. Explicit
+sub-agent names that cannot produce a stable ASCII id label are rejected before
+any child agent starts.
+
 ## Runtime Boundary
 
 - `spawn_agent`, `explore_agent`, `plan_agent`, and `team_create` generate a
@@ -25,16 +36,25 @@ messages.
   not write detached sidechain files.
 - Sidechain transcripts use `TranscriptScope::sidechain`, so every entry is
   marked `is_sidechain = true`.
+- Parent rollout events store the compact spawn edge. The parent transcript
+  remains free of child transcript content.
+- Persistence failure is result metadata, not a fatal tool error, once the child
+  agent has completed.
 
 ## Validation
 
 - `team_create_writes_parent_scoped_sidechain_transcripts`
 - `subagent_without_parent_context_does_not_write_sidechain`
+- `team_create_writes_parent_scoped_sidechain_transcripts` also asserts the
+  `SpawnAgent` rollout event.
+- `team_create_rejects_unstable_explicit_name_before_running_subagents`
+- `subagent_returns_result_when_sidechain_persistence_fails`
 - Existing `model_visible_messages` coverage confirms sidechain messages are not
   parent-visible context.
 
 ## Follow-Up
 
-- Persist durable parent/child spawn-edge metadata in `StateDb`.
+- Index parent/child spawn-edge metadata in `StateDb` for query and resume
+  surfaces.
 - Add background sub-agent resume and stop semantics on top of the same
   sidechain transcript contract.

--- a/docs/journal/2026-05-05-subagent-sidechain-transcripts.md
+++ b/docs/journal/2026-05-05-subagent-sidechain-transcripts.md
@@ -1,0 +1,40 @@
+# Sub-Agent Sidechain Transcripts
+
+## Checkpoint
+
+Foreground sub-agent tools now receive parent session context through
+`ToolCallContext` and write completed child histories to parent-scoped
+sidechain transcript files:
+
+```text
+rollouts/<parent_session_id>/subagents/agent-<agent_id>.jsonl
+```
+
+Each sub-agent result includes the generated `agent_id` and child `session_id`.
+The parent receives only the structured tool result summary; the child history
+stays in the sidechain file and is not projected into parent model-visible
+messages.
+
+## Runtime Boundary
+
+- `spawn_agent`, `explore_agent`, `plan_agent`, and `team_create` generate a
+  per-invocation `agent_id`.
+- Calls made from the main agent carry the parent `session_id` through
+  `ToolCallContext`.
+- Calls made directly without parent context return structured results but do
+  not write detached sidechain files.
+- Sidechain transcripts use `TranscriptScope::sidechain`, so every entry is
+  marked `is_sidechain = true`.
+
+## Validation
+
+- `team_create_writes_parent_scoped_sidechain_transcripts`
+- `subagent_without_parent_context_does_not_write_sidechain`
+- Existing `model_visible_messages` coverage confirms sidechain messages are not
+  parent-visible context.
+
+## Follow-Up
+
+- Persist durable parent/child spawn-edge metadata in `StateDb`.
+- Add background sub-agent resume and stop semantics on top of the same
+  sidechain transcript contract.

--- a/docs/journal/2026-05-05-subagent-sidechain-transcripts.md
+++ b/docs/journal/2026-05-05-subagent-sidechain-transcripts.md
@@ -36,8 +36,9 @@ any child agent starts.
   not write detached sidechain files.
 - Sidechain transcripts use `TranscriptScope::sidechain`, so every entry is
   marked `is_sidechain = true`.
-- Child sessions with local history but no `StateDb` row can still be loaded
-  through `ThreadStore` with fallback metadata.
+- Child sessions created from parent-scoped sub-agent calls get a `StateDb` row
+  with sub-agent lineage, plan state, and pending request-input state. Plain
+  history-only sessions are rejected instead of being misclassified.
 - Parent rollout events store the compact spawn edge. The parent transcript
   remains free of child transcript content.
 - Persistence failure is result metadata, not a fatal tool error, once the child
@@ -49,9 +50,10 @@ any child agent starts.
 - `spawn_agent_writes_parent_scoped_sidechain_transcript`
 - `plan_agent_writes_parent_scoped_sidechain_transcript`
 - `subagent_without_parent_context_does_not_write_sidechain`
-- `load_thread_uses_history_fallback_without_state_db_record`
+- `load_thread_rejects_history_without_state_db_record`
 - `formats_subagent_tool_result_with_returned_ids`
 - `team_create_rejects_unstable_explicit_name_before_running_subagents`
+- `spawn_agent_rejects_name_that_normalizes_empty_before_running_subagent`
 - `subagent_returns_result_when_sidechain_persistence_fails`
 - Existing `model_visible_messages` coverage confirms sidechain messages are not
   parent-visible context.

--- a/docs/journal/2026-05-05-subagent-sidechain-transcripts.md
+++ b/docs/journal/2026-05-05-subagent-sidechain-transcripts.md
@@ -36,6 +36,8 @@ any child agent starts.
   not write detached sidechain files.
 - Sidechain transcripts use `TranscriptScope::sidechain`, so every entry is
   marked `is_sidechain = true`.
+- Child sessions with local history but no `StateDb` row can still be loaded
+  through `ThreadStore` with fallback metadata.
 - Parent rollout events store the compact spawn edge. The parent transcript
   remains free of child transcript content.
 - Persistence failure is result metadata, not a fatal tool error, once the child
@@ -44,9 +46,11 @@ any child agent starts.
 ## Validation
 
 - `team_create_writes_parent_scoped_sidechain_transcripts`
+- `spawn_agent_writes_parent_scoped_sidechain_transcript`
+- `plan_agent_writes_parent_scoped_sidechain_transcript`
 - `subagent_without_parent_context_does_not_write_sidechain`
-- `team_create_writes_parent_scoped_sidechain_transcripts` also asserts the
-  `SpawnAgent` rollout event.
+- `load_thread_uses_history_fallback_without_state_db_record`
+- `formats_subagent_tool_result_with_returned_ids`
 - `team_create_rejects_unstable_explicit_name_before_running_subagents`
 - `subagent_returns_result_when_sidechain_persistence_fails`
 - Existing `model_visible_messages` coverage confirms sidechain messages are not

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -78,7 +78,8 @@ Active backlog only. Keep this file small and current.
 - [ ] Move raw session checkpoints into per-session append shards instead of the global LanceDB `conversations` table.
 - [ ] Promote `rollouts/<session_id>/transcript.jsonl` from compatibility mirror to canonical model-history source.
 - [x] Wire foreground sub-agent tools to write parent-scoped sidechain transcripts under `rollouts/<parent_session_id>/subagents/`.
-- [ ] Add durable parent/child spawn-edge metadata in `StateDb`.
+- [x] Add append-only parent/child spawn-edge rollout metadata for foreground sub-agent calls.
+- [ ] Index parent/child spawn-edge metadata in `StateDb` for resume/listing queries.
 - [ ] Add background sub-agent resume/stop over the sidechain transcript contract.
 - [ ] Add periodic promotion from session shards into global `MemoryRecord`s.
 - [ ] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -77,8 +77,9 @@ Active backlog only. Keep this file small and current.
 - [ ] Upgrade thread distillation from summary capture to LLM-assisted 2-8 record extraction with deduplication.
 - [ ] Move raw session checkpoints into per-session append shards instead of the global LanceDB `conversations` table.
 - [ ] Promote `rollouts/<session_id>/transcript.jsonl` from compatibility mirror to canonical model-history source.
-- [ ] Wire sub-agent tools to write parent-scoped sidechain transcripts under `rollouts/<parent_session_id>/subagents/`.
+- [x] Wire foreground sub-agent tools to write parent-scoped sidechain transcripts under `rollouts/<parent_session_id>/subagents/`.
 - [ ] Add durable parent/child spawn-edge metadata in `StateDb`.
+- [ ] Add background sub-agent resume/stop over the sidechain transcript contract.
 - [ ] Add periodic promotion from session shards into global `MemoryRecord`s.
 - [ ] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.
 - [ ] Define background task restart/reattach semantics.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -845,9 +845,10 @@ impl Agent {
     }
 
     fn tool_call_context(&self) -> ToolCallContext {
+        let context = ToolCallContext::default().with_session_id(self.session_id.clone());
         match self.cancellation_token.as_ref() {
-            Some(token) => ToolCallContext::default().with_cancellation(token.clone()),
-            None => ToolCallContext::default(),
+            Some(token) => context.with_cancellation(token.clone()),
+            None => context,
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -195,6 +195,31 @@ impl SessionManager {
         Ok(())
     }
 
+    pub fn save_spawn_agent_event(
+        &self,
+        session_id: &str,
+        event_id: &str,
+        agent_id: &str,
+        name: Option<&str>,
+        child_session_id: &str,
+        status: &str,
+        summary: Option<&str>,
+    ) -> Result<()> {
+        self.append_rollout_event(
+            session_id,
+            PersistedStructuredRolloutEvent::SpawnAgent {
+                recorded_at: Some(epoch_seconds()),
+                event_id: event_id.to_string(),
+                agent_id: agent_id.to_string(),
+                name: name.map(str::to_string),
+                child_session_id: child_session_id.to_string(),
+                status: status.to_string(),
+                summary: summary.map(str::to_string),
+            },
+        )?;
+        Ok(())
+    }
+
     pub fn load_compaction_events(
         &self,
         session_id: &str,
@@ -228,7 +253,8 @@ impl SessionManager {
                 }),
                 PersistedStructuredRolloutEvent::RuntimeState { .. }
                 | PersistedStructuredRolloutEvent::PlanState { .. }
-                | PersistedStructuredRolloutEvent::Interaction { .. } => None,
+                | PersistedStructuredRolloutEvent::Interaction { .. }
+                | PersistedStructuredRolloutEvent::SpawnAgent { .. } => None,
             })
             .collect::<Vec<_>>();
         if !structured_compactions.is_empty() {

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -93,6 +93,16 @@ pub enum PersistedStructuredRolloutEvent {
         #[serde(flatten)]
         interaction: PersistedInteraction,
     },
+    SpawnAgent {
+        #[serde(default)]
+        recorded_at: Option<i64>,
+        event_id: String,
+        agent_id: String,
+        name: Option<String>,
+        child_session_id: String,
+        status: String,
+        summary: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -639,7 +649,8 @@ impl StateDb {
                 } => {
                     interactions.push(interaction.clone());
                 }
-                PersistedStructuredRolloutEvent::Compaction { .. } => {}
+                PersistedStructuredRolloutEvent::Compaction { .. }
+                | PersistedStructuredRolloutEvent::SpawnAgent { .. } => {}
             }
         }
 

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -88,6 +88,7 @@ pub struct ThreadSummary {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ThreadMetadataSource {
     StateDb,
+    HistoryFallback,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -118,6 +119,7 @@ impl ThreadMaterializationProvenance {
     pub fn describe(&self) -> String {
         let metadata = match self.metadata_source {
             ThreadMetadataSource::StateDb => "StateDb (canonical)",
+            ThreadMetadataSource::HistoryFallback => "local history fallback",
         };
         let history = match self.history_source {
             ThreadHistorySource::CanonicalHistory => "canonical history.json",
@@ -156,6 +158,25 @@ impl From<PersistedThreadRecord> for ThreadMetadata {
 }
 
 impl ThreadMetadata {
+    fn from_history_fallback(session_id: &str, history_len: usize) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            cwd: String::new(),
+            branch: String::new(),
+            provider: String::new(),
+            model: String::new(),
+            base_url: None,
+            agent_mode: "subagent".to_string(),
+            bash_approval: String::new(),
+            created_at: 0,
+            origin_kind: "subagent".to_string(),
+            forked_from_thread_id: None,
+            history_len,
+            transcript_len: history_len,
+            updated_at: 0,
+        }
+    }
+
     /// Returns true when this thread was forked from another thread.
     pub fn is_fork(&self) -> bool {
         self.origin_kind == "fork" && self.forked_from_thread_id.is_some()
@@ -440,10 +461,19 @@ impl<'a> ThreadStore<'a> {
             }
             Err(err) => return Err(err),
         };
-        let metadata = self
-            .state_db
-            .load_thread_record(session_id)?
-            .ok_or_else(|| anyhow::anyhow!("Thread {session_id} not found in state db"))?;
+        let metadata_record = self.state_db.load_thread_record(session_id)?;
+        if metadata_record.is_none() && matches!(history_source, ThreadHistorySource::Missing) {
+            anyhow::bail!("Thread {session_id} not found in state db");
+        }
+        let has_metadata_record = metadata_record.is_some();
+        let metadata_source = if has_metadata_record {
+            ThreadMetadataSource::StateDb
+        } else {
+            ThreadMetadataSource::HistoryFallback
+        };
+        let metadata = metadata_record
+            .map(ThreadMetadata::from)
+            .unwrap_or_else(|| ThreadMetadata::from_history_fallback(session_id, history.len()));
         let LegacyNonTurnRolloutMigration {
             structured_events,
             runtime_rollout: migration_runtime_rollout,
@@ -463,9 +493,21 @@ impl<'a> ThreadStore<'a> {
                     .map(CompactionRecord::from)
                     .unwrap_or_default()
             });
-        let mut plan_explanation = self.state_db.load_session_plan_explanation(session_id)?;
-        let mut plan_steps = self.state_db.load_plan_steps(session_id)?;
-        let mut interactions = self.state_db.load_interactions(session_id)?;
+        let mut plan_explanation = if has_metadata_record {
+            self.state_db.load_session_plan_explanation(session_id)?
+        } else {
+            None
+        };
+        let mut plan_steps = if has_metadata_record {
+            self.state_db.load_plan_steps(session_id)?
+        } else {
+            Vec::new()
+        };
+        let mut interactions = if has_metadata_record {
+            self.state_db.load_interactions(session_id)?
+        } else {
+            Vec::new()
+        };
         let turn_items = self
             .state_db
             .load_turn_summaries(session_id)?
@@ -781,9 +823,9 @@ impl<'a> ThreadStore<'a> {
         };
 
         Ok(ThreadMaterializedState {
-            metadata: metadata.into(),
+            metadata,
             provenance: ThreadMaterializationProvenance {
-                metadata_source: ThreadMetadataSource::StateDb,
+                metadata_source,
                 history_source,
                 non_turn_rollout_source,
             },

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -88,7 +88,6 @@ pub struct ThreadSummary {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ThreadMetadataSource {
     StateDb,
-    HistoryFallback,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -119,7 +118,6 @@ impl ThreadMaterializationProvenance {
     pub fn describe(&self) -> String {
         let metadata = match self.metadata_source {
             ThreadMetadataSource::StateDb => "StateDb (canonical)",
-            ThreadMetadataSource::HistoryFallback => "local history fallback",
         };
         let history = match self.history_source {
             ThreadHistorySource::CanonicalHistory => "canonical history.json",
@@ -158,25 +156,6 @@ impl From<PersistedThreadRecord> for ThreadMetadata {
 }
 
 impl ThreadMetadata {
-    fn from_history_fallback(session_id: &str, history_len: usize) -> Self {
-        Self {
-            session_id: session_id.to_string(),
-            cwd: String::new(),
-            branch: String::new(),
-            provider: String::new(),
-            model: String::new(),
-            base_url: None,
-            agent_mode: "subagent".to_string(),
-            bash_approval: String::new(),
-            created_at: 0,
-            origin_kind: "subagent".to_string(),
-            forked_from_thread_id: None,
-            history_len,
-            transcript_len: history_len,
-            updated_at: 0,
-        }
-    }
-
     /// Returns true when this thread was forked from another thread.
     pub fn is_fork(&self) -> bool {
         self.origin_kind == "fork" && self.forked_from_thread_id.is_some()
@@ -462,18 +441,13 @@ impl<'a> ThreadStore<'a> {
             Err(err) => return Err(err),
         };
         let metadata_record = self.state_db.load_thread_record(session_id)?;
-        if metadata_record.is_none() && matches!(history_source, ThreadHistorySource::Missing) {
+        if metadata_record.is_none() {
             anyhow::bail!("Thread {session_id} not found in state db");
         }
-        let has_metadata_record = metadata_record.is_some();
-        let metadata_source = if has_metadata_record {
-            ThreadMetadataSource::StateDb
-        } else {
-            ThreadMetadataSource::HistoryFallback
-        };
+        let metadata_source = ThreadMetadataSource::StateDb;
         let metadata = metadata_record
             .map(ThreadMetadata::from)
-            .unwrap_or_else(|| ThreadMetadata::from_history_fallback(session_id, history.len()));
+            .expect("metadata record checked above");
         let LegacyNonTurnRolloutMigration {
             structured_events,
             runtime_rollout: migration_runtime_rollout,
@@ -493,21 +467,9 @@ impl<'a> ThreadStore<'a> {
                     .map(CompactionRecord::from)
                     .unwrap_or_default()
             });
-        let mut plan_explanation = if has_metadata_record {
-            self.state_db.load_session_plan_explanation(session_id)?
-        } else {
-            None
-        };
-        let mut plan_steps = if has_metadata_record {
-            self.state_db.load_plan_steps(session_id)?
-        } else {
-            Vec::new()
-        };
-        let mut interactions = if has_metadata_record {
-            self.state_db.load_interactions(session_id)?
-        } else {
-            Vec::new()
-        };
+        let mut plan_explanation = self.state_db.load_session_plan_explanation(session_id)?;
+        let mut plan_steps = self.state_db.load_plan_steps(session_id)?;
+        let mut interactions = self.state_db.load_interactions(session_id)?;
         let turn_items = self
             .state_db
             .load_turn_summaries(session_id)?

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -218,6 +218,14 @@ pub enum RolloutItem {
         steps: Vec<PersistedPlanStep>,
     },
     Interaction(PersistedInteraction),
+    SpawnAgent {
+        event_id: String,
+        agent_id: String,
+        name: Option<String>,
+        child_session_id: String,
+        status: String,
+        summary: Option<String>,
+    },
     Turn(RolloutTurnItem),
 }
 
@@ -567,6 +575,29 @@ impl<'a> ThreadStore<'a> {
                         RolloutItem::Interaction(interaction),
                     );
                 }
+                PersistedStructuredRolloutEvent::SpawnAgent {
+                    recorded_at,
+                    event_id,
+                    agent_id,
+                    name,
+                    child_session_id,
+                    status,
+                    summary,
+                } => {
+                    push_rollout_item(
+                        &mut ordered_rollout_items,
+                        &mut rollout_order,
+                        recorded_at.unwrap_or(0),
+                        RolloutItem::SpawnAgent {
+                            event_id,
+                            agent_id,
+                            name,
+                            child_session_id,
+                            status,
+                            summary,
+                        },
+                    );
+                }
             }
         }
 
@@ -708,7 +739,8 @@ impl<'a> ThreadStore<'a> {
                 RolloutItem::Turn(turn) => turn.summary.updated_at,
                 RolloutItem::Compaction(_)
                 | RolloutItem::PlanState { .. }
-                | RolloutItem::Interaction(_) => 0,
+                | RolloutItem::Interaction(_)
+                | RolloutItem::SpawnAgent { .. } => 0,
             };
             push_rollout_item(
                 &mut ordered_rollout_items,

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -209,7 +209,7 @@ fn load_thread_keeps_session_without_history_file() -> Result<()> {
 }
 
 #[test]
-fn load_thread_uses_history_fallback_without_state_db_record() -> Result<()> {
+fn load_thread_rejects_history_without_state_db_record() -> Result<()> {
     let temp = tempdir()?;
     let rara_dir = temp.path().join(".rara");
     let session_manager = SessionManager::new_for_rara_dir(rara_dir.clone())?;
@@ -223,18 +223,13 @@ fn load_thread_uses_history_fallback_without_state_db_record() -> Result<()> {
     )?;
 
     let store = ThreadStore::new(&session_manager, &state_db);
-    let snapshot = store.load_thread("child-session")?;
+    let err = store
+        .load_thread("child-session")
+        .expect_err("history-only session should not fabricate metadata");
 
-    assert_eq!(snapshot.metadata.session_id, "child-session");
-    assert_eq!(snapshot.metadata.agent_mode, "subagent");
-    assert_eq!(snapshot.history.len(), 1);
-    assert_eq!(
-        snapshot.provenance.metadata_source,
-        ThreadMetadataSource::HistoryFallback
-    );
-    assert_eq!(
-        snapshot.provenance.history_source,
-        ThreadHistorySource::CanonicalHistory
+    assert!(
+        err.to_string()
+            .contains("Thread child-session not found in state db")
     );
     Ok(())
 }

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -209,6 +209,37 @@ fn load_thread_keeps_session_without_history_file() -> Result<()> {
 }
 
 #[test]
+fn load_thread_uses_history_fallback_without_state_db_record() -> Result<()> {
+    let temp = tempdir()?;
+    let rara_dir = temp.path().join(".rara");
+    let session_manager = SessionManager::new_for_rara_dir(rara_dir.clone())?;
+    let state_db = StateDb::new_for_root_dir(rara_dir)?;
+    session_manager.save_session(
+        "child-session",
+        &[Message {
+            role: "assistant".to_string(),
+            content: serde_json::Value::String("Child result.".to_string()),
+        }],
+    )?;
+
+    let store = ThreadStore::new(&session_manager, &state_db);
+    let snapshot = store.load_thread("child-session")?;
+
+    assert_eq!(snapshot.metadata.session_id, "child-session");
+    assert_eq!(snapshot.metadata.agent_mode, "subagent");
+    assert_eq!(snapshot.history.len(), 1);
+    assert_eq!(
+        snapshot.provenance.metadata_source,
+        ThreadMetadataSource::HistoryFallback
+    );
+    assert_eq!(
+        snapshot.provenance.history_source,
+        ThreadHistorySource::CanonicalHistory
+    );
+    Ok(())
+}
+
+#[test]
 fn load_thread_backfills_legacy_history_file_into_rollout_root() -> Result<()> {
     let temp = tempdir()?;
     let rara_dir = temp.path().join(".rara");

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -89,6 +89,15 @@ fn load_thread_aggregates_history_state_and_rollout_items() -> Result<()> {
             summary: "Compacted earlier repository inspection.".to_string(),
         },
     )?;
+    session_manager.save_spawn_agent_event(
+        "session-1",
+        "spawn-1",
+        "worker-1",
+        Some("Worker 1"),
+        "child-session-1",
+        "done",
+        Some("Child completed."),
+    )?;
 
     let store = ThreadStore::new(&session_manager, &state_db);
     let snapshot = store.load_thread("session-1")?;
@@ -123,7 +132,7 @@ fn load_thread_aggregates_history_state_and_rollout_items() -> Result<()> {
     );
     assert_eq!(snapshot.plan_steps.len(), 1);
     assert_eq!(snapshot.interactions.len(), 1);
-    assert_eq!(snapshot.rollout_items.len(), 4);
+    assert_eq!(snapshot.rollout_items.len(), 5);
     assert!(snapshot.rollout_items.iter().any(|item| matches!(
         item,
         RolloutItem::Compaction(compaction) if compaction.compaction_count == 2
@@ -137,6 +146,22 @@ fn load_thread_aggregates_history_state_and_rollout_items() -> Result<()> {
         item,
         RolloutItem::Interaction(interaction)
             if interaction.kind == "approval" && interaction.status == "pending"
+    )));
+    assert!(snapshot.rollout_items.iter().any(|item| matches!(
+        item,
+        RolloutItem::SpawnAgent {
+            event_id,
+            agent_id,
+            name: Some(name),
+            child_session_id,
+            status,
+            summary: Some(summary),
+        } if event_id == "spawn-1"
+            && agent_id == "worker-1"
+            && name == "Worker 1"
+            && child_session_id == "child-session-1"
+            && status == "done"
+            && summary == "Child completed."
     )));
     assert!(snapshot.rollout_items.iter().any(|item| matches!(
         item,

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -35,12 +35,22 @@ pub enum ToolProgressEvent {
 #[derive(Clone, Debug, Default)]
 pub struct ToolCallContext {
     cancellation: Option<Arc<AtomicBool>>,
+    session_id: Option<String>,
 }
 
 impl ToolCallContext {
     pub fn with_cancellation(mut self, cancellation: Arc<AtomicBool>) -> Self {
         self.cancellation = Some(cancellation);
         self
+    }
+
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    pub fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
     }
 
     pub fn is_cancelled(&self) -> bool {

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -663,6 +663,30 @@ fn compact_subagent_result(tool_name: &str, result: &Value) -> String {
         _ => format!("{tool_name} {summary}"),
     };
 
+    if let Some(agent_id) = result
+        .get("agent_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        rendered.push_str(&format!("\nagent_id: {agent_id}"));
+    }
+    if let Some(session_id) = result
+        .get("session_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        rendered.push_str(&format!("\nsession_id: {session_id}"));
+    }
+    if let Some(persistence_error) = result
+        .get("persistence_error")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        rendered.push_str(&format!("\npersistence_error: {persistence_error}"));
+    }
     append_request_user_input(&mut rendered, result.get("request_user_input"));
     rendered
 }

--- a/src/tool_result/tests.rs
+++ b/src/tool_result/tests.rs
@@ -361,6 +361,8 @@ mod tests {
         let compacted = compact_subagent_result(
             "spawn_agent",
             &json!({
+                "agent_id": "fix-assembler-123",
+                "session_id": "child-session-123",
                 "name": "fix-assembler",
                 "status": "done",
                 "summary": "Removed the orphaned test block and kept one cfg(test) module.",
@@ -376,6 +378,8 @@ mod tests {
         );
 
         assert!(compacted.starts_with("spawn_agent fix-assembler: Removed"));
+        assert!(compacted.contains("agent_id: fix-assembler-123"));
+        assert!(compacted.contains("session_id: child-session-123"));
         assert!(compacted.contains("request_user_input: Proceed?"));
         assert!(compacted.contains("option: Yes | Apply the cleanup."));
         assert!(compacted.contains("option: No | Leave the file unchanged."));

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -167,13 +167,21 @@ impl AgentTool {
         i: Value,
         parent_session_id: Option<&str>,
     ) -> Result<Value, ToolError> {
-        let name = i["name"].as_str().unwrap_or("worker");
+        let name = i["name"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("name".into()))?;
+        if validate_agent_id_label(name).is_none() {
+            return Err(ToolError::InvalidInput(
+                "name must contain ascii letters, digits, '-' or '_'".into(),
+            ));
+        }
         let instruction = i["instruction"]
             .as_str()
             .ok_or(ToolError::InvalidInput("instruction".into()))?;
         let result = run_sub_agent(
             SubAgentKind::General,
             &next_subagent_id(SubAgentKind::General, Some(name)),
+            Some(name),
             parent_session_id,
             instruction,
             self.backend.clone(),
@@ -189,6 +197,7 @@ impl AgentTool {
             "name": name,
             "status": result.status,
             "summary": result.summary,
+            "persistence_error": result.persistence_error,
             "request_user_input": result
                 .request_user_input
                 .as_ref()
@@ -245,6 +254,7 @@ impl ExploreAgentTool {
         let result = run_sub_agent(
             SubAgentKind::Explore,
             &next_subagent_id(SubAgentKind::Explore, None),
+            None,
             parent_session_id,
             instruction,
             self.backend.clone(),
@@ -259,6 +269,7 @@ impl ExploreAgentTool {
             "session_id": result.session_id,
             "status": result.status,
             "summary": result.summary,
+            "persistence_error": result.persistence_error,
             "request_user_input": result
                 .request_user_input
                 .as_ref()
@@ -315,6 +326,7 @@ impl PlanAgentTool {
         let result = run_sub_agent(
             SubAgentKind::Plan,
             &next_subagent_id(SubAgentKind::Plan, None),
+            None,
             parent_session_id,
             instruction,
             self.backend.clone(),
@@ -329,6 +341,7 @@ impl PlanAgentTool {
             "session_id": result.session_id,
             "status": result.status,
             "summary": result.summary,
+            "persistence_error": result.persistence_error,
             "plan": result
                 .plan
                 .as_ref()
@@ -422,6 +435,7 @@ impl TeamCreateTool {
                 let result = run_sub_agent(
                     task.kind,
                     &agent_id,
+                    Some(&task.name),
                     parent_session_id.as_deref(),
                     &task.instruction,
                     backend,
@@ -454,6 +468,7 @@ struct SubAgentResult {
     session_id: String,
     status: &'static str,
     summary: String,
+    persistence_error: Option<String>,
     plan: Option<Vec<PlanStep>>,
     plan_explanation: Option<String>,
     request_user_input: Option<PendingUserInput>,
@@ -462,6 +477,7 @@ struct SubAgentResult {
 async fn run_sub_agent(
     kind: SubAgentKind,
     agent_id: &str,
+    name: Option<&str>,
     parent_session_id: Option<&str>,
     instruction: &str,
     backend: Arc<dyn LlmBackend>,
@@ -487,20 +503,54 @@ async fn run_sub_agent(
     .await
     .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
 
-    if let Some(parent_session_id) = parent_session_id {
-        write_subagent_sidechain(&session_manager, parent_session_id, agent_id, &sub)
-            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
-    }
+    let status = kind.result_status();
+    let summary = latest_assistant_text(&sub).unwrap_or_else(|| "Sub-agent finished.".to_string());
+
+    let persistence_error = parent_session_id.and_then(|parent_session_id| {
+        persist_subagent_edge(
+            &session_manager,
+            parent_session_id,
+            agent_id,
+            name,
+            &sub,
+            status,
+            &summary,
+        )
+        .err()
+        .map(|err| err.to_string())
+    });
 
     Ok(SubAgentResult {
         agent_id: agent_id.to_string(),
         session_id: sub.session_id.clone(),
-        status: kind.result_status(),
-        summary: latest_assistant_text(&sub).unwrap_or_else(|| "Sub-agent finished.".to_string()),
+        status,
+        summary,
+        persistence_error,
         plan: (!sub.current_plan.is_empty()).then_some(sub.current_plan.clone()),
         plan_explanation: sub.plan_explanation.clone(),
         request_user_input: sub.pending_user_input.clone(),
     })
+}
+
+fn persist_subagent_edge(
+    session_manager: &SessionManager,
+    parent_session_id: &str,
+    agent_id: &str,
+    name: Option<&str>,
+    sub: &Agent,
+    status: &str,
+    summary: &str,
+) -> anyhow::Result<()> {
+    write_subagent_sidechain(session_manager, parent_session_id, agent_id, sub)?;
+    session_manager.save_spawn_agent_event(
+        parent_session_id,
+        &format!("spawn-{}", uuid::Uuid::new_v4()),
+        agent_id,
+        name,
+        &sub.session_id,
+        status,
+        Some(summary),
+    )
 }
 
 fn write_subagent_sidechain(
@@ -541,10 +591,7 @@ fn normalize_team_tasks(tasks: &[Value]) -> Result<Vec<TeamTask>, ToolError> {
         .iter()
         .enumerate()
         .map(|(idx, task)| {
-            let name = task["name"]
-                .as_str()
-                .map(str::to_string)
-                .unwrap_or_else(|| format!("worker-{}", idx + 1));
+            let name = normalize_team_task_name(idx, task)?;
             let instruction = task["instruction"]
                 .as_str()
                 .map(str::to_string)
@@ -567,6 +614,23 @@ fn normalize_team_tasks(tasks: &[Value]) -> Result<Vec<TeamTask>, ToolError> {
         .collect()
 }
 
+fn normalize_team_task_name(idx: usize, task: &Value) -> Result<String, ToolError> {
+    match task.get("name") {
+        Some(value) => {
+            let name = value.as_str().ok_or_else(|| {
+                ToolError::InvalidInput(format!("tasks[{idx}].name must be a string"))
+            })?;
+            if validate_agent_id_label(name).is_none() {
+                return Err(ToolError::InvalidInput(format!(
+                    "tasks[{idx}].name must contain ascii letters, digits, '-' or '_'"
+                )));
+            }
+            Ok(name.to_string())
+        }
+        None => Ok(format!("worker-{}", idx + 1)),
+    }
+}
+
 fn parse_team_task_kind(idx: usize, kind: Option<&str>) -> Result<SubAgentKind, ToolError> {
     match kind.unwrap_or("explore") {
         "general" => Ok(SubAgentKind::General),
@@ -585,6 +649,7 @@ fn serialize_team_result(name: &str, result: SubAgentResult) -> Value {
         "name": name,
         "status": result.status,
         "summary": result.summary,
+        "persistence_error": result.persistence_error,
         "plan": result.plan.as_ref().map(|steps| serialize_plan_steps(steps)),
         "plan_explanation": result.plan_explanation,
         "request_user_input": result
@@ -596,14 +661,13 @@ fn serialize_team_result(name: &str, result: SubAgentResult) -> Value {
 
 fn next_subagent_id(kind: SubAgentKind, name: Option<&str>) -> String {
     let label = name
-        .map(sanitize_agent_id_part)
-        .filter(|name| !name.is_empty())
+        .and_then(validate_agent_id_label)
         .unwrap_or_else(|| kind.label().to_string());
     format!("{label}-{}", uuid::Uuid::new_v4())
 }
 
-fn sanitize_agent_id_part(value: &str) -> String {
-    value
+fn validate_agent_id_label(value: &str) -> Option<String> {
+    let label = value
         .chars()
         .map(|ch| {
             if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
@@ -614,7 +678,8 @@ fn sanitize_agent_id_part(value: &str) -> String {
         })
         .collect::<String>()
         .trim_matches('-')
-        .to_string()
+        .to_string();
+    (!label.is_empty()).then_some(label)
 }
 
 fn append_subagent_prompt(
@@ -711,8 +776,10 @@ mod tests {
     use crate::prompt::PromptRuntimeConfig;
     use crate::session::SessionManager;
     use crate::session_transcript::{load_transcript, model_visible_messages};
+    use crate::state_db::PersistedStructuredRolloutEvent;
+    use crate::thread_rollout_log;
     use crate::tool::{Tool, ToolCallContext, ToolError};
-    use crate::tools::agent::{ExploreAgentTool, TeamCreateTool};
+    use crate::tools::agent::{AgentTool, ExploreAgentTool, PlanAgentTool, TeamCreateTool};
     use crate::vectordb::VectorDB;
     use crate::workspace::WorkspaceMemory;
 
@@ -1059,6 +1126,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn team_create_rejects_unstable_explicit_name_before_running_subagents() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = temp.path().join(".rara");
+        std::fs::create_dir_all(&root).expect("workspace");
+        let tool = TeamCreateTool {
+            backend: Arc::new(CountingBackend {
+                calls: calls.clone(),
+            }),
+            vdb: Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager: Arc::new(
+                SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
+            ),
+            workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+            prompt_config: PromptRuntimeConfig::default(),
+        };
+
+        let err = tool
+            .call(json!({
+                "tasks": [
+                    {
+                        "name": "!!!",
+                        "instruction": "should not run"
+                    }
+                ]
+            }))
+            .await
+            .expect_err("invalid name");
+
+        assert!(
+            matches!(err, ToolError::InvalidInput(message) if message.contains("tasks[0].name"))
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn team_create_limits_concurrent_subagents() {
         let in_flight = Arc::new(AtomicUsize::new(0));
         let peak = Arc::new(AtomicUsize::new(0));
@@ -1136,6 +1242,8 @@ mod tests {
         let item = &result["team_results"][0];
         let agent_id = item["agent_id"].as_str().expect("agent_id");
         let child_session_id = item["session_id"].as_str().expect("session_id");
+        let result_status = item["status"].as_str().expect("status");
+        let result_summary = item["summary"].as_str().expect("summary");
         assert!(agent_id.starts_with("review-worker-"));
         let transcript_path = rara_dir
             .join("rollouts")
@@ -1157,6 +1265,149 @@ mod tests {
             } if session_id == child_session_id
                 && parent == "parent-session"
                 && entry_agent_id == agent_id
+        ));
+
+        let events =
+            thread_rollout_log::load_rollout_events(&rara_dir.join("rollouts"), "parent-session")
+                .expect("rollout events");
+        assert!(matches!(
+            events.as_slice(),
+            [PersistedStructuredRolloutEvent::SpawnAgent {
+                event_id,
+                agent_id: event_agent_id,
+                name: Some(name),
+                child_session_id: event_child_session_id,
+                status,
+                summary: Some(summary),
+                ..
+            }] if event_id.starts_with("spawn-")
+                && event_agent_id == agent_id
+                && name == "Review Worker"
+                && event_child_session_id == child_session_id
+                && status == result_status
+                && summary == result_summary
+        ));
+    }
+
+    #[tokio::test]
+    async fn spawn_agent_writes_parent_scoped_sidechain_transcript() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = temp.path().join(".rara");
+        std::fs::create_dir_all(&root).expect("workspace");
+        let tool = AgentTool {
+            backend: Arc::new(CountingBackend {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+            vdb: Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager: Arc::new(
+                SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
+            ),
+            workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
+            prompt_config: PromptRuntimeConfig::default(),
+        };
+
+        let mut progress = |_| {};
+        let result = tool
+            .call_with_context_events(
+                json!({
+                    "name": "General Worker",
+                    "instruction": "summarize this task"
+                }),
+                ToolCallContext::default().with_session_id("parent-session"),
+                &mut progress,
+            )
+            .await
+            .expect("spawn_agent result");
+
+        let agent_id = result["agent_id"].as_str().expect("agent_id");
+        let child_session_id = result["session_id"].as_str().expect("session_id");
+        assert!(agent_id.starts_with("general-worker-"));
+        let transcript_path = rara_dir
+            .join("rollouts")
+            .join("parent-session")
+            .join("subagents")
+            .join(format!("agent-{agent_id}.jsonl"));
+        let transcript = load_transcript(&transcript_path).expect("transcript");
+        assert_eq!(transcript.parse_errors, 0);
+        assert!(model_visible_messages(&transcript.entries).is_empty());
+
+        let events =
+            thread_rollout_log::load_rollout_events(&rara_dir.join("rollouts"), "parent-session")
+                .expect("rollout events");
+        assert!(matches!(
+            events.as_slice(),
+            [PersistedStructuredRolloutEvent::SpawnAgent {
+                agent_id: event_agent_id,
+                name: Some(name),
+                child_session_id: event_child_session_id,
+                status,
+                ..
+            }] if event_agent_id == agent_id
+                && name == "General Worker"
+                && event_child_session_id == child_session_id
+                && status == "done"
+        ));
+    }
+
+    #[tokio::test]
+    async fn plan_agent_writes_parent_scoped_sidechain_transcript() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = temp.path().join(".rara");
+        std::fs::create_dir_all(&root).expect("workspace");
+        let tool = PlanAgentTool {
+            backend: Arc::new(CountingBackend {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+            vdb: Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager: Arc::new(
+                SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
+            ),
+            workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
+            prompt_config: PromptRuntimeConfig::default(),
+        };
+
+        let mut progress = |_| {};
+        let result = tool
+            .call_with_context_events(
+                json!({ "instruction": "plan this task" }),
+                ToolCallContext::default().with_session_id("parent-session"),
+                &mut progress,
+            )
+            .await
+            .expect("plan_agent result");
+
+        let agent_id = result["agent_id"].as_str().expect("agent_id");
+        let child_session_id = result["session_id"].as_str().expect("session_id");
+        assert!(agent_id.starts_with("plan-"));
+        let transcript_path = rara_dir
+            .join("rollouts")
+            .join("parent-session")
+            .join("subagents")
+            .join(format!("agent-{agent_id}.jsonl"));
+        let transcript = load_transcript(&transcript_path).expect("transcript");
+        assert_eq!(transcript.parse_errors, 0);
+        assert!(model_visible_messages(&transcript.entries).is_empty());
+
+        let events =
+            thread_rollout_log::load_rollout_events(&rara_dir.join("rollouts"), "parent-session")
+                .expect("rollout events");
+        assert!(matches!(
+            events.as_slice(),
+            [PersistedStructuredRolloutEvent::SpawnAgent {
+                agent_id: event_agent_id,
+                name: None,
+                child_session_id: event_child_session_id,
+                status,
+                ..
+            }] if event_agent_id == agent_id
+                && event_child_session_id == child_session_id
+                && status == "planned"
         ));
     }
 
@@ -1192,6 +1443,61 @@ mod tests {
                 .starts_with("explore-")
         );
         assert!(!rara_dir.join("rollouts").join("subagents").exists());
+        assert!(
+            thread_rollout_log::load_rollout_events(&rara_dir.join("rollouts"), "parent-session")
+                .expect("rollout events")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_returns_result_when_sidechain_persistence_fails() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = temp.path().join(".rara");
+        std::fs::create_dir_all(&root).expect("workspace");
+        let rollouts_dir = rara_dir.join("rollouts");
+        std::fs::create_dir_all(&rollouts_dir).expect("rollouts");
+        std::fs::write(rollouts_dir.join("blocked-parent"), b"not a directory")
+            .expect("blocking file");
+        let tool = ExploreAgentTool {
+            backend: Arc::new(CountingBackend {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+            vdb: Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager: Arc::new(
+                SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
+            ),
+            workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+            prompt_config: PromptRuntimeConfig::default(),
+        };
+
+        let mut progress = |_| {};
+        let result = tool
+            .call_with_context_events(
+                json!({ "instruction": "look around" }),
+                ToolCallContext::default().with_session_id("blocked-parent"),
+                &mut progress,
+            )
+            .await
+            .expect("explore result");
+
+        assert_eq!(result["status"], "explored");
+        assert!(
+            result["summary"]
+                .as_str()
+                .expect("summary")
+                .starts_with("counted")
+        );
+        assert!(
+            result["persistence_error"]
+                .as_str()
+                .expect("persistence error")
+                .len()
+                > 0
+        );
     }
 
     #[tokio::test]

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -9,7 +9,8 @@ use crate::agent::{Agent, AgentExecutionMode, Message, PendingUserInput, PlanSte
 use crate::llm::LlmBackend;
 use crate::prompt::PromptRuntimeConfig;
 use crate::session::SessionManager;
-use crate::tool::{Tool, ToolError, ToolManager};
+use crate::session_transcript::{self, TranscriptScope};
+use crate::tool::{Tool, ToolCallContext, ToolError, ToolManager};
 use crate::tools::file::{ListFilesTool, ReadFileTool};
 use crate::tools::search::{GlobTool, GrepTool};
 use crate::vectordb::VectorDB;
@@ -113,6 +114,14 @@ impl SubAgentKind {
     fn read_only(self) -> bool {
         !matches!(self, SubAgentKind::General)
     }
+
+    fn label(self) -> &'static str {
+        match self {
+            SubAgentKind::General => "general",
+            SubAgentKind::Explore => "explore",
+            SubAgentKind::Plan => "plan",
+        }
+    }
 }
 
 pub struct AgentTool {
@@ -138,12 +147,34 @@ pub struct AgentTool {
 #[async_trait]
 impl Tool for AgentTool {
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
+        self.call_with_parent_session(i, None).await
+    }
+
+    async fn call_with_context_events(
+        &self,
+        input: Value,
+        context: ToolCallContext,
+        _report: &mut (dyn FnMut(crate::tool::ToolProgressEvent) + Send),
+    ) -> Result<Value, ToolError> {
+        self.call_with_parent_session(input, context.session_id())
+            .await
+    }
+}
+
+impl AgentTool {
+    async fn call_with_parent_session(
+        &self,
+        i: Value,
+        parent_session_id: Option<&str>,
+    ) -> Result<Value, ToolError> {
         let name = i["name"].as_str().unwrap_or("worker");
         let instruction = i["instruction"]
             .as_str()
             .ok_or(ToolError::InvalidInput("instruction".into()))?;
         let result = run_sub_agent(
             SubAgentKind::General,
+            &next_subagent_id(SubAgentKind::General, Some(name)),
+            parent_session_id,
             instruction,
             self.backend.clone(),
             self.vdb.clone(),
@@ -153,6 +184,8 @@ impl Tool for AgentTool {
         )
         .await?;
         Ok(json!({
+            "agent_id": result.agent_id,
+            "session_id": result.session_id,
             "name": name,
             "status": result.status,
             "summary": result.summary,
@@ -186,11 +219,33 @@ pub struct ExploreAgentTool {
 #[async_trait]
 impl Tool for ExploreAgentTool {
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
+        self.call_with_parent_session(i, None).await
+    }
+
+    async fn call_with_context_events(
+        &self,
+        input: Value,
+        context: ToolCallContext,
+        _report: &mut (dyn FnMut(crate::tool::ToolProgressEvent) + Send),
+    ) -> Result<Value, ToolError> {
+        self.call_with_parent_session(input, context.session_id())
+            .await
+    }
+}
+
+impl ExploreAgentTool {
+    async fn call_with_parent_session(
+        &self,
+        i: Value,
+        parent_session_id: Option<&str>,
+    ) -> Result<Value, ToolError> {
         let instruction = i["instruction"]
             .as_str()
             .ok_or(ToolError::InvalidInput("instruction".into()))?;
         let result = run_sub_agent(
             SubAgentKind::Explore,
+            &next_subagent_id(SubAgentKind::Explore, None),
+            parent_session_id,
             instruction,
             self.backend.clone(),
             self.vdb.clone(),
@@ -200,6 +255,8 @@ impl Tool for ExploreAgentTool {
         )
         .await?;
         Ok(json!({
+            "agent_id": result.agent_id,
+            "session_id": result.session_id,
             "status": result.status,
             "summary": result.summary,
             "request_user_input": result
@@ -232,11 +289,33 @@ pub struct PlanAgentTool {
 #[async_trait]
 impl Tool for PlanAgentTool {
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
+        self.call_with_parent_session(i, None).await
+    }
+
+    async fn call_with_context_events(
+        &self,
+        input: Value,
+        context: ToolCallContext,
+        _report: &mut (dyn FnMut(crate::tool::ToolProgressEvent) + Send),
+    ) -> Result<Value, ToolError> {
+        self.call_with_parent_session(input, context.session_id())
+            .await
+    }
+}
+
+impl PlanAgentTool {
+    async fn call_with_parent_session(
+        &self,
+        i: Value,
+        parent_session_id: Option<&str>,
+    ) -> Result<Value, ToolError> {
         let instruction = i["instruction"]
             .as_str()
             .ok_or(ToolError::InvalidInput("instruction".into()))?;
         let result = run_sub_agent(
             SubAgentKind::Plan,
+            &next_subagent_id(SubAgentKind::Plan, None),
+            parent_session_id,
             instruction,
             self.backend.clone(),
             self.vdb.clone(),
@@ -246,6 +325,8 @@ impl Tool for PlanAgentTool {
         )
         .await?;
         Ok(json!({
+            "agent_id": result.agent_id,
+            "session_id": result.session_id,
             "status": result.status,
             "summary": result.summary,
             "plan": result
@@ -298,6 +379,26 @@ pub struct TeamCreateTool {
 #[async_trait]
 impl Tool for TeamCreateTool {
     async fn call(&self, i: Value) -> Result<Value, ToolError> {
+        self.call_with_parent_session(i, None).await
+    }
+
+    async fn call_with_context_events(
+        &self,
+        input: Value,
+        context: ToolCallContext,
+        _report: &mut (dyn FnMut(crate::tool::ToolProgressEvent) + Send),
+    ) -> Result<Value, ToolError> {
+        self.call_with_parent_session(input, context.session_id())
+            .await
+    }
+}
+
+impl TeamCreateTool {
+    async fn call_with_parent_session(
+        &self,
+        i: Value,
+        parent_session_id: Option<&str>,
+    ) -> Result<Value, ToolError> {
         let tasks = i["tasks"]
             .as_array()
             .ok_or(ToolError::InvalidInput("tasks".into()))?;
@@ -314,10 +415,14 @@ impl Tool for TeamCreateTool {
             let session_manager = self.session_manager.clone();
             let workspace = self.workspace.clone();
             let prompt_config = self.prompt_config.clone();
+            let parent_session_id = parent_session_id.map(str::to_string);
+            let agent_id = next_subagent_id(task.kind, Some(&task.name));
 
             async move {
                 let result = run_sub_agent(
                     task.kind,
+                    &agent_id,
+                    parent_session_id.as_deref(),
                     &task.instruction,
                     backend,
                     vdb,
@@ -345,6 +450,8 @@ struct TeamTask {
 }
 
 struct SubAgentResult {
+    agent_id: String,
+    session_id: String,
     status: &'static str,
     summary: String,
     plan: Option<Vec<PlanStep>>,
@@ -354,6 +461,8 @@ struct SubAgentResult {
 
 async fn run_sub_agent(
     kind: SubAgentKind,
+    agent_id: &str,
+    parent_session_id: Option<&str>,
     instruction: &str,
     backend: Arc<dyn LlmBackend>,
     vdb: Arc<VectorDB>,
@@ -362,7 +471,13 @@ async fn run_sub_agent(
     prompt_config: PromptRuntimeConfig,
 ) -> Result<SubAgentResult, ToolError> {
     let tool_manager = build_subagent_tool_manager(kind);
-    let mut sub = Agent::new(tool_manager, backend, vdb, session_manager, workspace);
+    let mut sub = Agent::new(
+        tool_manager,
+        backend,
+        vdb,
+        session_manager.clone(),
+        workspace,
+    );
     sub.set_execution_mode(kind.execution_mode());
     sub.set_prompt_config(append_subagent_prompt(prompt_config, kind.append_prompt()));
     sub.query_with_mode(
@@ -372,13 +487,35 @@ async fn run_sub_agent(
     .await
     .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
 
+    if let Some(parent_session_id) = parent_session_id {
+        write_subagent_sidechain(&session_manager, parent_session_id, agent_id, &sub)
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+    }
+
     Ok(SubAgentResult {
+        agent_id: agent_id.to_string(),
+        session_id: sub.session_id.clone(),
         status: kind.result_status(),
         summary: latest_assistant_text(&sub).unwrap_or_else(|| "Sub-agent finished.".to_string()),
         plan: (!sub.current_plan.is_empty()).then_some(sub.current_plan.clone()),
         plan_explanation: sub.plan_explanation.clone(),
         request_user_input: sub.pending_user_input.clone(),
     })
+}
+
+fn write_subagent_sidechain(
+    session_manager: &SessionManager,
+    parent_session_id: &str,
+    agent_id: &str,
+    sub: &Agent,
+) -> anyhow::Result<()> {
+    let path = session_transcript::subagent_transcript_path(
+        &session_manager.storage_dir,
+        parent_session_id,
+        agent_id,
+    );
+    let scope = TranscriptScope::sidechain(parent_session_id, agent_id, sub.session_id.clone());
+    session_transcript::write_message_snapshot(&path, &scope, &sub.history)
 }
 
 fn build_read_only_tool_manager() -> ToolManager {
@@ -443,6 +580,8 @@ fn parse_team_task_kind(idx: usize, kind: Option<&str>) -> Result<SubAgentKind, 
 
 fn serialize_team_result(name: &str, result: SubAgentResult) -> Value {
     json!({
+        "agent_id": result.agent_id,
+        "session_id": result.session_id,
         "name": name,
         "status": result.status,
         "summary": result.summary,
@@ -453,6 +592,29 @@ fn serialize_team_result(name: &str, result: SubAgentResult) -> Value {
             .as_ref()
             .map(serialize_pending_user_input),
     })
+}
+
+fn next_subagent_id(kind: SubAgentKind, name: Option<&str>) -> String {
+    let label = name
+        .map(sanitize_agent_id_part)
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| kind.label().to_string());
+    format!("{label}-{}", uuid::Uuid::new_v4())
+}
+
+fn sanitize_agent_id_part(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
 }
 
 fn append_subagent_prompt(
@@ -548,8 +710,9 @@ mod tests {
     use crate::llm::{ContentBlock, LlmBackend, LlmResponse, MockLlm};
     use crate::prompt::PromptRuntimeConfig;
     use crate::session::SessionManager;
-    use crate::tool::{Tool, ToolError};
-    use crate::tools::agent::TeamCreateTool;
+    use crate::session_transcript::{load_transcript, model_visible_messages};
+    use crate::tool::{Tool, ToolCallContext, ToolError};
+    use crate::tools::agent::{ExploreAgentTool, TeamCreateTool};
     use crate::vectordb::VectorDB;
     use crate::workspace::WorkspaceMemory;
 
@@ -930,6 +1093,105 @@ mod tests {
         let observed_peak = peak.load(Ordering::SeqCst);
         assert!(observed_peak <= TEAM_CREATE_CONCURRENCY_LIMIT);
         assert!(observed_peak > 1);
+    }
+
+    #[tokio::test]
+    async fn team_create_writes_parent_scoped_sidechain_transcripts() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = temp.path().join(".rara");
+        std::fs::create_dir_all(&root).expect("workspace");
+        let tool = TeamCreateTool {
+            backend: Arc::new(CountingBackend {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+            vdb: Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager: Arc::new(
+                SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
+            ),
+            workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
+            prompt_config: PromptRuntimeConfig::default(),
+        };
+
+        let mut progress = |_| {};
+        let result = tool
+            .call_with_context_events(
+                json!({
+                    "tasks": [
+                        {
+                            "name": "Review Worker",
+                            "kind": "general",
+                            "instruction": "summarize this task"
+                        }
+                    ]
+                }),
+                ToolCallContext::default().with_session_id("parent-session"),
+                &mut progress,
+            )
+            .await
+            .expect("team_create result");
+
+        let item = &result["team_results"][0];
+        let agent_id = item["agent_id"].as_str().expect("agent_id");
+        let child_session_id = item["session_id"].as_str().expect("session_id");
+        assert!(agent_id.starts_with("review-worker-"));
+        let transcript_path = rara_dir
+            .join("rollouts")
+            .join("parent-session")
+            .join("subagents")
+            .join(format!("agent-{agent_id}.jsonl"));
+        let transcript = load_transcript(&transcript_path).expect("transcript");
+
+        assert_eq!(transcript.parse_errors, 0);
+        assert!(model_visible_messages(&transcript.entries).is_empty());
+        assert!(matches!(
+            &transcript.entries[0],
+            crate::session_transcript::SessionTranscriptEntry::SessionMeta {
+                session_id,
+                parent_session_id: Some(parent),
+                agent_id: Some(entry_agent_id),
+                is_sidechain: true,
+                ..
+            } if session_id == child_session_id
+                && parent == "parent-session"
+                && entry_agent_id == agent_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn subagent_without_parent_context_does_not_write_sidechain() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = temp.path().join(".rara");
+        std::fs::create_dir_all(&root).expect("workspace");
+        let tool = ExploreAgentTool {
+            backend: Arc::new(CountingBackend {
+                calls: Arc::new(AtomicUsize::new(0)),
+            }),
+            vdb: Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager: Arc::new(
+                SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
+            ),
+            workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
+            prompt_config: PromptRuntimeConfig::default(),
+        };
+
+        let result = tool
+            .call(json!({ "instruction": "look around" }))
+            .await
+            .expect("explore result");
+
+        assert!(
+            result["agent_id"]
+                .as_str()
+                .expect("agent_id")
+                .starts_with("explore-")
+        );
+        assert!(!rara_dir.join("rollouts").join("subagents").exists());
     }
 
     #[tokio::test]

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -5,11 +5,18 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 
-use crate::agent::{Agent, AgentExecutionMode, Message, PendingUserInput, PlanStep};
+use crate::agent::{
+    Agent, AgentExecutionMode, Message, PendingUserInput, PlanStep, PlanStepStatus,
+};
 use crate::llm::LlmBackend;
 use crate::prompt::PromptRuntimeConfig;
 use crate::session::SessionManager;
 use crate::session_transcript::{self, TranscriptScope};
+use crate::state_db::{
+    PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
+    StateDb,
+};
+use crate::thread_store::{ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeState};
 use crate::tool::{Tool, ToolCallContext, ToolError, ToolManager};
 use crate::tools::file::{ListFilesTool, ReadFileTool};
 use crate::tools::search::{GlobTool, GrepTool};
@@ -492,7 +499,7 @@ async fn run_sub_agent(
         backend,
         vdb,
         session_manager.clone(),
-        workspace,
+        workspace.clone(),
     );
     sub.set_execution_mode(kind.execution_mode());
     sub.set_prompt_config(append_subagent_prompt(prompt_config, kind.append_prompt()));
@@ -509,6 +516,7 @@ async fn run_sub_agent(
     let persistence_error = parent_session_id.and_then(|parent_session_id| {
         persist_subagent_edge(
             &session_manager,
+            &workspace,
             parent_session_id,
             agent_id,
             name,
@@ -534,6 +542,7 @@ async fn run_sub_agent(
 
 fn persist_subagent_edge(
     session_manager: &SessionManager,
+    workspace: &WorkspaceMemory,
     parent_session_id: &str,
     agent_id: &str,
     name: Option<&str>,
@@ -542,6 +551,7 @@ fn persist_subagent_edge(
     summary: &str,
 ) -> anyhow::Result<()> {
     write_subagent_sidechain(session_manager, parent_session_id, agent_id, sub)?;
+    persist_subagent_runtime_state(session_manager, workspace, parent_session_id, sub)?;
     session_manager.save_spawn_agent_event(
         parent_session_id,
         &format!("spawn-{}", uuid::Uuid::new_v4()),
@@ -566,6 +576,51 @@ fn write_subagent_sidechain(
     );
     let scope = TranscriptScope::sidechain(parent_session_id, agent_id, sub.session_id.clone());
     session_transcript::write_message_snapshot(&path, &scope, &sub.history)
+}
+
+fn persist_subagent_runtime_state(
+    session_manager: &SessionManager,
+    workspace: &WorkspaceMemory,
+    parent_session_id: &str,
+    sub: &Agent,
+) -> anyhow::Result<()> {
+    let rara_dir = session_manager
+        .storage_dir
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("session storage dir has no parent"))?;
+    let state_db = StateDb::new_for_root_dir(rara_dir.to_path_buf())?;
+    let recorder = ThreadRecorder::new(&state_db);
+    let (cwd, branch) = workspace.get_env_info();
+
+    recorder.persist_runtime_state_with_lineage(
+        &ThreadRuntimeState {
+            session_id: &sub.session_id,
+            cwd: &cwd,
+            branch: &branch,
+            provider: "subagent",
+            model: "subagent",
+            base_url: None,
+            agent_mode: sub.execution_mode_label(),
+            bash_approval: "unavailable",
+            plan_explanation: sub.plan_explanation.as_deref(),
+            prompt_runtime: PersistedPromptRuntimeState::default(),
+            history_len: sub.history.len(),
+            transcript_len: sub.history.len(),
+            compact_state: PersistedCompactState::default(),
+        },
+        &ThreadRuntimeLineage {
+            origin_kind: "subagent".to_string(),
+            forked_from_thread_id: Some(parent_session_id.to_string()),
+        },
+    )?;
+
+    recorder.replace_plan_steps(&sub.session_id, &persisted_plan_steps(&sub.current_plan))?;
+    recorder.replace_interactions(
+        &sub.session_id,
+        &persisted_pending_interactions(sub.pending_user_input.as_ref()),
+    )?;
+
+    Ok(())
 }
 
 fn build_read_only_tool_manager() -> ToolManager {
@@ -736,14 +791,30 @@ fn serialize_plan_steps(steps: &[PlanStep]) -> Vec<Value> {
         .map(|step| {
             json!({
                 "step": step.step,
-                "status": match step.status {
-                    crate::agent::PlanStepStatus::Pending => "pending",
-                    crate::agent::PlanStepStatus::InProgress => "in_progress",
-                    crate::agent::PlanStepStatus::Completed => "completed",
-                }
+                "status": plan_step_status_label(&step.status),
             })
         })
         .collect()
+}
+
+fn persisted_plan_steps(steps: &[PlanStep]) -> Vec<PersistedPlanStep> {
+    steps
+        .iter()
+        .enumerate()
+        .map(|(step_index, step)| PersistedPlanStep {
+            step_index,
+            status: plan_step_status_label(&step.status).to_string(),
+            step: step.step.clone(),
+        })
+        .collect()
+}
+
+fn plan_step_status_label(status: &PlanStepStatus) -> &'static str {
+    match status {
+        PlanStepStatus::Pending => "pending",
+        PlanStepStatus::InProgress => "in_progress",
+        PlanStepStatus::Completed => "completed",
+    }
 }
 
 fn serialize_pending_user_input(request: &PendingUserInput) -> Value {
@@ -752,6 +823,20 @@ fn serialize_pending_user_input(request: &PendingUserInput) -> Value {
         "options": request.options,
         "note": request.note,
     })
+}
+
+fn persisted_pending_interactions(request: Option<&PendingUserInput>) -> Vec<PersistedInteraction> {
+    request
+        .map(|request| {
+            vec![PersistedInteraction {
+                kind: "request_user_input".to_string(),
+                status: "pending".to_string(),
+                title: request.question.clone(),
+                summary: request.note.clone().unwrap_or_default(),
+                payload: Some(serialize_pending_user_input(request)),
+            }]
+        })
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -793,6 +878,8 @@ mod tests {
         peak: Arc<AtomicUsize>,
     }
 
+    struct PlanStateBackend;
+
     fn record_peak(current: usize, peak: &AtomicUsize) {
         let mut observed = peak.load(Ordering::SeqCst);
         while current > observed {
@@ -818,6 +905,35 @@ mod tests {
             Ok(LlmResponse {
                 content: vec![ContentBlock::Text {
                     text: format!("counted {last}"),
+                }],
+                stop_reason: Some("end_turn".to_string()),
+                usage: None,
+            })
+        }
+
+        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+            Ok(vec![0.0; 4])
+        }
+
+        async fn summarize(
+            &self,
+            _messages: &[Message],
+            _instruction: &str,
+        ) -> anyhow::Result<String> {
+            Ok("summary".to_string())
+        }
+    }
+
+    #[async_trait]
+    impl LlmBackend for PlanStateBackend {
+        async fn ask(
+            &self,
+            _messages: &[Message],
+            _tools: &[serde_json::Value],
+        ) -> anyhow::Result<LlmResponse> {
+            Ok(LlmResponse {
+                content: vec![ContentBlock::Text {
+                    text: "<proposed_plan>\n- [pending] Inspect subagent restore\n- [in_progress] Persist child state\n</proposed_plan>\nPlan state ready.".to_string(),
                 }],
                 stop_reason: Some("end_turn".to_string()),
                 usage: None,
@@ -1165,6 +1281,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn spawn_agent_rejects_name_that_normalizes_empty_before_running_subagent() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = temp.path().join(".rara");
+        std::fs::create_dir_all(&root).expect("workspace");
+        let tool = AgentTool {
+            backend: Arc::new(CountingBackend {
+                calls: calls.clone(),
+            }),
+            vdb: Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager: Arc::new(
+                SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
+            ),
+            workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+            prompt_config: PromptRuntimeConfig::default(),
+        };
+
+        let err = tool
+            .call(json!({
+                "name": "!!!",
+                "instruction": "should not run"
+            }))
+            .await
+            .expect_err("invalid name");
+
+        assert!(matches!(err, ToolError::InvalidInput(message)
+                if message == "name must normalize to a non-empty agent id label"));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn team_create_limits_concurrent_subagents() {
         let in_flight = Arc::new(AtomicUsize::new(0));
         let peak = Arc::new(AtomicUsize::new(0));
@@ -1358,7 +1508,12 @@ mod tests {
             .expect("child thread");
         assert_eq!(
             child.provenance.metadata_source,
-            ThreadMetadataSource::HistoryFallback
+            ThreadMetadataSource::StateDb
+        );
+        assert_eq!(child.metadata.origin_kind, "subagent");
+        assert_eq!(
+            child.metadata.forked_from_thread_id.as_deref(),
+            Some("parent-session")
         );
         assert!(!child.history.is_empty());
     }
@@ -1370,9 +1525,7 @@ mod tests {
         let rara_dir = temp.path().join(".rara");
         std::fs::create_dir_all(&root).expect("workspace");
         let tool = PlanAgentTool {
-            backend: Arc::new(CountingBackend {
-                calls: Arc::new(AtomicUsize::new(0)),
-            }),
+            backend: Arc::new(PlanStateBackend),
             vdb: Arc::new(VectorDB::new(
                 &rara_dir.join("lancedb").display().to_string(),
             )),
@@ -1420,6 +1573,21 @@ mod tests {
                 && event_child_session_id == child_session_id
                 && status == "planned"
         ));
+
+        let state_db = StateDb::new_for_root_dir(rara_dir).expect("state db");
+        let thread_store = ThreadStore::new(tool.session_manager.as_ref(), &state_db);
+        let child = thread_store
+            .load_thread(child_session_id)
+            .expect("child thread");
+        assert_eq!(
+            child.provenance.metadata_source,
+            ThreadMetadataSource::StateDb
+        );
+        assert_eq!(child.plan_steps.len(), 2);
+        assert_eq!(child.plan_steps[0].step, "Inspect subagent restore");
+        assert_eq!(child.plan_steps[0].status, "pending");
+        assert_eq!(child.plan_steps[1].step, "Persist child state");
+        assert_eq!(child.plan_steps[1].status, "in_progress");
     }
 
     #[tokio::test]

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -172,7 +172,7 @@ impl AgentTool {
             .ok_or(ToolError::InvalidInput("name".into()))?;
         if validate_agent_id_label(name).is_none() {
             return Err(ToolError::InvalidInput(
-                "name must contain ascii letters, digits, '-' or '_'".into(),
+                "name must normalize to a non-empty agent id label".into(),
             ));
         }
         let instruction = i["instruction"]
@@ -622,7 +622,7 @@ fn normalize_team_task_name(idx: usize, task: &Value) -> Result<String, ToolErro
             })?;
             if validate_agent_id_label(name).is_none() {
                 return Err(ToolError::InvalidInput(format!(
-                    "tasks[{idx}].name must contain ascii letters, digits, '-' or '_'"
+                    "tasks[{idx}].name must normalize to a non-empty agent id label"
                 )));
             }
             Ok(name.to_string())
@@ -776,8 +776,9 @@ mod tests {
     use crate::prompt::PromptRuntimeConfig;
     use crate::session::SessionManager;
     use crate::session_transcript::{load_transcript, model_visible_messages};
-    use crate::state_db::PersistedStructuredRolloutEvent;
+    use crate::state_db::{PersistedStructuredRolloutEvent, StateDb};
     use crate::thread_rollout_log;
+    use crate::thread_store::{ThreadMetadataSource, ThreadStore};
     use crate::tool::{Tool, ToolCallContext, ToolError};
     use crate::tools::agent::{AgentTool, ExploreAgentTool, PlanAgentTool, TeamCreateTool};
     use crate::vectordb::VectorDB;
@@ -1158,9 +1159,8 @@ mod tests {
             .await
             .expect_err("invalid name");
 
-        assert!(
-            matches!(err, ToolError::InvalidInput(message) if message.contains("tasks[0].name"))
-        );
+        assert!(matches!(err, ToolError::InvalidInput(message)
+                if message == "tasks[0].name must normalize to a non-empty agent id label"));
         assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
@@ -1350,6 +1350,17 @@ mod tests {
                 && event_child_session_id == child_session_id
                 && status == "done"
         ));
+
+        let state_db = StateDb::new_for_root_dir(rara_dir).expect("state db");
+        let thread_store = ThreadStore::new(tool.session_manager.as_ref(), &state_db);
+        let child = thread_store
+            .load_thread(child_session_id)
+            .expect("child thread");
+        assert_eq!(
+            child.provenance.metadata_source,
+            ThreadMetadataSource::HistoryFallback
+        );
+        assert!(!child.history.is_empty());
     }
 
     #[tokio::test]

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -466,6 +466,30 @@ pub(super) fn format_tool_result(name: &str, content: &str) -> String {
             } else {
                 format!("{name} {summary}")
             };
+            if let Some(agent_id) = value
+                .get("agent_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                rendered.push_str(&format!("\nagent_id: {agent_id}"));
+            }
+            if let Some(session_id) = value
+                .get("session_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                rendered.push_str(&format!("\nsession_id: {session_id}"));
+            }
+            if let Some(persistence_error) = value
+                .get("persistence_error")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                rendered.push_str(&format!("\npersistence_error: {persistence_error}"));
+            }
             if let Some(request) = value.get("request_user_input") {
                 if let Some(question) = request.get("question").and_then(serde_json::Value::as_str)
                 {

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -612,6 +612,26 @@ fn formats_spawn_agent_tool_result_with_agent_name() {
 }
 
 #[test]
+fn formats_subagent_tool_result_with_returned_ids() {
+    let rendered = format_tool_result(
+        "spawn_agent",
+        &json!({
+            "agent_id": "fix-assembler-1",
+            "session_id": "child-session-1",
+            "name": "fix-assembler",
+            "status": "done",
+            "summary": "Removed the orphaned code block.",
+            "persistence_error": "sidechain write failed"
+        })
+        .to_string(),
+    );
+
+    assert!(rendered.contains("agent_id: fix-assembler-1"));
+    assert!(rendered.contains("session_id: child-session-1"));
+    assert!(rendered.contains("persistence_error: sidechain write failed"));
+}
+
+#[test]
 fn formats_replace_lines_tool_result_as_edit_summary() {
     let rendered = format_tool_result(
         "replace_lines",

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -190,7 +190,8 @@ pub(super) fn restore_thread_by_id(
             RolloutItem::Turn(_)
             | RolloutItem::Compaction(_)
             | RolloutItem::PlanState { .. }
-            | RolloutItem::Interaction(_) => {}
+            | RolloutItem::Interaction(_)
+            | RolloutItem::SpawnAgent { .. } => {}
         }
     }
     if !turns.is_empty() {


### PR DESCRIPTION
## Summary

- pass parent session context through `ToolCallContext`
- generate `agent_id` values for foreground sub-agent invocations
- persist completed sub-agent histories under `rollouts/<parent_session_id>/subagents/agent-*.jsonl`
- update session transcript/context docs and todo follow-ups

## Tests

- `cargo test tools::agent::tests -- --nocapture`
- `cargo check`

## Notes

This PR is stacked on #212. After #212 lands, this branch can be rebased onto `main`.
