### PR TITLE
chore: move bedrock backend into crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9174,9 +9174,6 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "async-trait",
- "aws-config",
- "aws-sdk-bedrockruntime",
- "aws-smithy-types",
  "backon",
  "base64 0.22.1",
  "candle-core",
@@ -9205,6 +9202,7 @@ dependencies = [
  "portable-pty",
  "pulldown-cmark",
  "rand 0.10.1",
+ "rara-bedrock",
  "rara-config",
  "rara-instructions",
  "rara-provider-catalog",
@@ -9235,6 +9233,17 @@ dependencies = [
  "urlencoding",
  "uuid",
  "walkdir",
+]
+
+[[package]]
+name = "rara-bedrock"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aws-config",
+ "aws-sdk-bedrockruntime",
+ "aws-smithy-types",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     ".",
+    "crates/bedrock",
     "crates/config",
     "crates/instructions",
     "crates/provider-catalog",
@@ -37,10 +38,7 @@ clap = { version = "4.0", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.13", features = ["json", "stream"] }
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
-aws-sdk-bedrockruntime = { version = "1.130", features = ["behavior-version-latest"] }
 async-trait = "0.1"
-aws-smithy-types = "1.4"
 anyhow = "1.0"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting"] }
@@ -57,6 +55,7 @@ base64 = "0.22"
 sha2 = "0.11"
 secrecy = { version = "0.10", features = ["serde"] }
 rara-config = { path = "crates/config" }
+rara-bedrock = { path = "crates/bedrock" }
 rara-instructions = { path = "crates/instructions" }
 rara-provider-catalog = { path = "crates/provider-catalog" }
 rara-sandbox = { path = "crates/sandbox" }

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rara-bedrock"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+aws-sdk-bedrockruntime = { version = "1.130", features = ["behavior-version-latest"] }
+aws-smithy-types = "1.4"
+serde_json.workspace = true

--- a/crates/bedrock/src/lib.rs
+++ b/crates/bedrock/src/lib.rs
@@ -1,0 +1,386 @@
+use anyhow::{Result, anyhow};
+use aws_config::BehaviorVersion;
+use aws_sdk_bedrockruntime::Client as BedrockClient;
+use aws_sdk_bedrockruntime::types::{
+    ContentBlock as BedrockContentBlock, ConversationRole, InferenceConfiguration,
+    Message as BedrockMessage, StopReason, Tool, ToolConfiguration, ToolInputSchema,
+    ToolResultBlock, ToolResultContentBlock, ToolResultStatus, ToolSpecification, ToolUseBlock,
+};
+use aws_smithy_types::{Document, Number};
+use serde_json::Value;
+
+const DEFAULT_CONTEXT_WINDOW: usize = 200_000;
+const DEFAULT_OUTPUT_TOKENS: i32 = 8_192;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BedrockChatMessage {
+    pub role: BedrockChatRole,
+    pub content: Vec<BedrockChatContent>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BedrockChatRole {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BedrockChatContent {
+    Text(String),
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+        is_error: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BedrockToolSpec {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BedrockChatResponse {
+    pub content: Vec<BedrockResponseContent>,
+    pub stop_reason: Option<String>,
+    pub usage: Option<BedrockTokenUsage>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BedrockResponseContent {
+    Text(String),
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BedrockTokenUsage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+pub struct BedrockConverseClient {
+    client: BedrockClient,
+    model_id: String,
+    region: String,
+}
+
+impl BedrockConverseClient {
+    pub async fn new(region: Option<String>, model_id: String) -> Result<Self> {
+        let mut config_loader = aws_config::defaults(BehaviorVersion::latest());
+        if let Some(region) = region.as_deref() {
+            config_loader = config_loader.region(aws_config::Region::new(region.to_string()));
+        }
+        let sdk_config = config_loader.load().await;
+        let client = BedrockClient::new(&sdk_config);
+
+        Ok(Self {
+            client,
+            model_id,
+            region: region.unwrap_or_else(|| "default".to_string()),
+        })
+    }
+
+    pub fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    pub fn region(&self) -> &str {
+        &self.region
+    }
+
+    pub async fn ask(
+        &self,
+        messages: &[BedrockChatMessage],
+        tools: &[BedrockToolSpec],
+    ) -> Result<BedrockChatResponse> {
+        let bedrock_messages = to_bedrock_messages(messages)?;
+
+        let mut builder = self
+            .client
+            .converse()
+            .model_id(&self.model_id)
+            .set_messages(Some(bedrock_messages));
+
+        if !tools.is_empty() {
+            if let Ok(tool_config) = ToolConfiguration::builder()
+                .set_tools(Some(to_bedrock_tools(tools)))
+                .build()
+            {
+                builder = builder.tool_config(tool_config);
+            }
+        }
+
+        builder = builder.inference_config(
+            InferenceConfiguration::builder()
+                .temperature(0.7)
+                .max_tokens(DEFAULT_OUTPUT_TOKENS)
+                .build(),
+        );
+
+        let output = builder.send().await.map_err(|err| {
+            anyhow!(
+                "Bedrock API error (region={}, model={}): {err}",
+                self.region,
+                self.model_id
+            )
+        })?;
+
+        from_bedrock_response(output.output, output.stop_reason, output.usage)
+    }
+}
+
+pub fn model_context_window(model_id: &str) -> (usize, usize) {
+    let lower = model_id.to_lowercase();
+    let known = if lower.contains("claude-sonnet-4") || lower.contains("claude-3-5-sonnet") {
+        Some((200_000, 8_192))
+    } else if lower.contains("claude-3-opus") {
+        Some((200_000, 4_096))
+    } else if lower.contains("claude-3-haiku") {
+        Some((200_000, 4_096))
+    } else if lower.contains("claude-3") {
+        Some((200_000, 4_096))
+    } else if lower.contains("claude") {
+        Some((200_000, 4_096))
+    } else if lower.contains("llama") {
+        Some((128_000, 2_048))
+    } else if lower.contains("nova-pro") {
+        Some((300_000, 5_000))
+    } else if lower.contains("nova-lite") {
+        Some((300_000, 5_000))
+    } else if lower.contains("nova") {
+        Some((300_000, 5_000))
+    } else if lower.contains("command") {
+        Some((128_000, 4_096))
+    } else if lower.contains("mistral") {
+        Some((128_000, 4_096))
+    } else {
+        None
+    };
+
+    known.unwrap_or((DEFAULT_CONTEXT_WINDOW, DEFAULT_OUTPUT_TOKENS as usize))
+}
+
+fn value_to_document(value: &Value) -> Document {
+    match value {
+        Value::Null => Document::Null,
+        Value::Bool(value) => Document::Bool(*value),
+        Value::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                Document::Number(Number::NegInt(value))
+            } else if let Some(value) = value.as_u64() {
+                Document::Number(Number::PosInt(value))
+            } else if let Some(value) = value.as_f64() {
+                Document::Number(Number::Float(value))
+            } else {
+                Document::Null
+            }
+        }
+        Value::String(value) => Document::String(value.clone()),
+        Value::Array(values) => Document::Array(values.iter().map(value_to_document).collect()),
+        Value::Object(values) => Document::Object(
+            values
+                .iter()
+                .map(|(key, value)| (key.clone(), value_to_document(value)))
+                .collect(),
+        ),
+    }
+}
+
+fn document_to_value(document: &Document) -> Value {
+    match document {
+        Document::Object(values) => Value::Object(
+            values
+                .iter()
+                .map(|(key, value)| (key.clone(), document_to_value(value)))
+                .collect(),
+        ),
+        Document::Array(values) => Value::Array(values.iter().map(document_to_value).collect()),
+        Document::String(value) => Value::String(value.clone()),
+        Document::Number(value) => match value {
+            Number::PosInt(value) => Value::Number(serde_json::Number::from(*value)),
+            Number::NegInt(value) => Value::Number(serde_json::Number::from(*value)),
+            Number::Float(value) => serde_json::Number::from_f64(*value)
+                .map(Value::Number)
+                .unwrap_or(Value::Null),
+        },
+        Document::Bool(value) => Value::Bool(*value),
+        Document::Null => Value::Null,
+    }
+}
+
+fn to_bedrock_messages(messages: &[BedrockChatMessage]) -> Result<Vec<BedrockMessage>> {
+    messages
+        .iter()
+        .map(|message| {
+            let role = match message.role {
+                BedrockChatRole::User => ConversationRole::User,
+                BedrockChatRole::Assistant => ConversationRole::Assistant,
+            };
+            BedrockMessage::builder()
+                .role(role)
+                .set_content(if message.content.is_empty() {
+                    None
+                } else {
+                    Some(convert_content_to_bedrock(&message.content))
+                })
+                .build()
+                .map_err(|err| anyhow!("failed to build Bedrock message: {err}"))
+        })
+        .collect()
+}
+
+fn convert_content_to_bedrock(content: &[BedrockChatContent]) -> Vec<BedrockContentBlock> {
+    let mut blocks = Vec::new();
+
+    for item in content {
+        match item {
+            BedrockChatContent::Text(text) => {
+                if !text.trim().is_empty() {
+                    blocks.push(BedrockContentBlock::Text(text.clone()));
+                }
+            }
+            BedrockChatContent::ToolUse { id, name, input } => {
+                if let Ok(tool_use) = ToolUseBlock::builder()
+                    .tool_use_id(id.clone())
+                    .name(name.clone())
+                    .input(value_to_document(input))
+                    .build()
+                {
+                    blocks.push(BedrockContentBlock::ToolUse(tool_use));
+                }
+            }
+            BedrockChatContent::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
+                if let Ok(tool_result) = ToolResultBlock::builder()
+                    .tool_use_id(tool_use_id.clone())
+                    .set_content(Some(vec![ToolResultContentBlock::Text(content.clone())]))
+                    .set_status(if *is_error {
+                        Some(ToolResultStatus::Error)
+                    } else {
+                        Some(ToolResultStatus::Success)
+                    })
+                    .build()
+                {
+                    blocks.push(BedrockContentBlock::ToolResult(tool_result));
+                }
+            }
+        }
+    }
+
+    blocks
+}
+
+fn to_bedrock_tools(tools: &[BedrockToolSpec]) -> Vec<Tool> {
+    tools
+        .iter()
+        .map(|tool| {
+            let tool_name = tool.name.clone();
+            Tool::ToolSpec(
+                ToolSpecification::builder()
+                    .name(tool.name.clone())
+                    .description(tool.description.clone())
+                    .input_schema(ToolInputSchema::Json(value_to_document(&tool.input_schema)))
+                    .build()
+                    .unwrap_or_else(|_| panic!("invalid tool spec: {tool_name}")),
+            )
+        })
+        .collect()
+}
+
+fn from_bedrock_response(
+    output: Option<aws_sdk_bedrockruntime::types::ConverseOutput>,
+    stop_reason: StopReason,
+    usage: Option<aws_sdk_bedrockruntime::types::TokenUsage>,
+) -> Result<BedrockChatResponse> {
+    let message = match output {
+        Some(aws_sdk_bedrockruntime::types::ConverseOutput::Message(message)) => message,
+        _ => return Err(anyhow!("no message in Bedrock ConverseOutput")),
+    };
+
+    let mut content = Vec::new();
+    for block in message.content {
+        match block {
+            BedrockContentBlock::Text(text) => {
+                if !text.trim().is_empty() {
+                    content.push(BedrockResponseContent::Text(text));
+                }
+            }
+            BedrockContentBlock::ToolUse(tool_use) => {
+                content.push(BedrockResponseContent::ToolUse {
+                    id: tool_use.tool_use_id,
+                    name: tool_use.name,
+                    input: document_to_value(&tool_use.input),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    Ok(BedrockChatResponse {
+        content,
+        stop_reason: Some(format!("{stop_reason:?}")),
+        usage: usage.map(|usage| BedrockTokenUsage {
+            input_tokens: usage.input_tokens as u32,
+            output_tokens: usage.output_tokens as u32,
+        }),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn model_context_window_uses_bedrock_family_defaults() {
+        assert_eq!(
+            model_context_window("us.anthropic.claude-3-5-sonnet-20241022-v2:0"),
+            (200_000, 8_192)
+        );
+        assert_eq!(
+            model_context_window("us.amazon.nova-pro-v1:0"),
+            (300_000, 5_000)
+        );
+        assert_eq!(model_context_window("unknown-model"), (200_000, 8_192));
+    }
+
+    #[test]
+    fn document_conversion_roundtrips_json_values() {
+        let value = json!({
+            "string": "value",
+            "bool": true,
+            "int": -7,
+            "uint": 7_u64,
+            "float": 1.25,
+            "array": [null, "x"]
+        });
+
+        assert_eq!(document_to_value(&value_to_document(&value)), value);
+    }
+
+    #[test]
+    fn content_conversion_skips_blank_text() {
+        let blocks = convert_content_to_bedrock(&[
+            BedrockChatContent::Text("  ".to_string()),
+            BedrockChatContent::Text("hello".to_string()),
+        ]);
+
+        assert_eq!(blocks.len(), 1);
+        assert!(matches!(&blocks[0], BedrockContentBlock::Text(text) if text == "hello"));
+    }
+}

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -43,6 +43,8 @@ future appserver integrations can use.
 
 - `mcp-runtime.md`: source-aware MCP configuration, registry, status, refresh,
   reconnect, resource, and Tool Search contracts.
+- `bedrock-backend.md`: Bedrock SDK backend crate boundary and RARA adapter
+  contract.
 
 ## Release Specs
 

--- a/docs/features/bedrock-backend.md
+++ b/docs/features/bedrock-backend.md
@@ -1,0 +1,82 @@
+# Bedrock Backend Boundary
+
+## Problem
+
+RARA supports Amazon Bedrock through the AWS SDK Converse API. The original
+implementation kept SDK client construction, Bedrock request conversion, context
+budget defaults, and the `LlmBackend` adapter in `src/llm/bedrock.rs`.
+
+That made the provider transport harder to evolve independently from the agent
+runtime and kept AWS SDK dependencies attached directly to the main crate.
+
+## Scope
+
+- Keep the current Bedrock SDK Converse path.
+- Move Bedrock transport and Bedrock-native conversion into `rara-bedrock`.
+- Keep the main crate responsible for adapting RARA runtime types to the
+  provider crate.
+- Preserve the existing provider name, model configuration, and AWS SDK
+  credential-chain behavior.
+
+## Non-Goals
+
+- Do not add Codex-style Bedrock Mantle or OpenAI-compatible SigV4 transport.
+- Do not add AWS profile configuration in this change.
+- Do not change provider selection, TUI model presets, or user-facing Bedrock
+  configuration.
+- Do not add Bedrock embeddings.
+
+## Architecture
+
+`rara-bedrock` owns the AWS SDK boundary:
+
+- `BedrockConverseClient`
+- `BedrockChatMessage`
+- `BedrockChatContent`
+- `BedrockToolSpec`
+- `BedrockChatResponse`
+- context-window defaults for known Bedrock model families
+
+The main crate keeps a thin adapter in `src/llm/bedrock.rs`:
+
+- converts `agent::Message` into `BedrockChatMessage`;
+- converts tool schemas into `BedrockToolSpec`;
+- converts provider responses into `ContentBlock`, `LlmResponse`, and
+  `TokenUsage`;
+- implements `LlmBackend` for RARA's runtime.
+
+This split avoids a circular dependency. `LlmBackend` and `Message` still live
+in the main crate, so the provider crate cannot implement the runtime trait
+directly.
+
+## Contracts
+
+- `provider = "bedrock"` still builds `BedrockBackend` through
+  `runtime_context::build_backend_with_progress`.
+- Bedrock requests still use `aws_sdk_bedrockruntime::Client::converse`.
+- AWS credentials and signing remain delegated to the AWS SDK default chain.
+- Unsupported RARA message roles are skipped before provider conversion, as
+  before.
+- Provider usage maps to RARA usage with zero cache-hit and cache-miss tokens
+  because Bedrock Converse does not currently expose those fields through this
+  adapter.
+
+## Validation Matrix
+
+- `cargo test -p rara-bedrock -- --nocapture`
+- `cargo test llm::bedrock -- --nocapture`
+- `cargo fmt --check`
+- `cargo check`
+
+## Open Risks
+
+- The adapter boundary still depends on RARA runtime types in the main crate.
+  A later shared runtime-types crate would allow provider crates to implement
+  more of the backend contract directly.
+- AWS profile support remains a follow-up configuration task.
+- Streaming support remains inherited from the default `LlmBackend`
+  non-streaming fallback for this provider.
+
+## Source Journals
+
+- [2026-05-06-bedrock-backend-crate](../journal/2026-05-06-bedrock-backend-crate.md)

--- a/docs/journal/2026-05-06-bedrock-backend-crate.md
+++ b/docs/journal/2026-05-06-bedrock-backend-crate.md
@@ -1,0 +1,31 @@
+# Bedrock Backend Crate
+
+## Context
+
+The Bedrock SDK backend was still implemented directly inside the main crate.
+After adding separate crates for other runtime boundaries, the Bedrock provider
+was a good candidate for the same structure.
+
+## Implementation Checkpoint
+
+- Added `crates/bedrock` as `rara-bedrock`.
+- Moved AWS SDK Converse client construction and Bedrock-native request/response
+  conversion into the new crate.
+- Kept `src/llm/bedrock.rs` as a thin RARA adapter implementing `LlmBackend`.
+- Removed direct AWS SDK dependencies from the main crate dependency list.
+- Added focused tests for provider conversion and the main adapter mapping.
+
+## Validation
+
+- `cargo fmt --check`
+- `cargo test -p rara-bedrock -- --nocapture`
+- `cargo test llm::bedrock -- --nocapture`
+- `cargo check`
+
+## Follow-Up
+
+- Add explicit `aws_profile` support to Bedrock configuration.
+- Surface Bedrock region/profile/model in `/status` once provider details are
+  generalized.
+- Revisit a shared runtime-types crate if more provider crates need to implement
+  backend contracts directly.

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -1,333 +1,116 @@
-// AWS Bedrock backend using the Converse API.
-//
-// Bedrock Converse provides a unified messages API across Bedrock models
-// (Claude, Llama, Nova, etc.) similar to the OpenAI chat completions API.
-// Tool use / function calling is supported natively.
-
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
-use aws_sdk_bedrockruntime::Client as BedrockClient;
-use aws_sdk_bedrockruntime::types::{
-    ContentBlock as BedrockContentBlock, ConversationRole, InferenceConfiguration,
-    Message as BedrockMessage, StopReason, Tool, ToolConfiguration, ToolInputSchema,
-    ToolResultBlock, ToolResultContentBlock, ToolResultStatus, ToolSpecification, ToolUseBlock,
+use rara_bedrock::{
+    BedrockChatContent, BedrockChatMessage, BedrockChatRole, BedrockConverseClient,
+    BedrockResponseContent, BedrockToolSpec, model_context_window,
 };
-use aws_smithy_types::{Document, Number};
 use serde_json::{Value, json};
 
 use super::shared::{ContextBudget, LlmBackend};
 use crate::agent::Message;
 use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
 
-const DEFAULT_CONTEXT_WINDOW: usize = 200_000;
-const DEFAULT_OUTPUT_TOKENS: i32 = 8_192;
-
-fn model_context_window(model_id: &str) -> Option<(usize, usize)> {
-    let lower = model_id.to_lowercase();
-    if lower.contains("claude-sonnet-4") || lower.contains("claude-3-5-sonnet") {
-        Some((200_000, 8_192))
-    } else if lower.contains("claude-3-opus") {
-        Some((200_000, 4_096))
-    } else if lower.contains("claude-3-haiku") {
-        Some((200_000, 4_096))
-    } else if lower.contains("claude-3") {
-        Some((200_000, 4_096))
-    } else if lower.contains("claude") {
-        Some((200_000, 4_096))
-    } else if lower.contains("llama") {
-        Some((128_000, 2_048))
-    } else if lower.contains("nova-pro") {
-        Some((300_000, 5_000))
-    } else if lower.contains("nova-lite") {
-        Some((300_000, 5_000))
-    } else if lower.contains("nova") {
-        Some((300_000, 5_000))
-    } else if lower.contains("command") {
-        Some((128_000, 4_096))
-    } else if lower.contains("mistral") {
-        Some((128_000, 4_096))
-    } else {
-        None
-    }
-}
-
 pub struct BedrockBackend {
-    client: BedrockClient,
-    model_id: String,
-    region: String,
+    client: BedrockConverseClient,
 }
 
 impl BedrockBackend {
     pub async fn new(region: Option<String>, model_id: String) -> Result<Self> {
-        let mut config_loader = aws_config::from_env();
-        if let Some(r) = region.as_deref() {
-            config_loader = config_loader.region(aws_config::Region::new(r.to_string()));
-        }
-        let sdk_config = config_loader.load().await;
-        let client = BedrockClient::new(&sdk_config);
-
         Ok(Self {
-            client,
-            model_id,
-            region: region.unwrap_or_else(|| "default".to_string()),
+            client: BedrockConverseClient::new(region, model_id).await?,
         })
     }
 }
 
-// ── serde_json::Value ↔ aws_smithy_types::Document ──
-
-fn value_to_document(value: &Value) -> Document {
-    match value {
-        Value::Null => Document::Null,
-        Value::Bool(b) => Document::Bool(*b),
-        Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                Document::Number(Number::NegInt(i))
-            } else if let Some(u) = n.as_u64() {
-                Document::Number(Number::PosInt(u))
-            } else if let Some(f) = n.as_f64() {
-                Document::Number(Number::Float(f))
-            } else {
-                Document::Null
-            }
-        }
-        Value::String(s) => Document::String(s.clone()),
-        Value::Array(arr) => Document::Array(arr.iter().map(value_to_document).collect()),
-        Value::Object(obj) => {
-            let map: std::collections::HashMap<String, Document> = obj
-                .iter()
-                .map(|(k, v)| (k.clone(), value_to_document(v)))
-                .collect();
-            Document::Object(map)
-        }
-    }
-}
-
-fn document_to_value(doc: &Document) -> Value {
-    match doc {
-        Document::Object(map) => {
-            let mut obj = serde_json::Map::new();
-            for (k, v) in map {
-                obj.insert(k.clone(), document_to_value(v));
-            }
-            Value::Object(obj)
-        }
-        Document::Array(arr) => Value::Array(arr.iter().map(document_to_value).collect()),
-        Document::String(s) => Value::String(s.clone()),
-        Document::Number(n) => match n {
-            Number::PosInt(u) => Value::Number(serde_json::Number::from(*u)),
-            Number::NegInt(i) => Value::Number(serde_json::Number::from(*i)),
-            Number::Float(f) => serde_json::Number::from_f64(*f)
-                .map(Value::Number)
-                .unwrap_or(Value::Null),
-        },
-        Document::Bool(b) => Value::Bool(*b),
-        Document::Null => Value::Null,
-    }
-}
-
-// ── Message conversion ──
-
-fn to_bedrock_messages(messages: &[Message]) -> Result<Vec<BedrockMessage>> {
+fn to_bedrock_messages(messages: &[Message]) -> Vec<BedrockChatMessage> {
     messages
         .iter()
-        .filter_map(|msg| {
-            let role = match msg.role.as_str() {
-                "user" => ConversationRole::User,
-                "assistant" => ConversationRole::Assistant,
+        .filter_map(|message| {
+            let role = match message.role.as_str() {
+                "user" => BedrockChatRole::User,
+                "assistant" => BedrockChatRole::Assistant,
                 _ => return None,
             };
-            let content = convert_content_to_bedrock(&msg.content);
-            match BedrockMessage::builder()
-                .role(role)
-                .set_content(if content.is_empty() {
-                    None
-                } else {
-                    Some(content)
-                })
-                .build()
-            {
-                Ok(message) => Some(Ok(message)),
-                Err(e) => Some(Err(anyhow!("failed to build Bedrock message: {e}"))),
-            }
+            Some(BedrockChatMessage {
+                role,
+                content: convert_content_to_bedrock(&message.content),
+            })
         })
         .collect()
 }
 
-fn convert_content_to_bedrock(content: &Value) -> Vec<BedrockContentBlock> {
-    let mut blocks = Vec::new();
-
+fn convert_content_to_bedrock(content: &Value) -> Vec<BedrockChatContent> {
     if let Some(text) = content.as_str() {
-        if !text.trim().is_empty() {
-            blocks.push(BedrockContentBlock::Text(text.to_string()));
-        }
-        return blocks;
+        return vec![BedrockChatContent::Text(text.to_string())];
     }
 
     let Some(items) = content.as_array() else {
-        return blocks;
+        return Vec::new();
     };
 
-    for item in items {
-        match item.get("type").and_then(Value::as_str) {
-            Some("text") => {
-                if let Some(text) = item.get("text").and_then(Value::as_str) {
-                    if !text.trim().is_empty() {
-                        blocks.push(BedrockContentBlock::Text(text.to_string()));
-                    }
-                }
-            }
-            Some("tool_use") => {
-                let id = item["id"].as_str().unwrap_or_default().to_string();
-                let name = item["name"].as_str().unwrap_or_default().to_string();
-                let input = item
-                    .get("input")
-                    .map(value_to_document)
-                    .unwrap_or(Document::Null);
-                if let Ok(tool_use) = ToolUseBlock::builder()
-                    .tool_use_id(id)
-                    .name(name)
-                    .input(input)
-                    .build()
-                {
-                    blocks.push(BedrockContentBlock::ToolUse(tool_use));
-                }
-            }
-            Some("tool_result") => {
-                let tool_use_id = item["tool_use_id"].as_str().unwrap_or_default().to_string();
-                let result_content = item["content"].as_str().unwrap_or("");
-                let is_error = item["is_error"].as_bool().unwrap_or(false);
-                if let Ok(tr) = ToolResultBlock::builder()
-                    .tool_use_id(tool_use_id)
-                    .set_content(Some(vec![ToolResultContentBlock::Text(
-                        result_content.to_string(),
-                    )]))
-                    .set_status(if is_error {
-                        Some(ToolResultStatus::Error)
-                    } else {
-                        Some(ToolResultStatus::Success)
-                    })
-                    .build()
-                {
-                    blocks.push(BedrockContentBlock::ToolResult(tr));
-                }
-            }
-            _ => {}
-        }
-    }
-
-    blocks
-}
-
-// ── Tool conversion ──
-
-fn to_bedrock_tools(tools: &[Value]) -> Vec<Tool> {
-    tools
+    items
         .iter()
-        .map(|tool| {
-            let name = tool["name"].as_str().unwrap_or("unknown").to_string();
-            let description = tool["description"].as_str().unwrap_or("").to_string();
-            let schema = value_to_document(&tool["input_schema"]);
-            let tool_name = name.clone();
-            Tool::ToolSpec(
-                ToolSpecification::builder()
-                    .name(name)
-                    .description(description)
-                    .input_schema(ToolInputSchema::Json(schema))
-                    .build()
-                    .unwrap_or_else(|_| panic!("invalid tool spec: {tool_name}")),
-            )
+        .filter_map(|item| match item.get("type").and_then(Value::as_str) {
+            Some("text") => item
+                .get("text")
+                .and_then(Value::as_str)
+                .map(|text| BedrockChatContent::Text(text.to_string())),
+            Some("tool_use") => Some(BedrockChatContent::ToolUse {
+                id: item["id"].as_str().unwrap_or_default().to_string(),
+                name: item["name"].as_str().unwrap_or_default().to_string(),
+                input: item.get("input").cloned().unwrap_or(Value::Null),
+            }),
+            Some("tool_result") => Some(BedrockChatContent::ToolResult {
+                tool_use_id: item["tool_use_id"].as_str().unwrap_or_default().to_string(),
+                content: item["content"].as_str().unwrap_or("").to_string(),
+                is_error: item["is_error"].as_bool().unwrap_or(false),
+            }),
+            _ => None,
         })
         .collect()
 }
 
-// ── Response conversion ──
-
-fn from_bedrock_response(
-    output: Option<aws_sdk_bedrockruntime::types::ConverseOutput>,
-    stop_reason: StopReason,
-    usage: Option<aws_sdk_bedrockruntime::types::TokenUsage>,
-) -> Result<LlmResponse> {
-    let message = match output {
-        Some(aws_sdk_bedrockruntime::types::ConverseOutput::Message(msg)) => msg,
-        _ => return Err(anyhow!("no message in Bedrock ConverseOutput")),
-    };
-
-    let mut content = Vec::new();
-
-    for block in message.content {
-        match block {
-            BedrockContentBlock::Text(text) => {
-                if !text.trim().is_empty() {
-                    content.push(ContentBlock::Text { text });
-                }
-            }
-            BedrockContentBlock::ToolUse(tool_use) => {
-                let input = document_to_value(&tool_use.input);
-                content.push(ContentBlock::ToolUse {
-                    id: tool_use.tool_use_id,
-                    name: tool_use.name,
-                    input,
-                });
-            }
-            _ => {}
-        }
-    }
-
-    let reason_str = format!("{:?}", stop_reason);
-
-    let usage = usage.map(|u| TokenUsage {
-        input_tokens: u.input_tokens as u32,
-        output_tokens: u.output_tokens as u32,
-        cache_hit_tokens: 0,
-        cache_miss_tokens: 0,
-    });
-
-    Ok(LlmResponse {
-        content,
-        stop_reason: Some(reason_str),
-        usage,
-    })
+fn to_bedrock_tools(tools: &[Value]) -> Vec<BedrockToolSpec> {
+    tools
+        .iter()
+        .map(|tool| BedrockToolSpec {
+            name: tool["name"].as_str().unwrap_or("unknown").to_string(),
+            description: tool["description"].as_str().unwrap_or("").to_string(),
+            input_schema: tool["input_schema"].clone(),
+        })
+        .collect()
 }
-
-// ── LlmBackend impl ──
 
 #[async_trait]
 impl LlmBackend for BedrockBackend {
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
-        let bedrock_messages = to_bedrock_messages(messages)?;
-
-        let mut builder = self
+        let response = self
             .client
-            .converse()
-            .model_id(&self.model_id)
-            .set_messages(Some(bedrock_messages));
+            .ask(&to_bedrock_messages(messages), &to_bedrock_tools(tools))
+            .await?;
 
-        if !tools.is_empty() {
-            if let Ok(tool_config) = ToolConfiguration::builder()
-                .set_tools(Some(to_bedrock_tools(tools)))
-                .build()
-            {
-                builder = builder.tool_config(tool_config);
+        let mut content = Vec::new();
+        for block in response.content {
+            match block {
+                BedrockResponseContent::Text(text) => {
+                    content.push(ContentBlock::Text { text });
+                }
+                BedrockResponseContent::ToolUse { id, name, input } => {
+                    content.push(ContentBlock::ToolUse { id, name, input });
+                }
             }
         }
 
-        builder = builder.inference_config(
-            InferenceConfiguration::builder()
-                .temperature(0.7)
-                .max_tokens(DEFAULT_OUTPUT_TOKENS)
-                .build(),
-        );
-
-        let output = builder.send().await.map_err(|err| {
-            anyhow!(
-                "Bedrock API error (region={}, model={}): {err}",
-                self.region,
-                self.model_id
-            )
-        })?;
-
-        from_bedrock_response(output.output, output.stop_reason, output.usage)
+        Ok(LlmResponse {
+            content,
+            stop_reason: response.stop_reason,
+            usage: response.usage.map(|usage| TokenUsage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cache_hit_tokens: 0,
+                cache_miss_tokens: 0,
+            }),
+        })
     }
 
     async fn embed(&self, _text: &str) -> Result<Vec<f32>> {
@@ -352,12 +135,67 @@ impl LlmBackend for BedrockBackend {
     }
 
     fn context_budget(&self, _messages: &[Message], _tools: &[Value]) -> Option<ContextBudget> {
-        let (window, max_output) = model_context_window(&self.model_id)
-            .unwrap_or((DEFAULT_CONTEXT_WINDOW, DEFAULT_OUTPUT_TOKENS as usize));
+        let (window, max_output) = model_context_window(self.client.model_id());
         Some(ContextBudget {
             context_window_tokens: window,
             reserved_output_tokens: max_output,
             compact_threshold_tokens: window.saturating_sub(max_output),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn converts_rara_messages_to_bedrock_messages() {
+        let messages = vec![
+            Message {
+                role: "system".to_string(),
+                content: json!("ignored"),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type": "text", "text": "hello"},
+                    {"type": "tool_result", "tool_use_id": "call-1", "content": "ok", "is_error": false}
+                ]),
+            },
+        ];
+
+        let converted = to_bedrock_messages(&messages);
+
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].role, BedrockChatRole::User);
+        assert_eq!(
+            converted[0].content,
+            vec![
+                BedrockChatContent::Text("hello".to_string()),
+                BedrockChatContent::ToolResult {
+                    tool_use_id: "call-1".to_string(),
+                    content: "ok".to_string(),
+                    is_error: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn converts_rara_tool_schemas_to_bedrock_tool_specs() {
+        let tools = vec![json!({
+            "name": "read_file",
+            "description": "Read a file",
+            "input_schema": {"type": "object"}
+        })];
+
+        let converted = to_bedrock_tools(&tools);
+
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].name, "read_file");
+        assert_eq!(converted[0].description, "Read a file");
+        assert_eq!(converted[0].input_schema, json!({"type": "object"}));
     }
 }


### PR DESCRIPTION
## Summary

- add `rara-bedrock` as the Bedrock SDK Converse transport crate
- keep `src/llm/bedrock.rs` as the thin RARA `LlmBackend` adapter
- move AWS SDK dependencies out of the main crate dependency list
- document the Bedrock backend crate boundary and follow-up work

## Testing

- `cargo fmt --check`
- `cargo test -p rara-bedrock -- --nocapture`
- `cargo test llm::bedrock -- --nocapture`
- `cargo check`

## Notes

This keeps the current AWS SDK Converse path. It does not add Codex-style
Bedrock Mantle or OpenAI-compatible SigV4 transport.
