### PR TITLE
feat: add retrieval orchestration view

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -47,6 +47,8 @@ future appserver integrations can use.
   contract.
 - `file-search.md`: shared gitignore-aware file discovery and fuzzy path
   ranking crate for tools, TUI pickers, and context routing.
+- `retrieval-orchestration.md`: unified candidate-provider, ranking, dedupe,
+  budget, and `/context` contract for memory/context retrieval.
 
 ## Release Specs
 

--- a/docs/features/context-architecture.md
+++ b/docs/features/context-architecture.md
@@ -541,6 +541,10 @@ RARA should therefore model:
 - `Retriever`
   - produces candidate memory/context items from one or more retrieval
     backends.
+- `RetrievalOrchestrator`
+  - normalizes candidates from multiple source providers, applies cross-source
+    ranking/dedupe inputs, and emits the structured provider/candidate view
+    consumed by `/context`, ACP/Wire, and `MemorySelection`.
 
 ### Required Backend Classes
 
@@ -638,6 +642,12 @@ The runtime should converge on interfaces similar to:
   - relationship traversal and neighborhood expansion;
 - `Retriever`
   - orchestrates vector + graph + metadata ranking;
+- `RetrievalSourceProvider`
+  - produces typed candidates from one source family without deciding prompt
+    injection;
+- `RetrievalOrchestrator`
+  - merges providers, preserves provenance, attaches drop reasons, and forwards
+    normalized candidates to `MemorySelection`;
 - `MemorySelection`
   - final selected records for the current turn.
 

--- a/docs/features/memory-selection.md
+++ b/docs/features/memory-selection.md
@@ -43,6 +43,7 @@ runtime sources for the turn are known.
 - a replacement for `ThreadStore`;
 - the compaction algorithm;
 - a vector or graph retrieval backend;
+- the cross-source retrieval orchestrator;
 - a transcript renderer.
 
 It may reference outputs from these systems, but it does not own their storage
@@ -75,11 +76,12 @@ memory-like sources and recall candidates.
 The relationship is:
 
 1. runtime state and prompt sources are collected;
-2. `MemorySelection` classifies memory-like inputs into selected, available, and
+2. retrieval orchestration normalizes source hits into ranked candidates;
+3. `MemorySelection` classifies memory-like inputs into selected, available, and
    dropped groups;
-3. `ContextAssembler` uses selected memory items together with non-memory
+4. `ContextAssembler` uses selected memory items together with non-memory
    context layers;
-4. backend-specific rendering serializes the final context for the model.
+5. backend-specific rendering serializes the final context for the model.
 
 This separation keeps instruction ordering and prompt-source precedence stable
 while still making recall decisions inspectable.
@@ -350,3 +352,4 @@ answer to:
 
 - `docs/journal/2026-04-25-context-assembly-stage1.md`
 - `docs/journal/2026-05-01-memory-selection-spec.md`
+- `docs/features/retrieval-orchestration.md`

--- a/docs/features/retrieval-orchestration.md
+++ b/docs/features/retrieval-orchestration.md
@@ -1,0 +1,360 @@
+# Retrieval Orchestration
+
+Retrieval orchestration is the runtime layer that turns many possible context
+sources into a small, ranked, explainable candidate set for `MemorySelection`.
+
+It is deliberately separate from storage backends, prompt assembly, and final
+selection. Storage systems find raw material. Orchestration normalizes and
+ranks candidates. `MemorySelection` decides what fits the current turn budget.
+
+## Problem
+
+RARA already has several recall-like sources:
+
+- workspace memory prompt sources;
+- LanceDB-backed `MemoryRecord` search;
+- per-session context shard search;
+- compacted history source descriptors;
+- active turn state such as plans, pending interactions, latest request, and
+  recent tool results;
+- future file-search candidates from `crates/file-search`;
+- future MCP resources, hook output, and protocol-registered sources.
+
+Without a retrieval orchestration boundary, each source can leak directly into
+prompt assembly with its own ranking, dedupe, budget, and debug story. That
+makes `/context` less useful and makes ACP/Wire integration hard because there
+is no single structured candidate view to expose.
+
+## Scope
+
+This spec defines the target boundary and rollout path for a unified retrieval
+orchestration layer.
+
+In scope:
+
+- normalize memory-like and context-like source hits into typed candidates;
+- preserve provenance, scope, source id, ranking inputs, and budget estimates;
+- merge candidates from thread, workspace, session shard, file search, MCP,
+  hook, and future graph/vector sources;
+- provide deterministic ordering and explicit reasons for selection,
+  availability, and drops;
+- keep `/context`, `/status`, ACP, and Wire reading the same structured view.
+
+Out of scope for this spec:
+
+- implementing every backend source at once;
+- replacing `MemoryStore`, `ThreadStore`, or LanceDB internals;
+- changing the stable prompt prefix;
+- persisting volatile retrieval candidates as ordinary chat history;
+- auto-injecting file-search results before they pass through
+  `MemorySelection`.
+
+## Architecture
+
+The target pipeline has five stages:
+
+1. **Source discovery**
+   - Collect source providers available for the turn.
+   - Examples: active prompt sources, `MemoryStore`, session context shards,
+     file-search provider, MCP resource provider, hook context provider.
+
+2. **Candidate production**
+   - Each provider returns `RetrievalCandidate` values.
+   - Providers own source-specific search and metadata extraction.
+   - Providers do not decide prompt injection.
+
+3. **Orchestration**
+   - Merge candidates.
+   - Normalize scores and priorities.
+   - Apply source ownership rules and dedupe keys.
+   - Attach budget estimates and control-plane visibility fields.
+
+4. **Selection**
+   - Pass normalized candidates to `MemorySelection`.
+   - `MemorySelection` decides selected, available, and dropped items based on
+     fixed context, ranking, dedupe, and remaining budget.
+
+5. **Assembly**
+   - `ContextAssembler` injects selected volatile retrieval only in the volatile
+     suffix near the latest user request.
+   - Stable prompt prefixes remain byte-stable.
+
+Current code already has part of this shape:
+
+- `MemoryRetrievalOrchestrator` retrieves workspace memory and session context
+  candidates;
+- `RetrievalCandidate` and `RetrievalSourceRef` provide the first typed
+  candidate boundary for direct memory/session retrieval inputs;
+- `memory_selection()` ranks selected/available/dropped entries;
+- `SharedRuntimeContext.retrieval.memory_selection` is consumed by `/context`.
+
+The remaining missing layer is a source-provider contract and orchestration view
+shared by current memory retrieval and future file/MCP/hook/graph sources.
+
+## Candidate Contract
+
+Target candidate shape:
+
+```rust
+pub struct RetrievalCandidate {
+    pub id: String,
+    pub source: RetrievalSourceRef,
+    pub kind: RetrievalCandidateKind,
+    pub scope: RetrievalScope,
+    pub label: String,
+    pub detail: String,
+    pub summary: Option<String>,
+    pub rank: usize,
+    pub score: Option<f32>,
+    pub priority: usize,
+    pub dedupe_key: Option<String>,
+    pub budget_impact_tokens: Option<usize>,
+    pub selection_reason: String,
+    pub availability_reason: String,
+}
+```
+
+Required source fields:
+
+- stable source type, such as `memory_record`, `session_context`, `file_search`,
+  `mcp_resource`, `hook_output`, `graph_context`;
+- source id, if durable;
+- source path or URI, if available;
+- session id / thread id / workspace id where applicable;
+- freshness metadata such as created/updated time when available.
+
+Candidates must be deterministic:
+
+- same source inputs produce the same `id`, `dedupe_key`, and ordering;
+- ties are broken by source priority, rank, then stable label/id;
+- hash maps must not define externally visible ordering.
+
+## Source Providers
+
+Target trait shape:
+
+```rust
+pub trait RetrievalSourceProvider {
+    fn source_kind(&self) -> &'static str;
+
+    async fn candidates(
+        &self,
+        request: &RetrievalRequest,
+    ) -> anyhow::Result<Vec<RetrievalCandidate>>;
+}
+```
+
+`RetrievalRequest` should include:
+
+- latest user request text;
+- current session/thread/workspace ids;
+- execution mode;
+- budget hints;
+- enabled source classes;
+- optional query embedding;
+- current stable prompt-source manifest;
+- recent active-turn tool/result manifest.
+
+Provider responsibilities:
+
+- `MemoryStoreProvider`: search workspace/thread `MemoryRecord`s through
+  LanceDB-backed APIs.
+- `SessionShardProvider`: search per-session context shards.
+- `FileSearchProvider`: produce file candidates from `crates/file-search`;
+  it must not inject file contents directly.
+- `McpResourceProvider`: surface referenced MCP resources as candidates.
+- `HookContextProvider`: surface hook output as volatile candidates.
+- `GraphProvider`: later graph/vector composed context.
+
+## Ranking And Dedupe
+
+Orchestration owns cross-source ordering inputs. `MemorySelection` owns final
+budget decisions.
+
+Initial priority order:
+
+1. active fixed context already selected by owner layers;
+2. focused session/thread context relevant to the current request;
+3. workspace memory records;
+4. file candidates;
+5. MCP resource candidates;
+6. hook output;
+7. graph expansion candidates until graph confidence is proven.
+
+Initial dedupe rules:
+
+- compacted thread history beats raw thread history;
+- focused session context beats raw thread history;
+- selected workspace prompt memory beats duplicate retrieved workspace memory;
+- a memory record beats a file candidate when both point to the same durable
+  fact;
+- exact same source id and content hash dedupe to the highest-priority
+  candidate;
+- file candidates dedupe by canonical path;
+- MCP candidates dedupe by resource URI.
+
+Dropped candidates must retain the winning reason:
+
+- `deduped_by=<candidate id>`;
+- `budget_exceeded`;
+- `source_disabled`;
+- `below_score_threshold`;
+- `stale_or_superseded`;
+- `already_in_stable_prompt`;
+- `covered_by_compaction`.
+
+## Budget And Cache Stability
+
+Stable prefix order must remain:
+
+1. system prompt;
+2. tool schemas;
+3. stable skills and project memory;
+4. compacted history and carry-over;
+5. retrieval and volatile recent context;
+6. latest user input.
+
+Retrieved candidates belong in the volatile suffix unless explicitly promoted to
+workspace memory.
+
+Budget rules:
+
+- fixed selected items can report cost but do not consume retrieval budget;
+- volatile retrieval candidates consume `retrieved_memory_budget`;
+- file-search candidates should initially charge only manifest text, not file
+  contents;
+- selected file contents, when added later, must charge their rendered excerpt
+  cost;
+- per-source budgets should be explicit so one backend cannot starve all other
+  sources silently.
+
+## Future Compression Boundary
+
+Retrieval orchestration may later ask a compression stage to produce compact
+candidate summaries, but that is not part of the current rollout and must stay
+outside the stable prompt prefix.
+
+Do not start auxiliary/lite-model compaction until context observability is
+complete enough to show provider status, candidate status, budget usage, drop
+reasons, and injected summary provenance in `/context` and the future OTEL
+event stream.
+
+Rules:
+
+- keep compression behind an explicit provider capability and feature gate;
+- keep the original candidate detail available for `/context` and auditability;
+- record whether a candidate summary was generated by the main model,
+  auxiliary model, or a deterministic local compactor;
+- never use compression output to overwrite durable memory records unless the
+  user explicitly requests promotion or memory update.
+
+If this becomes necessary later, reuse the existing auxiliary-model routing
+instead of creating a separate `lite` model concept inside retrieval.
+
+## Runtime And Control Plane Contract
+
+The orchestration result should be a structured runtime artifact:
+
+```rust
+pub struct RetrievalOrchestrationView {
+    pub request_id: String,
+    pub query: String,
+    pub providers: Vec<RetrievalProviderStatus>,
+    pub candidates: Vec<RetrievalCandidateView>,
+    pub selected: Vec<RetrievalCandidateView>,
+    pub available: Vec<RetrievalCandidateView>,
+    pub dropped: Vec<RetrievalCandidateView>,
+    pub budget: RetrievalBudgetView,
+}
+```
+
+This view must be readable by:
+
+- `/context`;
+- `/status` summary;
+- ACP/Wire subscribers;
+- future OTEL exporters.
+
+Protocol adapters must not concatenate raw retrieved text into prompts. They may
+register source providers or request retrieval, but final injection stays behind
+`MemorySelection` and `ContextAssembler`.
+
+## `/context` Display Contract
+
+`/context` should answer:
+
+- which providers ran;
+- which providers were skipped and why;
+- which candidates were produced;
+- which candidates were selected;
+- which candidates were available but omitted;
+- which candidates were dropped by dedupe, ranking, or budget;
+- how much budget selected candidates consumed;
+- whether the injected material is stable or volatile.
+
+The display should keep details compact and path/URI-like fields visible.
+
+## Phased Rollout
+
+### Phase 1: Shape The Candidate Boundary
+
+- Status: implemented for current direct memory/session retrieval candidates.
+- `RetrievedMemoryCandidate` now adapts through `RetrievalCandidate` before it
+  becomes a `MemorySelectionCandidate`.
+- Existing memory/session retrieval behavior remains unchanged.
+- Unit tests cover typed boundary fields and deterministic selection order.
+
+### Phase 2: Orchestration View
+
+- Status: implemented for structured runtime state and `/context` display.
+- Add `RetrievalOrchestrationView` to `SharedRuntimeContext`.
+- Make `/context` read richer provider/candidate details from that view.
+- Keep `/status` as summary only.
+- Emit ACP/Wire-ready structured events from the same view.
+
+### Phase 3: File Candidate Provider
+
+- Add `FileSearchProvider` using `crates/file-search`.
+- Return file manifest candidates only.
+- Do not inject file contents until a later excerpt-selection step exists.
+
+### Phase 4: Source-Specific Budgets And Dedupe
+
+- Status: initial deterministic dedupe is implemented for current retrieval
+  candidates.
+- Add per-source budget caps.
+- Add durable source ids and dedupe keys for future providers.
+- Add tests for duplicate memory/file/session candidates.
+
+### Phase 5: Graph/MCP/Hook Sources
+
+- Add MCP resource candidates.
+- Add hook output candidates.
+- Add graph candidates once graph index confidence is sufficient.
+
+## Validation Matrix
+
+- Provider failures are visible but do not fail the whole turn unless the
+  provider is required.
+- Candidate order is deterministic with identical inputs.
+- Dedupe preserves the winning candidate and records the losing reason.
+- Tight budget drops candidates with explicit `budget_exceeded` reason.
+- `/context` shows provider status, selected, available, dropped, and budget.
+- ACP/Wire view uses the same structured data as `/context`.
+- Retrieved candidates are not persisted as ordinary chat history.
+- Stable prompt-prefix bytes are unchanged when only volatile retrieval changes.
+
+## Open Risks
+
+- Score normalization across vector, keyword, graph, and file-search sources can
+  become misleading. Prefer source priority plus local rank until enough data
+  exists.
+- File-search candidates may tempt agents to inject too many files. Keep file
+  contents behind a separate excerpt-selection step.
+- Provider failure handling needs care: missing optional retrieval should be
+  visible, not noisy.
+- Per-source budget caps can hide useful context if defaults are too strict.
+
+## Source Journals
+
+- `docs/journal/2026-05-07-retrieval-orchestration-spec.md`

--- a/docs/journal/2026-05-07-retrieval-orchestration-spec.md
+++ b/docs/journal/2026-05-07-retrieval-orchestration-spec.md
@@ -1,0 +1,47 @@
+# Retrieval Orchestration Spec
+
+Added a dedicated retrieval orchestration spec to separate three concepts that
+were previously easy to blur:
+
+- source providers that produce raw recall candidates;
+- orchestration that normalizes, ranks, dedupes, and explains candidates;
+- `MemorySelection` that performs final selected/available/dropped decisions
+  against the current turn budget.
+
+The spec records the current implementation checkpoint:
+
+- `MemoryRetrievalOrchestrator` already retrieves LanceDB-backed workspace
+  memory and session shard candidates.
+- `memory_selection()` already reports selected, available, dropped, and budget.
+- `SharedRuntimeContext` already carries a retrieval view for `/context`.
+
+Implemented the first slice after the spec:
+
+- added `RetrievalSourceRef` and `RetrievalCandidate` as the typed boundary;
+- adapted current direct memory/session retrieval inputs through that boundary
+  before `MemorySelectionCandidate`;
+- kept prompt injection and selected/available/dropped behavior unchanged;
+- added focused tests for candidate metadata and deterministic selection order.
+
+The next implementation slice should add an orchestration view with provider
+status and candidate-level explainability for `/context` and future ACP/Wire
+consumers.
+
+Implemented the second thin slice:
+
+- added `RetrievalOrchestrationView` with provider status, selected, available,
+  dropped, combined candidates, and budget rollups;
+- derived the view from existing retrieval source status plus
+  `MemorySelectionContextView`;
+- carried the view through `SharedRuntimeContext` and the TUI runtime snapshot;
+- switched `/context` to render provider and candidate groups from the
+  orchestration view;
+- added deterministic candidate ordering and dedupe by retrieval dedupe key;
+- added an ACP/Wire-ready `ContextEvent::RetrievalOrchestrationUpdated`
+  contract carrying the same orchestration view;
+- kept prompt assembly unchanged.
+
+Auxiliary/lite-model compaction is explicitly deferred until context
+observability is complete. The orchestration view only leaves enough structure
+for a future compression capability to preserve original candidate detail and
+report summary provenance if that work is picked up later.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -101,9 +101,11 @@ Active backlog only. Keep this file small and current.
 - [ ] Surface terminal metadata in `/status` diagnostics and future OTEL attributes.
 - [ ] Add provider-gated cache-edit microcompact only for backends that explicitly declare cache-edit support.
 - [ ] Surface main model vs auxiliary model routing in `/status` and `/context`.
+- [ ] After context observability is complete, add an auxiliary-model compression hook for retrieval candidates without changing durable memory records.
 - [x] `ThreadStore` / `ThreadRecorder`: from façade over `SessionManager`+`StateDb` to true structured thread store.
 - [ ] Thread-scoped and workspace-scoped `MemoryRecord` storage with promotion rules.
-- [ ] Retrieval orchestration layer from `docs/features/context-architecture.md`.
+- [x] Initial retrieval orchestration layer from `docs/features/retrieval-orchestration.md`: typed candidates, orchestration view, richer `/context`, deterministic dedupe, and ACP/Wire event exposure.
+- [ ] Add `RetrievalSourceProvider` trait implementations for file/MCP/hook/graph sources after the current memory/session path is stable.
 - [x] Initialize LanceDB and wire FTS/vector/hybrid search paths behind the existing memory index façade.
 - [ ] Make memory mutation/query control-plane-ready so ACP/Wire can inspect and add memory without directly editing prompt text.
 

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -4,7 +4,7 @@ use crate::agent::{CompactState, Message, PlanStepStatus};
 use crate::context::assembly_view::assemble_context_view;
 use crate::context::compaction_view::compaction_source_entries;
 use crate::context::memory_selection::memory_selection;
-use crate::context::retrieval_view::retrieval_source_entries;
+use crate::context::retrieval_view::{retrieval_orchestration_view, retrieval_source_entries};
 use crate::context::{
     CompactionContextView, ContextBudgetView, MemorySelectionItemContextEntry, PlanContextView,
     PromptContextView, RetrievalContextView, RetrievedMemoryCandidate, SharedRuntimeContext,
@@ -154,21 +154,30 @@ impl<'a> ContextAssembler<'a> {
                 .saturating_sub(active_turn_budget)
                 .saturating_sub(compacted_history_budget)
         });
+        let memory_selection = memory_selection(
+            effective_prompt.sources.as_slice(),
+            inputs.plan_explanation.as_deref(),
+            inputs.plan_steps.as_slice(),
+            inputs.pending_interactions.as_slice(),
+            compaction.source_entries.as_slice(),
+            inputs.history,
+            inputs.session_id.as_str(),
+            inputs.vdb_uri,
+            inputs.retrieved_memory_candidates.as_slice(),
+            inputs.file_search_candidates.as_slice(),
+            selection_budget,
+        );
         let retrieval = RetrievalContextView {
-            entries: retrieval_entries,
-            memory_selection: memory_selection(
-                effective_prompt.sources.as_slice(),
-                inputs.plan_explanation.as_deref(),
-                inputs.plan_steps.as_slice(),
-                inputs.pending_interactions.as_slice(),
-                compaction.source_entries.as_slice(),
-                inputs.history,
+            orchestration: retrieval_orchestration_view(
                 inputs.session_id.as_str(),
-                inputs.vdb_uri,
-                inputs.retrieved_memory_candidates.as_slice(),
-                inputs.file_search_candidates.as_slice(),
-                selection_budget,
+                latest_user_request(inputs.history)
+                    .as_deref()
+                    .unwrap_or_default(),
+                retrieval_entries.as_slice(),
+                &memory_selection,
             ),
+            entries: retrieval_entries,
+            memory_selection,
         };
         let retrieved_memory_budget = retrieval
             .memory_selection

--- a/src/context/memory_selection.rs
+++ b/src/context/memory_selection.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde_json::Value;
 
@@ -9,9 +9,9 @@ use crate::context::assembler::{
 use crate::context::{
     CompactionSourceContextEntry, DropReason, MemorySelectionContextView,
     MemorySelectionItemContextEntry, RETRIEVED_THREAD_CONTEXT_KIND,
-    RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievedMemoryCandidate, RetrievedMemoryRenderItem,
-    is_retrieved_memory_kind, render_retrieved_memory_context,
-    render_retrieved_memory_context_item,
+    RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalCandidate, RetrievalSourceRef,
+    RetrievedMemoryCandidate, RetrievedMemoryRenderItem, is_retrieved_memory_kind,
+    render_retrieved_memory_context, render_retrieved_memory_context_item,
 };
 use crate::prompt::PromptSource;
 
@@ -85,6 +85,7 @@ struct MemorySelectionCandidate {
     selection_reason: String,
     budget_impact_tokens: Option<usize>,
     priority: usize,
+    dedupe_key: Option<String>,
     selectable: bool,
     dropped_reason: DropReason,
 }
@@ -264,36 +265,112 @@ fn direct_retrieved_memory_candidates(
 ) -> Vec<MemorySelectionCandidate> {
     retrieved_memory_candidates
         .iter()
-        .map(|candidate| {
-            let base_priority = match candidate.kind.as_str() {
-                RETRIEVED_THREAD_CONTEXT_KIND => 10,
-                RETRIEVED_WORKSPACE_MEMORY_KIND => 20,
-                _ => 25,
-            };
-            MemorySelectionCandidate {
-                kind: candidate.kind.clone(),
-                label: candidate.label.clone(),
-                detail: candidate.detail.clone(),
-                selection_reason: candidate.selection_reason.clone(),
-                budget_impact_tokens: Some(direct_retrieved_memory_budget_impact(candidate)),
-                priority: base_priority + candidate.rank,
-                selectable: true,
-                dropped_reason: DropReason::NotSelected {
-                    reason:
-                        "not selected after ranking the retrieved memory candidate against the current memory-selection budget"
-                            .to_string(),
-                },
-            }
-        })
+        .map(retrieval_candidate_from_retrieved_memory)
+        .map(memory_selection_candidate_from_retrieval_candidate)
         .collect()
 }
 
-fn direct_retrieved_memory_budget_impact(candidate: &RetrievedMemoryCandidate) -> usize {
+fn retrieval_candidate_from_retrieved_memory(
+    candidate: &RetrievedMemoryCandidate,
+) -> RetrievalCandidate {
+    let source_type = match candidate.kind.as_str() {
+        RETRIEVED_THREAD_CONTEXT_KIND => "session_context",
+        RETRIEVED_WORKSPACE_MEMORY_KIND => "memory_record",
+        _ => "retrieved_memory",
+    };
+    let scope = match candidate.kind.as_str() {
+        RETRIEVED_THREAD_CONTEXT_KIND => "thread",
+        RETRIEVED_WORKSPACE_MEMORY_KIND => "workspace",
+        _ => "unknown",
+    };
+    let priority = match candidate.kind.as_str() {
+        RETRIEVED_THREAD_CONTEXT_KIND => 10,
+        RETRIEVED_WORKSPACE_MEMORY_KIND => 20,
+        _ => 25,
+    } + candidate.rank;
+    let dedupe_key = format!(
+        "{}:{}:{}",
+        source_type,
+        candidate.kind,
+        stable_retrieval_text_id(candidate.detail.as_str())
+    );
+    RetrievalCandidate {
+        id: format!(
+            "{}:{}:{}",
+            source_type,
+            candidate.rank,
+            stable_retrieval_text_id(candidate.label.as_str())
+        ),
+        source: RetrievalSourceRef {
+            source_type: source_type.to_string(),
+            source_id: None,
+            source_path: None,
+            source_uri: None,
+            session_id: None,
+            thread_id: None,
+            workspace_id: None,
+        },
+        kind: candidate.kind.clone(),
+        scope: scope.to_string(),
+        label: candidate.label.clone(),
+        detail: candidate.detail.clone(),
+        summary: None,
+        rank: candidate.rank,
+        score: None,
+        priority,
+        dedupe_key: Some(dedupe_key),
+        budget_impact_tokens: Some(direct_retrieval_candidate_budget_impact(candidate)),
+        selection_reason: candidate.selection_reason.clone(),
+        availability_reason:
+            "available because a retrieval provider returned this candidate for the current turn"
+                .to_string(),
+    }
+}
+
+fn memory_selection_candidate_from_retrieval_candidate(
+    candidate: RetrievalCandidate,
+) -> MemorySelectionCandidate {
+    MemorySelectionCandidate {
+        kind: candidate.kind,
+        label: candidate.label,
+        detail: candidate.detail,
+        selection_reason: candidate.selection_reason,
+        budget_impact_tokens: candidate.budget_impact_tokens,
+        priority: candidate.priority,
+        dedupe_key: candidate.dedupe_key,
+        selectable: true,
+        dropped_reason: DropReason::NotSelected {
+            reason:
+                "not selected after ranking the retrieved memory candidate against the current memory-selection budget"
+                    .to_string(),
+        },
+    }
+}
+
+fn direct_retrieval_candidate_budget_impact(candidate: &RetrievedMemoryCandidate) -> usize {
     let item = RetrievedMemoryRenderItem {
         label: candidate.label.as_str(),
         detail: candidate.detail.as_str(),
     };
     estimate_text_tokens(&render_retrieved_memory_context_item(item))
+}
+
+fn stable_retrieval_text_id(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .take(8)
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 fn retrieval_tool_candidates(history: &[Message]) -> Vec<MemorySelectionCandidate> {
@@ -392,6 +469,7 @@ fn merge_file_search_candidates(
             selection_reason: entry.selection_reason.clone(),
             budget_impact_tokens: entry.budget_impact_tokens,
             priority: 30 + entry.order,
+            dedupe_key: None,
             selectable: true,
             dropped_reason: DropReason::NotSelected {
                 reason:
@@ -408,7 +486,14 @@ fn select_memory_candidates(
     selection_budget_tokens: Option<usize>,
     fixed_selected_kinds: &[String],
 ) -> MemorySelectionDecision {
-    candidates.sort_by_key(|candidate| candidate.priority);
+    candidates.sort_by(|left, right| {
+        left.priority
+            .cmp(&right.priority)
+            .then_with(|| left.dedupe_key.cmp(&right.dedupe_key))
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.label.cmp(&right.label))
+            .then_with(|| left.detail.cmp(&right.detail))
+    });
     let mut remaining_budget = selection_budget_tokens;
     let has_compacted_history = fixed_selected_kinds
         .iter()
@@ -416,6 +501,7 @@ fn select_memory_candidates(
     let mut decision = MemorySelectionDecision::default();
     let mut selected_kinds = fixed_selected_kinds.to_vec();
     let mut selected_retrieved_items: Vec<(String, String)> = Vec::new();
+    let mut selected_dedupe_keys = BTreeMap::<String, String>::new();
 
     for candidate in candidates {
         let candidate_budget_impact =
@@ -425,6 +511,16 @@ fn select_memory_candidates(
             is_retrieved_memory.then(|| (candidate.label.clone(), candidate.detail.clone()));
         let should_drop: Option<DropReason> = if !candidate.selectable {
             Some(candidate.dropped_reason.clone())
+        } else if let Some((dedupe_key, winning_label)) = candidate
+            .dedupe_key
+            .as_ref()
+            .and_then(|key| selected_dedupe_keys.get_key_value(key))
+        {
+            Some(DropReason::NotSelected {
+                reason: format!(
+                    "deduped_by={winning_label} because candidate dedupe_key={dedupe_key} already won selection"
+                ),
+            })
         } else if candidate.kind == "thread_history" && has_compacted_history {
             Some(DropReason::NotSelected {
                 reason: "not selected because compacted thread history already provides a more focused carried-over thread view".to_string(),
@@ -472,6 +568,9 @@ fn select_memory_candidates(
         }
         if let Some(item) = selected_retrieved_item {
             selected_retrieved_items.push(item);
+        }
+        if let Some(dedupe_key) = candidate.dedupe_key.as_ref() {
+            selected_dedupe_keys.insert(dedupe_key.clone(), candidate.label.clone());
         }
         selected_kinds.push(candidate.kind.clone());
         decision
@@ -568,6 +667,7 @@ fn thread_history_candidate(history: &[Message], session_id: &str) -> MemorySele
             format!("session={session_id} messages={}", history.len()).as_str(),
         )),
         priority: 30,
+        dedupe_key: None,
         selectable: !history.is_empty(),
         dropped_reason: DropReason::NotSelected { reason: if history.is_empty() {
             "no thread history is available for selection".to_string()
@@ -589,6 +689,7 @@ fn vector_memory_candidate(vdb_uri: &str) -> MemorySelectionCandidate {
         selection_reason: "the vector-backed memory slot is part of the selection contract even before full ranked retrieval is implemented".to_string(),
         budget_impact_tokens: None,
         priority: 40,
+        dedupe_key: None,
         selectable: false,
         dropped_reason: DropReason::NotSelected { reason: if vdb_uri.is_empty() {
             "no vector-backed memory store is configured".to_string()
@@ -624,6 +725,7 @@ fn retrieval_tool_candidate(
                 detail,
                 selection_reason: "selected because the retrieval tool returned relevant durable memory candidates for the current task".to_string(),
                 priority: 10,
+                dedupe_key: None,
                 selectable: true,
                 dropped_reason: DropReason::NotSelected { reason: "not selected after ranking the retrieved workspace-memory candidates against the current memory-selection budget".to_string() },
             }
@@ -640,6 +742,7 @@ fn retrieval_tool_candidate(
                 detail,
                 selection_reason: "selected because the retrieval tool returned focused thread-context material for the current task".to_string(),
                 priority: 20,
+                dedupe_key: None,
                 selectable: true,
                 dropped_reason: DropReason::NotSelected { reason: "not selected after ranking the retrieved thread-context candidate against the current memory-selection budget".to_string() },
             }
@@ -653,6 +756,7 @@ fn retrieval_tool_candidate(
             selection_reason: "selected because a retrieval tool result was returned in the current thread history".to_string(),
             budget_impact_tokens: Some(estimate_text_tokens(content)),
             priority: 50,
+            dedupe_key: None,
             selectable: true,
             dropped_reason: DropReason::NotSelected { reason: "not selected after ranking the retrieval candidate against the current memory-selection budget".to_string() },
         },
@@ -1065,6 +1169,158 @@ mod tests {
         assert_eq!(
             selected.budget_impact_tokens,
             Some(estimate_text_tokens(&expected_rendered))
+        );
+    }
+
+    #[test]
+    fn retrieved_memory_adapter_builds_typed_candidate_boundary() {
+        let candidate = RetrievedMemoryCandidate {
+            kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+            label: "Memory: Reference Project Path".to_string(),
+            detail: "content: Reference project source lives at /Users/example/reference-project."
+                .to_string(),
+            selection_reason: "retrieved as a candidate for the current turn query".to_string(),
+            rank: 3,
+        };
+
+        let typed = retrieval_candidate_from_retrieved_memory(&candidate);
+
+        assert_eq!(typed.source.source_type, "memory_record");
+        assert_eq!(typed.scope, "workspace");
+        assert_eq!(typed.priority, 23);
+        assert_eq!(typed.rank, 3);
+        assert_eq!(
+            typed.dedupe_key.as_deref(),
+            Some(
+                "memory_record:retrieved_workspace_memory:content-reference-project-source-lives-at-users-example"
+            )
+        );
+        assert!(typed.budget_impact_tokens.is_some());
+        assert!(typed.availability_reason.contains("retrieval provider"));
+    }
+
+    #[test]
+    fn typed_retrieval_candidate_priority_drives_selection_order() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"What happened in the prior session?"}]),
+        }];
+        let retrieved = vec![
+            RetrievedMemoryCandidate {
+                kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+                label: "Memory: workspace fact".to_string(),
+                detail: "content: workspace fact".to_string(),
+                selection_reason: "retrieved workspace memory".to_string(),
+                rank: 1,
+            },
+            RetrievedMemoryCandidate {
+                kind: RETRIEVED_THREAD_CONTEXT_KIND.to_string(),
+                label: "Session Context session-1#2".to_string(),
+                detail: "content: focused session context".to_string(),
+                selection_reason: "retrieved session context".to_string(),
+                rank: 1,
+            },
+        ];
+
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "memory://vdb",
+            &retrieved,
+            &[],
+            Some(10_000),
+        );
+
+        let selected_retrieval = result
+            .selected_items
+            .iter()
+            .filter(|item| {
+                matches!(
+                    item.kind.as_str(),
+                    RETRIEVED_THREAD_CONTEXT_KIND | RETRIEVED_WORKSPACE_MEMORY_KIND
+                )
+            })
+            .map(|item| item.kind.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            selected_retrieval,
+            vec![
+                RETRIEVED_THREAD_CONTEXT_KIND,
+                RETRIEVED_WORKSPACE_MEMORY_KIND
+            ],
+            "typed priorities should preserve focused thread context before workspace memory"
+        );
+    }
+
+    #[test]
+    fn retrieved_memory_dedupe_key_keeps_first_winner_and_reports_loser() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"Where is the reference project?"}]),
+        }];
+        let retrieved = vec![
+            RetrievedMemoryCandidate {
+                kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+                label: "Memory: reference project path".to_string(),
+                detail:
+                    "content: Reference project source lives at /Users/example/reference-project."
+                        .to_string(),
+                selection_reason: "retrieved as a candidate for the current turn query".to_string(),
+                rank: 1,
+            },
+            RetrievedMemoryCandidate {
+                kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+                label: "Memory: duplicate reference project path".to_string(),
+                detail:
+                    "content: Reference project source lives at /Users/example/reference-project."
+                        .to_string(),
+                selection_reason: "retrieved as a candidate for the current turn query".to_string(),
+                rank: 2,
+            },
+        ];
+
+        let result = memory_selection(
+            &[],
+            None,
+            &[],
+            &[],
+            &[],
+            &history,
+            "session-1",
+            "memory://vdb",
+            &retrieved,
+            &[],
+            Some(10_000),
+        );
+
+        let selected_retrieved = result
+            .selected_items
+            .iter()
+            .filter(|item| item.kind == RETRIEVED_WORKSPACE_MEMORY_KIND)
+            .collect::<Vec<_>>();
+        assert_eq!(selected_retrieved.len(), 1);
+        assert_eq!(
+            selected_retrieved[0].label,
+            "Memory: reference project path"
+        );
+
+        let duplicate = result
+            .available_items
+            .iter()
+            .find(|item| item.label == "Memory: duplicate reference project path")
+            .expect("duplicate should remain observable as available");
+        assert!(
+            duplicate
+                .dropped_reason
+                .as_ref()
+                .expect("dedupe reason")
+                .reason()
+                .contains("deduped_by=Memory: reference project path")
         );
     }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -27,7 +27,9 @@ pub use self::runtime::{
     CacheStatus, CompactionContextView, CompactionSourceContextEntry, ContextAssemblyEntry,
     ContextAssemblyView, ContextBudgetView, DropReason, MemorySelectionContextView,
     MemorySelectionItemContextEntry, PlanContextView, PromptContextView, PromptSourceContextEntry,
-    RETRIEVED_THREAD_CONTEXT_KIND, RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalContextView,
-    RetrievalSourceContextEntry, RetrievedMemoryCandidate, SharedRuntimeContext, TodoContextView,
+    RETRIEVED_THREAD_CONTEXT_KIND, RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalBudgetContextView,
+    RetrievalCandidate, RetrievalCandidateContextEntry, RetrievalContextView,
+    RetrievalOrchestrationView, RetrievalProviderStatus, RetrievalSourceContextEntry,
+    RetrievalSourceRef, RetrievedMemoryCandidate, SharedRuntimeContext, TodoContextView,
     is_retrieved_memory_kind,
 };

--- a/src/context/retrieval_view.rs
+++ b/src/context/retrieval_view.rs
@@ -1,5 +1,9 @@
 use crate::agent::Message;
-use crate::context::RetrievalSourceContextEntry;
+use crate::context::{
+    DropReason, MemorySelectionContextView, MemorySelectionItemContextEntry,
+    RetrievalBudgetContextView, RetrievalCandidateContextEntry, RetrievalOrchestrationView,
+    RetrievalProviderStatus, RetrievalSourceContextEntry,
+};
 use crate::prompt::PromptSource;
 use crate::workspace::WorkspaceMemory;
 
@@ -71,4 +75,202 @@ pub(crate) fn retrieval_source_entries(
             },
         },
     ]
+}
+
+pub(crate) fn retrieval_orchestration_view(
+    request_id: &str,
+    query: &str,
+    providers: &[RetrievalSourceContextEntry],
+    memory_selection: &MemorySelectionContextView,
+) -> RetrievalOrchestrationView {
+    let selected = candidate_entries_from_memory_selection(
+        "selected",
+        &memory_selection.selected_items,
+        MemorySelectionReasonSource::SelectionReason,
+    );
+    let available = candidate_entries_from_memory_selection(
+        "available",
+        &memory_selection.available_items,
+        MemorySelectionReasonSource::DropReason,
+    );
+    let dropped = candidate_entries_from_memory_selection(
+        "dropped",
+        &memory_selection.dropped_items,
+        MemorySelectionReasonSource::DropReason,
+    );
+    let mut candidates = Vec::new();
+    candidates.extend(selected.clone());
+    candidates.extend(available.clone());
+    candidates.extend(dropped.clone());
+    for (idx, candidate) in candidates.iter_mut().enumerate() {
+        candidate.order = idx + 1;
+    }
+
+    RetrievalOrchestrationView {
+        request_id: request_id.to_string(),
+        query: query.to_string(),
+        providers: providers.iter().map(provider_status_from_source).collect(),
+        budget: RetrievalBudgetContextView {
+            selection_budget_tokens: memory_selection.selection_budget_tokens,
+            selected_tokens: sum_candidate_tokens(&selected),
+            available_tokens: sum_candidate_tokens(&available),
+            dropped_tokens: sum_candidate_tokens(&dropped),
+        },
+        candidates,
+        selected,
+        available,
+        dropped,
+    }
+}
+
+#[derive(Clone, Copy)]
+enum MemorySelectionReasonSource {
+    SelectionReason,
+    DropReason,
+}
+
+fn candidate_entries_from_memory_selection(
+    status: &str,
+    items: &[MemorySelectionItemContextEntry],
+    reason_source: MemorySelectionReasonSource,
+) -> Vec<RetrievalCandidateContextEntry> {
+    items
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| RetrievalCandidateContextEntry {
+            order: idx + 1,
+            kind: item.kind.clone(),
+            label: item.label.clone(),
+            detail: item.detail.clone(),
+            status: status.to_string(),
+            source_kind: source_kind_for_memory_selection_item(item.kind.as_str()).to_string(),
+            budget_impact_tokens: item.budget_impact_tokens,
+            reason: memory_selection_reason(item, reason_source),
+        })
+        .collect()
+}
+
+fn provider_status_from_source(source: &RetrievalSourceContextEntry) -> RetrievalProviderStatus {
+    RetrievalProviderStatus {
+        order: source.order,
+        kind: source.kind.clone(),
+        label: source.label.clone(),
+        status: source.status.clone(),
+        detail: source.detail.clone(),
+        inclusion_reason: source.inclusion_reason.clone(),
+    }
+}
+
+fn memory_selection_reason(
+    item: &MemorySelectionItemContextEntry,
+    reason_source: MemorySelectionReasonSource,
+) -> String {
+    match reason_source {
+        MemorySelectionReasonSource::SelectionReason => item.selection_reason.clone(),
+        MemorySelectionReasonSource::DropReason => item
+            .dropped_reason
+            .as_ref()
+            .map(drop_reason_text)
+            .unwrap_or_else(|| item.selection_reason.clone()),
+    }
+}
+
+fn drop_reason_text(reason: &DropReason) -> String {
+    reason.reason().to_string()
+}
+
+fn source_kind_for_memory_selection_item(kind: &str) -> &'static str {
+    match kind {
+        "retrieved_thread_context" => "session_context",
+        "retrieved_workspace_memory" => "memory_record",
+        "thread_history" => "thread_history",
+        "vector_memory" => "vector_memory",
+        "workspace_memory" => "workspace_memory",
+        "tool_retrieval_result" => "tool_result",
+        _ => "runtime_context",
+    }
+}
+
+fn sum_candidate_tokens(candidates: &[RetrievalCandidateContextEntry]) -> usize {
+    candidates
+        .iter()
+        .map(|candidate| candidate.budget_impact_tokens.unwrap_or_default())
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orchestration_view_projects_provider_status_and_candidate_sets() {
+        let providers = vec![RetrievalSourceContextEntry {
+            order: 1,
+            kind: "vector_memory".to_string(),
+            label: "Vector Memory Store".to_string(),
+            status: "available".to_string(),
+            detail: "memory://vdb".to_string(),
+            inclusion_reason: "configured as durable memory".to_string(),
+        }];
+        let memory_selection = MemorySelectionContextView {
+            selection_budget_tokens: Some(100),
+            selected_items: vec![MemorySelectionItemContextEntry {
+                order: 1,
+                kind: "retrieved_workspace_memory".to_string(),
+                label: "Memory: path".to_string(),
+                detail: "content: path fact".to_string(),
+                selection_reason: "retrieved for the current turn".to_string(),
+                budget_impact_tokens: Some(11),
+                dropped_reason: None,
+            }],
+            available_items: vec![MemorySelectionItemContextEntry {
+                order: 1,
+                kind: "thread_history".to_string(),
+                label: "Thread History".to_string(),
+                detail: "session=s1 messages=2".to_string(),
+                selection_reason: "available for recall".to_string(),
+                budget_impact_tokens: Some(7),
+                dropped_reason: Some(DropReason::NotSelected {
+                    reason: "compacted history already covers it".to_string(),
+                }),
+            }],
+            dropped_items: vec![MemorySelectionItemContextEntry {
+                order: 1,
+                kind: "retrieved_thread_context".to_string(),
+                label: "Session Context s1#1".to_string(),
+                detail: "content: old context".to_string(),
+                selection_reason: "retrieved session context".to_string(),
+                budget_impact_tokens: Some(13),
+                dropped_reason: Some(DropReason::BudgetExceeded {
+                    reason: "budget_exceeded".to_string(),
+                }),
+            }],
+        };
+
+        let view = retrieval_orchestration_view(
+            "s1",
+            "where is the reference project?",
+            providers.as_slice(),
+            &memory_selection,
+        );
+
+        assert_eq!(view.request_id, "s1");
+        assert_eq!(view.query, "where is the reference project?");
+        assert_eq!(view.providers[0].kind, "vector_memory");
+        assert_eq!(view.selected[0].source_kind, "memory_record");
+        assert_eq!(view.available[0].source_kind, "thread_history");
+        assert_eq!(
+            view.available[0].reason,
+            "compacted history already covers it"
+        );
+        assert_eq!(view.dropped[0].source_kind, "session_context");
+        assert_eq!(view.dropped[0].reason, "budget_exceeded");
+        assert_eq!(view.budget.selected_tokens, 11);
+        assert_eq!(view.budget.available_tokens, 7);
+        assert_eq!(view.budget.dropped_tokens, 13);
+        assert_eq!(view.candidates.len(), 3);
+        assert_eq!(view.candidates[0].status, "selected");
+        assert_eq!(view.candidates[1].status, "available");
+        assert_eq!(view.candidates[2].status, "dropped");
+    }
 }

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -280,6 +280,7 @@ pub struct SharedRuntimeContext {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RetrievalContextView {
     pub entries: Vec<RetrievalSourceContextEntry>,
+    pub orchestration: RetrievalOrchestrationView,
     pub memory_selection: MemorySelectionContextView,
 }
 
@@ -300,6 +301,77 @@ pub struct RetrievedMemoryCandidate {
     pub detail: String,
     pub selection_reason: String,
     pub rank: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetrievalSourceRef {
+    pub source_type: String,
+    pub source_id: Option<String>,
+    pub source_path: Option<String>,
+    pub source_uri: Option<String>,
+    pub session_id: Option<String>,
+    pub thread_id: Option<String>,
+    pub workspace_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetrievalCandidate {
+    pub id: String,
+    pub source: RetrievalSourceRef,
+    pub kind: String,
+    pub scope: String,
+    pub label: String,
+    pub detail: String,
+    pub summary: Option<String>,
+    pub rank: usize,
+    pub score: Option<f32>,
+    pub priority: usize,
+    pub dedupe_key: Option<String>,
+    pub budget_impact_tokens: Option<usize>,
+    pub selection_reason: String,
+    pub availability_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct RetrievalOrchestrationView {
+    pub request_id: String,
+    pub query: String,
+    pub providers: Vec<RetrievalProviderStatus>,
+    pub candidates: Vec<RetrievalCandidateContextEntry>,
+    pub selected: Vec<RetrievalCandidateContextEntry>,
+    pub available: Vec<RetrievalCandidateContextEntry>,
+    pub dropped: Vec<RetrievalCandidateContextEntry>,
+    pub budget: RetrievalBudgetContextView,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RetrievalProviderStatus {
+    pub order: usize,
+    pub kind: String,
+    pub label: String,
+    pub status: String,
+    pub detail: String,
+    pub inclusion_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RetrievalCandidateContextEntry {
+    pub order: usize,
+    pub kind: String,
+    pub label: String,
+    pub detail: String,
+    pub status: String,
+    pub source_kind: String,
+    pub budget_impact_tokens: Option<usize>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct RetrievalBudgetContextView {
+    pub selection_budget_tokens: Option<usize>,
+    pub selected_tokens: usize,
+    pub available_tokens: usize,
+    pub dropped_tokens: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::agent::{AgentEvent, BashApprovalDecision};
+use crate::context::RetrievalOrchestrationView;
 use crate::mcp_status::{McpConnectionState, McpStatusSnapshot};
 use crate::todo::TodoState;
 use crate::tool::ToolOutputStream;
@@ -523,6 +524,7 @@ pub enum HookEvent {
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ContextEvent {
     SnapshotUpdated,
+    RetrievalOrchestrationUpdated { view: RetrievalOrchestrationView },
 }
 
 #[allow(dead_code)]
@@ -847,6 +849,104 @@ mod tests {
                     "type": "reconnect",
                     "payload": {
                         "server_name": "docs"
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn retrieval_orchestration_event_uses_structured_wire_shape() {
+        let event = RuntimeEvent::Context(ContextEvent::RetrievalOrchestrationUpdated {
+            view: RetrievalOrchestrationView {
+                request_id: "session-1".to_string(),
+                query: "where is the reference project?".to_string(),
+                providers: vec![crate::context::RetrievalProviderStatus {
+                    order: 1,
+                    kind: "vector_memory".to_string(),
+                    label: "Vector Memory Store".to_string(),
+                    status: "available".to_string(),
+                    detail: "memory://vdb".to_string(),
+                    inclusion_reason: "configured as durable memory".to_string(),
+                }],
+                candidates: vec![crate::context::RetrievalCandidateContextEntry {
+                    order: 1,
+                    kind: "retrieved_workspace_memory".to_string(),
+                    label: "Memory: reference project".to_string(),
+                    detail: "content: reference project path".to_string(),
+                    status: "selected".to_string(),
+                    source_kind: "memory_record".to_string(),
+                    budget_impact_tokens: Some(11),
+                    reason: "selected for current turn".to_string(),
+                }],
+                selected: vec![crate::context::RetrievalCandidateContextEntry {
+                    order: 1,
+                    kind: "retrieved_workspace_memory".to_string(),
+                    label: "Memory: reference project".to_string(),
+                    detail: "content: reference project path".to_string(),
+                    status: "selected".to_string(),
+                    source_kind: "memory_record".to_string(),
+                    budget_impact_tokens: Some(11),
+                    reason: "selected for current turn".to_string(),
+                }],
+                available: Vec::new(),
+                dropped: Vec::new(),
+                budget: crate::context::RetrievalBudgetContextView {
+                    selection_budget_tokens: Some(100),
+                    selected_tokens: 11,
+                    available_tokens: 0,
+                    dropped_tokens: 0,
+                },
+            },
+        });
+
+        assert_eq!(
+            serde_json::to_value(event).unwrap(),
+            json!({
+                "type": "context",
+                "payload": {
+                    "type": "retrieval_orchestration_updated",
+                    "payload": {
+                        "view": {
+                            "request_id": "session-1",
+                            "query": "where is the reference project?",
+                            "providers": [{
+                                "order": 1,
+                                "kind": "vector_memory",
+                                "label": "Vector Memory Store",
+                                "status": "available",
+                                "detail": "memory://vdb",
+                                "inclusion_reason": "configured as durable memory"
+                            }],
+                            "candidates": [{
+                                "order": 1,
+                                "kind": "retrieved_workspace_memory",
+                                "label": "Memory: reference project",
+                                "detail": "content: reference project path",
+                                "status": "selected",
+                                "source_kind": "memory_record",
+                                "budget_impact_tokens": 11,
+                                "reason": "selected for current turn"
+                            }],
+                            "selected": [{
+                                "order": 1,
+                                "kind": "retrieved_workspace_memory",
+                                "label": "Memory: reference project",
+                                "detail": "content: reference project path",
+                                "status": "selected",
+                                "source_kind": "memory_record",
+                                "budget_impact_tokens": 11,
+                                "reason": "selected for current turn"
+                            }],
+                            "available": [],
+                            "dropped": [],
+                            "budget": {
+                                "selection_budget_tokens": 100,
+                                "selected_tokens": 11,
+                                "available_tokens": 0,
+                                "dropped_tokens": 0
+                            }
+                        }
                     }
                 }
             })

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -1,7 +1,7 @@
 use time::{OffsetDateTime, format_description};
 
 use crate::config::RaraConfig;
-use crate::context::{CacheStatus, DropReason};
+use crate::context::{CacheStatus, RetrievalCandidateContextEntry, RetrievalProviderStatus};
 use crate::tui::format::cache_hit_rate_label;
 use crate::tui::session_restore::provider_requires_api_key;
 use crate::tui::state::{
@@ -83,58 +83,87 @@ fn render_context_assembly_entries(app: &TuiApp, layer: &str, title: &str) -> St
     format!("{title}\n{body}")
 }
 
-fn render_memory_selection(app: &TuiApp) -> String {
-    let budget = app
-        .snapshot
-        .memory_selection
+fn render_retrieval_orchestration(app: &TuiApp) -> String {
+    let view = &app.snapshot.retrieval_orchestration;
+    let budget = view
+        .budget
         .selection_budget_tokens
         .map(format_token_count)
         .unwrap_or_else(|| "unlimited".to_string());
-
-    let render_items = |items: &[crate::context::MemorySelectionItemContextEntry]| -> String {
-        if items.is_empty() {
-            return "    (none)".to_string();
-        }
-        items
-            .iter()
-            .enumerate()
-            .map(|(idx, item)| {
-                let (connector, vertical) = if idx + 1 == items.len() {
-                    ("└──", " ")
-                } else {
-                    ("├──", "│")
-                };
-                let budget = item
-                    .budget_impact_tokens
-                    .map(|v| format!(" {}", format_token_count(v)))
-                    .unwrap_or_default();
-                let detail_preview = truncate_preview(&item.detail, 60);
-                let selection_reason = truncate_preview(&item.selection_reason, 70);
-                let drop_note = match &item.dropped_reason {
-                    Some(DropReason::NotSelected { reason }) if !reason.is_empty() => {
-                        format!(" ── reason: {reason}")
-                    }
-                    Some(DropReason::BudgetExceeded { reason }) => {
-                        format!(" ── reason: {reason}")
-                    }
-                    _ => String::new(),
-                };
-                format!(
-                    "    {connector} [{kind}] {label}{budget}\n    {vertical}   detail: {detail_preview}{drop_note}\n    {vertical}   reason: {selection_reason}",
-                    kind = item.kind,
-                    label = item.label,
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    };
+    let providers = render_retrieval_providers(view.providers.as_slice());
+    let selected = render_retrieval_candidates(view.selected.as_slice());
+    let available = render_retrieval_candidates(view.available.as_slice());
+    let dropped = render_retrieval_candidates(view.dropped.as_slice());
 
     format!(
-        "Memory Selection  (budget: {budget})\n  ├── selected:\n{}\n  ├── available:\n{}\n  └── dropped:\n{}",
-        render_items(&app.snapshot.memory_selection.selected_items),
-        render_items(&app.snapshot.memory_selection.available_items),
-        render_items(&app.snapshot.memory_selection.dropped_items),
+        "Retrieval Orchestration  (budget: {budget}; selected: {selected_tokens}; available: {available_tokens}; dropped: {dropped_tokens})\n  query: {query}\n  providers:\n{providers}\n  candidates:\n    selected:\n{selected}\n    available:\n{available}\n    dropped:\n{dropped}",
+        selected_tokens = format_token_count(view.budget.selected_tokens),
+        available_tokens = format_token_count(view.budget.available_tokens),
+        dropped_tokens = format_token_count(view.budget.dropped_tokens),
+        query = if view.query.trim().is_empty() {
+            "-"
+        } else {
+            view.query.as_str()
+        },
     )
+}
+
+fn render_retrieval_providers(providers: &[RetrievalProviderStatus]) -> String {
+    if providers.is_empty() {
+        return "    (none)".to_string();
+    }
+
+    providers
+        .iter()
+        .enumerate()
+        .map(|(idx, provider)| {
+            let (connector, vertical) = if idx + 1 == providers.len() {
+                ("└──", " ")
+            } else {
+                ("├──", "│")
+            };
+            let detail = truncate_preview(provider.detail.as_str(), 70);
+            let reason = truncate_preview(provider.inclusion_reason.as_str(), 80);
+            format!(
+                "    {connector} [{kind}] {label} status={status}\n    {vertical}   detail: {detail}\n    {vertical}   reason: {reason}",
+                kind = provider.kind,
+                label = provider.label,
+                status = provider.status,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_retrieval_candidates(candidates: &[RetrievalCandidateContextEntry]) -> String {
+    if candidates.is_empty() {
+        return "      (none)".to_string();
+    }
+
+    candidates
+        .iter()
+        .enumerate()
+        .map(|(idx, candidate)| {
+            let (connector, vertical) = if idx + 1 == candidates.len() {
+                ("└──", " ")
+            } else {
+                ("├──", "│")
+            };
+            let budget = candidate
+                .budget_impact_tokens
+                .map(|v| format!(" {}", format_token_count(v)))
+                .unwrap_or_default();
+            let detail = truncate_preview(candidate.detail.as_str(), 60);
+            let reason = truncate_preview(candidate.reason.as_str(), 80);
+            format!(
+                "      {connector} [{source_kind}/{kind}] {label}{budget}\n      {vertical}   detail: {detail}\n      {vertical}   reason: {reason}",
+                source_kind = candidate.source_kind,
+                kind = candidate.kind,
+                label = candidate.label,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 pub(crate) fn truncate_preview(text: &str, max_len: usize) -> String {
@@ -432,7 +461,7 @@ pub fn status_context_text(app: &TuiApp) -> String {
             "Workspace Prompt Sources",
         ),
         render_context_assembly_entries(app, "active_memory_inputs", "Active Memory Inputs"),
-        render_memory_selection(app),
+        render_retrieval_orchestration(app),
         render_context_assembly_entries(app, "compacted_history", "Compacted History"),
         render_context_assembly_entries(app, "active_turn_state", "Active Turn State"),
         render_context_assembly_entries(app, "retrieval_ready", "Retrieval-ready"),

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -392,6 +392,72 @@ fn status_context_text_includes_prompt_sources_and_plan_state() {
                     "included now because the local workspace memory file was discovered as an explicit prompt source".into(),
             },
         ],
+        retrieval_orchestration: crate::context::RetrievalOrchestrationView {
+            request_id: "session-123".into(),
+            query: "continue context work".into(),
+            providers: vec![crate::context::RetrievalProviderStatus {
+                order: 1,
+                kind: "workspace_memory".into(),
+                label: "Workspace Memory".into(),
+                status: "active".into(),
+                detail: "/workspace/rara/.rara/memory.md".into(),
+                inclusion_reason:
+                    "included now because the local workspace memory file was discovered as an explicit prompt source".into(),
+            }],
+            selected: vec![crate::context::RetrievalCandidateContextEntry {
+                order: 1,
+                kind: "retrieved_workspace_memory".into(),
+                label: "Retrieved Experience".into(),
+                detail: "content: prior implementation detail".into(),
+                status: "selected".into(),
+                source_kind: "memory_record".into(),
+                budget_impact_tokens: Some(32),
+                reason:
+                    "selected because the retrieval tool returned relevant durable memory candidates for the current task".into(),
+            }],
+            available: vec![crate::context::RetrievalCandidateContextEntry {
+                order: 1,
+                kind: "thread_history".into(),
+                label: "Thread History".into(),
+                detail: "session=session-123 messages=10".into(),
+                status: "available".into(),
+                source_kind: "thread_history".into(),
+                budget_impact_tokens: None,
+                reason:
+                    "available for recall, but not selected into the current assembled context".into(),
+            }],
+            dropped: Vec::new(),
+            candidates: vec![
+                crate::context::RetrievalCandidateContextEntry {
+                    order: 1,
+                    kind: "retrieved_workspace_memory".into(),
+                    label: "Retrieved Experience".into(),
+                    detail: "content: prior implementation detail".into(),
+                    status: "selected".into(),
+                    source_kind: "memory_record".into(),
+                    budget_impact_tokens: Some(32),
+                    reason:
+                        "selected because the retrieval tool returned relevant durable memory candidates for the current task".into(),
+                },
+                crate::context::RetrievalCandidateContextEntry {
+                    order: 2,
+                    kind: "thread_history".into(),
+                    label: "Thread History".into(),
+                    detail: "session=session-123 messages=10".into(),
+                    status: "available".into(),
+                    source_kind: "thread_history".into(),
+                    budget_impact_tokens: None,
+                    reason:
+                        "available for recall, but not selected into the current assembled context".into(),
+                },
+            ],
+            budget: crate::context::RetrievalBudgetContextView {
+                selection_budget_tokens: Some(189_772),
+                selected_tokens: 32,
+                available_tokens: 0,
+                dropped_tokens: 0,
+            },
+        },
         assembly_entries: vec![
             crate::context::ContextAssemblyEntry {
                 cache_status: None,
@@ -515,7 +581,10 @@ fn status_context_text_includes_prompt_sources_and_plan_state() {
     assert!(rendered.contains("Stable Instructions"));
     assert!(rendered.contains("Workspace Prompt Sources"));
     assert!(rendered.contains("Active Memory Inputs"));
-    assert!(rendered.contains("Memory Selection"));
+    assert!(rendered.contains("Retrieval Orchestration"));
+    assert!(rendered.contains("query: continue context work"));
+    assert!(rendered.contains("[workspace_memory] Workspace Memory status=active"));
+    assert!(rendered.contains("[memory_record/retrieved_workspace_memory] Retrieved Experience"));
     assert!(rendered.contains("Compacted History"));
     assert!(rendered.contains("path: history.compaction.summary"));
     assert!(rendered.contains("Active Turn State"));

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1042,6 +1042,7 @@ impl TuiApp {
             prompt_append_system_prompt: runtime_context.prompt.append_system_prompt,
             prompt_warnings: runtime_context.prompt.warnings,
             retrieval_source_entries: runtime_context.retrieval.entries,
+            retrieval_orchestration: runtime_context.retrieval.orchestration,
             memory_selection: runtime_context.retrieval.memory_selection,
             assembly_entries: runtime_context.assembly.entries,
             // ── Extensions ──────────────────────────────────────

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -216,6 +216,7 @@ pub struct RuntimeSnapshot {
     pub prompt_append_system_prompt: Option<String>,
     pub prompt_warnings: Vec<String>,
     pub retrieval_source_entries: Vec<RetrievalSourceContextEntry>,
+    pub retrieval_orchestration: crate::context::RetrievalOrchestrationView,
     pub memory_selection: crate::context::MemorySelectionContextView,
     pub assembly_entries: Vec<ContextAssemblyEntry>,
     // ── Extensions ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- add a retrieval orchestration spec and checkpoint journal
- introduce typed retrieval candidates and deterministic dedupe before memory selection
- expose `RetrievalOrchestrationView` through runtime context, `/context`, and ACP/Wire-ready events

## Purpose

This creates the first shared runtime boundary for memory/context retrieval. The goal is to keep retrieval sources explainable without changing the stable prompt prefix or directly injecting backend-specific results into prompt assembly.

## Tests

- `cargo fmt`
- `cargo test context::memory_selection::tests -- --nocapture`
- `cargo test context::retrieval_view::tests -- --nocapture`
- `cargo test runtime_control::tests::retrieval_orchestration_event_uses_structured_wire_shape -- --nocapture`
- `cargo test tui::command::tests::status_context_text_includes_prompt_sources_and_plan_state -- --nocapture`
- `cargo check`
- `git diff --check`

Existing unused/dead-code warnings remain.
