### PR TITLE
fix(tui): preserve interleaved agent output

### DIFF
--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -170,6 +170,9 @@ impl ActiveCell for ActiveTurnCell<'_> {
                             compact_summary_lines(items.as_slice(), 4, "more exploration step(s)");
                         cells.push(Box::new(ExploringCell::new(summary, turn_live)));
                     }
+                    OrderedActiveSegment::Progress(role, messages) => {
+                        push_progress_group(&mut cells, *role, messages.clone(), turn_live);
+                    }
                     OrderedActiveSegment::Agent(message) => {
                         cells.push(Box::new(MessageCell::new(
                             "Agent",
@@ -203,9 +206,11 @@ impl ActiveCell for ActiveTurnCell<'_> {
             );
         }
 
-        let explicit_progress_groups =
-            (!has_live_events && !has_live_thinking && !has_active_pending_interaction)
-                .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
+        let explicit_progress_groups = (!uses_ordered_exploration_agent_segments
+            && !has_live_events
+            && !has_live_thinking
+            && !has_active_pending_interaction)
+            .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
         if let Some(groups) = explicit_progress_groups.as_ref() {
             for (role, messages) in groups {
                 push_progress_group(&mut cells, *role, messages.clone(), turn_live);
@@ -256,7 +261,10 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Planning")
             .map(|entry| entry.message.clone());
 
-        let planning_summary = if has_live_events || has_explicit_progress_groups {
+        let planning_summary = if has_live_events
+            || has_explicit_progress_groups
+            || uses_ordered_exploration_agent_segments
+        {
             None
         } else if has_live_planning {
             Some(compact_progress_summary_lines(
@@ -279,7 +287,10 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Running")
             .map(|entry| entry.message.clone());
 
-        let running_summary = if has_live_events || has_explicit_progress_groups {
+        let running_summary = if has_live_events
+            || has_explicit_progress_groups
+            || uses_ordered_exploration_agent_segments
+        {
             None
         } else if has_live_running {
             Some(compact_recent_first_summary_lines(

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -946,6 +946,75 @@ fn active_turn_cell_preserves_agent_then_exploration_order() {
 }
 
 #[test]
+fn active_turn_cell_preserves_interleaved_agent_and_progress_output() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Continue the migration".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "First I will sync the branch.".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Running".into(),
+                message: "Run git rebase main".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Agent".into(),
+                message: "The first conflict is in keymap.rs.".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Running".into(),
+                message: "Run cargo test tui::keymap".into(),
+                payload: None,
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let first_agent = rendered.find("First I will sync the branch.").unwrap();
+    let first_running = rendered.find("Run git rebase main").unwrap();
+    let second_agent = rendered
+        .find("The first conflict is in keymap.rs.")
+        .unwrap();
+    let second_running = rendered.find("Run cargo test tui::keymap").unwrap();
+
+    assert!(first_agent < first_running);
+    assert!(first_running < second_agent);
+    assert!(second_agent < second_running);
+    assert_eq!(
+        rendered.matches("• First I will sync the branch.").count(),
+        1
+    );
+    assert_eq!(
+        rendered
+            .matches("• The first conflict is in keymap.rs.")
+            .count(),
+        1
+    );
+    assert_eq!(rendered.matches("Run git rebase main").count(), 1);
+    assert_eq!(rendered.matches("Run cargo test tui::keymap").count(), 1);
+}
+
+#[test]
 fn active_turn_cell_uses_lightweight_busy_response_when_not_streaming() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells/cells_tests/committed.rs
+++ b/src/tui/render/cells/cells_tests/committed.rs
@@ -190,6 +190,67 @@ fn committed_turn_cell_keeps_progress_segments_and_terminal_output() {
 }
 
 #[test]
+fn committed_turn_cell_preserves_interleaved_agent_and_progress_output() {
+    let entries = vec![
+        TranscriptEntry {
+            role: "You".into(),
+            message: "Sync the branch".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Agent".into(),
+            message: "First I will sync the branch.".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Running".into(),
+            message: "Run git rebase main".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Agent".into(),
+            message: "The first conflict is in keymap.rs.".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Running".into(),
+            message: "Run cargo test tui::keymap".into(),
+            payload: None,
+        },
+    ];
+
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let first_agent = rendered.find("• First I will sync the branch.").unwrap();
+    let first_running = rendered.find("Run git rebase main").unwrap();
+    let second_agent = rendered
+        .find("• The first conflict is in keymap.rs.")
+        .unwrap();
+    let second_running = rendered.find("Run cargo test tui::keymap").unwrap();
+
+    assert_eq!(
+        rendered.matches("• First I will sync the branch.").count(),
+        1
+    );
+    assert_eq!(
+        rendered
+            .matches("• The first conflict is in keymap.rs.")
+            .count(),
+        1
+    );
+    assert_eq!(rendered.matches("Run git rebase main").count(), 1);
+    assert_eq!(rendered.matches("Run cargo test tui::keymap").count(), 1);
+    assert!(first_agent < first_running);
+    assert!(first_running < second_agent);
+    assert!(second_agent < second_running);
+}
+
+#[test]
 fn committed_turn_cell_appends_adjacent_progress_entries() {
     let entries = vec![
         TranscriptEntry {

--- a/src/tui/render/cells/committed_turn.rs
+++ b/src/tui/render/cells/committed_turn.rs
@@ -4,7 +4,9 @@ use ratatui::text::Line;
 
 use super::super::history_pipeline::{narrative_entries, ordered_completion_entries};
 use super::components::{CommittedInteractionCell, ExploredCell, MessageCell, RanCell, UserCell};
-use super::progress::{explicit_progress_entry_groups, push_progress_group};
+use super::progress::{
+    ProgressRole, explicit_progress_entry_groups, progress_entry_message_lines, push_progress_group,
+};
 use super::terminal::terminal_cell_from_entries;
 use super::{
     HistoryCell, InteractionCompletionKind, is_progress_stack_title, trim_trailing_empty_lines,
@@ -33,13 +35,22 @@ impl HistoryCell for CommittedTurnCell<'_> {
 
         let entry_refs = self.entries.iter().collect::<Vec<_>>();
         let explicit_progress_groups = explicit_progress_entry_groups(self.entries.iter());
+        let preserve_interleaved_agent_order = self
+            .entries
+            .iter()
+            .filter(|entry| entry.role == "Agent")
+            .count()
+            > 1
+            && !explicit_progress_groups.is_empty();
         let has_tool_activity = entry_refs.iter().any(|entry| {
             matches!(
                 entry.role.as_str(),
                 "Tool" | "Tool Result" | "Tool Error" | "Tool Progress"
             ) || matches!(entry.payload, Some(TranscriptEntryPayload::Terminal(_)))
         });
-        if explicit_progress_groups.is_empty() {
+        if preserve_interleaved_agent_order {
+            push_ordered_committed_activity(&mut cells, self.entries, self.cwd);
+        } else if explicit_progress_groups.is_empty() {
             if let Some(summary) =
                 current_turn_exploration_summary_from_entries(entry_refs.as_slice(), false, None)
             {
@@ -62,42 +73,44 @@ impl HistoryCell for CommittedTurnCell<'_> {
             }
         }
 
-        let completion_entries = ordered_completion_entries(self.entries);
-        let narrative_entries = narrative_entries(
-            self.entries,
-            has_tool_activity,
-            super::is_renderable_system_message,
-        );
+        if !preserve_interleaved_agent_order {
+            let completion_entries = ordered_completion_entries(self.entries);
+            let narrative_entries = narrative_entries(
+                self.entries,
+                has_tool_activity,
+                super::is_renderable_system_message,
+            );
 
-        for entry in completion_entries {
-            let kind = match entry.kind {
-                super::super::history_pipeline::CommittedCompletionKind::ShellApprovalCompleted => {
-                    InteractionCompletionKind::ShellApprovalCompleted
-                }
-                super::super::history_pipeline::CommittedCompletionKind::PlanningQuestionAnswered => {
-                    InteractionCompletionKind::PlanningQuestionAnswered
-                }
-                super::super::history_pipeline::CommittedCompletionKind::ExplorationQuestionAnswered => {
-                    InteractionCompletionKind::ExplorationQuestionAnswered
-                }
-                super::super::history_pipeline::CommittedCompletionKind::SubAgentQuestionAnswered => {
-                    InteractionCompletionKind::SubAgentQuestionAnswered
-                }
-                super::super::history_pipeline::CommittedCompletionKind::QuestionAnswered => {
-                    InteractionCompletionKind::QuestionAnswered
-                }
-            };
-            cells.push(Box::new(CommittedInteractionCell::new(kind, entry.message)));
-        }
+            for entry in completion_entries {
+                let kind = match entry.kind {
+                    super::super::history_pipeline::CommittedCompletionKind::ShellApprovalCompleted => {
+                        InteractionCompletionKind::ShellApprovalCompleted
+                    }
+                    super::super::history_pipeline::CommittedCompletionKind::PlanningQuestionAnswered => {
+                        InteractionCompletionKind::PlanningQuestionAnswered
+                    }
+                    super::super::history_pipeline::CommittedCompletionKind::ExplorationQuestionAnswered => {
+                        InteractionCompletionKind::ExplorationQuestionAnswered
+                    }
+                    super::super::history_pipeline::CommittedCompletionKind::SubAgentQuestionAnswered => {
+                        InteractionCompletionKind::SubAgentQuestionAnswered
+                    }
+                    super::super::history_pipeline::CommittedCompletionKind::QuestionAnswered => {
+                        InteractionCompletionKind::QuestionAnswered
+                    }
+                };
+                cells.push(Box::new(CommittedInteractionCell::new(kind, entry.message)));
+            }
 
-        for entry in narrative_entries {
-            let max_lines = if entry.role == "Agent" { usize::MAX } else { 4 };
-            cells.push(Box::new(MessageCell::new(
-                &entry.role,
-                &entry.message,
-                max_lines,
-                self.cwd,
-            )));
+            for entry in narrative_entries {
+                let max_lines = if entry.role == "Agent" { usize::MAX } else { 4 };
+                cells.push(Box::new(MessageCell::new(
+                    &entry.role,
+                    &entry.message,
+                    max_lines,
+                    self.cwd,
+                )));
+            }
         }
 
         let mut lines = Vec::new();
@@ -117,4 +130,71 @@ impl HistoryCell for CommittedTurnCell<'_> {
         trim_trailing_empty_lines(&mut lines);
         lines
     }
+}
+
+fn push_ordered_committed_activity<'a>(
+    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+    entries: &'a [TranscriptEntry],
+    cwd: Option<&'a Path>,
+) {
+    let mut pending_progress: Option<(ProgressRole, Vec<String>)> = None;
+
+    let flush_progress =
+        |cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+         pending_progress: &mut Option<(ProgressRole, Vec<String>)>| {
+            if let Some((role, messages)) = pending_progress.take() {
+                push_progress_group(cells, role, messages, false);
+            }
+        };
+
+    for entry in entries {
+        if entry.role == "You" {
+            continue;
+        }
+
+        if let Some(role) = ProgressRole::from_entry_role(entry.role.as_str()) {
+            let messages = progress_entry_message_lines(role, &entry.message);
+            if messages.is_empty() {
+                continue;
+            }
+            if let Some((last_role, last_messages)) = pending_progress.as_mut()
+                && *last_role == role
+            {
+                last_messages.extend(messages);
+            } else {
+                flush_progress(cells, &mut pending_progress);
+                pending_progress = Some((role, messages));
+            }
+            continue;
+        }
+
+        flush_progress(cells, &mut pending_progress);
+
+        if let Some(cell) = terminal_cell_from_entries(std::iter::once(entry)) {
+            cells.push(Box::new(cell));
+            continue;
+        }
+
+        if let Some(kind) = InteractionCompletionKind::from_role(entry.role.as_str()) {
+            cells.push(Box::new(CommittedInteractionCell::new(
+                kind,
+                entry.message.clone(),
+            )));
+            continue;
+        }
+
+        if entry.role == "Agent"
+            || (entry.role == "System" && super::is_renderable_system_message(&entry.message))
+        {
+            let max_lines = if entry.role == "Agent" { usize::MAX } else { 4 };
+            cells.push(Box::new(MessageCell::new(
+                &entry.role,
+                &entry.message,
+                max_lines,
+                cwd,
+            )));
+        }
+    }
+
+    flush_progress(cells, &mut pending_progress);
 }

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -26,8 +26,9 @@ pub(crate) trait ActiveCell {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>>;
 }
 
-pub(super) enum OrderedActiveSegment<'a> {
+enum OrderedActiveSegment<'a> {
     Exploration(Vec<String>),
+    Progress(ProgressRole, Vec<String>),
     Agent(&'a str),
 }
 
@@ -101,6 +102,25 @@ fn ordered_exploration_agent_segments<'a>(
                     exploration_items.push(item);
                 }
             }
+            role if let Some(progress_role) = ProgressRole::from_entry_role(role) => {
+                let messages =
+                    progress::progress_entry_message_lines(progress_role, &entry.message);
+                if messages.is_empty() {
+                    continue;
+                }
+                if !exploration_items.is_empty() || !segments.is_empty() {
+                    saw_interleaving = true;
+                }
+                flush_exploration(&mut segments, &mut exploration_items);
+                if let Some(OrderedActiveSegment::Progress(last_role, last_messages)) =
+                    segments.last_mut()
+                    && *last_role == progress_role
+                {
+                    last_messages.extend(messages);
+                } else {
+                    segments.push(OrderedActiveSegment::Progress(progress_role, messages));
+                }
+            }
             "Agent" => {
                 if !exploration_items.is_empty() {
                     saw_interleaving = true;
@@ -108,12 +128,7 @@ fn ordered_exploration_agent_segments<'a>(
                 }
                 segments.push(OrderedActiveSegment::Agent(entry.message.as_str()));
             }
-            role if ProgressRole::from_entry_role(role).is_some()
-                || matches!(
-                    role,
-                    "Tool Result" | "Tool Error" | "Tool Progress" | "System"
-                ) =>
-            {
+            "Tool Result" | "Tool Error" | "Tool Progress" | "System" => {
                 if !exploration_items.is_empty() {
                     saw_interleaving = true;
                     flush_exploration(&mut segments, &mut exploration_items);

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -36,7 +36,7 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                 app.append_agent_thinking_delta(&message);
                 return;
             } else if role == "Tool" || role == "Tool Result" || role == "Tool Error" {
-                app.flush_agent_thinking_stream_to_live_event();
+                app.finalize_agent_stream(None);
                 if role == "Tool" {
                     if let Some(action) = exploration_action_label(&message) {
                         app.record_exploration_action(action);
@@ -211,7 +211,7 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
             );
         }
         TuiEvent::Terminal(event) => {
-            app.flush_agent_thinking_stream_to_live_event();
+            app.finalize_agent_stream(None);
             let role = event.transcript_role();
             let message = event.to_transcript_message();
             if role == "Tool" {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -867,6 +867,55 @@ fn streamed_agent_output_appends_visible_text_after_internal_block() {
 }
 
 #[test]
+fn finalized_agent_stream_does_not_replace_agent_text_before_tool_boundary() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.push_entry("You", "Fix the rendering order");
+
+    app.append_agent_delta("First assistant segment.");
+    app.finalize_agent_stream(None);
+    app.push_entry("Running", "Run cargo check");
+    app.append_agent_delta("Second assistant segment.");
+    app.finalize_agent_stream(None);
+
+    let agent_entries = app
+        .active_turn
+        .entries
+        .iter()
+        .filter(|entry| entry.role == "Agent")
+        .map(|entry| entry.message.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        agent_entries,
+        vec!["First assistant segment.", "Second assistant segment."]
+    );
+
+    let first_agent = app
+        .active_turn
+        .entries
+        .iter()
+        .position(|entry| entry.message == "First assistant segment.")
+        .unwrap();
+    let running = app
+        .active_turn
+        .entries
+        .iter()
+        .position(|entry| entry.message == "Run cargo check")
+        .unwrap();
+    let second_agent = app
+        .active_turn
+        .entries
+        .iter()
+        .position(|entry| entry.message == "Second assistant segment.")
+        .unwrap();
+    assert!(first_agent < running);
+    assert!(running < second_agent);
+}
+
+#[test]
 fn flushed_agent_thinking_stream_scrubs_internal_runtime_blocks() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -31,18 +31,42 @@ fn legacy_active_live_sections(live: &ActiveLiveSections) -> Vec<(&'static str, 
     ]
 }
 
+fn is_agent_segment_boundary(entry: &TranscriptEntry) -> bool {
+    matches!(
+        entry.role.as_str(),
+        "Tool"
+            | "Tool Result"
+            | "Tool Error"
+            | "Tool Progress"
+            | "Thinking"
+            | "Exploring"
+            | "Planning"
+            | "Running"
+    ) || matches!(
+        entry.payload,
+        Some(crate::tui::state::TranscriptEntryPayload::Terminal(_))
+    )
+}
+
 impl TuiApp {
-    fn replace_turn_agent_message(turn: &mut TranscriptTurn, message: String) -> bool {
-        let Some(last_agent_idx) = turn.entries.iter().rposition(|entry| entry.role == "Agent")
+    fn replace_current_agent_segment_message(turn: &mut TranscriptTurn, message: String) -> bool {
+        let segment_start = turn
+            .entries
+            .iter()
+            .rposition(|entry| is_agent_segment_boundary(entry))
+            .map_or(0, |idx| idx + 1);
+        let Some(last_agent_idx) = turn.entries[segment_start..]
+            .iter()
+            .rposition(|entry| entry.role == "Agent")
+            .map(|idx| segment_start + idx)
         else {
             return false;
         };
 
         turn.entries[last_agent_idx].message = message;
-
         let mut retained = Vec::with_capacity(turn.entries.len());
         for (idx, entry) in turn.entries.drain(..).enumerate() {
-            if entry.role == "Agent" && idx != last_agent_idx {
+            if idx >= segment_start && idx != last_agent_idx && entry.role == "Agent" {
                 continue;
             }
             retained.push(entry);
@@ -168,13 +192,13 @@ impl TuiApp {
             return;
         }
 
-        if Self::replace_turn_agent_message(&mut self.active_turn, message.clone()) {
+        if Self::replace_current_agent_segment_message(&mut self.active_turn, message.clone()) {
             self.reset_transcript_scroll_if_following_tail();
             return;
         }
         if self.active_turn.entries.is_empty() {
             if let Some(turn) = self.committed_turns.last_mut() {
-                if Self::replace_turn_agent_message(turn, message.clone()) {
+                if Self::replace_current_agent_segment_message(turn, message.clone()) {
                     self.invalidate_committed_render_cache();
                     self.reset_transcript_scroll_if_following_tail();
                     return;


### PR DESCRIPTION
## Summary

- Preserve assistant text segments when tool, terminal, or progress events arrive between them.
- Render active and committed turns in event order for interleaved `Agent` and progress entries.
- Add regressions for active rendering, committed rendering, and transcript state updates.

## Why

Agent output could be collapsed into one long `Agent` paragraph after interleaved progress/tool events. This made the TUI show the right content with the wrong chronology.

## Tests

- `cargo fmt --check`
- `cargo test active_turn_cell_preserves_interleaved_agent_and_progress_output`
- `cargo test committed_turn_cell_preserves_interleaved_agent_and_progress_output`
- `cargo test finalized_agent_stream_does_not_replace_agent_text_before_tool_boundary`
- `cargo check`
