### PR TITLE
refactor: replace state_db type defs with re-exports, move thread_metadata into rara-persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9328,6 +9328,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/rara-persistence/Cargo.toml
+++ b/crates/rara-persistence/Cargo.toml
@@ -11,3 +11,4 @@ url = "2"
 tempfile.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json.workspace = true
+uuid = { version = "1", features = ["v4"] }

--- a/crates/rara-persistence/src/lib.rs
+++ b/crates/rara-persistence/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod atomic_file;
 pub mod redaction;
 pub mod thread_data;
+pub mod thread_metadata;

--- a/crates/rara-persistence/src/thread_metadata.rs
+++ b/crates/rara-persistence/src/thread_metadata.rs
@@ -3,10 +3,10 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use rara_persistence::atomic_file;
 use uuid::Uuid;
 
-use crate::state_db::PersistedThreadRecord;
+use crate::atomic_file;
+use crate::thread_data::PersistedThreadRecord;
 
 const THREAD_METADATA_FILE: &str = "thread.json";
 
@@ -14,7 +14,7 @@ pub(crate) fn thread_metadata_path(root_dir: &Path, session_id: &str) -> PathBuf
     root_dir.join(session_id).join(THREAD_METADATA_FILE)
 }
 
-pub(crate) fn load_thread_record(
+pub fn load_thread_record(
     root_dir: &Path,
     session_id: &str,
 ) -> Result<Option<PersistedThreadRecord>> {
@@ -28,7 +28,7 @@ pub(crate) fn load_thread_record(
     Ok(Some(record))
 }
 
-pub(crate) fn write_thread_record(root_dir: &Path, record: &PersistedThreadRecord) -> Result<()> {
+pub fn write_thread_record(root_dir: &Path, record: &PersistedThreadRecord) -> Result<()> {
     let path = thread_metadata_path(root_dir, &record.session_id);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,6 @@ mod shell_env;
 mod skill;
 mod state_db;
 mod thread_cli;
-mod thread_metadata;
 mod thread_rollout_log;
 mod thread_store;
 mod thread_turn_log;

--- a/src/state_db.rs
+++ b/src/state_db.rs
@@ -4,6 +4,7 @@ use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
+pub use rara_persistence::thread_data::{PersistedThreadLineage, PersistedThreadRecord};
 use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -174,21 +175,6 @@ pub enum PersistedLegacyRolloutSource {
     Empty,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PersistedThreadLineage {
-    pub origin_kind: String,
-    pub forked_from_thread_id: Option<String>,
-}
-
-impl Default for PersistedThreadLineage {
-    fn default() -> Self {
-        Self {
-            origin_kind: "fresh".to_string(),
-            forked_from_thread_id: None,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct PersistedRecentThreadSummary {
     pub session_id: String,
@@ -226,25 +212,6 @@ pub struct PersistedRecentThreadRecord {
     pub last_compaction_recent_file_count: Option<usize>,
     pub last_compaction_boundary_version: Option<u32>,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PersistedThreadRecord {
-    pub session_id: String,
-    pub cwd: String,
-    pub branch: String,
-    pub provider: String,
-    pub model: String,
-    pub base_url: Option<String>,
-    pub agent_mode: String,
-    pub bash_approval: String,
-    pub created_at: i64,
-    pub lineage: PersistedThreadLineage,
-    pub plan_explanation: Option<String>,
-    pub history_len: usize,
-    pub transcript_len: usize,
-    pub updated_at: i64,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PersistedSpawnAgentEdge {
     pub parent_session_id: String,

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 use rara_persistence::atomic_file;
+use rara_persistence::thread_metadata;
 use uuid::Uuid;
 
 use crate::agent::Message;
@@ -27,7 +28,6 @@ use crate::state_db::{
     PersistedThreadLineage, PersistedThreadRecord, PersistedTurnEntry, PersistedTurnSummary,
     StateDb,
 };
-use crate::thread_metadata;
 use crate::thread_rollout_log::{self, RolloutEventRecorder};
 use crate::thread_turn_log;
 

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use rara_persistence::thread_metadata;
 use serde_json::Value;
 use tempfile::tempdir;
 
@@ -20,7 +21,6 @@ use crate::state_db::{
     PersistedRuntimeRolloutItem, PersistedStructuredRolloutEvent, PersistedThreadLineage,
     PersistedThreadRecord, PersistedTurnEntry, StateDb,
 };
-use crate::thread_metadata;
 use crate::thread_rollout_log;
 use crate::thread_turn_log;
 use crate::vectordb::VectorDB;


### PR DESCRIPTION
## Summary

Completes the `rara-persistence` crate by moving `thread_metadata` and replacing `state_db.rs` type definitions with re-exports.

### Changes
- `state_db.rs`: remove `PersistedThreadLineage` + `PersistedThreadRecord` definitions, replace with `pub use rara_persistence::thread_data::{...};`
- `rara-persistence`: add `thread_metadata` module (moved from src/)
- `rara-persistence`: add `uuid` dependency
- `src/`: update all `crate::thread_metadata` → `rara_persistence::thread_metadata` (3 files)

### Verification
- `cargo test` — **948 passed, 0 failed**