### PR TITLE
fix: resume full access approvals

### DIFF
--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use super::app_event::AppEvent;
-use super::auth_mode_picker::AUTH_MODE_OPTION_COUNT;
 use super::command::{palette_command_by_index, palette_commands};
 #[allow(unused_imports)]
 use super::list_picker;
@@ -16,8 +15,8 @@ use super::runtime::{
 };
 use super::session_restore::restore_thread_by_id;
 use super::state::{
-    ActivePendingInteractionKind, ListPickerKind, OpenAiModelPickerAction, Overlay,
-    PROVIDER_FAMILIES, PermissionMode, ProviderFamily, TuiApp,
+    ActivePendingInteractionKind, ListPickerKind, OpenAiModelPickerAction, Overlay, PermissionMode,
+    ProviderFamily, TuiApp,
 };
 use super::submit::{apply_openai_model_picker_action, handle_submit};
 use super::terminal_ui::is_ssh_session;
@@ -41,6 +40,9 @@ pub(crate) async fn dispatch_event(
             app.input_cursor_offset = None;
         }
         AppEvent::SubmitComposer => {
+            if resume_pending_shell_approval_after_full_access(app, agent_slot) {
+                return Ok(false);
+            }
             if handle_submit(app, agent_slot, oauth_manager).await? {
                 return Ok(true);
             }
@@ -123,6 +125,9 @@ pub(crate) async fn dispatch_event(
             app.permission_picker_idx = idx.min(3usize);
         }
         AppEvent::SelectPendingOption(idx) => {
+            if resume_pending_shell_approval_after_full_access(app, agent_slot) {
+                return Ok(false);
+            }
             if let Some(interaction) = app.active_pending_interaction() {
                 match interaction.kind {
                     ActivePendingInteractionKind::PlanApproval => {
@@ -163,7 +168,6 @@ pub(crate) async fn dispatch_event(
                             }
                         }
                     }
-                    _ => {}
                 }
             }
         }
@@ -487,12 +491,35 @@ pub(crate) async fn dispatch_event(
                     apply_permission_mode(app, agent_slot, mode);
                     app.permission_mode = mode;
                     let label = mode.label();
-                    app.push_notice(format!("Permission mode: {label}."));
                     app.close_overlay();
+                    if !resume_pending_shell_approval_after_full_access(app, agent_slot) {
+                        app.push_notice(format!("Permission mode: {label}."));
+                    }
                 }
             }
             _ => {}
         },
     }
     Ok(false)
+}
+
+fn resume_pending_shell_approval_after_full_access(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+) -> bool {
+    if app.permission_mode != PermissionMode::FullAccess
+        || !app.active_pending_interaction().is_some_and(|interaction| {
+            interaction.kind == ActivePendingInteractionKind::ShellApproval
+        })
+        || app.is_busy()
+    {
+        return false;
+    }
+
+    if let Some(agent) = agent_slot.take() {
+        start_pending_approval_task(app, BashApprovalDecision::Once, agent);
+    } else {
+        app.push_notice("Permission mode: full-access. Approval is still preparing.");
+    }
+    true
 }

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -1,7 +1,7 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::app_event::AppEvent;
-use super::state::{HelpTab, Overlay, ProviderFamily, StatusTab, TuiApp};
+use super::state::{HelpTab, Overlay, StatusTab, TuiApp};
 
 pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
     let code = key.code;

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -11,10 +11,17 @@ use super::event_stream::{UiEvent, translate_event};
 use super::provider_flow::{
     codex_auth_is_available, open_provider_family_overlay, sync_codex_credential_from_auth_store,
 };
+use crate::agent::{Agent, PendingApproval};
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
 use crate::config::{ConfigManager, OpenAiEndpointKind};
 use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL};
+use crate::llm::MockLlm;
+use crate::session::SessionManager;
+use crate::tool::ToolManager;
+use crate::tools::bash::BashCommandInput;
 use crate::tui::command::palette_commands;
+use crate::vectordb::VectorDB;
+use crate::workspace::WorkspaceMemory;
 
 fn key(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::NONE)
@@ -34,7 +41,7 @@ fn mouse_scroll(kind: MouseEventKind) -> Event {
 }
 use super::state::{
     InteractionKind, ListPickerKind, Overlay, PendingApprovalSnapshot, PendingInteractionSnapshot,
-    ProviderFamily, RunningTask, StatusTab, TaskKind, TuiApp,
+    PermissionMode, ProviderFamily, RunningTask, StatusTab, TaskKind, TuiApp,
 };
 use super::{dispatch_event, map_key_to_event};
 
@@ -457,6 +464,57 @@ fn add_pending_shell_approval(app: &mut TuiApp) {
         });
 }
 
+fn add_pending_plan_approval(app: &mut TuiApp) {
+    app.snapshot
+        .pending_interactions
+        .push(PendingInteractionSnapshot {
+            kind: InteractionKind::PlanApproval,
+            title: "Plan Ready".into(),
+            summary: "Review the plan.".into(),
+            options: Vec::new(),
+            note: None,
+            approval: None,
+            source: None,
+        });
+}
+
+fn test_agent_for_pending_approval(temp: &tempfile::TempDir) -> Agent {
+    let rara_dir = temp.path().join(".rara");
+    std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+    std::fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+    std::fs::create_dir_all(rara_dir.join("tool-results")).expect("tool results");
+
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        Arc::new(MockLlm),
+        Arc::new(VectorDB::new(
+            &rara_dir.join("lancedb").display().to_string(),
+        )),
+        Arc::new(SessionManager {
+            storage_dir: rara_dir.join("rollouts"),
+            legacy_storage_dir: rara_dir.join("sessions"),
+        }),
+        Arc::new(WorkspaceMemory::from_paths(
+            temp.path().join("repo"),
+            rara_dir,
+        )),
+    );
+    agent.pending_approval = Some(PendingApproval {
+        tool_use_id: "tool-1".to_string(),
+        request: BashCommandInput {
+            command: Some("git rebase --continue".to_string()),
+            ..Default::default()
+        },
+    });
+    agent
+}
+
+fn abort_running_task(app: &mut TuiApp) {
+    if let Some(task) = app.running_task.take() {
+        task.handle.abort();
+    }
+}
+
 fn add_pending_request_input(app: &mut TuiApp, option_count: usize) {
     app.snapshot
         .pending_interactions
@@ -509,6 +567,112 @@ fn pending_shell_approval_does_not_render_as_request_input() {
         Some(super::state::ActivePendingInteractionKind::ShellApproval)
     );
     assert_eq!(app.active_pending_option_count(), 4);
+}
+
+#[tokio::test]
+async fn full_access_permission_picker_resumes_pending_shell_approval_in_local_and_ssh() {
+    for ssh in [false, true] {
+        let _ssh_env = super::terminal_ui::test_env::set_ssh_session(ssh);
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        add_pending_shell_approval(&mut app);
+        app.open_overlay(Overlay::PermissionPicker);
+
+        let oauth_manager = Arc::new(
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager"),
+        );
+        let mut agent_slot = Some(test_agent_for_pending_approval(&temp));
+
+        dispatch_event(
+            AppEvent::SetPermissionSelection(3),
+            &mut app,
+            &mut agent_slot,
+            &oauth_manager,
+        )
+        .await
+        .expect("select full access");
+        dispatch_event(
+            AppEvent::ApplyOverlaySelection,
+            &mut app,
+            &mut agent_slot,
+            &oauth_manager,
+        )
+        .await
+        .expect("apply full access");
+
+        assert_eq!(app.permission_mode, PermissionMode::FullAccess);
+        assert!(app.pending_command_approval().is_none());
+        assert!(agent_slot.is_none());
+        assert!(app.running_task.is_some());
+        abort_running_task(&mut app);
+    }
+}
+
+#[tokio::test]
+async fn full_access_mode_resumes_stale_pending_shell_approval_from_shortcuts() {
+    for event in [AppEvent::SelectPendingOption(3), AppEvent::SubmitComposer] {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        add_pending_shell_approval(&mut app);
+        app.permission_mode = PermissionMode::FullAccess;
+
+        let oauth_manager = Arc::new(
+            crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+                .expect("oauth manager"),
+        );
+        let mut agent_slot = Some(test_agent_for_pending_approval(&temp));
+
+        dispatch_event(event.clone(), &mut app, &mut agent_slot, &oauth_manager)
+            .await
+            .expect("dispatch stale approval");
+
+        assert!(app.pending_command_approval().is_none());
+        assert!(agent_slot.is_none());
+        assert!(app.running_task.is_some());
+        abort_running_task(&mut app);
+    }
+}
+
+#[tokio::test]
+async fn full_access_mode_does_not_resume_shell_approval_behind_active_plan_approval() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    add_pending_shell_approval(&mut app);
+    add_pending_plan_approval(&mut app);
+    app.permission_mode = PermissionMode::FullAccess;
+
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = Some(test_agent_for_pending_approval(&temp));
+
+    dispatch_event(
+        AppEvent::SubmitComposer,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("dispatch submit");
+
+    assert_eq!(
+        app.active_pending_interaction().map(|item| item.kind),
+        Some(super::state::ActivePendingInteractionKind::PlanApproval)
+    );
+    assert!(app.pending_command_approval().is_some());
+    assert!(agent_slot.is_some());
+    assert!(app.running_task.is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Resume pending shell approval automatically when full-access mode is active.
- Cover the permission picker path for both local and SSH sessions.
- Cover stale approval cards reached through numeric shortcuts and normal submit.

## Testing

- cargo fmt --check
- cargo test full_access_permission_picker_resumes_pending_shell_approval_in_local_and_ssh -- --nocapture
- cargo test full_access_mode_resumes_stale_pending_shell_approval_from_shortcuts -- --nocapture
