### PR TITLE
feat(agent): inline reasoning content into assistant output

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -419,8 +419,17 @@ impl Agent {
                         report(AgentEvent::AssistantDelta(delta));
                     }
                     LlmStreamEvent::ReasoningDelta(delta) => {
-                        streamed_any_reasoning_delta |= !delta.trim().is_empty();
-                        report(AgentEvent::AssistantThinkingDelta(delta));
+                        let non_empty = !delta.trim().is_empty();
+                        if non_empty {
+                            if !streamed_any_reasoning_delta {
+                                streamed_any_reasoning_delta = true;
+                                report(AgentEvent::AssistantDelta(format!(
+                                    "[Thinking] {delta}"
+                                )));
+                            } else {
+                                report(AgentEvent::AssistantDelta(delta));
+                            }
+                        }
                     }
                 }
             })

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -423,9 +423,7 @@ impl Agent {
                         if non_empty {
                             if !streamed_any_reasoning_delta {
                                 streamed_any_reasoning_delta = true;
-                                report(AgentEvent::AssistantDelta(format!(
-                                    "[Thinking] {delta}"
-                                )));
+                                report(AgentEvent::AssistantDelta(format!("[Thinking] {delta}")));
                             } else {
                                 report(AgentEvent::AssistantDelta(delta));
                             }


### PR DESCRIPTION
## What changed

Changed `ReasoningDelta` stream events to emit `AssistantDelta` (text output) instead of `AssistantThinkingDelta` (separate thinking panel). The first reasoning delta is prefixed with `[Thinking]` so it's visually distinguishable in the chat.

## Why

The thinking panel in the TUI had no visible content. Instead of maintaining a separate rendering path for reasoning, this PR folds reasoning directly into the agent's text stream — user sees thinking as part of the normal output.

## Changes

| File | Change |
|---|---|
| `src/agent.rs:421-433` | `ReasoningDelta` now emits `AssistantDelta` with `[Thinking]` prefix on first delta |

## Verification

- Local `cargo check` passes (no new warnings)
- CI will verify build/clippy/fmt/test