### PR TITLE
fix(agent): continue on reasoning-only turns regardless of agentic_turn count

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -38,6 +38,7 @@ use crate::workspace::WorkspaceMemory;
 
 const MAX_RUNTIME_ERROR_RECOVERY_ATTEMPTS: usize = 1;
 const MAX_PLAN_EXIT_REPAIR_ATTEMPTS: usize = 1;
+const MAX_CONSECUTIVE_REASONING_ONLY_TURNS: usize = 1;
 
 pub use self::compact::{CompactBoundaryMetadata, CompactState, latest_compact_boundary_metadata};
 pub use self::planning::{
@@ -158,6 +159,7 @@ pub struct Agent {
     pending_plan_exit_tool_id: Option<String>,
     prompt_config: PromptRuntimeConfig,
     cancellation_token: Option<Arc<AtomicBool>>,
+    consecutive_reasoning_only_turns: usize,
 }
 
 impl Agent {
@@ -230,6 +232,7 @@ impl Agent {
             pending_plan_exit_tool_id: None,
             prompt_config: PromptRuntimeConfig::default(),
             cancellation_token: None,
+            consecutive_reasoning_only_turns: 0,
         }
     }
 
@@ -575,6 +578,27 @@ impl Agent {
             }
 
             if turn_output.tool_calls.is_empty() {
+                // Reset consecutive reasoning-only counter when the model
+                // produces visible text.
+                if turn_output.had_text_response {
+                    self.consecutive_reasoning_only_turns = 0;
+                }
+                let is_reasoning_only = Self::is_reasoning_only_turn(
+                    turn_output.had_text_response,
+                    turn_output.had_reasoning_response,
+                );
+                if is_reasoning_only {
+                    self.consecutive_reasoning_only_turns += 1;
+                    if self.consecutive_reasoning_only_turns > MAX_CONSECUTIVE_REASONING_ONLY_TURNS
+                    {
+                        report(AgentEvent::Status(
+                            "Model produced reasoning-only for too many consecutive turns. Stopping."
+                                .to_string(),
+                        ));
+                        self.complete_active_plan_step();
+                        break;
+                    }
+                }
                 if self.should_continue_plan_without_tools(
                     turn_output.plan_updated,
                     turn_output.continue_inspection,
@@ -586,7 +610,11 @@ impl Agent {
                         "Plan mode needs more evidence. Continuing in read-only mode.".to_string(),
                     ));
                     *agentic_turns += 1;
-                    let phase = RuntimeContinuationPhase::PlanContinuationRequired;
+                    let phase = if is_reasoning_only {
+                        RuntimeContinuationPhase::ReasoningOnlyContinuationRequired
+                    } else {
+                        RuntimeContinuationPhase::PlanContinuationRequired
+                    };
                     self.push_history_message(
                         self.runtime_continuation_message(phase, *agentic_turns),
                     );
@@ -594,16 +622,11 @@ impl Agent {
                     continue;
                 }
                 if self.should_continue_execute_without_tools(
-                    *agentic_turns,
                     turn_output.continue_inspection,
                     turn_output.had_text_response,
                     turn_output.had_reasoning_response,
                 ) {
-                    let phase = if Self::is_reasoning_only_initial_turn(
-                        turn_output.had_text_response,
-                        turn_output.had_reasoning_response,
-                        *agentic_turns,
-                    ) {
+                    let phase = if is_reasoning_only {
                         report(AgentEvent::Status(
                             "Model produced reasoning only. Continuing for a visible answer or tool call."
                                 .to_string(),
@@ -626,6 +649,9 @@ impl Agent {
                 self.complete_active_plan_step();
                 break;
             }
+            // Reset consecutive reasoning-only counter when the model
+            // produces tool calls.
+            self.consecutive_reasoning_only_turns = 0;
             *agentic_turns += 1;
 
             let tool_results = self

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -511,11 +511,8 @@ impl Agent {
     ) -> bool {
         let shallow_initial_plan =
             plan_updated && agentic_turns == 0 && self.current_plan.len() <= 1;
-        let reasoning_only_initial_turn = Self::is_reasoning_only_initial_turn(
-            had_text_response,
-            had_reasoning_response,
-            agentic_turns,
-        );
+        let reasoning_only_turn =
+            Self::is_reasoning_only_turn(had_text_response, had_reasoning_response);
         let has_inspection_evidence = self.inspection_progress.has_any_evidence();
         let still_missing_inspection_evidence = agentic_turns > 0
             && !plan_updated
@@ -525,40 +522,35 @@ impl Agent {
             && (continue_inspection
                 || shallow_initial_plan
                 || still_missing_inspection_evidence
-                || reasoning_only_initial_turn)
+                || reasoning_only_turn)
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
             && (continue_inspection
                 || has_inspection_evidence
                 || !self.current_plan.is_empty()
                 || had_text_response
-                || reasoning_only_initial_turn)
+                || reasoning_only_turn)
     }
 
     pub(super) fn should_continue_execute_without_tools(
         &self,
-        agentic_turns: usize,
         continue_inspection: bool,
         had_text_response: bool,
         had_reasoning_response: bool,
     ) -> bool {
-        let reasoning_only_initial_turn = Self::is_reasoning_only_initial_turn(
-            had_text_response,
-            had_reasoning_response,
-            agentic_turns,
-        );
+        let reasoning_only_turn =
+            Self::is_reasoning_only_turn(had_text_response, had_reasoning_response);
         matches!(self.execution_mode, AgentExecutionMode::Execute)
-            && (continue_inspection || reasoning_only_initial_turn)
+            && (continue_inspection || reasoning_only_turn)
             && self.pending_user_input.is_none()
             && self.pending_approval.is_none()
     }
 
-    pub(super) fn is_reasoning_only_initial_turn(
+    pub(super) fn is_reasoning_only_turn(
         had_text_response: bool,
         had_reasoning_response: bool,
-        agentic_turns: usize,
     ) -> bool {
-        had_reasoning_response && !had_text_response && agentic_turns == 0
+        had_reasoning_response && !had_text_response
     }
 
     pub(super) fn ensure_active_plan_step(&mut self) {

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -704,7 +704,7 @@ async fn plan_mode_consecutive_reasoning_only_turns_stop_after_one_continuation(
         },
         LlmResponse {
             content: vec![ContentBlock::Text {
-                text: "This response should not be reached.".to_string(),
+                text: "plan-mode unreachable text".to_string(),
             }],
             stop_reason: Some("end_turn".to_string()),
             usage: Some(TokenUsage::default()),
@@ -740,7 +740,64 @@ async fn plan_mode_consecutive_reasoning_only_turns_stop_after_one_continuation(
         message
             .content
             .to_string()
-            .contains("This response should not be reached.")
+            .contains("plan-mode unreachable text")
+    }));
+}
+
+#[tokio::test]
+async fn execute_mode_consecutive_reasoning_only_turns_stop_after_one_continuation() {
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: json!("Let me think about this first."),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: json!("Still thinking only."),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "execute-mode unreachable text".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.set_execution_mode(AgentExecutionMode::Execute);
+
+    agent
+        .query_with_mode(
+            "do a thing".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("consecutive reasoning-only execute turns should stop after one retry");
+
+    let observed_messages = backend.observed_messages();
+    assert_eq!(observed_messages.len(), 2);
+    assert!(!agent.history.iter().any(|message| {
+        message
+            .content
+            .to_string()
+            .contains("execute-mode unreachable text")
     }));
 }
 
@@ -2147,11 +2204,14 @@ fn missing_minimum_review_evidence_continues_without_plan_update() {
 }
 
 #[test]
-fn reasoning_only_initial_plan_turn_continues_once() {
+fn reasoning_only_plan_turn_signals_continuation() {
+    // should_continue_plan_without_tools always returns true for
+    // reasoning-only turns. The consecutive-turn cap is enforced in
+    // run_agent_loop_with_limit.
     let agent = new_planning_agent();
 
-    assert!(agent.should_continue_plan_without_tools(false, false, false, true, 0,));
-    assert!(!agent.should_continue_plan_without_tools(false, false, false, true, 1,));
+    assert!(agent.should_continue_plan_without_tools(false, false, false, true, 0));
+    assert!(agent.should_continue_plan_without_tools(false, false, false, true, 1));
 }
 
 #[test]
@@ -2160,13 +2220,17 @@ fn execute_mode_continuation_requires_structured_inspection_marker() {
     agent.set_execution_mode(AgentExecutionMode::Execute);
     agent.inspection_progress.source_reads = 1;
 
-    assert!(!agent.should_continue_execute_without_tools(1, false, true, false));
-    assert!(agent.should_continue_execute_without_tools(1, true, true, false));
-    assert!(agent.should_continue_execute_without_tools(0, false, false, true));
-    assert!(!agent.should_continue_execute_without_tools(1, false, false, true));
+    // Without continue_inspection or reasoning, bare text doesn't continue.
+    assert!(!agent.should_continue_execute_without_tools(false, true, false));
+    // With continue_inspection, text continues.
+    assert!(agent.should_continue_execute_without_tools(true, true, false));
+    // Reasoning-only turn always continues at this level (cap in agent loop).
+    assert!(agent.should_continue_execute_without_tools(false, false, true));
+    // Same — reasoning-only continuation is turn-agnostic here.
+    assert!(agent.should_continue_execute_without_tools(false, false, true));
 
     agent.inspection_progress.source_reads = 2;
-    assert!(agent.should_continue_execute_without_tools(1, true, true, false));
+    assert!(agent.should_continue_execute_without_tools(true, true, false));
 }
 
 #[test]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -521,10 +521,13 @@ fn user_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
     let message = crate::tui::display_sanitize::sanitize_display_text(message);
     let message = message.as_str();
     let body_max = max_lines.saturating_sub(1);
-    let header = Line::from(Span::styled(
-        "▌ You",
-        Style::default().fg(ROLE_USER).add_modifier(Modifier::BOLD),
-    ));
+    let header = Line::from(vec![
+        Span::styled("▌", Style::default().fg(ROLE_USER)),
+        Span::styled(
+            " You",
+            Style::default().fg(ROLE_USER).add_modifier(Modifier::BOLD),
+        ),
+    ]);
     let message_lines = message.lines().collect::<Vec<_>>();
     if message_lines.is_empty() {
         return vec![header];
@@ -549,10 +552,13 @@ fn agent_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
     let message = crate::tui::display_sanitize::sanitize_display_text(message);
     let message = message.as_str();
     let body_max = max_lines.saturating_sub(1);
-    let mut lines = vec![Line::from(Span::styled(
-        "▌ Agent",
-        Style::default().fg(ROLE_AGENT).add_modifier(Modifier::BOLD),
-    ))];
+    let mut lines = vec![Line::from(vec![
+        Span::styled("▌", Style::default().fg(ROLE_AGENT)),
+        Span::styled(
+            " Agent",
+            Style::default().fg(ROLE_AGENT).add_modifier(Modifier::BOLD),
+        ),
+    ])];
     let message_lines: Vec<&str> = message.lines().collect();
     if message_lines.is_empty() {
         return lines;
@@ -578,12 +584,15 @@ fn system_message_lines(message: &str, max_lines: usize) -> Vec<Line<'static>> {
     let message = crate::tui::display_sanitize::sanitize_display_text(message);
     let message = message.as_str();
     let body_max = max_lines.saturating_sub(1);
-    let mut lines = vec![Line::from(Span::styled(
-        "▌ System",
-        Style::default()
-            .fg(ROLE_SYSTEM)
-            .add_modifier(Modifier::BOLD),
-    ))];
+    let mut lines = vec![Line::from(vec![
+        Span::styled("▌", Style::default().fg(ROLE_SYSTEM)),
+        Span::styled(
+            " System",
+            Style::default()
+                .fg(ROLE_SYSTEM)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ])];
     let message_lines: Vec<&str> = message.lines().collect();
     if message_lines.is_empty() {
         return lines;
@@ -615,21 +624,27 @@ pub(crate) fn formatted_message_lines(
     let message = message.as_str();
     let role_kind = MessageRole::try_from_str(role);
     if role_kind == Some(MessageRole::Agent) {
-        let mut lines = vec![Line::from(Span::styled(
-            "▌ Agent",
-            Style::default().fg(ROLE_AGENT).add_modifier(Modifier::BOLD),
-        ))];
+        let mut lines = vec![Line::from(vec![
+            Span::styled("▌", Style::default().fg(ROLE_AGENT)),
+            Span::styled(
+                " Agent",
+                Style::default().fg(ROLE_AGENT).add_modifier(Modifier::BOLD),
+            ),
+        ])];
         let body = bulleted_markdown_message_lines(message, max_lines, cwd);
         lines.extend(body);
         return lines;
     }
     if role_kind == Some(MessageRole::System) {
-        let mut lines = vec![Line::from(Span::styled(
-            "▌ System",
-            Style::default()
-                .fg(ROLE_SYSTEM)
-                .add_modifier(Modifier::BOLD),
-        ))];
+        let mut lines = vec![Line::from(vec![
+            Span::styled("▌", Style::default().fg(ROLE_SYSTEM)),
+            Span::styled(
+                " System",
+                Style::default()
+                    .fg(ROLE_SYSTEM)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ])];
         let body_max = max_lines.saturating_sub(1);
         let mut rendered = Vec::new();
         super::markdown::append_markdown(message, None, cwd, &mut rendered);

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -215,39 +215,87 @@ fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
 
 fn render_command_palette(f: &mut Frame, app: &TuiApp, area: Rect) {
     let query = app.command_query();
-    let items = if query.is_empty() {
-        palette_items_for_empty_query(app)
+    let items: Vec<&CommandSpec> = if query.is_empty() {
+        palette_commands(app, "")
     } else {
-        palette_items_for_matches(app, query)
+        matching_commands(query)
     };
+    let is_filtering = !query.is_empty();
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    // Header border
+    let header_block = Block::default()
+        .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+        .title_top(Line::from(vec![
+            Span::styled("Commands", Style::default().add_modifier(Modifier::BOLD)),
+            if is_filtering {
+                Span::styled(
+                    format!("  matching \"{}\"", query),
+                    Style::default().fg(TEXT_MUTED),
+                )
+            } else {
+                Span::raw("")
+            },
+        ]));
+    f.render_widget(header_block, chunks[0]);
+
+    // Separator line
+    let sep = Block::default().borders(Borders::LEFT | Borders::RIGHT);
+    f.render_widget(sep, chunks[1]);
+
+    // List area
+    let list_items: Vec<ListItem> = items
+        .iter()
+        .map(|spec| command_palette_item(spec))
+        .collect();
+    let list_block = Block::default().borders(Borders::LEFT | Borders::RIGHT);
+    let inner_area = list_block.inner(chunks[2]);
+    f.render_widget(list_block, chunks[2]);
     let mut state = command_palette_list_state(app.command_palette_idx);
     f.render_stateful_widget(
-        List::new(items)
+        List::new(list_items)
             .highlight_style(command_list_highlight_style())
             .highlight_symbol("› "),
-        area,
+        inner_area,
         &mut state,
     );
+
+    // Footer with hint
+    let footer_block = Block::default().borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT);
+    let footer_inner = footer_block.inner(chunks[3]);
+    f.render_widget(footer_block, chunks[3]);
+    let hint = if is_filtering {
+        Line::from(Span::styled(
+            "Esc to clear filter",
+            Style::default().fg(TEXT_MUTED),
+        ))
+    } else {
+        Line::from(vec![
+            Span::styled("Type to filter", Style::default().fg(TEXT_MUTED)),
+            Span::raw("  ·  "),
+            Span::styled("↑↓ to move", Style::default().fg(TEXT_MUTED)),
+            Span::raw("  ·  "),
+            Span::styled("Enter to select", Style::default().fg(TEXT_MUTED)),
+            Span::raw("  ·  "),
+            Span::styled("Esc to close", Style::default().fg(TEXT_MUTED)),
+        ])
+    };
+    f.render_widget(Paragraph::new(hint).centered(), footer_inner);
 }
 
 fn command_palette_list_state(selected_index: usize) -> ListState {
     let mut state = ListState::default();
     state.select(Some(selected_index));
     state
-}
-
-fn palette_items_for_empty_query(app: &TuiApp) -> Vec<ListItem<'static>> {
-    palette_commands(app, "")
-        .into_iter()
-        .map(command_palette_item)
-        .collect()
-}
-
-fn palette_items_for_matches(_app: &TuiApp, query: &str) -> Vec<ListItem<'static>> {
-    matching_commands(query)
-        .into_iter()
-        .map(command_palette_item)
-        .collect()
 }
 
 fn help_command_items(query: &str) -> Vec<&'static CommandSpec> {
@@ -259,13 +307,16 @@ fn command_palette_item(spec: &CommandSpec) -> ListItem<'static> {
 }
 
 fn command_palette_line(spec: &CommandSpec) -> Line<'static> {
-    Line::from(vec![
-        Span::styled(
-            format!("{:<11}", spec.usage),
-            Style::default().add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(spec.summary.to_string(), Style::default().fg(TEXT_MUTED)),
-    ])
+    let name_span = Span::styled(
+        format!("{:<12}", spec.usage),
+        Style::default().add_modifier(Modifier::BOLD),
+    );
+    let sep_span = Span::styled("│", Style::default().fg(TEXT_MUTED));
+    let summary_span = Span::styled(
+        format!(" {}", spec.summary),
+        Style::default().fg(TEXT_SECONDARY),
+    );
+    Line::from(vec![name_span, sep_span, summary_span])
 }
 
 fn panel_text(title: &str, body: &str) -> String {
@@ -311,12 +362,13 @@ mod tests {
     }
 
     #[test]
-    fn command_palette_line_is_compact_single_row() {
+    fn command_palette_line_has_name_and_summary_separated() {
         let spec = &COMMAND_SPECS[0];
         let line = command_palette_line(spec).to_string();
 
         assert!(line.contains(spec.usage));
         assert!(line.contains(spec.summary));
+        assert!(line.contains('│'), "should contain separator character");
         assert!(!line.contains('\n'));
     }
 
@@ -352,8 +404,11 @@ mod tests {
         let popup = command_palette_rect(area, bottom_pane, &app);
 
         assert!(popup.bottom() <= bottom_pane.y);
-        assert_eq!(popup.x, 0);
-        assert_eq!(popup.width, area.width);
+        assert!(popup.x > 0, "palette should be centered, not at x=0");
+        assert!(
+            popup.width < area.width,
+            "palette should be narrower than full width"
+        );
     }
 
     #[test]
@@ -370,7 +425,14 @@ mod tests {
         let popup = command_palette_rect(area, bottom_pane, &app);
 
         assert!(popup.height >= 12);
-        assert_eq!(popup.width, area.width);
+        assert!(
+            popup.width <= area.width,
+            "palette should not exceed screen width"
+        );
+        assert!(
+            popup.x > 0 || area.width <= 62,
+            "should be centered when screen is wider than max palette width"
+        );
     }
 
     #[test]
@@ -501,11 +563,11 @@ fn command_palette_rect(area: Rect, bottom_pane_area: Rect, app: &TuiApp) -> Rec
     } else {
         matching_commands(query).len()
     };
-    let max_visible_rows = area.height.saturating_sub(6).clamp(6, 14) as usize;
-    let visible_rows = item_count.clamp(1, max_visible_rows) as u16;
-    let height = visible_rows.min(area.height.saturating_sub(2).max(4));
-    let width = area.width;
-    let x = area.x;
+    let max_visible_rows = area.height.saturating_sub(8).clamp(4, 16) as usize;
+    let visible_rows = item_count.max(1).min(max_visible_rows) as u16;
+    let height = (visible_rows + 4).min(area.height.saturating_sub(2).max(6));
+    let width = area.width.min(62).max(40);
+    let x = area.x.saturating_add(area.width.saturating_sub(width) / 2);
     let max_y = bottom_pane_area.y.saturating_sub(1);
     let y = max_y.saturating_sub(height).max(area.y);
 


### PR DESCRIPTION
## Problem

When a model (especially DeepSeek with thinking enabled) produces only reasoning content (no text, no tool calls) on a non-initial turn, the agent loop silently exited with "Prompt finished." The TUI showed nothing — the Thinking card vanished and no response appeared.

Root cause: `is_reasoning_only_initial_turn` required `agentic_turns == 0`. Reasoning-only continuation only worked on the very first turn.

## Fix

- Renamed `is_reasoning_only_initial_turn` → `is_reasoning_only_turn` (removed `agentic_turns == 0` gate)
- Added `consecutive_reasoning_only_turns` counter to `Agent`, capped by `MAX_CONSECUTIVE_REASONING_ONLY_TURNS = 1`
- Counter resets when model produces text or tool calls; increments (and guards) on reasoning-only turns
- Guard applies before both plan-mode and execute-mode continuation paths
- Updated the plan-mode test and added an execute-mode regression test

## Changes

- `src/agent.rs`: +26/-12 — consecutive reasoning counter, restructured no-tool-calls block
- `src/agent/planning.rs`: +6/-6 — renamed fn, removed turn-0 gate, updated callers
- `src/agent/tests/planning.rs`: +84/-19 — updated plan test, added execute-mode test

## Validation

- `cargo test agent` — 143 passed, 0 failed
- `cargo test planning` — 56 passed, 0 failed
- `cargo fmt` — clean