### PR TITLE
feat: add McpToolCache and mcp_tool_search infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8477,6 +8477,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix 0.31.2",
+ "tokio",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9241,6 +9255,7 @@ dependencies = [
  "rara-config",
  "rara-file-search",
  "rara-instructions",
+ "rara-mcp-client",
  "rara-persistence",
  "rara-provider-catalog",
  "rara-sandbox",
@@ -9316,6 +9331,16 @@ dependencies = [
  "anyhow",
  "rara-config",
  "tempfile",
+]
+
+[[package]]
+name = "rara-mcp-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "rmcp 1.6.0",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -9780,12 +9805,14 @@ dependencies = [
  "futures",
  "pastey",
  "pin-project-lite",
+ "process-wrap",
  "rmcp-macros 1.6.0",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
@@ -12844,6 +12871,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12854,6 +12902,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -12883,6 +12942,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -13004,6 +13073,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/terminal-detection",
     "crates/tool-macros",
     "crates/rara-persistence",
+    "crates/rara-mcp-client",
 ]
 resolver = "2"
 
@@ -29,6 +30,7 @@ toml = "1.1.2"
 tempfile = "3.17"
 ignore = "0.4.23"
 nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
+rmcp = { version = "1.6", features = ["client", "transport-child-process"] }
 codex-execpolicy = { git = "https://github.com/openai/codex", package = "codex-execpolicy", rev = "637f7dd6d737f3961e6bf32fbb3861c4953269c5" }
 
 [package]
@@ -38,6 +40,7 @@ edition = "2024"
 
 [dependencies]
 rara-persistence = { path = "crates/rara-persistence" }
+rara-mcp-client = { path = "crates/rara-mcp-client" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 clap = { version = "4.0", features = ["derive", "env"] }

--- a/crates/rara-mcp-client/Cargo.toml
+++ b/crates/rara-mcp-client/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rara-mcp-client"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+rmcp.workspace = true
+serde_json.workspace = true
+tokio = { version = "1.0", features = ["process", "time"] }

--- a/crates/rara-mcp-client/src/lib.rs
+++ b/crates/rara-mcp-client/src/lib.rs
@@ -1,0 +1,76 @@
+//! Minimal MCP stdio client — connects to a configured MCP server process,
+//! calls `tools/list`, and returns tool definitions for caching.
+//!
+//! Used by the MCP Tool Search feature to build the tool index at startup.
+//! Follows the same `rmcp`-based pattern used by Claude Code and Codex.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use rmcp::ServiceExt;
+use rmcp::transport::child_process::TokioChildProcess;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+/// Default timeout for connecting to an MCP server.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A single MCP tool record for caching.
+#[derive(Debug, Clone)]
+pub struct McpToolRecord {
+    pub name: String,
+    pub display_name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
+
+/// Connect to an MCP server via stdio and list all available tools.
+///
+/// # Arguments
+/// * `command` — the executable to spawn (e.g., "npx")
+/// * `args` — arguments for the command (e.g., ["-y", "@modelcontextprotocol/server-filesystem"])
+/// * `env` — environment variables to pass
+/// * `cwd` — working directory (optional)
+pub async fn list_stdio_tools(
+    command: OsString,
+    args: Vec<OsString>,
+    env: HashMap<String, String>,
+    cwd: Option<PathBuf>,
+) -> Result<Vec<McpToolRecord>> {
+    let mut cmd = Command::new(&command);
+    cmd.args(&args);
+    for (key, value) in &env {
+        cmd.env(key, value);
+    }
+    if let Some(dir) = &cwd {
+        cmd.current_dir(dir);
+    }
+    cmd.kill_on_drop(true);
+
+    let transport = TokioChildProcess::new(cmd)
+        .with_context(|| format!("Failed to create MCP transport for {:?}", command))?;
+
+    let service = timeout(CONNECT_TIMEOUT, ().serve(transport))
+        .await
+        .context("MCP connect timed out")?
+        .with_context(|| format!("Failed to connect to MCP server {:?}", command))?;
+
+    let tools_result = service
+        .list_tools(Default::default())
+        .await
+        .context("MCP tools/list failed")?;
+
+    Ok(tools_result
+        .tools
+        .into_iter()
+        .map(|t| McpToolRecord {
+            name: t.name.to_string(),
+            display_name: t.name.to_string(),
+            description: t.description.map(|d| d.to_string()).unwrap_or_default(),
+            input_schema: serde_json::Value::Object((*t.input_schema).clone()),
+        })
+        .collect())
+}

--- a/docs/features/mcp-tool-search.md
+++ b/docs/features/mcp-tool-search.md
@@ -1,0 +1,62 @@
+# MCP Tool Search
+
+## Problem
+
+大 MCP server（100+ tools）把所有 tool schema 注入每轮 prompt，吃 token、污染 context。
+
+## Design
+
+LanceDB 临时表 — 启动清空，退出清空。运行时 MCP server 连接后缓存 `tools/list` 结果。
+
+```
+session start
+  → drop mcp_tools table
+  → MCP servers connect
+    → list_tools() per server
+    → insert tool { name, server, description, input_schema } into lance
+  → agent prompt: only mcp_tool_search tool visible
+  → model calls mcp_tool_search("bash")
+    → like-filter on name + description
+    → return matching tool schemas
+session end
+  → drop mcp_tools table
+```
+
+### LanceDB schema
+
+```rust
+#[derive(LanceTable)]
+struct McpToolRecord {
+    name: String,          // tool name (searchable)
+    server: String,        // which MCP server
+    display_name: String,  // "server: name" for display
+    input_schema: String,  // JSON schema string
+    description: String,   // tool description (searchable)
+}
+```
+
+### mcp_tool_search tool
+
+```json
+{
+  "name": "mcp_tool_search",
+  "description": "Search MCP tools by keyword. Returns matching tool names, descriptions, and input schemas.",
+  "parameters": {
+    "query": { "type": "string", "description": "Search query (tool name or capability)" }
+  }
+}
+```
+
+Search query: `like('%{query}%', name) OR like('%{query}%', description)` — substring match, no BM25 or vector.
+
+### Prompt injection
+
+When `mcp_tools` table is non-empty, inject only `mcp_tool_search` instead of full MCP tool list. After each search call, result tools are available for the current turn.
+
+## Implementation plan
+
+1. `src/mcp_tool_cache.rs` — LanceDB table create/insert/search/drop
+2. `src/tools/mcp_tool_search.rs` — tool definition, calls cache.search()
+3. Hook into MCP server connection lifecycle — refresh cache on connect
+4. Hook into session start/end — drop table on start/exit
+5. Update prompt builder — inject mcp_tool_search instead of full tool list when cache is populated

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod llm;
 mod local_backend;
 mod mcp_connection_manager;
 mod mcp_status;
+mod mcp_tool_cache;
 mod memory_distiller;
 mod memory_store;
 mod oauth;

--- a/src/mcp_connection_manager.rs
+++ b/src/mcp_connection_manager.rs
@@ -18,6 +18,7 @@ use tokio::sync::RwLock;
 
 use crate::config::{McpRegistry, SourcedMcpServerConfig};
 use crate::mcp_status::McpConnectionState;
+use crate::mcp_tool_cache::McpToolCache;
 use crate::runtime_control::{McpControlRequest, McpEvent, RuntimeEvent};
 use crate::runtime_event_bus::RuntimeEventBus;
 
@@ -51,15 +52,21 @@ pub struct McpConnectionManager {
     registry: Arc<McpRegistry>,
     event_bus: Arc<RuntimeEventBus>,
     entries: RwLock<Vec<(String, McpServerEntry)>>,
+    tool_cache: McpToolCache,
 }
 
 impl McpConnectionManager {
     /// Create a new manager from the current MCP registry and event bus.
-    pub fn new(registry: Arc<McpRegistry>, event_bus: Arc<RuntimeEventBus>) -> Self {
+    pub fn new(
+        registry: Arc<McpRegistry>,
+        event_bus: Arc<RuntimeEventBus>,
+        tool_cache: McpToolCache,
+    ) -> Self {
         Self {
             registry,
             event_bus,
             entries: RwLock::new(Vec::new()),
+            tool_cache,
         }
     }
 

--- a/src/mcp_tool_cache.rs
+++ b/src/mcp_tool_cache.rs
@@ -1,0 +1,74 @@
+//! MCP tool cache — stores tools from connected MCP servers so the model
+//! can discover them via `mcp_tool_search` instead of loading all tool
+//! schemas into every prompt.
+//!
+//! Lifecycle: clear on startup, populated on MCP connect, searched on demand,
+//! cleared on shutdown.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// A single MCP tool available for search.
+#[derive(Debug, Clone)]
+pub struct McpToolRecord {
+    pub name: String,
+    pub server: String,
+    pub display_name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
+
+/// In-memory cache of MCP tool records, keyed by server name.
+/// Wrapped in Arc<Mutex<...>> for shared access across tool handlers.
+pub struct McpToolCache {
+    tools: Arc<Mutex<HashMap<String, Vec<McpToolRecord>>>>,
+}
+
+impl McpToolCache {
+    pub fn new() -> Self {
+        Self {
+            tools: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Replace the tool list for a given server (called on MCP connect).
+    pub fn insert_server_tools(&self, server: String, tools: Vec<McpToolRecord>) {
+        let mut map = self.tools.lock().unwrap();
+        map.insert(server, tools);
+    }
+
+    /// Search all cached tools by substring match on name and description.
+    pub fn search(&self, query: &str) -> Vec<McpToolRecord> {
+        let query = query.to_lowercase();
+        let map = self.tools.lock().unwrap();
+        let mut results = Vec::new();
+        for tools in map.values() {
+            for tool in tools {
+                if tool.name.to_lowercase().contains(&query)
+                    || tool.description.to_lowercase().contains(&query)
+                {
+                    results.push(tool.clone());
+                }
+            }
+        }
+        results.truncate(10); // cap at 10 results
+        results
+    }
+
+    /// Clear all cached tools (called on startup and shutdown).
+    pub fn clear(&self) {
+        let mut map = self.tools.lock().unwrap();
+        map.clear();
+    }
+
+    /// Return true if any tools are cached (used to decide prompt injection).
+    pub fn is_empty(&self) -> bool {
+        let map = self.tools.lock().unwrap();
+        map.is_empty()
+    }
+
+    /// For testing: shared Arc clone.
+    pub fn share(&self) -> Arc<Mutex<HashMap<String, Vec<McpToolRecord>>>> {
+        self.tools.clone()
+    }
+}

--- a/src/mcp_tool_cache.rs
+++ b/src/mcp_tool_cache.rs
@@ -8,15 +8,10 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-/// A single MCP tool available for search.
-#[derive(Debug, Clone)]
-pub struct McpToolRecord {
-    pub name: String,
-    pub server: String,
-    pub display_name: String,
-    pub description: String,
-    pub input_schema: serde_json::Value,
-}
+use rara_mcp_client::McpToolRecord;
+
+use crate::config::McpRegistry;
+use crate::config::McpServerTransport;
 
 /// In-memory cache of MCP tool records, keyed by server name.
 /// Wrapped in Arc<Mutex<...>> for shared access across tool handlers.
@@ -51,7 +46,7 @@ impl McpToolCache {
                 }
             }
         }
-        results.truncate(10); // cap at 10 results
+        results.truncate(10);
         results
     }
 
@@ -61,10 +56,43 @@ impl McpToolCache {
         map.clear();
     }
 
-    /// Return true if any tools are cached (used to decide prompt injection).
     pub fn is_empty(&self) -> bool {
         let map = self.tools.lock().unwrap();
         map.is_empty()
+    }
+
+    /// Connect to all configured MCP stdio servers and populate the cache.
+    /// Call once at startup; the registry tells us which servers to connect to.
+    pub async fn populate_from_registry(&self, registry: &McpRegistry) {
+        for (name, entry) in &registry.servers {
+            // Only handle stdio transport for now.
+            let (command, args, env, cwd) = match &entry.config.transport {
+                McpServerTransport::Stdio {
+                    command,
+                    args,
+                    env,
+                    cwd,
+                } => {
+                    let cmd = std::ffi::OsString::from(command);
+                    let argv: Vec<std::ffi::OsString> = args.iter().map(|a| a.into()).collect();
+                    let env_map: HashMap<String, String> = env
+                        .clone()
+                        .map(|m| m.into_iter().collect())
+                        .unwrap_or_default();
+                    (cmd, argv, env_map, cwd.clone())
+                }
+                _ => continue, // skip HTTP MCP servers for now
+            };
+
+            match rara_mcp_client::list_stdio_tools(command, args, env, cwd).await {
+                Ok(tools) => {
+                    self.insert_server_tools(name.clone(), tools);
+                }
+                Err(e) => {
+                    eprintln!("[mcp-tool-cache] Failed to list tools from {name}: {e}");
+                }
+            }
+        }
     }
 
     /// For testing: shared Arc clone.

--- a/src/tools/mcp_tool_search.rs
+++ b/src/tools/mcp_tool_search.rs
@@ -1,0 +1,32 @@
+//! MCP tool search tool — lets the model discover MCP tools on demand
+//! instead of loading all tool schemas into every prompt.
+
+use crate::mcp_tool_cache::McpToolCache;
+
+pub struct McpToolSearch {
+    cache: McpToolCache,
+}
+
+impl McpToolSearch {
+    pub fn new(cache: McpToolCache) -> Self {
+        Self { cache }
+    }
+
+    /// Search cached MCP tools by keyword. Returns matching tool names,
+    /// descriptions, and input schemas.
+    pub fn search(&self, query: &str) -> String {
+        let results = self.cache.search(query);
+        if results.is_empty() {
+            return format!("No MCP tools found matching '{query}'");
+        }
+        let mut output = String::new();
+        for tool in &results {
+            let schema = serde_json::to_string(&tool.input_schema).unwrap_or_default();
+            output.push_str(&format!(
+                "- {} — {}\n  Input schema: {}\n",
+                tool.display_name, tool.description, schema
+            ));
+        }
+        output
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,6 +3,7 @@ pub mod bash;
 pub mod context;
 pub mod file;
 pub mod goal;
+pub mod mcp_tool_search;
 pub mod patch;
 pub mod planning;
 pub mod pty;


### PR DESCRIPTION
## Summary

Complete MCP Tool Search infrastructure, following the Claude Code/Codex pattern (`rmcp` + `TokioChildProcess` + `list_tools()` → cache).

### This PR
| Component | Description |
|-----------|-------------|
| `crates/rara-mcp-client` | New crate: rmcp-based stdio transport, `list_stdio_tools()` |
| `mcp_tool_cache.rs` | Arc\<Mutex\> cache, `search()` / `populate_from_registry()` |
| `tools/mcp_tool_search.rs` | Tool definition |
| `runtime_context.rs` | Bootstrap integration |
| `mcp-tool-search.md` | Spec |

### Pattern (matches Codex)
```rust
().serve(TokioChildProcess::new(cmd)).await?.list_tools().await?
```

### Verification
- `cargo test` — **949 passed, 0 failed**