### PR TITLE
feat: add prefix-stable microcompact

### DIFF
--- a/.agents/skills/context-cache-management/SKILL.md
+++ b/.agents/skills/context-cache-management/SKILL.md
@@ -84,6 +84,12 @@ For provider cache capability changes:
 - Add a focused backend test for the declared `ProviderCacheProfile`.
 - Add usage parsing tests when the provider reports cache hit/miss tokens.
 
+For observability changes:
+
+- Prefer structured projection reports over scraping status text.
+- Keep transient status events short; put detailed per-request accounting in
+  `/context` or another structured context surface.
+
 ## Common Mistakes
 
 - Replacing old tool results inside the persisted transcript during a normal

--- a/.agents/skills/context-cache-management/SKILL.md
+++ b/.agents/skills/context-cache-management/SKILL.md
@@ -89,6 +89,8 @@ For observability changes:
 - Prefer structured projection reports over scraping status text.
 - Keep transient status events short; put detailed per-request accounting in
   `/context` or another structured context surface.
+- Keep the same report shape OTEL-ready. Local `/context` output and future
+  telemetry exporters should read from the same data model.
 
 ## Common Mistakes
 

--- a/.agents/skills/context-cache-management/SKILL.md
+++ b/.agents/skills/context-cache-management/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: context-cache-management
+description: Extend RARA context compression, provider cache behavior, memory placement, or model context budgeting while preserving stable prompt prefixes.
+---
+
+# Context Cache Management
+
+Use this skill when changing RARA's context compression, tool-result projection,
+provider cache handling, memory placement, context budget calculation, or
+model-provider integration.
+
+## Core Rules
+
+- Treat the local transcript as source of truth. Request-time projection may
+  shrink model input, but it must not rewrite persisted history unless the user
+  explicitly asked for lifecycle compaction.
+- Preserve `tool_use` / `tool_result` pairing. Do not remove a block from only
+  one side of the pair.
+- Keep stable prompt prefixes stable:
+  1. system prompt
+  2. tool schemas
+  3. stable skills and project memory
+  4. compacted history and carry-over
+  5. retrieval and volatile recent context
+  6. latest user input
+- Keep retrieved memory in the volatile suffix unless it has been explicitly
+  promoted to a stable workspace memory prompt source.
+- Never infer cache-edit support from OpenAI-compatible request shape. Cache
+  editing is a provider capability, not a protocol default.
+- Do not inject provider-specific cache-retention parameters unless the backend
+  explicitly declares retention control support.
+
+## Provider Cache Capability Checklist
+
+When adding or updating a model backend, declare these capabilities separately:
+
+- `automatic_prefix_cache`: repeated prompt prefixes may be cached by the
+  provider without request parameters.
+- `cache_usage_accounting`: usage metadata reports cache hit/miss tokens.
+- `cache_edit`: the provider can delete or edit cached content without changing
+  local prompt content.
+- `cache_retention_control`: request parameters can control cache lifetime.
+
+DeepSeek is the reference example for automatic prefix cache with usage
+accounting but without cache edit or retention control.
+
+## Choosing A Compression Strategy
+
+- If `cache_edit = false`, use request projection and ordinary history
+  compaction. This reduces input size but may reduce prefix-cache hits after the
+  edited point.
+- If `cache_edit = true`, add a provider-specific pass that queues cache edits
+  while leaving local messages unchanged.
+- If the cache is likely cold, content projection is acceptable because the
+  provider would rewrite the prefix anyway.
+- If the cache is warm and no cache-edit API exists, prefer preserving recent
+  raw turns and compacting only older volatile tool results.
+
+## Memory Placement
+
+- Stable workspace memory belongs with prompt sources and must render in a
+  deterministic order.
+- Retrieved memory belongs near the latest user request because it is
+  query-dependent and changes turn by turn.
+- Do not put retrieval results before tool schemas, system guidance, or stable
+  project memory.
+- If retrieved content becomes durable policy or project knowledge, promote it
+  into stable workspace memory instead of repeatedly injecting it as volatile
+  retrieval context.
+
+## Tests To Add
+
+For projection or microcompact changes:
+
+- Unit-test the projection helper directly.
+- Assert the original messages are unchanged.
+- Assert recent compactable tool results remain visible.
+- Assert non-compactable tool results remain unchanged.
+- Add one agent-level test proving the model request is projected while
+  `Agent.history` still contains the original tool result content.
+
+For provider cache capability changes:
+
+- Add a focused backend test for the declared `ProviderCacheProfile`.
+- Add usage parsing tests when the provider reports cache hit/miss tokens.
+
+## Common Mistakes
+
+- Replacing old tool results inside the persisted transcript during a normal
+  model request.
+- Treating `prompt_cache_retention` or cache-edit fields as generally available
+  across OpenAI-compatible providers.
+- Adding dynamic per-turn retrieval before stable system/tool/skill context.
+- Treating retrieved memory and workspace memory as the same cache-stability
+  class.
+- Clearing all old tool results and leaving the model with no working evidence.
+- Reporting cache behavior from display text instead of structured provider
+  usage fields or explicit backend capability.

--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -173,6 +173,11 @@ have automatic prefix caching but no cache-edit API. It reduces volatile
 history size while preserving the full local transcript for restore,
 distillation, and debugging.
 
+The first runtime slice exposes projection only as a transient status event when
+old tool results are projected out of a model request. Durable observability
+belongs in `/context`, backed by structured per-request projection reports
+rather than display text scraping.
+
 Provider-specific cache-edit microcompaction is a future optional branch. It
 must be gated by a declared provider capability and must not be inferred from
 OpenAI-compatible request shape alone.

--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -178,6 +178,12 @@ old tool results are projected out of a model request. Durable observability
 belongs in `/context`, backed by structured per-request projection reports
 rather than display text scraping.
 
+The same structured projection report should be reusable by future OpenTelemetry
+exporters. `/context` remains the local debugging surface, while OTEL should
+export session-scoped events, counters, histograms, and trace context from the
+same runtime data model. Context compression must not introduce a separate
+display-only accounting path that would drift from exported telemetry.
+
 Provider-specific cache-edit microcompaction is a future optional branch. It
 must be gated by a declared provider capability and must not be inferred from
 OpenAI-compatible request shape alone.

--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -21,6 +21,7 @@ For long coding sessions, this increases the risk of losing:
 - The compacted history marker that gets written back into `Agent.history`.
 - Recent-file carry-over and compact observability in `/status`.
 - Limited recent-file excerpt carry-over for the most recent `read_file` results.
+- Per-request tool-result projection before model calls.
 - Compact-boundary metadata persistence across session save/restore.
 - Focused tests for compaction prompt and stored summary shape.
 
@@ -29,6 +30,8 @@ For long coding sessions, this increases the risk of losing:
 - Full recent-file snippet reattachment after compaction.
 - Token-cache aware prompt reuse.
 - Provider-specific remote compaction APIs.
+- Claude-style cache-edit microcompaction for providers that do not expose a
+  cache-edit API.
 
 ## Architecture
 
@@ -147,7 +150,86 @@ deterministic descriptor namespace.
 - The retained recent API-round suffix always comes after compact metadata, summary, and carry-over
   sources. This keeps deterministic system/context material before volatile conversation history.
 
-### 7) Dedicated Compact Worker
+### 7) Tool Result Projection
+
+Tool-result projection is a read-time microcompact pass that runs before the
+model request and before summary autocompaction pressure becomes the only
+option.
+
+The projection pass:
+
+- operates on the request copy of `Agent.history`, not the persisted transcript;
+- targets only high-volume tools such as shell, file read/search, web, and edit
+  tools;
+- keeps the most recent compactable tool results verbatim;
+- replaces older compactable tool-result content with a short structured
+  marker only when the projected request would exceed the per-request
+  tool-result budget;
+- never changes `tool_use` / `tool_result` pairing or removes the block itself;
+- never rewrites stable system, tool schema, skill, or memory prompt prefixes.
+
+This is the safe baseline for DeepSeek and OpenAI-compatible providers that
+have automatic prefix caching but no cache-edit API. It reduces volatile
+history size while preserving the full local transcript for restore,
+distillation, and debugging.
+
+Provider-specific cache-edit microcompaction is a future optional branch. It
+must be gated by a declared provider capability and must not be inferred from
+OpenAI-compatible request shape alone.
+
+### 8) Provider Cache Profiles
+
+Model backends expose a cache profile with these independent capabilities:
+
+- `automatic_prefix_cache`: repeated prompt prefixes may be cached by the
+  provider without request parameters.
+- `cache_usage_accounting`: usage metadata can report cache hit/miss tokens.
+- `cache_edit`: the provider can delete or edit cached content without
+  rewriting the local prompt content.
+- `cache_retention_control`: the request API supports explicit cache retention
+  controls.
+
+DeepSeek is modeled as automatic prefix cache plus usage accounting, with no
+cache edit and no retention control. OpenAI-compatible custom endpoints default
+to no declared cache capability unless RARA has a provider-specific contract.
+
+Compression logic must choose behavior from the cache profile:
+
+- no `cache_edit`: use projection and ordinary compaction only;
+- `cache_edit`: a future pass may submit cache edits while preserving local
+  messages;
+- no `cache_retention_control`: do not inject provider-specific retention
+  parameters.
+
+### 9) Memory Placement
+
+RARA has two memory classes with different cache behavior:
+
+- Stable workspace memory, such as `.rara/memory.md`, is a prompt source. It
+  belongs with stable instructions and should keep deterministic source order.
+- Retrieved memory from session, thread, workspace, vector, or hybrid search is
+  volatile per-turn context. It should be selected by `MemorySelection` and
+  injected after stable prompt material, compacted carry-over, and the retained
+  history projection, close to the latest user request.
+
+Retrieved memory must not be prepended to the stable system prompt or inserted
+before tool schemas. Doing so would make automatic prefix caches less useful for
+providers such as DeepSeek. The current runtime injects selected retrieved memory
+into the latest user message and does not persist that injected block to
+`Agent.history`; this is the correct baseline until RARA has a first-class
+attachment carrier for volatile context.
+
+When future models are added, memory placement must follow the provider cache
+profile:
+
+- providers without cache edit: keep retrieved memory in the volatile suffix;
+- providers with cache edit: cache-edit may optimize old tool results, but
+  retrieved memory still remains per-turn volatile context unless explicitly
+  promoted to workspace memory;
+- providers without cache usage accounting: do not infer cache hit quality from
+  memory placement alone.
+
+### 10) Dedicated Compact Worker
 
 Compaction can be executed by a dedicated internal worker, but it should not be exposed as a normal
 model-callable sub-agent tool. Compact is a runtime lifecycle operation, not delegated task work.
@@ -245,3 +327,4 @@ This is similar in spirit to sub-agent isolation, but its storage model is diffe
 ## Source Journals
 
 - [2026-04-19-context-compression](../journal/2026-04-19-context-compression.md)
+- [2026-05-06-prefix-stable-microcompact](../journal/2026-05-06-prefix-stable-microcompact.md)

--- a/docs/journal/2026-05-06-prefix-stable-microcompact.md
+++ b/docs/journal/2026-05-06-prefix-stable-microcompact.md
@@ -1,0 +1,38 @@
+# Prefix-Stable Microcompact
+
+## Context
+
+DeepSeek exposes automatic prefix caching and cache hit/miss usage fields, but
+does not expose a Claude-style cache-edit API or explicit cache-retention
+controls. RARA therefore should not model OpenAI-compatible providers as if they
+all support remote cache editing.
+
+## Decision
+
+Added the first provider-neutral microcompact slice as a request projection:
+
+- keep the full transcript unchanged;
+- project older compactable tool results out of the model request when the
+  per-request tool-result budget is exceeded;
+- keep recent compactable tool results verbatim;
+- leave stable prompt prefixes, tool schemas, skills, and memory ordering alone;
+- represent provider cache behavior as explicit capability flags.
+
+## Implementation Checkpoint
+
+- Added `ToolResultProjectionPolicy` and `project_tool_results_for_context`.
+- Wired the projection pass into model request assembly before adding the stable
+  system prompt.
+- Added `ProviderCacheProfile` with DeepSeek configured as automatic prefix
+  cache plus usage accounting, without cache edit or retention control.
+- Added focused tests for projection behavior, transcript non-mutation, and
+  DeepSeek cache profile.
+
+## Follow-Up
+
+- Surface projection stats in `/context` after the runtime context event model
+  can carry per-request compression reports.
+- Add provider-specific cache-edit microcompact only after a backend declares
+  `cache_edit = true`.
+- Add configurable per-tool projection budgets once tool result size policies
+  move out of constants.

--- a/docs/journal/2026-05-06-prefix-stable-microcompact.md
+++ b/docs/journal/2026-05-06-prefix-stable-microcompact.md
@@ -30,8 +30,8 @@ Added the first provider-neutral microcompact slice as a request projection:
 
 ## Follow-Up
 
-- Surface projection stats in `/context` after the runtime context event model
-  can carry per-request compression reports.
+- Add `/context` observability after the runtime context event model can carry
+  per-request compression reports.
 - Add provider-specific cache-edit microcompact only after a backend declares
   `cache_edit = true`.
 - Add configurable per-tool projection budgets once tool result size policies

--- a/docs/journal/2026-05-06-prefix-stable-microcompact.md
+++ b/docs/journal/2026-05-06-prefix-stable-microcompact.md
@@ -32,6 +32,8 @@ Added the first provider-neutral microcompact slice as a request projection:
 
 - Add `/context` observability after the runtime context event model can carry
   per-request compression reports.
+- Keep the same projection report reusable for future OTEL exporters, so local
+  `/context` output and remote telemetry share one accounting source.
 - Add provider-specific cache-edit microcompact only after a backend declares
   `cache_edit = true`.
 - Add configurable per-tool projection budgets once tool result size policies

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -95,6 +95,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add concrete hook/MCP carry-over producers.
 - [x] Add prefix-stable tool-result projection before model requests.
 - [ ] Add per-request microcompact observability to `/context`.
+- [ ] Add an OTEL-ready context observability event model for compaction, microcompact projection, cache usage, and memory retrieval.
 - [ ] Add provider-gated cache-edit microcompact only for backends that explicitly declare cache-edit support.
 - [ ] Surface main model vs auxiliary model routing in `/status` and `/context`.
 - [x] `ThreadStore` / `ThreadRecorder`: from façade over `SessionManager`+`StateDb` to true structured thread store.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -94,7 +94,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add concrete invoked-skill carry-over producer.
 - [x] Add concrete hook/MCP carry-over producers.
 - [x] Add prefix-stable tool-result projection before model requests.
-- [ ] Surface per-request microcompact projection stats in `/context`.
+- [ ] Add per-request microcompact observability to `/context`.
 - [ ] Add provider-gated cache-edit microcompact only for backends that explicitly declare cache-edit support.
 - [ ] Surface main model vs auxiliary model routing in `/status` and `/context`.
 - [x] `ThreadStore` / `ThreadRecorder`: from façade over `SessionManager`+`StateDb` to true structured thread store.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -93,6 +93,9 @@ Active backlog only. Keep this file small and current.
 - [x] Add concrete retrieved-memory carry-over producer.
 - [x] Add concrete invoked-skill carry-over producer.
 - [x] Add concrete hook/MCP carry-over producers.
+- [x] Add prefix-stable tool-result projection before model requests.
+- [ ] Surface per-request microcompact projection stats in `/context`.
+- [ ] Add provider-gated cache-edit microcompact only for backends that explicitly declare cache-edit support.
 - [ ] Surface main model vs auxiliary model routing in `/status` and `/context`.
 - [x] `ThreadStore` / `ThreadRecorder`: from façade over `SessionManager`+`StateDb` to true structured thread store.
 - [ ] Thread-scoped and workspace-scoped `MemoryRecord` storage with promotion rules.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -27,8 +27,8 @@ use crate::todo::TodoState;
 use crate::tool::ToolOutputStream;
 use crate::tool::{ToolCallContext, ToolManager, ToolProgressEvent};
 use crate::tool_result::{
-    ToolResultStore, default_tool_result_store_dir, enforce_tool_result_batch_budget,
-    repair_tool_result_history,
+    ToolResultProjectionPolicy, ToolResultStore, default_tool_result_store_dir,
+    enforce_tool_result_batch_budget, project_tool_results_for_context, repair_tool_result_history,
 };
 use crate::tools::bash::BashCommandInput;
 use crate::tools::planning::{ENTER_PLAN_MODE_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME};
@@ -361,12 +361,22 @@ impl Agent {
         let turn_metadata = self.llm_turn_metadata();
         turn_metadata.ensure_not_cancelled()?;
         let assembled = self.assemble_turn_context();
-        let mut messages = self
+        let history_for_query = self
             .history
             .iter()
             .filter(|message| !is_compact_boundary_message(message))
             .cloned()
             .collect::<Vec<_>>();
+        let (mut messages, projection_report) = project_tool_results_for_context(
+            &history_for_query,
+            &ToolResultProjectionPolicy::default(),
+        );
+        if projection_report.cleared_results > 0 {
+            report(AgentEvent::Status(format!(
+                "Projected {} old tool result(s) out of this model request.",
+                projection_report.cleared_results
+            )));
+        }
         messages.insert(
             0,
             Message {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1,4 +1,5 @@
 mod compaction;
 mod context_view;
+mod microcompact;
 mod planning;
 mod support;

--- a/src/agent/tests/microcompact.rs
+++ b/src/agent/tests/microcompact.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use serde_json::json;
+
+use super::support::{SequencedBackend, test_runtime_storage};
+use crate::agent::{Agent, AgentOutputMode, Message};
+use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
+use crate::tool::ToolManager;
+use crate::vectordb::VectorDB;
+
+#[tokio::test]
+async fn model_request_projects_old_tool_results_without_mutating_history() {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::Text {
+            text: "done".to_string(),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+
+    agent.history = (0..8)
+        .flat_map(|idx| {
+            [
+                Message {
+                    role: "assistant".to_string(),
+                    content: json!([{
+                        "type": "tool_use",
+                        "id": format!("tool-{idx}"),
+                        "name": "read_file",
+                        "input": { "path": format!("src/{idx}.rs") }
+                    }]),
+                },
+                Message {
+                    role: "user".to_string(),
+                    content: json!([{
+                        "type": "tool_result",
+                        "tool_use_id": format!("tool-{idx}"),
+                        "content": format!("old-result-{idx}\n{}", "x".repeat(12_000))
+                    }]),
+                },
+            ]
+        })
+        .collect();
+    agent.compact_state.estimated_history_tokens = 1;
+
+    agent
+        .query_with_mode("continue".to_string(), AgentOutputMode::Silent)
+        .await
+        .expect("query");
+
+    let observed = backend.observed_messages();
+    let request = observed.first().expect("first model request");
+    let request_text = serde_json::to_string(request).expect("request json");
+    assert!(request_text.contains("Old tool result content cleared"));
+    assert!(!request_text.contains("old-result-0"));
+    assert!(request_text.contains("old-result-7"));
+
+    let persisted_history = serde_json::to_string(&agent.history).expect("history json");
+    assert!(persisted_history.contains("old-result-0"));
+    assert!(persisted_history.contains("old-result-7"));
+}

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -16,10 +16,11 @@ use serde_json::{Value, json};
 use self::usage::parse_openai_token_usage;
 use super::deepseek_dsml;
 use super::shared::{
-    ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata, collect_assistant_content,
-    context_budget_from_window, extract_message_text, http_client_for_target,
-    is_retryable_http_error, model_context_budget, next_stream_item_with_idle_timeout,
-    parse_tool_arguments, render_openai_message_content, retry_send_json,
+    ContextBudget, LlmBackend, LlmStreamEvent, LlmTurnMetadata, ProviderCacheProfile,
+    collect_assistant_content, context_budget_from_window, extract_message_text,
+    http_client_for_target, is_retryable_http_error, model_context_budget,
+    next_stream_item_with_idle_timeout, parse_tool_arguments, render_openai_message_content,
+    retry_send_json,
 };
 use crate::agent::Message;
 use crate::config::OpenAiEndpointKind;
@@ -535,6 +536,17 @@ impl LlmBackend for OpenAiCompatibleBackend {
             (Some(main), None) => Some(main),
             (None, Some(summary)) => Some(summary),
             (None, None) => None,
+        }
+    }
+
+    fn cache_profile(&self) -> ProviderCacheProfile {
+        match self.endpoint_kind {
+            OpenAiEndpointKind::Deepseek => {
+                ProviderCacheProfile::automatic_prefix_cache_with_usage()
+            }
+            OpenAiEndpointKind::Custom
+            | OpenAiEndpointKind::Kimi
+            | OpenAiEndpointKind::Openrouter => ProviderCacheProfile::none(),
         }
     }
 }

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -28,6 +28,34 @@ pub struct ContextBudget {
     pub compact_threshold_tokens: usize,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProviderCacheProfile {
+    pub automatic_prefix_cache: bool,
+    pub cache_usage_accounting: bool,
+    pub cache_edit: bool,
+    pub cache_retention_control: bool,
+}
+
+impl ProviderCacheProfile {
+    pub const fn none() -> Self {
+        Self {
+            automatic_prefix_cache: false,
+            cache_usage_accounting: false,
+            cache_edit: false,
+            cache_retention_control: false,
+        }
+    }
+
+    pub const fn automatic_prefix_cache_with_usage() -> Self {
+        Self {
+            automatic_prefix_cache: true,
+            cache_usage_accounting: true,
+            cache_edit: false,
+            cache_retention_control: false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LlmExecutionMode {
     Execute,
@@ -127,6 +155,9 @@ pub trait LlmBackend: Send + Sync {
     async fn summarize(&self, messages: &[Message], instruction: &str) -> Result<String>;
     fn context_budget(&self, _messages: &[Message], _tools: &[Value]) -> Option<ContextBudget> {
         None
+    }
+    fn cache_profile(&self) -> ProviderCacheProfile {
+        ProviderCacheProfile::none()
     }
 }
 

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -19,7 +19,9 @@ use super::shared::{
 };
 use crate::agent::Message;
 use crate::config::OpenAiEndpointKind;
-use crate::llm::{ContentBlock, LlmStreamEvent, LlmTurnMetadata};
+use crate::llm::{
+    ContentBlock, LlmBackend, LlmStreamEvent, LlmTurnMetadata, OpenAiCompatibleBackend,
+};
 use crate::tool::Tool;
 use crate::tools::planning::ExitPlanModeTool;
 
@@ -343,6 +345,23 @@ fn openai_usage_tracks_cache_hit_and_miss_tokens() {
     assert_eq!(usage.output_tokens, 4);
     assert_eq!(usage.cache_hit_tokens, 64);
     assert_eq!(usage.cache_miss_tokens, 36);
+}
+
+#[test]
+fn deepseek_cache_profile_uses_automatic_prefix_cache_without_cache_edit() {
+    let backend = OpenAiCompatibleBackend::new_with_endpoint_kind(
+        None,
+        "https://api.deepseek.com".to_string(),
+        "deepseek-chat".to_string(),
+        OpenAiEndpointKind::Deepseek,
+    )
+    .expect("backend");
+
+    let profile = backend.cache_profile();
+    assert!(profile.automatic_prefix_cache);
+    assert!(profile.cache_usage_accounting);
+    assert!(!profile.cache_edit);
+    assert!(!profile.cache_retention_control);
 }
 
 #[test]

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 
@@ -18,6 +19,44 @@ const BASH_SUCCESS_HEAD_CHARS: usize = 2_000;
 const BASH_SUCCESS_TAIL_CHARS: usize = 2_000;
 const BASH_ERROR_HEAD_CHARS: usize = 1_000;
 const BASH_ERROR_TAIL_CHARS: usize = 3_000;
+const MICROCOMPACT_TOOL_RESULT_BUDGET: usize = 48_000;
+const MICROCOMPACT_KEEP_RECENT_TOOL_RESULTS: usize = 6;
+const MICROCOMPACT_CLEARED_MESSAGE: &str =
+    "[Old tool result content cleared by RARA microcompact projection]";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolResultProjectionPolicy {
+    pub enabled: bool,
+    pub budget_chars: usize,
+    pub keep_recent: usize,
+}
+
+impl Default for ToolResultProjectionPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            budget_chars: MICROCOMPACT_TOOL_RESULT_BUDGET,
+            keep_recent: MICROCOMPACT_KEEP_RECENT_TOOL_RESULTS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolResultProjectionReport {
+    pub original_chars: usize,
+    pub projected_chars: usize,
+    pub cleared_results: usize,
+    pub kept_results: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolResultProjectionCandidate {
+    message_index: usize,
+    block_index: usize,
+    tool_use_id: String,
+    tool_name: String,
+    chars: usize,
+}
 
 pub struct ToolResultStore {
     base_dir: PathBuf,
@@ -176,6 +215,168 @@ pub fn enforce_tool_result_batch_budget(mut messages: Vec<Message>) -> Vec<Messa
     }
 
     messages
+}
+
+pub fn project_tool_results_for_context(
+    messages: &[Message],
+    policy: &ToolResultProjectionPolicy,
+) -> (Vec<Message>, ToolResultProjectionReport) {
+    if !policy.enabled || policy.budget_chars == 0 {
+        return (messages.to_vec(), ToolResultProjectionReport::default());
+    }
+
+    let tool_names = compactable_tool_use_names(messages);
+    if tool_names.is_empty() {
+        return (messages.to_vec(), ToolResultProjectionReport::default());
+    }
+
+    let candidates = projection_candidates(messages, &tool_names);
+    let original_chars = candidates
+        .iter()
+        .map(|candidate| candidate.chars)
+        .sum::<usize>();
+    if original_chars <= policy.budget_chars {
+        return (
+            messages.to_vec(),
+            ToolResultProjectionReport {
+                original_chars,
+                projected_chars: original_chars,
+                cleared_results: 0,
+                kept_results: candidates.len(),
+            },
+        );
+    }
+
+    let keep_recent = policy.keep_recent.max(1);
+    let keep_ids = candidates
+        .iter()
+        .rev()
+        .take(keep_recent)
+        .map(|candidate| candidate.tool_use_id.as_str())
+        .collect::<HashSet<_>>();
+    let mut projected = messages.to_vec();
+    let mut projected_chars = original_chars;
+    let mut cleared_results = 0usize;
+
+    for candidate in &candidates {
+        if projected_chars <= policy.budget_chars
+            || keep_ids.contains(candidate.tool_use_id.as_str())
+        {
+            continue;
+        }
+        let Some(content) = tool_result_content_mut(
+            &mut projected,
+            candidate.message_index,
+            candidate.block_index,
+        ) else {
+            continue;
+        };
+        if content == MICROCOMPACT_CLEARED_MESSAGE {
+            continue;
+        }
+        let replacement = microcompact_cleared_tool_result(&candidate.tool_name);
+        projected_chars = projected_chars
+            .saturating_sub(candidate.chars)
+            .saturating_add(replacement.chars().count());
+        *content = replacement;
+        cleared_results += 1;
+    }
+
+    (
+        projected,
+        ToolResultProjectionReport {
+            original_chars,
+            projected_chars,
+            cleared_results,
+            kept_results: candidates.len().saturating_sub(cleared_results),
+        },
+    )
+}
+
+fn compactable_tool_use_names(messages: &[Message]) -> HashMap<String, String> {
+    let mut tool_names = HashMap::new();
+    for message in messages {
+        if message.role != "assistant" {
+            continue;
+        }
+        let Some(blocks) = message.content.as_array() else {
+            continue;
+        };
+        for block in blocks {
+            if block.get("type").and_then(Value::as_str) != Some("tool_use") {
+                continue;
+            }
+            let Some(id) = block.get("id").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(name) = block.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            if is_microcompactable_tool(name) {
+                tool_names.insert(id.to_string(), name.to_string());
+            }
+        }
+    }
+    tool_names
+}
+
+fn projection_candidates(
+    messages: &[Message],
+    tool_names: &HashMap<String, String>,
+) -> Vec<ToolResultProjectionCandidate> {
+    let mut candidates = Vec::new();
+    for (message_index, message) in messages.iter().enumerate() {
+        if message.role != "user" {
+            continue;
+        }
+        let Some(blocks) = message.content.as_array() else {
+            continue;
+        };
+        for (block_index, block) in blocks.iter().enumerate() {
+            if block.get("type").and_then(Value::as_str) != Some("tool_result") {
+                continue;
+            }
+            let Some(tool_use_id) = block.get("tool_use_id").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(tool_name) = tool_names.get(tool_use_id) else {
+                continue;
+            };
+            let Some(content) = block.get("content").and_then(Value::as_str) else {
+                continue;
+            };
+            candidates.push(ToolResultProjectionCandidate {
+                message_index,
+                block_index,
+                tool_use_id: tool_use_id.to_string(),
+                tool_name: tool_name.clone(),
+                chars: content.chars().count(),
+            });
+        }
+    }
+    candidates
+}
+
+fn is_microcompactable_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "bash"
+            | "read_file"
+            | "grep"
+            | "glob"
+            | "web_search"
+            | "web_fetch"
+            | "apply_patch"
+            | "write_file"
+            | "replace"
+            | "replace_lines"
+    )
+}
+
+fn microcompact_cleared_tool_result(tool_name: &str) -> String {
+    format!(
+        "{MICROCOMPACT_CLEARED_MESSAGE}\ntool={tool_name}\nreason=older compactable tool results exceeded the per-request projection budget; original transcript remains unchanged"
+    )
 }
 
 #[derive(Debug)]

--- a/src/tool_result/tests.rs
+++ b/src/tool_result/tests.rs
@@ -4,8 +4,9 @@ mod tests {
 
     use crate::agent::Message;
     use crate::tool_result::{
-        TOOL_RESULT_BATCH_BUDGET, ToolResultStore, compact_read_file, compact_subagent_result,
-        compact_web_search, default_tool_result_store_dir, enforce_tool_result_batch_budget,
+        TOOL_RESULT_BATCH_BUDGET, ToolResultProjectionPolicy, ToolResultStore, compact_read_file,
+        compact_subagent_result, compact_web_search, default_tool_result_store_dir,
+        enforce_tool_result_batch_budget, project_tool_results_for_context,
         repair_tool_result_history, tool_result_content_candidates,
     };
 
@@ -242,6 +243,85 @@ mod tests {
                 .filter_map(|message| message.content[0]["content"].as_str())
                 .any(|content| content.contains("tool_result shortened"))
         );
+    }
+
+    #[test]
+    fn projects_old_compactable_tool_results_without_changing_source_messages() {
+        let messages = (0..4)
+            .flat_map(|idx| {
+                [
+                    Message {
+                        role: "assistant".to_string(),
+                        content: json!([{
+                            "type": "tool_use",
+                            "id": format!("tool-{idx}"),
+                            "name": "read_file",
+                            "input": {}
+                        }]),
+                    },
+                    Message {
+                        role: "user".to_string(),
+                        content: json!([{
+                            "type": "tool_result",
+                            "tool_use_id": format!("tool-{idx}"),
+                            "content": format!("result-{idx}-{}", "x".repeat(128))
+                        }]),
+                    },
+                ]
+            })
+            .collect::<Vec<_>>();
+
+        let (projected, report) = project_tool_results_for_context(
+            &messages,
+            &ToolResultProjectionPolicy {
+                enabled: true,
+                budget_chars: 180,
+                keep_recent: 1,
+            },
+        );
+        let projected_text = serde_json::to_string(&projected).expect("projected json");
+        let source_text = serde_json::to_string(&messages).expect("source json");
+
+        assert!(report.cleared_results > 0);
+        assert!(projected_text.contains("Old tool result content cleared"));
+        assert!(!projected_text.contains("result-0-"));
+        assert!(projected_text.contains("result-3-"));
+        assert!(source_text.contains("result-0-"));
+    }
+
+    #[test]
+    fn projection_ignores_non_compactable_tool_results() {
+        let messages = vec![
+            Message {
+                role: "assistant".to_string(),
+                content: json!([{
+                    "type": "tool_use",
+                    "id": "tool-1",
+                    "name": "remember_project_memory",
+                    "input": {}
+                }]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([{
+                    "type": "tool_result",
+                    "tool_use_id": "tool-1",
+                    "content": format!("memory-result-{}", "x".repeat(1_000))
+                }]),
+            },
+        ];
+
+        let (projected, report) = project_tool_results_for_context(
+            &messages,
+            &ToolResultProjectionPolicy {
+                enabled: true,
+                budget_chars: 1,
+                keep_recent: 1,
+            },
+        );
+
+        assert_eq!(projected, messages);
+        assert_eq!(report.cleared_results, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add request-time tool-result projection before model calls while preserving the full local transcript
- add provider cache capability flags and mark DeepSeek as automatic-prefix-cache with usage accounting only
- document prefix-stable memory placement and add a reusable context-cache-management skill

## Testing

- `cargo fmt --check`
- `cargo test projects_old_compactable_tool_results_without_changing_source_messages -- --nocapture`
- `cargo test projection_ignores_non_compactable_tool_results -- --nocapture`
- `cargo test agent::tests::microcompact::model_request_projects_old_tool_results_without_mutating_history -- --nocapture`
- `cargo test llm::tests::deepseek_cache_profile_uses_automatic_prefix_cache_without_cache_edit -- --nocapture`
- `cargo check`
