### PR TITLE
chore: clarify engineering guidance placement

### DIFF
--- a/.agents/skills/add_tests/SKILL.md
+++ b/.agents/skills/add_tests/SKILL.md
@@ -40,6 +40,17 @@ For a non-trivial change, choose the narrowest useful test surface:
 
 ## Repository-Specific Guidance
 
+### Assertion Style
+
+- Prefer object-level equality assertions when the whole value is the contract.
+- Use field-by-field assertions only when each field communicates a distinct
+  behavior or failure mode.
+- Avoid assertions that only check debug text when the same behavior can be
+  asserted through structured state or typed events.
+- Avoid mutating global process environment in tests. Prefer passing
+  environment-derived inputs through constructors, config structs, or small test
+  doubles.
+
 ### TUI Tests
 
 Common places:
@@ -77,6 +88,25 @@ Use snapshots for:
 - other transcript-heavy cards where ordering and grouping matter
 
 Do not use snapshots when a short structural assertion is enough.
+
+When a snapshot changes:
+
+- Review the generated snapshot text before accepting it.
+- Confirm that the visible ordering, labels, grouping, and truncation behavior
+  match the intended user-visible contract.
+- Do not accept snapshots only to make CI green.
+
+### Runtime / Protocol Tests
+
+For agent-loop, provider, Wire/ACP, or tool-result tests:
+
+- Assert structured request or event payloads where possible instead of
+  substring-matching serialized JSON.
+- Keep fixtures close to the behavior under test and avoid broad provider mocks
+  when a narrow fake backend is enough.
+- If a regression depends on transcript order, assert the ordered typed entries
+  first, then add rendered text or snapshot coverage only when the UI contract is
+  also affected.
 
 ## What Good Tests Look Like Here
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,30 @@ The current product direction is to make local inference a first-class path inst
 - Non-trivial behavior changes should add or update focused tests when practical.
 - Before implementing any non-trivial behavior change, first inspect the relevant Codex and Claude Code implementations, extract the interaction or runtime pattern that applies, write a short plan for how RARA should mirror or adapt it, and only then start implementation.
 
+## 3.1 Rust Engineering Rules
+
+- Avoid ambiguous positional booleans, numeric literals, or `Option` arguments in new APIs when they make call sites hard to read. Prefer enums, newtypes, named methods, or small parameter structs.
+- Prefer exhaustive `match` statements over wildcard arms when the variants are part of a meaningful state machine or protocol contract.
+- Newly introduced traits should include concise doc comments that explain the trait role and what implementors must preserve.
+- Keep modules private by default and expose public APIs intentionally through explicit module exports.
+- Do not add helper functions that are only used once unless they name a non-obvious invariant or isolate a testable boundary.
+- When adding a new concept, first check whether it belongs in an existing narrow crate/module or whether a small new module avoids growing a high-touch orchestration file.
+
+## 3.2 TUI Engineering Rules
+
+- Keep TUI state, display data, and rendering separate. State modules should not build Ratatui `Line`, `Span`, color, or layout objects.
+- Prefer semantic theme/style helpers over hardcoded colors. Avoid hardcoded white; use default foreground or theme constants unless a specific semantic color is required.
+- Use shared wrapping and display-sanitization helpers instead of hand-rolled wrapping, ANSI stripping, or width accounting in individual renderers.
+- User-visible TUI behavior changes should add or update focused render tests or snapshots when layout, ordering, labels, grouping, or card boundaries are the contract.
+- Review generated snapshot changes before accepting them. Do not update snapshots just because the test output changed.
+
+## 3.3 Runtime Prompt And Tool Guidance
+
+- Rules that shape agent behavior across all tasks belong in the default prompt only when they materially affect task completion, correctness, or safety.
+- Tool-selection rules belong in the relevant tool descriptions when the model needs the rule at call time.
+- RARA repository maintenance rules belong in this file, specs, or skills instead of being added to every runtime prompt.
+- Keep prompt-section order stable. New prompt material should prefer additive sections near related guidance instead of reordering existing sections, to preserve provider cache-prefix stability.
+
 ## 4. Current Key Decisions
 
 1. Local model support uses Hugging Face `candle` from the upstream `main` branch.

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -349,6 +349,19 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
             ),
         ),
         PromptSection::new(
+            "software_engineering_context",
+            section(
+                "Software Engineering Task Context",
+                &[
+                    "Most user requests in a repository are software-engineering tasks. Interpret terse or generic instructions in the current workspace context before treating them as abstract text transformations.",
+                    "If the user asks to rename, convert, clean up, review, fix, update, sync, merge, or continue something and local context can identify the target, inspect and act on the repository target instead of only explaining the phrase.",
+                    "When the target is ambiguous, search current files, git state, open PR state, available project docs, and recent runtime context before asking the user to restate information that can be discovered locally.",
+                    "Do not create planning, decision, analysis, README, or other documentation files unless the user explicitly asks for documentation.",
+                    "Keep user-visible updates concise: state what changed, what was verified, and what remains. Do not narrate private deliberation or every intermediate next step.",
+                ],
+            ),
+        ),
+        PromptSection::new(
             "communication",
             section(
                 "Communicating With The User",
@@ -360,6 +373,12 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "While working, only send short progress updates at meaningful milestones.",
                     "Write user-facing text in complete sentences and avoid unexplained internal shorthand.",
                     "Do not use a colon immediately before a tool call; write a normal sentence instead.",
+                    "User-facing text is rendered as GitHub-flavored Markdown in a terminal.",
+                    "Match Markdown structure to task complexity: simple answers should not use headings, while longer findings, reviews, plans, or validation reports may use short headings and concise bullet lists.",
+                    "Use fenced code blocks with language tags for multi-line code, commands, or structured examples. Use inline code for paths, commands, symbols, field names, and literal values.",
+                    "When referencing local code, prefer path:line locations when practical, and include only code snippets whose exact text is necessary to understand the point.",
+                    "Avoid large tables in normal terminal replies unless a comparison is clearly easier to read as a table.",
+                    "Avoid emojis unless the user explicitly asks for them.",
                     "Report outcomes faithfully. If something is not verified or not completed, say so plainly.",
                     "When you make a mistake, say so and fix it. Do not spiral into apology or self-deprecation.",
                 ],
@@ -1155,6 +1174,7 @@ mod tests {
         );
 
         for key in [
+            "software_engineering_context",
             "codebase_search_and_evidence",
             "external_sources_and_web_search",
             "task_workflow",
@@ -1168,6 +1188,42 @@ mod tests {
             );
         }
 
+        assert!(
+            effective
+                .text
+                .contains("Most user requests in a repository are software-engineering tasks.")
+        );
+        assert!(
+            effective.text.contains(
+                "Interpret terse or generic instructions in the current workspace context"
+            )
+        );
+        assert!(effective.text.contains(
+            "inspect and act on the repository target instead of only explaining the phrase"
+        ));
+        assert!(effective.text.contains(
+            "Do not create planning, decision, analysis, README, or other documentation files"
+        ));
+        assert!(
+            effective
+                .text
+                .contains("GitHub-flavored Markdown in a terminal")
+        );
+        assert!(
+            effective
+                .text
+                .contains("simple answers should not use headings")
+        );
+        assert!(
+            effective
+                .text
+                .contains("fenced code blocks with language tags")
+        );
+        assert!(effective.text.contains("path:line locations"));
+        assert!(effective.text.contains("Avoid large tables"));
+        assert!(effective.text.contains("Avoid emojis"));
+        assert!(!effective.text.contains("Specification-Driven Development"));
+        assert!(!effective.text.contains("SDD"));
         assert!(
             effective
                 .text

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -57,12 +57,27 @@ The effective prompt is assembled in this order:
 
 The default base prompt includes source-grounded engineering workflow guidance for:
 
+- software-engineering task interpretation for terse repository instructions;
+- terminal Markdown output rules for user-facing assistant text;
 - factual verification before claims about repository, PR, CI, provider, or local-tool behavior;
 - external-source and web-search selection, including when to prefer local source, GitHub tooling,
   MCP resources, upstream open-source documentation, or fetched web evidence;
 - structured tool use, including edit-tool discipline and unfiltered command-output inspection;
 - reviewable implementation workflow, focused validation, and PR hygiene;
 - Git conflict resolution when conflict markers are present.
+
+Software-engineering task interpretation is adapted from Claude-style task framing. In a repository,
+short user requests such as "rename this", "clean it up", "continue", or "review this" should be
+interpreted against the current workspace, git state, PR state, project docs, and runtime
+context before being treated as abstract prose. The model should inspect and act on discoverable
+repository targets rather than returning a text-only transformation.
+
+Terminal Markdown guidance is adapted from Claude Code's terminal harness behavior and Codex's TUI
+markdown-rendering contract. The default prompt should tell the model that user-facing text is
+GitHub-flavored Markdown rendered in a terminal, match structure to task complexity, avoid headings
+for simple answers, use concise bullets for longer reports, use language-tagged fenced code blocks
+for multi-line code or commands, prefer `path:line` code references, avoid large tables unless they
+improve comparison, and avoid emojis unless explicitly requested.
 
 Git conflict guidance is intentionally conservative. It tells the model to inspect the current git
 state and conflicted file, preserve complementary changes instead of blindly choosing one side, use
@@ -89,6 +104,25 @@ resources, or project-provided references over secondary summaries, and should f
 content before treating search results as evidence when a page-open/fetch tool is available. If web
 tools are unavailable or fail, the model should report that limitation instead of pretending to
 browse.
+
+### 3.2) Guidance Placement Rules
+
+Prompt guidance is intentionally split by responsibility:
+
+- Runtime system prompt: behavior that materially affects task completion, correctness, safety,
+  evidence quality, memory staleness, and agent-loop continuation.
+- Tool descriptions and input schemas: call-time constraints such as shell-vs-PTY selection,
+  dedicated file/edit tool preference, `cwd` handling, background task controls, and stdout/stderr
+  handling.
+- Workspace instruction files such as `AGENTS.md`: repository-maintenance conventions, Rust API
+  style, TUI module boundaries, snapshot expectations, commit rules, and documentation workflow.
+- Skills: deeper task-specific workflows that should be loaded only when relevant.
+
+This mirrors the Codex/Claude split without copying product-specific internals into every turn.
+New always-on prompt text should be rare, additive, and placed near related sections without
+reordering existing prompt sections, because stable prefixes matter for provider prompt-cache reuse.
+RARA-specific documentation conventions such as SDD, journals, and TODO hygiene belong in
+workspace instructions and documentation, not in the default runtime system prompt.
 
 ### 4) Compact Prompt
 
@@ -189,4 +223,5 @@ browse.
 - [2026-04-24-context-observability-and-restore](../journal/2026-04-24-context-observability-and-restore.md)
 - [2026-04-25-context-assembly-stage1](../journal/2026-04-25-context-assembly-stage1.md)
 - [2026-05-02-git-conflict-prompt-guidance](../journal/2026-05-02-git-conflict-prompt-guidance.md)
+- [2026-05-07-engineering-guidance-placement](../journal/2026-05-07-engineering-guidance-placement.md)
 - [Runtime Control Plane](runtime-control-plane.md)

--- a/docs/journal/2026-05-07-engineering-guidance-placement.md
+++ b/docs/journal/2026-05-07-engineering-guidance-placement.md
@@ -1,0 +1,42 @@
+# Engineering Guidance Placement
+
+## Summary
+
+RARA now records a clearer split between always-on runtime prompt rules, tool
+description rules, repository engineering conventions, and task-specific skills.
+
+## Background
+
+Codex and Claude Code both carry software-engineering guidance, but they place
+different rules at different layers. Broad agent behavior belongs in the runtime
+prompt, call-time tool constraints belong in tool descriptions, and repository
+maintenance conventions belong in workspace instructions or skills.
+
+## Scope
+
+- Added a small runtime prompt section for software-engineering task framing.
+- Added terminal Markdown output guidance to the runtime prompt.
+- Kept RARA-specific SDD, journal, and TODO rules out of the default runtime
+  prompt.
+- Added Rust, TUI, prompt-placement, and testing conventions to repository
+  guidance.
+
+## Key Decisions
+
+- The default runtime prompt may tell the model to interpret terse repository
+  requests in the current workspace context.
+- User-facing assistant text is terminal-rendered GitHub-flavored Markdown, so
+  prompt guidance should prefer concise structure, language-tagged code fences,
+  `path:line` references, and no emojis unless requested.
+- The default runtime prompt must not encode RARA-only documentation workflow
+  terms such as SDD or journal requirements.
+- `AGENTS.md` is the right home for RARA repository maintenance rules.
+- Test-skill guidance is the right home for deeper assertion, snapshot, and
+  protocol-test expectations.
+
+## Validation
+
+- Focused prompt tests should assert that the new software-engineering section
+  is present.
+- Focused prompt tests should also assert that RARA-only SDD terminology is not
+  injected into the default runtime prompt.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -121,6 +121,7 @@ Active backlog only. Keep this file small and current.
 - [x] Tool-action summaries more source-aware and file-aware.
 - [ ] Live `bash` transcript: lifecycle framing, streamed stdout/stderr, long-output folding.
 - [ ] High-fidelity render pass for `write/update`, inline diffs, approval cards, message-card hierarchy.
+- [ ] Strengthen terminal Markdown rendering parity: GitHub-flavored Markdown coverage, local file-link rendering, fenced code blocks, list wrapping, and focused snapshot coverage.
 - [ ] Expand TUI snapshot coverage.
 - [ ] Keep transcript and pending-interaction state backed by structured events that ACP/Wire output subscribers can reuse.
 - [x] Add first-class todo sections to `/context` and `/status` from `TodoContextView`.


### PR DESCRIPTION
## Summary

- add a small default prompt section for software-engineering task framing
- document where runtime prompt, tool descriptions, AGENTS rules, and skills should live
- add RARA Rust/TUI engineering conventions and stronger testing-skill guidance

## Notes

- RARA-specific SDD, journal, and TODO workflow rules remain project guidance, not default runtime prompt content.
- The prompt test now asserts that the default runtime prompt includes software-engineering task framing and does not inject SDD terminology.

## Validation

- `cargo test -p rara-instructions prompt -- --nocapture`
- `cargo check` (passes with existing warnings)
