### PR TITLE
feat: add thread_data types to rara-persistence crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9324,6 +9324,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "regex",
+ "serde",
+ "serde_json",
  "tempfile",
  "url",
 ]

--- a/crates/rara-persistence/Cargo.toml
+++ b/crates/rara-persistence/Cargo.toml
@@ -9,3 +9,5 @@ anyhow.workspace = true
 regex = "1"
 url = "2"
 tempfile.workspace = true
+serde = { version = "1", features = ["derive"] }
+serde_json.workspace = true

--- a/crates/rara-persistence/src/lib.rs
+++ b/crates/rara-persistence/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod atomic_file;
 pub mod redaction;
+pub mod thread_data;

--- a/crates/rara-persistence/src/thread_data.rs
+++ b/crates/rara-persistence/src/thread_data.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedThreadLineage {
+    pub origin_kind: String,
+    pub forked_from_thread_id: Option<String>,
+}
+
+impl Default for PersistedThreadLineage {
+    fn default() -> Self {
+        Self {
+            origin_kind: "fresh".to_string(),
+            forked_from_thread_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedThreadRecord {
+    pub session_id: String,
+    pub cwd: String,
+    pub branch: String,
+    pub provider: String,
+    pub model: String,
+    pub base_url: Option<String>,
+    pub agent_mode: String,
+    pub bash_approval: String,
+    pub created_at: i64,
+    pub lineage: PersistedThreadLineage,
+    pub plan_explanation: Option<String>,
+    pub history_len: usize,
+    pub transcript_len: usize,
+    pub updated_at: i64,
+}


### PR DESCRIPTION
## Summary

Preparatory step for moving `thread_metadata` into `rara-persistence`. Adds `PersistedThreadLineage` and `PersistedThreadRecord` to the crate. The types co-exist in `state_db.rs` (not yet removed — that's a follow-up PR).

### Changes
- New: `crates/rara-persistence/src/thread_data.rs` — the two struct types
- Update: `lib.rs` — adds `pub mod thread_data`
- Update: `Cargo.toml` — adds `serde` dependency

### Follow-up
- Remove struct definitions from `state_db.rs`, replace with `pub use rara_persistence::thread_data::{...};`
- Move `thread_metadata.rs` into `rara-persistence`

### Verification
- `cargo test` — **948 passed, 0 failed**