### PR TITLE
feat(tui): replace /permissions cycle with Codex/Claude-style picker overlay

### DIFF
--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -25,6 +25,8 @@ pub enum AppEvent {
     MoveOpenAiProfileSelection(i32),
     MoveAuthModeSelection(i32),
     MoveReasoningEffortSelection(i32),
+    MovePermissionSelection(i32),
+    SetPermissionSelection(usize),
     MoveResumeSelection(i32),
     MoveSkillsSelection(i32),
     ToggleSkillSelection,

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -7,6 +7,7 @@ use super::provider_flow::{
     open_provider_family_overlay, should_open_codex_auth_guide,
     sync_codex_credential_from_auth_store,
 };
+use super::runtime::apply_permission_mode;
 use super::runtime::{
     request_running_task_cancellation, start_deepseek_model_list_task, start_oauth_task,
     start_pending_approval_task, start_rebuild_task,
@@ -14,7 +15,7 @@ use super::runtime::{
 use super::session_restore::restore_thread_by_id;
 use super::state::{
     ActivePendingInteractionKind, OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES,
-    ProviderFamily, TuiApp,
+    PermissionMode, ProviderFamily, TuiApp,
 };
 use super::submit::{apply_openai_model_picker_action, handle_submit};
 use super::terminal_ui::is_ssh_session;
@@ -142,6 +143,15 @@ pub(crate) async fn dispatch_event(
             let max_idx = AUTH_MODE_OPTION_COUNT.saturating_sub(1);
             let next = (app.auth_mode_idx as i32 + delta).clamp(0, max_idx as i32);
             app.auth_mode_idx = next as usize;
+        }
+        AppEvent::MovePermissionSelection(delta) => {
+            let max_idx = 3i32; // Auto, AcceptEdits, ReadOnly, FullAccess
+            let next = (app.permission_picker_idx as i32 + delta).clamp(0, max_idx);
+            app.permission_picker_idx = next as usize;
+        }
+        AppEvent::SetPermissionSelection(idx) => {
+            let max = 3usize;
+            app.permission_picker_idx = idx.min(max);
         }
         AppEvent::SetProviderSelection(idx) => {
             app.provider_picker_idx = idx.min(PROVIDER_FAMILIES.len() - 1);
@@ -542,6 +552,24 @@ pub(crate) async fn dispatch_event(
                 }
                 _ => {}
             },
+            Some(Overlay::PermissionPicker) => {
+                if app.is_busy() {
+                    app.push_notice("A task is already running. Wait for it to finish.");
+                } else {
+                    let mode = match app.permission_picker_idx {
+                        0 => PermissionMode::Auto,
+                        1 => PermissionMode::AcceptEdits,
+                        2 => PermissionMode::ReadOnly,
+                        3 => PermissionMode::FullAccess,
+                        _ => PermissionMode::Auto,
+                    };
+                    apply_permission_mode(app, agent_slot, mode);
+                    app.permission_mode = mode;
+                    let label = mode.label();
+                    app.push_notice(format!("Permission mode: {label}."));
+                    app.close_overlay();
+                }
+            }
             _ => {}
         },
     }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -243,6 +243,17 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             KeyCode::Enter => AppEvent::ApplyOverlaySelection,
             _ => AppEvent::Noop,
         },
+        Some(Overlay::PermissionPicker) => match code {
+            KeyCode::Esc => AppEvent::CloseOverlay,
+            KeyCode::Up | KeyCode::Char('k') => AppEvent::MovePermissionSelection(-1),
+            KeyCode::Down | KeyCode::Char('j') => AppEvent::MovePermissionSelection(1),
+            KeyCode::Char('1') => AppEvent::SetPermissionSelection(0),
+            KeyCode::Char('2') => AppEvent::SetPermissionSelection(1),
+            KeyCode::Char('3') => AppEvent::SetPermissionSelection(2),
+            KeyCode::Char('4') => AppEvent::SetPermissionSelection(3),
+            KeyCode::Enter => AppEvent::ApplyOverlaySelection,
+            _ => AppEvent::Noop,
+        },
         None => {
             if app.input.is_empty()
                 && let Some(index) = pending_shortcut_index(code, app)

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -13,8 +13,9 @@ use self::overlay_setup::{
     render_api_key_editor_modal, render_auth_mode_picker_modal, render_base_url_editor_modal,
     render_model_name_editor_modal, render_model_picker_modal,
     render_openai_endpoint_kind_picker_modal, render_openai_profile_label_editor_modal,
-    render_openai_profile_picker_modal, render_provider_picker_modal,
-    render_reasoning_effort_picker_modal, render_resume_picker_modal, render_skills_picker_modal,
+    render_openai_profile_picker_modal, render_permission_picker_modal,
+    render_provider_picker_modal, render_reasoning_effort_picker_modal, render_resume_picker_modal,
+    render_skills_picker_modal,
 };
 use super::super::command::{
     general_help_text, matching_commands, model_help_text, palette_commands,
@@ -91,6 +92,12 @@ pub(super) fn render_overlay(
             let popup = centered_rect(78, 70, f.area());
             f.render_widget(Clear, popup);
             render_reasoning_effort_picker_modal(f, app, popup);
+            None
+        }
+        Overlay::PermissionPicker => {
+            let popup = centered_rect(72, 70, f.area());
+            f.render_widget(Clear, popup);
+            render_permission_picker_modal(f, app, popup);
             None
         }
         Overlay::BaseUrlEditor => {

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -18,7 +18,8 @@ use crate::tui::command::api_key_status;
 use crate::tui::is_ssh_session;
 use crate::tui::render::bottom_pane::editor_cursor_position;
 use crate::tui::state::{
-    PROVIDER_FAMILIES, ProviderFamily, TuiApp, current_model_presets, openai_profile_setup_kinds,
+    PROVIDER_FAMILIES, PermissionMode, ProviderFamily, TuiApp, current_model_presets,
+    openai_profile_setup_kinds,
 };
 use crate::tui::theme::*;
 
@@ -670,6 +671,85 @@ pub(super) fn render_reasoning_effort_picker_modal(f: &mut Frame, app: &TuiApp, 
     );
     f.render_widget(
         Paragraph::new("1-5 jump  Up/Down move  Enter apply  Esc back")
+            .alignment(Alignment::Center),
+        chunks[2],
+    );
+}
+
+pub(super) fn render_permission_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
+    // Keep in sync with PermissionMode enum order (skip Custom).
+    let modes: &[(PermissionMode, &str, &str)] = &[
+        (
+            PermissionMode::Auto,
+            "Ask Permissions",
+            "Ask before file edits and commands. Only reads are auto-approved. Best for sensitive work.",
+        ),
+        (
+            PermissionMode::AcceptEdits,
+            "Auto Accept Edits",
+            "Auto-approve file edits and common filesystem commands. Ask for network and destructive operations.",
+        ),
+        (
+            PermissionMode::ReadOnly,
+            "Plan Mode",
+            "Read and explore only. No file changes permitted. Best for codebase analysis.",
+        ),
+        (
+            PermissionMode::FullAccess,
+            "Full Access",
+            "Auto-approve everything including network access. For isolated, trusted tasks.",
+        ),
+    ];
+
+    let title = " Permission Mode ";
+    let items = modes
+        .iter()
+        .enumerate()
+        .map(|(idx, (mode, label, desc))| {
+            let is_current = app.permission_mode == *mode
+                || (app.permission_mode == PermissionMode::Custom
+                    && idx == app.permission_picker_idx);
+            let style = if idx == app.permission_picker_idx {
+                Style::default()
+                    .fg(TEXT_ACCENT)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let current_marker = if is_current && app.permission_mode != PermissionMode::Custom {
+                " (current)"
+            } else {
+                ""
+            };
+            let mode_label = format!("[{}] {}{}", idx + 1, label, current_marker);
+            ListItem::new(vec![
+                Line::from(mode_label),
+                Line::from(desc.to_string()),
+                Line::from(""),
+            ])
+            .style(style)
+        })
+        .collect::<Vec<_>>();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(8),
+            Constraint::Length(2),
+        ])
+        .split(area);
+    f.render_widget(
+        Paragraph::new("Choose how RARA handles file edits, commands, and network access. Press Enter to apply the selected mode.")
+            .block(Block::default().borders(Borders::ALL).title(title)),
+        chunks[0],
+    );
+    f.render_widget(
+        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
+        chunks[1],
+    );
+    f.render_widget(
+        Paragraph::new("1-4 jump  Up/Down move  Enter apply  Esc back")
             .alignment(Alignment::Center),
         chunks[2],
     );

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -1,4 +1,5 @@
 mod commands;
+pub(crate) use commands::apply_permission_mode;
 mod events;
 mod tasks;
 

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -149,14 +149,20 @@ pub(super) async fn execute_local_command(
             }
         }
         LocalCommandKind::Permissions => {
-            let next_mode = app.permission_mode.cycle();
-            app.permission_mode = next_mode;
-            apply_permission_mode(app, agent_slot, next_mode);
-            let notice = format!(
-                "Permission mode: {label}.",
-                label = app.permission_mode_label()
+            // Sync picker index to current mode before opening.
+            let current_idx = match app.permission_mode {
+                PermissionMode::Auto => 0,
+                PermissionMode::AcceptEdits => 1,
+                PermissionMode::ReadOnly => 2,
+                PermissionMode::FullAccess => 3,
+                PermissionMode::Custom => 0,
+            };
+            app.permission_picker_idx = current_idx;
+            app.set_runtime_phase(
+                RuntimePhase::LocalCommand,
+                Some("opening permission picker".into()),
             );
-            app.push_notice(notice);
+            app.open_overlay(Overlay::PermissionPicker);
         }
         LocalCommandKind::Quit => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("quitting".into()));
@@ -413,7 +419,11 @@ fn capture_git_diff(cwd: &str) -> String {
     }
 }
 
-fn apply_permission_mode(app: &mut TuiApp, agent_slot: &mut Option<Agent>, mode: PermissionMode) {
+pub(crate) fn apply_permission_mode(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    mode: PermissionMode,
+) {
     use std::sync::atomic::Ordering;
 
     let (execution, approval, allow_net) = match mode {

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -210,6 +210,7 @@ impl TuiApp {
             openai_profile_picker_idx: 0,
             reasoning_effort_picker_idx: 0,
             auth_mode_idx: 0,
+            permission_picker_idx: 0,
             command_palette_idx: 0,
             base_url_input: String::new(),
             base_url_cursor_offset: None,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -57,6 +57,7 @@ pub enum Overlay {
     OpenAiProfileLabelEditor,
     ReasoningEffortPicker,
     SkillsPicker,
+    PermissionPicker,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -542,6 +543,7 @@ pub struct TuiApp {
     pub openai_profile_picker_idx: usize,
     pub reasoning_effort_picker_idx: usize,
     pub auth_mode_idx: usize,
+    pub permission_picker_idx: usize,
     pub command_palette_idx: usize,
     pub base_url_input: String,
     pub base_url_cursor_offset: Option<usize>,


### PR DESCRIPTION
## Summary

Replace the linear `/permissions` cycling with an interactive picker overlay, similar to Claude Code's mode selector UX.

## Changes

- Add `Overlay::PermissionPicker` — a centered overlay modal
- Each of the 4 modes has a user-facing label and description:
  - **Ask Permissions** (Auto) — Ask before file edits and commands
  - **Auto Accept Edits** — Auto-approve file edits and common filesystem commands
  - **Plan Mode** (ReadOnly) — Read and explore only
  - **Full Access** — Auto-approve everything including network
- Keyboard: ↑↓/jk navigate, 1-4 jump, Enter apply, Esc cancel
- Current mode marked with `(current)` indicator
- Bottom-pane badge continues to show active permission mode

## Testing

- `cargo check`: no new errors
- `cargo test`: 818 passed, 0 failed
- `cargo fmt`: clean