### PR TITLE
chore: add windows build ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,24 @@ jobs:
 
       - name: Build
         run: cargo build --locked
+
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-05-02
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7762,6 +7762,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ arrow-schema = "57.2"
 lance-index = "=4.0.0"
 futures = "0.3"
 eventsource-stream = "0.2.3"
-rusqlite = "0.39"
+rusqlite = { version = "0.39", features = ["bundled"] }
 pulldown-cmark = "0.13"
 textwrap = "0.16.2"
 unicode-width = "0.2"

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -90,6 +90,15 @@ jobs should not run unless the release assets exist.
 
 ## Current Pipeline
 
+Daily and pull-request CI now includes:
+
+- Linux build, fmt, clippy, and test jobs on `ubuntu-latest`;
+- a Windows build gate on `windows-latest` using the pinned Rust toolchain and
+  `cargo build --locked`.
+
+Windows tests are intentionally not part of the first daily CI slice. The
+release workflow still owns Windows archive packaging and native smoke tests.
+
 `.github/workflows/release.yml` implements the first release slice:
 
 - tag validation for `vX.Y.Z`, `vX.Y.Z-alpha(.N)`, and `vX.Y.Z-beta(.N)`;

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -98,6 +98,8 @@ Daily and pull-request CI now includes:
 
 Windows tests are intentionally not part of the first daily CI slice. The
 release workflow still owns Windows archive packaging and native smoke tests.
+SQLite is built through `rusqlite`'s bundled feature so Windows builds do not
+depend on a runner-provided `sqlite3.lib`.
 
 `.github/workflows/release.yml` implements the first release slice:
 

--- a/docs/journal/2026-05-08-windows-ci-build.md
+++ b/docs/journal/2026-05-08-windows-ci-build.md
@@ -20,6 +20,16 @@ The `build` workflow now includes a dedicated `build-windows` job:
 This intentionally starts as a compile gate only. Windows tests can be added as
 a later focused step after terminal and TUI behavior is audited on Windows.
 
+The first Windows run failed in the linker with:
+
+```text
+LINK : fatal error LNK1181: cannot open input file 'sqlite3.lib'
+```
+
+RARA uses `rusqlite` for the local state database. The dependency now enables
+the `bundled` feature so `libsqlite3-sys` builds SQLite from source instead of
+expecting a system SQLite import library on Windows.
+
 ## Validation
 
 The PR should pass:

--- a/docs/journal/2026-05-08-windows-ci-build.md
+++ b/docs/journal/2026-05-08-windows-ci-build.md
@@ -1,0 +1,31 @@
+# Windows CI Build Gate
+
+## Context
+
+The release workflow already builds Windows archives for
+`x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`, but pull-request CI only
+validated Linux build, test, clippy, and formatting jobs.
+
+That left Windows compile failures to surface late, during tag release builds.
+
+## Change
+
+The `build` workflow now includes a dedicated `build-windows` job:
+
+- runner: `windows-latest`;
+- toolchain: pinned `nightly-2026-05-02`, matching existing CI;
+- dependency setup: `arduino/setup-protoc`;
+- command: `cargo build --locked`.
+
+This intentionally starts as a compile gate only. Windows tests can be added as
+a later focused step after terminal and TUI behavior is audited on Windows.
+
+## Validation
+
+The PR should pass:
+
+- Linux `build`;
+- Windows `build-windows`;
+- `fmt`;
+- `clippy`;
+- `test`.


### PR DESCRIPTION
## Summary

- add a Windows build job to the daily and pull-request build workflow
- document the split between daily Windows compile coverage and release archive packaging
- record the implementation checkpoint in the journal

## Purpose

Windows release artifacts already exist in the tag-driven release pipeline, but PR CI did not catch Windows compile failures before release time. This adds an earlier compile-only gate without expanding the first slice into Windows test coverage.

## Related Issue

- None

## Testing

- Not run locally; this PR is intended to validate through GitHub Actions.
