### PR TITLE
chore(hooks): add file filters, --locked, --all-targets, --all-features, remove redundant cargo-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ repos:
         name: cargo fmt
         entry: cargo fmt --check
         language: system
-        files: \.rs$
+        files: (\.rs|\.?rustfmt\.toml)$
         stages: [pre-commit]
         pass_filenames: false
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy --workspace --all-targets --all-features --no-deps --locked -- -D warnings
+        entry: cargo clippy --locked --all-targets --no-deps -- -D warnings
         language: system
-        files: \.(rs|toml)$
+        files: \.(rs|toml|lock)$
         stages: [pre-commit]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,19 +5,14 @@ repos:
         name: cargo fmt
         entry: cargo fmt --check
         language: system
+        files: \.rs$
         stages: [pre-commit]
         pass_filenames: false
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy --no-deps -- -D warnings
+        entry: cargo clippy --workspace --all-targets --all-features --no-deps --locked -- -D warnings
         language: system
-        stages: [pre-commit]
-        pass_filenames: false
-
-      - id: cargo-check
-        name: cargo check
-        entry: cargo check
-        language: system
+        files: \.(rs|toml)$
         stages: [pre-commit]
         pass_filenames: false


### PR DESCRIPTION
## Summary

Follow-up to #217. Addresses all review feedback:

### Changes

| Hook | Change | Rationale |
|------|--------|-----------|
| `cargo-fmt` | Add `files: \.rs$` | Skip on non-Rust commits |
| `cargo-clippy` | Add `--workspace --all-targets --all-features --locked`, `files: \.(rs\|toml)$` | Match CI behavior, comprehensive coverage, prevent Cargo.lock mutation |
| `cargo-check` | Removed | Redundant — clippy already compiles the crate |

### Final config

```yaml
repos:
  - repo: local
    hooks:
      - id: cargo-fmt
        name: cargo fmt
        entry: cargo fmt --check
        language: system
        files: \.rs$
        stages: [pre-commit]
        pass_filenames: false

      - id: cargo-clippy
        name: cargo clippy
        entry: cargo clippy --workspace --all-targets --all-features --no-deps --locked -- -D warnings
        language: system
        files: \.(rs|toml)$
        stages: [pre-commit]
        pass_filenames: false
```