### PR TITLE
feat(context): add retrieval provider boundary

### DIFF
--- a/docs/features/retrieval-orchestration.md
+++ b/docs/features/retrieval-orchestration.md
@@ -298,9 +298,15 @@ The display should keep details compact and path/URI-like fields visible.
 
 ### Phase 1: Shape The Candidate Boundary
 
-- Status: implemented for current direct memory/session retrieval candidates.
+- Status: implemented for current direct memory/session retrieval candidates
+  and the first provider boundary.
 - `RetrievedMemoryCandidate` now adapts through `RetrievalCandidate` before it
   becomes a `MemorySelectionCandidate`.
+- `RetrievalRequest` and `RetrievalSourceProvider` are now the source-provider
+  boundary for current in-process retrieval sources.
+- Current direct memory retrieval, retrieval tool results, thread history,
+  vector-store slot, and file-search candidates all normalize into
+  `RetrievalCandidate` before discretionary `MemorySelection`.
 - Existing memory/session retrieval behavior remains unchanged.
 - Unit tests cover typed boundary fields and deterministic selection order.
 
@@ -314,6 +320,7 @@ The display should keep details compact and path/URI-like fields visible.
 
 ### Phase 3: File Candidate Provider
 
+- Status: first candidate adapter implemented.
 - Add `FileSearchProvider` using `crates/file-search`.
 - Return file manifest candidates only.
 - Do not inject file contents until a later excerpt-selection step exists.
@@ -331,6 +338,8 @@ The display should keep details compact and path/URI-like fields visible.
 - Add MCP resource candidates.
 - Add hook output candidates.
 - Add graph candidates once graph index confidence is sufficient.
+- Reuse the same `RetrievalSourceProvider` and `RetrievalCandidate` contract;
+  do not add source-specific inputs to `MemorySelection`.
 
 ## Validation Matrix
 

--- a/docs/journal/2026-05-07-retrieval-provider-boundary.md
+++ b/docs/journal/2026-05-07-retrieval-provider-boundary.md
@@ -1,0 +1,38 @@
+# 2026-05-07 · Retrieval Provider Boundary
+
+## Context
+
+The retrieval orchestration view already exposed selected, available, dropped,
+provider status, and budget rollups. The remaining structural gap was that
+`MemorySelection` still accepted source-specific inputs directly: retrieved
+memory candidates, file-search candidates, thread history, and vector-store
+status were merged inside the selector.
+
+## Implementation
+
+- Added `RetrievalRequest` and `RetrievalSourceProvider` as the first source
+  provider boundary.
+- Added current-source adapters for direct retrieved memory, retrieval tool
+  results, thread history, vector-store slot, and precomputed file-search
+  candidates.
+- Changed file search to produce typed `RetrievalCandidate` values before the
+  compatibility `MemorySelectionItemContextEntry` conversion.
+- Changed discretionary `memory_selection()` input to a normalized
+  `RetrievalCandidate` slice.
+- Kept selected retrieved-memory prompt injection unchanged: it remains
+  volatile per-turn context prepended to the latest user request and is not
+  persisted into stable prompt sources.
+
+## Validation
+
+- `cargo test context::retrieval_provider -- --nocapture`
+- `cargo test context::memory_selection -- --nocapture`
+- `cargo test context::file_search_provider -- --nocapture`
+
+## Follow-up
+
+- Add MCP resource providers through the same source-provider contract.
+- Add hook and graph providers after the current memory/session/file path
+  remains stable.
+- Add structured provider failure and skip reporting before auxiliary-model
+  candidate compression.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -105,7 +105,8 @@ Active backlog only. Keep this file small and current.
 - [x] `ThreadStore` / `ThreadRecorder`: from façade over `SessionManager`+`StateDb` to true structured thread store.
 - [ ] Thread-scoped and workspace-scoped `MemoryRecord` storage with promotion rules.
 - [x] Initial retrieval orchestration layer from `docs/features/retrieval-orchestration.md`: typed candidates, orchestration view, richer `/context`, deterministic dedupe, and ACP/Wire event exposure.
-- [ ] Add `RetrievalSourceProvider` trait implementations for file/MCP/hook/graph sources after the current memory/session path is stable.
+- [x] Add the first `RetrievalSourceProvider` boundary for current memory, session, thread-history, vector-slot, tool-result, and file-search candidates.
+- [ ] Add `RetrievalSourceProvider` implementations for MCP resource, hook, and graph sources after the current memory/session/file path is stable.
 - [x] Initialize LanceDB and wire FTS/vector/hybrid search paths behind the existing memory index façade.
 - [ ] Make memory mutation/query control-plane-ready so ACP/Wire can inspect and add memory without directly editing prompt text.
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -13,9 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use crate::context::{
-    FileSearchCandidateProvider, MemorySelectionItemContextEntry, RetrievedMemoryCandidate,
-};
+use crate::context::{FileSearchCandidateProvider, RetrievalCandidate, RetrievedMemoryCandidate};
 use crate::control_tokens::scrub_internal_control_tokens;
 use crate::llm::{ContentBlock, LlmBackend, LlmStreamEvent, LlmTurnMetadata};
 use crate::mcp_status::McpStatusSnapshot;
@@ -155,7 +153,7 @@ pub struct Agent {
     pub approved_bash_prefixes: Vec<String>,
     pub compact_state: CompactState,
     pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
-    pub file_search_candidates: Vec<MemorySelectionItemContextEntry>,
+    pub file_search_candidates: Vec<RetrievalCandidate>,
     file_search_provider: FileSearchCandidateProvider,
     inspection_progress: InspectionProgress,
     last_query_plan_updated: bool,

--- a/src/agent/memory_retrieval.rs
+++ b/src/agent/memory_retrieval.rs
@@ -23,7 +23,7 @@ impl Agent {
             self.file_search_candidates = Vec::new();
             return;
         }
-        self.file_search_candidates = self.file_search_provider.context_candidates(&query, 64);
+        self.file_search_candidates = self.file_search_provider.retrieval_candidates(&query, 64);
     }
 
     pub(super) fn selected_memory_context_text(

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -6,9 +6,9 @@ use crate::context::compaction_view::compaction_source_entries;
 use crate::context::memory_selection::memory_selection;
 use crate::context::retrieval_view::{retrieval_orchestration_view, retrieval_source_entries};
 use crate::context::{
-    CompactionContextView, ContextBudgetView, MemorySelectionItemContextEntry, PlanContextView,
-    PromptContextView, RetrievalContextView, RetrievedMemoryCandidate, SharedRuntimeContext,
-    TodoContextView,
+    CompactionContextView, ContextBudgetView, PlanContextView, PromptContextView,
+    RetrievalCandidate, RetrievalContextView, RetrievalRequest, RetrievedMemoryCandidate,
+    SharedRuntimeContext, TodoContextView, retrieval_candidates,
 };
 use crate::llm::{ContextBudget, LlmBackend};
 use crate::prompt::{self, EffectivePrompt, PromptMode, PromptRuntimeConfig};
@@ -47,7 +47,7 @@ pub struct RuntimeContextInputs<'a> {
     pub pending_interactions: Vec<RuntimeInteractionInput>,
     pub skill_listing: Option<String>,
     pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
-    pub file_search_candidates: Vec<MemorySelectionItemContextEntry>,
+    pub file_search_candidates: Vec<RetrievalCandidate>,
 }
 
 #[derive(Debug, Clone)]
@@ -154,6 +154,18 @@ impl<'a> ContextAssembler<'a> {
                 .saturating_sub(active_turn_budget)
                 .saturating_sub(compacted_history_budget)
         });
+        let retrieval_query = latest_user_request(inputs.history).unwrap_or_default();
+        let retrieval_request = RetrievalRequest {
+            query: retrieval_query.as_str(),
+            session_id: inputs.session_id.as_str(),
+            history: inputs.history,
+            vdb_uri: inputs.vdb_uri,
+        };
+        let retrieval_candidates = retrieval_candidates(
+            &retrieval_request,
+            inputs.retrieved_memory_candidates.as_slice(),
+            inputs.file_search_candidates.as_slice(),
+        );
         let memory_selection = memory_selection(
             effective_prompt.sources.as_slice(),
             inputs.plan_explanation.as_deref(),
@@ -161,18 +173,13 @@ impl<'a> ContextAssembler<'a> {
             inputs.pending_interactions.as_slice(),
             compaction.source_entries.as_slice(),
             inputs.history,
-            inputs.session_id.as_str(),
-            inputs.vdb_uri,
-            inputs.retrieved_memory_candidates.as_slice(),
-            inputs.file_search_candidates.as_slice(),
+            retrieval_candidates.as_slice(),
             selection_budget,
         );
         let retrieval = RetrievalContextView {
             orchestration: retrieval_orchestration_view(
                 inputs.session_id.as_str(),
-                latest_user_request(inputs.history)
-                    .as_deref()
-                    .unwrap_or_default(),
+                retrieval_query.as_str(),
                 retrieval_entries.as_slice(),
                 &memory_selection,
             ),

--- a/src/context/file_search_provider.rs
+++ b/src/context/file_search_provider.rs
@@ -12,7 +12,10 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use rara_file_search::FileSearchOptions;
 
-use crate::context::runtime::MemorySelectionItemContextEntry;
+use crate::context::retrieval_provider::stable_retrieval_text_id;
+use crate::context::runtime::{
+    MemorySelectionItemContextEntry, RetrievalCandidate, RetrievalSourceRef,
+};
 
 /// A file match from the file-search engine, ready for context routing.
 #[derive(Debug, Clone)]
@@ -76,11 +79,27 @@ impl FileSearchCandidateProvider {
     ///
     /// Each candidate carries provenance, budget, and a stable order
     /// (score descending, path ascending).
+    #[allow(dead_code)]
     pub fn context_candidates(
         &self,
         query: &str,
         max_results: usize,
     ) -> Vec<MemorySelectionItemContextEntry> {
+        self.retrieval_candidates(query, max_results)
+            .into_iter()
+            .map(|candidate| MemorySelectionItemContextEntry {
+                order: candidate.rank,
+                kind: candidate.kind,
+                label: candidate.label,
+                detail: candidate.detail,
+                selection_reason: candidate.selection_reason,
+                budget_impact_tokens: candidate.budget_impact_tokens,
+                dropped_reason: None,
+            })
+            .collect()
+    }
+
+    pub fn retrieval_candidates(&self, query: &str, max_results: usize) -> Vec<RetrievalCandidate> {
         let mut candidates = self.search(query, max_results);
 
         // Stable ordering: score descending, path ascending
@@ -94,14 +113,37 @@ impl FileSearchCandidateProvider {
         candidates
             .into_iter()
             .enumerate()
-            .map(|(idx, c)| MemorySelectionItemContextEntry {
-                order: idx + 1,
-                kind: "file_search".to_string(),
-                label: c.path,
-                detail: c.provenance,
-                selection_reason: format!("candidate from file search (score {:.3})", c.score),
-                budget_impact_tokens: Some(c.token_budget),
-                dropped_reason: None,
+            .map(|(idx, c)| {
+                let rank = idx + 1;
+                RetrievalCandidate {
+                    id: format!("file_search:{rank}:{}", stable_retrieval_text_id(&c.path)),
+                    source: RetrievalSourceRef {
+                        source_type: "file_search".to_string(),
+                        source_id: None,
+                        source_path: Some(c.path.clone()),
+                        source_uri: None,
+                        session_id: None,
+                        thread_id: None,
+                        workspace_id: None,
+                    },
+                    kind: "file_search".to_string(),
+                    scope: "workspace".to_string(),
+                    label: c.path,
+                    detail: c.provenance,
+                    summary: None,
+                    rank,
+                    score: Some(c.score as f32),
+                    priority: 30 + rank,
+                    dedupe_key: None,
+                    budget_impact_tokens: Some(c.token_budget),
+                    selection_reason: format!("candidate from file search (score {:.3})", c.score),
+                    availability_reason:
+                        "available because file search matched the current turn query".to_string(),
+                    not_selected_reason:
+                        "not selected after ranking the file-search candidate against the current memory-selection budget"
+                            .to_string(),
+                    selectable: true,
+                }
             })
             .collect()
     }

--- a/src/context/memory_selection.rs
+++ b/src/context/memory_selection.rs
@@ -1,6 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
-
-use serde_json::Value;
+use std::collections::BTreeMap;
 
 use crate::agent::{Message, PlanStepStatus};
 use crate::context::assembler::{
@@ -8,10 +6,8 @@ use crate::context::assembler::{
 };
 use crate::context::{
     CompactionSourceContextEntry, DropReason, MemorySelectionContextView,
-    MemorySelectionItemContextEntry, RETRIEVED_THREAD_CONTEXT_KIND,
-    RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalCandidate, RetrievalSourceRef,
-    RetrievedMemoryCandidate, RetrievedMemoryRenderItem, is_retrieved_memory_kind,
-    render_retrieved_memory_context, render_retrieved_memory_context_item,
+    MemorySelectionItemContextEntry, RetrievalCandidate, RetrievedMemoryRenderItem,
+    is_retrieved_memory_kind, render_retrieved_memory_context,
 };
 use crate::prompt::PromptSource;
 
@@ -22,10 +18,7 @@ pub(crate) fn memory_selection(
     pending_interactions: &[RuntimeInteractionInput],
     compacted_history: &[CompactionSourceContextEntry],
     history: &[Message],
-    session_id: &str,
-    vdb_uri: &str,
-    retrieved_memory_candidates: &[RetrievedMemoryCandidate],
-    file_search_candidates: &[MemorySelectionItemContextEntry],
+    retrieval_candidates: &[RetrievalCandidate],
     selection_budget_tokens: Option<usize>,
 ) -> MemorySelectionContextView {
     let mut selected_items = fixed_memory_selection_items(
@@ -41,10 +34,11 @@ pub(crate) fn memory_selection(
         .map(|item| item.kind.clone())
         .collect::<Vec<_>>();
     let mut discretionary = select_memory_candidates(
-        merge_file_search_candidates(
-            retrieval_memory_candidates(history, session_id, vdb_uri, retrieved_memory_candidates),
-            file_search_candidates,
-        ),
+        retrieval_candidates
+            .iter()
+            .cloned()
+            .map(memory_selection_candidate_from_retrieval_candidate)
+            .collect(),
         selection_budget_tokens,
         fixed_kinds.as_slice(),
     );
@@ -247,86 +241,6 @@ fn compacted_history_selected_items(
         .collect()
 }
 
-fn retrieval_memory_candidates(
-    history: &[Message],
-    session_id: &str,
-    vdb_uri: &str,
-    retrieved_memory_candidates: &[RetrievedMemoryCandidate],
-) -> Vec<MemorySelectionCandidate> {
-    let mut candidates = direct_retrieved_memory_candidates(retrieved_memory_candidates);
-    candidates.extend(retrieval_tool_candidates(history));
-    candidates.push(thread_history_candidate(history, session_id));
-    candidates.push(vector_memory_candidate(vdb_uri));
-    candidates
-}
-
-fn direct_retrieved_memory_candidates(
-    retrieved_memory_candidates: &[RetrievedMemoryCandidate],
-) -> Vec<MemorySelectionCandidate> {
-    retrieved_memory_candidates
-        .iter()
-        .map(retrieval_candidate_from_retrieved_memory)
-        .map(memory_selection_candidate_from_retrieval_candidate)
-        .collect()
-}
-
-fn retrieval_candidate_from_retrieved_memory(
-    candidate: &RetrievedMemoryCandidate,
-) -> RetrievalCandidate {
-    let source_type = match candidate.kind.as_str() {
-        RETRIEVED_THREAD_CONTEXT_KIND => "session_context",
-        RETRIEVED_WORKSPACE_MEMORY_KIND => "memory_record",
-        _ => "retrieved_memory",
-    };
-    let scope = match candidate.kind.as_str() {
-        RETRIEVED_THREAD_CONTEXT_KIND => "thread",
-        RETRIEVED_WORKSPACE_MEMORY_KIND => "workspace",
-        _ => "unknown",
-    };
-    let priority = match candidate.kind.as_str() {
-        RETRIEVED_THREAD_CONTEXT_KIND => 10,
-        RETRIEVED_WORKSPACE_MEMORY_KIND => 20,
-        _ => 25,
-    } + candidate.rank;
-    let dedupe_key = format!(
-        "{}:{}:{}",
-        source_type,
-        candidate.kind,
-        stable_retrieval_text_id(candidate.detail.as_str())
-    );
-    RetrievalCandidate {
-        id: format!(
-            "{}:{}:{}",
-            source_type,
-            candidate.rank,
-            stable_retrieval_text_id(candidate.label.as_str())
-        ),
-        source: RetrievalSourceRef {
-            source_type: source_type.to_string(),
-            source_id: None,
-            source_path: None,
-            source_uri: None,
-            session_id: None,
-            thread_id: None,
-            workspace_id: None,
-        },
-        kind: candidate.kind.clone(),
-        scope: scope.to_string(),
-        label: candidate.label.clone(),
-        detail: candidate.detail.clone(),
-        summary: None,
-        rank: candidate.rank,
-        score: None,
-        priority,
-        dedupe_key: Some(dedupe_key),
-        budget_impact_tokens: Some(direct_retrieval_candidate_budget_impact(candidate)),
-        selection_reason: candidate.selection_reason.clone(),
-        availability_reason:
-            "available because a retrieval provider returned this candidate for the current turn"
-                .to_string(),
-    }
-}
-
 fn memory_selection_candidate_from_retrieval_candidate(
     candidate: RetrievalCandidate,
 ) -> MemorySelectionCandidate {
@@ -338,147 +252,11 @@ fn memory_selection_candidate_from_retrieval_candidate(
         budget_impact_tokens: candidate.budget_impact_tokens,
         priority: candidate.priority,
         dedupe_key: candidate.dedupe_key,
-        selectable: true,
+        selectable: candidate.selectable,
         dropped_reason: DropReason::NotSelected {
-            reason:
-                "not selected after ranking the retrieved memory candidate against the current memory-selection budget"
-                    .to_string(),
+            reason: candidate.not_selected_reason,
         },
     }
-}
-
-fn direct_retrieval_candidate_budget_impact(candidate: &RetrievedMemoryCandidate) -> usize {
-    let item = RetrievedMemoryRenderItem {
-        label: candidate.label.as_str(),
-        detail: candidate.detail.as_str(),
-    };
-    estimate_text_tokens(&render_retrieved_memory_context_item(item))
-}
-
-fn stable_retrieval_text_id(value: &str) -> String {
-    value
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>()
-        .split('-')
-        .filter(|part| !part.is_empty())
-        .take(8)
-        .collect::<Vec<_>>()
-        .join("-")
-}
-
-fn retrieval_tool_candidates(history: &[Message]) -> Vec<MemorySelectionCandidate> {
-    let mut pending = HashMap::new();
-    let mut items = Vec::new();
-
-    for message in history {
-        match message.role.as_str() {
-            "assistant" => collect_pending_retrieval_tool_uses(&mut pending, message),
-            "user" => collect_retrieval_tool_results(&mut pending, &mut items, message),
-            _ => {}
-        }
-    }
-
-    items
-}
-
-fn collect_pending_retrieval_tool_uses(
-    pending: &mut HashMap<String, (String, Option<String>)>,
-    message: &Message,
-) {
-    let Some(items) = message.content.as_array() else {
-        return;
-    };
-    for item in items {
-        let Some(item_type) = item.get("type").and_then(Value::as_str) else {
-            continue;
-        };
-        if item_type != "tool_use" {
-            continue;
-        }
-        let Some(name) = item.get("name").and_then(Value::as_str) else {
-            continue;
-        };
-        if !matches!(name, "retrieve_experience" | "retrieve_session_context") {
-            continue;
-        }
-        let Some(tool_use_id) = item.get("id").and_then(Value::as_str) else {
-            continue;
-        };
-        let query = item
-            .get("input")
-            .and_then(Value::as_object)
-            .and_then(|input| input.get("query"))
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        pending.insert(tool_use_id.to_string(), (name.to_string(), query));
-    }
-}
-
-fn collect_retrieval_tool_results(
-    pending: &mut HashMap<String, (String, Option<String>)>,
-    items: &mut Vec<MemorySelectionCandidate>,
-    message: &Message,
-) {
-    let Some(blocks) = message.content.as_array() else {
-        return;
-    };
-    for block in blocks {
-        let Some(item_type) = block.get("type").and_then(Value::as_str) else {
-            continue;
-        };
-        if item_type != "tool_result" {
-            continue;
-        }
-        let Some(tool_use_id) = block.get("tool_use_id").and_then(Value::as_str) else {
-            continue;
-        };
-        let Some((name, query)) = pending.remove(tool_use_id) else {
-            continue;
-        };
-        let content = block
-            .get("content")
-            .and_then(Value::as_str)
-            .unwrap_or_default();
-        items.push(retrieval_tool_candidate(
-            name.as_str(),
-            query.as_deref(),
-            content,
-        ));
-    }
-}
-
-/// Merge file-search candidates into the memory-selection candidate pool.
-/// Each entry is converted to a `MemorySelectionCandidate` with priority
-/// derived from its sort order (lower order = higher priority).
-fn merge_file_search_candidates(
-    mut candidates: Vec<MemorySelectionCandidate>,
-    file_search: &[MemorySelectionItemContextEntry],
-) -> Vec<MemorySelectionCandidate> {
-    for entry in file_search {
-        candidates.push(MemorySelectionCandidate {
-            kind: entry.kind.clone(),
-            label: entry.label.clone(),
-            detail: entry.detail.clone(),
-            selection_reason: entry.selection_reason.clone(),
-            budget_impact_tokens: entry.budget_impact_tokens,
-            priority: 30 + entry.order,
-            dedupe_key: None,
-            selectable: true,
-            dropped_reason: DropReason::NotSelected {
-                reason:
-                    "not selected after ranking the file-search candidate against the current memory-selection budget"
-                        .to_string(),
-            },
-        });
-    }
-    candidates
 }
 
 fn select_memory_candidates(
@@ -657,112 +435,6 @@ fn workspace_memory_available_item(
     }
 }
 
-fn thread_history_candidate(history: &[Message], session_id: &str) -> MemorySelectionCandidate {
-    MemorySelectionCandidate {
-        kind: "thread_history".to_string(),
-        label: "Thread History".to_string(),
-        detail: format!("session={session_id} messages={}", history.len()),
-        selection_reason: "thread history remains available as a recall source even when only active-turn state is currently injected".to_string(),
-        budget_impact_tokens: Some(estimate_text_tokens(
-            format!("session={session_id} messages={}", history.len()).as_str(),
-        )),
-        priority: 30,
-        dedupe_key: None,
-        selectable: !history.is_empty(),
-        dropped_reason: DropReason::NotSelected { reason: if history.is_empty() {
-            "no thread history is available for selection".to_string()
-        } else {
-            "raw thread history was not selected directly because the current turn already has sufficient active-turn and compacted-history context".to_string()
-        }},
-    }
-}
-
-fn vector_memory_candidate(vdb_uri: &str) -> MemorySelectionCandidate {
-    MemorySelectionCandidate {
-        kind: "vector_memory".to_string(),
-        label: "Vector Memory Store".to_string(),
-        detail: if vdb_uri.is_empty() {
-            "-".to_string()
-        } else {
-            vdb_uri.to_string()
-        },
-        selection_reason: "the vector-backed memory slot is part of the selection contract even before full ranked retrieval is implemented".to_string(),
-        budget_impact_tokens: None,
-        priority: 40,
-        dedupe_key: None,
-        selectable: false,
-        dropped_reason: DropReason::NotSelected { reason: if vdb_uri.is_empty() {
-            "no vector-backed memory store is configured".to_string()
-        } else {
-            "not selected because vector-backed candidate ranking is not implemented yet".to_string()
-        }},
-    }
-}
-
-fn retrieval_tool_candidate(
-    tool_name: &str,
-    query: Option<&str>,
-    content: &str,
-) -> MemorySelectionCandidate {
-    match tool_name {
-        "retrieve_experience" => {
-            let experiences = extract_json_array_strings(content, "relevant_experiences");
-            let preview = if experiences.is_empty() {
-                "no recalled experiences".to_string()
-            } else {
-                format!(
-                    "recalled={} item(s); preview: {}",
-                    experiences.len(),
-                    experiences.join(" | ")
-                )
-            };
-            let query = query.unwrap_or("query unavailable");
-            let detail = format!("query={query}; {preview}");
-            MemorySelectionCandidate {
-                kind: "retrieved_workspace_memory".to_string(),
-                label: "Retrieved Experience".to_string(),
-                budget_impact_tokens: Some(estimate_text_tokens(detail.as_str())),
-                detail,
-                selection_reason: "selected because the retrieval tool returned relevant durable memory candidates for the current task".to_string(),
-                priority: 10,
-                dedupe_key: None,
-                selectable: true,
-                dropped_reason: DropReason::NotSelected { reason: "not selected after ranking the retrieved workspace-memory candidates against the current memory-selection budget".to_string() },
-            }
-        }
-        "retrieve_session_context" => {
-            let summary = extract_json_string_field(content, "summary")
-                .unwrap_or_else(|| "no session-context summary".to_string());
-            let query = query.unwrap_or("query unavailable");
-            let detail = format!("query={query}; summary: {summary}");
-            MemorySelectionCandidate {
-                kind: "retrieved_thread_context".to_string(),
-                label: "Retrieved Session Context".to_string(),
-                budget_impact_tokens: Some(estimate_text_tokens(detail.as_str())),
-                detail,
-                selection_reason: "selected because the retrieval tool returned focused thread-context material for the current task".to_string(),
-                priority: 20,
-                dedupe_key: None,
-                selectable: true,
-                dropped_reason: DropReason::NotSelected { reason: "not selected after ranking the retrieved thread-context candidate against the current memory-selection budget".to_string() },
-            }
-        }
-        other => MemorySelectionCandidate {
-            kind: other.to_string(),
-            label: other.to_string(),
-            detail: query
-                .map(|query| format!("query={query}"))
-                .unwrap_or_else(|| "query unavailable".to_string()),
-            selection_reason: "selected because a retrieval tool result was returned in the current thread history".to_string(),
-            budget_impact_tokens: Some(estimate_text_tokens(content)),
-            priority: 50,
-            dedupe_key: None,
-            selectable: true,
-            dropped_reason: DropReason::NotSelected { reason: "not selected after ranking the retrieval candidate against the current memory-selection budget".to_string() },
-        },
-    }
-}
-
 fn summarize_workspace_memory_source(content: &str) -> String {
     let line_count = content
         .lines()
@@ -775,56 +447,53 @@ fn summarize_workspace_memory_source(content: &str) -> String {
     }
 }
 
-fn extract_json_array_strings(content: &str, key: &str) -> Vec<String> {
-    extract_tool_result_payload(content)
-        .and_then(|payload| payload.get(key).and_then(Value::as_array).cloned())
-        .into_iter()
-        .flatten()
-        .filter_map(|item| item.as_str().map(str::trim).map(str::to_string))
-        .filter(|value| !value.is_empty())
-        .collect()
-}
-
-fn extract_json_string_field(content: &str, key: &str) -> Option<String> {
-    extract_tool_result_payload(content)
-        .and_then(|payload| payload.get(key).and_then(Value::as_str).map(str::to_string))
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-
-pub(crate) fn extract_tool_result_payload(content: &str) -> Option<Value> {
-    let payload = content
-        .split_once("Payload:\n")
-        .map(|(_, payload)| payload)
-        .unwrap_or(content)
-        .trim();
-    serde_json::from_str(payload).ok()
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::context::retrieval_provider::retrieval_candidate_from_retrieved_memory;
+    use crate::context::{
+        RETRIEVED_THREAD_CONTEXT_KIND, RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalRequest,
+        RetrievedMemoryCandidate, retrieval_candidates,
+    };
 
-    #[test]
-    fn extract_tool_result_payload_falls_back_to_plain_json_content() {
-        let payload = extract_tool_result_payload(
-            r#"{
-                "status": "ok",
-                "summary": "plain json payload without wrapper"
-            }"#,
+    #[allow(clippy::too_many_arguments)]
+    fn memory_selection_for_test(
+        prompt_sources: &[PromptSource],
+        plan_explanation: Option<&str>,
+        plan_steps: &[(PlanStepStatus, String)],
+        pending_interactions: &[RuntimeInteractionInput],
+        compacted_history: &[CompactionSourceContextEntry],
+        history: &[Message],
+        session_id: &str,
+        vdb_uri: &str,
+        retrieved_memory_candidates: &[RetrievedMemoryCandidate],
+        file_search_candidates: &[RetrievalCandidate],
+        selection_budget_tokens: Option<usize>,
+    ) -> MemorySelectionContextView {
+        let query = latest_user_request(history).unwrap_or_default();
+        let request = RetrievalRequest {
+            query: query.as_str(),
+            session_id,
+            history,
+            vdb_uri,
+        };
+        let candidates = retrieval_candidates(
+            &request,
+            retrieved_memory_candidates,
+            file_search_candidates,
+        );
+        memory_selection(
+            prompt_sources,
+            plan_explanation,
+            plan_steps,
+            pending_interactions,
+            compacted_history,
+            history,
+            candidates.as_slice(),
+            selection_budget_tokens,
         )
-        .expect("payload should parse from raw json");
-
-        assert_eq!(
-            payload.get("status").and_then(serde_json::Value::as_str),
-            Some("ok")
-        );
-        assert_eq!(
-            payload.get("summary").and_then(serde_json::Value::as_str),
-            Some("plain json payload without wrapper")
-        );
     }
 
     // ── Non-vector selection path ──────────────────────────────────────────
@@ -841,7 +510,7 @@ mod tests {
                 content: json!("hi there"),
             },
         ];
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -885,7 +554,7 @@ mod tests {
             detail: "previous work".to_string(),
             inclusion_reason: "carried forward".to_string(),
         }];
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -933,7 +602,7 @@ mod tests {
             detail: "stable transcript path".to_string(),
             inclusion_reason: "carried forward".to_string(),
         }];
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -969,7 +638,7 @@ mod tests {
     #[test]
     fn vector_memory_is_available_but_not_selectable() {
         let history: Vec<Message> = vec![];
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -1033,7 +702,7 @@ mod tests {
         ];
         // Budget of 1 token forces the retrieval candidate to be dropped,
         // proving it was captured as a candidate.
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -1100,7 +769,7 @@ mod tests {
                 ]),
             },
         ];
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -1140,7 +809,7 @@ mod tests {
             rank: 1,
         }];
 
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -1222,7 +891,7 @@ mod tests {
             },
         ];
 
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -1284,7 +953,7 @@ mod tests {
             },
         ];
 
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -1361,7 +1030,7 @@ mod tests {
         .expect("retrieved memory context should render");
         let exact_budget = estimate_text_tokens(&rendered);
 
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -1410,7 +1079,7 @@ mod tests {
             rank: 1,
         }];
 
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],
@@ -1445,7 +1114,7 @@ mod tests {
             role: "user".to_string(),
             content: json!("hello"),
         }];
-        let result = memory_selection(
+        let result = memory_selection_for_test(
             &[],
             None,
             &[],

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -8,6 +8,7 @@ mod assembly_view;
 mod compaction_view;
 mod file_search_provider;
 mod memory_selection;
+mod retrieval_provider;
 mod retrieval_view;
 mod retrieved_memory_render;
 mod retriever;
@@ -17,7 +18,8 @@ pub use self::assembler::{
     AssembledContext, AssembledTurnContext, ContextAssembler, RuntimeContextInputs,
     RuntimeInteractionInput,
 };
-pub(crate) use self::file_search_provider::{FileSearchCandidate, FileSearchCandidateProvider};
+pub(crate) use self::file_search_provider::FileSearchCandidateProvider;
+pub(crate) use self::retrieval_provider::{RetrievalRequest, retrieval_candidates};
 pub(crate) use self::retrieved_memory_render::{
     RetrievedMemoryRenderItem, render_retrieved_memory_context,
     render_retrieved_memory_context_item,

--- a/src/context/retrieval_provider.rs
+++ b/src/context/retrieval_provider.rs
@@ -1,0 +1,645 @@
+use crate::agent::Message;
+use crate::context::assembler::estimate_text_tokens;
+use crate::context::{
+    RETRIEVED_THREAD_CONTEXT_KIND, RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalCandidate,
+    RetrievalSourceRef, RetrievedMemoryCandidate, RetrievedMemoryRenderItem,
+    render_retrieved_memory_context_item,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RetrievalRequest<'a> {
+    pub query: &'a str,
+    pub session_id: &'a str,
+    pub history: &'a [Message],
+    pub vdb_uri: &'a str,
+}
+
+pub(crate) trait RetrievalSourceProvider {
+    fn source_kind(&self) -> &'static str;
+    fn candidates(&self, request: &RetrievalRequest<'_>) -> Vec<RetrievalCandidate>;
+}
+
+pub(crate) fn retrieval_candidates(
+    request: &RetrievalRequest<'_>,
+    retrieved_memory_candidates: &[RetrievedMemoryCandidate],
+    file_search_candidates: &[RetrievalCandidate],
+) -> Vec<RetrievalCandidate> {
+    let _query = request.query;
+    let mut candidates = Vec::new();
+    let direct_memory = DirectRetrievedMemoryProvider {
+        candidates: retrieved_memory_candidates,
+    };
+    let retrieval_tools = RetrievalToolResultProvider;
+    let thread_history = ThreadHistoryProvider;
+    let vector_memory = VectorMemoryProvider;
+    let file_search = PrecomputedFileSearchProvider {
+        candidates: file_search_candidates,
+    };
+
+    let _source_order = [
+        direct_memory.source_kind(),
+        retrieval_tools.source_kind(),
+        thread_history.source_kind(),
+        vector_memory.source_kind(),
+        file_search.source_kind(),
+    ];
+    candidates.extend(direct_memory.candidates(request));
+    candidates.extend(retrieval_tools.candidates(request));
+    candidates.extend(thread_history.candidates(request));
+    candidates.extend(vector_memory.candidates(request));
+    candidates.extend(file_search.candidates(request));
+    candidates
+}
+
+pub(crate) struct DirectRetrievedMemoryProvider<'a> {
+    candidates: &'a [RetrievedMemoryCandidate],
+}
+
+impl RetrievalSourceProvider for DirectRetrievedMemoryProvider<'_> {
+    fn source_kind(&self) -> &'static str {
+        "retrieved_memory"
+    }
+
+    fn candidates(&self, _request: &RetrievalRequest<'_>) -> Vec<RetrievalCandidate> {
+        self.candidates
+            .iter()
+            .map(retrieval_candidate_from_retrieved_memory)
+            .collect()
+    }
+}
+
+pub(crate) struct PrecomputedFileSearchProvider<'a> {
+    candidates: &'a [RetrievalCandidate],
+}
+
+impl RetrievalSourceProvider for PrecomputedFileSearchProvider<'_> {
+    fn source_kind(&self) -> &'static str {
+        "file_search"
+    }
+
+    fn candidates(&self, _request: &RetrievalRequest<'_>) -> Vec<RetrievalCandidate> {
+        self.candidates.to_vec()
+    }
+}
+
+pub(crate) struct RetrievalToolResultProvider;
+
+impl RetrievalSourceProvider for RetrievalToolResultProvider {
+    fn source_kind(&self) -> &'static str {
+        "retrieval_tool_result"
+    }
+
+    fn candidates(&self, request: &RetrievalRequest<'_>) -> Vec<RetrievalCandidate> {
+        retrieval_tool_candidates(request.history)
+    }
+}
+
+pub(crate) struct ThreadHistoryProvider;
+
+impl RetrievalSourceProvider for ThreadHistoryProvider {
+    fn source_kind(&self) -> &'static str {
+        "thread_history"
+    }
+
+    fn candidates(&self, request: &RetrievalRequest<'_>) -> Vec<RetrievalCandidate> {
+        vec![thread_history_candidate(
+            request.history,
+            request.session_id,
+        )]
+    }
+}
+
+pub(crate) struct VectorMemoryProvider;
+
+impl RetrievalSourceProvider for VectorMemoryProvider {
+    fn source_kind(&self) -> &'static str {
+        "vector_memory"
+    }
+
+    fn candidates(&self, request: &RetrievalRequest<'_>) -> Vec<RetrievalCandidate> {
+        vec![vector_memory_candidate(request.vdb_uri)]
+    }
+}
+
+pub(crate) fn retrieval_candidate_from_retrieved_memory(
+    candidate: &RetrievedMemoryCandidate,
+) -> RetrievalCandidate {
+    let source_type = match candidate.kind.as_str() {
+        RETRIEVED_THREAD_CONTEXT_KIND => "session_context",
+        RETRIEVED_WORKSPACE_MEMORY_KIND => "memory_record",
+        _ => "retrieved_memory",
+    };
+    let scope = match candidate.kind.as_str() {
+        RETRIEVED_THREAD_CONTEXT_KIND => "thread",
+        RETRIEVED_WORKSPACE_MEMORY_KIND => "workspace",
+        _ => "unknown",
+    };
+    let priority = match candidate.kind.as_str() {
+        RETRIEVED_THREAD_CONTEXT_KIND => 10,
+        RETRIEVED_WORKSPACE_MEMORY_KIND => 20,
+        _ => 25,
+    } + candidate.rank;
+    let dedupe_key = format!(
+        "{}:{}:{}",
+        source_type,
+        candidate.kind,
+        stable_retrieval_text_id(candidate.detail.as_str())
+    );
+    RetrievalCandidate {
+        id: format!(
+            "{}:{}:{}",
+            source_type,
+            candidate.rank,
+            stable_retrieval_text_id(candidate.label.as_str())
+        ),
+        source: RetrievalSourceRef {
+            source_type: source_type.to_string(),
+            source_id: None,
+            source_path: None,
+            source_uri: None,
+            session_id: None,
+            thread_id: None,
+            workspace_id: None,
+        },
+        kind: candidate.kind.clone(),
+        scope: scope.to_string(),
+        label: candidate.label.clone(),
+        detail: candidate.detail.clone(),
+        summary: None,
+        rank: candidate.rank,
+        score: None,
+        priority,
+        dedupe_key: Some(dedupe_key),
+        budget_impact_tokens: Some(direct_retrieval_candidate_budget_impact(candidate)),
+        selection_reason: candidate.selection_reason.clone(),
+        availability_reason:
+            "available because a retrieval provider returned this candidate for the current turn"
+                .to_string(),
+        not_selected_reason:
+            "not selected after ranking the retrieved memory candidate against the current memory-selection budget"
+                .to_string(),
+        selectable: true,
+    }
+}
+
+pub(crate) fn stable_retrieval_text_id(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .take(8)
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn direct_retrieval_candidate_budget_impact(candidate: &RetrievedMemoryCandidate) -> usize {
+    let item = RetrievedMemoryRenderItem {
+        label: candidate.label.as_str(),
+        detail: candidate.detail.as_str(),
+    };
+    estimate_text_tokens(&render_retrieved_memory_context_item(item))
+}
+
+fn retrieval_tool_candidates(history: &[Message]) -> Vec<RetrievalCandidate> {
+    let mut pending = std::collections::HashMap::new();
+    let mut items = Vec::new();
+
+    for message in history {
+        match message.role.as_str() {
+            "assistant" => collect_pending_retrieval_tool_uses(&mut pending, message),
+            "user" => collect_retrieval_tool_results(&mut pending, &mut items, message),
+            _ => {}
+        }
+    }
+
+    items
+}
+
+fn collect_pending_retrieval_tool_uses(
+    pending: &mut std::collections::HashMap<String, (String, Option<String>)>,
+    message: &Message,
+) {
+    let Some(items) = message.content.as_array() else {
+        return;
+    };
+    for item in items {
+        let Some(item_type) = item.get("type").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if item_type != "tool_use" {
+            continue;
+        }
+        let Some(name) = item.get("name").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if !matches!(name, "retrieve_experience" | "retrieve_session_context") {
+            continue;
+        }
+        let Some(tool_use_id) = item.get("id").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let query = item
+            .get("input")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|input| input.get("query"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        pending.insert(tool_use_id.to_string(), (name.to_string(), query));
+    }
+}
+
+fn collect_retrieval_tool_results(
+    pending: &mut std::collections::HashMap<String, (String, Option<String>)>,
+    items: &mut Vec<RetrievalCandidate>,
+    message: &Message,
+) {
+    let Some(blocks) = message.content.as_array() else {
+        return;
+    };
+    for block in blocks {
+        let Some(item_type) = block.get("type").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if item_type != "tool_result" {
+            continue;
+        }
+        let Some(tool_use_id) = block.get("tool_use_id").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let Some((name, query)) = pending.remove(tool_use_id) else {
+            continue;
+        };
+        let content = block
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        items.push(retrieval_tool_candidate(
+            name.as_str(),
+            query.as_deref(),
+            content,
+        ));
+    }
+}
+
+fn retrieval_tool_candidate(
+    tool_name: &str,
+    query: Option<&str>,
+    content: &str,
+) -> RetrievalCandidate {
+    match tool_name {
+        "retrieve_experience" => {
+            let experiences = extract_json_array_strings(content, "relevant_experiences");
+            let preview = if experiences.is_empty() {
+                "no recalled experiences".to_string()
+            } else {
+                format!(
+                    "recalled={} item(s); preview: {}",
+                    experiences.len(),
+                    experiences.join(" | ")
+                )
+            };
+            let query = query.unwrap_or("query unavailable");
+            let detail = format!("query={query}; {preview}");
+            RetrievalCandidate {
+                id: format!("tool:retrieve_experience:{}", stable_retrieval_text_id(&detail)),
+                source: RetrievalSourceRef {
+                    source_type: "tool_result".to_string(),
+                    source_id: None,
+                    source_path: None,
+                    source_uri: None,
+                    session_id: None,
+                    thread_id: None,
+                    workspace_id: None,
+                },
+                kind: "retrieved_workspace_memory".to_string(),
+                scope: "workspace".to_string(),
+                label: "Retrieved Experience".to_string(),
+                detail: detail.clone(),
+                summary: None,
+                rank: 0,
+                score: None,
+                priority: 10,
+                dedupe_key: None,
+                budget_impact_tokens: Some(estimate_text_tokens(detail.as_str())),
+                selection_reason: "selected because the retrieval tool returned relevant durable memory candidates for the current task".to_string(),
+                availability_reason: "available because a retrieval tool result was found in thread history".to_string(),
+                not_selected_reason: "not selected after ranking the retrieved workspace-memory candidates against the current memory-selection budget".to_string(),
+                selectable: true,
+            }
+        }
+        "retrieve_session_context" => {
+            let summary = extract_json_string_field(content, "summary")
+                .unwrap_or_else(|| "no session-context summary".to_string());
+            let query = query.unwrap_or("query unavailable");
+            let detail = format!("query={query}; summary: {summary}");
+            RetrievalCandidate {
+                id: format!(
+                    "tool:retrieve_session_context:{}",
+                    stable_retrieval_text_id(&detail)
+                ),
+                source: RetrievalSourceRef {
+                    source_type: "tool_result".to_string(),
+                    source_id: None,
+                    source_path: None,
+                    source_uri: None,
+                    session_id: None,
+                    thread_id: None,
+                    workspace_id: None,
+                },
+                kind: "retrieved_thread_context".to_string(),
+                scope: "thread".to_string(),
+                label: "Retrieved Session Context".to_string(),
+                detail: detail.clone(),
+                summary: None,
+                rank: 0,
+                score: None,
+                priority: 20,
+                dedupe_key: None,
+                budget_impact_tokens: Some(estimate_text_tokens(detail.as_str())),
+                selection_reason: "selected because the retrieval tool returned focused thread-context material for the current task".to_string(),
+                availability_reason: "available because a retrieval tool result was found in thread history".to_string(),
+                not_selected_reason: "not selected after ranking the retrieved thread-context candidate against the current memory-selection budget".to_string(),
+                selectable: true,
+            }
+        }
+        other => {
+            let detail = query
+                .map(|query| format!("query={query}"))
+                .unwrap_or_else(|| "query unavailable".to_string());
+            RetrievalCandidate {
+                id: format!("tool:{other}:{}", stable_retrieval_text_id(&detail)),
+                source: RetrievalSourceRef {
+                    source_type: "tool_result".to_string(),
+                    source_id: None,
+                    source_path: None,
+                    source_uri: None,
+                    session_id: None,
+                    thread_id: None,
+                    workspace_id: None,
+                },
+                kind: other.to_string(),
+                scope: "thread".to_string(),
+                label: other.to_string(),
+                detail,
+                summary: None,
+                rank: 0,
+                score: None,
+                priority: 50,
+                dedupe_key: None,
+                budget_impact_tokens: Some(estimate_text_tokens(content)),
+                selection_reason: "selected because a retrieval tool result was returned in the current thread history".to_string(),
+                availability_reason: "available because a retrieval tool result was found in thread history".to_string(),
+                not_selected_reason: "not selected after ranking the retrieval candidate against the current memory-selection budget".to_string(),
+                selectable: true,
+            }
+        }
+    }
+}
+
+fn thread_history_candidate(history: &[Message], session_id: &str) -> RetrievalCandidate {
+    let detail = format!("session={session_id} messages={}", history.len());
+    RetrievalCandidate {
+        id: format!("thread_history:{session_id}"),
+        source: RetrievalSourceRef {
+            source_type: "thread_history".to_string(),
+            source_id: None,
+            source_path: None,
+            source_uri: None,
+            session_id: Some(session_id.to_string()),
+            thread_id: None,
+            workspace_id: None,
+        },
+        kind: "thread_history".to_string(),
+        scope: "thread".to_string(),
+        label: "Thread History".to_string(),
+        detail: detail.clone(),
+        summary: None,
+        rank: 0,
+        score: None,
+        priority: 30,
+        dedupe_key: None,
+        budget_impact_tokens: Some(estimate_text_tokens(detail.as_str())),
+        selection_reason:
+            "thread history remains available as a recall source even when only active-turn state is currently injected"
+                .to_string(),
+        availability_reason: if history.is_empty() {
+            "no thread history is available for selection".to_string()
+        } else {
+            "raw thread history was not selected directly because the current turn already has sufficient active-turn and compacted-history context".to_string()
+        },
+        not_selected_reason: if history.is_empty() {
+            "no thread history is available for selection".to_string()
+        } else {
+            "raw thread history was not selected directly because the current turn already has sufficient active-turn and compacted-history context".to_string()
+        },
+        selectable: !history.is_empty(),
+    }
+}
+
+fn vector_memory_candidate(vdb_uri: &str) -> RetrievalCandidate {
+    let configured = !vdb_uri.is_empty();
+    RetrievalCandidate {
+        id: "vector_memory".to_string(),
+        source: RetrievalSourceRef {
+            source_type: "vector_memory".to_string(),
+            source_id: None,
+            source_path: None,
+            source_uri: configured.then(|| vdb_uri.to_string()),
+            session_id: None,
+            thread_id: None,
+            workspace_id: None,
+        },
+        kind: "vector_memory".to_string(),
+        scope: "workspace".to_string(),
+        label: "Vector Memory Store".to_string(),
+        detail: if configured {
+            vdb_uri.to_string()
+        } else {
+            "-".to_string()
+        },
+        summary: None,
+        rank: 0,
+        score: None,
+        priority: 40,
+        dedupe_key: None,
+        budget_impact_tokens: None,
+        selection_reason:
+            "the vector-backed memory slot is part of the selection contract even before full ranked retrieval is implemented"
+                .to_string(),
+        availability_reason: if configured {
+            "not selected because vector-backed candidate ranking is not implemented yet".to_string()
+        } else {
+            "no vector-backed memory store is configured".to_string()
+        },
+        not_selected_reason: if configured {
+            "not selected because vector-backed candidate ranking is not implemented yet".to_string()
+        } else {
+            "no vector-backed memory store is configured".to_string()
+        },
+        selectable: false,
+    }
+}
+
+fn extract_json_array_strings(content: &str, key: &str) -> Vec<String> {
+    extract_tool_result_payload(content)
+        .and_then(|payload| {
+            payload
+                .get(key)
+                .and_then(serde_json::Value::as_array)
+                .cloned()
+        })
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.as_str().map(str::trim).map(str::to_string))
+        .filter(|value| !value.is_empty())
+        .collect()
+}
+
+fn extract_json_string_field(content: &str, key: &str) -> Option<String> {
+    extract_tool_result_payload(content)
+        .and_then(|payload| {
+            payload
+                .get(key)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+pub(crate) fn extract_tool_result_payload(content: &str) -> Option<serde_json::Value> {
+    let payload = content
+        .split_once("Payload:\n")
+        .map(|(_, payload)| payload)
+        .unwrap_or(content)
+        .trim();
+    serde_json::from_str(payload).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn retrieval_request_keeps_current_turn_source_inputs() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!("where is the path?"),
+        }];
+        let request = RetrievalRequest {
+            query: "where is the path?",
+            session_id: "session-1",
+            history: &history,
+            vdb_uri: "memory://vdb",
+        };
+
+        assert_eq!(request.query, "where is the path?");
+        assert_eq!(request.session_id, "session-1");
+        assert_eq!(request.history.len(), 1);
+        assert_eq!(request.vdb_uri, "memory://vdb");
+    }
+
+    #[test]
+    fn provider_boundary_collects_current_sources_in_stable_order() {
+        let history = vec![Message {
+            role: "user".to_string(),
+            content: json!("where is the path?"),
+        }];
+        let request = RetrievalRequest {
+            query: "where is the path?",
+            session_id: "session-1",
+            history: &history,
+            vdb_uri: "memory://vdb",
+        };
+        let retrieved = vec![RetrievedMemoryCandidate {
+            kind: RETRIEVED_WORKSPACE_MEMORY_KIND.to_string(),
+            label: "Memory: path".to_string(),
+            detail: "content: /tmp/project".to_string(),
+            selection_reason: "retrieved".to_string(),
+            rank: 1,
+        }];
+        let file = vec![RetrievalCandidate {
+            id: "file:src/main.rs".to_string(),
+            source: RetrievalSourceRef {
+                source_type: "file_search".to_string(),
+                source_id: None,
+                source_path: Some("src/main.rs".to_string()),
+                source_uri: None,
+                session_id: None,
+                thread_id: None,
+                workspace_id: None,
+            },
+            kind: "file_search".to_string(),
+            scope: "workspace".to_string(),
+            label: "src/main.rs".to_string(),
+            detail: "file_search(name_match, score=1.000)".to_string(),
+            summary: None,
+            rank: 1,
+            score: Some(1.0),
+            priority: 31,
+            dedupe_key: Some("file_search:src/main.rs".to_string()),
+            budget_impact_tokens: Some(9),
+            selection_reason: "candidate from file search (score 1.000)".to_string(),
+            availability_reason: "available because file search matched the current turn query"
+                .to_string(),
+            not_selected_reason:
+                "not selected after ranking the file-search candidate against the current memory-selection budget"
+                    .to_string(),
+            selectable: true,
+        }];
+
+        let memory_provider = DirectRetrievedMemoryProvider {
+            candidates: &retrieved,
+        };
+        let file_provider = PrecomputedFileSearchProvider { candidates: &file };
+        assert_eq!(memory_provider.source_kind(), "retrieved_memory");
+        assert_eq!(file_provider.source_kind(), "file_search");
+
+        let candidates = retrieval_candidates(&request, &retrieved, &file);
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.kind.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                RETRIEVED_WORKSPACE_MEMORY_KIND,
+                "thread_history",
+                "vector_memory",
+                "file_search"
+            ]
+        );
+        assert_eq!(candidates[0].source.source_type, "memory_record");
+        assert_eq!(candidates[3].source.source_type, "file_search");
+    }
+
+    #[test]
+    fn extract_tool_result_payload_falls_back_to_plain_json_content() {
+        let payload = extract_tool_result_payload(
+            r#"{
+                "status": "ok",
+                "summary": "plain json payload without wrapper"
+            }"#,
+        )
+        .expect("payload should parse from raw json");
+
+        assert_eq!(
+            payload.get("status").and_then(serde_json::Value::as_str),
+            Some("ok")
+        );
+        assert_eq!(
+            payload.get("summary").and_then(serde_json::Value::as_str),
+            Some("plain json payload without wrapper")
+        );
+    }
+}

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -330,6 +330,8 @@ pub struct RetrievalCandidate {
     pub budget_impact_tokens: Option<usize>,
     pub selection_reason: String,
     pub availability_reason: String,
+    pub not_selected_reason: String,
+    pub selectable: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Summary

- Add the first `RetrievalRequest` / `RetrievalSourceProvider` boundary.
- Normalize current retrieval inputs into `RetrievalCandidate` before `MemorySelection`.
- Route file-search candidates through typed retrieval candidates while keeping compatibility conversion.
- Update retrieval orchestration spec, TODO, and journal.

## Purpose

This keeps `MemorySelection` focused on selected/available/dropped decisions and
prepares MCP, hook, and graph retrieval sources to plug into the same candidate
contract without adding source-specific arguments.

## Tests

- `cargo test context:: -- --nocapture`
- `cargo check`

## Notes

- Prompt injection behavior is unchanged.
- Selected retrieved memory still stays in volatile per-turn context near the
  latest user request, not in the stable prompt prefix.
