### PR TITLE
chore: split agent::compact into directory module

### DIFF
--- a/src/agent/compact/main.rs
+++ b/src/agent/compact/main.rs
@@ -1,7 +1,7 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use super::*;
+use crate::agent::*;
 use crate::context::RetrievedMemoryCandidate;
 use crate::llm::{ContextBudget, is_context_window_error};
 use crate::session::PersistedCompactionEvent;

--- a/src/agent/compact/mod.rs
+++ b/src/agent/compact/mod.rs
@@ -1,0 +1,1 @@
+include!("main.rs");


### PR DESCRIPTION
1522 lines → src/agent/compact/main.rs. Uses include! macro to avoid visibility changes.