### PR TITLE
fix(tui): show feedback when no task to cancel (Esc/Ctrl+C)

### DIFF
--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -450,6 +450,7 @@ pub(super) fn start_deepseek_model_list_task(app: &mut TuiApp) {
 
 pub(super) fn request_running_task_cancellation(app: &mut TuiApp) {
     let Some(task) = app.running_task.as_mut() else {
+        app.notice = Some("No running task to cancel.".into());
         return;
     };
     if !matches!(task.kind, TaskKind::Query) {


### PR DESCRIPTION
## Problem

Pressing Esc (or Ctrl+C) to cancel had two unreported failure modes:

1. **No running task**: `request_running_task_cancellation` silently returned when `running_task` was `None` — a common race condition when the task finishes between the keypress and event dispatch. User sees no reaction.
2. **Non-query tasks**: Returns a notice but no cancellation (expected — only queries can be cancelled).

## Fix

Show `"No running task to cancel."` notice when Esc/Ctrl+C is pressed with no active task, so the user knows the keypress was received.

## Note

This is the same root cause as the empty-Enter issue (#222) — silent returns make users feel the UI is broken. The actual cancellation path (query running → cancel) was already working correctly for both Esc and Ctrl+C.