### PR TITLE
fix: honor full access approval entrypoints

### DIFF
--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -48,6 +48,11 @@ pub(super) async fn execute_local_command(
                 BashApprovalMode::Once => BashApprovalMode::Suggestion,
                 BashApprovalMode::Always => BashApprovalMode::Suggestion,
             };
+            if next_mode == BashApprovalMode::Always {
+                apply_permission_mode(app, agent_slot, PermissionMode::FullAccess);
+                app.push_notice("Permission mode: full-access.");
+                return Ok(false);
+            }
             app.bash_approval_mode = next_mode;
             app.permission_mode = PermissionMode::Custom;
             if let Some(agent) = agent_slot.as_mut() {
@@ -468,6 +473,7 @@ pub(crate) fn apply_permission_mode(
         PermissionMode::Custom => return,
     };
 
+    app.permission_mode = mode;
     app.set_agent_execution_mode(execution);
     app.bash_approval_mode = approval;
     app.sandbox_network_access
@@ -495,7 +501,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::{execute_local_command, handle_mcp_command, mcp_project_root_from_cwd};
-    use crate::agent::AgentEvent;
+    use crate::agent::{AgentEvent, BashApprovalMode};
     use crate::config::ConfigManager;
     use crate::oauth::OAuthManager;
     use crate::runtime_event_bus::RuntimeEventBus;
@@ -602,6 +608,7 @@ command = "docs-server"
             path: dir.path().join("config.json"),
         })
         .expect("app");
+        app.bash_approval_mode = BashApprovalMode::Suggestion;
         let oauth_manager = Arc::new(
             OAuthManager::new_for_config_dir(dir.path().join("oauth")).expect("oauth manager"),
         );
@@ -652,5 +659,38 @@ command = "docs-server"
         .expect("permissions command should be handled");
         assert!(app.overlay.is_none());
         assert_ne!(app.overlay, Some(Overlay::PermissionPicker));
+    }
+
+    #[tokio::test]
+    async fn approval_command_switches_always_to_full_access() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager = Arc::new(
+            OAuthManager::new_for_config_dir(dir.path().join("oauth")).expect("oauth manager"),
+        );
+        let mut agent_slot = None;
+
+        execute_local_command(
+            LocalCommand {
+                kind: LocalCommandKind::Approval,
+                arg: None,
+            },
+            &mut app,
+            &mut agent_slot,
+            &oauth_manager,
+        )
+        .await
+        .expect("approval command should be handled");
+
+        assert_eq!(app.permission_mode, PermissionMode::FullAccess);
+        assert_eq!(app.bash_approval_mode_label(), "always");
+        assert!(
+            app.sandbox_network_access
+                .load(std::sync::atomic::Ordering::Relaxed)
+        );
+        assert_eq!(app.notice.as_deref(), Some("Permission mode: full-access."));
     }
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -252,6 +252,16 @@ pub(super) fn start_pending_approval_task(
     selection: BashApprovalDecision,
     mut agent: Agent,
 ) {
+    if selection == BashApprovalDecision::Always {
+        app.permission_mode = PermissionMode::FullAccess;
+        app.sandbox_network_access
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        app.set_agent_execution_mode(crate::agent::AgentExecutionMode::Execute);
+        app.bash_approval_mode = crate::agent::BashApprovalMode::Always;
+        agent.set_execution_mode(crate::agent::AgentExecutionMode::Execute);
+        agent.set_bash_approval_mode(crate::agent::BashApprovalMode::Always);
+        agent.set_full_access_mode(true);
+    }
     let (sender, receiver) = mpsc::unbounded_channel();
     let cancellation_token = Arc::new(AtomicBool::new(false));
     let bus = app.event_bus.clone();

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -613,6 +613,42 @@ async fn full_access_permission_picker_resumes_pending_shell_approval_in_local_a
 }
 
 #[tokio::test]
+async fn always_shell_approval_promotes_full_access_for_follow_up_commands() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    add_pending_shell_approval(&mut app);
+
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = Some(test_agent_for_pending_approval(&temp));
+
+    dispatch_event(
+        AppEvent::SelectPendingOption(2),
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("approve for session");
+
+    assert_eq!(app.permission_mode, PermissionMode::FullAccess);
+    assert_eq!(app.bash_approval_mode_label(), "always");
+    assert!(
+        app.sandbox_network_access
+            .load(std::sync::atomic::Ordering::Relaxed)
+    );
+    assert!(app.pending_command_approval().is_none());
+    assert!(agent_slot.is_none());
+    assert!(app.running_task.is_some());
+    abort_running_task(&mut app);
+}
+
+#[tokio::test]
 async fn full_access_mode_resumes_stale_pending_shell_approval_from_shortcuts() {
     for event in [AppEvent::SelectPendingOption(3), AppEvent::SubmitComposer] {
         let temp = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

- centralize permission mode state updates in `apply_permission_mode`
- make `/approval` promote the session to full access when it switches bash approval to always
- promote the approval-card always/session choice to full access for follow-up escalated shell commands

## Testing

- `cargo fmt --check`
- `cargo check`
- `cargo test always_shell_approval_promotes_full_access_for_follow_up_commands -- --nocapture`
- `cargo test approval_command_switches_always_to_full_access -- --nocapture`
- `cargo test full_access_permission_picker_resumes_pending_shell_approval_in_local_and_ssh -- --nocapture`
- `cargo test full_access_mode_resumes_stale_pending_shell_approval_from_shortcuts -- --nocapture`
