### PR TITLE
chore: split llm::openai_compatible into directory module

### DIFF
--- a/src/llm/openai_compatible/main.rs
+++ b/src/llm/openai_compatible/main.rs
@@ -1,5 +1,3 @@
-mod codex;
-mod usage;
 
 use std::borrow::Cow;
 use std::fmt;

--- a/src/llm/openai_compatible/mod.rs
+++ b/src/llm/openai_compatible/mod.rs
@@ -1,0 +1,4 @@
+mod codex;
+mod usage;
+
+include!("main.rs");


### PR DESCRIPTION
1410 lines → src/llm/openai_compatible/main.rs. Mod declarations moved to mod.rs; main.rs included via include!.