### PR TITLE
feat: add file search crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,6 +5589,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7338,6 +7354,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nucleo"
+version = "0.5.0"
+source = "git+https://github.com/helix-editor/nucleo.git?rev=4253de9faabb4e5c6d81d946a5e35a90f87347ee#4253de9faabb4e5c6d81d946a5e35a90f87347ee"
+dependencies = [
+ "nucleo-matcher",
+ "parking_lot",
+ "rayon",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "git+https://github.com/helix-editor/nucleo.git?rev=4253de9faabb4e5c6d81d946a5e35a90f87347ee#4253de9faabb4e5c6d81d946a5e35a90f87347ee"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -9204,6 +9239,7 @@ dependencies = [
  "rand 0.10.1",
  "rara-bedrock",
  "rara-config",
+ "rara-file-search",
  "rara-instructions",
  "rara-provider-catalog",
  "rara-sandbox",
@@ -9258,6 +9294,17 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "rara-file-search"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ignore",
+ "nucleo",
+ "serde",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     ".",
     "crates/bedrock",
     "crates/config",
+    "crates/file-search",
     "crates/instructions",
     "crates/provider-catalog",
     "crates/sandbox",
@@ -25,6 +26,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1.2"
 tempfile = "3.17"
+ignore = "0.4.23"
+nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
 codex-execpolicy = { git = "https://github.com/openai/codex", package = "codex-execpolicy", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
 
 [package]
@@ -56,6 +59,7 @@ sha2 = "0.11"
 secrecy = { version = "0.10", features = ["serde"] }
 rara-config = { path = "crates/config" }
 rara-bedrock = { path = "crates/bedrock" }
+rara-file-search = { path = "crates/file-search" }
 rara-instructions = { path = "crates/instructions" }
 rara-provider-catalog = { path = "crates/provider-catalog" }
 rara-sandbox = { path = "crates/sandbox" }

--- a/crates/file-search/Cargo.toml
+++ b/crates/file-search/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rara-file-search"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+ignore = { workspace = true }
+nucleo = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/file-search/src/lib.rs
+++ b/crates/file-search/src/lib.rs
@@ -1,0 +1,334 @@
+use std::cmp::Ordering;
+use std::num::NonZero;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use ignore::WalkBuilder;
+use ignore::overrides::OverrideBuilder;
+use nucleo::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
+use nucleo::{Config, Matcher, Utf32Str};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MatchType {
+    File,
+    Directory,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileMatch {
+    pub score: u32,
+    pub path: PathBuf,
+    pub root: PathBuf,
+    pub match_type: MatchType,
+}
+
+impl FileMatch {
+    pub fn full_path(&self) -> PathBuf {
+        self.root.join(&self.path)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileEntry {
+    pub path: PathBuf,
+    pub root: PathBuf,
+    pub match_type: MatchType,
+}
+
+impl FileEntry {
+    pub fn full_path(&self) -> PathBuf {
+        self.root.join(&self.path)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FileSearchOptions {
+    pub limit: NonZero<usize>,
+    pub exclude: Vec<String>,
+    pub respect_gitignore: bool,
+    pub include_hidden: bool,
+    pub follow_links: bool,
+}
+
+impl Default for FileSearchOptions {
+    fn default() -> Self {
+        Self {
+            #[expect(clippy::unwrap_used)]
+            limit: NonZero::new(64).unwrap(),
+            exclude: Vec::new(),
+            respect_gitignore: true,
+            include_hidden: true,
+            follow_links: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileSearchResults {
+    pub matches: Vec<FileMatch>,
+    pub total_match_count: usize,
+    pub scanned_entry_count: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileListResults {
+    pub entries: Vec<FileEntry>,
+    pub total_entry_count: usize,
+    pub truncated: bool,
+}
+
+pub fn search_files(
+    pattern_text: &str,
+    roots: Vec<PathBuf>,
+    options: FileSearchOptions,
+) -> Result<FileSearchResults> {
+    let entries = collect_entries(&roots, &options)?;
+    let pattern = Pattern::new(
+        pattern_text,
+        CaseMatching::Ignore,
+        Normalization::Smart,
+        AtomKind::Fuzzy,
+    );
+    let mut matcher = Matcher::new(Config::DEFAULT.match_paths());
+    let mut utf32buf = Vec::<char>::new();
+    let mut matches = entries
+        .iter()
+        .filter_map(|entry| {
+            let text = entry.path.to_string_lossy();
+            utf32buf.clear();
+            let haystack = Utf32Str::new(&text, &mut utf32buf);
+            pattern
+                .score(haystack, &mut matcher)
+                .map(|score| FileMatch {
+                    score,
+                    path: entry.path.clone(),
+                    root: entry.root.clone(),
+                    match_type: entry.match_type,
+                })
+        })
+        .collect::<Vec<_>>();
+    matches.sort_by(cmp_match);
+
+    let total_match_count = matches.len();
+    let limit = options.limit.get();
+    let truncated = total_match_count > limit;
+    matches.truncate(limit);
+
+    Ok(FileSearchResults {
+        matches,
+        total_match_count,
+        scanned_entry_count: entries.len(),
+        truncated,
+    })
+}
+
+pub fn list_files(root: impl Into<PathBuf>, options: FileSearchOptions) -> Result<FileListResults> {
+    let mut entries = collect_entries(&[root.into()], &options)?;
+    entries.retain(|entry| entry.match_type == MatchType::File);
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let total_entry_count = entries.len();
+    let limit = options.limit.get();
+    let truncated = total_entry_count > limit;
+    entries.truncate(limit);
+
+    Ok(FileListResults {
+        entries,
+        total_entry_count,
+        truncated,
+    })
+}
+
+fn collect_entries(roots: &[PathBuf], options: &FileSearchOptions) -> Result<Vec<FileEntry>> {
+    let Some(first_root) = roots.first() else {
+        anyhow::bail!("at least one search root is required");
+    };
+    let override_matcher = build_override_matcher(first_root, &options.exclude)?;
+    let mut walk_builder = WalkBuilder::new(first_root);
+    for root in roots.iter().skip(1) {
+        walk_builder.add(root);
+    }
+    walk_builder
+        .hidden(!options.include_hidden)
+        .follow_links(options.follow_links)
+        .require_git(true);
+    if !options.respect_gitignore {
+        walk_builder
+            .git_ignore(false)
+            .git_global(false)
+            .git_exclude(false)
+            .ignore(false)
+            .parents(false);
+    }
+    if let Some(override_matcher) = override_matcher {
+        walk_builder.overrides(override_matcher);
+    }
+
+    let mut entries = Vec::new();
+    for entry in walk_builder.build() {
+        let entry = entry?;
+        let path = entry.path();
+        if path == first_root {
+            continue;
+        }
+        let Some((root, relative_path)) = relative_entry(path, roots) else {
+            continue;
+        };
+        let match_type = if entry
+            .file_type()
+            .is_some_and(|file_type| file_type.is_dir())
+        {
+            MatchType::Directory
+        } else {
+            MatchType::File
+        };
+        entries.push(FileEntry {
+            path: relative_path.to_path_buf(),
+            root: root.to_path_buf(),
+            match_type,
+        });
+    }
+    Ok(entries)
+}
+
+fn build_override_matcher(
+    root: &Path,
+    exclude: &[String],
+) -> Result<Option<ignore::overrides::Override>> {
+    if exclude.is_empty() {
+        return Ok(None);
+    }
+    let mut builder = OverrideBuilder::new(root);
+    for pattern in exclude {
+        builder
+            .add(&format!("!{pattern}"))
+            .with_context(|| format!("invalid exclude pattern {pattern:?}"))?;
+    }
+    Ok(Some(builder.build()?))
+}
+
+fn relative_entry<'a>(path: &'a Path, roots: &'a [PathBuf]) -> Option<(&'a Path, &'a Path)> {
+    let mut best_match: Option<&PathBuf> = None;
+    for root in roots {
+        if path.strip_prefix(root).is_ok() {
+            match best_match {
+                Some(best) if best.components().count() >= root.components().count() => {}
+                _ => best_match = Some(root),
+            }
+        }
+    }
+    let root = best_match?;
+    let relative = path.strip_prefix(root).ok()?;
+    Some((root.as_path(), relative))
+}
+
+fn cmp_match(a: &FileMatch, b: &FileMatch) -> Ordering {
+    b.score.cmp(&a.score).then_with(|| a.path.cmp(&b.path))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn list_files_respects_gitignore_inside_git_repo() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let root = tempdir.path();
+        fs::create_dir(root.join(".git")).expect("git dir");
+        fs::create_dir(root.join("src")).expect("src dir");
+        fs::create_dir(root.join("target")).expect("target dir");
+        fs::write(root.join(".gitignore"), "target/\n").expect("gitignore");
+        fs::write(root.join("src/main.rs"), "fn main() {}\n").expect("source");
+        fs::write(root.join("target/app"), "bin").expect("ignored");
+
+        let result = list_files(root, FileSearchOptions::default()).expect("list files");
+        let rendered = render_entries(&result.entries);
+
+        assert!(contains_entry(&rendered, "src/main.rs"));
+        assert!(!contains_entry(&rendered, "target/app"));
+    }
+
+    #[test]
+    fn list_files_can_include_ignored_entries() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let root = tempdir.path();
+        fs::create_dir(root.join(".git")).expect("git dir");
+        fs::create_dir(root.join("target")).expect("target dir");
+        fs::write(root.join(".gitignore"), "target/\n").expect("gitignore");
+        fs::write(root.join("target/app"), "bin").expect("ignored");
+
+        let result = list_files(
+            root,
+            FileSearchOptions {
+                respect_gitignore: false,
+                ..FileSearchOptions::default()
+            },
+        )
+        .expect("list files");
+
+        assert!(contains_entry(
+            &render_entries(&result.entries),
+            "target/app"
+        ));
+    }
+
+    #[test]
+    fn list_files_is_bounded_and_stably_sorted() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let root = tempdir.path();
+        fs::write(root.join("b.txt"), "b").expect("b");
+        fs::write(root.join("a.txt"), "a").expect("a");
+        fs::write(root.join("c.txt"), "c").expect("c");
+
+        let result = list_files(
+            root,
+            FileSearchOptions {
+                #[expect(clippy::unwrap_used)]
+                limit: NonZero::new(2).unwrap(),
+                ..FileSearchOptions::default()
+            },
+        )
+        .expect("list files");
+
+        assert_eq!(render_entries(&result.entries), vec!["a.txt", "b.txt"]);
+        assert_eq!(result.total_entry_count, 3);
+        assert!(result.truncated);
+    }
+
+    #[test]
+    fn search_files_ranks_fuzzy_matches() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let root = tempdir.path();
+        fs::create_dir(root.join("src")).expect("src");
+        fs::write(root.join("src/context_display.rs"), "").expect("context");
+        fs::write(root.join("src/terminal.rs"), "").expect("terminal");
+
+        let result = search_files(
+            "ctxdisplay",
+            vec![root.to_path_buf()],
+            FileSearchOptions::default(),
+        )
+        .expect("search files");
+
+        assert_eq!(
+            result.matches[0].path,
+            PathBuf::from("src/context_display.rs")
+        );
+    }
+
+    fn render_entries(entries: &[FileEntry]) -> Vec<String> {
+        entries
+            .iter()
+            .map(|entry| entry.path.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn contains_entry(entries: &[String], expected: &str) -> bool {
+        entries.iter().any(|entry| entry == expected)
+    }
+}

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -45,6 +45,8 @@ future appserver integrations can use.
   reconnect, resource, and Tool Search contracts.
 - `bedrock-backend.md`: Bedrock SDK backend crate boundary and RARA adapter
   contract.
+- `file-search.md`: shared gitignore-aware file discovery and fuzzy path
+  ranking crate for tools, TUI pickers, and context routing.
 
 ## Release Specs
 

--- a/docs/features/file-search.md
+++ b/docs/features/file-search.md
@@ -1,0 +1,109 @@
+# File Search
+
+RARA provides a shared file-search crate for workspace file discovery.
+The crate is intentionally separate from model-facing tools so TUI pickers,
+context routing, skills, and tool adapters can share the same traversal and
+ranking behavior.
+
+## Problem
+
+RARA's file discovery behavior was split across `list_files`, `glob`, and
+`grep`, with directory filtering implemented as local hard-coded path checks.
+That made ignore behavior less accurate than ripgrep-style traversal and left
+no reusable search primitive for TUI file pickers or context file routing.
+
+## Scope
+
+The first implementation introduces a reusable file-search crate and routes the
+`list_files` tool through it.
+
+In scope:
+
+- Use git-aware ignore semantics instead of ad hoc directory filtering.
+- Keep file discovery bounded and stable for model-facing tool results.
+- Provide fuzzy path ranking for future TUI pickers and context file routing.
+- Keep RARA-specific policy, such as build-artifact suppression, outside the
+  generic crate.
+
+## Non-Goals
+
+- Replace content search in `grep`.
+- Add a TUI file picker in the first slice.
+- Inject selected files into context automatically.
+- Persist file-search indexes.
+
+## Architecture
+
+`crates/file-search` is a pure library crate. It owns traversal, fuzzy matching,
+stable ordering, and result metadata. Tool adapters decide which options to use
+for their model-facing contracts.
+
+This mirrors Codex's separation between a file-search crate and higher-level UI
+or CLI consumers while keeping RARA-specific tool policy out of the shared
+crate.
+
+## Contracts
+
+`crates/file-search` exposes:
+
+- `list_files(root, options)` for bounded file listing.
+- `search_files(query, roots, options)` for fuzzy path search.
+- structured results with relative path, root, match type, total count, and
+  truncation status.
+
+Traversal uses the `ignore` crate, following the same family of behavior used
+by ripgrep. Fuzzy path ranking uses `nucleo`.
+
+The crate defaults to:
+
+- respecting git ignore files;
+- applying `.gitignore` only in a git context;
+- including hidden entries;
+- following symlinks;
+- returning stable path ordering for plain listing;
+- sorting fuzzy matches by score descending, then path ascending.
+
+### Tool Adapter Policy
+
+The `list_files` tool uses the shared crate but preserves RARA's model-facing
+contract:
+
+- output remains a `files` array;
+- results are bounded by `limit`;
+- `total_count` and `truncated` report omitted entries;
+- `include_ignored` disables both gitignore handling and RARA build-artifact
+  suppression.
+
+The tool adapter owns RARA-specific default excludes such as `target`,
+`node_modules`, `dist`, and virtual environments. Those excludes do not belong
+in the generic crate because other callers may need exact git-aware traversal.
+
+## Validation Matrix
+
+- `.gitignore` in a git workspace suppresses ignored files.
+- `respect_gitignore = false` includes ignored entries.
+- plain listing is stable and bounded.
+- fuzzy search ranks matching paths.
+- `list_files` still suppresses build artifacts by default.
+- `list_files include_ignored=true` includes those artifacts.
+- `list_files limit` reports `total_count` and `truncated`.
+
+## Open Risks
+
+- The current crate performs a fresh walk per call. Large-workspace TUI pickers
+  should use a session-style incremental search surface instead.
+- `glob` and `grep` still have their own traversal paths. They should move to
+  the shared crate only when their output contracts and ignore semantics are
+  updated deliberately.
+- File search is not yet connected to `MemorySelection`; automatic context
+  injection must preserve budget and cache-prefix stability.
+
+## Follow-Up
+
+Future work should add a session-style incremental search surface for TUI
+pickers, then use the same crate for context file routing before injecting
+candidate files into `MemorySelection`.
+
+## Source Journals
+
+- `docs/journal/2026-05-07-file-search-crate.md`

--- a/docs/journal/2026-05-07-file-search-crate.md
+++ b/docs/journal/2026-05-07-file-search-crate.md
@@ -1,0 +1,23 @@
+# File Search Crate
+
+Introduced `crates/file-search` as the shared workspace file-discovery layer.
+
+Implemented:
+
+- gitignore-aware traversal through `ignore`;
+- fuzzy path ranking through `nucleo`;
+- bounded file listing with total count and truncation metadata;
+- stable ordering for list results and fuzzy score tie-breaks;
+- `list_files` tool adapter using the new crate while preserving RARA's
+  build-artifact suppression policy.
+
+Validation:
+
+- `cargo test -p rara-file-search -- --nocapture`
+- `cargo test tools::file::tests::list_files_skips_build_artifacts_by_default -- --nocapture`
+
+Observed existing noise:
+
+- root crate tests still emit unrelated dead-code warnings;
+- macOS linker warned that the `__eh_frame` section is too large during the
+  focused root test link.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -44,6 +44,7 @@ Active backlog only. Keep this file small and current.
 
 ## Workspace / Skills / Prompt Sources
 
+- [ ] Add session-style incremental file search for TUI file pickers and context file routing on top of `crates/file-search`.
 - [ ] Tests for workspace prompt-source discovery and cache invalidation (cwd changes, git branches, nested workspaces).
 - [ ] Define `WorkspaceMemory` cache invalidation rules for prompt files and environment info.
 - [ ] Unify `discover_prompt_sources()` and TUI `/status` source reporting.

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -1,15 +1,16 @@
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader};
+use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
 use async_trait::async_trait;
+use rara_file_search::{FileSearchOptions, list_files};
 use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader as AsyncBufReader};
-use walkdir::WalkDir;
 
 use crate::tool::{Tool, ToolError};
 
@@ -756,7 +757,8 @@ pub struct ListFilesTool;
         "type": "object",
         "properties": {
             "path": { "type": "string" },
-            "include_ignored": { "type": "boolean" }
+            "include_ignored": { "type": "boolean" },
+            "limit": { "type": "integer", "minimum": 1, "default": 200 }
         },
         "required": ["path"]
     }
@@ -771,33 +773,52 @@ impl Tool for ListFilesTool {
             .get("include_ignored")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        let files: Vec<String> = WalkDir::new(p)
-            .into_iter()
-            .filter_entry(|entry| include_ignored || !is_ignored_path(entry.path()))
-            .filter_map(|e| e.ok())
-            .map(|e| e.path().display().to_string())
-            .collect();
-        Ok(json!({ "files": files }))
+        let limit = optional_positive_usize(&i, "limit")?.unwrap_or(200);
+        let limit = NonZero::new(limit)
+            .ok_or_else(|| ToolError::InvalidInput("limit must be >= 1".into()))?;
+        let result = list_files(
+            p,
+            FileSearchOptions {
+                limit,
+                exclude: if include_ignored {
+                    Vec::new()
+                } else {
+                    default_list_files_excludes()
+                },
+                respect_gitignore: !include_ignored,
+                ..FileSearchOptions::default()
+            },
+        )
+        .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
+        let files = result
+            .entries
+            .iter()
+            .map(|entry| entry.full_path().display().to_string())
+            .collect::<Vec<_>>();
+        Ok(json!({
+            "files": files,
+            "total_count": result.total_entry_count,
+            "truncated": result.truncated,
+        }))
     }
 }
 
-fn is_ignored_path(path: &Path) -> bool {
-    path.components().any(|component| {
-        let name = component.as_os_str().to_string_lossy();
-        matches!(
-            name.as_ref(),
-            ".git"
-                | "target"
-                | "node_modules"
-                | "dist"
-                | "build"
-                | ".next"
-                | ".cache"
-                | "__pycache__"
-                | ".venv"
-                | "venv"
-        )
-    })
+fn default_list_files_excludes() -> Vec<String> {
+    [
+        ".git/**",
+        "target/**",
+        "node_modules/**",
+        "dist/**",
+        "build/**",
+        ".next/**",
+        ".cache/**",
+        "__pycache__/**",
+        ".venv/**",
+        "venv/**",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
 }
 
 fn preview_snippet(value: &str) -> String {

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -187,6 +187,52 @@ async fn list_files_skips_build_artifacts_by_default() {
 }
 
 #[tokio::test]
+async fn list_files_can_include_build_artifacts_when_requested() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let root = tempdir.path();
+    std::fs::create_dir_all(root.join("target/debug")).expect("mkdir target");
+    std::fs::write(root.join("target/debug/app"), "bin").expect("write artifact");
+
+    let tool = ListFilesTool;
+    let result = tool
+        .call(json!({
+            "path": root.display().to_string(),
+            "include_ignored": true
+        }))
+        .await
+        .expect("list files");
+    let files = result["files"].as_array().expect("files array");
+    let rendered = files
+        .iter()
+        .filter_map(|value| value.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("target/debug/app"));
+}
+
+#[tokio::test]
+async fn list_files_reports_limit_and_truncated_status() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let root = tempdir.path();
+    std::fs::write(root.join("a.txt"), "a").expect("write a");
+    std::fs::write(root.join("b.txt"), "b").expect("write b");
+
+    let tool = ListFilesTool;
+    let result = tool
+        .call(json!({
+            "path": root.display().to_string(),
+            "limit": 1
+        }))
+        .await
+        .expect("list files");
+
+    assert_eq!(result["files"].as_array().expect("files array").len(), 1);
+    assert_eq!(result["total_count"], 2);
+    assert_eq!(result["truncated"], true);
+}
+
+#[tokio::test]
 async fn write_file_reports_created_or_overwritten() {
     let tempdir = tempfile::tempdir().expect("tempdir");
     let path = tempdir.path().join("sample.txt");


### PR DESCRIPTION
## Summary

- add a standalone `rara-file-search` crate with gitignore-aware traversal and fuzzy path ranking
- route the `list_files` tool through the shared crate while preserving RARA's default build-artifact suppression
- document the file-search contract, follow-up TUI/context routing work, and implementation checkpoint

## Testing

- `cargo test -p rara-file-search -- --nocapture`
- `cargo test tools::file::tests -- --nocapture`
- `cargo check`

## Notes

`cargo check` passes with existing unused/dead-code warnings in unrelated modules.
