### PR TITLE
feat(subagent): index spawn edges

### DIFF
--- a/docs/features/session-transcript.md
+++ b/docs/features/session-transcript.md
@@ -184,9 +184,8 @@ This mirrors Codex's fork filtering while keeping Claude-style sidechain files.
   still return structured results without writing detached sidechain files.
 - Sidechain persistence failures are reported through `persistence_error`; they
   do not abort an otherwise completed foreground sub-agent call.
-- `StateDb` still stores parent/child relationships only indirectly through
-  rollout events. A queryable spawn-edge table is needed before cross-session
-  sub-agent resume is complete.
+- `StateDb` indexes parent/child spawn edges from rollout events, but live
+  background resume/stop semantics still need to consume that index.
 - Context compaction must preserve transcript boundaries and avoid injecting
   summaries before stable prompt-prefix sources.
 - Background sub-agent execution, resume, and stop semantics remain future work.
@@ -195,3 +194,4 @@ This mirrors Codex's fork filtering while keeping Claude-style sidechain files.
 
 - 2026-05-04-session-transcript-foundation.md
 - 2026-05-05-subagent-sidechain-transcripts.md
+- 2026-05-05-subagent-spawn-edge-index.md

--- a/docs/journal/2026-05-05-subagent-spawn-edge-index.md
+++ b/docs/journal/2026-05-05-subagent-spawn-edge-index.md
@@ -1,0 +1,27 @@
+# Sub-Agent Spawn Edge Index
+
+## Checkpoint
+
+RARA now mirrors parent-scoped `SpawnAgent` rollout events into a queryable
+`StateDb` table. The append-only rollout log remains the durable event source;
+the SQLite table is an index for listing, resume, and later stop operations.
+
+## Runtime Boundary
+
+- `spawn_agent_edges` stores parent session id, event id, agent id, optional
+  display name, child session id, status, summary, and recorded timestamp.
+- `ThreadStore::load_thread` synchronizes the index from structured rollout
+  events while materializing a thread snapshot, but skips the database write
+  when the indexed edge set already matches the rollout log.
+- The parent model context still only receives the compacted tool result and
+  does not inline sidechain transcript content.
+
+## Validation
+
+- `indexes_spawn_agent_edges_for_listing_queries`
+- `load_thread_aggregates_history_state_and_rollout_items`
+
+## Follow-up
+
+- Background sub-agent resume/stop should query this index instead of scanning
+  parent rollout files directly.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -79,7 +79,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Promote `rollouts/<session_id>/transcript.jsonl` from compatibility mirror to canonical model-history source.
 - [x] Wire foreground sub-agent tools to write parent-scoped sidechain transcripts under `rollouts/<parent_session_id>/subagents/`.
 - [x] Add append-only parent/child spawn-edge rollout metadata for foreground sub-agent calls.
-- [ ] Index parent/child spawn-edge metadata in `StateDb` for resume/listing queries.
+- [x] Index parent/child spawn-edge metadata in `StateDb` for resume/listing queries.
 - [ ] Add background sub-agent resume/stop over the sidechain transcript contract.
 - [ ] Add periodic promotion from session shards into global `MemoryRecord`s.
 - [ ] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -191,6 +191,18 @@ pub struct PersistedThreadRecord {
     pub updated_at: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistedSpawnAgentEdge {
+    pub parent_session_id: String,
+    pub event_id: String,
+    pub agent_id: String,
+    pub name: Option<String>,
+    pub child_session_id: String,
+    pub status: String,
+    pub summary: Option<String>,
+    pub recorded_at: Option<i64>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct PersistedCompactState {
     pub compaction_count: usize,
@@ -665,6 +677,85 @@ impl StateDb {
         )
     }
 
+    pub fn sync_spawn_agent_edges_from_events(
+        &self,
+        parent_session_id: &str,
+        events: &[PersistedStructuredRolloutEvent],
+    ) -> Result<()> {
+        let desired_edges = spawn_agent_edges_from_events(parent_session_id, events);
+        if desired_edges == self.load_spawn_agent_edges(parent_session_id)? {
+            return Ok(());
+        }
+
+        let mut conn = self.conn.lock().expect("state db mutex poisoned");
+        let tx = conn.transaction()?;
+        tx.execute(
+            "DELETE FROM spawn_agent_edges WHERE parent_session_id = ?",
+            params![parent_session_id],
+        )?;
+        let now = epoch_seconds();
+        for edge in desired_edges {
+            tx.execute(
+                "INSERT INTO spawn_agent_edges (
+                    parent_session_id, event_id, agent_id, name, child_session_id,
+                    status, summary, recorded_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(parent_session_id, event_id) DO UPDATE SET
+                    agent_id = excluded.agent_id,
+                    name = excluded.name,
+                    child_session_id = excluded.child_session_id,
+                    status = excluded.status,
+                    summary = excluded.summary,
+                    recorded_at = excluded.recorded_at,
+                    updated_at = excluded.updated_at",
+                params![
+                    edge.parent_session_id,
+                    edge.event_id,
+                    edge.agent_id,
+                    edge.name,
+                    edge.child_session_id,
+                    edge.status,
+                    edge.summary,
+                    edge.recorded_at,
+                    now
+                ],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn load_spawn_agent_edges(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<Vec<PersistedSpawnAgentEdge>> {
+        let conn = self.conn.lock().expect("state db mutex poisoned");
+        let mut stmt = conn.prepare(
+            "SELECT parent_session_id, event_id, agent_id, name, child_session_id,
+                    status, summary, recorded_at
+             FROM spawn_agent_edges
+             WHERE parent_session_id = ?
+             ORDER BY COALESCE(recorded_at, 0) ASC, event_id ASC",
+        )?;
+        let rows = stmt.query_map(params![parent_session_id], |row| {
+            Ok(PersistedSpawnAgentEdge {
+                parent_session_id: row.get(0)?,
+                event_id: row.get(1)?,
+                agent_id: row.get(2)?,
+                name: row.get(3)?,
+                child_session_id: row.get(4)?,
+                status: row.get(5)?,
+                summary: row.get(6)?,
+                recorded_at: row.get(7)?,
+            })
+        })?;
+        let mut edges = Vec::new();
+        for row in rows {
+            edges.push(row?);
+        }
+        Ok(edges)
+    }
+
     pub fn load_plan_steps(&self, session_id: &str) -> Result<Vec<PersistedPlanStep>> {
         let conn = self.conn.lock().expect("state db mutex poisoned");
         let mut stmt = conn.prepare(
@@ -1063,12 +1154,30 @@ impl StateDb {
                 updated_at INTEGER NOT NULL
             );
 
+            CREATE TABLE IF NOT EXISTS spawn_agent_edges (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                parent_session_id TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                agent_id TEXT NOT NULL,
+                name TEXT,
+                child_session_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                summary TEXT,
+                recorded_at INTEGER,
+                updated_at INTEGER NOT NULL,
+                UNIQUE(parent_session_id, event_id)
+            );
+
             CREATE INDEX IF NOT EXISTS idx_turns_session_ordinal
                 ON turns(session_id, ordinal);
             CREATE INDEX IF NOT EXISTS idx_plan_steps_session_step
                 ON plan_steps(session_id, step_index);
             CREATE INDEX IF NOT EXISTS idx_interactions_session_kind
                 ON interactions(session_id, kind);
+            CREATE INDEX IF NOT EXISTS idx_spawn_agent_edges_parent_agent
+                ON spawn_agent_edges(parent_session_id, agent_id);
+            CREATE INDEX IF NOT EXISTS idx_spawn_agent_edges_child
+                ON spawn_agent_edges(child_session_id);
             ",
         )?;
         ensure_column(&conn, "sessions", "plan_explanation", "TEXT")?;
@@ -1177,6 +1286,46 @@ fn legacy_runtime_interactions(items: &[PersistedRuntimeRolloutItem]) -> Vec<Per
             PersistedRuntimeRolloutItem::PlanState { .. } => None,
         })
         .collect()
+}
+
+fn spawn_agent_edges_from_events(
+    parent_session_id: &str,
+    events: &[PersistedStructuredRolloutEvent],
+) -> Vec<PersistedSpawnAgentEdge> {
+    let mut edges = events
+        .iter()
+        .filter_map(|event| {
+            let PersistedStructuredRolloutEvent::SpawnAgent {
+                recorded_at,
+                event_id,
+                agent_id,
+                name,
+                child_session_id,
+                status,
+                summary,
+            } = event
+            else {
+                return None;
+            };
+            Some(PersistedSpawnAgentEdge {
+                parent_session_id: parent_session_id.to_string(),
+                event_id: event_id.clone(),
+                agent_id: agent_id.clone(),
+                name: name.clone(),
+                child_session_id: child_session_id.clone(),
+                status: status.clone(),
+                summary: summary.clone(),
+                recorded_at: *recorded_at,
+            })
+        })
+        .collect::<Vec<_>>();
+    edges.sort_by(|left, right| {
+        left.recorded_at
+            .unwrap_or_default()
+            .cmp(&right.recorded_at.unwrap_or_default())
+            .then_with(|| left.event_id.cmp(&right.event_id))
+    });
+    edges
 }
 
 fn turn_preview(entries: &[PersistedTurnEntry]) -> String {

--- a/src/state_db/tests.rs
+++ b/src/state_db/tests.rs
@@ -510,6 +510,73 @@ fn load_rollout_events_prefers_append_only_log_without_snapshot_rewrite() -> Res
 }
 
 #[test]
+fn indexes_spawn_agent_edges_for_listing_queries() -> Result<()> {
+    let temp = tempdir()?;
+    let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;
+    db.sync_spawn_agent_edges_from_events(
+        "parent-session",
+        &[
+            PersistedStructuredRolloutEvent::PlanState {
+                recorded_at: Some(9),
+                explanation: Some("ignored".to_string()),
+                steps: Vec::new(),
+            },
+            PersistedStructuredRolloutEvent::SpawnAgent {
+                recorded_at: Some(10),
+                event_id: "spawn-1".to_string(),
+                agent_id: "worker-1".to_string(),
+                name: Some("Worker 1".to_string()),
+                child_session_id: "child-1".to_string(),
+                status: "done".to_string(),
+                summary: Some("Finished.".to_string()),
+            },
+        ],
+    )?;
+
+    let edges = db.load_spawn_agent_edges("parent-session")?;
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].parent_session_id, "parent-session");
+    assert_eq!(edges[0].event_id, "spawn-1");
+    assert_eq!(edges[0].agent_id, "worker-1");
+    assert_eq!(edges[0].name.as_deref(), Some("Worker 1"));
+    assert_eq!(edges[0].child_session_id, "child-1");
+    assert_eq!(edges[0].status, "done");
+    assert_eq!(edges[0].summary.as_deref(), Some("Finished."));
+    assert_eq!(edges[0].recorded_at, Some(10));
+
+    let original_id: i64 = {
+        let verify = Connection::open(db.path())?;
+        verify.query_row(
+            "SELECT id FROM spawn_agent_edges WHERE parent_session_id = 'parent-session'",
+            [],
+            |row| row.get(0),
+        )?
+    };
+    db.sync_spawn_agent_edges_from_events(
+        "parent-session",
+        &[PersistedStructuredRolloutEvent::SpawnAgent {
+            recorded_at: Some(10),
+            event_id: "spawn-1".to_string(),
+            agent_id: "worker-1".to_string(),
+            name: Some("Worker 1".to_string()),
+            child_session_id: "child-1".to_string(),
+            status: "done".to_string(),
+            summary: Some("Finished.".to_string()),
+        }],
+    )?;
+    let id_after_noop_sync: i64 = {
+        let verify = Connection::open(db.path())?;
+        verify.query_row(
+            "SELECT id FROM spawn_agent_edges WHERE parent_session_id = 'parent-session'",
+            [],
+            |row| row.get(0),
+        )?
+    };
+    assert_eq!(id_after_noop_sync, original_id);
+    Ok(())
+}
+
+#[test]
 fn load_legacy_rollout_migration_collects_structured_and_runtime_fallbacks() -> Result<()> {
     let temp = tempdir()?;
     let db = StateDb::new_for_root_dir(temp.path().join(".rara"))?;

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -455,6 +455,8 @@ impl<'a> ThreadStore<'a> {
             rollout_source,
             compaction_source,
         } = self.load_legacy_non_turn_rollout_migration(session_id)?;
+        self.state_db
+            .sync_spawn_agent_edges_from_events(session_id, &structured_events)?;
         let had_structured_events = !structured_events.is_empty();
         let had_compaction_events = !compaction_events.is_empty();
         let compaction = compaction_events

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -101,8 +101,12 @@ fn load_thread_aggregates_history_state_and_rollout_items() -> Result<()> {
 
     let store = ThreadStore::new(&session_manager, &state_db);
     let snapshot = store.load_thread("session-1")?;
+    let spawn_edges = state_db.load_spawn_agent_edges("session-1")?;
 
     assert_eq!(snapshot.metadata.session_id, "session-1");
+    assert_eq!(spawn_edges.len(), 1);
+    assert_eq!(spawn_edges[0].agent_id, "worker-1");
+    assert_eq!(spawn_edges[0].child_session_id, "child-session-1");
     assert_eq!(
         snapshot.provenance.metadata_source,
         ThreadMetadataSource::StateDb


### PR DESCRIPTION
## Summary

- Add a queryable StateDb `spawn_agent_edges` index for parent/child sub-agent edges.
- Synchronize the index from structured rollout events during thread materialization.
- Update transcript docs, journal, and TODO checkpoint.

## Tests

- `cargo fmt --check`
- `cargo check`
- `cargo test state_db::tests -- --nocapture`
- `cargo test thread_store::tests -- --nocapture`

## Notes

This is stacked on #214 and should be retargeted to `main` after #214 is merged.
