### PR TITLE
feat: plumb McpToolCache through into_parts/into_agent/builder

### DIFF
--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -223,7 +223,7 @@ async fn run_tui_command(
     emit_bootstrap_warnings(&bootstrap.warnings);
     let sandbox_network_access = bootstrap.sandbox_network_access.clone();
     let event_bus = bootstrap.event_bus.clone();
-    let (agent, _warnings, _network, goal_handle) = bootstrap.into_parts();
+    let (agent, _warnings, _network, goal_handle, _mcp_cache) = bootstrap.into_parts();
     let resumed_thread_id = crate::tui::run_tui(
         agent,
         goal_handle,

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -44,11 +44,19 @@ pub(crate) struct RuntimeBootstrap {
 
 impl RuntimeBootstrap {
     pub(crate) fn into_agent(self) -> Agent {
-        let (agent, _, _, _) = self.into_parts();
+        let (agent, _, _, _, _) = self.into_parts();
         agent
     }
 
-    pub(crate) fn into_parts(self) -> (Agent, Vec<String>, Arc<AtomicBool>, GoalHandle) {
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        Agent,
+        Vec<String>,
+        Arc<AtomicBool>,
+        GoalHandle,
+        McpToolCache,
+    ) {
         let mut agent = Agent::new(
             self.tool_manager,
             self.backend,
@@ -62,6 +70,7 @@ impl RuntimeBootstrap {
             self.warnings,
             self.sandbox_network_access,
             self.goal_handle,
+            self.mcp_tool_cache,
         )
     }
 }

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -5,11 +5,13 @@ pub(super) async fn rebuild_agent_with_progress(
     progress: Option<crate::local_backend::LocalProgressReporter>,
 ) -> anyhow::Result<RebuildSuccess> {
     let bootstrap = crate::runtime_context::initialize_rara_context(config, progress).await?;
-    let (agent, warnings, sandbox_network_access, goal_handle) = bootstrap.into_parts();
+    let (agent, warnings, sandbox_network_access, goal_handle, mcp_tool_cache) =
+        bootstrap.into_parts();
     Ok(RebuildSuccess {
         agent,
         warnings,
         sandbox_network_access,
         goal_handle,
+        mcp_tool_cache,
     })
 }

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -322,6 +322,7 @@ pub struct RebuildSuccess {
     pub sandbox_network_access: Arc<AtomicBool>,
     /// Shared goal handle for model-facing tools.
     pub goal_handle: crate::tui::state::GoalHandle,
+    pub mcp_tool_cache: crate::mcp_tool_cache::McpToolCache,
 }
 
 pub enum TuiEvent {


### PR DESCRIPTION
## Summary

Plumbs `McpToolCache` through the bootstrap → builder → agent pipeline so it can be accessed at the TUI level for `populate_from_registry`.

### Changes
- `runtime_context.rs`: add `mcp_tool_cache` to `into_parts()` return value
- `types.rs`: add `mcp_tool_cache` to `RebuildSuccess`
- `builder.rs`: destructure and pass through builder
- `app_cli.rs`: update destructuring (5 elements)

### Next step
- Call `mcp_tool_cache.populate_from_registry(&registry)` from TUI init where `project_root` is available

### Verification
- `cargo test` — **953 passed, 0 failed**