### PR TITLE
chore: require warning-clean rust changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,10 @@ The current product direction is to make local inference a first-class path inst
 
 ## 3.1 Rust Engineering Rules
 
+- New or modified Rust code must not introduce new compiler or Clippy warnings.
+  The existing codebase may still contain legacy warnings; keep changes
+  warning-clean within the touched scope, and prefer fixing nearby warnings
+  only when they are directly caused by or blocking the current change.
 - Avoid ambiguous positional booleans, numeric literals, or `Option` arguments in new APIs when they make call sites hard to read. Prefer enums, newtypes, named methods, or small parameter structs.
 - Prefer exhaustive `match` statements over wildcard arms when the variants are part of a meaningful state machine or protocol contract.
 - Newly introduced traits should include concise doc comments that explain the trait role and what implementors must preserve.


### PR DESCRIPTION
## Summary

- add a repository rule that new or modified Rust code must not introduce compiler or Clippy warnings
- scope the rule to touched code so legacy warnings do not block unrelated changes

## Purpose

RARA currently has a large warning surface. This records the forward rule in `AGENTS.md`: future changes should keep their own touched scope warning-clean instead of adding to the backlog.

## Related Issue

- None

## Testing

- Not run; documentation-only project guidance change.
