### PR TITLE
feat: add runtime input control bridge

### DIFF
--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -174,6 +174,15 @@ editing are UI state, not agent input. If an appserver later needs remote UI
 control, it should use a separate UI-control request family such as
 `CloseOverlay` instead of overloading input control.
 
+When queued input is blocked behind a long-running turn, protocol adapters may
+request explicit preemption through `SessionControlRequest::InterruptCurrentTurn`
+or `SessionControlRequest::CancelCurrentTurn`. This is the protocol equivalent
+of the local busy-turn `Esc` behavior, but it remains a semantic runtime intent:
+the runtime decides whether the active task can be interrupted, records the
+state transition, and only then accepts or rejects later input. Adapters must
+not simulate terminal key presses or silently reorder queued input to force a
+pause.
+
 The runtime needs a single input-control handler that can be called by the local
 TUI and protocol adapters. It should reuse the same pending-interaction state,
 queue policy, approval policy, and cancellation path that the TUI uses today.
@@ -182,6 +191,15 @@ runtime accepts or applies the semantic action. For example, a queued follow-up
 event is emitted when the follow-up is actually queued, and a pending-input
 answered event is emitted when the answer is applied to the active pending
 interaction.
+
+The first runtime slice introduces the local semantic handler in the TUI path:
+composer submit, queued follow-up, pending-input answers, plan approval, shell
+approval, and cancel requests are routed through input-control helpers before
+mutating `TuiApp`. This keeps local behavior intact while creating the seam that
+future appserver, ACP, and Wire adapters should call. The next slice should move
+the handler behind a protocol-neutral runtime handle so
+`control_plane::dispatch` can process `RuntimeControlRequest::Input` and
+`SessionControlRequest::CancelCurrentTurn` without depending on TUI internals.
 
 ### Output Subscription
 
@@ -423,6 +441,22 @@ runtime must still decide when the input is safely consumed. The Wire adapter
 should emit the corresponding consumed-input event only after the follow-up has
 actually been appended to the next model step, not when the client request is
 merely accepted.
+
+RARA should also ship a `support-acp` integration skill for IDE and third-party
+application authors. This skill is documentation and workflow guidance, not a
+runtime shortcut. It should explain how to:
+
+- start or attach to RARA's ACP surface;
+- submit prompts, follow-ups, pending-input answers, approval decisions, and
+  cancellation/preemption through semantic runtime-control requests;
+- subscribe to structured output events instead of scraping TUI text;
+- register prompt, memory, skill, hook, or MCP context sources without breaking
+  stable prompt-prefix ordering;
+- handle queue backpressure, turn interruption, and approval prompts safely;
+- test adapter behavior with replayable fixtures.
+
+The skill should be updated alongside ACP/control-plane behavior changes so IDE
+integrations do not infer behavior from internal TUI implementation details.
 
 ## Observability
 

--- a/docs/journal/2026-05-08-runtime-input-control.md
+++ b/docs/journal/2026-05-08-runtime-input-control.md
@@ -1,0 +1,35 @@
+# Runtime Input Control Checkpoint
+
+This checkpoint starts the P0+ input-control bridge described in
+`runtime-control-plane.md`.
+
+## What Changed
+
+- Added a local semantic input-control helper for the TUI runtime path.
+- Routed composer submit, busy follow-up queueing, pending request-input
+  answers, plan approvals, shell approvals, and cancel requests through that
+  helper.
+- Published structured input/session events when semantic input actions are
+  applied.
+- Kept raw terminal keys such as `Esc` inside local key mapping. Busy `Esc`
+  becomes a cancellation intent; overlay close and editor navigation remain UI
+  state.
+- Documented the preemption rule for blocked protocol input: adapters use
+  `InterruptCurrentTurn` or `CancelCurrentTurn`, and the runtime decides whether
+  the active turn can actually pause or stop.
+- Added follow-up planning for a `support-acp` integration skill so IDE and
+  third-party app authors can connect through ACP/control-plane contracts
+  without copying TUI internals.
+
+## Boundary
+
+This is not the final appserver bridge. `control_plane::dispatch` still lacks a
+runtime handle that can mutate the active TUI/runtime state. The next slice
+should move this semantic handler behind a protocol-neutral runtime handle and
+route `RuntimeControlRequest::Input` plus `SessionControlRequest::CancelCurrentTurn`
+through it.
+
+## Validation
+
+No local tests were run for this checkpoint. CI should cover the focused input
+control tests and existing TUI submit behavior.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -33,6 +33,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add protocol-safe memory mutation/query scaffolding that creates memory records and selection views without bypassing `MemorySelection` (scaffold via protocol_sources.rs).
 - [x] Add hook declaration scaffolding for protocol and repo extensions; keep execution disabled until permission and sandbox policy are explicit.
 - [ ] Ensure every new skill, memory, prompt, hook, planning, approval, and output feature is control-plane-ready rather than TUI-only.
+- [ ] Add a `support-acp` integration skill for IDE and third-party app authors, covering ACP startup, runtime-control input intents, output event subscription, cancellation/preemption, approvals, MCP/tool-search expectations, and safe context-source registration.
 
 ## Configuration / Provider Surface
 

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -507,8 +507,8 @@ fn resume_pending_shell_approval_after_full_access(
         return false;
     }
 
-    if let Some(agent) = agent_slot.take() {
-        start_pending_approval_task(app, BashApprovalDecision::Once, agent);
+    if agent_slot.is_some() {
+        input_control::answer_shell_approval(app, agent_slot, ShellApprovalDecision::Once);
     } else {
         app.push_notice("Permission mode: full-access. Approval is still preparing.");
     }

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use super::app_event::AppEvent;
 use super::command::{palette_command_by_index, palette_commands};
+use super::input_control;
 #[allow(unused_imports)]
 use super::list_picker;
 use super::provider_flow::{
@@ -9,10 +10,7 @@ use super::provider_flow::{
     sync_codex_credential_from_auth_store,
 };
 use super::runtime::apply_permission_mode;
-use super::runtime::{
-    request_running_task_cancellation, start_deepseek_model_list_task, start_oauth_task,
-    start_pending_approval_task, start_rebuild_task,
-};
+use super::runtime::{start_deepseek_model_list_task, start_oauth_task, start_rebuild_task};
 use super::session_restore::restore_thread_by_id;
 use super::state::{
     ActivePendingInteractionKind, ListPickerKind, OpenAiModelPickerAction, Overlay, PermissionMode,
@@ -20,9 +18,10 @@ use super::state::{
 };
 use super::submit::{apply_openai_model_picker_action, handle_submit};
 use super::terminal_ui::is_ssh_session;
-use crate::agent::{Agent, BashApprovalDecision};
+use crate::agent::Agent;
 use crate::config::DEFAULT_CODEX_BASE_URL;
 use crate::oauth::{OAuthManager, SavedCodexAuthMode};
+use crate::runtime_control::{SessionControlRequest, ShellApprovalDecision};
 
 pub(crate) async fn dispatch_event(
     event: AppEvent,
@@ -34,7 +33,9 @@ pub(crate) async fn dispatch_event(
         AppEvent::Noop => {}
         AppEvent::OpenOverlay(overlay) => app.open_overlay(overlay),
         AppEvent::CloseOverlay => app.close_overlay(),
-        AppEvent::CancelRunningTask => request_running_task_cancellation(app),
+        AppEvent::CancelRunningTask => {
+            input_control::handle_session_control(app, SessionControlRequest::CancelCurrentTurn);
+        }
         AppEvent::ClearComposer => {
             app.input.clear();
             app.input_cursor_offset = None;
@@ -132,39 +133,29 @@ pub(crate) async fn dispatch_event(
                 match interaction.kind {
                     ActivePendingInteractionKind::PlanApproval => {
                         if let 0 | 1 = idx {
-                            if let Some(agent) = agent_slot.take() {
-                                let continue_planning = idx == 1;
-                                super::runtime::start_plan_approval_resume_task(
-                                    app,
-                                    continue_planning,
-                                    agent,
-                                );
-                            }
+                            input_control::answer_plan_approval(app, agent_slot, idx == 0);
                         }
                     }
                     ActivePendingInteractionKind::ShellApproval => {
-                        if let Some(agent) = agent_slot.take() {
-                            let selection = match idx {
-                                0 => BashApprovalDecision::Once,
-                                1 => BashApprovalDecision::Prefix,
-                                2 => BashApprovalDecision::Always,
-                                _ => BashApprovalDecision::Suggestion,
-                            };
-                            start_pending_approval_task(app, selection, agent);
-                        }
+                        let selection = match idx {
+                            0 => ShellApprovalDecision::Once,
+                            1 => ShellApprovalDecision::Prefix,
+                            2 => ShellApprovalDecision::Always,
+                            _ => ShellApprovalDecision::Suggestion,
+                        };
+                        input_control::answer_shell_approval(app, agent_slot, selection);
                     }
                     ActivePendingInteractionKind::PlanningQuestion
                     | ActivePendingInteractionKind::ExplorationQuestion
                     | ActivePendingInteractionKind::SubAgentQuestion
                     | ActivePendingInteractionKind::RequestInput => {
                         if let Some(label) = app.pending_question_option_label(idx) {
-                            if let Some(agent) = agent_slot.as_mut() {
-                                agent.consume_pending_user_input(&label);
-                                app.sync_snapshot(agent);
-                            }
-                            app.set_input(label);
-                            if handle_submit(app, agent_slot, oauth_manager).await? {
-                                return Ok(true);
+                            if let Some(agent) = agent_slot.take() {
+                                input_control::answer_pending_input(app, agent_slot, agent, label);
+                            } else {
+                                app.push_notice(
+                                    "Request input is still preparing. Try the shortcut again.",
+                                );
                             }
                         }
                     }

--- a/src/tui/input_control.rs
+++ b/src/tui/input_control.rs
@@ -1,0 +1,326 @@
+use crate::agent::{Agent, BashApprovalDecision};
+use crate::runtime_control::{
+    InputEvent, RuntimeEvent, SessionControlRequest, SessionEvent, ShellApprovalDecision,
+};
+use crate::tui::runtime::{
+    request_running_task_cancellation, start_pending_approval_task,
+    start_plan_approval_resume_task, start_query_task,
+};
+use crate::tui::state::{ActivePendingInteractionKind, InteractionKind, TaskKind, TuiApp};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InputControlOutcome {
+    Noop,
+    Queued,
+    Submitted,
+    Answered,
+    CancelRequested,
+    Rejected,
+}
+
+pub(crate) fn submit_user_prompt(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    prompt: String,
+) -> InputControlOutcome {
+    let prompt = prompt.trim().to_string();
+    if prompt.is_empty() {
+        if app.notice.is_none() {
+            app.notice = Some("Ready.".into());
+        }
+        return InputControlOutcome::Noop;
+    }
+
+    if app.is_busy() {
+        let pending_for_tool_boundary = app
+            .running_task
+            .as_ref()
+            .is_some_and(|task| matches!(&task.kind, TaskKind::Query));
+        return submit_follow_up(app, prompt, pending_for_tool_boundary);
+    }
+
+    if app.active_pending_interaction().is_some() && app.pending_request_input().is_none() {
+        return submit_follow_up(app, prompt, false);
+    }
+
+    let Some(agent) = agent_slot.take() else {
+        app.push_notice("Agent is not ready for input.");
+        return InputControlOutcome::Rejected;
+    };
+
+    if app.pending_request_input().is_some() {
+        answer_pending_input(app, agent_slot, agent, prompt);
+        return InputControlOutcome::Answered;
+    }
+
+    app.clear_pending_planning_suggestion();
+    publish_input_event(app, InputEvent::UserPromptSubmitted);
+    start_query_task(app, prompt, agent);
+    InputControlOutcome::Submitted
+}
+
+pub(crate) fn submit_follow_up(
+    app: &mut TuiApp,
+    prompt: String,
+    release_after_next_tool_boundary: bool,
+) -> InputControlOutcome {
+    let prompt = prompt.trim().to_string();
+    if prompt.is_empty() {
+        return InputControlOutcome::Noop;
+    }
+
+    let queued = if release_after_next_tool_boundary {
+        app.queue_follow_up_message_after_next_tool_boundary(prompt)
+    } else {
+        app.queue_follow_up_message(prompt)
+    };
+    let suffix = if queued > 1 {
+        format!(" {queued} follow-up messages are queued.")
+    } else {
+        " 1 follow-up message is queued.".to_string()
+    };
+    app.notice = Some(format!(
+        "{}{suffix}",
+        if release_after_next_tool_boundary {
+            "Queued for after the next tool call boundary."
+        } else if app.active_pending_interaction().is_some()
+            && app.pending_request_input().is_none()
+        {
+            "Queued until the pending interaction is answered."
+        } else {
+            "Queued for after the current task finishes."
+        }
+    ));
+    publish_input_event(
+        app,
+        InputEvent::FollowUpQueued {
+            queue_len: queued as u32,
+        },
+    );
+    InputControlOutcome::Queued
+}
+
+pub(crate) fn answer_pending_input(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    mut agent: Agent,
+    answer: String,
+) {
+    publish_input_event(app, InputEvent::PendingInputAnswered);
+    if app.has_local_pending_request_input() {
+        start_local_request_input_continuation(app, agent, answer);
+        return;
+    }
+
+    agent.consume_pending_user_input(&answer);
+    app.sync_snapshot(&agent);
+    app.clear_pending_planning_suggestion();
+    start_query_task(app, answer, agent);
+    *agent_slot = None;
+}
+
+pub(crate) fn answer_plan_approval(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    approved: bool,
+) -> InputControlOutcome {
+    if !app.has_pending_plan_approval() {
+        app.push_notice("No pending plan approval.");
+        return InputControlOutcome::Rejected;
+    }
+    let Some(agent) = agent_slot.take() else {
+        app.push_notice("Approval is still preparing. Try again.");
+        return InputControlOutcome::Rejected;
+    };
+    start_plan_approval_resume_task(app, !approved, agent);
+    InputControlOutcome::Answered
+}
+
+pub(crate) fn answer_shell_approval(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    decision: ShellApprovalDecision,
+) -> InputControlOutcome {
+    let Some(interaction) = app.active_pending_interaction() else {
+        app.push_notice("No pending shell approval.");
+        return InputControlOutcome::Rejected;
+    };
+    if interaction.kind != ActivePendingInteractionKind::ShellApproval {
+        app.push_notice("No pending shell approval.");
+        return InputControlOutcome::Rejected;
+    }
+    let Some(agent) = agent_slot.take() else {
+        app.push_notice("Approval is still preparing. Try again.");
+        return InputControlOutcome::Rejected;
+    };
+    let decision = BashApprovalDecision::from(decision);
+    start_pending_approval_task(app, decision, agent);
+    InputControlOutcome::Answered
+}
+
+pub(crate) fn handle_session_control(
+    app: &mut TuiApp,
+    request: SessionControlRequest,
+) -> InputControlOutcome {
+    match request {
+        SessionControlRequest::CancelCurrentTurn => {
+            request_running_task_cancellation(app);
+            if app
+                .notice
+                .as_deref()
+                .is_some_and(|notice| notice == "Cancellation requested.")
+            {
+                publish_session_event(app, SessionEvent::TurnCancelled);
+                InputControlOutcome::CancelRequested
+            } else {
+                InputControlOutcome::Rejected
+            }
+        }
+        SessionControlRequest::InterruptCurrentTurn => {
+            request_running_task_cancellation(app);
+            if app
+                .notice
+                .as_deref()
+                .is_some_and(|notice| notice == "Cancellation requested.")
+            {
+                publish_session_event(app, SessionEvent::TurnInterrupted);
+                InputControlOutcome::CancelRequested
+            } else {
+                InputControlOutcome::Rejected
+            }
+        }
+        _ => InputControlOutcome::Rejected,
+    }
+}
+
+fn start_local_request_input_continuation(app: &mut TuiApp, agent: Agent, answer: String) {
+    let Some(interaction) = app.pending_request_input().cloned() else {
+        app.clear_pending_planning_suggestion();
+        start_query_task(app, answer, agent);
+        return;
+    };
+
+    let source = interaction
+        .source
+        .clone()
+        .unwrap_or_else(|| "sub-agent".to_string());
+    app.record_completed_interaction(
+        InteractionKind::RequestInput,
+        interaction.title.clone(),
+        format!("Answered with: {}", answer),
+        interaction.source.clone(),
+    );
+    app.clear_local_request_input();
+
+    let mut prompt = format!(
+        "Continue the parent task after a delegated {source} requested additional user input.\nQuestion: {}\nAnswer: {}\n\nUse the delegated result already present in the transcript as context; do not assume the child sub-agent session is still attached.",
+        interaction.title, answer
+    );
+    if let Some(note) = interaction.note.as_deref()
+        && !note.trim().is_empty()
+    {
+        prompt.push_str(&format!("\nContext: {}", note.trim()));
+    }
+    start_query_task(app, prompt, agent);
+}
+
+fn publish_input_event(app: &TuiApp, event: InputEvent) {
+    if let Some(bus) = app.event_bus.as_ref() {
+        bus.publish_control(RuntimeEvent::Input(event));
+    }
+}
+
+fn publish_session_event(app: &TuiApp, event: SessionEvent) {
+    if let Some(bus) = app.event_bus.as_ref() {
+        bus.publish_control(RuntimeEvent::Session(event));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Instant;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::config::ConfigManager;
+    use crate::runtime_control::RuntimeEvent;
+    use crate::runtime_event_bus::RuntimeEventBus;
+    use crate::tui::state::{RunningTask, TaskCompletion};
+
+    fn test_app() -> TuiApp {
+        let dir = tempfile::tempdir().expect("tempdir");
+        TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app")
+    }
+
+    fn mark_query_busy(app: &mut TuiApp, cancellation_token: Option<Arc<AtomicBool>>) {
+        let (_sender, receiver) = mpsc::unbounded_channel();
+        app.running_task = Some(RunningTask {
+            kind: TaskKind::Query,
+            receiver,
+            handle: tokio::spawn(async { std::future::pending::<TaskCompletion>().await }),
+            started_at: Instant::now(),
+            next_heartbeat_after_secs: 2,
+            cancellation_token,
+            cancellation_requested: false,
+        });
+    }
+
+    #[tokio::test]
+    async fn submit_follow_up_publishes_structured_input_event() {
+        let mut app = test_app();
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let mut rx = bus.subscribe_control();
+        app.event_bus = Some(bus);
+        mark_query_busy(&mut app, None);
+
+        let outcome = submit_user_prompt(&mut app, &mut None, "continue".to_string());
+
+        assert_eq!(outcome, InputControlOutcome::Queued);
+        assert_eq!(app.pending_follow_up_count(), 1);
+        let event = rx.try_recv().expect("input event");
+        assert!(matches!(
+            event.event,
+            RuntimeEvent::Input(InputEvent::FollowUpQueued { queue_len: 1 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_current_turn_publishes_session_event_when_cancelled() {
+        let mut app = test_app();
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let mut rx = bus.subscribe_control();
+        app.event_bus = Some(bus);
+        let token = Arc::new(AtomicBool::new(false));
+        mark_query_busy(&mut app, Some(token.clone()));
+
+        let outcome = handle_session_control(&mut app, SessionControlRequest::CancelCurrentTurn);
+
+        assert_eq!(outcome, InputControlOutcome::CancelRequested);
+        assert!(token.load(Ordering::SeqCst));
+        let event = rx.try_recv().expect("session event");
+        assert!(matches!(
+            event.event,
+            RuntimeEvent::Session(SessionEvent::TurnCancelled)
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_current_turn_publishes_session_event_only_when_cancelled() {
+        let mut app = test_app();
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let mut rx = bus.subscribe_control();
+        app.event_bus = Some(bus);
+        mark_query_busy(&mut app, None);
+
+        let outcome = handle_session_control(&mut app, SessionControlRequest::CancelCurrentTurn);
+
+        assert_eq!(outcome, InputControlOutcome::Rejected);
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -10,6 +10,7 @@ mod event_loop;
 mod event_stream;
 mod format;
 mod highlight;
+mod input_control;
 mod interaction_text;
 mod keymap;
 mod layout_utils;

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use super::command::{palette_command_by_index, parse_local_command};
-use super::runtime::{execute_local_command, start_query_task};
-use super::state::{LocalCommandKind, OpenAiModelPickerAction, Overlay, TaskKind, TuiApp};
+use super::input_control;
+use super::runtime::execute_local_command;
+use super::state::{LocalCommandKind, OpenAiModelPickerAction, Overlay, TuiApp};
 use crate::agent::Agent;
 
 mod pending;
@@ -52,28 +53,7 @@ pub(crate) async fn handle_submit(
                 "A task is already running. Wait for it to finish before running a slash command.",
             );
         } else {
-            let pending_for_tool_boundary = app
-                .running_task
-                .as_ref()
-                .is_some_and(|task| matches!(&task.kind, TaskKind::Query));
-            let queued = if pending_for_tool_boundary {
-                app.queue_follow_up_message_after_next_tool_boundary(trimmed.clone())
-            } else {
-                app.queue_follow_up_message(trimmed.clone())
-            };
-            let suffix = if queued > 1 {
-                format!(" {queued} follow-up messages are queued.")
-            } else {
-                " 1 follow-up message is queued.".to_string()
-            };
-            app.notice = Some(format!(
-                "{}{suffix}",
-                if pending_for_tool_boundary {
-                    "Queued for after the next tool call boundary."
-                } else {
-                    "Queued for after the current task finishes."
-                }
-            ));
+            input_control::submit_user_prompt(app, agent_slot, trimmed);
         }
         return Ok(false);
     }
@@ -93,25 +73,8 @@ pub(crate) async fn handle_submit(
         app.push_notice(format!("Unknown command '{}'. Use /help.", trimmed));
     } else if pending::handle_pending_option_submit(app, agent_slot, &trimmed) {
         return Ok(false);
-    } else if app.active_pending_interaction().is_some() && app.pending_request_input().is_none() {
-        let queued = app.queue_follow_up_message(trimmed.clone());
-        let suffix = if queued > 1 {
-            format!(" {queued} follow-up messages are queued.")
-        } else {
-            " 1 follow-up message is queued.".to_string()
-        };
-        app.notice = Some(format!(
-            "Queued until the pending interaction is answered.{suffix}"
-        ));
-        return Ok(false);
-    } else if let Some(agent) = agent_slot.take() {
-        if app.pending_request_input().is_some() {
-            pending::handle_request_input_answer(app, agent_slot, agent, trimmed);
-            return Ok(false);
-        }
-        let prompt = trimmed;
-        app.clear_pending_planning_suggestion();
-        start_query_task(app, prompt, agent);
+    } else {
+        input_control::submit_user_prompt(app, agent_slot, trimmed);
     }
     Ok(false)
 }

--- a/src/tui/submit/pending.rs
+++ b/src/tui/submit/pending.rs
@@ -1,8 +1,7 @@
-use crate::agent::{Agent, BashApprovalDecision};
-use crate::tui::runtime::{
-    start_pending_approval_task, start_plan_approval_resume_task, start_query_task,
-};
-use crate::tui::state::{ActivePendingInteractionKind, InteractionKind, TuiApp};
+use crate::agent::Agent;
+use crate::runtime_control::ShellApprovalDecision;
+use crate::tui::input_control;
+use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
 
 pub(super) fn handle_pending_option_submit(
     app: &mut TuiApp,
@@ -20,25 +19,17 @@ pub(super) fn handle_pending_option_submit(
     };
     match interaction.kind {
         ActivePendingInteractionKind::PlanApproval => {
-            if let Some(agent) = agent_slot.take() {
-                start_plan_approval_resume_task(app, index == 1, agent);
-            } else {
-                app.push_notice("Approval is still preparing. Try the shortcut again.");
-            }
+            input_control::answer_plan_approval(app, agent_slot, index == 0);
             true
         }
         ActivePendingInteractionKind::ShellApproval => {
-            if let Some(agent) = agent_slot.take() {
-                let selection = match index {
-                    0 => BashApprovalDecision::Once,
-                    1 => BashApprovalDecision::Prefix,
-                    2 => BashApprovalDecision::Always,
-                    _ => BashApprovalDecision::Suggestion,
-                };
-                start_pending_approval_task(app, selection, agent);
-            } else {
-                app.push_notice("Approval is still preparing. Try the shortcut again.");
-            }
+            let selection = match index {
+                0 => ShellApprovalDecision::Once,
+                1 => ShellApprovalDecision::Prefix,
+                2 => ShellApprovalDecision::Always,
+                _ => ShellApprovalDecision::Suggestion,
+            };
+            input_control::answer_shell_approval(app, agent_slot, selection);
             true
         }
         ActivePendingInteractionKind::PlanningQuestion
@@ -47,7 +38,7 @@ pub(super) fn handle_pending_option_submit(
         | ActivePendingInteractionKind::RequestInput => {
             if let Some(label) = app.pending_question_option_label(index) {
                 if let Some(agent) = agent_slot.take() {
-                    handle_request_input_answer(app, agent_slot, agent, label);
+                    input_control::answer_pending_input(app, agent_slot, agent, label);
                 } else {
                     app.push_notice("Request input is still preparing. Try the shortcut again.");
                 }
@@ -56,55 +47,6 @@ pub(super) fn handle_pending_option_submit(
             false
         }
     }
-}
-
-pub(super) fn handle_request_input_answer(
-    app: &mut TuiApp,
-    agent_slot: &mut Option<Agent>,
-    mut agent: Agent,
-    answer: String,
-) {
-    if app.has_local_pending_request_input() {
-        start_local_request_input_continuation(app, agent, answer);
-        return;
-    }
-
-    agent.consume_pending_user_input(&answer);
-    app.sync_snapshot(&agent);
-    app.clear_pending_planning_suggestion();
-    start_query_task(app, answer, agent);
-    *agent_slot = None;
-}
-
-fn start_local_request_input_continuation(app: &mut TuiApp, agent: Agent, answer: String) {
-    let Some(interaction) = app.pending_request_input().cloned() else {
-        app.clear_pending_planning_suggestion();
-        start_query_task(app, answer, agent);
-        return;
-    };
-
-    let source = interaction
-        .source
-        .clone()
-        .unwrap_or_else(|| "sub-agent".to_string());
-    app.record_completed_interaction(
-        InteractionKind::RequestInput,
-        interaction.title.clone(),
-        format!("Answered with: {}", answer),
-        interaction.source.clone(),
-    );
-    app.clear_local_request_input();
-
-    let mut prompt = format!(
-        "Continue the parent task after a delegated {source} requested additional user input.\nQuestion: {}\nAnswer: {}\n\nUse the delegated result already present in the transcript as context; do not assume the child sub-agent session is still attached.",
-        interaction.title, answer
-    );
-    if let Some(note) = interaction.note.as_deref()
-        && !note.trim().is_empty()
-    {
-        prompt.push_str(&format!("\nContext: {}", note.trim()));
-    }
-    start_query_task(app, prompt, agent);
 }
 
 fn pending_option_index_from_text(input: &str) -> Option<usize> {


### PR DESCRIPTION
## Summary

- add a semantic TUI input-control helper for prompt submit, follow-up queueing, pending-input answers, approvals, and cancellation intents
- route local TUI submit, pending shortcuts, shell approval, plan approval, and busy Esc through the shared helper
- publish structured input/session events for applied input-control actions
- document blocked-input preemption and the follow-up support-acp integration skill

## Testing

- Not run locally; validation is delegated to CI per request.
