### PR TITLE
chore: limit dependabot cargo majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       time: "09:00"
       timezone: "Asia/Shanghai"
     open-pull-requests-limit: 8
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       rust-minor-patch-dependencies:
         applies-to: "version-updates"


### PR DESCRIPTION
## Summary

- ignore Cargo semver-major updates from Dependabot's automatic version update flow
- keep the existing grouped minor/patch Rust dependency updates

## Motivation

Dependabot PR #174 updated `arrow-schema` as an isolated major Cargo dependency change and produced a `Cargo.lock` state that Cargo wanted to rewrite during `cargo build --locked`, `cargo clippy --locked`, and `cargo test --locked`.

For tightly-coupled Rust dependency families such as Arrow, DataFusion, Lance, and LanceDB, major bumps should be handled as explicit coordinated upgrade PRs instead of isolated automatic lockfile updates.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "ok"'`
- `git diff --check`
