### PR TITLE
chore: run windows build after merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         run: cargo build --locked
 
   build-windows:
+    if: ${{ github.event_name == 'push' }}
     runs-on: windows-latest
 
     steps:

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -90,13 +90,14 @@ jobs should not run unless the release assets exist.
 
 ## Current Pipeline
 
-Daily and pull-request CI now includes:
+Pull-request CI includes:
 
 - Linux build, fmt, clippy, and test jobs on `ubuntu-latest`;
-- a Windows build gate on `windows-latest` using the pinned Rust toolchain and
-  `cargo build --locked`.
 
-Windows tests are intentionally not part of the first daily CI slice. The
+Post-merge CI additionally includes a Windows build gate on `windows-latest`
+using the pinned Rust toolchain and `cargo build --locked`.
+
+Windows tests are intentionally not part of the first post-merge CI slice. The
 release workflow still owns Windows archive packaging and native smoke tests.
 SQLite is built through `rusqlite`'s bundled feature so Windows builds do not
 depend on a runner-provided `sqlite3.lib`.

--- a/docs/journal/2026-05-08-windows-build-post-merge.md
+++ b/docs/journal/2026-05-08-windows-build-post-merge.md
@@ -1,0 +1,22 @@
+# Windows Build After Merge
+
+## Context
+
+The first Windows CI slice added a `build-windows` job to the build workflow.
+That made every pull request run a full Windows dependency build, which is more
+expensive than the Linux PR gate and not necessary for every review iteration.
+
+## Change
+
+The `build-windows` job now runs only for `push` events. Because the build
+workflow only pushes on `main`, Windows compile coverage becomes a post-merge
+gate.
+
+Pull requests still run the existing Linux build, fmt, clippy, and test jobs.
+The release workflow continues to build Windows release archives and run native
+smoke tests where configured.
+
+## Follow-up
+
+If Windows regressions become frequent, add a manual `workflow_dispatch` path or
+path-filtered PR Windows builds for platform-sensitive changes.


### PR DESCRIPTION
## Summary

- run `build-windows` only on push events to `main`
- keep pull-request CI on the existing Linux build, fmt, clippy, and test gates
- update release distribution docs and add a journal note for the CI policy change

## Purpose

Windows compile coverage is useful, but it is expensive for every PR iteration. This keeps Windows coverage as a post-merge gate while release builds continue to produce Windows artifacts.

## Related Issue

- None

## Testing

- Not run locally; this is a GitHub Actions policy change and should be validated by PR checks plus the next main push.
