### PR TITLE
feat: add release distribution pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,317 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to stage, for example v0.1.0"
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
+jobs:
+  tag-check:
+    name: tag-check
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate tag and extract version
+        id: version
+        shell: bash
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            tag="${DISPATCH_TAG}"
+          else
+            [[ "${GITHUB_REF_TYPE}" == "tag" ]] || {
+              echo "Release workflow must run from a tag push or workflow_dispatch." >&2
+              exit 1
+            }
+            tag="${GITHUB_REF_NAME}"
+          fi
+
+          [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)(\.[0-9]+)?)?$ ]] || {
+            echo "Tag '${tag}' must match vX.Y.Z, vX.Y.Z-alpha(.N), or vX.Y.Z-beta(.N)." >&2
+            exit 1
+          }
+
+          version="${tag#v}"
+          prerelease=false
+          if [[ "${version}" == *-* ]]; then
+            prerelease=true
+          fi
+
+          git rev-parse --verify --quiet "refs/tags/${tag}^{commit}" >/dev/null || {
+            echo "Tag '${tag}' does not exist in this repository." >&2
+            exit 1
+          }
+          git checkout --detach "${tag}"
+
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+
+      - name: Read pinned Rust toolchain
+        id: rust-toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/{print $2; exit}' rust-toolchain.toml)"
+          [[ -n "${channel}" ]] || {
+            echo "Failed to read Rust toolchain channel from rust-toolchain.toml." >&2
+            exit 1
+          }
+          echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+
+      - name: Validate Cargo package version
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          cargo_version="$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+          [[ "${cargo_version}" == "${VERSION}" ]] || {
+            echo "Tag version ${VERSION} does not match Cargo package version ${cargo_version}." >&2
+            exit 1
+          }
+
+  build:
+    needs: tag-check
+    name: build-${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            target: aarch64-apple-darwin
+            archive: tar.gz
+            smoke: true
+          - runner: macos-13
+            target: x86_64-apple-darwin
+            archive: tar.gz
+            smoke: true
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            archive: tar.gz
+            smoke: true
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            archive: tar.gz
+            build_with: cross
+            smoke: false
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: zip
+            smoke: true
+          - runner: windows-latest
+            target: aarch64-pc-windows-msvc
+            archive: zip
+            smoke: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.tag-check.outputs.tag }}
+
+      - name: Read pinned Rust toolchain
+        id: rust-toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/{print $2; exit}' rust-toolchain.toml)"
+          [[ -n "${channel}" ]] || {
+            echo "Failed to read Rust toolchain channel from rust-toolchain.toml." >&2
+            exit 1
+          }
+          echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+          targets: ${{ matrix.target }}
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install musl tools
+        if: ${{ runner.os == 'Linux' && contains(matrix.target, 'musl') && matrix.build_with != 'cross' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y musl-tools
+
+      - name: Install cross
+        if: ${{ matrix.build_with == 'cross' }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build
+        if: ${{ matrix.build_with != 'cross' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --locked --release --target "${{ matrix.target }}" --bin rara
+
+      - name: Cross build
+        if: ${{ matrix.build_with == 'cross' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cross build --locked --release --target "${{ matrix.target }}" --bin rara
+
+      - name: Package unix archive
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        env:
+          VERSION: ${{ needs.tag-check.outputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          dist_dir="dist/${TARGET}"
+          mkdir -p "${dist_dir}"
+          cp "target/${TARGET}/release/rara" "${dist_dir}/rara"
+          chmod +x "${dist_dir}/rara"
+          tar -C "${dist_dir}" -czf "dist/rara-${VERSION}-${TARGET}.tar.gz" rara
+
+      - name: Package windows archive
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.tag-check.outputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          $distDir = "dist/$env:TARGET"
+          New-Item -ItemType Directory -Force -Path $distDir | Out-Null
+          Copy-Item "target/$env:TARGET/release/rara.exe" "$distDir/rara.exe"
+          Compress-Archive -Path "$distDir/rara.exe" -DestinationPath "dist/rara-$env:VERSION-$env:TARGET.zip" -Force
+
+      - name: Smoke test unix archive
+        if: ${{ runner.os != 'Windows' && matrix.smoke }}
+        shell: bash
+        env:
+          VERSION: ${{ needs.tag-check.outputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          smoke_dir="dist/smoke-${TARGET}"
+          mkdir -p "${smoke_dir}"
+          tar -C "${smoke_dir}" -xzf "dist/rara-${VERSION}-${TARGET}.tar.gz"
+          "${smoke_dir}/rara" --version
+
+      - name: Smoke test windows archive
+        if: ${{ runner.os == 'Windows' && matrix.smoke }}
+        shell: pwsh
+        env:
+          VERSION: ${{ needs.tag-check.outputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          $smokeDir = "dist/smoke-$env:TARGET"
+          New-Item -ItemType Directory -Force -Path $smokeDir | Out-Null
+          Expand-Archive -Path "dist/rara-$env:VERSION-$env:TARGET.zip" -DestinationPath $smokeDir -Force
+          & "$smokeDir/rara.exe" --version
+
+      - name: Upload release archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: rara-${{ matrix.target }}
+          path: dist/rara-${{ needs.tag-check.outputs.version }}-${{ matrix.target }}.${{ matrix.archive }}
+          if-no-files-found: error
+
+  release:
+    needs:
+      - tag-check
+      - build
+    name: github-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.tag-check.outputs.tag }}
+
+      - name: Download release archives
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/artifacts
+
+      - name: Stage checksums
+        shell: bash
+        env:
+          VERSION: ${{ needs.tag-check.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist/release
+          find dist/artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -print0 \
+            | xargs -0 -I{} cp "{}" dist/release/
+
+          expected=6
+          actual="$(find dist/release -type f \( -name "*.tar.gz" -o -name "*.zip" \) | wc -l | tr -d ' ')"
+          [[ "${actual}" == "${expected}" ]] || {
+            echo "Expected ${expected} release archives, found ${actual}." >&2
+            find dist/release -maxdepth 1 -type f -print >&2
+            exit 1
+          }
+
+          (
+            cd dist/release
+            shasum -a 256 rara-"${VERSION}"-* > checksums.txt
+            while read -r checksum filename; do
+              printf "%s  %s\n" "${checksum}" "${filename}" > "${filename}.sha256"
+            done < checksums.txt
+          )
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ needs.tag-check.outputs.version }}
+          tag_name: ${{ needs.tag-check.outputs.tag }}
+          generate_release_notes: true
+          prerelease: ${{ needs.tag-check.outputs.prerelease }}
+          files: |
+            dist/release/rara-${{ needs.tag-check.outputs.version }}-*.tar.gz
+            dist/release/rara-${{ needs.tag-check.outputs.version }}-*.zip
+            dist/release/rara-${{ needs.tag-check.outputs.version }}-*.sha256
+            dist/release/checksums.txt

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -43,3 +43,8 @@ future appserver integrations can use.
 
 - `mcp-runtime.md`: source-aware MCP configuration, registry, status, refresh,
   reconnect, resource, and Tool Search contracts.
+
+## Release Specs
+
+- `release-distribution.md`: tag-driven binary release, GitHub Release assets,
+  Homebrew adapter, and npm adapter contracts.

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -1,0 +1,180 @@
+# Release Distribution
+
+## Problem
+
+RARA currently has CI coverage for formatting, build, clippy, and tests, but it
+does not have a release pipeline that turns a version tag into downloadable
+artifacts or downstream package updates.
+
+Without a documented release contract, future Homebrew and npm distribution work
+would likely grow as ad hoc workflow logic. The release path should be designed
+around stable artifacts first, then package-manager adapters.
+
+## Scope
+
+- Define a tag-driven release workflow for the `rara` binary.
+- Define the release artifact naming and platform matrix.
+- Define how GitHub Releases, Homebrew, and npm should connect to the same
+  canonical artifacts.
+- Define validation gates before publishing.
+
+## Non-Goals
+
+- Publish Homebrew formulae or npm packages in this phase.
+- Add install scripts or binary auto-update behavior in this phase.
+- Replace existing build, fmt, clippy, or test CI jobs.
+
+## Architecture
+
+The release pipeline should have four layers:
+
+1. **Tag validation.** A release starts from a pushed `vX.Y.Z` tag. Pre-release
+   tags use `vX.Y.Z-alpha.N` or `vX.Y.Z-beta.N`.
+2. **Matrix build.** Build one binary per supported target with the pinned Rust
+   toolchain from `rust-toolchain.toml`.
+3. **Artifact staging.** Package binaries into deterministic archives and expose
+   checksums.
+4. **Distribution adapters.** Publish GitHub Release assets first. Homebrew and
+   npm consume those assets instead of rebuilding from source.
+
+This keeps GitHub Release assets as the source of truth. Homebrew and npm are
+thin distribution layers over the same build outputs.
+
+## Target Matrix
+
+Initial release targets:
+
+| Target | Runner | Archive |
+| --- | --- | --- |
+| `aarch64-apple-darwin` | `macos-14` | `.tar.gz` |
+| `x86_64-apple-darwin` | `macos-13` | `.tar.gz` |
+| `x86_64-unknown-linux-musl` | `ubuntu-latest` | `.tar.gz` |
+| `aarch64-unknown-linux-musl` | `ubuntu-latest` with `cross` | `.tar.gz` |
+| `x86_64-pc-windows-msvc` | `windows-latest` | `.zip` |
+| `aarch64-pc-windows-msvc` | `windows-latest` | `.zip` |
+
+The matrix can be narrowed before the first public release if local dependency
+or linker behavior makes a target unreliable.
+
+## Artifact Contract
+
+Each build produces one executable archive:
+
+- Unix: `rara-${VERSION}-${TARGET}.tar.gz`
+- Windows: `rara-${VERSION}-${TARGET}.zip`
+
+Each release should also publish checksum files:
+
+- `rara-${VERSION}-${TARGET}.sha256`
+- `checksums.txt`
+
+Archives contain only the executable at the archive root:
+
+- `rara`
+- `rara.exe`
+
+## GitHub Release Contract
+
+The GitHub Release job should:
+
+- download all matrix build artifacts;
+- verify expected target coverage;
+- generate checksums;
+- create or update the release for the tag;
+- mark versions containing `-` as pre-releases;
+- attach all binary archives and checksums;
+- use generated release notes.
+
+GitHub Release publishing is the first distribution gate. Downstream publish
+jobs should not run unless the release assets exist.
+
+## Current Pipeline
+
+`.github/workflows/release.yml` implements the first release slice:
+
+- tag validation for `vX.Y.Z`, `vX.Y.Z-alpha(.N)`, and `vX.Y.Z-beta(.N)`;
+- explicit tag checkout for both tag push and manual dispatch releases;
+- Cargo package version validation against the tag version;
+- pinned Rust toolchain discovery from `rust-toolchain.toml`;
+- target matrix release builds;
+- deterministic binary archives;
+- runnable archive smoke tests on native runner/target pairs;
+- checksum generation;
+- GitHub Release asset publishing.
+
+It intentionally does not publish Homebrew or npm packages yet.
+
+## Homebrew Adapter
+
+Homebrew should be a follow-up adapter, not the first release mechanism.
+
+The adapter should:
+
+- read `checksums.txt` from the GitHub Release;
+- update a formula in a tap repository;
+- map `darwin-aarch64` and `darwin-x86_64` archives to the same formula;
+- avoid publishing pre-release tags unless a separate tap policy is defined.
+
+Open design choice:
+
+- use a dedicated tap repository such as `linkerdog/homebrew-tap`, or keep a
+  formula under this repository until the release process stabilizes.
+
+## npm Adapter
+
+npm should use a meta-package plus platform packages:
+
+- `rara`: JavaScript wrapper and platform selection logic.
+- `@rara/darwin-arm64`
+- `@rara/darwin-x64`
+- `@rara/linux-x64`
+- `@rara/linux-arm64`
+- `@rara/win32-x64`
+- `@rara/win32-arm64`
+
+The npm staging script should:
+
+- consume GitHub Release archives;
+- generate platform package tarballs;
+- keep the top-level package small;
+- run package tests before publishing;
+- use npm trusted publishing through OIDC.
+
+Stable tags publish to `latest`. Pre-release tags can publish to `alpha` or
+`beta` only when the tag format explicitly matches that channel.
+
+## Validation Matrix
+
+Before creating release assets:
+
+- `cargo fmt --check`
+- `cargo build --locked --release --target <target>`
+- `cargo test --locked` on at least the host target
+- archive smoke test: unpack and run `rara --version`
+- checksum verification
+
+Before npm publishing:
+
+- packaging script unit tests
+- unpacked package smoke test
+- platform package resolution test
+
+Before Homebrew publishing:
+
+- formula syntax audit
+- install test on supported macOS runners when practical
+
+## Open Risks
+
+- `rara` currently has a large dependency graph. Release builds may expose
+  platform-specific linker or cross-compilation failures.
+- Local model backends and native dependencies may require target-specific
+  feature decisions before binary distribution.
+- npm package ownership, scope naming, and trusted publishing setup are external
+  operational prerequisites.
+- Homebrew tap ownership and formula update permissions are external
+  operational prerequisites.
+
+## Source Journals
+
+- `docs/journal/2026-05-06-release-distribution-planning.md`

--- a/docs/journal/2026-05-06-release-distribution-planning.md
+++ b/docs/journal/2026-05-06-release-distribution-planning.md
@@ -1,0 +1,51 @@
+# Release Distribution Planning
+
+## Context
+
+Reviewed a tag-driven Rust CLI release workflow that builds target-specific
+binaries, stages GitHub Release assets, and publishes npm packages from staged
+tarballs.
+
+RARA currently has CI workflows for build, clippy, fmt, and test, but no release
+workflow or package distribution contract.
+
+## Extracted Pattern
+
+- Validate release tags before doing expensive work.
+- Read the pinned Rust toolchain from `rust-toolchain.toml`.
+- Build a platform matrix instead of relying on one host build.
+- Package binaries into deterministic archives.
+- Upload build artifacts from matrix jobs and assemble the GitHub Release in a
+  separate job.
+- Treat GitHub Release assets as canonical.
+- Run package staging and package tests before publishing npm artifacts.
+- Use npm trusted publishing instead of long-lived npm tokens.
+- Publish pre-release channels only for explicit pre-release tag patterns.
+
+## RARA Decision
+
+RARA should first define the release artifact contract, then add distribution
+adapters.
+
+The first implementation slice should add a GitHub Release workflow that only
+builds and uploads binary archives plus checksums. Homebrew and npm should be
+follow-up adapters that consume those release assets.
+
+## Implementation Checkpoint
+
+Added `.github/workflows/release.yml` for the first release slice:
+
+- validate tags and Cargo package version;
+- checkout the validated tag before building release artifacts;
+- build six target archives;
+- smoke-test runnable native archives with `rara --version`;
+- generate per-archive and aggregate checksums;
+- publish GitHub Release assets.
+
+Also enabled the `rara --version` CLI flag so release smoke tests can run
+without entering the TUI.
+
+## Follow-Up
+
+- Add npm package layout and staging tests.
+- Add Homebrew tap update strategy after release assets are stable.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -11,6 +11,7 @@ Active backlog only. Keep this file small and current.
 5. Memory / retrieval / thread persistence
 6. TUI transcript parity and command-surface polish
 7. Terminal-Bench evaluation readiness
+8. Release distribution and package-manager adapters
 
 ## Runtime Control Plane / ACP / Wire
 
@@ -133,6 +134,14 @@ Active backlog only. Keep this file small and current.
 ## Evaluation / Benchmarks
 
 - [ ] Terminal-Bench readiness: add a headless adapter, preserve structured trajectories, and start with a small smoke run that records RARA revision, dataset version, provider/model, sandbox mode, and failure taxonomy.
+
+## Release / Distribution
+
+- [x] Add tag-driven GitHub Release workflow for `rara` binary archives and checksums.
+- [x] Add release matrix smoke test that unpacks each archive and runs `rara --version`.
+- [ ] Add npm package layout and staging script for meta-package plus platform packages.
+- [ ] Add npm packaging tests and trusted-publishing workflow step.
+- [ ] Decide Homebrew tap ownership and add formula update workflow consuming GitHub Release checksums.
 
 ## Code Organization / Docs
 

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -15,7 +15,7 @@ use crate::tui::StartupResumeTarget;
 
 #[derive(Parser)]
 #[command(name = "rara")]
-#[command(about = "RARA: RARA Automates Rust Agents", long_about = None)]
+#[command(version, about = "RARA: RARA Automates Rust Agents", long_about = None)]
 pub(crate) struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -411,6 +411,16 @@ mod tests {
             }
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn clap_supports_version_flag_for_release_smoke_tests() {
+        let err = match Cli::try_parse_from(["rara", "--version"]) {
+            Ok(_) => panic!("version should exit early"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
+        assert!(err.to_string().starts_with("rara "));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a tag-driven release workflow for multi-platform `rara` binary archives.
- Publish deterministic GitHub Release assets with aggregate and per-archive checksums.
- Add `rara --version` support so release jobs can smoke-test packaged archives.
- Document the release artifact contract plus future Homebrew and npm adapters.

## Testing

- `cargo fmt --check`
- `cargo test clap_supports_version_flag_for_release_smoke_tests -- --nocapture`
- `cargo run -- --version`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "ok"'`
- `git diff --check`

## Follow-up

- Add npm meta-package and platform package staging.
- Add npm packaging tests and trusted publishing.
- Decide Homebrew tap ownership and add formula update workflow.
