### PR TITLE
fix(llm): improve DeepSeek v4 compaction reliability

### DIFF
--- a/src/agent/compact.rs
+++ b/src/agent/compact.rs
@@ -16,7 +16,7 @@ const ROLE_ASSISTANT: &str = "assistant";
 // compaction after a timeout or backend failure.
 const AUTO_COMPACTION_RETRY_HYSTERESIS_TOKENS: usize = 8_192;
 #[cfg(not(test))]
-const COMPACTION_SUMMARY_TIMEOUT: Duration = Duration::from_secs(120);
+const COMPACTION_SUMMARY_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[cfg(test)]
 const TEST_COMPACTION_SUMMARY_TIMEOUT: Duration = Duration::from_millis(10);

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -642,12 +642,12 @@ pub(crate) fn infer_openai_compatible_auxiliary_model(
 fn infer_deepseek_lite_model(model: &str) -> Option<Cow<'_, str>> {
     let trimmed = model.trim();
     let lower = trimmed.to_ascii_lowercase();
-    if !lower.contains("deepseek") || lower.contains("lite") {
+    if !lower.contains("deepseek") || lower.contains("flash") {
         return None;
     }
     if lower.contains("v4") && lower.ends_with("-pro") {
         let prefix = &trimmed[..trimmed.len().saturating_sub("-pro".len())];
-        return Some(Cow::Owned(format!("{prefix}-lite")));
+        return Some(Cow::Owned(format!("{prefix}-flash")));
     }
     None
 }

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -373,7 +373,7 @@ pub(super) fn should_bypass_proxy(base_url: &str) -> bool {
 }
 
 pub(super) fn context_budget_from_window(context_window_tokens: usize) -> ContextBudget {
-    let reserved_output_tokens = (context_window_tokens / 8).clamp(1024, 4096);
+    let reserved_output_tokens = (context_window_tokens / 8).clamp(1024, 16384);
     let compact_threshold_tokens = context_window_tokens
         .saturating_sub(reserved_output_tokens)
         .saturating_sub(2048);
@@ -384,7 +384,7 @@ pub(super) fn context_budget_from_window(context_window_tokens: usize) -> Contex
     }
 }
 
-const DEEPSEEK_LONG_CONTEXT_WINDOW_TOKENS: usize = 1_000_000;
+const DEEPSEEK_LONG_CONTEXT_WINDOW_TOKENS: usize = 1_048_576;
 const OPENAI_LONG_CONTEXT_WINDOW_TOKENS: usize = 200_000;
 const OPENAI_GPT4_CONTEXT_WINDOW_TOKENS: usize = 128_000;
 const DEEPSEEK_LONG_CONTEXT_MODEL_MARKERS: &[&str] = &["deepseek-v4"];

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -492,19 +492,19 @@ fn deepseek_reasoner_defaults_preserve_standard_body() {
 }
 
 #[test]
-fn deepseek_v4_pro_infers_lite_auxiliary_model() {
+fn deepseek_v4_pro_infers_flash_auxiliary_model() {
     assert_eq!(
         infer_openai_compatible_auxiliary_model("deepseek-v4-pro", OpenAiEndpointKind::Deepseek)
             .as_deref(),
-        Some("deepseek-v4-lite")
+        Some("deepseek-v4-flash")
     );
     assert_eq!(
         infer_openai_compatible_auxiliary_model("DeepSeek-V4-PRO", OpenAiEndpointKind::Deepseek)
             .as_deref(),
-        Some("DeepSeek-V4-lite")
+        Some("DeepSeek-V4-flash")
     );
     assert_eq!(
-        infer_openai_compatible_auxiliary_model("deepseek-v4-lite", OpenAiEndpointKind::Deepseek),
+        infer_openai_compatible_auxiliary_model("deepseek-v4-flash", OpenAiEndpointKind::Deepseek),
         None
     );
     assert_eq!(
@@ -2092,7 +2092,7 @@ fn derives_context_budget_for_codex_like_models() {
 #[test]
 fn derives_context_budget_for_deepseek_v4_models() {
     let budget = model_context_budget("deepseek-v4-preview").expect("budget");
-    assert_eq!(budget.context_window_tokens, 1_000_000);
+    assert_eq!(budget.context_window_tokens, 1_048_576);
     assert!(budget.compact_threshold_tokens > 900_000);
 }
 


### PR DESCRIPTION
## Summary

Three fixes for DeepSeek v4 compaction reliability:

1. **Auxiliary model**: `deepseek-v4-lite` → `deepseek-v4-flash` (API dropped v4-lite)
2. **Context window**: `1,000,000` → `1,048,576` (actual API limit is 2^20)
3. **Timeout**: `120s` → `300s` (1M+ token summaries need more time)

## Changes

- `src/llm/openai_compatible.rs`: auxiliary model inference -lite → -flash, filter condition
- `src/llm/shared.rs`: window constant 1M → 1,048,576; reserved_output clamp 4096 → 16384
- `src/agent/compact.rs`: compaction timeout 120s → 300s
- `src/llm/tests.rs`: updated assertions

## Problems Fixed

- "This model's maximum context length is 1048576 tokens. However, you requested 1048918 tokens"
- "history compaction timed out after 120 seconds"
- Compaction not triggering before hitting API limit