### PR TITLE
feat: add PrintConsumer — non-TUI agent output as plain text

### DIFF
--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -10,6 +10,7 @@ use crate::config::{
     ConfigManager, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, RaraConfig,
 };
 use crate::oauth::{OAuthManager, SavedCodexAuthMode};
+use crate::print_consumer::PrintConsumer;
 use crate::runtime_context;
 use crate::thread_cli;
 use crate::tui::StartupResumeTarget;
@@ -72,6 +73,10 @@ enum Commands {
         with_api_key: bool,
     },
     Logout,
+    Print {
+        /// The prompt to send to the agent.
+        prompt: String,
+    },
     Tui,
 }
 
@@ -114,6 +119,7 @@ pub(crate) async fn run_cli() -> Result<()> {
             .await?
         }
         Commands::Logout => run_logout_command(&mut config, &config_manager, &oauth_manager)?,
+        Commands::Print { prompt } => run_print_command(&config, prompt).await?,
         Commands::Tui => {
             run_tui_command(
                 &config,
@@ -165,6 +171,15 @@ async fn run_ask_command(config: &RaraConfig, prompt: String) -> Result<()> {
     emit_bootstrap_warnings(&bootstrap.warnings);
     let mut agent = bootstrap.into_agent();
     agent.query(prompt).await
+}
+
+async fn run_print_command(config: &RaraConfig, prompt: String) -> Result<()> {
+    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+    emit_bootstrap_warnings(&bootstrap.warnings);
+    let event_bus = bootstrap.event_bus.clone();
+    let agent = bootstrap.into_agent();
+    let consumer = PrintConsumer::new(agent, event_bus, prompt);
+    consumer.run().await
 }
 
 async fn run_distill_command(config: &RaraConfig, thread_id: &str) -> Result<()> {
@@ -231,7 +246,8 @@ fn startup_resume_target_for_command(command: &Commands) -> Option<StartupResume
         | Commands::Thread { .. }
         | Commands::Threads { .. }
         | Commands::Login { .. }
-        | Commands::Logout => None,
+        | Commands::Logout
+        | Commands::Print { .. } => None,
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod mcp_status;
 mod memory_distiller;
 mod memory_store;
 mod oauth;
+mod print_consumer;
 mod prompt;
 mod protocol_sources;
 mod runtime_context;

--- a/src/print_consumer.rs
+++ b/src/print_consumer.rs
@@ -1,0 +1,63 @@
+//! Print-mode consumer: subscribes to RuntimeEventBus and renders
+//! AgentEvent as plain text to stdout/stderr. No TUI, no JSON.
+//!
+//! The consumer owns the agent lifecycle: it spawns the query task
+//! and consumes events until the task completes.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::agent::Agent;
+use crate::agent::AgentEvent;
+use crate::runtime_event_bus::RuntimeEventBus;
+
+pub struct PrintConsumer {
+    agent: Agent,
+    event_bus: Arc<RuntimeEventBus>,
+    prompt: String,
+}
+
+impl PrintConsumer {
+    pub fn new(agent: Agent, event_bus: Arc<RuntimeEventBus>, prompt: String) -> Self {
+        Self {
+            agent,
+            event_bus,
+            prompt,
+        }
+    }
+
+    /// Run the agent query and print streaming output until completion.
+    pub async fn run(mut self) -> Result<()> {
+        let mut rx = self.event_bus.subscribe();
+        let handle = tokio::spawn(async move { self.agent.query(self.prompt).await });
+
+        while let Ok(event) = rx.recv().await {
+            Self::render_event(&event);
+        }
+
+        let _ = handle.await?;
+        println!(); // trailing newline
+        Ok(())
+    }
+
+    fn render_event(event: &AgentEvent) {
+        match event {
+            AgentEvent::AssistantDelta(text) | AgentEvent::AssistantText(text) => {
+                print!("{text}");
+            }
+            AgentEvent::ToolUse { name, .. } => {
+                eprintln!("\n[Tool: {name}]");
+            }
+            AgentEvent::ToolResult { name, is_error, .. } => {
+                if *is_error {
+                    eprintln!("\n[Tool error: {name}]");
+                }
+            }
+            AgentEvent::Status(msg) => {
+                eprintln!("\n[{msg}]");
+            }
+            _ => {}
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `PrintConsumer` that subscribes to `RuntimeEventBus` and renders `AgentEvent` as plain text. This is a peer consumer to `TuiMaintainer` (Ratatui) and `AcpServer` (ACP JSON-RPC) — all three consume the same event stream.

### Design
- `PrintConsumer::new(agent, event_bus, prompt)` — owns the agent lifecycle
- `run()` — spawns agent query, subscribes to event bus, renders text
- `AssistantDelta`/ `AssistantText` → stdout
- `ToolUse` / `ToolResult` / `Status` → stderr
- Terminates when agent query completes

### Next Steps
- Wire into CLI: add `Commands::Print` variant + `--print` flag
- Add `--wire` mode as protocol sibling (same pattern)

### Verification
- `cargo test` — **948 passed, 0 failed**