### PR TITLE
chore: add bottom pane tui plan

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -109,6 +109,9 @@ Active backlog only. Keep this file small and current.
 ## TUI / Transcript
 
 - [ ] Decouple overlays from transcript layout (pure top layer, no viewport perturbation).
+- [ ] Split the bottom pane into composable activity, composer, queued-preview, and footer modules.
+- [ ] Introduce a `BottomPaneModel` so bottom-pane rendering consumes structured view data instead of reading broad `TuiApp` state directly.
+- [ ] Move approval, request-input, command-palette, and picker flows toward a Codex-style bottom-pane view stack after the rendering split is stable.
 - [ ] Post-exit resume hint (e.g. `rara resume --last`).
 - [x] Claude-style repo context hints beneath input area (GitHub PR link).
 - [x] Codex/Claude-style transcript role cards (`You` / `Agent` / `System`).


### PR DESCRIPTION
## Summary

- add bottom-pane modularization tasks to the TUI / Transcript backlog
- capture the Codex-style direction: composable bottom-pane modules, structured view model, and future view stack

## Testing

- Not run; TODO-only change.
