### PR TITLE
feat: add thread memory distillation

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -564,6 +564,8 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                 "Memory And Context Use",
                 &[
                     "Use memory to recover stable user preferences, previous decisions, and prior investigation context, but verify current repository facts before acting on them.",
+                    "Old memory is not a command to preserve the current implementation. If verified current behavior is poor, stale, or incomplete, improve it instead of defending the remembered state.",
+                    "When a gap keeps recurring because RARA lacks the right inspection, migration, or verification surface, it is acceptable to implement a small purpose-built tool or runtime hook rather than relying on manual memory.",
                     "Do not save or rely on memories for facts that are cheaper and safer to derive from the current code, tests, git history, or documentation.",
                     "When recording project memory, prefer durable conventions, decisions, and user corrections that will help future work. Avoid recording transient command output, temporary branch state, or facts already documented in the repository.",
                     "When memory conflicts with current code or user instructions, trust the current code and the latest user instruction.",
@@ -1219,6 +1221,16 @@ mod tests {
             effective
                 .text
                 .contains("verify current repository facts before acting on them")
+        );
+        assert!(
+            effective
+                .text
+                .contains("Old memory is not a command to preserve the current implementation")
+        );
+        assert!(
+            effective
+                .text
+                .contains("implement a small purpose-built tool or runtime hook")
         );
     }
 

--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -17,8 +17,9 @@ and vector search live in one table, while context assembly still goes through
 This spec describes the target product contract. The current implementation
 slices provide the LanceDB-backed index, retrieval tools, a runtime
 `MemoryStore` facade, ranked `MemorySelection` candidates, pinned retention
-metadata, and update/delete/list-label scaffolding. Filtering and multi-record
-distillation remain follow-up work.
+metadata, update/delete/list-label scaffolding, and LLM-assisted thread
+distillation into multiple durable records. Background promotion and richer
+filtering remain follow-up work.
 
 ## Six Design Laws (Cross-Industry Consensus)
 
@@ -118,7 +119,7 @@ Importance scale:
 | Memory update | Existing records can be edited without creating duplicates. | Partial. `MemoryStore::update` updates domain records and refreshes the LanceDB row when content changes; external protocol execution remains future work. |
 | Memory delete | User or control-plane request can delete records with audit-safe semantics. | Partial. `MemoryStore::delete` removes the domain record and search rehydration filters stale indexed rows; physical LanceDB row cleanup remains future work. |
 | Memory retention | Pinned, user-created, and high-importance memories are protected from automatic cleanup; explicit delete remains possible with provenance. | Implemented as a domain guard on `MemoryRecord`; no automatic cleanup path exists yet. |
-| Thread distillation | Thread history can be distilled into 2-8 durable memory records. | Partial. `ThreadStore::distill_thread_summary` can persist one thread-linked summary record; LLM extraction and deduplication remain future work. |
+| Thread distillation | Thread history can be distilled into 2-8 durable memory records. | Implemented for loaded threads through `ThreadStore::distill_thread_memories`, with LLM-assisted extraction, batch/existing-memory deduplication, and thread provenance. Long-thread chunking remains future work. |
 | Context injection | Ranked memory candidates pass through `MemorySelection` before prompt injection. | Partial. LanceDB-backed memory and session search now produce direct ranked `MemorySelection` candidates; retention, deduplication, and protocol mutation remain future work. |
 | Graph retrieval | Entity and relationship traversal complements vector recall. | Future work. |
 | Working memory | Daily or session briefing summarizes recent and important memories. | Future work. |
@@ -246,8 +247,18 @@ Current implementation checkpoint:
   `relevant_experiences` and memory diagnostics.
 - `retrieve_session_context` searches per-session context shards instead of
   returning a stub response.
-- `ThreadStore::distill_thread_summary` can promote a loaded thread summary into
-  a thread-linked `MemoryRecord` with `session_id`, `thread_id`, and source span.
+- `ThreadStore::distill_thread_summary` remains as the compatibility path for
+  promoting one summary-style record.
+- `ThreadStore::distill_thread_memories` promotes a loaded thread into 2-8
+  independently useful `MemoryRecord`s using `MemoryDistiller`.
+- The distillation prompt treats older memory and prior conclusions as
+  historical context, not current truth. If the inspected thread proves the
+  current design is stale or poor, the distiller should extract the corrected
+  durable fact, procedure, or need for a small purpose-built tool instead of
+  preserving the old state.
+- Generated records preserve `session_id`, `thread_id`, and a source span over
+  the source thread. The first implementation uses the whole loaded thread as
+  the span; finer per-message spans remain future work.
 - Agent turn checkpoints write to per-session `context.jsonl` shards under
   `rollouts/<session_id>/`.
 - `MemoryRetrievalOrchestrator` promotes LanceDB-backed workspace memories and
@@ -272,8 +283,9 @@ Current implementation checkpoint:
    memories are excluded from automatic cleanup. Done.
 9. Add update/delete/list-label control-plane scaffolding without exposing
    storage internals. Done.
-10. Add thread distillation into `MemoryRecord`. Partial: summary distillation is
-   implemented; multi-record LLM extraction and deduplication remain open.
+10. Add thread distillation into `MemoryRecord`. Done for loaded threads:
+    summary distillation remains as compatibility, and LLM-assisted multi-record
+    extraction with deduplication is available through `distill_thread_memories`.
 11. Move raw session checkpoints out of the global `conversations` LanceDB table
    into per-session append shards. Done.
 12. Add periodic promotion from session shards into global `MemoryRecord`s.

--- a/docs/features/threads.md
+++ b/docs/features/threads.md
@@ -150,6 +150,12 @@ Optional YAML frontmatter with `title`, `source`, `date`.
 - Identify independently meaningful units.
 - Auto-generate title, labels, importance.
 - For >50 messages: chunked Smart Background Distillation.
+- Treat older memories and earlier conclusions as historical context, not
+  current truth. If the thread proves that a prior memory is stale, incomplete,
+  or tied to a poor current design, distillation should capture the corrected
+  durable fact or procedure.
+- It is valid to distill a durable tooling need when a thread establishes that
+  reliable future work needs a small purpose-built tool or runtime hook.
 
 Distillation rules:
 
@@ -165,8 +171,11 @@ Runtime status:
 
 - Implemented: summary distillation for a loaded thread into one
   `ThreadDistill` memory record with `session_id`, `thread_id`, and source span.
-- Open: LLM-assisted extraction of 2-8 independently useful records,
-  duplicate detection against existing memories, and long-thread chunking.
+- Implemented: LLM-assisted extraction of 2-8 independently useful records
+  through `ThreadStore::distill_thread_memories`, with duplicate detection
+  against same-batch drafts and existing memory search hits.
+- Open: long-thread chunking, finer per-memory source spans, and background
+  promotion scheduling.
 
 ## Source Journals
 

--- a/docs/journal/2026-05-06-thread-memory-distillation.md
+++ b/docs/journal/2026-05-06-thread-memory-distillation.md
@@ -1,0 +1,38 @@
+# 2026-05-06 · Thread Memory Distillation
+
+## Context
+
+Thread distillation previously produced a single summary-style
+`ThreadDistill` memory record. That was useful as a compatibility checkpoint,
+but it did not satisfy the memory product contract: memories should be
+independently useful durable units such as decisions, facts, procedures,
+insights, and experiences.
+
+## Implementation
+
+- Added `MemoryDistiller` as the LLM-assisted extraction boundary for loaded
+  thread markdown.
+- Added `ThreadStore::distill_thread_memories`, which loads a thread, asks the
+  distiller for 2-8 memory drafts, deduplicates against existing memory search
+  hits and same-batch duplicates, and persists the resulting `MemoryRecord`s
+  through `MemoryStore`.
+- Kept `ThreadStore::distill_thread_summary` as the compatibility path for a
+  single summary-style memory record.
+- Preserved thread provenance on generated records through `session_id`,
+  `thread_id`, and a whole-thread source span.
+- Updated the distillation prompt and default agent memory guidance so old
+  memories are treated as historical context rather than current truth. If a
+  thread proves that current behavior is stale, incomplete, or poorly designed,
+  RARA should capture the corrected durable fact or the need for a small
+  purpose-built tool rather than preserving the old state.
+
+## Validation
+
+- `cargo test memory_distiller -- --nocapture`
+- `cargo test distill_thread -- --nocapture`
+
+## Follow-up
+
+- Add long-thread chunking for threads with many messages.
+- Add finer source-span attribution per extracted memory.
+- Wire periodic session-shard promotion into this distillation path.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -74,7 +74,7 @@ Active backlog only. Keep this file small and current.
 - [x] Promote LanceDB-backed retrieval from `MemoryStore` into ranked `MemorySelection` candidates.
 - [x] Add pinned/retention policy so pinned, user-created, and high-importance memories are excluded from automatic cleanup.
 - [x] Add memory update/delete/list-label control-plane scaffolding for ACP/Wire without exposing LanceDB APIs.
-- [ ] Upgrade thread distillation from summary capture to LLM-assisted 2-8 record extraction with deduplication.
+- [x] Upgrade thread distillation from summary capture to LLM-assisted 2-8 record extraction with deduplication.
 - [x] Move raw session checkpoints into per-session append shards instead of the global LanceDB `conversations` table.
 - [x] Promote `rollouts/<session_id>/transcript.jsonl` from compatibility mirror to canonical model-history source.
 - [x] Wire foreground sub-agent tools to write parent-scoped sidechain transcripts under `rollouts/<parent_session_id>/subagents/`.

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -46,6 +46,10 @@ enum Commands {
         #[arg(value_name = "THREAD_ID")]
         thread_id: String,
     },
+    Distill {
+        #[arg(value_name = "THREAD_ID")]
+        thread_id: String,
+    },
     Thread {
         #[arg(value_name = "THREAD_ID")]
         thread_id: String,
@@ -83,6 +87,7 @@ pub(crate) async fn run_cli() -> Result<()> {
         Commands::Acp => run_acp_command(&config).await?,
         Commands::Ask { prompt } => run_ask_command(&config, prompt).await?,
         Commands::Fork { thread_id } => thread_cli::run_fork_command(&thread_id)?,
+        Commands::Distill { thread_id } => run_distill_command(&config, &thread_id).await?,
         Commands::Thread { thread_id } => thread_cli::run_thread_command(&thread_id)?,
         Commands::Threads { limit } => thread_cli::run_threads_command(limit)?,
         Commands::Resume { thread_id, last } => {
@@ -160,6 +165,23 @@ async fn run_ask_command(config: &RaraConfig, prompt: String) -> Result<()> {
     agent.query(prompt).await
 }
 
+async fn run_distill_command(config: &RaraConfig, thread_id: &str) -> Result<()> {
+    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+    emit_bootstrap_warnings(&bootstrap.warnings);
+    let state_db = crate::state_db::StateDb::new()?;
+    let memory_store =
+        crate::memory_store::MemoryStore::new(bootstrap.backend.clone(), bootstrap.vdb.clone());
+    let thread_store = crate::thread_store::ThreadStore::new(&bootstrap.session_manager, &state_db);
+    let memories = thread_store
+        .distill_thread_memories(&memory_store, thread_id)
+        .await?;
+    print!(
+        "{}",
+        thread_cli::format_distilled_memories(thread_id, &memories)
+    );
+    Ok(())
+}
+
 async fn run_tui_command(
     config: &RaraConfig,
     oauth_manager: OAuthManager,
@@ -202,6 +224,7 @@ fn startup_resume_target_for_command(command: &Commands) -> Option<StartupResume
         Commands::Tui => Some(StartupResumeTarget::Fresh),
         Commands::Acp
         | Commands::Ask { .. }
+        | Commands::Distill { .. }
         | Commands::Fork { .. }
         | Commands::Thread { .. }
         | Commands::Threads { .. }
@@ -373,6 +396,17 @@ mod tests {
         let cli = Cli::try_parse_from(["rara", "fork", "thread-123"]).expect("parse fork");
         match cli.command.expect("command") {
             Commands::Fork { thread_id } => {
+                assert_eq!(thread_id, "thread-123");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clap_parses_distill_command() {
+        let cli = Cli::try_parse_from(["rara", "distill", "thread-123"]).expect("parse distill");
+        match cli.command.expect("command") {
+            Commands::Distill { thread_id } => {
                 assert_eq!(thread_id, "thread-123");
             }
             other => panic!("unexpected command: {other:?}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod hooks;
 mod llm;
 mod local_backend;
 mod mcp_status;
+mod memory_distiller;
 mod memory_store;
 mod oauth;
 mod prompt;

--- a/src/memory_distiller.rs
+++ b/src/memory_distiller.rs
@@ -1,0 +1,315 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::agent::Message;
+use crate::llm::{ContentBlock, LlmBackend, LlmTurnMetadata};
+use crate::memory_store::{MemoryLabel, MemoryRecordSearchHit, NewMemoryRecord};
+
+const MIN_DISTILLED_MEMORIES: usize = 2;
+const MAX_DISTILLED_MEMORIES: usize = 8;
+const DUPLICATE_SCORE_THRESHOLD: f32 = 0.92;
+
+pub struct MemoryDistiller {
+    backend: Arc<dyn LlmBackend>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DistilledMemoryDraft {
+    pub title: String,
+    pub content: String,
+    pub labels: Vec<MemoryLabel>,
+    pub importance: f32,
+}
+
+impl MemoryDistiller {
+    pub fn new(backend: Arc<dyn LlmBackend>) -> Self {
+        Self { backend }
+    }
+
+    pub async fn distill_thread_markdown(
+        &self,
+        thread_markdown: &str,
+    ) -> Result<Vec<DistilledMemoryDraft>> {
+        if thread_markdown.trim().is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let response = self
+            .backend
+            .ask_with_context(
+                &[Message {
+                    role: "user".to_string(),
+                    content: serde_json::json!(distillation_prompt(thread_markdown)),
+                }],
+                &[],
+                LlmTurnMetadata::execute(),
+            )
+            .await
+            .context("distill thread memories")?;
+        let text = response_text(&response.content);
+        parse_distilled_memories(&text)
+    }
+}
+
+pub fn dedupe_memory_drafts(
+    drafts: Vec<DistilledMemoryDraft>,
+    existing_hits: &[Vec<MemoryRecordSearchHit>],
+) -> Vec<DistilledMemoryDraft> {
+    let mut seen = HashSet::new();
+    drafts
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, draft)| {
+            let hits = existing_hits
+                .get(index)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let content_key = normalize_dedupe_key(&draft.content);
+            let title_key = normalize_dedupe_key(&draft.title);
+            if content_key.is_empty() || !seen.insert(content_key.clone()) {
+                return None;
+            }
+            let duplicate = hits.iter().any(|hit| {
+                hit.score >= DUPLICATE_SCORE_THRESHOLD
+                    || normalize_dedupe_key(&hit.record.content) == content_key
+                    || normalize_dedupe_key(&hit.record.title) == title_key
+            });
+            (!duplicate).then_some(draft)
+        })
+        .collect()
+}
+
+pub fn new_memory_record_from_draft(
+    draft: DistilledMemoryDraft,
+    mut base: NewMemoryRecord,
+) -> NewMemoryRecord {
+    base.title = Some(draft.title);
+    base.content = draft.content;
+    base.labels = draft.labels;
+    base.importance = draft.importance;
+    base
+}
+
+fn distillation_prompt(thread_markdown: &str) -> String {
+    format!(
+        "{}{}",
+        concat!(
+            "Extract durable memories from this coding-agent thread.\n\n",
+            "Rules:\n",
+            "- Return only JSON with a top-level `memories` array.\n",
+            "- Extract 2 to 8 memories when the thread contains enough durable material.\n",
+            "- A memory must stand alone without the full conversation.\n",
+            "- Prefer decisions, facts, procedures, insights, and reusable experiences.\n",
+            "- Do not save transient status, command progress, or vague summaries.\n",
+            "- Treat older memories or prior conclusions as historical context, not the current truth.\n",
+            "- If the thread proves that a previous memory is stale or the current design is poor, extract the corrected durable fact or procedure instead of preserving the old state.\n",
+            "- It is valid to record that the agent should create or improve tooling when the thread establishes that a missing tool blocks reliable future work.\n",
+            "- Labels must use only: insight, decision, fact, procedure, experience.\n",
+            "- Importance must be a number from 0.1 to 1.0.\n\n",
+            "Schema:\n",
+            "{{\"memories\":[{{\"title\":\"short title\",\"content\":\"markdown memory\",\"labels\":[\"decision\"],\"importance\":0.7}}]}}\n\n",
+            "Thread:\n"
+        ),
+        thread_markdown
+    )
+}
+
+fn response_text(content: &[ContentBlock]) -> String {
+    content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            ContentBlock::ToolUse { .. } | ContentBlock::ProviderMetadata { .. } => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn parse_distilled_memories(text: &str) -> Result<Vec<DistilledMemoryDraft>> {
+    let value = parse_json_payload(text)?;
+    let response: DistilledMemoryResponse =
+        serde_json::from_value(value).context("parse distilled memory response")?;
+    let mut drafts = response
+        .memories
+        .into_iter()
+        .filter_map(ParsedDistilledMemory::into_draft)
+        .take(MAX_DISTILLED_MEMORIES)
+        .collect::<Vec<_>>();
+    if !drafts.is_empty() && drafts.len() < MIN_DISTILLED_MEMORIES {
+        bail!("thread distillation returned one memory; expected 2-8 or zero");
+    }
+    if drafts.len() > MAX_DISTILLED_MEMORIES {
+        drafts.truncate(MAX_DISTILLED_MEMORIES);
+    }
+    Ok(drafts)
+}
+
+fn parse_json_payload(text: &str) -> Result<Value> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        bail!("thread distillation returned empty response");
+    }
+    if let Ok(value) = serde_json::from_str(trimmed) {
+        return Ok(value);
+    }
+    let start = trimmed
+        .find('{')
+        .context("distillation response did not contain a JSON object")?;
+    let end = trimmed
+        .rfind('}')
+        .context("distillation response did not contain a complete JSON object")?;
+    serde_json::from_str(&trimmed[start..=end])
+        .context("parse JSON object from distillation response")
+}
+
+#[derive(Debug, Deserialize)]
+struct DistilledMemoryResponse {
+    memories: Vec<ParsedDistilledMemory>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParsedDistilledMemory {
+    title: Option<String>,
+    content: Option<String>,
+    #[serde(default)]
+    labels: Vec<MemoryLabel>,
+    importance: Option<f32>,
+}
+
+impl ParsedDistilledMemory {
+    fn into_draft(self) -> Option<DistilledMemoryDraft> {
+        let title = self.title?.trim().to_string();
+        let content = self.content?.trim().to_string();
+        if title.is_empty() || content.is_empty() {
+            return None;
+        }
+        Some(DistilledMemoryDraft {
+            title,
+            content,
+            labels: normalize_labels(self.labels),
+            importance: self.importance.unwrap_or(0.5).clamp(0.1, 1.0),
+        })
+    }
+}
+
+fn normalize_labels(labels: Vec<MemoryLabel>) -> Vec<MemoryLabel> {
+    let mut normalized = Vec::new();
+    for label in labels {
+        if !normalized.contains(&label) {
+            normalized.push(label);
+        }
+    }
+    if normalized.is_empty() {
+        normalized.push(MemoryLabel::Experience);
+    }
+    normalized
+}
+
+fn normalize_dedupe_key(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DistilledMemoryDraft, dedupe_memory_drafts, parse_distilled_memories};
+    use crate::memory_store::{
+        MemoryLabel, MemoryRecord, MemoryRecordSearchHit, MemoryScope, MemorySource,
+    };
+
+    #[test]
+    fn parses_json_distillation_response_with_label_defaults() {
+        let drafts = parse_distilled_memories(
+            r#"{
+              "memories": [
+                {
+                  "title": "Path decision",
+                  "content": "Use `/tmp/rara` for session shards.",
+                  "labels": ["decision"],
+                  "importance": 0.8
+                },
+                {
+                  "title": "Review workflow",
+                  "content": "Resolve review threads after applying comments.",
+                  "labels": [],
+                  "importance": 2.0
+                }
+              ]
+            }"#,
+        )
+        .expect("parse drafts");
+
+        assert_eq!(drafts.len(), 2);
+        assert_eq!(drafts[0].labels, vec![MemoryLabel::Decision]);
+        assert_eq!(drafts[1].labels, vec![MemoryLabel::Experience]);
+        assert_eq!(drafts[1].importance, 1.0);
+    }
+
+    #[test]
+    fn dedupes_drafts_against_existing_hits_and_same_batch() {
+        let drafts = vec![
+            DistilledMemoryDraft {
+                title: "Path decision".to_string(),
+                content: "Use /tmp/rara for session shards.".to_string(),
+                labels: vec![MemoryLabel::Decision],
+                importance: 0.8,
+            },
+            DistilledMemoryDraft {
+                title: "Path decision".to_string(),
+                content: "Use /tmp/rara for session shards.".to_string(),
+                labels: vec![MemoryLabel::Decision],
+                importance: 0.8,
+            },
+            DistilledMemoryDraft {
+                title: "Review workflow".to_string(),
+                content: "Resolve review threads after applying comments.".to_string(),
+                labels: vec![MemoryLabel::Procedure],
+                importance: 0.7,
+            },
+        ];
+        let existing_hits = vec![
+            vec![MemoryRecordSearchHit {
+                record: memory_record(
+                    "existing-1",
+                    "Path decision",
+                    "Use /tmp/rara for session shards.",
+                ),
+                score: 0.5,
+                vector_distance: None,
+                fts_score: None,
+            }],
+            Vec::new(),
+            Vec::new(),
+        ];
+
+        let kept = dedupe_memory_drafts(drafts, &existing_hits);
+
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].title, "Review workflow");
+    }
+
+    fn memory_record(id: &str, title: &str, content: &str) -> MemoryRecord {
+        MemoryRecord {
+            id: id.to_string(),
+            title: title.to_string(),
+            content: content.to_string(),
+            labels: vec![MemoryLabel::Decision],
+            importance: 0.8,
+            pinned: false,
+            source: MemorySource::ThreadDistill,
+            scope: MemoryScope::Thread,
+            session_id: None,
+            thread_id: None,
+            source_span: None,
+            created_at_unix_seconds: 1,
+            updated_at_unix_seconds: 1,
+        }
+    }
+}

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -161,6 +161,10 @@ impl MemoryStore {
         }
     }
 
+    pub(crate) fn backend(&self) -> Arc<dyn LlmBackend> {
+        Arc::clone(&self.backend)
+    }
+
     pub async fn insert(&self, input: NewMemoryRecord) -> Result<MemoryRecord> {
         let content = input.content.trim();
         if content.is_empty() {

--- a/src/thread_cli.rs
+++ b/src/thread_cli.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use anyhow::Result;
 
+use crate::memory_store::{MemoryLabel, MemoryRecord};
 use crate::session::SessionManager;
 use crate::state_db::StateDb;
 use crate::thread_store::{ThreadSnapshot, ThreadStore, ThreadSummary};
@@ -33,6 +34,42 @@ pub(crate) fn run_fork_command(thread_id: &str) -> Result<()> {
         "Forked thread {thread_id} -> {forked_thread_id}\nUse `rara resume {forked_thread_id}` to continue the forked thread.\n"
     );
     Ok(())
+}
+
+pub(crate) fn format_distilled_memories(thread_id: &str, memories: &[MemoryRecord]) -> String {
+    if memories.is_empty() {
+        return format!("No durable memories distilled from thread {thread_id}.\n");
+    }
+
+    let mut lines = vec![format!(
+        "Distilled {} memories from thread {thread_id}:",
+        memories.len()
+    )];
+    for memory in memories {
+        lines.push(format!(
+            "- {}  importance={:.1}  labels={}  id={}",
+            memory.title,
+            memory.importance,
+            memory
+                .labels
+                .iter()
+                .map(memory_label_name)
+                .collect::<Vec<_>>()
+                .join(","),
+            memory.id
+        ));
+    }
+    format!("{}\n", lines.join("\n"))
+}
+
+fn memory_label_name(label: &MemoryLabel) -> &'static str {
+    match label {
+        MemoryLabel::Insight => "insight",
+        MemoryLabel::Decision => "decision",
+        MemoryLabel::Fact => "fact",
+        MemoryLabel::Procedure => "procedure",
+        MemoryLabel::Experience => "experience",
+    }
 }
 
 fn format_recent_threads(threads: &[ThreadSummary], limit: usize) -> String {
@@ -173,7 +210,8 @@ fn workspace_label(cwd: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_recent_threads, format_thread_snapshot};
+    use super::{format_distilled_memories, format_recent_threads, format_thread_snapshot};
+    use crate::memory_store::{MemoryLabel, MemoryRecord, MemoryScope, MemorySource};
     use crate::state_db::PersistedInteraction;
     use crate::thread_store::{
         CompactionRecord, RolloutItem, ThreadHistorySource, ThreadMaterializationProvenance,
@@ -268,5 +306,32 @@ mod tests {
         assert!(output.contains("interactions=1"));
         assert!(output.contains("compactions=3"));
         assert!(output.contains("compaction_recent_files=src/main.rs, src/thread_store.rs"));
+    }
+
+    #[test]
+    fn distilled_memories_output_lists_titles_labels_and_ids() {
+        let output = format_distilled_memories(
+            "thread-123",
+            &[MemoryRecord {
+                id: "mem-1".to_string(),
+                title: "Use thread distillation".to_string(),
+                content: "Distill durable thread decisions into memory records.".to_string(),
+                labels: vec![MemoryLabel::Decision, MemoryLabel::Procedure],
+                importance: 0.8,
+                pinned: false,
+                source: MemorySource::ThreadDistill,
+                scope: MemoryScope::Thread,
+                session_id: Some("thread-123".to_string()),
+                thread_id: Some("thread-123".to_string()),
+                source_span: None,
+                created_at_unix_seconds: 1,
+                updated_at_unix_seconds: 1,
+            }],
+        );
+
+        assert!(output.contains("Distilled 1 memories from thread thread-123:"));
+        assert!(output.contains(
+            "- Use thread distillation  importance=0.8  labels=decision,procedure  id=mem-1"
+        ));
     }
 }

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -8,6 +8,9 @@ use uuid::Uuid;
 
 use crate::agent::Message;
 use crate::atomic_file;
+use crate::memory_distiller::{
+    MemoryDistiller, dedupe_memory_drafts, new_memory_record_from_draft,
+};
 use crate::memory_store::{
     MemoryLabel, MemoryRecord, MemoryScope, MemorySource, MemorySourceSpan, MemoryStore,
     NewMemoryRecord,
@@ -382,6 +385,36 @@ impl<'a> ThreadStore<'a> {
             return Ok(None);
         };
         Ok(Some(memory_store.insert(input).await?))
+    }
+
+    pub async fn distill_thread_memories(
+        &self,
+        memory_store: &MemoryStore,
+        session_id: &str,
+    ) -> Result<Vec<MemoryRecord>> {
+        let snapshot = self.load_thread(session_id)?;
+        let markdown = format_thread_markdown(&snapshot);
+        let distiller = MemoryDistiller::new(memory_store.backend());
+        let drafts = distiller.distill_thread_markdown(&markdown).await?;
+        if drafts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut existing_hits = Vec::with_capacity(drafts.len());
+        for draft in &drafts {
+            existing_hits.push(memory_store.search(&draft.content, 5).await?);
+        }
+
+        let base = thread_distilled_memory_base(&snapshot);
+        let mut records = Vec::new();
+        for draft in dedupe_memory_drafts(drafts, &existing_hits) {
+            records.push(
+                memory_store
+                    .insert(new_memory_record_from_draft(draft, base.clone()))
+                    .await?,
+            );
+        }
+        Ok(records)
     }
 
     pub fn fork_thread(&self, source_thread_id: &str) -> Result<String> {
@@ -1353,27 +1386,34 @@ fn thread_summary_memory_record(thread: &ThreadSnapshot) -> Option<NewMemoryReco
         .or_else(|| first_user_message(thread));
     let summary = summary?;
     let title = thread_title(thread);
-    let end_turn_index = thread.history.len().saturating_sub(1) as u32;
-    Some(NewMemoryRecord {
-        title: Some(title),
-        content: format!(
-            concat!(
-                "## Summary\n",
-                "{summary}\n\n",
-                "## Provenance\n",
-                "- session_id: {session_id}\n",
-                "- thread_id: {thread_id}\n",
-                "- workspace: {workspace}\n",
-                "- provider: {provider}\n",
-                "- model: {model}\n"
-            ),
-            summary = summary.as_str(),
-            session_id = thread.metadata.session_id.as_str(),
-            thread_id = thread.metadata.session_id.as_str(),
-            workspace = thread.metadata.cwd.as_str(),
-            provider = thread.metadata.provider.as_str(),
-            model = thread.metadata.model.as_str(),
+    let mut record = thread_distilled_memory_base(thread);
+    record.title = Some(title);
+    record.content = format!(
+        concat!(
+            "## Summary\n",
+            "{summary}\n\n",
+            "## Provenance\n",
+            "- session_id: {session_id}\n",
+            "- thread_id: {thread_id}\n",
+            "- workspace: {workspace}\n",
+            "- provider: {provider}\n",
+            "- model: {model}\n"
         ),
+        summary = summary.as_str(),
+        session_id = thread.metadata.session_id.as_str(),
+        thread_id = thread.metadata.session_id.as_str(),
+        workspace = thread.metadata.cwd.as_str(),
+        provider = thread.metadata.provider.as_str(),
+        model = thread.metadata.model.as_str(),
+    );
+    Some(record)
+}
+
+fn thread_distilled_memory_base(thread: &ThreadSnapshot) -> NewMemoryRecord {
+    let end_turn_index = thread.history.len().saturating_sub(1) as u32;
+    NewMemoryRecord {
+        title: None,
+        content: String::new(),
         labels: vec![MemoryLabel::Experience],
         importance: 0.6,
         pinned: false,
@@ -1385,7 +1425,7 @@ fn thread_summary_memory_record(thread: &ThreadSnapshot) -> Option<NewMemoryReco
             start_turn_index: 0,
             end_turn_index,
         }),
-    })
+    }
 }
 
 fn thread_title(thread: &ThreadSnapshot) -> String {

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -1,7 +1,10 @@
 use std::fs;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
 use tempfile::tempdir;
 
 use super::{
@@ -9,8 +12,8 @@ use super::{
     ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeState, ThreadStore,
 };
 use crate::agent::Message;
-use crate::llm::MockLlm;
-use crate::memory_store::{MemoryScope, MemorySource, MemoryStore};
+use crate::llm::{ContentBlock, LlmBackend, LlmResponse, MockLlm, TokenUsage};
+use crate::memory_store::{MemoryLabel, MemoryScope, MemorySource, MemoryStore};
 use crate::session::{PersistedCompactionEvent, SessionManager};
 use crate::state_db::{
     PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
@@ -1556,6 +1559,126 @@ async fn distill_thread_summary_persists_thread_linked_memory_record() -> Result
         .expect("persisted memory record");
     assert_eq!(reloaded.thread_id.as_deref(), Some("thread-distill"));
     Ok(())
+}
+
+#[tokio::test]
+async fn distill_thread_memories_persists_multiple_deduped_records() -> Result<()> {
+    let temp = tempdir()?;
+    let rara_dir = temp.path().join(".rara");
+    let session_manager = SessionManager::new_for_rara_dir(rara_dir.clone())?;
+    let state_db = StateDb::new_for_root_dir(rara_dir.clone())?;
+    session_manager.save_session(
+        "thread-distill-many",
+        &[
+            Message {
+                role: "user".to_string(),
+                content: serde_json::json!("How should memory promotion work?"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: serde_json::json!(
+                    "Use session shards first, then distill durable takeaways into MemoryRecords."
+                ),
+            },
+        ],
+    )?;
+    state_db.upsert_session(
+        "thread-distill-many",
+        "/tmp/workspace",
+        "main",
+        "codex",
+        "gpt-5",
+        None,
+        "execute",
+        "always",
+        None,
+        &PersistedPromptRuntimeState::default(),
+        2,
+        2,
+        &PersistedCompactState::default(),
+    )?;
+    let memory_store = MemoryStore::new(
+        Arc::new(DistillMockLlm),
+        Arc::new(VectorDB::new(
+            rara_dir.join("lancedb").to_str().expect("utf8 path"),
+        )),
+    );
+    let store = ThreadStore::new(&session_manager, &state_db);
+
+    let memories = store
+        .distill_thread_memories(&memory_store, "thread-distill-many")
+        .await?;
+
+    assert_eq!(memories.len(), 2);
+    assert_eq!(memories[0].source, MemorySource::ThreadDistill);
+    assert_eq!(memories[0].scope, MemoryScope::Thread);
+    assert_eq!(
+        memories[0].session_id.as_deref(),
+        Some("thread-distill-many")
+    );
+    assert_eq!(memories[0].labels, vec![MemoryLabel::Decision]);
+    assert!(
+        memories
+            .iter()
+            .any(|memory| memory.title == "Session shards before global memory")
+    );
+    assert!(
+        memories
+            .iter()
+            .any(|memory| memory.title == "Promotion records keep provenance")
+    );
+    let labels = memory_store.list_labels(Some(MemoryScope::Thread)).await?;
+    assert!(
+        labels
+            .iter()
+            .any(|label| label.label == MemoryLabel::Decision)
+    );
+    Ok(())
+}
+
+struct DistillMockLlm;
+
+#[async_trait]
+impl LlmBackend for DistillMockLlm {
+    async fn ask(&self, _messages: &[Message], _tools: &[Value]) -> Result<LlmResponse> {
+        Ok(LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: serde_json::json!({
+                    "memories": [
+                        {
+                            "title": "Session shards before global memory",
+                            "content": "Use per-session append shards for raw checkpoints before promoting durable takeaways into global MemoryRecords.",
+                            "labels": ["decision"],
+                            "importance": 0.8
+                        },
+                        {
+                            "title": "Session shards before global memory",
+                            "content": "Use per-session append shards for raw checkpoints before promoting durable takeaways into global MemoryRecords.",
+                            "labels": ["decision"],
+                            "importance": 0.8
+                        },
+                        {
+                            "title": "Promotion records keep provenance",
+                            "content": "Thread distillation should preserve session_id, thread_id, and source span on generated MemoryRecords.",
+                            "labels": ["procedure"],
+                            "importance": 0.7
+                        }
+                    ]
+                })
+                .to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        })
+    }
+
+    async fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+        Ok(vec![0.1; 128])
+    }
+
+    async fn summarize(&self, _messages: &[Message], _instruction: &str) -> Result<String> {
+        Ok("summary".to_string())
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `MemoryDistiller` for LLM-assisted extraction of durable thread memories
- wire `ThreadStore::distill_thread_memories` and `rara distill <THREAD_ID>` to persist deduped `MemoryRecord`s
- update memory/context prompts and specs so stale memories are treated as historical context, not current truth

## Testing

- `cargo fmt --check`
- `cargo test memory_distiller -- --nocapture`
- `cargo test distill_thread -- --nocapture`
- `cargo test -p rara-instructions default_system_prompt_includes_workflow_standards -- --nocapture`
- `cargo test clap_parses_distill_command -- --nocapture`
- `cargo test distilled_memories_output_lists_titles_labels_and_ids -- --nocapture`
- `cargo check`
