### PR TITLE
chore(hooks): add pre-commit hooks for cargo fmt, clippy, and check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --check
+        language: system
+        stages: [pre-commit]
+        pass_filenames: false
+
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --no-deps -- -D warnings
+        language: system
+        stages: [pre-commit]
+        pass_filenames: false
+
+      - id: cargo-check
+        name: cargo check
+        entry: cargo check
+        language: system
+        stages: [pre-commit]
+        pass_filenames: false


### PR DESCRIPTION
## Summary

Add `prek`-based pre-commit hooks that run before every `git commit`:

| Hook | Command | Purpose |
|------|---------|---------|
| `cargo-fmt` | `cargo fmt --check` | Block commit if code is not formatted |
| `cargo-clippy` | `cargo clippy --no-deps -- -D warnings` | Block commit on any clippy warning |
| `cargo-check` | `cargo check` | Block commit if code doesn't compile |

## Configuration

Uses `.pre-commit-config.yaml` with `prek` as the hook manager. All hooks are `language: system` (run directly, no virtual envs).

## Setup for developers

```bash
prek install
```

## Tested

- `prek run --stage pre-commit --last-commit` passes (skips on non-Rust commits)
- `git commit` triggers all three hooks in sequence