### PR TITLE
fix: honor full access for command approval

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -141,6 +141,7 @@ pub struct Agent {
     pub tool_result_store: ToolResultStore,
     pub execution_mode: AgentExecutionMode,
     pub bash_approval_mode: BashApprovalMode,
+    pub full_access_mode: bool,
     pub current_plan: Vec<PlanStep>,
     pub plan_explanation: Option<String>,
     pub pending_user_input: Option<PendingUserInput>,
@@ -212,6 +213,7 @@ impl Agent {
             }),
             execution_mode: AgentExecutionMode::Execute,
             bash_approval_mode: BashApprovalMode::Always,
+            full_access_mode: false,
             current_plan: Vec::new(),
             plan_explanation: None,
             pending_user_input: None,
@@ -761,6 +763,7 @@ impl Agent {
                 }
             }
             if let Some(request) = bash_request.as_ref()
+                && !self.full_access_mode
                 && (request.requires_escalated_permissions()
                     || matches!(self.bash_approval_mode, BashApprovalMode::Suggestion))
             {

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -166,6 +166,10 @@ impl Agent {
         self.bash_approval_mode = mode;
     }
 
+    pub fn set_full_access_mode(&mut self, full_access: bool) {
+        self.full_access_mode = full_access;
+    }
+
     pub fn is_bash_prefix_approved(&self, request: &BashCommandInput) -> bool {
         request.is_allowed_by_approval_prefixes(&self.approved_bash_prefixes)
     }

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -1008,6 +1008,55 @@ async fn always_mode_still_requires_approval_for_escalated_sandbox_request() {
 }
 
 #[tokio::test]
+async fn full_access_mode_auto_allows_escalated_sandbox_request() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "tool-escalated-bash".to_string(),
+                name: "bash".to_string(),
+                input: json!({
+                    "program": "cargo",
+                    "args": ["check"],
+                    "sandbox_permissions": "require_escalated"
+                }),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "done".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubBashTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.bash_approval_mode = crate::agent::BashApprovalMode::Always;
+    agent.set_full_access_mode(true);
+
+    agent
+        .query_with_mode(
+            "run check with full access".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("full access should auto-allow escalated bash");
+
+    assert!(agent.pending_approval.is_none());
+    assert_eq!(backend.observed_messages().len(), 2);
+}
+
+#[tokio::test]
 async fn approved_prefix_auto_allows_matching_escalated_request() {
     let backend = Arc::new(SequencedBackend::new(vec![
         LlmResponse {

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -39,6 +39,10 @@ pub(super) async fn execute_local_command(
     });
     match command.kind {
         LocalCommandKind::Approval => {
+            if app.is_busy() {
+                app.push_notice("A task is already running. Wait for it to finish.");
+                return Ok(false);
+            }
             let next_mode = match app.bash_approval_mode {
                 BashApprovalMode::Suggestion => BashApprovalMode::Always,
                 BashApprovalMode::Once => BashApprovalMode::Suggestion,
@@ -48,6 +52,7 @@ pub(super) async fn execute_local_command(
             app.permission_mode = PermissionMode::Custom;
             if let Some(agent) = agent_slot.as_mut() {
                 agent.set_bash_approval_mode(next_mode);
+                agent.set_full_access_mode(false);
             }
             let notice = match next_mode {
                 BashApprovalMode::Always => "Bash approval set to always.",
@@ -110,6 +115,10 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Model => handle_model_command(command.arg.as_deref(), app)?,
         LocalCommandKind::Mcp => handle_mcp_command(app),
         LocalCommandKind::Plan => {
+            if app.is_busy() {
+                app.push_notice("A task is already running. Wait for it to finish.");
+                return Ok(false);
+            }
             app.set_runtime_phase(
                 RuntimePhase::LocalCommand,
                 Some("entering planning mode".into()),
@@ -119,6 +128,7 @@ pub(super) async fn execute_local_command(
             app.set_agent_execution_mode(AgentExecutionMode::Plan);
             if let Some(agent) = agent_slot.as_mut() {
                 agent.set_execution_mode(AgentExecutionMode::Plan);
+                agent.set_full_access_mode(false);
             }
             app.push_notice("Planning mode enabled. Read-only planning; approve to execute.");
         }
@@ -149,6 +159,10 @@ pub(super) async fn execute_local_command(
             }
         }
         LocalCommandKind::Permissions => {
+            if app.is_busy() {
+                app.push_notice("A task is already running. Wait for it to finish.");
+                return Ok(false);
+            }
             // Sync picker index to current mode before opening.
             let current_idx = match app.permission_mode {
                 PermissionMode::Auto => 0,
@@ -426,19 +440,31 @@ pub(crate) fn apply_permission_mode(
 ) {
     use std::sync::atomic::Ordering;
 
-    let (execution, approval, allow_net) = match mode {
-        PermissionMode::Auto => (AgentExecutionMode::Execute, BashApprovalMode::Always, false),
+    let (execution, approval, allow_net, full_access) = match mode {
+        PermissionMode::Auto => (
+            AgentExecutionMode::Execute,
+            BashApprovalMode::Always,
+            false,
+            false,
+        ),
         PermissionMode::AcceptEdits => (
             AgentExecutionMode::Execute,
             BashApprovalMode::Suggestion,
+            false,
             false,
         ),
         PermissionMode::ReadOnly => (
             AgentExecutionMode::Plan,
             BashApprovalMode::Suggestion,
             false,
+            false,
         ),
-        PermissionMode::FullAccess => (AgentExecutionMode::Execute, BashApprovalMode::Always, true),
+        PermissionMode::FullAccess => (
+            AgentExecutionMode::Execute,
+            BashApprovalMode::Always,
+            true,
+            true,
+        ),
         PermissionMode::Custom => return,
     };
 
@@ -450,6 +476,7 @@ pub(crate) fn apply_permission_mode(
     if let Some(agent) = agent_slot.as_mut() {
         agent.set_execution_mode(execution);
         agent.set_bash_approval_mode(approval);
+        agent.set_full_access_mode(full_access);
     }
 
     app.set_runtime_phase(
@@ -463,12 +490,32 @@ pub(crate) fn apply_permission_mode(
 mod tests {
     use std::fs;
     use std::sync::Arc;
+    use std::time::Instant;
 
-    use super::{handle_mcp_command, mcp_project_root_from_cwd};
+    use tokio::sync::mpsc;
+
+    use super::{execute_local_command, handle_mcp_command, mcp_project_root_from_cwd};
     use crate::agent::AgentEvent;
     use crate::config::ConfigManager;
+    use crate::oauth::OAuthManager;
     use crate::runtime_event_bus::RuntimeEventBus;
-    use crate::tui::state::TuiApp;
+    use crate::tui::state::{
+        LocalCommand, LocalCommandKind, Overlay, PermissionMode, RunningTask, TaskCompletion,
+        TaskKind, TuiApp,
+    };
+
+    fn mark_app_busy(app: &mut TuiApp) {
+        let (_sender, receiver) = mpsc::unbounded_channel();
+        app.running_task = Some(RunningTask {
+            kind: TaskKind::DeepSeekModels,
+            receiver,
+            handle: tokio::spawn(async { TaskCompletion::DeepSeekModels { result: Ok(vec![]) } }),
+            started_at: Instant::now(),
+            next_heartbeat_after_secs: 2,
+            cancellation_token: None,
+            cancellation_requested: false,
+        });
+    }
 
     #[test]
     fn mcp_project_root_walks_up_to_project_config() {
@@ -546,5 +593,64 @@ command = "docs-server"
             panic!("expected mcp load failure event");
         };
         assert!(message.contains("config.toml"));
+    }
+
+    #[tokio::test]
+    async fn mode_changing_commands_are_rejected_while_busy() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager = Arc::new(
+            OAuthManager::new_for_config_dir(dir.path().join("oauth")).expect("oauth manager"),
+        );
+        let mut agent_slot = None;
+
+        mark_app_busy(&mut app);
+        execute_local_command(
+            LocalCommand {
+                kind: LocalCommandKind::Approval,
+                arg: None,
+            },
+            &mut app,
+            &mut agent_slot,
+            &oauth_manager,
+        )
+        .await
+        .expect("approval command should be handled");
+        assert_eq!(app.bash_approval_mode_label(), "suggestion");
+        assert_eq!(app.permission_mode, PermissionMode::Auto);
+        assert_eq!(
+            app.notice.as_deref(),
+            Some("A task is already running. Wait for it to finish.")
+        );
+
+        execute_local_command(
+            LocalCommand {
+                kind: LocalCommandKind::Plan,
+                arg: None,
+            },
+            &mut app,
+            &mut agent_slot,
+            &oauth_manager,
+        )
+        .await
+        .expect("plan command should be handled");
+        assert_eq!(app.agent_execution_mode_label(), "execute");
+
+        execute_local_command(
+            LocalCommand {
+                kind: LocalCommandKind::Permissions,
+                arg: None,
+            },
+            &mut app,
+            &mut agent_slot,
+            &oauth_manager,
+        )
+        .await
+        .expect("permissions command should be handled");
+        assert!(app.overlay.is_none());
+        assert_ne!(app.overlay, Some(Overlay::PermissionPicker));
     }
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -18,8 +18,8 @@ use secrecy::ExposeSecret;
 use tokio::sync::mpsc;
 
 use super::super::state::{
-    GoalStatus, OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp,
-    TuiEvent,
+    GoalStatus, OAuthLoginMode, PermissionMode, RunningTask, RuntimePhase, TaskCompletion,
+    TaskKind, TuiApp, TuiEvent,
 };
 use super::events::{apply_tui_event, convert_agent_event, format_error_chain};
 use crate::agent::{Agent, AgentOutputMode, BashApprovalDecision};
@@ -45,6 +45,12 @@ fn forward_event_to_bus(
     }
 }
 
+fn sync_agent_permission_state(app: &TuiApp, agent: &mut Agent) {
+    agent.set_execution_mode(app.agent_execution_mode);
+    agent.set_bash_approval_mode(app.bash_approval_mode);
+    agent.set_full_access_mode(app.permission_mode == PermissionMode::FullAccess);
+}
+
 fn merge_rebuilt_agent(mut rebuilt: Agent, previous: Agent) -> Agent {
     let previous_prompt_config = previous.prompt_config().clone();
     rebuilt.session_id = previous.session_id;
@@ -56,6 +62,7 @@ fn merge_rebuilt_agent(mut rebuilt: Agent, previous: Agent) -> Agent {
     rebuilt.tool_result_store = previous.tool_result_store;
     rebuilt.execution_mode = previous.execution_mode;
     rebuilt.bash_approval_mode = previous.bash_approval_mode;
+    rebuilt.full_access_mode = previous.full_access_mode;
     rebuilt.approved_bash_prefixes = previous.approved_bash_prefixes;
     rebuilt.current_plan = previous.current_plan;
     rebuilt.plan_explanation = previous.plan_explanation;
@@ -136,8 +143,7 @@ pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agen
     app.clear_pending_planning_suggestion();
     app.clear_active_live_sections();
     app.begin_running_turn();
-    agent.set_execution_mode(app.agent_execution_mode);
-    agent.set_bash_approval_mode(app.bash_approval_mode);
+    sync_agent_permission_state(app, &mut agent);
     sync_bash_prefixes_from_config(app, &mut agent);
     app.notice = Some("Running prompt.".into());
     app.set_runtime_phase(RuntimePhase::SendingPrompt, Some("sending prompt".into()));
@@ -172,8 +178,7 @@ pub(super) fn start_compact_task(app: &mut TuiApp, mut agent: Agent) {
     let (sender, receiver) = mpsc::unbounded_channel();
     let bus = app.event_bus.clone();
     let event_provenance = local_tui_event_provenance(&agent.session_id);
-    agent.set_execution_mode(app.agent_execution_mode);
-    agent.set_bash_approval_mode(app.bash_approval_mode);
+    sync_agent_permission_state(app, &mut agent);
     app.notice = Some("Compacting conversation history.".into());
     app.set_runtime_phase(
         RuntimePhase::ProcessingResponse,
@@ -212,6 +217,7 @@ pub(super) fn start_review_task(app: &mut TuiApp, prompt: String, mut agent: Age
     let event_provenance = local_tui_event_provenance(&agent.session_id);
     agent.set_execution_mode(AgentExecutionMode::Review);
     agent.set_bash_approval_mode(BashApprovalMode::Always);
+    agent.set_full_access_mode(false);
     app.notice = Some("Running code review.".into());
     app.set_runtime_phase(
         RuntimePhase::ProcessingResponse,
@@ -265,6 +271,7 @@ pub(super) fn start_pending_approval_task(
         Some("resuming after approval".into()),
     );
     sync_bash_prefixes_from_config(app, &mut agent);
+    agent.set_full_access_mode(app.permission_mode == PermissionMode::FullAccess);
     agent.set_cancellation_token(Some(cancellation_token.clone()));
 
     let handle = tokio::spawn(async move {
@@ -341,6 +348,7 @@ fn start_plan_resume_task(
     } else {
         crate::agent::AgentExecutionMode::Execute
     });
+    agent.set_full_access_mode(app.permission_mode == PermissionMode::FullAccess);
     app.set_agent_execution_mode(agent.execution_mode);
     agent.set_cancellation_token(Some(cancellation_token.clone()));
 
@@ -774,8 +782,7 @@ pub(super) async fn finish_running_task_if_ready(
                 if let Some(previous) = agent_slot.take() {
                     agent = merge_rebuilt_agent(agent, previous);
                 }
-                agent.set_execution_mode(app.agent_execution_mode);
-                agent.set_bash_approval_mode(app.bash_approval_mode);
+                sync_agent_permission_state(app, &mut agent);
                 // Preserve any runtime /permissions override across rebuilds.
                 rebuilt.sandbox_network_access.store(
                     app.sandbox_network_access

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -270,6 +270,7 @@ fn merge_rebuilt_agent_preserves_session_and_turn_state() {
     previous.total_cache_miss_tokens = 10;
     previous.execution_mode = AgentExecutionMode::Plan;
     previous.bash_approval_mode = BashApprovalMode::Suggestion;
+    previous.set_full_access_mode(true);
     previous.approved_bash_prefixes = vec!["git push".to_string()];
     previous.current_plan = vec![PlanStep {
         step: "Keep session continuity".into(),
@@ -318,6 +319,7 @@ fn merge_rebuilt_agent_preserves_session_and_turn_state() {
     assert_eq!(merged.total_cache_miss_tokens, 10);
     assert_eq!(merged.execution_mode, AgentExecutionMode::Plan);
     assert_eq!(merged.bash_approval_mode, BashApprovalMode::Suggestion);
+    assert!(merged.full_access_mode);
     assert_eq!(merged.approved_bash_prefixes, vec!["git push".to_string()]);
     assert_eq!(merged.current_plan.len(), 1);
     assert_eq!(merged.compact_state.estimated_history_tokens, 1_200);


### PR DESCRIPTION
## Summary

- Add an explicit full-access execution flag to the agent runtime.
- Make `/permissions -> full-access` bypass escalated bash approval, while keeping `/approval`'s bash-only mode scoped to bash approval.
- Preserve the full-access flag across agent rebuilds and runtime task synchronization.

## Tests

- `cargo test agent::tests::planning -- --nocapture`
- `cargo test tui::runtime::tasks::tests::merge_rebuilt_agent_preserves_session_and_turn_state -- --nocapture`
- `cargo check`

Note: the commands pass with existing warnings on `main`.
