### PR TITLE
chore: extract compact types into separate module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,27 @@
 This document records RARA goals, scope, architecture constraints, and documentation rules.
 It is the baseline index for future implementation and evolution.
 
+---
+
+## Index
+
+### Project
+- [1. Project Goals](#1-project-goals)
+- [2. Scope](#2-scope)
+- [3. Architecture Constraints](#3-architecture-constraints)
+- [4. Current Key Decisions](#4-current-key-decisions)
+- [5. Documentation Rules](#5-documentation-rules)
+- [6. Near-Term Focus](#6-near-term-focus)
+- [7. Commit Rules](#7-commit-rules)
+
+### Docs
+- [docs/features/](docs/features/README.md) — engineering specs and contracts (28 files)
+- [docs/journal/](docs/journal/) — dated implementation notes and checkpoints
+- [docs/journal/2026-05-07-file-split-lessons.md](docs/journal/2026-05-07-file-split-lessons.md) — file splitting patterns, pitfalls, and workflow
+- [docs/todo.md](docs/todo.md) — active follow-up work
+
+---
+
 ## 1. Project Goals
 
 RARA is a local-first coding agent runtime with:

--- a/docs/journal/2026-05-07-file-split-lessons.md
+++ b/docs/journal/2026-05-07-file-split-lessons.md
@@ -1,0 +1,67 @@
+# File Split Lessons Learned
+
+**Date**: 2026-05-07
+**Context**: Split 11 oversized source files (>800 lines) into directory modules.
+**Result**: One correct split (#265, `compact.rs`), 14 invalid `include!` PRs closed (#250-#263), one revert in progress (#268).
+
+---
+
+## What Went Wrong
+
+### `include!` Is Not Splitting
+
+```rust
+// mod.rs
+include!("main.rs");
+```
+
+This moves a file into a directory but keeps it as a single monolithic file. Zero structural change.
+
+## Correct Pattern: Types Extraction
+
+Successful split of `compact.rs` (#265):
+
+| File | Lines | Content |
+|------|-------|---------|
+| `types.rs` | 116 | All struct/enum/const definitions, `pub(crate)` visibility |
+| `main.rs` | ~1325 | `impl Agent` + helpers, `use crate::agent::*` replaces `use super::*` |
+| `tests.rs` | ~140 | Test module |
+| `mod.rs` | 13 | Submodule declarations + targeted re-exports |
+
+### Required Visibility Changes
+
+| Change | Why |
+|--------|-----|
+| `struct → pub(crate) struct` | Cross-submodule visibility |
+| Fields → `pub(crate)` | Helpers need to read struct fields |
+| `pub(super) → pub(crate)` | After split, `super` is the directory module, not the original parent |
+| `use super::* → use crate::X::*` | Same reason |
+
+
+
+## Pitfalls
+
+1. **Line number drift**: inserting `use` statements shifts all subsequent line numbers. Use `git show` to verify boundaries against the original file.
+
+2. **Struct boundary off-by-one**: `sed -n 'start,endp'` easily misses the closing `}`. Always visualize the extracted range before deleting:
+   ```
+   git show HEAD:src/file.rs | sed -n 'start,endp'
+   ```
+
+3. **Private Agent methods**: `push_history_message`, `replace_history`, `extend_history_messages` are `impl Agent` methods called from helpers within the same module. After splitting into submodules, they need `pub(crate)`.
+
+4. **`#[cfg(test)]` constants**: If types.rs contains test-only constants, keep them there with `#[cfg(test)]` or replicate in tests.rs.
+
+5. **Don't touch `impl` + helpers boundary**: The most fragile split point. Compact's agent_impl was 332 lines (safe) and helpers were 895 lines (slightly over). Leaving them together in main.rs avoided 15+ visibility errors.
+
+## Recommended Workflow
+
+```
+1. Restore original from git: git show COMMIT^:path > file.rs
+2. grep -n to find struct, fn, cfg(test) boundaries
+3. sed with exact line ranges, visualize first
+4. Add pub(crate) to types and struct fields
+5. cargo check → fix errors iteratively
+6. Verify each sub-file < 800 lines
+7. One PR per file
+```

--- a/src/agent/compact/main.rs
+++ b/src/agent/compact/main.rs
@@ -339,7 +339,7 @@ impl Agent {
     }
 }
 
-fn build_compact_plan(
+pub(crate) fn build_compact_plan(
     history: &[Message],
     threshold: usize,
     force: bool,
@@ -414,7 +414,7 @@ fn ensure_api_round_boundary_range(history: &[Message], from: usize, up_to: usiz
     Ok(())
 }
 
-fn group_history_by_api_round(history: &[Message]) -> Result<Vec<ApiRoundGroup>> {
+pub(crate) fn group_history_by_api_round(history: &[Message]) -> Result<Vec<ApiRoundGroup>> {
     let bpe = tokenizer()?;
     let mut groups = Vec::new();
     let mut group_start = 0usize;
@@ -1115,7 +1115,9 @@ fn collect_recent_file_excerpts(
     excerpts
 }
 
-fn read_file_line_range(input: &serde_json::Map<String, Value>) -> Option<(usize, usize)> {
+pub(crate) fn read_file_line_range(
+    input: &serde_json::Map<String, Value>,
+) -> Option<(usize, usize)> {
     match (
         input.get("offset").and_then(Value::as_u64),
         input.get("limit").and_then(Value::as_u64),

--- a/src/agent/compact/main.rs
+++ b/src/agent/compact/main.rs
@@ -1,117 +1,10 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use super::*;
-use crate::context::RetrievedMemoryCandidate;
+use super::types::*;
+use crate::agent::*;
 use crate::llm::{ContextBudget, is_context_window_error};
 use crate::session::PersistedCompactionEvent;
-
-const RECENT_FILE_CARRY_OVER_LIMIT: usize = 5;
-const RECENT_FILE_EXCERPT_LIMIT: usize = 3;
-const RECENT_FILE_EXCERPT_CHAR_LIMIT: usize = 600;
-const MEMORY_CARRY_OVER_LIMIT: usize = 3;
-const SKILL_CARRY_OVER_LIMIT: usize = 3;
-const SKILL_INSTRUCTION_PREVIEW_CHAR_LIMIT: usize = 600;
-const HOOK_CARRY_OVER_LIMIT: usize = 3;
-const MCP_CARRY_OVER_LIMIT: usize = 3;
-const RETAINED_HISTORY_BUDGET_FRACTION: usize = 2;
-const COMPACT_BOUNDARY_KIND: &str = "compact_boundary";
-const COMPACT_BOUNDARY_VERSION: u32 = 1;
-const ROLE_ASSISTANT: &str = "assistant";
-// Wait for about two 4K chunks of new context before retrying automatic
-// compaction after a timeout or backend failure.
-const AUTO_COMPACTION_RETRY_HYSTERESIS_TOKENS: usize = 8_192;
-#[cfg(not(test))]
-const COMPACTION_SUMMARY_TIMEOUT: Duration = Duration::from_secs(300);
-
-#[cfg(test)]
-const TEST_COMPACTION_SUMMARY_TIMEOUT: Duration = Duration::from_millis(10);
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct CompactBoundaryMetadata {
-    pub version: u32,
-    pub before_tokens: usize,
-    pub recent_file_count: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RecentFileExcerpt {
-    path: String,
-    line_range: Option<(usize, usize)>,
-    snippet: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ApiRoundGroup {
-    start: usize,
-    end: usize,
-    token_estimate: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct CompactPlan {
-    summarize_end: usize,
-    retained_start: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct CompactCarryOver {
-    summary: String,
-    recent_files: Vec<String>,
-    recent_file_excerpts: Vec<RecentFileExcerpt>,
-    retrieved_memory: Vec<RetrievedMemoryCandidate>,
-    invoked_skills: Vec<InvokedSkillCarryOver>,
-    retained_hooks: Vec<RetainedContextCarryOver>,
-    retained_mcp: Vec<RetainedContextCarryOver>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct InvokedSkillCarryOver {
-    name: String,
-    title: Option<String>,
-    scope: Option<String>,
-    display_path: Option<String>,
-    args: Option<String>,
-    instruction_preview: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RetainedContextCarryOver {
-    label: String,
-    source_descriptor: String,
-    detail: String,
-    inclusion_reason: Option<String>,
-}
-
-#[derive(Debug)]
-struct CompactionSummaryTimeout;
-
-impl std::fmt::Display for CompactionSummaryTimeout {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "history compaction timed out after {} seconds",
-            compaction_summary_timeout().as_secs()
-        )
-    }
-}
-
-impl std::error::Error for CompactionSummaryTimeout {}
-
-#[derive(Debug, Clone, Default)]
-pub struct CompactState {
-    pub estimated_history_tokens: usize,
-    pub context_window_tokens: Option<usize>,
-    pub compact_threshold_tokens: usize,
-    pub reserved_output_tokens: usize,
-    pub compaction_count: usize,
-    pub last_compaction_before_tokens: Option<usize>,
-    pub last_compaction_after_tokens: Option<usize>,
-    pub last_compaction_recent_files: Vec<String>,
-    pub last_compaction_boundary: Option<CompactBoundaryMetadata>,
-    pub consecutive_auto_compaction_failures: usize,
-    pub auto_compaction_retry_after_tokens: Option<usize>,
-}
 
 impl Agent {
     pub async fn compact_if_needed(&mut self) -> Result<()> {
@@ -397,23 +290,23 @@ impl Agent {
         }
     }
 
-    pub(super) fn current_compact_budget(&self) -> Option<ContextBudget> {
+    pub(crate) fn current_compact_budget(&self) -> Option<ContextBudget> {
         let tools = self.visible_tool_schemas();
         self.context_assembler()
             .budget_for(self.llm_backend.as_ref(), &self.history, &tools)
     }
 
-    pub(super) fn push_history_message(&mut self, message: Message) {
+    pub(crate) fn push_history_message(&mut self, message: Message) {
         self.record_history_message_tokens(&message);
         self.history.push(message);
     }
 
-    pub(super) fn extend_history_messages(&mut self, messages: Vec<Message>) {
+    pub(crate) fn extend_history_messages(&mut self, messages: Vec<Message>) {
         self.record_history_messages_tokens(&messages);
         self.history.extend(messages);
     }
 
-    pub(super) fn replace_history(&mut self, history: Vec<Message>) {
+    pub(crate) fn replace_history(&mut self, history: Vec<Message>) {
         self.history = history;
         self.recompute_history_token_estimate();
     }
@@ -749,7 +642,7 @@ fn compact_source_content(text: String, source_item: Value) -> Value {
     ])
 }
 
-fn compaction_summary_timeout() -> Duration {
+pub(crate) fn compaction_summary_timeout() -> Duration {
     #[cfg(test)]
     {
         TEST_COMPACTION_SUMMARY_TIMEOUT
@@ -787,7 +680,7 @@ fn estimate_message_tokens_with_bpe(
     Ok(bpe.encode_with_special_tokens(content).len())
 }
 
-fn tokenizer() -> Result<&'static tiktoken_rs::CoreBPE> {
+pub(crate) fn tokenizer() -> Result<&'static tiktoken_rs::CoreBPE> {
     static BPE: OnceLock<std::result::Result<tiktoken_rs::CoreBPE, String>> = OnceLock::new();
     match BPE.get_or_init(|| tiktoken_rs::cl100k_base().map_err(|err| err.to_string())) {
         Ok(bpe) => Ok(bpe),

--- a/src/agent/compact/mod.rs
+++ b/src/agent/compact/mod.rs
@@ -1,11 +1,11 @@
-#[path = "types.rs"]
-pub(crate) mod types;
 #[path = "main.rs"]
 pub(crate) mod main;
 #[cfg(test)]
 #[path = "tests.rs"]
 mod tests;
+#[path = "types.rs"]
+pub(crate) mod types;
 
-pub use types::{CompactBoundaryMetadata, CompactState};
-pub use main::latest_compact_boundary_metadata;
 pub(crate) use main::compact_boundary_item;
+pub use main::latest_compact_boundary_metadata;
+pub use types::{CompactBoundaryMetadata, CompactState};

--- a/src/agent/compact/mod.rs
+++ b/src/agent/compact/mod.rs
@@ -1,0 +1,11 @@
+#[path = "types.rs"]
+pub(crate) mod types;
+#[path = "main.rs"]
+pub(crate) mod main;
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+pub use types::{CompactBoundaryMetadata, CompactState};
+pub use main::latest_compact_boundary_metadata;
+pub(crate) use main::compact_boundary_item;

--- a/src/agent/compact/tests.rs
+++ b/src/agent/compact/tests.rs
@@ -8,7 +8,8 @@ use super::*;
 mod tests {
     use serde_json::{Map, Value, json};
 
-    use super::{build_compact_plan, group_history_by_api_round, read_file_line_range};
+    use super::main::{build_compact_plan, group_history_by_api_round, read_file_line_range};
+    use super::types::COMPACTION_SUMMARY_TIMEOUT;
     use crate::agent::Message;
 
     fn object(value: Value) -> Map<String, Value> {

--- a/src/agent/compact/tests.rs
+++ b/src/agent/compact/tests.rs
@@ -1,0 +1,185 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use super::*;
+use super::*;
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Map, Value, json};
+
+    use super::{build_compact_plan, group_history_by_api_round, read_file_line_range};
+    use crate::agent::Message;
+
+    fn object(value: Value) -> Map<String, Value> {
+        value.as_object().expect("object").clone()
+    }
+
+    #[test]
+    fn read_file_line_range_rejects_overflowing_offset_limit() {
+        let input = object(json!({
+            "offset": usize::MAX,
+            "limit": 2,
+        }));
+
+        assert_eq!(read_file_line_range(&input), None);
+    }
+
+    #[test]
+    fn read_file_line_range_accepts_checked_offset_limit() {
+        let input = object(json!({
+            "offset": 10,
+            "limit": 3,
+        }));
+
+        assert_eq!(read_file_line_range(&input), Some((10, 12)));
+    }
+
+    #[test]
+    fn api_round_grouping_keeps_tool_result_with_assistant_round() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!("start"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/main.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content":"fn main() {}"}
+                ]),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!("done"),
+            },
+        ];
+
+        let groups = group_history_by_api_round(&history).expect("groups");
+
+        assert_eq!(
+            groups
+                .iter()
+                .map(|group| (group.start, group.end))
+                .collect::<Vec<_>>(),
+            vec![(0, 1), (1, 3), (3, 4)]
+        );
+    }
+
+    #[test]
+    fn compact_plan_uses_api_round_boundary_for_retained_suffix() {
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!("old request"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/old.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content":"old output ".repeat(1_000)}
+                ]),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-2","name":"read_file","input":{"path":"src/new.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-2","content":"new output"}
+                ]),
+            },
+        ];
+
+        let plan = build_compact_plan(&history, 600, false)
+            .expect("plan")
+            .expect("compact plan");
+
+        assert_eq!(plan.summarize_end, 3);
+        assert_eq!(plan.retained_start, 3);
+    }
+
+    #[test]
+    fn compact_plan_does_not_split_single_assistant_tool_round() {
+        let history = vec![
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/main.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content":"fn main() {}"}
+                ]),
+            },
+        ];
+
+        let plan = build_compact_plan(&history, 1, false).expect("plan");
+
+        assert!(
+            plan.is_none(),
+            "single API round must not retain a detached tool_result"
+        );
+    }
+
+    #[test]
+    fn compact_plan_summarizes_oversized_latest_api_round() {
+        let large_tool_output = "recent output ".repeat(2_000);
+        let history = vec![
+            Message {
+                role: "user".to_string(),
+                content: json!("old request"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!("old answer"),
+            },
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"tool_use","id":"tool-1","name":"read_file","input":{"path":"src/main.rs"}}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([
+                    {"type":"tool_result","tool_use_id":"tool-1","content": large_tool_output}
+                ]),
+            },
+        ];
+
+        let plan = build_compact_plan(&history, 100, false)
+            .expect("plan")
+            .expect("compact plan");
+        assert_eq!(plan.summarize_end, history.len());
+        assert_eq!(plan.retained_start, history.len());
+    }
+
+    #[test]
+    fn cached_token_estimate_avoids_recomputation() {
+        // Verify that CompactState stores estimated_history_tokens
+        // and the compact_plan builder uses thresholds correctly.
+        // The cache is populated incrementally by increment_history_tokens.
+        use crate::agent::CompactState;
+        let state = CompactState {
+            estimated_history_tokens: 500,
+            ..Default::default()
+        };
+        assert_eq!(state.estimated_history_tokens, 500);
+    }
+}

--- a/src/agent/compact/types.rs
+++ b/src/agent/compact/types.rs
@@ -20,7 +20,7 @@ pub(crate) const ROLE_ASSISTANT: &str = "assistant";
 // Wait for about two 4K chunks of new context before retrying automatic
 // compaction after a timeout or backend failure.
 pub(crate) const AUTO_COMPACTION_RETRY_HYSTERESIS_TOKENS: usize = 8_192;
-#[cfg(not(test))]
+
 pub(crate) const COMPACTION_SUMMARY_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[cfg(test)]
@@ -111,4 +111,3 @@ pub struct CompactState {
     pub consecutive_auto_compaction_failures: usize,
     pub auto_compaction_retry_after_tokens: Option<usize>,
 }
-

--- a/src/agent/compact/types.rs
+++ b/src/agent/compact/types.rs
@@ -1,0 +1,114 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use crate::context::RetrievedMemoryCandidate;
+use crate::llm::{ContextBudget, is_context_window_error};
+use crate::session::PersistedCompactionEvent;
+
+pub(crate) const RECENT_FILE_CARRY_OVER_LIMIT: usize = 5;
+pub(crate) const RECENT_FILE_EXCERPT_LIMIT: usize = 3;
+pub(crate) const RECENT_FILE_EXCERPT_CHAR_LIMIT: usize = 600;
+pub(crate) const MEMORY_CARRY_OVER_LIMIT: usize = 3;
+pub(crate) const SKILL_CARRY_OVER_LIMIT: usize = 3;
+pub(crate) const SKILL_INSTRUCTION_PREVIEW_CHAR_LIMIT: usize = 600;
+pub(crate) const HOOK_CARRY_OVER_LIMIT: usize = 3;
+pub(crate) const MCP_CARRY_OVER_LIMIT: usize = 3;
+pub(crate) const RETAINED_HISTORY_BUDGET_FRACTION: usize = 2;
+pub(crate) const COMPACT_BOUNDARY_KIND: &str = "compact_boundary";
+pub(crate) const COMPACT_BOUNDARY_VERSION: u32 = 1;
+pub(crate) const ROLE_ASSISTANT: &str = "assistant";
+// Wait for about two 4K chunks of new context before retrying automatic
+// compaction after a timeout or backend failure.
+pub(crate) const AUTO_COMPACTION_RETRY_HYSTERESIS_TOKENS: usize = 8_192;
+#[cfg(not(test))]
+pub(crate) const COMPACTION_SUMMARY_TIMEOUT: Duration = Duration::from_secs(300);
+
+#[cfg(test)]
+pub(crate) const TEST_COMPACTION_SUMMARY_TIMEOUT: Duration = Duration::from_millis(10);
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CompactBoundaryMetadata {
+    pub version: u32,
+    pub before_tokens: usize,
+    pub recent_file_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RecentFileExcerpt {
+    pub(crate) path: String,
+    pub(crate) line_range: Option<(usize, usize)>,
+    pub(crate) snippet: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ApiRoundGroup {
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+    pub(crate) token_estimate: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompactPlan {
+    pub(crate) summarize_end: usize,
+    pub(crate) retained_start: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CompactCarryOver {
+    pub(crate) summary: String,
+    pub(crate) recent_files: Vec<String>,
+    pub(crate) recent_file_excerpts: Vec<RecentFileExcerpt>,
+    pub(crate) retrieved_memory: Vec<RetrievedMemoryCandidate>,
+    pub(crate) invoked_skills: Vec<InvokedSkillCarryOver>,
+    pub(crate) retained_hooks: Vec<RetainedContextCarryOver>,
+    pub(crate) retained_mcp: Vec<RetainedContextCarryOver>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InvokedSkillCarryOver {
+    pub(crate) name: String,
+    pub(crate) title: Option<String>,
+    pub(crate) scope: Option<String>,
+    pub(crate) display_path: Option<String>,
+    pub(crate) args: Option<String>,
+    pub(crate) instruction_preview: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RetainedContextCarryOver {
+    pub(crate) label: String,
+    pub(crate) source_descriptor: String,
+    pub(crate) detail: String,
+    pub(crate) inclusion_reason: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct CompactionSummaryTimeout;
+
+impl std::fmt::Display for CompactionSummaryTimeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "history compaction timed out after {} seconds",
+            COMPACTION_SUMMARY_TIMEOUT.as_secs()
+        )
+    }
+}
+
+impl std::error::Error for CompactionSummaryTimeout {}
+
+#[derive(Debug, Clone, Default)]
+pub struct CompactState {
+    pub estimated_history_tokens: usize,
+    pub context_window_tokens: Option<usize>,
+    pub compact_threshold_tokens: usize,
+    pub reserved_output_tokens: usize,
+    pub compaction_count: usize,
+    pub last_compaction_before_tokens: Option<usize>,
+    pub last_compaction_after_tokens: Option<usize>,
+    pub last_compaction_recent_files: Vec<String>,
+    pub last_compaction_boundary: Option<CompactBoundaryMetadata>,
+    pub consecutive_auto_compaction_failures: usize,
+    pub auto_compaction_retry_after_tokens: Option<usize>,
+}
+


### PR DESCRIPTION
Split src/agent/compact.rs (1522 lines) into:
- types.rs (116 lines): all type definitions and constants
- main.rs (~1325 lines): impl Agent + helper functions  
- tests.rs (~186 lines): test module

Visibility fixes: structs→pub(crate), fields→pub(crate), 3 Agent methods→pub(crate)