### PR TITLE
feat: add multi edit tool guidance

### DIFF
--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -88,11 +88,19 @@ Large-write guidance follows the same edit-tool boundary:
 
 - use diff-shaped edit tools or `apply_patch` for modifications to existing files;
 - reserve `write_file` for new files or intentional complete rewrites after reading an existing file;
+- use `replace` for one exact unique replacement, `replace_lines` for verified line-range edits,
+  and `multi_edit` for several related exact replacements in one file;
 - treat failed, truncated, or apparently non-persistent large writes as tool-result failures to
   diagnose, not as a reason to fall back to shell heredocs, redirection, or PTY writes;
 - preserve the Codex distinction that heredoc can be a transport for `apply_patch`, while Claude's
   Bash/PowerShell guidance routes ordinary file writes through Write rather than `cat <<EOF`,
   `echo >`, `Set-Content`, or `Out-File`.
+
+Tool-schema edit guidance is part of the runtime contract, not only prose in the
+base prompt. `bash` should explicitly route file modifications to direct edit
+tools. `replace`, `replace_lines`, `multi_edit`, and `apply_patch` should each
+state the safe edit boundary they own so the model sees the instruction at the
+call site where it chooses a tool.
 
 External-source guidance is evidence routing, not a requirement to browse for every question. For
 repository, branch, PR, CI, local-tool, and local-configuration claims, the model should prefer the

--- a/docs/journal/2026-05-01-terminal-tool-schema-prompts.md
+++ b/docs/journal/2026-05-01-terminal-tool-schema-prompts.md
@@ -22,6 +22,17 @@ shell execution.
 - Strengthened the `bash` tool description and input schema with command
   discipline for dedicated tools, `cwd`, sandbox escalation, background tasks,
   and shell-edit avoidance.
+- Added `multi_edit` for ordered exact replacements within one file. It follows
+  the Claude Code `MultiEdit` shape: the file must be read fully first, each
+  `old_string` is applied in order against the current file state, and ambiguous
+  sequential replacements are rejected.
+- Strengthened `replace`, `replace_lines`, `multi_edit`, `apply_patch`, and
+  `bash` descriptions so edit intent is visible in the tool schema itself:
+  shell `sed`, `awk`, `perl`, heredocs, redirection, and ad-hoc scripts are not
+  the preferred path when a direct edit tool can express the change.
+- Normalized `rg`-based bash exploration labels so TUI progress shows semantic
+  `Find files ...` / `Search ...` actions instead of raw shell command text, and
+  so those actions are not duplicated as running commands.
 - Added a Codex-style foreground Bash result contract: raw results now include
   `aggregated_output` and `duration_ms`, and model-facing compaction renders a
   stable exit-code, duration, and output block from the captured result.
@@ -38,4 +49,10 @@ shell execution.
 - `cargo test pty_tool_schema_guides_interactive_command_discipline -- --nocapture`
 - `cargo test streaming_call_reports_stdout_and_stderr_chunks -- --nocapture`
 - `cargo test compacts_bash_results_with_exit_code_duration_and_aggregated_output -- --nocapture`
+- `cargo test tools::file::tests::multi_edit -- --nocapture`
+- `cargo test tools::file::tests::file_tool_descriptions_encode_safe_edit_contract -- --nocapture`
+- `cargo test tools::patch::tests::apply_patch_description_encodes_safe_edit_contract -- --nocapture`
+- `cargo test tui::render::tests::exploration_summary_uses_codex_style_search_labels -- --nocapture`
+- `cargo test tui::render::tests::rg_bash_search_is_not_duplicated_as_running_tool -- --nocapture`
+- `cargo test tui::runtime::events::tests::bash_rg_tool_use_is_shown_as_exploration -- --nocapture`
 - `cargo check`

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -17,7 +17,8 @@ use crate::tools::bash::{
 };
 use crate::tools::context::RetrieveSessionContextTool;
 use crate::tools::file::{
-    FileReadState, ListFilesTool, ReadFileTool, ReplaceLinesTool, ReplaceTool, WriteFileTool,
+    FileReadState, ListFilesTool, MultiEditTool, ReadFileTool, ReplaceLinesTool, ReplaceTool,
+    WriteFileTool,
 };
 use crate::tools::goal::{CreateGoalTool, GetGoalTool, UpdateGoalTool};
 use crate::tools::patch::ApplyPatchTool;
@@ -106,7 +107,8 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(WriteFileTool::new(file_read_state.clone())));
     tm.register(Box::new(ListFilesTool));
     tm.register(Box::new(ReplaceTool::new(file_read_state.clone())));
-    tm.register(Box::new(ReplaceLinesTool::new(file_read_state)));
+    tm.register(Box::new(ReplaceLinesTool::new(file_read_state.clone())));
+    tm.register(Box::new(MultiEditTool::new(file_read_state)));
     tm.register(Box::new(WebFetchTool));
     tm.register(Box::new(WebSearchTool::from_env()));
     tm.register(Box::new(GlobTool));

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -924,13 +924,13 @@ fn command_env_for_wrapped(
 
 #[tool_spec(
     name = "bash",
-    description = "Run a shell command in the sandbox for commands that need process execution. Prefer dedicated RARA tools for file search, file reads, and file edits; do not use shell redirection, sed, awk, perl, or ad-hoc scripts to edit files when apply_patch or direct file tools can do the job. Use the cwd field instead of prepending cd. Avoid newline-separated command chaining. If commands are independent and can run in parallel, make multiple bash tool calls in one assistant turn instead of joining them with &&, ;, or pipelines. Do not add 2>&1, head, tail, or grep only to reduce displayed output; RARA preserves stdout/stderr and provides bounded model-facing previews. Commands must be non-interactive: do not start editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, always supply the message with git commit -m or git commit -F; never run bare git commit and wait for an editor. Keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop.",
+    description = "Run a shell command in the sandbox for commands that need process execution. Prefer dedicated RARA tools for file search, file reads, and file edits. Edit files with apply_patch, replace, replace_lines, or write_file; do not use shell redirection, sed -i, awk, perl, heredocs, or ad-hoc scripts to edit files when direct edit tools can do the job. Use the cwd field instead of prepending cd. Avoid newline-separated command chaining. If commands are independent and can run in parallel, make multiple bash tool calls in one assistant turn instead of joining them with &&, ;, or pipelines. Do not add 2>&1, head, tail, or grep only to reduce displayed output; RARA preserves stdout/stderr and provides bounded model-facing previews. Commands must be non-interactive: do not start editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, always supply the message with git commit -m or git commit -F; never run bare git commit and wait for an editor. Keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop.",
     input_schema = {
         "type": "object",
         "properties": {
             "command": {
                 "type": "string",
-                "description": "Legacy shell command string. Prefer program+args for new calls. Avoid newline-separated command chaining. Do not join independent validation commands with &&, ;, or pipelines just to run them together; make multiple bash tool calls instead. Do not add 2>&1, head, tail, or grep only to trim output for the model. Do not run interactive editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, use git commit -m or git commit -F, never bare git commit. Do not use this field for file edits when apply_patch or direct file tools can do the job."
+                "description": "Legacy shell command string. Prefer program+args for new calls. Avoid newline-separated command chaining. Do not join independent validation commands with &&, ;, or pipelines just to run them together; make multiple bash tool calls instead. Do not add 2>&1, head, tail, or grep only to trim output for the model. Do not run interactive editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, use git commit -m or git commit -F, never bare git commit. Do not use this field for file edits when apply_patch, replace, replace_lines, or write_file can do the job; avoid sed -i, awk, perl, shell redirection, and heredocs for edits."
             },
             "program": {
                 "type": "string",
@@ -1722,6 +1722,9 @@ mod tests {
 
         let description = tool.description();
         assert!(description.contains("Prefer dedicated RARA tools"));
+        assert!(description.contains("Edit files with apply_patch"));
+        assert!(description.contains("replace_lines"));
+        assert!(description.contains("sed -i"));
         assert!(description.contains("apply_patch"));
         assert!(description.contains("cwd field"));
         assert!(description.contains("newline-separated command chaining"));
@@ -1732,7 +1735,7 @@ mod tests {
 
         let schema = tool.input_schema().to_string();
         assert!(schema.contains("Prefer program+args"));
-        assert!(schema.contains("direct file tools"));
+        assert!(schema.contains("apply_patch, replace, replace_lines"));
         assert!(schema.contains("never bare git commit"));
         assert!(schema.contains("prefer this over prepending cd"));
         assert!(schema.contains("sandbox failure evidence"));

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -149,6 +149,23 @@ impl FileReadState {
         Ok(())
     }
 
+    pub(crate) fn validate_full_content_edit(&self, path: &str) -> Result<(), ToolError> {
+        let key = canonical_existing_path(path)?;
+        let files = self.files.lock().expect("file read state lock");
+        let Some(entry) = files.get(&key) else {
+            return Err(ToolError::ExecutionFailed(
+                "File has not been read yet. Read it first before writing to it.".into(),
+            ));
+        };
+        if entry.is_partial || entry.content.is_none() {
+            return Err(ToolError::ExecutionFailed(
+                "File was not fully read. Read the full file before using multi_edit.".into(),
+            ));
+        }
+        drop(files);
+        self.validate_existing_edit(path)
+    }
+
     pub(crate) fn validate_exact_replace_edit(&self, path: &str) -> Result<(), ToolError> {
         let key = canonical_existing_path(path)?;
         let files = self.files.lock().expect("file read state lock");
@@ -585,7 +602,7 @@ impl Default for ReplaceTool {
 
 #[tool_spec(
     name = "replace",
-    description = "Replace one exact, unique string in a file. Read the relevant file content first and prefer apply_patch for structured multi-line edits.",
+    description = "Replace one exact, unique string in a file. Use this instead of shell sed, awk, perl, redirection, or ad-hoc scripts for simple text edits. Read the relevant file content first, copy old_string exactly including whitespace and indentation, and provide enough surrounding context so old_string appears exactly once. Prefer apply_patch for structured multi-line edits or related edits across multiple locations.",
     input_schema = {
         "type": "object",
         "properties": {
@@ -653,7 +670,7 @@ impl Default for ReplaceLinesTool {
 
 #[tool_spec(
     name = "replace_lines",
-    description = "Replace an inclusive line range in a file. Use after reading the relevant portion of the file and verifying the current line numbers. A sub-range read via offset/limit is sufficient as long as the targeted lines have been seen.",
+    description = "Replace an inclusive line range in a file. Use this instead of shell sed, awk, perl, redirection, or ad-hoc scripts when the safe edit boundary is a verified line range, especially for large deletions or replacements that would make old_string unwieldy. Read the relevant portion of the file and verify the current line numbers first. A sub-range read via offset/limit is sufficient as long as the targeted lines have been seen.",
     input_schema = {
         "type": "object",
         "properties": {
@@ -745,6 +762,137 @@ impl Tool for ReplaceLinesTool {
             "removed_string": removed_string,
             "inserted_lines": replacement_lines.len(),
             "line_delta": replacement_lines.len() as i64 - removed_line_count as i64,
+        }))
+    }
+}
+
+pub struct MultiEditTool {
+    read_state: Option<SharedFileReadState>,
+}
+
+impl MultiEditTool {
+    pub fn new(read_state: SharedFileReadState) -> Self {
+        Self {
+            read_state: Some(read_state),
+        }
+    }
+}
+
+impl Default for MultiEditTool {
+    fn default() -> Self {
+        Self { read_state: None }
+    }
+}
+
+#[tool_spec(
+    name = "multi_edit",
+    description = "Apply multiple exact string replacements to one file in order. Use this instead of shell sed, awk, perl, redirection, or ad-hoc scripts when several related small edits belong in the same file. Read the full file first, copy each old_string exactly including whitespace and indentation, and ensure every old_string is unique in the current file state before its replacement is applied. Prefer apply_patch for larger structured edits or edits across multiple files.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "path": { "type": "string", "description": "Path to edit." },
+            "edits": {
+                "type": "array",
+                "minItems": 1,
+                "description": "Ordered exact replacements to apply to the same file.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "old_string": { "type": "string", "description": "Exact text to replace. It must appear exactly once at the time this edit is applied." },
+                        "new_string": { "type": "string", "description": "Replacement text." }
+                    },
+                    "required": ["old_string", "new_string"]
+                }
+            }
+        },
+        "required": ["path", "edits"]
+    }
+)]
+#[async_trait]
+impl Tool for MultiEditTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let path = input["path"]
+            .as_str()
+            .ok_or(ToolError::InvalidInput("path".into()))?;
+        let edits = input["edits"]
+            .as_array()
+            .ok_or(ToolError::InvalidInput("edits".into()))?;
+        if edits.is_empty() {
+            return Err(ToolError::InvalidInput(
+                "edits must contain at least one replacement".into(),
+            ));
+        }
+        if let Some(read_state) = &self.read_state {
+            read_state.validate_full_content_edit(path)?;
+        }
+
+        let original = read_file_content(path)?;
+        let mut updated = original.clone();
+        let mut applied = Vec::with_capacity(edits.len());
+        let mut previous_new_strings: Vec<String> = Vec::with_capacity(edits.len());
+
+        for (index, edit) in edits.iter().enumerate() {
+            let edit_number = index + 1;
+            let old_string = edit
+                .get("old_string")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    ToolError::InvalidInput(format!("edits[{index}].old_string is required"))
+                })?;
+            let new_string = edit
+                .get("new_string")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    ToolError::InvalidInput(format!("edits[{index}].new_string is required"))
+                })?;
+            if old_string.is_empty() {
+                return Err(ToolError::InvalidInput(format!(
+                    "edits[{index}].old_string must not be empty; use write_file for file creation or full rewrites"
+                )));
+            }
+            if old_string == new_string {
+                return Err(ToolError::InvalidInput(format!(
+                    "edits[{index}] has identical old_string and new_string"
+                )));
+            }
+            if previous_new_strings
+                .iter()
+                .any(|previous| previous.contains(old_string))
+            {
+                return Err(ToolError::ExecutionFailed(format!(
+                    "edits[{index}].old_string is contained in a previous new_string; split the edit or use apply_patch to avoid ambiguous sequential replacements"
+                )));
+            }
+
+            let matches = updated.matches(old_string).count();
+            if matches != 1 {
+                return Err(ToolError::ExecutionFailed(format!(
+                    "Edit {edit_number} expected old_string to appear exactly once, found {matches}"
+                )));
+            }
+
+            updated = updated.replacen(old_string, new_string, 1);
+            applied.push(json!({
+                "index": edit_number,
+                "old_preview": preview_snippet(old_string),
+                "new_preview": preview_snippet(new_string),
+                "old_bytes": old_string.len(),
+                "new_bytes": new_string.len(),
+            }));
+            previous_new_strings.push(new_string.to_string());
+        }
+
+        fs::write(path, &updated)?;
+        if let Some(read_state) = &self.read_state {
+            record_write_best_effort(read_state, path, &updated);
+        }
+
+        Ok(json!({
+            "status": "ok",
+            "path": path,
+            "edits_applied": applied.len(),
+            "edits": applied,
+            "line_delta": updated.lines().count() as i64 - original.lines().count() as i64,
         }))
     }
 }

--- a/src/tools/file/tests.rs
+++ b/src/tools/file/tests.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use serde_json::{Value, json};
 
 use super::{
-    FileReadState, ListFilesTool, MAX_READ_LINE_BYTES, MAX_READ_LINE_CHARS, ReadFileTool,
-    ReplaceLinesTool, ReplaceTool, WriteFileTool,
+    FileReadState, ListFilesTool, MAX_READ_LINE_BYTES, MAX_READ_LINE_CHARS, MultiEditTool,
+    ReadFileTool, ReplaceLinesTool, ReplaceTool, WriteFileTool,
 };
 use crate::tool::Tool;
 
@@ -500,11 +500,131 @@ async fn replace_lines_replaces_inclusive_range_without_old_string() {
     assert_eq!(result["line_delta"], -1);
 }
 
+#[tokio::test]
+async fn multi_edit_applies_ordered_unique_replacements() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "alpha\nbeta\ngamma\n").expect("write sample");
+
+    let tool = MultiEditTool::default();
+    let result = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "edits": [
+                {
+                    "old_string": "alpha",
+                    "new_string": "one"
+                },
+                {
+                    "old_string": "gamma",
+                    "new_string": "three\nfour"
+                }
+            ]
+        }))
+        .await
+        .expect("multi edit");
+
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read updated"),
+        "one\nbeta\nthree\nfour\n"
+    );
+    assert_eq!(result["edits_applied"], 2);
+    assert_eq!(result["line_delta"], 1);
+    assert_eq!(result["edits"][0]["old_preview"], "alpha");
+    assert_eq!(result["edits"][1]["new_preview"], "three\\nfour");
+}
+
+#[tokio::test]
+async fn multi_edit_requires_prior_full_read_when_state_is_enabled() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "one\ntwo\nthree\n").expect("write sample");
+    let read_state = Arc::new(FileReadState::default());
+    let read_tool = ReadFileTool::new(read_state.clone());
+    let multi_edit_tool = MultiEditTool::new(read_state);
+
+    read_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "offset": 1,
+            "limit": 1
+        }))
+        .await
+        .expect("partial read");
+
+    let error = multi_edit_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "edits": [
+                {
+                    "old_string": "two",
+                    "new_string": "TWO"
+                }
+            ]
+        }))
+        .await
+        .expect_err("multi_edit should require full read");
+    assert!(error.to_string().contains("File was not fully read"));
+
+    read_tool
+        .call(json!({ "path": path.display().to_string() }))
+        .await
+        .expect("full read");
+    multi_edit_tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "edits": [
+                {
+                    "old_string": "two",
+                    "new_string": "TWO"
+                }
+            ]
+        }))
+        .await
+        .expect("multi_edit after full read");
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read updated"),
+        "one\nTWO\nthree\n"
+    );
+}
+
+#[tokio::test]
+async fn multi_edit_rejects_ambiguous_sequential_replacements() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let path = tempdir.path().join("sample.txt");
+    std::fs::write(&path, "foo\nbar\n").expect("write sample");
+
+    let tool = MultiEditTool::default();
+    let error = tool
+        .call(json!({
+            "path": path.display().to_string(),
+            "edits": [
+                {
+                    "old_string": "foo",
+                    "new_string": "bar"
+                },
+                {
+                    "old_string": "bar",
+                    "new_string": "baz"
+                }
+            ]
+        }))
+        .await
+        .expect_err("ambiguous sequential replacement should fail");
+
+    assert!(error.to_string().contains("previous new_string"));
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read unchanged"),
+        "foo\nbar\n"
+    );
+}
+
 #[test]
 fn file_tool_descriptions_encode_safe_edit_contract() {
     let write_tool = WriteFileTool::default();
     let replace_tool = ReplaceTool::default();
     let replace_lines_tool = ReplaceLinesTool::default();
+    let multi_edit_tool = MultiEditTool::default();
 
     assert!(write_tool.description().contains("Create a new file"));
     assert!(
@@ -521,14 +641,46 @@ fn file_tool_descriptions_encode_safe_edit_contract() {
             .contains("shell heredoc fallbacks")
     );
     assert!(replace_tool.description().contains("exact, unique string"));
+    assert!(replace_tool.description().contains("instead of shell sed"));
+    assert!(
+        replace_tool
+            .description()
+            .contains("copy old_string exactly")
+    );
     assert!(
         replace_tool
             .description()
             .contains("Read the relevant file content first")
     );
     assert!(
+        replace_tool
+            .description()
+            .contains("related edits across multiple locations")
+    );
+    assert!(
         replace_lines_tool
             .description()
-            .contains("verifying the current line numbers")
+            .contains("verify the current line numbers first")
     );
+    assert!(
+        replace_lines_tool
+            .description()
+            .contains("safe edit boundary is a verified line range")
+    );
+    assert!(
+        replace_lines_tool
+            .description()
+            .contains("old_string unwieldy")
+    );
+    assert!(
+        multi_edit_tool
+            .description()
+            .contains("multiple exact string replacements")
+    );
+    assert!(
+        multi_edit_tool
+            .description()
+            .contains("Read the full file first")
+    );
+    assert!(multi_edit_tool.description().contains("shell sed"));
 }

--- a/src/tools/patch.rs
+++ b/src/tools/patch.rs
@@ -82,7 +82,7 @@ struct PatchStats {
 
 #[tool_spec(
     name = "apply_patch",
-    description = "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files. Update operations verify hunks against current file contents.",
+    description = "Apply structured file edits using Begin Patch syntax. Prefer this for editing existing files and for related edits across multiple locations. Use this instead of shell sed, awk, perl, redirection, heredocs, or ad-hoc scripts for reviewable file edits. Update operations verify hunks against current file contents.",
     input_schema = {
         "type": "object",
         "properties": {
@@ -646,6 +646,17 @@ mod tests {
     use super::ApplyPatchTool;
     use crate::tool::Tool;
     use crate::tools::file::{FileReadState, ReadFileTool};
+
+    #[test]
+    fn apply_patch_description_encodes_safe_edit_contract() {
+        let tool = ApplyPatchTool::default();
+        let description = tool.description();
+
+        assert!(description.contains("structured file edits"));
+        assert!(description.contains("related edits across multiple locations"));
+        assert!(description.contains("instead of shell sed"));
+        assert!(description.contains("heredocs"));
+    }
 
     #[tokio::test]
     async fn applies_update_patch() {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -27,7 +27,9 @@ use self::viewport::TranscriptViewport;
 use super::custom_terminal::Frame;
 use super::line_utils::prefix_lines;
 use super::state::{TranscriptEntry, TuiApp};
-use super::tool_text::{compact_delegate_rest, compact_instruction};
+use super::tool_text::{
+    bash_rg_exploration_action_label, compact_delegate_rest, compact_instruction,
+};
 use crate::tui::sub_agent_display::SubAgentKind;
 use crate::tui::theme::*;
 
@@ -787,6 +789,10 @@ fn exploration_action_label(message: &str) -> Option<String> {
     let name = parts.next()?;
     let rest = parts.collect::<Vec<_>>().join(" ");
     match name {
+        "list_files" => Some(format!(
+            "List {}",
+            if rest.is_empty() { "." } else { rest.as_str() }
+        )),
         "read_file" => Some(format!(
             "Read {}",
             if rest.is_empty() {
@@ -795,6 +801,23 @@ fn exploration_action_label(message: &str) -> Option<String> {
                 rest.as_str()
             }
         )),
+        "glob" => Some(format!(
+            "Find files {}",
+            if rest.is_empty() {
+                "workspace"
+            } else {
+                rest.as_str()
+            }
+        )),
+        "grep" => Some(format!(
+            "Search {}",
+            if rest.is_empty() {
+                "workspace"
+            } else {
+                rest.as_str()
+            }
+        )),
+        "bash" => bash_rg_exploration_action_label(&rest),
         _ => None,
     }
 }
@@ -802,7 +825,7 @@ fn exploration_action_label(message: &str) -> Option<String> {
 fn tool_action_label(message: &str) -> Option<String> {
     let mut parts = message.split_whitespace();
     let name = parts.next()?;
-    if is_exploration_tool(name) {
+    if is_exploration_tool(name) || exploration_action_label(message).is_some() {
         return None;
     }
 
@@ -833,6 +856,14 @@ fn tool_action_label(message: &str) -> Option<String> {
             }
         )),
         "replace" => Some(format!(
+            "Edit {}",
+            if rest.is_empty() {
+                "file"
+            } else {
+                rest.as_str()
+            }
+        )),
+        "multi_edit" => Some(format!(
             "Edit {}",
             if rest.is_empty() {
                 "file"

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -51,12 +51,14 @@ fn active_turn_cell_keeps_sections_in_stable_order() {
         .join("\n");
 
     let you_idx = rendered.find("Inspect the codebase").unwrap();
+    let exploring_idx = rendered.find(" Exploring ").unwrap();
     let running_idx = rendered.find(" Running ").unwrap();
     let plan_idx = rendered.find("Updated Plan").unwrap();
     let approval_idx = rendered.find(" Request Input ").unwrap();
 
-    assert!(!rendered.contains(" Exploring "));
+    assert!(rendered.contains("List src"));
     assert!(you_idx < running_idx);
+    assert!(exploring_idx < running_idx);
     assert!(running_idx < plan_idx);
     assert!(plan_idx < approval_idx);
 }

--- a/src/tui/render/cells/cells_tests/committed.rs
+++ b/src/tui/render/cells/cells_tests/committed.rs
@@ -54,12 +54,14 @@ fn committed_turn_cell_keeps_user_summary_and_agent_sections_in_order() {
         .join("\n");
 
     let you_idx = rendered.find("Review this repo").unwrap();
+    let explored_idx = rendered.find(" Explored ").unwrap();
     let ran_idx = rendered.find(" Ran ").unwrap();
     let agent_idx = rendered.find("• Final recommendation").unwrap();
 
-    assert!(!rendered.contains(" Explored "));
+    assert!(rendered.contains("List ."));
+    assert!(you_idx < explored_idx);
+    assert!(explored_idx < ran_idx);
     assert!(ran_idx < agent_idx);
-    assert!(you_idx < ran_idx);
 }
 
 #[test]

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -641,7 +641,7 @@ fn transcript_viewport_visible_window_slices_to_visible_rows() {
 }
 
 #[test]
-fn exploration_summary_only_keeps_read_actions() {
+fn exploration_summary_uses_codex_style_search_labels() {
     let entries = vec![
         TranscriptEntry {
             role: "Tool".into(),
@@ -664,6 +664,16 @@ fn exploration_summary_only_keeps_read_actions() {
             payload: None,
         },
         TranscriptEntry {
+            role: "Tool".into(),
+            message: "bash rg --files src/tui".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Tool".into(),
+            message: "bash cd src && rg -n \"render\" tui".into(),
+            payload: None,
+        },
+        TranscriptEntry {
             role: "Agent".into(),
             message: "I will start by listing files and then inspect the main entrypoint.".into(),
             payload: None,
@@ -673,11 +683,23 @@ fn exploration_summary_only_keeps_read_actions() {
 
     let rendered = current_turn_exploration_summary_from_entries(refs.as_slice(), false, None)
         .expect("exploration summary");
+    assert!(rendered.contains("Find files src/tui"));
+    assert!(rendered.contains("Search planning mode src"));
     assert!(rendered.contains("Read src/main.rs"));
-    assert!(!rendered.contains("List ."));
+    assert!(rendered.contains("Search render src/tui"));
+    assert!(rendered.contains("more file(s) inspected"));
     assert!(!rendered.contains("Glob src/**/*.rs"));
-    assert!(!rendered.contains("Search planning mode src"));
     assert!(!rendered.contains("listing files"));
+}
+
+#[test]
+fn rg_bash_search_is_not_duplicated_as_running_tool() {
+    assert!(tool_action_label("bash rg --files src/tui").is_none());
+    assert!(tool_action_label("bash cd src && rg -n \"render\" tui").is_none());
+    assert_eq!(
+        tool_action_label("bash cargo check"),
+        Some("Run cargo check".to_string())
+    );
 }
 
 #[test]

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -5,7 +5,9 @@ use crate::tui::state::TuiApp;
 use crate::tui::terminal_event::{
     TerminalEvent, output_tail_preview as terminal_output_tail_preview,
 };
-use crate::tui::tool_text::{compact_delegate_rest, compact_instruction};
+use crate::tui::tool_text::{
+    bash_rg_exploration_action_label, compact_delegate_rest, compact_instruction,
+};
 
 pub(super) fn is_oauth_prompt_message(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();
@@ -60,26 +62,6 @@ pub(super) fn exploration_action_label(message: &str) -> Option<String> {
     }
 }
 
-fn bash_rg_exploration_action_label(command: &str) -> Option<String> {
-    let command = command.trim();
-    if command.is_empty() || !contains_rg_invocation(command) {
-        return None;
-    }
-
-    if command.split_whitespace().any(|part| part == "--files") {
-        Some(format!("Find files {command}"))
-    } else {
-        Some(format!("Search {command}"))
-    }
-}
-
-fn contains_rg_invocation(command: &str) -> bool {
-    command
-        .split([';', '|', '&'])
-        .map(str::trim)
-        .any(|segment| segment == "rg" || segment.starts_with("rg ") || segment.starts_with("rg\t"))
-}
-
 pub(super) fn planning_action_label(message: &str) -> Option<String> {
     let mut parts = message.split_whitespace();
     let name = parts.next()?;
@@ -127,6 +109,14 @@ pub(super) fn tool_action_label(message: &str) -> Option<String> {
             }
         )),
         "replace" => Some(format!(
+            "Edit {}",
+            if rest.is_empty() {
+                "file"
+            } else {
+                rest.as_str()
+            }
+        )),
+        "multi_edit" => Some(format!(
             "Edit {}",
             if rest.is_empty() {
                 "file"
@@ -282,6 +272,11 @@ pub(super) fn format_tool_use(name: &str, input: &serde_json::Value) -> String {
             .get("path")
             .and_then(serde_json::Value::as_str)
             .map(|path| format!("replace {path}"))
+            .unwrap_or_else(|| format!("{name} {input}")),
+        "multi_edit" => input
+            .get("path")
+            .and_then(serde_json::Value::as_str)
+            .map(|path| format!("multi_edit {path}"))
             .unwrap_or_else(|| format!("{name} {input}")),
         "replace_lines" => format_replace_lines_use(input),
         "list_files" => input

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -520,8 +520,8 @@ fn bash_rg_tool_use_is_shown_as_exploration() {
     assert_eq!(
         app.active_live.exploration_actions,
         vec![
-            "Find files rg --files src/tui".to_string(),
-            "Search cd src && rg -n \"render\" tui".to_string()
+            "Find files src/tui".to_string(),
+            "Search render src/tui".to_string()
         ]
     );
     assert!(app.active_live.running_actions.is_empty());

--- a/src/tui/tool_text.rs
+++ b/src/tui/tool_text.rs
@@ -35,3 +35,71 @@ pub(crate) fn compact_instruction(instruction: &str) -> String {
     truncated.push('…');
     truncated
 }
+
+pub(crate) fn bash_rg_exploration_action_label(command: &str) -> Option<String> {
+    let command = command.trim();
+    if command.is_empty() || !contains_rg_invocation(command) {
+        return None;
+    }
+
+    let tokens = command.split_whitespace().collect::<Vec<_>>();
+    let rg_index = tokens.iter().position(|part| *part == "rg")?;
+    let cwd = command_prefix_cwd(tokens.as_slice(), rg_index);
+    let args = &tokens[rg_index + 1..];
+
+    if args.iter().any(|part| *part == "--files") {
+        let target = args
+            .iter()
+            .filter(|part| !part.starts_with('-'))
+            .next_back()
+            .copied()
+            .unwrap_or("workspace");
+        Some(format!("Find files {}", display_path_in_cwd(cwd, target)))
+    } else {
+        let terms = args
+            .iter()
+            .filter(|part| !part.starts_with('-'))
+            .map(|part| part.trim_matches('"').trim_matches('\''))
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>();
+        match terms.as_slice() {
+            [] => Some("Search workspace".to_string()),
+            [query] => Some(format!("Search {query}")),
+            [query, target, ..] => Some(format!(
+                "Search {query} {}",
+                display_path_in_cwd(cwd, target)
+            )),
+        }
+    }
+}
+
+fn contains_rg_invocation(command: &str) -> bool {
+    command
+        .split([';', '|', '&'])
+        .map(str::trim)
+        .any(|segment| segment == "rg" || segment.starts_with("rg ") || segment.starts_with("rg\t"))
+}
+
+fn command_prefix_cwd<'a>(tokens: &'a [&str], rg_index: usize) -> Option<&'a str> {
+    if rg_index >= 3 && tokens.first() == Some(&"cd") && tokens.get(2) == Some(&"&&") {
+        tokens.get(1).copied()
+    } else {
+        None
+    }
+}
+
+fn display_path_in_cwd(cwd: Option<&str>, target: &str) -> String {
+    let target = target.trim_matches('"').trim_matches('\'');
+    match cwd {
+        Some(cwd)
+            if target != "workspace"
+                && !target.starts_with('/')
+                && target != "."
+                && !target.starts_with("./") =>
+        {
+            format!("{}/{}", cwd.trim_end_matches('/'), target)
+        }
+        Some(cwd) if target == "." => cwd.to_string(),
+        _ => target.to_string(),
+    }
+}


### PR DESCRIPTION
## Summary

- add a `multi_edit` file tool for ordered exact replacements in one file
- strengthen edit-tool and bash tool descriptions so models prefer direct edit tools over shell edits
- render `rg`-based bash exploration as semantic `Find files` / `Search` progress without duplicate running-tool entries
- document the tool-schema guidance contract in the prompt runtime spec and journal

## Tests

- `cargo fmt`
- `cargo test tools::file::tests::multi_edit -- --nocapture`
- `cargo test tools::file::tests::file_tool_descriptions_encode_safe_edit_contract -- --nocapture`
- `cargo test tools::patch::tests::apply_patch_description_encodes_safe_edit_contract -- --nocapture`
- `cargo test tui::render::tests::exploration_summary_uses_codex_style_search_labels -- --nocapture`
- `cargo test tui::render::tests::rg_bash_search_is_not_duplicated_as_running_tool -- --nocapture`
- `cargo test tui::runtime::events::tests::bash_rg_tool_use_is_shown_as_exploration -- --nocapture`

## Notes

- Local tests still emit existing warnings, including the macOS linker `__eh_frame section too large` warning.
