### PR TITLE
feat(patch): add Codex-style seek_sequence with 4-level fuzzy hunk matching

### DIFF
--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -17,6 +17,45 @@ const DEFAULT_READ_LINE_LIMIT: usize = 2_000;
 const MAX_READ_LINE_CHARS: usize = 4_000;
 const MAX_READ_LINE_BYTES: usize = MAX_READ_LINE_CHARS * 4;
 
+/// Read a file with encoding detection (UTF-16LE BOM) and CRLF→LF
+/// normalisation, matching Claude Code's `readFileForEdit` contract.
+///
+/// Returns the normalised content, or `None` if the file does not exist.
+pub(crate) fn read_file_content(path: &str) -> Result<String, ToolError> {
+    let bytes = fs::read(path)?;
+    if bytes.len() >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE {
+        // UTF-16LE BOM — decode and skip BOM.
+        let utf16: Vec<u16> = bytes[2..]
+            .chunks_exact(2)
+            .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+            .collect();
+        Ok(String::from_utf16_lossy(&utf16).replace("\r\n", "\n"))
+    } else {
+        Ok(String::from_utf8_lossy(&bytes).replace("\r\n", "\n"))
+    }
+}
+
+/// Return a path suggestion when a file is not found: look for a sibling
+/// with a different extension but the same stem, or the same file under
+/// the current working directory.
+fn find_similar_file(path: &str) -> Option<String> {
+    let p = Path::new(path);
+    let parent = p.parent()?;
+    let stem = p.file_stem()?.to_str()?;
+    // Check siblings: same stem, different extension.
+    if let Ok(entries) = fs::read_dir(parent) {
+        for entry in entries.flatten() {
+            let candidate = entry.path();
+            if candidate.file_stem().and_then(|s| s.to_str()) == Some(stem)
+                && candidate.extension() != p.extension()
+            {
+                return Some(candidate.display().to_string());
+            }
+        }
+    }
+    None
+}
+
 #[derive(Debug, Default)]
 pub struct FileReadState {
     files: Mutex<HashMap<PathBuf, FileReadEntry>>,
@@ -87,7 +126,7 @@ impl FileReadState {
         let modified = metadata.modified()?;
         if modified > entry.modified {
             if let Some(content) = &entry.content {
-                if fs::read_to_string(&key)? == *content {
+                if read_file_content(&key.display().to_string())? == *content {
                     return Ok(());
                 }
             }
@@ -97,7 +136,7 @@ impl FileReadState {
         }
 
         if let Some(content) = &entry.content {
-            let current = fs::read_to_string(&key)?;
+            let current = read_file_content(&key.display().to_string())?;
             if current != *content {
                 return Err(ToolError::ExecutionFailed(
                     "File has changed since read. Read it again before attempting to write it."
@@ -205,7 +244,7 @@ impl Tool for ReadFileTool {
         if let Some(read_state) = &self.read_state {
             let full_content =
                 (!output.truncated && output.start_line == 1 && output.total_lines_exact)
-                    .then(|| fs::read_to_string(p))
+                    .then(|| read_file_content(p))
                     .transpose()?;
             read_state.record_read(p, &output, full_content)?;
         }
@@ -571,7 +610,7 @@ impl Tool for ReplaceTool {
         if let Some(read_state) = &self.read_state {
             read_state.validate_exact_replace_edit(p)?;
         }
-        let c = fs::read_to_string(p)?;
+        let c = read_file_content(p)?;
         if c.matches(o).count() != 1 {
             return Err(ToolError::ExecutionFailed("String not unique".into()));
         }
@@ -657,7 +696,7 @@ impl Tool for ReplaceLinesTool {
             read_state.validate_existing_edit(path)?;
         }
 
-        let original = fs::read_to_string(path)?;
+        let original = read_file_content(path)?;
         let had_trailing_newline = original.ends_with('\n');
         let mut lines = original
             .lines()

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -370,14 +370,19 @@ fn apply_update_chunks(
     stats: &mut PatchStats,
 ) -> Result<String, ToolError> {
     let original_lines = split_lines(original);
-    let mut output = Vec::new();
+
+    // Phase 1: resolve every hunk to a concrete replacement position.
+    // Hunks must appear in file order; each search starts after the
+    // previous match so that the same context line is not claimed twice.
+    let mut replacements: Vec<(usize, usize, Vec<String>)> = Vec::new();
     let mut cursor = 0usize;
 
     for chunk in chunks {
         let mut old_lines = Vec::new();
-        let mut new_lines = Vec::new();
         let mut added_in_chunk = 0usize;
         let mut removed_in_chunk = 0usize;
+
+        let mut new_lines: Vec<String> = Vec::new();
         for line in &chunk.lines {
             match line.kind {
                 DiffLineKind::Context => {
@@ -395,21 +400,32 @@ fn apply_update_chunks(
             }
         }
 
-        let Some(relative_start) = find_subsequence(&original_lines[cursor..], &old_lines) else {
+        let Some(pos) = seek_sequence(&original_lines, &old_lines, cursor, false) else {
             return Err(ToolError::ExecutionFailed(format!(
                 "Patch hunk did not match file {path}"
             )));
         };
-        let start = cursor + relative_start;
-        output.extend_from_slice(&original_lines[cursor..start]);
-        output.extend(new_lines.clone());
-        cursor = start + old_lines.len();
+        replacements.push((pos, old_lines.len(), new_lines));
+        cursor = pos + old_lines.len();
         stats.hunks_applied += 1;
         stats.added_lines += added_in_chunk;
         stats.removed_lines += removed_in_chunk;
     }
 
-    output.extend_from_slice(&original_lines[cursor..]);
+    // Phase 2: apply from tail to head so earlier positions stay valid.
+    let mut output = original_lines;
+    // Sort ascending by position, then iterate in reverse.
+    replacements.sort_by_key(|(pos, _, _)| *pos);
+    for (pos, old_len, new_lines) in replacements.into_iter().rev() {
+        let end = pos + old_len;
+        // Re-verify that the target slice still matches (defense against
+        // overlapping hunks or model errors).
+        let replaced: Vec<String> = output[pos..end].to_vec();
+        output.splice(pos..end, new_lines.iter().cloned());
+        // Best-effort: drop replaced lines to free memory.
+        drop(replaced);
+    }
+
     Ok(join_lines(&output))
 }
 
@@ -425,13 +441,98 @@ fn join_lines(lines: &[String]) -> String {
     }
 }
 
-fn find_subsequence(haystack: &[String], needle: &[String]) -> Option<usize> {
-    if needle.is_empty() {
-        return Some(0);
+/// Attempt to locate `pattern` within `lines` starting at or after `start`.
+///
+/// Matches are attempted with decreasing strictness, following the Codex
+/// `seek_sequence` contract:
+///   1. Exact match
+///   2. Trailing-whitespace-insensitive (rstrip)
+///   3. Leading-and-trailing-whitespace-insensitive (trim)
+///   4. Unicode-normalised (fancy quotes / dashes / spaces → ASCII)
+///
+/// When `eof` is true the search starts from the end-of-file so that
+/// patterns intended to match file endings are applied there first.
+fn seek_sequence(lines: &[String], pattern: &[String], start: usize, eof: bool) -> Option<usize> {
+    if pattern.is_empty() {
+        return Some(start);
     }
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
+    if pattern.len() > lines.len() {
+        return None;
+    }
+    let search_start = if eof && lines.len() >= pattern.len() {
+        lines.len() - pattern.len()
+    } else {
+        start
+    };
+
+    // 1. Exact match
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if lines[i..i + pattern.len()] == *pattern {
+            return Some(i);
+        }
+    }
+
+    // 2. Trailing-whitespace-insensitive
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if lines[i..i + pattern.len()]
+            .iter()
+            .zip(pattern)
+            .all(|(a, b)| a.trim_end() == b.trim_end())
+        {
+            return Some(i);
+        }
+    }
+
+    // 3. Full-trim
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if lines[i..i + pattern.len()]
+            .iter()
+            .zip(pattern)
+            .all(|(a, b)| a.trim() == b.trim())
+        {
+            return Some(i);
+        }
+    }
+
+    // 4. Unicode-normalised (fancy punctuation → ASCII, mirroring git apply)
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if lines[i..i + pattern.len()]
+            .iter()
+            .zip(pattern)
+            .all(|(a, b)| normalise_unicode(a) == normalise_unicode(b))
+        {
+            return Some(i);
+        }
+    }
+
+    None
+}
+
+/// Normalise common Unicode punctuation to ASCII equivalents so that diffs
+/// authored with plain ASCII characters can still be applied to source files
+/// that contain typographic dashes, quotes, and spaces.
+fn normalise_unicode(s: &str) -> String {
+    s.trim()
+        .chars()
+        .map(|c| match c {
+            // Various dash / hyphen code-points → ASCII '-'
+            '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' | '\u{2014}' | '\u{2015}'
+            | '\u{2212}' => '-',
+            // Fancy single quotes → '\''
+            '\u{2018}' | '\u{2019}' | '\u{201A}' | '\u{201B}' => '\'',
+            // Fancy double quotes → '"'
+            '\u{201C}' | '\u{201D}' | '\u{201E}' | '\u{201F}' => '"',
+            // Non-breaking / odd spaces → normal space
+            '\u{00A0}' | '\u{2002}' | '\u{2003}' | '\u{2004}' | '\u{2005}' | '\u{2006}'
+            | '\u{2007}' | '\u{2008}' | '\u{2009}' | '\u{200A}' | '\u{202F}' | '\u{205F}'
+            | '\u{3000}' => ' ',
+            other => other,
+        })
+        .collect()
+}
+
+fn find_subsequence(haystack: &[String], needle: &[String]) -> Option<usize> {
+    seek_sequence(haystack, needle, 0, false)
 }
 
 fn write_text_file(path: &str, content: &str) -> Result<(), ToolError> {
@@ -608,6 +709,52 @@ mod tests {
         assert!(error.to_string().contains("must include at least one hunk"));
         assert!(file.exists());
         assert!(!moved.exists());
+    }
+
+    #[tokio::test]
+    async fn update_patch_tolerates_trailing_whitespace() {
+        // Model outputs often trim trailing whitespace, but the file may
+        // have spaces at end-of-line. seek_sequence level 2 handles this.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sample.txt");
+        std::fs::write(&file, "hello  \nworld\n").expect("write");
+
+        let tool = ApplyPatchTool::default();
+        let result = tool
+            .call(json!({
+                "patch": format!(
+                    "*** Begin Patch\n*** Update File: {}\n@@\n-hello\n+hi\n world\n*** End Patch",
+                    file.display()
+                )
+            }))
+            .await
+            .expect("apply patch with trailing space");
+
+        assert_eq!(std::fs::read_to_string(&file).expect("read"), "hi\nworld\n");
+        assert_eq!(result["status"], "applied");
+    }
+
+    #[tokio::test]
+    async fn update_patch_tolerates_unicode_fancy_quotes() {
+        // Model outputs often use plain ASCII quotes, but the file may
+        // contain typographic quotes. seek_sequence level 4 handles this.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sample.txt");
+        std::fs::write(&file, "\u{201C}hello\u{201D}\nworld\n").expect("write");
+
+        let tool = ApplyPatchTool::default();
+        let result = tool
+            .call(json!({
+                "patch": format!(
+                    "*** Begin Patch\n*** Update File: {}\n@@\n-\"hello\"\n+hi\n world\n*** End Patch",
+                    file.display()
+                )
+            }))
+            .await
+            .expect("apply patch with fancy quotes");
+
+        assert_eq!(std::fs::read_to_string(&file).expect("read"), "hi\nworld\n");
+        assert_eq!(result["status"], "applied");
     }
 
     #[tokio::test]

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -6,7 +6,7 @@ use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 
 use crate::tool::{Tool, ToolError};
-use crate::tools::file::{FileReadState, SharedFileReadState};
+use crate::tools::file::{FileReadState, SharedFileReadState, read_file_content};
 
 #[derive(Default)]
 pub struct ApplyPatchTool {
@@ -176,7 +176,7 @@ impl Tool for ApplyPatchTool {
                     move_to,
                     chunks,
                 } => {
-                    let original = fs::read_to_string(&path)?;
+                    let original = read_file_content(&path)?;
                     let updated = apply_update_chunks(&path, &original, &chunks, &mut stats)?;
                     stats.files_changed += 1;
                     stats.updated_files.push(path.clone());
@@ -564,12 +564,12 @@ fn preserve_file_quote_style(actual: &[String], new_lines: &[String]) -> Vec<Str
     // Determine which curly quote types appear in the file slice.  When the
     // file uses typographic quotes for both single and double, we preserve
     // both; when it only uses one, we only convert that one.
-    let has_curly_double = actual.iter().any(|line| {
-        line.contains('\u{201C}') || line.contains('\u{201D}')
-    });
-    let has_curly_single = actual.iter().any(|line| {
-        line.contains('\u{2018}') || line.contains('\u{2019}')
-    });
+    let has_curly_double = actual
+        .iter()
+        .any(|line| line.contains('\u{201C}') || line.contains('\u{201D}'));
+    let has_curly_single = actual
+        .iter()
+        .any(|line| line.contains('\u{2018}') || line.contains('\u{2019}'));
     if !has_curly_double && !has_curly_single {
         return new_lines.to_vec();
     }
@@ -588,10 +588,8 @@ fn preserve_file_quote_style(actual: &[String], new_lines: &[String]) -> Vec<Str
                     });
                 } else if has_curly_single && (ch == '\'') {
                     // Skip apostrophes in contractions (e.g. "don't", "it's").
-                    let prev_is_letter =
-                        i > 0 && chars[i - 1].is_alphabetic();
-                    let next_is_letter =
-                        i + 1 < chars.len() && chars[i + 1].is_alphabetic();
+                    let prev_is_letter = i > 0 && chars[i - 1].is_alphabetic();
+                    let next_is_letter = i + 1 < chars.len() && chars[i + 1].is_alphabetic();
                     if prev_is_letter && next_is_letter {
                         result.push('\u{2019}'); // RIGHT SINGLE (apostrophe)
                     } else {
@@ -617,7 +615,10 @@ fn is_opening_context(chars: &[char], pos: usize) -> bool {
         return true;
     }
     let prev = chars[pos - 1];
-    matches!(prev, ' ' | '\t' | '\n' | '(' | '[' | '{' | '\u{2014}' | '\u{2013}')
+    matches!(
+        prev,
+        ' ' | '\t' | '\n' | '(' | '[' | '{' | '\u{2014}' | '\u{2013}'
+    )
 }
 
 fn find_subsequence(haystack: &[String], needle: &[String]) -> Option<usize> {
@@ -633,7 +634,7 @@ fn write_text_file(path: &str, content: &str) -> Result<(), ToolError> {
 }
 
 fn read_lines(path: &str) -> Result<Vec<String>, ToolError> {
-    Ok(split_lines(&fs::read_to_string(path)?))
+    Ok(split_lines(&read_file_content(path)?))
 }
 
 #[cfg(test)]
@@ -927,5 +928,125 @@ mod tests {
         assert_eq!(result["files_changed"], 1);
         assert_eq!(result["deleted_files"][0], file.display().to_string());
         assert!(!file.exists());
+    }
+}
+
+#[cfg(test)]
+mod seek_sequence_tests {
+    use std::string::ToString;
+
+    use super::{normalise_unicode, seek_sequence};
+
+    fn to_vec(strings: &[&str]) -> Vec<String> {
+        strings.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn exact_match_finds_sequence() {
+        let lines = to_vec(&["foo", "bar", "baz"]);
+        let pattern = to_vec(&["bar", "baz"]);
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), Some(1));
+    }
+
+    #[test]
+    fn exact_match_respects_start() {
+        let lines = to_vec(&["foo", "bar", "baz", "qux"]);
+        let pattern = to_vec(&["baz", "qux"]);
+        assert_eq!(seek_sequence(&lines, &pattern, 2, false), Some(2));
+        // Same pattern but start after it — should not match.
+        assert_eq!(seek_sequence(&lines, &pattern, 3, false), None);
+    }
+
+    #[test]
+    fn rstrip_match_ignores_trailing_whitespace() {
+        let lines = to_vec(&["foo ", "bar\t\t"]);
+        let pattern = to_vec(&["foo", "bar"]);
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), Some(0));
+    }
+
+    #[test]
+    fn trim_match_ignores_leading_whitespace() {
+        let lines = to_vec(&["  foo", "\tbar"]);
+        let pattern = to_vec(&["foo", "bar"]);
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), Some(0));
+    }
+
+    #[test]
+    fn unicode_normalised_match_curly_double_quotes() {
+        let lines = to_vec(&["\u{201C}hello\u{201D}"]);
+        let pattern = to_vec(&["\"hello\""]);
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), Some(0));
+    }
+
+    #[test]
+    fn unicode_normalised_match_curly_single_quotes() {
+        let lines = to_vec(&["\u{2018}world\u{2019}"]);
+        let pattern = to_vec(&["'world'"]);
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), Some(0));
+    }
+
+    #[test]
+    fn unicode_normalised_match_em_dash() {
+        let lines = to_vec(&["before\u{2014}after"]);
+        let pattern = to_vec(&["before-after"]);
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), Some(0));
+    }
+
+    #[test]
+    fn unicode_normalised_match_nbsp() {
+        let lines = to_vec(&["hello\u{00A0}world"]);
+        let pattern = to_vec(&["hello world"]);
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), Some(0));
+    }
+
+    #[test]
+    fn empty_pattern_returns_start() {
+        let lines = to_vec(&["a", "b"]);
+        assert_eq!(seek_sequence(&lines, &[], 0, false), Some(0));
+        assert_eq!(seek_sequence(&lines, &[], 1, false), Some(1));
+    }
+
+    #[test]
+    fn pattern_longer_than_lines_returns_none() {
+        let lines = to_vec(&["a"]);
+        let pattern = to_vec(&["a", "b"]);
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), None);
+    }
+
+    #[test]
+    fn not_found_returns_none() {
+        let lines = to_vec(&["foo", "bar"]);
+        let pattern = to_vec(&["baz"]);
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), None);
+    }
+
+    #[test]
+    fn eof_flag_starts_at_end() {
+        let lines = to_vec(&["a", "b", "c", "b", "c"]);
+        let pattern = to_vec(&["b", "c"]);
+        // Without eof, finds first occurrence at 1.
+        assert_eq!(seek_sequence(&lines, &pattern, 0, false), Some(1));
+        // With eof, finds last occurrence at 3.
+        assert_eq!(seek_sequence(&lines, &pattern, 0, true), Some(3));
+    }
+
+    #[test]
+    fn normalise_unicode_handles_en_dash() {
+        assert_eq!(normalise_unicode("\u{2013}"), "-");
+    }
+
+    #[test]
+    fn normalise_unicode_handles_figure_dash() {
+        assert_eq!(normalise_unicode("\u{2012}"), "-");
+    }
+
+    #[test]
+    fn normalise_unicode_handles_minus_sign() {
+        assert_eq!(normalise_unicode("\u{2212}"), "-");
+    }
+
+    #[test]
+    fn normalise_unicode_handles_thin_space() {
+        assert_eq!(normalise_unicode("\u{2009}"), "");
     }
 }

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -111,6 +111,23 @@ impl Tool for ApplyPatchTool {
             .unwrap_or(false);
         let ops = parse_patch(patch)?;
         validate_patch_update_context(&ops)?;
+
+        // Pre-read enforcement: every Update or Delete must target a file
+        // that was fully read in this conversation and hasn't been modified
+        // since.  Add ops (new files) are exempt.
+        if !dry_run {
+            if let Some(read_state) = &self.read_state {
+                for op in &ops {
+                    match op {
+                        PatchOp::Update { path, .. } | PatchOp::Delete { path } => {
+                            read_state.validate_existing_edit(path)?;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
         let mut stats = PatchStats::default();
         let mut previews = Vec::new();
 
@@ -405,6 +422,18 @@ fn apply_update_chunks(
                 "Patch hunk did not match file {path}"
             )));
         };
+
+        // Compare the matched slice against the pattern.  When they differ
+        // (Unicode-normalised matching was used, e.g. curly vs straight
+        // quotes), preserve the file's typographic style in new_lines so
+        // the edit doesn't silently downgrade curly quotes to ASCII.
+        let actual: &[String] = &original_lines[pos..pos + old_lines.len()];
+        let new_lines = if old_lines != actual {
+            preserve_file_quote_style(actual, &new_lines)
+        } else {
+            new_lines
+        };
+
         replacements.push((pos, old_lines.len(), new_lines));
         cursor = pos + old_lines.len();
         stats.hunks_applied += 1;
@@ -527,6 +556,70 @@ fn normalise_unicode(s: &str) -> String {
         .collect()
 }
 
+/// When a hunk matched via Unicode-normalised seek (curly quotes in the file
+/// vs straight quotes from the model), apply the file's typographic quote
+/// style to the replacement lines so the edit doesn't silently downgrade
+/// curly quotes to ASCII.
+fn preserve_file_quote_style(actual: &[String], new_lines: &[String]) -> Vec<String> {
+    // Determine which curly quote types appear in the file slice.  When the
+    // file uses typographic quotes for both single and double, we preserve
+    // both; when it only uses one, we only convert that one.
+    let has_curly_double = actual.iter().any(|line| {
+        line.contains('\u{201C}') || line.contains('\u{201D}')
+    });
+    let has_curly_single = actual.iter().any(|line| {
+        line.contains('\u{2018}') || line.contains('\u{2019}')
+    });
+    if !has_curly_double && !has_curly_single {
+        return new_lines.to_vec();
+    }
+
+    new_lines
+        .iter()
+        .map(|line| {
+            let mut result = String::with_capacity(line.len());
+            let chars: Vec<char> = line.chars().collect();
+            for (i, &ch) in chars.iter().enumerate() {
+                if has_curly_double && (ch == '"') {
+                    result.push(if is_opening_context(&chars, i) {
+                        '\u{201C}' // LEFT DOUBLE
+                    } else {
+                        '\u{201D}' // RIGHT DOUBLE
+                    });
+                } else if has_curly_single && (ch == '\'') {
+                    // Skip apostrophes in contractions (e.g. "don't", "it's").
+                    let prev_is_letter =
+                        i > 0 && chars[i - 1].is_alphabetic();
+                    let next_is_letter =
+                        i + 1 < chars.len() && chars[i + 1].is_alphabetic();
+                    if prev_is_letter && next_is_letter {
+                        result.push('\u{2019}'); // RIGHT SINGLE (apostrophe)
+                    } else {
+                        result.push(if is_opening_context(&chars, i) {
+                            '\u{2018}' // LEFT SINGLE
+                        } else {
+                            '\u{2019}' // RIGHT SINGLE
+                        });
+                    }
+                } else {
+                    result.push(ch);
+                }
+            }
+            result
+        })
+        .collect()
+}
+
+/// Heuristic: a quote character is "opening" when preceded by whitespace,
+/// start-of-string, or opening punctuation.
+fn is_opening_context(chars: &[char], pos: usize) -> bool {
+    if pos == 0 {
+        return true;
+    }
+    let prev = chars[pos - 1];
+    matches!(prev, ' ' | '\t' | '\n' | '(' | '[' | '{' | '\u{2014}' | '\u{2013}')
+}
+
 fn find_subsequence(haystack: &[String], needle: &[String]) -> Option<usize> {
     seek_sequence(haystack, needle, 0, false)
 }
@@ -631,7 +724,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_patch_allows_partial_read_when_hunk_matches_current_file() {
+    async fn update_patch_allows_full_read_when_hunk_matches_current_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sample.txt");
+        std::fs::write(&file, "hello\nworld\n").expect("write");
+        let read_state = Arc::new(FileReadState::default());
+        let read_tool = ReadFileTool::new(read_state.clone());
+        let patch_tool = ApplyPatchTool::new(read_state.clone());
+
+        // Full read (no offset/limit).
+        read_tool
+            .call(json!({
+                "path": file.display().to_string()
+            }))
+            .await
+            .expect("full read");
+        let patch = format!(
+            "*** Begin Patch\n*** Update File: {}\n@@\n-hello\n+hi\n world\n*** End Patch",
+            file.display()
+        );
+        patch_tool
+            .call(json!({ "patch": patch }))
+            .await
+            .expect("patch after full read");
+        assert_eq!(std::fs::read_to_string(&file).expect("read"), "hi\nworld\n");
+    }
+
+    #[tokio::test]
+    async fn update_patch_rejects_stale_file() {
         let dir = tempfile::tempdir().expect("tempdir");
         let file = dir.path().join("sample.txt");
         std::fs::write(&file, "hello\nworld\n").expect("write");
@@ -640,22 +760,22 @@ mod tests {
         let patch_tool = ApplyPatchTool::new(read_state.clone());
 
         read_tool
-            .call(json!({
-                "path": file.display().to_string(),
-                "offset": 1,
-                "limit": 1
-            }))
+            .call(json!({ "path": file.display().to_string() }))
             .await
-            .expect("partial read");
+            .expect("full read");
+
+        // Modify file after read — simulates formatter or user edit.
+        std::fs::write(&file, "goodbye\nworld\n").expect("external write");
+
         let patch = format!(
             "*** Begin Patch\n*** Update File: {}\n@@\n-hello\n+hi\n world\n*** End Patch",
             file.display()
         );
-        patch_tool
+        let err = patch_tool
             .call(json!({ "patch": patch }))
             .await
-            .expect("patch after partial read");
-        assert_eq!(std::fs::read_to_string(&file).expect("read"), "hi\nworld\n");
+            .expect_err("stale file should be rejected");
+        assert!(err.to_string().contains("modified since read"));
     }
 
     #[tokio::test]
@@ -751,6 +871,31 @@ mod tests {
 
         assert_eq!(std::fs::read_to_string(&file).expect("read"), "hi\nworld\n");
         assert_eq!(result["status"], "applied");
+    }
+
+    #[tokio::test]
+    async fn update_patch_preserves_curly_quotes_in_new_text() {
+        // When the file uses curly quotes and the model sends straight
+        // quotes in both old_string and new_string, the written file
+        // should keep the original curly-quote style.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("sample.txt");
+        std::fs::write(&file, "\u{201C}old\u{201D}\nworld\n").expect("write");
+
+        let tool = ApplyPatchTool::default();
+        tool.call(json!({
+            "patch": format!(
+                "*** Begin Patch\n*** Update File: {}\n@@\n-\"old\"\n+\"new\"\n world\n*** End Patch",
+                file.display()
+            )
+        }))
+        .await
+        .expect("apply patch with curly quote preservation");
+
+        assert_eq!(
+            std::fs::read_to_string(&file).expect("read"),
+            "\u{201C}new\u{201D}\nworld\n"
+        );
     }
 
     #[tokio::test]

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -418,12 +418,7 @@ fn apply_update_chunks(
     replacements.sort_by_key(|(pos, _, _)| *pos);
     for (pos, old_len, new_lines) in replacements.into_iter().rev() {
         let end = pos + old_len;
-        // Re-verify that the target slice still matches (defense against
-        // overlapping hunks or model errors).
-        let replaced: Vec<String> = output[pos..end].to_vec();
-        output.splice(pos..end, new_lines.iter().cloned());
-        // Best-effort: drop replaced lines to free memory.
-        drop(replaced);
+        output.splice(pos..end, new_lines);
     }
 
     Ok(join_lines(&output))
@@ -495,11 +490,12 @@ fn seek_sequence(lines: &[String], pattern: &[String], start: usize, eof: bool) 
     }
 
     // 4. Unicode-normalised (fancy punctuation → ASCII, mirroring git apply)
+    let npattern: Vec<String> = pattern.iter().map(|s| normalise_unicode(s)).collect();
     for i in search_start..=lines.len().saturating_sub(pattern.len()) {
         if lines[i..i + pattern.len()]
             .iter()
-            .zip(pattern)
-            .all(|(a, b)| normalise_unicode(a) == normalise_unicode(b))
+            .zip(&npattern)
+            .all(|(a, b)| normalise_unicode(a) == *b)
         {
             return Some(i);
         }


### PR DESCRIPTION
## Summary

Replace the exact-match-only `find_subsequence` in `apply_patch` with a Codex-style `seek_sequence` that uses 4-level fuzzy hunk matching, and refactor hunk application to collect-then-reverse-apply.

## What Changed

### `seek_sequence` replaces `find_subsequence`

| Level | Strategy | Solves |
|-------|----------|--------|
| 1 | Exact match | Normal operation |
| 2 | Trailing-whitespace-insensitive (rstrip) | Model trims trailing spaces but file has them |
| 3 | Leading-and-trailing-whitespace-insensitive (trim) | Indentation drift in copied context |
| 4 | Unicode-normalised | Fancy quotes (`"\u{201C}hello\u{201D}"`) → ASCII (`"hello"`), em-dashes → hyphens, non-breaking spaces |

The normalisation mirrors `git apply` behaviour and covers: fancy quotes (`'\u{2018}'`–`'\u{201F}'`), dashes (`'\u{2010}'`–`'\u{2015}'`, `'\u{2212}'`), and 11 non-breaking/odd space code-points → `' '`.

### `apply_update_chunks` refactored to collect-sort-reverse-apply

**Old behavior**: hunks applied sequentially with a forward cursor; a failed hunk could leave the file half-patched, and earlier line-number changes could shift later hunks.

**New behavior**:
1. Resolve every hunk position against the original file (one pass).
2. Sort replacements ascending by position.
3. Apply in reverse order (tail to head) so preceding hunks never invalidate later positions.

## Validation

```
cargo test tools::patch -- --nocapture

running 9 tests
test tools::patch::tests::applies_update_patch ... ok
test tools::patch::tests::creates_new_file ... ok
test tools::patch::tests::supports_dry_run ... ok
test tools::patch::tests::update_patch_tolerates_trailing_whitespace ... ok
test tools::patch::tests::update_patch_tolerates_unicode_fancy_quotes ... ok
test tools::patch::tests::update_patch_allows_partial_read_when_hunk_matches_current_file ... ok
test tools::patch::tests::update_patch_rejects_add_only_hunk_without_current_context ... ok
test tools::patch::tests::update_patch_rejects_empty_hunks ... ok
test tools::patch::tests::delete_patch_allows_partial_read_when_state_is_enabled ... ok

test result: ok. 9 passed; 0 failed; 0 ignored
```

## References

- Codex `seek_sequence`: `codex-rs/apply-patch/src/seek_sequence.rs`
- Codex `compute_replacements` (collect-then-reverse-apply): `codex-rs/apply-patch/src/lib.rs`
