### PR TITLE
fix: sanitize tui display text

### DIFF
--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -201,6 +201,24 @@ The TUI should keep input state, display data, and visual cells separate:
 - Tool-result compactors should emit renderer-neutral text. Renderer helpers
   may add the tool name, styling, and truncation frame, but should not need
   bash-specific source cleanup for normal output.
+- All text that can reach the terminal renderer must pass through one
+  display-sanitization boundary before it is printed or converted into markdown
+  display lines. This includes streaming agent deltas, committed agent
+  messages, live progress events such as Thinking/Exploring/Running, terminal
+  event previews, and inline history insertion. The sanitizer must preserve
+  user-visible text and line boundaries while removing terminal control effects
+  such as ANSI/OSC escape sequences, carriage returns, backspaces, bells, and
+  other non-printing controls. Tabs should be normalized to spaces so display
+  width and wrapping stay stable.
+- The transcript data model may still preserve richer raw payloads where needed,
+  but the TUI must never `Print` raw model/tool text that can move the terminal
+  cursor or rewrite previous cells. Rendering tests should cover both active
+  streaming text and committed transcript text when this contract changes.
+- Code-level ownership lives in a single display-sanitization module. Renderer
+  code should call that module instead of duplicating ANSI/control-character
+  stripping. Inline history insertion must sanitize full `Line` objects before
+  both width/row calculation and terminal printing, so row accounting and
+  visible output are derived from the same display-safe text.
 
 This mirrors the Codex-style split where queued follow-up input is active
 transcript status and the composer remains a prompt/input surface. It also keeps

--- a/docs/journal/2026-05-06-tui-display-sanitization.md
+++ b/docs/journal/2026-05-06-tui-display-sanitization.md
@@ -1,0 +1,73 @@
+# 2026-05-06 · TUI display sanitization boundary
+
+## Context
+
+Agent output could visibly corrupt the terminal transcript when model text or
+tool summaries contained terminal control characters. The user-visible symptom
+was stale characters and misaligned words in `Agent`, `Running`, and approval
+sections after mixed progress output and shell approval completion.
+
+The root issue was not one specific card. Multiple render paths could receive
+raw text:
+
+- streaming agent deltas;
+- committed agent messages;
+- live progress events such as Thinking, Exploring, Planning, and Running;
+- terminal event output previews;
+- inline history insertion.
+
+If a raw carriage return, ANSI/OSC escape sequence, backspace, bell, or other
+control character reached terminal printing, it could move the cursor or rewrite
+cells outside Ratatui's normal buffer diff.
+
+## Decision
+
+Add one TUI display-sanitization boundary and route display text through it
+before rendering. The sanitizer preserves visible text and line boundaries, but
+removes terminal side effects.
+
+The code-level rule is:
+
+- raw transcript or tool payloads may remain available for persistence or full
+  inspection;
+- anything entering markdown display collectors, committed message rendering,
+  terminal-event display previews, or inline terminal `Print` must use
+  `tui::display_sanitize`;
+- inline history insertion sanitizes the full `Line` before width/row
+  calculation and printing, so wrapping math and visible output use the same
+  display-safe text.
+
+This makes the contract explicit instead of relying on each renderer to remember
+its own control-character handling.
+
+## Implementation
+
+- Added `src/tui/display_sanitize.rs` as the central display sanitizer.
+- Sanitized streaming `AgentMarkdownStreamState` deltas before feeding the
+  markdown stream collector.
+- Sanitized committed `Agent`, `User`, `System`, and generic formatted message
+  inputs before markdown rendering.
+- Sanitized live progress event writes before they reach active-turn rendering.
+- Reused the same sanitizer for terminal-event output lines.
+- Sanitized inline history `Line` segments before physical row calculation and
+  terminal printing.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo test sanitize -- --nocapture`
+- `cargo check`
+
+The test set covers:
+
+- plain sanitizer behavior;
+- styled `Line` sanitization without losing style;
+- terminal event previews;
+- active streaming agent display;
+- active live progress event display;
+- committed agent markdown display.
+
+## Follow-up
+
+No new backlog item is needed. The remaining broader TUI transcript polish stays
+under the existing `TUI / Transcript` todo section.

--- a/src/tui/display_sanitize.rs
+++ b/src/tui/display_sanitize.rs
@@ -1,0 +1,143 @@
+//! Display-text sanitization boundary for the TUI.
+//!
+//! Any user/model/tool text that can reach a terminal `Print` command or a
+//! markdown display collector must pass through this module first. The rule is
+//! intentionally centralized: renderers should not open-code their own
+//! ANSI/control-character handling, because missed call sites can move the
+//! terminal cursor and corrupt the visible transcript.
+//!
+//! The sanitizer preserves visible text and line boundaries, but removes
+//! terminal side effects. Raw payloads may still be persisted elsewhere when
+//! needed; this module defines the display contract only.
+
+use ratatui::text::{Line, Span};
+
+pub(crate) fn sanitize_display_text(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            strip_escape_sequence(&mut chars);
+            continue;
+        }
+
+        match ch {
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                output.push('\n');
+            }
+            '\n' => output.push('\n'),
+            '\t' => output.push_str("    "),
+            ch if ch.is_control() => {}
+            ch => output.push(ch),
+        }
+    }
+    output
+}
+
+pub(crate) fn sanitize_display_line(input: &str) -> String {
+    sanitize_display_text(input)
+        .replace('\n', "")
+        .trim_end()
+        .to_string()
+}
+
+pub(crate) fn sanitize_display_line_segments(line: &Line<'_>) -> Line<'static> {
+    let spans = line
+        .spans
+        .iter()
+        .map(|span| Span {
+            content: sanitize_display_line(span.content.as_ref()).into(),
+            style: span.style,
+        })
+        .collect::<Vec<_>>();
+    Line {
+        spans,
+        style: line.style,
+        alignment: line.alignment,
+    }
+}
+
+fn strip_escape_sequence<I>(chars: &mut std::iter::Peekable<I>)
+where
+    I: Iterator<Item = char>,
+{
+    match chars.peek().copied() {
+        Some('[') => {
+            chars.next();
+            for next in chars.by_ref() {
+                if ('@'..='~').contains(&next) {
+                    break;
+                }
+            }
+        }
+        Some(']') => {
+            chars.next();
+            strip_string_control_sequence(chars);
+        }
+        Some('P' | 'X' | '^' | '_') => {
+            chars.next();
+            strip_string_control_sequence(chars);
+        }
+        Some(_) => {
+            chars.next();
+        }
+        None => {}
+    }
+}
+
+fn strip_string_control_sequence<I>(chars: &mut std::iter::Peekable<I>)
+where
+    I: Iterator<Item = char>,
+{
+    let mut previous_escape = false;
+    for next in chars.by_ref() {
+        if next == '\u{7}' || (previous_escape && next == '\\') {
+            break;
+        }
+        previous_escape = next == '\u{1b}';
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::style::{Color, Style};
+    use ratatui::text::{Line, Span};
+
+    use super::{sanitize_display_line, sanitize_display_line_segments, sanitize_display_text};
+
+    #[test]
+    fn removes_terminal_controls_from_display_text() {
+        assert_eq!(
+            sanitize_display_text(
+                "start\u{1b}[31mred\u{1b}[0m\rnext\u{8}!\u{1b}]0;title\u{7}\tend"
+            ),
+            "startred\nnext!    end"
+        );
+    }
+
+    #[test]
+    fn display_line_never_contains_cursor_moving_controls() {
+        assert_eq!(
+            sanitize_display_line("abc\r\u{1b}[2Kdef\u{7}\tghi\u{1b}Ppayload\u{1b}\\j"),
+            "abcdef    ghij"
+        );
+    }
+
+    #[test]
+    fn line_segments_are_sanitized_without_losing_style() {
+        let line = Line::from(vec![Span::styled(
+            "ok\r\u{1b}[31mred\u{1b}[0m",
+            Style::default().fg(Color::Red),
+        )]);
+
+        let sanitized = sanitize_display_line_segments(&line);
+
+        assert_eq!(sanitized.to_string(), "okred");
+        assert_eq!(sanitized.spans[0].style.fg, Some(Color::Red));
+        assert!(!sanitized.to_string().contains('\r'));
+        assert!(!sanitized.to_string().contains('\u{1b}'));
+    }
+}

--- a/src/tui/insert_history.rs
+++ b/src/tui/insert_history.rs
@@ -195,7 +195,9 @@ where
 /// set foreground/background colors, and write styled spans. Caller is responsible
 /// for cursor positioning and any leading `\r\n`.
 fn write_history_line<W: Write>(writer: &mut W, line: &Line, wrap_width: usize) -> io::Result<()> {
-    let physical_rows = crate::tui::layout_utils::line_visual_rows(line, wrap_width) as u16;
+    let sanitized_line = crate::tui::display_sanitize::sanitize_display_line_segments(line);
+    let physical_rows =
+        crate::tui::layout_utils::line_visual_rows(&sanitized_line, wrap_width) as u16;
     if physical_rows > 1 {
         queue!(writer, SavePosition)?;
         for _ in 1..physical_rows {
@@ -214,11 +216,11 @@ fn write_history_line<W: Write>(writer: &mut W, line: &Line, wrap_width: usize) 
     queue!(writer, Clear(ClearType::UntilNewLine))?;
     // Merge line-level style into each span so that ANSI colors reflect
     // line styles (e.g., blockquotes with green fg).
-    let merged_spans: Vec<Span> = line
+    let merged_spans: Vec<Span> = sanitized_line
         .spans
         .iter()
         .map(|s| Span {
-            style: s.style.patch(line.style),
+            style: s.style.patch(sanitized_line.style),
             content: s.content.clone(),
         })
         .collect();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,6 +4,7 @@ mod command;
 mod constants;
 mod context_display;
 mod custom_terminal;
+mod display_sanitize;
 mod event_dispatch;
 mod event_loop;
 mod event_stream;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -471,6 +471,8 @@ pub(crate) fn prefixed_message_lines(
     max_lines: usize,
 ) -> Vec<Line<'static>> {
     use crate::tui::message_role::MessageRole;
+    let message = crate::tui::display_sanitize::sanitize_display_text(message);
+    let message = message.as_str();
     let role_kind = MessageRole::try_from_str(role);
     if role_kind == Some(MessageRole::User) {
         return user_message_lines(message, usize::MAX);
@@ -516,6 +518,8 @@ pub(crate) fn prefixed_message_lines(
     lines
 }
 fn user_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let message = crate::tui::display_sanitize::sanitize_display_text(message);
+    let message = message.as_str();
     let body_max = max_lines.saturating_sub(1);
     let header = Line::from(Span::styled(
         "▌ You",
@@ -542,6 +546,8 @@ fn user_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
 }
 
 fn agent_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let message = crate::tui::display_sanitize::sanitize_display_text(message);
+    let message = message.as_str();
     let body_max = max_lines.saturating_sub(1);
     let mut lines = vec![Line::from(Span::styled(
         "▌ Agent",
@@ -569,6 +575,8 @@ fn agent_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
 }
 
 fn system_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
+    let message = crate::tui::display_sanitize::sanitize_display_text(message);
+    let message = message.as_str();
     let body_max = max_lines.saturating_sub(1);
     let mut lines = vec![Line::from(Span::styled(
         "▌ System",
@@ -603,6 +611,8 @@ pub(crate) fn formatted_message_lines(
     cwd: Option<&Path>,
 ) -> Vec<Line<'static>> {
     use crate::tui::message_role::MessageRole;
+    let message = crate::tui::display_sanitize::sanitize_display_text(message);
+    let message = message.as_str();
     let role_kind = MessageRole::try_from_str(role);
     if role_kind == Some(MessageRole::Agent) {
         let mut lines = vec![Line::from(Span::styled(

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -1036,6 +1036,26 @@ fn formatted_agent_markdown_keeps_first_and_latest_lines() {
 }
 
 #[test]
+fn formatted_agent_markdown_sanitizes_terminal_controls() {
+    let rendered = formatted_message_lines(
+        "Agent",
+        "Again\rcommit-to-main\u{1b}[31m red\u{1b}[0m\u{8}!",
+        10,
+        Some(Path::new(".")),
+    )
+    .into_iter()
+    .map(|line| line.to_string())
+    .collect::<Vec<_>>()
+    .join("\n");
+
+    assert!(rendered.contains("Again"));
+    assert!(rendered.contains("commit-to-main red!"));
+    assert!(!rendered.contains('\r'));
+    assert!(!rendered.contains('\u{1b}'));
+    assert!(!rendered.contains('\u{8}'));
+}
+
+#[test]
 fn context_overlay_snapshot_with_typical_budget() {
     use crate::context::ContextAssemblyEntry;
     use crate::tui::context_display::render_context_lines;

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1,9 +1,10 @@
 use tempfile::tempdir;
 
 use super::{
-    ActivePendingInteractionKind, InteractionKind, ListPickerKind, Overlay, PROVIDER_FAMILIES,
-    PendingInteractionSnapshot, ProviderFamily, RuntimeSnapshot, TranscriptEntry, TranscriptTurn,
-    TuiApp, input_requests_command_palette, parse_repo_slug, state_db_status_error,
+    ActivePendingInteractionKind, AgentMarkdownStreamState, InteractionKind, ListPickerKind,
+    Overlay, PROVIDER_FAMILIES, PendingInteractionSnapshot, ProviderFamily, RuntimeSnapshot,
+    TranscriptEntry, TranscriptTurn, TuiApp, input_requests_command_palette, parse_repo_slug,
+    state_db_status_error,
 };
 use crate::agent::{Agent, PendingApproval};
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
@@ -44,6 +45,26 @@ fn redacts_secrets_in_state_db_status_messages() {
     assert!(rendered.contains("[REDACTED_SECRET]"));
     assert!(!rendered.contains("supersecretvalue"));
     assert!(!rendered.contains("abcdefghijklmnopqrstuvwxyz"));
+}
+
+#[test]
+fn agent_markdown_stream_sanitizes_terminal_controls() {
+    let mut stream = AgentMarkdownStreamState::new(std::path::PathBuf::from("."));
+
+    stream.push_delta("First\rSecond\u{1b}[31m red\u{1b}[0m\u{8}!");
+
+    assert_eq!(stream.sanitized_raw_text(), "First\nSecond red!");
+    let rendered = stream
+        .display_lines
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("First"));
+    assert!(rendered.contains("Second red!"));
+    assert!(!rendered.contains('\r'));
+    assert!(!rendered.contains('\u{1b}'));
+    assert!(!rendered.contains('\u{8}'));
 }
 
 #[test]
@@ -937,6 +958,25 @@ fn flushed_agent_thinking_stream_scrubs_internal_runtime_blocks() {
     assert_eq!(event.message(), "Visible thought.\n\nNext thought.");
     assert!(!event.message().contains("agent_runtime"));
     assert!(!event.message().contains("tool_results_available"));
+}
+
+#[test]
+fn live_progress_events_sanitize_terminal_controls() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+
+    app.record_running_action("Run\r\u{1b}[31mcargo check\u{1b}[0m\u{8}");
+    app.record_exploration_note("Read\tfile\u{7}");
+
+    assert_eq!(app.active_live.events.len(), 2);
+    assert_eq!(app.active_live.events[0].message(), "Run\ncargo check");
+    assert_eq!(app.active_live.events[1].message(), "Read    file");
+    assert!(!app.active_live.events[0].message().contains('\r'));
+    assert!(!app.active_live.events[0].message().contains('\u{1b}'));
+    assert!(!app.active_live.events[1].message().contains('\u{7}'));
 }
 
 #[test]

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -187,7 +187,9 @@ impl TuiApp {
         let Some(message) = final_message.or(fallback) else {
             return;
         };
-        let message = crate::control_tokens::scrub_internal_control_tokens(&message);
+        let message = crate::tui::display_sanitize::sanitize_display_text(
+            &crate::control_tokens::scrub_internal_control_tokens(&message),
+        );
         if message.trim().is_empty() {
             return;
         }
@@ -365,11 +367,13 @@ impl TuiApp {
     }
 
     fn push_active_live_event(&mut self, event: ActiveLiveEvent) {
-        self.active_live.events.push(event);
+        self.active_live
+            .events
+            .push(sanitize_active_live_event(event));
     }
 
     pub fn record_exploration_action(&mut self, action: impl Into<String>) {
-        let action = action.into();
+        let action = crate::tui::display_sanitize::sanitize_display_text(&action.into());
         if !self
             .active_live
             .exploration_actions
@@ -382,7 +386,7 @@ impl TuiApp {
     }
 
     pub fn record_exploration_note(&mut self, note: impl Into<String>) {
-        let note = note.into();
+        let note = crate::tui::display_sanitize::sanitize_display_text(&note.into());
         if !self
             .active_live
             .exploration_notes
@@ -395,7 +399,7 @@ impl TuiApp {
     }
 
     pub fn record_running_action(&mut self, action: impl Into<String>) {
-        let action = action.into();
+        let action = crate::tui::display_sanitize::sanitize_display_text(&action.into());
         if !self
             .active_live
             .running_actions
@@ -408,7 +412,7 @@ impl TuiApp {
     }
 
     pub fn record_planning_action(&mut self, action: impl Into<String>) {
-        let action = action.into();
+        let action = crate::tui::display_sanitize::sanitize_display_text(&action.into());
         if !self
             .active_live
             .planning_actions
@@ -421,7 +425,7 @@ impl TuiApp {
     }
 
     pub fn record_planning_note(&mut self, note: impl Into<String>) {
-        let note = note.into();
+        let note = crate::tui::display_sanitize::sanitize_display_text(&note.into());
         if !self
             .active_live
             .planning_notes
@@ -555,5 +559,28 @@ impl TuiApp {
 
     pub fn clear_pending_planning_suggestion(&mut self) {
         self.pending_planning_suggestion = None;
+    }
+}
+
+fn sanitize_active_live_event(event: ActiveLiveEvent) -> ActiveLiveEvent {
+    match event {
+        ActiveLiveEvent::Thinking(message) => ActiveLiveEvent::Thinking(
+            crate::tui::display_sanitize::sanitize_display_text(&message),
+        ),
+        ActiveLiveEvent::ExplorationAction(message) => ActiveLiveEvent::ExplorationAction(
+            crate::tui::display_sanitize::sanitize_display_text(&message),
+        ),
+        ActiveLiveEvent::ExplorationNote(message) => ActiveLiveEvent::ExplorationNote(
+            crate::tui::display_sanitize::sanitize_display_text(&message),
+        ),
+        ActiveLiveEvent::PlanningAction(message) => ActiveLiveEvent::PlanningAction(
+            crate::tui::display_sanitize::sanitize_display_text(&message),
+        ),
+        ActiveLiveEvent::PlanningNote(message) => ActiveLiveEvent::PlanningNote(
+            crate::tui::display_sanitize::sanitize_display_text(&message),
+        ),
+        ActiveLiveEvent::RunningAction(message) => ActiveLiveEvent::RunningAction(
+            crate::tui::display_sanitize::sanitize_display_text(&message),
+        ),
     }
 }

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -23,6 +23,7 @@ use crate::state_db::StateDb;
 use crate::thread_store::ThreadSummary;
 use crate::tool::ToolOutputStream;
 use crate::tools::bash::BashCommandInput;
+use crate::tui::display_sanitize::sanitize_display_text;
 use crate::tui::terminal_event::TerminalEvent;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -450,14 +451,17 @@ impl AgentMarkdownStreamState {
     pub(crate) fn push_delta(&mut self, delta: &str) {
         if self.incremental_passthrough && !delta.contains('<') {
             self.raw_text.push_str(delta);
-            self.last_visible_text.push_str(delta);
-            self.collector.push_delta(delta);
-            self.refresh_display_lines();
+            let visible_delta = sanitize_display_text(delta);
+            self.last_visible_text.push_str(&visible_delta);
+            if !visible_delta.is_empty() {
+                self.collector.push_delta(&visible_delta);
+                self.refresh_display_lines();
+            }
             return;
         }
 
         self.raw_text.push_str(delta);
-        let visible_text = scrub_internal_control_tokens(&self.raw_text);
+        let visible_text = sanitize_display_text(&scrub_internal_control_tokens(&self.raw_text));
         if let Some(new_visible_delta) = visible_text.strip_prefix(&self.last_visible_text) {
             if !new_visible_delta.is_empty() {
                 self.collector.push_delta(new_visible_delta);
@@ -471,7 +475,7 @@ impl AgentMarkdownStreamState {
     }
 
     pub(crate) fn sanitized_raw_text(&self) -> String {
-        scrub_internal_control_tokens(&self.raw_text)
+        sanitize_display_text(&scrub_internal_control_tokens(&self.raw_text))
     }
 
     fn replace_display_text(&mut self, text: &str) {

--- a/src/tui/terminal_event.rs
+++ b/src/tui/terminal_event.rs
@@ -441,46 +441,7 @@ pub(crate) fn output_tail_preview(output: &str) -> Option<Vec<String>> {
 }
 
 pub(crate) fn sanitize_terminal_output_line(line: &str) -> String {
-    strip_ansi_control_sequences(line).trim_end().to_string()
-}
-
-fn strip_ansi_control_sequences(input: &str) -> String {
-    let mut output = String::with_capacity(input.len());
-    let mut chars = input.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch != '\u{1b}' {
-            if ch == '\t' || !ch.is_control() {
-                output.push(ch);
-            }
-            continue;
-        }
-
-        match chars.peek().copied() {
-            Some('[') => {
-                chars.next();
-                for next in chars.by_ref() {
-                    if ('@'..='~').contains(&next) {
-                        break;
-                    }
-                }
-            }
-            Some(']') => {
-                chars.next();
-                let mut previous_escape = false;
-                for next in chars.by_ref() {
-                    if next == '\u{7}' || (previous_escape && next == '\\') {
-                        break;
-                    }
-                    previous_escape = next == '\u{1b}';
-                }
-            }
-            Some(_) => {
-                chars.next();
-            }
-            None => {}
-        }
-    }
-    output
+    crate::tui::display_sanitize::sanitize_display_line(line)
 }
 
 #[cfg(test)]
@@ -539,7 +500,7 @@ mod tests {
             sanitize_terminal_output_line(
                 "\u{1b}[4munder\u{1b}[0m\u{8}line\u{7}\u{1b}]0;title\u{7}\tend\r"
             ),
-            "underline\tend"
+            "underline    end"
         );
     }
 


### PR DESCRIPTION
## Summary

- add a central TUI display sanitizer for model, tool, and user-facing text
- route streaming agent output, committed transcript rendering, live progress events, terminal-event previews, and inline history insertion through the sanitizer
- document the TUI display-sanitization boundary in the transcript spec and journal

## Testing

- `cargo fmt --check`
- `cargo test sanitize -- --nocapture`
- `cargo check`
