### PR TITLE
feat(context): add observability view

### DIFF
--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -190,6 +190,15 @@ The context observability model also carries cache usage, compaction summary
 counters, and retrieval accounting so `/context`, ACP/Wire, and future OTEL
 exporters can share the same event shape instead of parsing TUI strings.
 
+Agent turn trace is part of the same observability model. Each latest turn
+records whether the model produced visible text, reasoning, stream deltas, tool
+calls, a persisted assistant message, and the loop outcome or continuation
+phase chosen by the runtime. This is the debugging surface for "thinking-only"
+stalls: a trace with `reasoning_only = true`, `tool_call_count = 0`, and no
+continuation phase points to a runtime decision bug; a trace with missing tool
+calls after DSML text points to provider parsing; a trace with a continuation
+phase but no later response points to the next model request or transport path.
+
 Provider-specific cache-edit microcompaction is a future optional branch. It
 must be gated by a declared provider capability and must not be inferred from
 OpenAI-compatible request shape alone.

--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -173,16 +173,22 @@ have automatic prefix caching but no cache-edit API. It reduces volatile
 history size while preserving the full local transcript for restore,
 distillation, and debugging.
 
-The first runtime slice exposes projection only as a transient status event when
-old tool results are projected out of a model request. Durable observability
-belongs in `/context`, backed by structured per-request projection reports
-rather than display text scraping.
+The runtime exposes projection as a transient status event when old tool
+results are projected out of a model request and as a structured context
+observability view after the request. The view records the policy, original
+chars, projected chars, saved chars, cleared result count, and retained result
+count. It is read-only accounting over the request projection and must not be
+used to rewrite persisted transcript history.
 
 The same structured projection report should be reusable by future OpenTelemetry
 exporters. `/context` remains the local debugging surface, while OTEL should
 export session-scoped events, counters, histograms, and trace context from the
 same runtime data model. Context compression must not introduce a separate
 display-only accounting path that would drift from exported telemetry.
+
+The context observability model also carries cache usage, compaction summary
+counters, and retrieval accounting so `/context`, ACP/Wire, and future OTEL
+exporters can share the same event shape instead of parsing TUI strings.
 
 Provider-specific cache-edit microcompaction is a future optional branch. It
 must be gated by a declared provider capability and must not be inferred from

--- a/docs/features/retrieval-orchestration.md
+++ b/docs/features/retrieval-orchestration.md
@@ -239,6 +239,13 @@ complete enough to show provider status, candidate status, budget usage, drop
 reasons, and injected summary provenance in `/context` and the future OTEL
 event stream.
 
+The first observability boundary is now shared with context compression:
+`ContextObservabilityView` summarizes retrieval provider count, candidate
+count, selected/available/dropped counts, and budget token totals. Detailed
+candidate explanations remain in `RetrievalOrchestrationView`; the
+observability view is the stable summary shape for `/context`, ACP/Wire, and
+future OTEL export.
+
 Rules:
 
 - keep compression behind an explicit provider capability and feature gate;

--- a/docs/journal/2026-05-07-context-observability.md
+++ b/docs/journal/2026-05-07-context-observability.md
@@ -1,0 +1,38 @@
+# Context Observability View
+
+## Summary
+
+RARA now has a structured `ContextObservabilityView` that summarizes the
+runtime context accounting needed by `/context`, ACP/Wire, and future
+OpenTelemetry export.
+
+## Runtime Shape
+
+The view is attached to `SharedRuntimeContext` and contains:
+
+- cache usage: cache hit tokens, miss tokens, and hit-rate basis points;
+- compaction: estimated history tokens, threshold, count, last before/after
+  tokens, and saved tokens;
+- microcompact projection: enabled flag, policy budget, kept recent count,
+  original/projected/saved chars, cleared result count, and kept result count;
+- retrieval: request id, provider/candidate counts, selected/available/dropped
+  counts, and budget token totals.
+
+The model is also exposed through a `ContextEvent::ObservabilityUpdated` wire
+shape so downstream control planes can consume the same structure without
+scraping TUI text.
+
+## Prefix Stability
+
+This change is observability-only. It does not alter prompt source ordering,
+tool schemas, stable memory placement, retrieved-memory suffix placement, or
+the persisted transcript. Tool-result microcompaction still projects only the
+request copy of history and keeps `tool_use` / `tool_result` blocks paired.
+
+## Validation
+
+Focused tests cover:
+
+- runtime assembly of cache, microcompact, and retrieval observability fields;
+- structured runtime-control serialization for context observability events;
+- agent-level microcompact projection accounting without mutating history.

--- a/docs/journal/2026-05-07-context-observability.md
+++ b/docs/journal/2026-05-07-context-observability.md
@@ -17,6 +17,9 @@ The view is attached to `SharedRuntimeContext` and contains:
   original/projected/saved chars, cleared result count, and kept result count;
 - retrieval: request id, provider/candidate counts, selected/available/dropped
   counts, and budget token totals.
+- agent turn trace: execution mode, model stop reason, loop outcome,
+  continuation phase, text/reasoning/tool-call booleans, assistant-history
+  recording, and consecutive reasoning-only count.
 
 The model is also exposed through a `ContextEvent::ObservabilityUpdated` wire
 shape so downstream control planes can consume the same structure without
@@ -36,3 +39,6 @@ Focused tests cover:
 - runtime assembly of cache, microcompact, and retrieval observability fields;
 - structured runtime-control serialization for context observability events;
 - agent-level microcompact projection accounting without mutating history.
+- reasoning-only continuation traces so "thinking-only then stop" can be
+  separated into model output, parser, runtime decision, or follow-up request
+  failures.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -95,8 +95,8 @@ Active backlog only. Keep this file small and current.
 - [x] Add concrete invoked-skill carry-over producer.
 - [x] Add concrete hook/MCP carry-over producers.
 - [x] Add prefix-stable tool-result projection before model requests.
-- [ ] Add per-request microcompact observability to `/context`.
-- [ ] Add an OTEL-ready context observability event model for compaction, microcompact projection, cache usage, and memory retrieval.
+- [x] Add per-request microcompact observability to `/context`.
+- [x] Add an OTEL-ready context observability event model for compaction, microcompact projection, cache usage, and memory retrieval.
 - [x] Add terminal environment detection for TUI compatibility, diagnostics, and future OTEL attributes.
 - [ ] Surface terminal metadata in `/status` diagnostics and future OTEL attributes.
 - [ ] Add provider-gated cache-edit microcompact only for backends that explicitly declare cache-edit support.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -27,8 +27,9 @@ use crate::todo::TodoState;
 use crate::tool::ToolOutputStream;
 use crate::tool::{ToolCallContext, ToolManager, ToolProgressEvent};
 use crate::tool_result::{
-    ToolResultProjectionPolicy, ToolResultStore, default_tool_result_store_dir,
-    enforce_tool_result_batch_budget, project_tool_results_for_context, repair_tool_result_history,
+    ToolResultProjectionPolicy, ToolResultProjectionReport, ToolResultStore,
+    default_tool_result_store_dir, enforce_tool_result_batch_budget,
+    project_tool_results_for_context, repair_tool_result_history,
 };
 use crate::tools::bash::BashCommandInput;
 use crate::tools::planning::{ENTER_PLAN_MODE_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME};
@@ -154,6 +155,7 @@ pub struct Agent {
     pub compact_state: CompactState,
     pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
     pub file_search_candidates: Vec<RetrievalCandidate>,
+    pub last_tool_result_projection_report: ToolResultProjectionReport,
     file_search_provider: FileSearchCandidateProvider,
     inspection_progress: InspectionProgress,
     last_query_plan_updated: bool,
@@ -230,6 +232,7 @@ impl Agent {
             compact_state: CompactState::default(),
             retrieved_memory_candidates: Vec::new(),
             file_search_candidates: Vec::new(),
+            last_tool_result_projection_report: ToolResultProjectionReport::default(),
             file_search_provider: FileSearchCandidateProvider::new(root, true),
             inspection_progress: InspectionProgress::default(),
             last_query_plan_updated: false,
@@ -380,6 +383,7 @@ impl Agent {
             &history_for_query,
             &ToolResultProjectionPolicy::default(),
         );
+        self.last_tool_result_projection_report = projection_report.clone();
         if projection_report.cleared_results > 0 {
             report(AgentEvent::Status(format!(
                 "Projected {} old tool result(s) out of this model request.",

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
-use crate::context::{FileSearchCandidateProvider, RetrievalCandidate, RetrievedMemoryCandidate};
+use crate::context::{
+    AgentTurnTraceView, FileSearchCandidateProvider, RetrievalCandidate, RetrievedMemoryCandidate,
+};
 use crate::control_tokens::scrub_internal_control_tokens;
 use crate::llm::{ContentBlock, LlmBackend, LlmStreamEvent, LlmTurnMetadata};
 use crate::mcp_status::McpStatusSnapshot;
@@ -124,6 +126,9 @@ struct TurnOutput {
     continue_inspection: bool,
     had_text_response: bool,
     had_reasoning_response: bool,
+    streamed_text_delta: bool,
+    streamed_reasoning_delta: bool,
+    model_stop_reason: Option<String>,
 }
 
 pub struct Agent {
@@ -156,6 +161,7 @@ pub struct Agent {
     pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
     pub file_search_candidates: Vec<RetrievalCandidate>,
     pub last_tool_result_projection_report: ToolResultProjectionReport,
+    pub last_agent_turn_trace: AgentTurnTraceView,
     file_search_provider: FileSearchCandidateProvider,
     inspection_progress: InspectionProgress,
     last_query_plan_updated: bool,
@@ -233,6 +239,7 @@ impl Agent {
             retrieved_memory_candidates: Vec::new(),
             file_search_candidates: Vec::new(),
             last_tool_result_projection_report: ToolResultProjectionReport::default(),
+            last_agent_turn_trace: AgentTurnTraceView::default(),
             file_search_provider: FileSearchCandidateProvider::new(root, true),
             inspection_progress: InspectionProgress::default(),
             last_query_plan_updated: false,
@@ -516,6 +523,9 @@ impl Agent {
             continue_inspection,
             had_text_response,
             had_reasoning_response,
+            streamed_text_delta: streamed_any_text_delta,
+            streamed_reasoning_delta: streamed_any_reasoning_delta,
+            model_stop_reason: response.stop_reason,
         })
     }
 
@@ -557,6 +567,7 @@ impl Agent {
         loop {
             self.ensure_active_plan_step();
             let mut turn_output = self.run_model_turn(output_mode, report).await?;
+            self.record_agent_turn_trace(&turn_output, *agentic_turns, None, None, false);
             self.last_query_plan_updated = turn_output.plan_updated;
             self.last_turn_had_tool_calls = !turn_output.tool_calls.is_empty();
             if turn_output
@@ -578,6 +589,13 @@ impl Agent {
                 if plan_exit_repair_attempts < MAX_PLAN_EXIT_REPAIR_ATTEMPTS {
                     plan_exit_repair_attempts += 1;
                     *agentic_turns += 1;
+                    self.record_agent_turn_trace(
+                        &turn_output,
+                        *agentic_turns,
+                        Some("continued"),
+                        Some(RuntimeContinuationPhase::PlanExitRepairRequired.label()),
+                        false,
+                    );
                     report(AgentEvent::Status(
                         "Plan exit was missing a structured proposed plan. Asking the model to repair the submission."
                             .to_string(),
@@ -589,13 +607,28 @@ impl Agent {
                     self.checkpoint_session()?;
                     continue;
                 }
+                self.record_agent_turn_trace(
+                    &turn_output,
+                    *agentic_turns,
+                    Some("stopped"),
+                    Some("plan_exit_repair_exhausted"),
+                    false,
+                );
                 self.checkpoint_session()?;
                 break;
             }
+            let assistant_message_recorded = turn_output.assistant_message.is_some();
             if let Some(message) = turn_output.assistant_message.take() {
                 self.push_history_message(message);
                 self.checkpoint_session()?;
             }
+            self.record_agent_turn_trace(
+                &turn_output,
+                *agentic_turns,
+                None,
+                None,
+                assistant_message_recorded,
+            );
 
             if turn_output.tool_calls.is_empty() {
                 // Reset consecutive reasoning-only counter when the model
@@ -611,6 +644,13 @@ impl Agent {
                     self.consecutive_reasoning_only_turns += 1;
                     if self.consecutive_reasoning_only_turns > MAX_CONSECUTIVE_REASONING_ONLY_TURNS
                     {
+                        self.record_agent_turn_trace(
+                            &turn_output,
+                            *agentic_turns,
+                            Some("stopped"),
+                            Some("reasoning_only_limit"),
+                            assistant_message_recorded,
+                        );
                         report(AgentEvent::Status(
                             "Model produced reasoning-only for too many consecutive turns. Stopping."
                                 .to_string(),
@@ -635,6 +675,13 @@ impl Agent {
                     } else {
                         RuntimeContinuationPhase::PlanContinuationRequired
                     };
+                    self.record_agent_turn_trace(
+                        &turn_output,
+                        *agentic_turns,
+                        Some("continued"),
+                        Some(phase.label()),
+                        assistant_message_recorded,
+                    );
                     self.push_history_message(
                         self.runtime_continuation_message(phase, *agentic_turns),
                     );
@@ -660,12 +707,26 @@ impl Agent {
                         RuntimeContinuationPhase::ExecutionContinuationRequired
                     };
                     *agentic_turns += 1;
+                    self.record_agent_turn_trace(
+                        &turn_output,
+                        *agentic_turns,
+                        Some("continued"),
+                        Some(phase.label()),
+                        assistant_message_recorded,
+                    );
                     self.push_history_message(
                         self.runtime_continuation_message(phase, *agentic_turns),
                     );
                     self.checkpoint_session()?;
                     continue;
                 }
+                self.record_agent_turn_trace(
+                    &turn_output,
+                    *agentic_turns,
+                    Some("stopped"),
+                    Some("final_no_tool_response"),
+                    assistant_message_recorded,
+                );
                 self.complete_active_plan_step();
                 break;
             }
@@ -673,6 +734,13 @@ impl Agent {
             // produces tool calls.
             self.consecutive_reasoning_only_turns = 0;
             *agentic_turns += 1;
+            self.record_agent_turn_trace(
+                &turn_output,
+                *agentic_turns,
+                Some("running_tools"),
+                Some("tool_calls_available"),
+                assistant_message_recorded,
+            );
 
             let tool_results = self
                 .execute_tool_calls(turn_output.tool_calls, report)
@@ -685,6 +753,38 @@ impl Agent {
             self.extend_history_for_next_turn(tool_results, report, *agentic_turns)?;
         }
         Ok(())
+    }
+
+    fn record_agent_turn_trace(
+        &mut self,
+        turn_output: &TurnOutput,
+        agentic_turn_index: usize,
+        loop_outcome: Option<&str>,
+        continuation_phase: Option<&str>,
+        assistant_message_recorded: bool,
+    ) {
+        let reasoning_only = Self::is_reasoning_only_turn(
+            turn_output.had_text_response,
+            turn_output.had_reasoning_response,
+        );
+        self.last_agent_turn_trace = AgentTurnTraceView {
+            agentic_turn_index,
+            execution_mode: self.execution_mode_label().to_string(),
+            model_stop_reason: turn_output.model_stop_reason.clone(),
+            loop_outcome: loop_outcome.map(ToString::to_string),
+            continuation_phase: continuation_phase.map(ToString::to_string),
+            had_text_response: turn_output.had_text_response,
+            had_reasoning_response: turn_output.had_reasoning_response,
+            reasoning_only,
+            streamed_text_delta: turn_output.streamed_text_delta,
+            streamed_reasoning_delta: turn_output.streamed_reasoning_delta,
+            assistant_message_recorded,
+            tool_call_count: turn_output.tool_calls.len(),
+            plan_updated: turn_output.plan_updated,
+            continue_inspection: turn_output.continue_inspection,
+            malformed_proposed_plan: turn_output.malformed_proposed_plan,
+            consecutive_reasoning_only_turns: self.consecutive_reasoning_only_turns,
+        };
     }
 
     async fn try_continue_after_recoverable_runtime_error<F>(

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -996,7 +996,7 @@ pub(super) fn parse_request_user_input_block(text: &str) -> Option<PendingUserIn
 }
 
 impl RuntimeContinuationPhase {
-    fn label(self) -> &'static str {
+    pub(super) fn label(self) -> &'static str {
         match self {
             Self::ToolResultsAvailable => "tool_results_available",
             Self::PlanContinuationRequired => "plan_continuation_required",

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -3,6 +3,7 @@ use crate::context::{
     AssembledContext, AssembledTurnContext, ContextAssembler, RuntimeContextInputs,
     RuntimeInteractionInput,
 };
+use crate::tool_result::ToolResultProjectionPolicy;
 
 impl Agent {
     pub fn assemble_context(&self) -> AssembledContext {
@@ -65,6 +66,8 @@ impl Agent {
             skill_listing: prompt::render_skill_listing(&self.prompt_config.available_skills),
             retrieved_memory_candidates: self.retrieved_memory_candidates.clone(),
             file_search_candidates: self.file_search_candidates.clone(),
+            tool_result_projection_policy: ToolResultProjectionPolicy::default(),
+            tool_result_projection_report: self.last_tool_result_projection_report.clone(),
         }
     }
 

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -68,6 +68,7 @@ impl Agent {
             file_search_candidates: self.file_search_candidates.clone(),
             tool_result_projection_policy: ToolResultProjectionPolicy::default(),
             tool_result_projection_report: self.last_tool_result_projection_report.clone(),
+            agent_turn_trace: self.last_agent_turn_trace.clone(),
         }
     }
 

--- a/src/agent/tests/microcompact.rs
+++ b/src/agent/tests/microcompact.rs
@@ -62,6 +62,13 @@ async fn model_request_projects_old_tool_results_without_mutating_history() {
     assert!(request_text.contains("Old tool result content cleared"));
     assert!(!request_text.contains("old-result-0"));
     assert!(request_text.contains("old-result-7"));
+    let runtime_context = agent.shared_runtime_context();
+    assert!(runtime_context.observability.microcompact.cleared_results > 0);
+    assert!(runtime_context.observability.microcompact.saved_chars > 0);
+    assert_eq!(
+        runtime_context.observability.microcompact.budget_chars,
+        48_000
+    );
 
     let persisted_history = serde_json::to_string(&agent.history).expect("history json");
     assert!(persisted_history.contains("old-result-0"));

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -613,6 +613,14 @@ async fn reasoning_only_turn_is_not_persisted_as_empty_assistant_message() {
             .to_string()
             .contains("reasoning_only_continuation_required")
     }));
+    let trace = agent.shared_runtime_context().observability.agent_turn;
+    assert_eq!(trace.loop_outcome.as_deref(), Some("stopped"));
+    assert_eq!(
+        trace.continuation_phase.as_deref(),
+        Some("final_no_tool_response")
+    );
+    assert!(trace.had_text_response);
+    assert!(!trace.reasoning_only);
     let assistant_messages = agent
         .history
         .iter()
@@ -799,6 +807,14 @@ async fn execute_mode_consecutive_reasoning_only_turns_stop_after_one_continuati
             .to_string()
             .contains("execute-mode unreachable text")
     }));
+    let trace = agent.shared_runtime_context().observability.agent_turn;
+    assert_eq!(trace.loop_outcome.as_deref(), Some("stopped"));
+    assert_eq!(
+        trace.continuation_phase.as_deref(),
+        Some("reasoning_only_limit")
+    );
+    assert!(trace.reasoning_only);
+    assert_eq!(trace.consecutive_reasoning_only_turns, 2);
 }
 
 #[tokio::test]

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -6,13 +6,16 @@ use crate::context::compaction_view::compaction_source_entries;
 use crate::context::memory_selection::memory_selection;
 use crate::context::retrieval_view::{retrieval_orchestration_view, retrieval_source_entries};
 use crate::context::{
-    CompactionContextView, ContextBudgetView, PlanContextView, PromptContextView,
-    RetrievalCandidate, RetrievalContextView, RetrievalRequest, RetrievedMemoryCandidate,
-    SharedRuntimeContext, TodoContextView, retrieval_candidates,
+    CompactionContextView, ContextBudgetView, ContextCacheObservationView,
+    ContextCompactionObservationView, ContextObservabilityView, MicrocompactProjectionContextView,
+    PlanContextView, PromptContextView, RetrievalCandidate, RetrievalContextView,
+    RetrievalObservationView, RetrievalRequest, RetrievedMemoryCandidate, SharedRuntimeContext,
+    TodoContextView, retrieval_candidates,
 };
 use crate::llm::{ContextBudget, LlmBackend};
 use crate::prompt::{self, EffectivePrompt, PromptMode, PromptRuntimeConfig};
 use crate::todo::TodoState;
+use crate::tool_result::{ToolResultProjectionPolicy, ToolResultProjectionReport};
 use crate::workspace::WorkspaceMemory;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,6 +51,8 @@ pub struct RuntimeContextInputs<'a> {
     pub skill_listing: Option<String>,
     pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
     pub file_search_candidates: Vec<RetrievalCandidate>,
+    pub tool_result_projection_policy: ToolResultProjectionPolicy,
+    pub tool_result_projection_report: ToolResultProjectionReport,
 }
 
 #[derive(Debug, Clone)]
@@ -186,6 +191,18 @@ impl<'a> ContextAssembler<'a> {
             entries: retrieval_entries,
             memory_selection,
         };
+        let observability = ContextObservabilityView {
+            cache: ContextCacheObservationView::from_usage(
+                inputs.total_cache_hit_tokens,
+                inputs.total_cache_miss_tokens,
+            ),
+            compaction: ContextCompactionObservationView::from_compaction(&compaction),
+            microcompact: MicrocompactProjectionContextView::from_report(
+                &inputs.tool_result_projection_policy,
+                &inputs.tool_result_projection_report,
+            ),
+            retrieval: RetrievalObservationView::from_orchestration(&retrieval.orchestration),
+        };
         let retrieved_memory_budget = retrieval
             .memory_selection
             .selected_items
@@ -238,6 +255,7 @@ impl<'a> ContextAssembler<'a> {
             todo: TodoContextView::from_state(inputs.todo_state),
             compaction,
             retrieval,
+            observability,
         }
     }
 
@@ -440,8 +458,8 @@ mod tests {
                 history_len: 3,
                 total_input_tokens: 11,
                 total_output_tokens: 7,
-                total_cache_hit_tokens: 0,
-                total_cache_miss_tokens: 0,
+                total_cache_hit_tokens: 8,
+                total_cache_miss_tokens: 2,
                 execution_mode: "plan".to_string(),
                 plan_steps: vec![(PlanStepStatus::Pending, "inspect bootstrap".to_string())],
                 plan_explanation: Some("Keep one assembly path.".to_string()),
@@ -459,6 +477,13 @@ mod tests {
                 skill_listing: None,
                 retrieved_memory_candidates: Vec::new(),
                 file_search_candidates: vec![],
+                tool_result_projection_policy: ToolResultProjectionPolicy::default(),
+                tool_result_projection_report: ToolResultProjectionReport {
+                    original_chars: 60_000,
+                    projected_chars: 40_000,
+                    cleared_results: 2,
+                    kept_results: 6,
+                },
             },
         );
 
@@ -477,6 +502,22 @@ mod tests {
         );
         assert_eq!(runtime_context.retrieval.entries.len(), 3);
         assert_eq!(runtime_context.compaction.source_entries.len(), 1);
+        assert_eq!(
+            runtime_context.observability.cache.hit_rate_basis_points,
+            Some(8_000)
+        );
+        assert_eq!(
+            runtime_context.observability.microcompact.saved_chars,
+            20_000
+        );
+        assert_eq!(
+            runtime_context.observability.microcompact.cleared_results,
+            2
+        );
+        assert_eq!(
+            runtime_context.observability.retrieval.provider_count,
+            runtime_context.retrieval.entries.len()
+        );
     }
 
     #[test]
@@ -520,6 +561,8 @@ mod tests {
                 skill_listing: None,
                 retrieved_memory_candidates: Vec::new(),
                 file_search_candidates: vec![],
+                tool_result_projection_policy: ToolResultProjectionPolicy::default(),
+                tool_result_projection_report: ToolResultProjectionReport::default(),
             },
         );
 
@@ -603,6 +646,8 @@ mod tests {
                 skill_listing: None,
                 retrieved_memory_candidates: Vec::new(),
                 file_search_candidates: vec![],
+                tool_result_projection_policy: ToolResultProjectionPolicy::default(),
+                tool_result_projection_report: ToolResultProjectionReport::default(),
             },
         );
 
@@ -686,6 +731,8 @@ mod tests {
                     rank: 1,
                 }],
                 file_search_candidates: vec![],
+                tool_result_projection_policy: ToolResultProjectionPolicy::default(),
+                tool_result_projection_report: ToolResultProjectionReport::default(),
             },
         );
 
@@ -757,6 +804,8 @@ mod tests {
                 skill_listing: None,
                 retrieved_memory_candidates: Vec::new(),
                 file_search_candidates: vec![],
+                tool_result_projection_policy: ToolResultProjectionPolicy::default(),
+                tool_result_projection_report: ToolResultProjectionReport::default(),
             },
         );
 

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -6,7 +6,7 @@ use crate::context::compaction_view::compaction_source_entries;
 use crate::context::memory_selection::memory_selection;
 use crate::context::retrieval_view::{retrieval_orchestration_view, retrieval_source_entries};
 use crate::context::{
-    CompactionContextView, ContextBudgetView, ContextCacheObservationView,
+    AgentTurnTraceView, CompactionContextView, ContextBudgetView, ContextCacheObservationView,
     ContextCompactionObservationView, ContextObservabilityView, MicrocompactProjectionContextView,
     PlanContextView, PromptContextView, RetrievalCandidate, RetrievalContextView,
     RetrievalObservationView, RetrievalRequest, RetrievedMemoryCandidate, SharedRuntimeContext,
@@ -53,6 +53,7 @@ pub struct RuntimeContextInputs<'a> {
     pub file_search_candidates: Vec<RetrievalCandidate>,
     pub tool_result_projection_policy: ToolResultProjectionPolicy,
     pub tool_result_projection_report: ToolResultProjectionReport,
+    pub agent_turn_trace: AgentTurnTraceView,
 }
 
 #[derive(Debug, Clone)]
@@ -202,6 +203,7 @@ impl<'a> ContextAssembler<'a> {
                 &inputs.tool_result_projection_report,
             ),
             retrieval: RetrievalObservationView::from_orchestration(&retrieval.orchestration),
+            agent_turn: inputs.agent_turn_trace,
         };
         let retrieved_memory_budget = retrieval
             .memory_selection
@@ -484,6 +486,7 @@ mod tests {
                     cleared_results: 2,
                     kept_results: 6,
                 },
+                agent_turn_trace: AgentTurnTraceView::default(),
             },
         );
 
@@ -563,6 +566,7 @@ mod tests {
                 file_search_candidates: vec![],
                 tool_result_projection_policy: ToolResultProjectionPolicy::default(),
                 tool_result_projection_report: ToolResultProjectionReport::default(),
+                agent_turn_trace: AgentTurnTraceView::default(),
             },
         );
 
@@ -648,6 +652,7 @@ mod tests {
                 file_search_candidates: vec![],
                 tool_result_projection_policy: ToolResultProjectionPolicy::default(),
                 tool_result_projection_report: ToolResultProjectionReport::default(),
+                agent_turn_trace: AgentTurnTraceView::default(),
             },
         );
 
@@ -733,6 +738,7 @@ mod tests {
                 file_search_candidates: vec![],
                 tool_result_projection_policy: ToolResultProjectionPolicy::default(),
                 tool_result_projection_report: ToolResultProjectionReport::default(),
+                agent_turn_trace: AgentTurnTraceView::default(),
             },
         );
 
@@ -806,6 +812,7 @@ mod tests {
                 file_search_candidates: vec![],
                 tool_result_projection_policy: ToolResultProjectionPolicy::default(),
                 tool_result_projection_report: ToolResultProjectionReport::default(),
+                agent_turn_trace: AgentTurnTraceView::default(),
             },
         );
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -27,10 +27,12 @@ pub(crate) use self::retrieved_memory_render::{
 pub(crate) use self::retriever::MemoryRetrievalOrchestrator;
 pub use self::runtime::{
     CacheStatus, CompactionContextView, CompactionSourceContextEntry, ContextAssemblyEntry,
-    ContextAssemblyView, ContextBudgetView, DropReason, MemorySelectionContextView,
-    MemorySelectionItemContextEntry, PlanContextView, PromptContextView, PromptSourceContextEntry,
-    RETRIEVED_THREAD_CONTEXT_KIND, RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalBudgetContextView,
-    RetrievalCandidate, RetrievalCandidateContextEntry, RetrievalContextView,
+    ContextAssemblyView, ContextBudgetView, ContextCacheObservationView,
+    ContextCompactionObservationView, ContextObservabilityView, DropReason,
+    MemorySelectionContextView, MemorySelectionItemContextEntry, MicrocompactProjectionContextView,
+    PlanContextView, PromptContextView, PromptSourceContextEntry, RETRIEVED_THREAD_CONTEXT_KIND,
+    RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalBudgetContextView, RetrievalCandidate,
+    RetrievalCandidateContextEntry, RetrievalContextView, RetrievalObservationView,
     RetrievalOrchestrationView, RetrievalProviderStatus, RetrievalSourceContextEntry,
     RetrievalSourceRef, RetrievedMemoryCandidate, SharedRuntimeContext, TodoContextView,
     is_retrieved_memory_kind,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -26,8 +26,8 @@ pub(crate) use self::retrieved_memory_render::{
 };
 pub(crate) use self::retriever::MemoryRetrievalOrchestrator;
 pub use self::runtime::{
-    CacheStatus, CompactionContextView, CompactionSourceContextEntry, ContextAssemblyEntry,
-    ContextAssemblyView, ContextBudgetView, ContextCacheObservationView,
+    AgentTurnTraceView, CacheStatus, CompactionContextView, CompactionSourceContextEntry,
+    ContextAssemblyEntry, ContextAssemblyView, ContextBudgetView, ContextCacheObservationView,
     ContextCompactionObservationView, ContextObservabilityView, DropReason,
     MemorySelectionContextView, MemorySelectionItemContextEntry, MicrocompactProjectionContextView,
     PlanContextView, PromptContextView, PromptSourceContextEntry, RETRIEVED_THREAD_CONTEXT_KIND,

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -1,6 +1,7 @@
 use crate::agent::{CompactState, PlanStepStatus};
 use crate::prompt::{EffectivePrompt, PromptSource};
 use crate::todo::{TodoState, TodoSummary};
+use crate::tool_result::{ToolResultProjectionPolicy, ToolResultProjectionReport};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheStatus {
@@ -275,6 +276,121 @@ pub struct SharedRuntimeContext {
     pub todo: TodoContextView,
     pub compaction: CompactionContextView,
     pub retrieval: RetrievalContextView,
+    pub observability: ContextObservabilityView,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct ContextObservabilityView {
+    pub cache: ContextCacheObservationView,
+    pub compaction: ContextCompactionObservationView,
+    pub microcompact: MicrocompactProjectionContextView,
+    pub retrieval: RetrievalObservationView,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct ContextCacheObservationView {
+    pub hit_tokens: u32,
+    pub miss_tokens: u32,
+    pub hit_rate_basis_points: Option<u32>,
+}
+
+impl ContextCacheObservationView {
+    pub fn from_usage(hit_tokens: u32, miss_tokens: u32) -> Self {
+        let total = hit_tokens.saturating_add(miss_tokens);
+        let hit_rate_basis_points = (total > 0)
+            .then(|| ((u64::from(hit_tokens) * 10_000) / u64::from(total)).min(10_000) as u32);
+        Self {
+            hit_tokens,
+            miss_tokens,
+            hit_rate_basis_points,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct ContextCompactionObservationView {
+    pub estimated_history_tokens: usize,
+    pub compact_threshold_tokens: usize,
+    pub compaction_count: usize,
+    pub last_before_tokens: Option<usize>,
+    pub last_after_tokens: Option<usize>,
+    pub last_saved_tokens: Option<usize>,
+}
+
+impl ContextCompactionObservationView {
+    pub fn from_compaction(compaction: &CompactionContextView) -> Self {
+        let last_saved_tokens = compaction
+            .last_compaction_before_tokens
+            .zip(compaction.last_compaction_after_tokens)
+            .map(|(before, after)| before.saturating_sub(after));
+        Self {
+            estimated_history_tokens: compaction.estimated_history_tokens,
+            compact_threshold_tokens: compaction.compact_threshold_tokens,
+            compaction_count: compaction.compaction_count,
+            last_before_tokens: compaction.last_compaction_before_tokens,
+            last_after_tokens: compaction.last_compaction_after_tokens,
+            last_saved_tokens,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct MicrocompactProjectionContextView {
+    pub enabled: bool,
+    pub budget_chars: usize,
+    pub keep_recent: usize,
+    pub original_chars: usize,
+    pub projected_chars: usize,
+    pub saved_chars: usize,
+    pub cleared_results: usize,
+    pub kept_results: usize,
+}
+
+impl MicrocompactProjectionContextView {
+    pub fn from_report(
+        policy: &ToolResultProjectionPolicy,
+        report: &ToolResultProjectionReport,
+    ) -> Self {
+        Self {
+            enabled: policy.enabled,
+            budget_chars: policy.budget_chars,
+            keep_recent: policy.keep_recent,
+            original_chars: report.original_chars,
+            projected_chars: report.projected_chars,
+            saved_chars: report.original_chars.saturating_sub(report.projected_chars),
+            cleared_results: report.cleared_results,
+            kept_results: report.kept_results,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct RetrievalObservationView {
+    pub request_id: String,
+    pub provider_count: usize,
+    pub candidate_count: usize,
+    pub selected_count: usize,
+    pub available_count: usize,
+    pub dropped_count: usize,
+    pub selected_tokens: usize,
+    pub available_tokens: usize,
+    pub dropped_tokens: usize,
+}
+
+impl RetrievalObservationView {
+    pub fn from_orchestration(orchestration: &RetrievalOrchestrationView) -> Self {
+        Self {
+            request_id: orchestration.request_id.clone(),
+            provider_count: orchestration.providers.len(),
+            candidate_count: orchestration.candidates.len(),
+            selected_count: orchestration.selected.len(),
+            available_count: orchestration.available.len(),
+            dropped_count: orchestration.dropped.len(),
+            selected_tokens: orchestration.budget.selected_tokens,
+            available_tokens: orchestration.budget.available_tokens,
+            dropped_tokens: orchestration.budget.dropped_tokens,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -285,6 +285,7 @@ pub struct ContextObservabilityView {
     pub compaction: ContextCompactionObservationView,
     pub microcompact: MicrocompactProjectionContextView,
     pub retrieval: RetrievalObservationView,
+    pub agent_turn: AgentTurnTraceView,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
@@ -375,6 +376,26 @@ pub struct RetrievalObservationView {
     pub selected_tokens: usize,
     pub available_tokens: usize,
     pub dropped_tokens: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct AgentTurnTraceView {
+    pub agentic_turn_index: usize,
+    pub execution_mode: String,
+    pub model_stop_reason: Option<String>,
+    pub loop_outcome: Option<String>,
+    pub continuation_phase: Option<String>,
+    pub had_text_response: bool,
+    pub had_reasoning_response: bool,
+    pub reasoning_only: bool,
+    pub streamed_text_delta: bool,
+    pub streamed_reasoning_delta: bool,
+    pub assistant_message_recorded: bool,
+    pub tool_call_count: usize,
+    pub plan_updated: bool,
+    pub continue_inspection: bool,
+    pub malformed_proposed_plan: bool,
+    pub consecutive_reasoning_only_turns: usize,
 }
 
 impl RetrievalObservationView {

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::agent::{AgentEvent, BashApprovalDecision};
-use crate::context::RetrievalOrchestrationView;
+use crate::context::{ContextObservabilityView, RetrievalOrchestrationView};
 use crate::mcp_status::{McpConnectionState, McpStatusSnapshot};
 use crate::todo::TodoState;
 use crate::tool::ToolOutputStream;
@@ -525,6 +525,7 @@ pub enum HookEvent {
 pub enum ContextEvent {
     SnapshotUpdated,
     RetrievalOrchestrationUpdated { view: RetrievalOrchestrationView },
+    ObservabilityUpdated { view: ContextObservabilityView },
 }
 
 #[allow(dead_code)]
@@ -945,6 +946,96 @@ mod tests {
                                 "selected_tokens": 11,
                                 "available_tokens": 0,
                                 "dropped_tokens": 0
+                            }
+                        }
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn context_observability_event_uses_structured_wire_shape() {
+        let event = RuntimeEvent::Context(ContextEvent::ObservabilityUpdated {
+            view: ContextObservabilityView {
+                cache: crate::context::ContextCacheObservationView {
+                    hit_tokens: 90,
+                    miss_tokens: 10,
+                    hit_rate_basis_points: Some(9000),
+                },
+                compaction: crate::context::ContextCompactionObservationView {
+                    estimated_history_tokens: 12_000,
+                    compact_threshold_tokens: 10_000,
+                    compaction_count: 2,
+                    last_before_tokens: Some(9_000),
+                    last_after_tokens: Some(3_000),
+                    last_saved_tokens: Some(6_000),
+                },
+                microcompact: crate::context::MicrocompactProjectionContextView {
+                    enabled: true,
+                    budget_chars: 48_000,
+                    keep_recent: 6,
+                    original_chars: 60_000,
+                    projected_chars: 30_000,
+                    saved_chars: 30_000,
+                    cleared_results: 4,
+                    kept_results: 6,
+                },
+                retrieval: crate::context::RetrievalObservationView {
+                    request_id: "session-1".to_string(),
+                    provider_count: 3,
+                    candidate_count: 5,
+                    selected_count: 2,
+                    available_count: 2,
+                    dropped_count: 1,
+                    selected_tokens: 500,
+                    available_tokens: 300,
+                    dropped_tokens: 200,
+                },
+            },
+        });
+
+        assert_eq!(
+            serde_json::to_value(event).unwrap(),
+            json!({
+                "type": "context",
+                "payload": {
+                    "type": "observability_updated",
+                    "payload": {
+                        "view": {
+                            "cache": {
+                                "hit_tokens": 90,
+                                "miss_tokens": 10,
+                                "hit_rate_basis_points": 9000
+                            },
+                            "compaction": {
+                                "estimated_history_tokens": 12000,
+                                "compact_threshold_tokens": 10000,
+                                "compaction_count": 2,
+                                "last_before_tokens": 9000,
+                                "last_after_tokens": 3000,
+                                "last_saved_tokens": 6000
+                            },
+                            "microcompact": {
+                                "enabled": true,
+                                "budget_chars": 48000,
+                                "keep_recent": 6,
+                                "original_chars": 60000,
+                                "projected_chars": 30000,
+                                "saved_chars": 30000,
+                                "cleared_results": 4,
+                                "kept_results": 6
+                            },
+                            "retrieval": {
+                                "request_id": "session-1",
+                                "provider_count": 3,
+                                "candidate_count": 5,
+                                "selected_count": 2,
+                                "available_count": 2,
+                                "dropped_count": 1,
+                                "selected_tokens": 500,
+                                "available_tokens": 300,
+                                "dropped_tokens": 200
                             }
                         }
                     }

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -992,6 +992,24 @@ mod tests {
                     available_tokens: 300,
                     dropped_tokens: 200,
                 },
+                agent_turn: crate::context::AgentTurnTraceView {
+                    agentic_turn_index: 1,
+                    execution_mode: "execute".to_string(),
+                    model_stop_reason: Some("end_turn".to_string()),
+                    loop_outcome: Some("continued".to_string()),
+                    continuation_phase: Some("reasoning_only_continuation_required".to_string()),
+                    had_text_response: false,
+                    had_reasoning_response: true,
+                    reasoning_only: true,
+                    streamed_text_delta: false,
+                    streamed_reasoning_delta: true,
+                    assistant_message_recorded: false,
+                    tool_call_count: 0,
+                    plan_updated: false,
+                    continue_inspection: false,
+                    malformed_proposed_plan: false,
+                    consecutive_reasoning_only_turns: 1,
+                },
             },
         });
 
@@ -1036,6 +1054,24 @@ mod tests {
                                 "selected_tokens": 500,
                                 "available_tokens": 300,
                                 "dropped_tokens": 200
+                            },
+                            "agent_turn": {
+                                "agentic_turn_index": 1,
+                                "execution_mode": "execute",
+                                "model_stop_reason": "end_turn",
+                                "loop_outcome": "continued",
+                                "continuation_phase": "reasoning_only_continuation_required",
+                                "had_text_response": false,
+                                "had_reasoning_response": true,
+                                "reasoning_only": true,
+                                "streamed_text_delta": false,
+                                "streamed_reasoning_delta": true,
+                                "assistant_message_recorded": false,
+                                "tool_call_count": 0,
+                                "plan_updated": false,
+                                "continue_inspection": false,
+                                "malformed_proposed_plan": false,
+                                "consecutive_reasoning_only_turns": 1
                             }
                         }
                     }

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -286,7 +286,7 @@ fn format_char_count(chars: usize) -> String {
 fn render_context_observability(app: &TuiApp) -> String {
     let view = &app.snapshot.context_observability;
     format!(
-        "Observability\n  cache: hit={} miss={} hit_rate={}\n  microcompact: enabled={} cleared={} kept={} saved={} budget={} keep_recent={}\n  retrieval: providers={} candidates={} selected={} available={} dropped={} selected_budget={}",
+        "Observability\n  cache: hit={} miss={} hit_rate={}\n  microcompact: enabled={} cleared={} kept={} saved={} budget={} keep_recent={}\n  retrieval: providers={} candidates={} selected={} available={} dropped={} selected_budget={}\n  agent_turn: idx={} mode={} stop={} outcome={} phase={} text={} reasoning={} reasoning_only={} streamed_text={} streamed_reasoning={} assistant_recorded={} tools={} consecutive_reasoning_only={}",
         format_token_count(view.cache.hit_tokens as usize),
         format_token_count(view.cache.miss_tokens as usize),
         format_basis_points(view.cache.hit_rate_basis_points),
@@ -302,6 +302,19 @@ fn render_context_observability(app: &TuiApp) -> String {
         view.retrieval.available_count,
         view.retrieval.dropped_count,
         format_token_count(view.retrieval.selected_tokens),
+        view.agent_turn.agentic_turn_index,
+        view.agent_turn.execution_mode,
+        view.agent_turn.model_stop_reason.as_deref().unwrap_or("-"),
+        view.agent_turn.loop_outcome.as_deref().unwrap_or("-"),
+        view.agent_turn.continuation_phase.as_deref().unwrap_or("-"),
+        view.agent_turn.had_text_response,
+        view.agent_turn.had_reasoning_response,
+        view.agent_turn.reasoning_only,
+        view.agent_turn.streamed_text_delta,
+        view.agent_turn.streamed_reasoning_delta,
+        view.agent_turn.assistant_message_recorded,
+        view.agent_turn.tool_call_count,
+        view.agent_turn.consecutive_reasoning_only_turns,
     )
 }
 

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -273,6 +273,38 @@ fn render_context_usage_summary(app: &TuiApp) -> String {
     lines.join("\n")
 }
 
+fn format_basis_points(value: Option<u32>) -> String {
+    value
+        .map(|basis_points| format!("{:.1}%", basis_points as f64 / 100.0))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn format_char_count(chars: usize) -> String {
+    format!("{chars} chars")
+}
+
+fn render_context_observability(app: &TuiApp) -> String {
+    let view = &app.snapshot.context_observability;
+    format!(
+        "Observability\n  cache: hit={} miss={} hit_rate={}\n  microcompact: enabled={} cleared={} kept={} saved={} budget={} keep_recent={}\n  retrieval: providers={} candidates={} selected={} available={} dropped={} selected_budget={}",
+        format_token_count(view.cache.hit_tokens as usize),
+        format_token_count(view.cache.miss_tokens as usize),
+        format_basis_points(view.cache.hit_rate_basis_points),
+        view.microcompact.enabled,
+        view.microcompact.cleared_results,
+        view.microcompact.kept_results,
+        format_char_count(view.microcompact.saved_chars),
+        format_char_count(view.microcompact.budget_chars),
+        view.microcompact.keep_recent,
+        view.retrieval.provider_count,
+        view.retrieval.candidate_count,
+        view.retrieval.selected_count,
+        view.retrieval.available_count,
+        view.retrieval.dropped_count,
+        format_token_count(view.retrieval.selected_tokens),
+    )
+}
+
 fn todo_summary_line(app: &TuiApp) -> String {
     let summary = &app.snapshot.todo.summary;
     if summary.total == 0 {
@@ -446,6 +478,7 @@ pub fn status_context_text(app: &TuiApp) -> String {
                 .unwrap_or_else(|| "-".to_string()),
             last_boundary
         ),
+        render_context_observability(app),
         format!(
             "Plan\n  mode: {}  explanation: {}\n{}",
             app.agent_execution_mode_label(),

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1044,6 +1044,7 @@ impl TuiApp {
             retrieval_source_entries: runtime_context.retrieval.entries,
             retrieval_orchestration: runtime_context.retrieval.orchestration,
             memory_selection: runtime_context.retrieval.memory_selection,
+            context_observability: runtime_context.observability,
             assembly_entries: runtime_context.assembly.entries,
             // ── Extensions ──────────────────────────────────────
             // ── Extensions ──────────────────────────────────────

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -218,6 +218,7 @@ pub struct RuntimeSnapshot {
     pub retrieval_source_entries: Vec<RetrievalSourceContextEntry>,
     pub retrieval_orchestration: crate::context::RetrievalOrchestrationView,
     pub memory_selection: crate::context::MemorySelectionContextView,
+    pub context_observability: crate::context::ContextObservabilityView,
     pub assembly_entries: Vec<ContextAssemblyEntry>,
     // ── Extensions ──────────────────────────────────────
     pub extension_skill_count: usize,


### PR DESCRIPTION
## Summary

- add a structured `ContextObservabilityView` for cache, compaction, microcompact projection, and retrieval accounting
- surface the observability summary in `/context` and expose a structured `ContextEvent::ObservabilityUpdated`
- record the SDD checkpoint and mark the context observability TODO items complete

## Purpose

This keeps context accounting source-grounded and reusable across TUI, ACP/Wire, and future OpenTelemetry export without scraping display text or changing prompt prefix order.

## Tests

- `cargo fmt --check`
- `cargo test context::assembler -- --nocapture`
- `cargo test microcompact -- --nocapture`
- `cargo test runtime_control::tests::context_observability_event_uses_structured_wire_shape -- --nocapture`
