### PR TITLE
feat: execute memory control requests

### DIFF
--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -123,7 +123,7 @@ Importance scale:
 | Context injection | Ranked memory candidates pass through `MemorySelection` before prompt injection. | Partial. LanceDB-backed memory and session search now produce direct ranked `MemorySelection` candidates; retention, deduplication, and protocol mutation remain future work. |
 | Graph retrieval | Entity and relationship traversal complements vector recall. | Future work. |
 | Working memory | Daily or session briefing summarizes recent and important memories. | Future work. |
-| MCP / ACP / Wire memory APIs | Protocol clients can query and mutate memory through the runtime control plane. | Future work over the `MemoryStore` boundary. |
+| MCP / ACP / Wire memory APIs | Protocol clients can query and mutate memory through the runtime control plane. | Initial runtime-control handler is implemented for add, update, delete, list-label, and metadata queries over `MemoryStore`; transport-specific command surfaces remain follow-up work. |
 
 ## Memories vs Threads
 
@@ -238,6 +238,10 @@ Current implementation checkpoint:
   touching the LanceDB search row.
 - `MemoryStore::update`, `delete`, and `list_labels` provide the memory-domain
   API needed by future ACP/Wire adapters without exposing LanceDB operations.
+- Protocol memory control requests now execute add, update, delete, list-label,
+  and metadata operations through `MemoryStore` and publish structured memory
+  events. Protocol adapters still must route their transport-specific commands
+  through the shared control-plane dispatcher.
 - Search rehydration treats persisted `MemoryRecord`s as the source of truth:
   indexed rows with deleted ids are filtered instead of reconstructed.
 - `MemoryRecord::is_protected_from_automatic_cleanup` protects pinned,

--- a/docs/journal/2026-05-09-memory-control-plane.md
+++ b/docs/journal/2026-05-09-memory-control-plane.md
@@ -1,0 +1,39 @@
+# Memory Control Plane Execution
+
+## Context
+
+RARA already had structured memory control request types for ACP/Wire-style
+adapters, but the protocol memory handler only emitted placeholder events. That
+meant protocol clients could describe memory mutations, but they could not
+actually inspect or mutate durable memory through the runtime boundary.
+
+## Change
+
+`MemoryControlHandler` now has a `MemoryStore`-backed execution path:
+
+- `AddRecord` writes a protocol-origin `MemoryRecord` through `MemoryStore`;
+- `UpdateRecord` maps protocol patches to `MemoryRecordPatch`;
+- `DeleteRecord` removes the durable record through `MemoryStore`;
+- `ListLabels` returns structured label counts;
+- `QueryMetadata` returns record count plus label counts.
+
+All successful operations publish structured `MemoryEvent` values on the
+runtime event bus. This keeps ACP/Wire integrations behind the same domain
+facade as local tools and avoids direct prompt-text mutation or LanceDB access.
+
+## Boundaries
+
+- Retrieved memory placement remains governed by `MemorySelection` and
+  `ContextAssembler`.
+- Protocol memory writes do not inject text into the stable prompt prefix.
+- Transport-specific ACP/Wire command surfaces still need to call the shared
+  control-plane dispatcher.
+
+## Validation
+
+Focused tests cover:
+
+- protocol add writes a durable `MemoryRecord` with protocol provenance and
+  emits the stored id;
+- protocol update/list/delete use the same `MemoryStore` record truth and emit
+  structured events.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -110,7 +110,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add the first `RetrievalSourceProvider` boundary for current memory, session, thread-history, vector-slot, tool-result, and file-search candidates.
 - [ ] Add `RetrievalSourceProvider` implementations for MCP resource, hook, and graph sources after the current memory/session/file path is stable.
 - [x] Initialize LanceDB and wire FTS/vector/hybrid search paths behind the existing memory index façade.
-- [ ] Make memory mutation/query control-plane-ready so ACP/Wire can inspect and add memory without directly editing prompt text.
+- [x] Make memory mutation/query control-plane-ready so ACP/Wire can inspect and add memory without directly editing prompt text.
 
 ## TUI / Transcript
 

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -44,10 +44,10 @@ where
             skill_registry.handle_control(skill_request).await;
             Ok(())
         }
-        RuntimeControlRequest::Memory(memory_request) => {
-            memory_handler.handle_control(memory_request).await;
-            Ok(())
-        }
+        RuntimeControlRequest::Memory(memory_request) => memory_handler
+            .handle_control(memory_request)
+            .await
+            .map_err(|err| err.to_string()),
         _ => Err("control-plane dispatch not yet implemented for this request variant".to_string()),
     }
 }

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -166,14 +166,26 @@ impl MemoryStore {
     }
 
     pub async fn insert(&self, input: NewMemoryRecord) -> Result<MemoryRecord> {
+        self.insert_with_id(None, input).await
+    }
+
+    pub async fn insert_with_id(
+        &self,
+        id: Option<String>,
+        input: NewMemoryRecord,
+    ) -> Result<MemoryRecord> {
         let content = input.content.trim();
         if content.is_empty() {
             bail!("memory content must not be empty");
         }
+        let id = id
+            .map(|id| id.trim().to_string())
+            .filter(|id| !id.is_empty())
+            .unwrap_or_else(|| format!("memory-{}", uuid::Uuid::new_v4()));
         let importance = clamp_importance(input.importance);
         let now = unix_timestamp_seconds();
         let record = MemoryRecord {
-            id: format!("memory-{}", uuid::Uuid::new_v4()),
+            id,
             title: input
                 .title
                 .filter(|title| !title.trim().is_empty())
@@ -278,6 +290,10 @@ impl MemoryStore {
     pub async fn list_labels(&self, scope: Option<MemoryScope>) -> Result<Vec<MemoryLabelCount>> {
         let records = self.records.load_map().await?;
         Ok(list_label_counts(records.values(), scope.as_ref()))
+    }
+
+    pub async fn record_count(&self) -> Result<usize> {
+        Ok(self.records.load_map().await?.len())
     }
 }
 

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -17,11 +17,18 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use anyhow::{Result, bail};
+use serde_json::Value;
 use tokio::sync::RwLock;
 
+use crate::memory_store::{
+    MemoryLabel, MemoryLabelCount, MemoryRecordPatch, MemoryScope as StoreMemoryScope,
+    MemorySource, MemoryStore, NewMemoryRecord,
+};
 use crate::runtime_control::{
-    MemoryControlRequest, PromptSourceControlRequest, PromptSourceEvent, PromptSourceLifetime,
-    PromptSourceRegistration, RuntimeEvent, SkillSourceControlRequest,
+    MemoryControlRequest, MemoryEvent, MemoryLabelSummary, MemoryRecordControlPatch,
+    MemoryScope as ControlMemoryScope, PromptSourceControlRequest, PromptSourceEvent,
+    PromptSourceLifetime, PromptSourceRegistration, RuntimeEvent, SkillSourceControlRequest,
 };
 use crate::runtime_event_bus::RuntimeEventBus;
 
@@ -214,32 +221,430 @@ impl SkillSourceRegistry {
 
 /// Handler for protocol-originated memory control requests.
 ///
-/// Currently records the request and emits an event; full integration
-/// with the memory backend (`MemoryBackend`) will add/update/delete
-/// the actual store.
 pub struct MemoryControlHandler {
     event_bus: Arc<RuntimeEventBus>,
+    memory_store: Option<Arc<MemoryStore>>,
 }
 
 impl MemoryControlHandler {
     pub fn new(event_bus: Arc<RuntimeEventBus>) -> Self {
-        Self { event_bus }
+        Self {
+            event_bus,
+            memory_store: None,
+        }
     }
 
-    #[allow(unused_variables)]
-    pub async fn handle_control(&self, request: &MemoryControlRequest) {
-        // Memory integration is pending the MemoryBackend trait refactor.
-        // For now, record the request through an event.
-        let memory_id = match request {
-            MemoryControlRequest::AddRecord { memory_id, .. } => memory_id.clone(),
-            MemoryControlRequest::UpdateRecord { memory_id, .. } => memory_id.clone(),
-            MemoryControlRequest::DeleteRecord { memory_id } => memory_id.clone(),
-            MemoryControlRequest::ListLabels { .. } => "query".into(),
-            MemoryControlRequest::QueryMetadata => "query".into(),
-            MemoryControlRequest::SelectionSnapshot => "snapshot".into(),
+    pub fn with_store(event_bus: Arc<RuntimeEventBus>, memory_store: Arc<MemoryStore>) -> Self {
+        Self {
+            event_bus,
+            memory_store: Some(memory_store),
+        }
+    }
+
+    pub async fn handle_control(&self, request: &MemoryControlRequest) -> Result<()> {
+        let Some(memory_store) = &self.memory_store else {
+            self.publish_scaffold_event(request);
+            return Ok(());
         };
-        let _ = self.event_bus.publish_control(RuntimeEvent::Memory(
-            crate::runtime_control::MemoryEvent::RecordAdded { memory_id },
+
+        match request {
+            MemoryControlRequest::AddRecord {
+                memory_id,
+                scope,
+                content,
+                metadata,
+            } => {
+                if memory_store.get(memory_id).await?.is_some() {
+                    bail!("memory record {memory_id:?} already exists");
+                }
+                let record = memory_store
+                    .insert_with_id(
+                        Some(memory_id.clone()),
+                        new_memory_record_from_control(scope, content, metadata)?,
+                    )
+                    .await?;
+                self.publish_memory_event(MemoryEvent::RecordAdded {
+                    memory_id: record.id,
+                });
+            }
+            MemoryControlRequest::UpdateRecord { memory_id, patch } => {
+                memory_store
+                    .update(memory_id, memory_patch_from_control(patch)?)
+                    .await?;
+                self.publish_memory_event(MemoryEvent::RecordUpdated {
+                    memory_id: memory_id.clone(),
+                });
+            }
+            MemoryControlRequest::DeleteRecord { memory_id } => {
+                memory_store.delete(memory_id).await?;
+                self.publish_memory_event(MemoryEvent::RecordDeleted {
+                    memory_id: memory_id.clone(),
+                });
+            }
+            MemoryControlRequest::ListLabels { scope } => {
+                let labels = memory_store
+                    .list_labels(scope.clone().map(store_scope_from_control))
+                    .await?;
+                self.publish_memory_event(MemoryEvent::LabelsListed {
+                    scope: scope.clone(),
+                    labels: label_summaries(labels),
+                });
+            }
+            MemoryControlRequest::QueryMetadata => {
+                let labels = memory_store.list_labels(None).await?;
+                let record_count = memory_store.record_count().await?;
+                self.publish_memory_event(MemoryEvent::MetadataQueried {
+                    record_count,
+                    labels: label_summaries(labels),
+                });
+            }
+            MemoryControlRequest::SelectionSnapshot => {
+                self.publish_memory_event(MemoryEvent::SelectionUpdated);
+            }
+        }
+        Ok(())
+    }
+
+    fn publish_scaffold_event(&self, request: &MemoryControlRequest) {
+        let event = match request {
+            MemoryControlRequest::AddRecord { memory_id, .. } => MemoryEvent::RecordAdded {
+                memory_id: memory_id.clone(),
+            },
+            MemoryControlRequest::UpdateRecord { memory_id, .. } => MemoryEvent::RecordUpdated {
+                memory_id: memory_id.clone(),
+            },
+            MemoryControlRequest::DeleteRecord { memory_id } => MemoryEvent::RecordDeleted {
+                memory_id: memory_id.clone(),
+            },
+            MemoryControlRequest::ListLabels { scope } => MemoryEvent::LabelsListed {
+                scope: scope.clone(),
+                labels: Vec::new(),
+            },
+            MemoryControlRequest::QueryMetadata => MemoryEvent::MetadataQueried {
+                record_count: 0,
+                labels: Vec::new(),
+            },
+            MemoryControlRequest::SelectionSnapshot => MemoryEvent::SelectionUpdated,
+        };
+        self.publish_memory_event(event);
+    }
+
+    fn publish_memory_event(&self, event: MemoryEvent) {
+        let _ = self.event_bus.publish_control(RuntimeEvent::Memory(event));
+    }
+}
+
+fn new_memory_record_from_control(
+    scope: &ControlMemoryScope,
+    content: &str,
+    metadata: &Value,
+) -> Result<NewMemoryRecord> {
+    Ok(NewMemoryRecord {
+        title: metadata_string(metadata, "title"),
+        content: content.to_string(),
+        labels: metadata_labels(metadata)?,
+        importance: metadata
+            .get("importance")
+            .and_then(Value::as_f64)
+            .unwrap_or(0.5) as f32,
+        pinned: metadata
+            .get("pinned")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        source: MemorySource::ProtocolWrite,
+        scope: store_scope_from_control(scope.clone()),
+        session_id: metadata_string(metadata, "session_id"),
+        thread_id: metadata_string(metadata, "thread_id"),
+        source_span: None,
+    })
+}
+
+fn memory_patch_from_control(patch: &MemoryRecordControlPatch) -> Result<MemoryRecordPatch> {
+    Ok(MemoryRecordPatch {
+        title: patch.title.clone(),
+        content: patch.content.clone(),
+        labels: patch
+            .labels
+            .as_ref()
+            .map(|labels| {
+                labels
+                    .iter()
+                    .map(|label| memory_label_from_str(label))
+                    .collect()
+            })
+            .transpose()?,
+        importance: patch.importance.map(|importance| importance as f32),
+        pinned: patch.pinned,
+        scope: patch.scope.clone().map(store_scope_from_control),
+        session_id: patch.session_id.clone(),
+        thread_id: patch.thread_id.clone(),
+        source_span: None,
+    })
+}
+
+fn metadata_labels(metadata: &Value) -> Result<Vec<MemoryLabel>> {
+    let Some(labels) = metadata.get("labels") else {
+        return Ok(Vec::new());
+    };
+    let Some(labels) = labels.as_array() else {
+        bail!("memory metadata labels must be an array");
+    };
+    labels
+        .iter()
+        .map(|label| {
+            let Some(label) = label.as_str() else {
+                bail!("memory metadata labels must be strings");
+            };
+            memory_label_from_str(label)
+        })
+        .collect()
+}
+
+fn metadata_string(metadata: &Value, key: &str) -> Option<String> {
+    metadata
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn memory_label_from_str(label: &str) -> Result<MemoryLabel> {
+    match label.trim().to_ascii_lowercase().as_str() {
+        "insight" => Ok(MemoryLabel::Insight),
+        "decision" => Ok(MemoryLabel::Decision),
+        "fact" => Ok(MemoryLabel::Fact),
+        "procedure" => Ok(MemoryLabel::Procedure),
+        "experience" => Ok(MemoryLabel::Experience),
+        other => bail!("unknown memory label {other:?}"),
+    }
+}
+
+fn store_scope_from_control(scope: ControlMemoryScope) -> StoreMemoryScope {
+    match scope {
+        ControlMemoryScope::Thread => StoreMemoryScope::Thread,
+        ControlMemoryScope::Workspace => StoreMemoryScope::Workspace,
+    }
+}
+
+fn label_summaries(labels: Vec<MemoryLabelCount>) -> Vec<MemoryLabelSummary> {
+    labels
+        .into_iter()
+        .map(|label| MemoryLabelSummary {
+            label: memory_label_name(&label.label).to_string(),
+            count: label.count,
+        })
+        .collect()
+}
+
+fn memory_label_name(label: &MemoryLabel) -> &'static str {
+    match label {
+        MemoryLabel::Insight => "insight",
+        MemoryLabel::Decision => "decision",
+        MemoryLabel::Fact => "fact",
+        MemoryLabel::Procedure => "procedure",
+        MemoryLabel::Experience => "experience",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::llm::MockLlm;
+    use crate::runtime_control::RuntimeEvent;
+    use crate::vectordb::VectorDB;
+
+    fn test_memory_store(root: &std::path::Path) -> Arc<MemoryStore> {
+        Arc::new(MemoryStore::new_with_record_path(
+            Arc::new(MockLlm),
+            Arc::new(VectorDB::new(
+                root.join("lancedb").to_str().expect("utf8 path"),
+            )),
+            root.join("memories").join("records.json"),
+        ))
+    }
+
+    #[tokio::test]
+    async fn memory_control_add_record_writes_memory_store_and_emits_actual_id() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let mut events = bus.subscribe_control();
+        let store = test_memory_store(temp.path());
+        let handler = MemoryControlHandler::with_store(bus, store.clone());
+
+        handler
+            .handle_control(&MemoryControlRequest::AddRecord {
+                memory_id: "protocol-memory-1".to_string(),
+                scope: ControlMemoryScope::Workspace,
+                content: "ACP memory writes should go through MemoryStore.".to_string(),
+                metadata: json!({
+                    "title": "ACP memory bridge",
+                    "labels": ["decision", "fact"],
+                    "importance": 0.9,
+                    "pinned": true,
+                    "thread_id": "thread-1"
+                }),
+            })
+            .await
+            .expect("add memory");
+
+        let saved = store
+            .get("protocol-memory-1")
+            .await
+            .expect("get memory")
+            .expect("saved memory");
+        assert_eq!(saved.id, "protocol-memory-1");
+        assert_eq!(saved.title, "ACP memory bridge");
+        assert_eq!(saved.labels, vec![MemoryLabel::Decision, MemoryLabel::Fact]);
+        assert_eq!(saved.source, MemorySource::ProtocolWrite);
+        assert_eq!(saved.scope, StoreMemoryScope::Workspace);
+        assert_eq!(saved.thread_id.as_deref(), Some("thread-1"));
+        assert!(saved.pinned);
+
+        let event = events.recv().await.expect("memory event");
+        assert!(matches!(
+            event.event,
+            RuntimeEvent::Memory(MemoryEvent::RecordAdded { memory_id })
+                if memory_id == "protocol-memory-1"
         ));
+    }
+
+    #[tokio::test]
+    async fn memory_control_update_delete_and_labels_use_memory_store() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bus = Arc::new(RuntimeEventBus::new(16));
+        let mut events = bus.subscribe_control();
+        let store = test_memory_store(temp.path());
+        let handler = MemoryControlHandler::with_store(bus, store.clone());
+        store
+            .insert_with_id(
+                Some("protocol-memory-2".to_string()),
+                NewMemoryRecord {
+                    title: Some("Initial".to_string()),
+                    content: "Initial memory body.".to_string(),
+                    labels: vec![MemoryLabel::Experience],
+                    importance: 0.5,
+                    pinned: false,
+                    source: MemorySource::ProtocolWrite,
+                    scope: StoreMemoryScope::Thread,
+                    session_id: None,
+                    thread_id: Some("thread-2".to_string()),
+                    source_span: None,
+                },
+            )
+            .await
+            .expect("seed memory");
+
+        handler
+            .handle_control(&MemoryControlRequest::UpdateRecord {
+                memory_id: "protocol-memory-2".to_string(),
+                patch: MemoryRecordControlPatch {
+                    title: Some("Updated".to_string()),
+                    labels: Some(vec!["procedure".to_string()]),
+                    importance: Some(0.8),
+                    scope: Some(ControlMemoryScope::Workspace),
+                    ..Default::default()
+                },
+            })
+            .await
+            .expect("update memory");
+
+        let updated = store
+            .get("protocol-memory-2")
+            .await
+            .expect("get memory")
+            .expect("updated memory");
+        assert_eq!(updated.title, "Updated");
+        assert_eq!(updated.labels, vec![MemoryLabel::Procedure]);
+        assert_eq!(updated.scope, StoreMemoryScope::Workspace);
+
+        handler
+            .handle_control(&MemoryControlRequest::ListLabels { scope: None })
+            .await
+            .expect("list labels");
+
+        let mut saw_update = false;
+        let mut saw_labels = false;
+        for _ in 0..2 {
+            let event = events.recv().await.expect("memory event");
+            match event.event {
+                RuntimeEvent::Memory(MemoryEvent::RecordUpdated { memory_id }) => {
+                    saw_update = memory_id == "protocol-memory-2";
+                }
+                RuntimeEvent::Memory(MemoryEvent::LabelsListed { labels, .. }) => {
+                    saw_labels = labels
+                        == vec![MemoryLabelSummary {
+                            label: "procedure".to_string(),
+                            count: 1,
+                        }];
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_update);
+        assert!(saw_labels);
+
+        handler
+            .handle_control(&MemoryControlRequest::DeleteRecord {
+                memory_id: "protocol-memory-2".to_string(),
+            })
+            .await
+            .expect("delete memory");
+
+        assert!(
+            store
+                .get("protocol-memory-2")
+                .await
+                .expect("get deleted memory")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_control_without_store_keeps_scaffold_events() {
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let mut events = bus.subscribe_control();
+        let handler = MemoryControlHandler::new(bus);
+
+        handler
+            .handle_control(&MemoryControlRequest::ListLabels {
+                scope: Some(ControlMemoryScope::Thread),
+            })
+            .await
+            .expect("list labels");
+
+        let event = events.recv().await.expect("memory event");
+        assert!(matches!(
+            event.event,
+            RuntimeEvent::Memory(MemoryEvent::LabelsListed { scope: Some(ControlMemoryScope::Thread), labels })
+                if labels.is_empty()
+        ));
+    }
+
+    #[tokio::test]
+    async fn memory_control_add_record_rejects_duplicate_protocol_id() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let store = test_memory_store(temp.path());
+        let handler = MemoryControlHandler::with_store(bus, store.clone());
+        let request = MemoryControlRequest::AddRecord {
+            memory_id: "protocol-memory-duplicate".to_string(),
+            scope: ControlMemoryScope::Thread,
+            content: "Duplicate protocol ids should not upsert.".to_string(),
+            metadata: json!({"labels": ["fact"]}),
+        };
+
+        handler
+            .handle_control(&request)
+            .await
+            .expect("first add memory");
+        let err = handler
+            .handle_control(&request)
+            .await
+            .expect_err("duplicate add should fail");
+
+        assert!(err.to_string().contains("already exists"));
     }
 }

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -499,10 +499,31 @@ pub enum McpEvent {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum MemoryEvent {
-    RecordAdded { memory_id: String },
-    RecordUpdated { memory_id: String },
-    RecordDeleted { memory_id: String },
+    RecordAdded {
+        memory_id: String,
+    },
+    RecordUpdated {
+        memory_id: String,
+    },
+    RecordDeleted {
+        memory_id: String,
+    },
+    LabelsListed {
+        scope: Option<MemoryScope>,
+        labels: Vec<MemoryLabelSummary>,
+    },
+    MetadataQueried {
+        record_count: usize,
+        labels: Vec<MemoryLabelSummary>,
+    },
     SelectionUpdated,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryLabelSummary {
+    pub label: String,
+    pub count: usize,
 }
 
 #[allow(dead_code)]
@@ -1151,6 +1172,53 @@ mod tests {
                     "type": "list_labels",
                     "payload": {
                         "scope": "thread"
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn memory_label_and_metadata_events_use_structured_wire_shape() {
+        let labels = serde_json::to_value(RuntimeEvent::Memory(MemoryEvent::LabelsListed {
+            scope: Some(MemoryScope::Workspace),
+            labels: vec![MemoryLabelSummary {
+                label: "decision".to_string(),
+                count: 2,
+            }],
+        }))
+        .unwrap();
+        assert_eq!(
+            labels,
+            json!({
+                "type": "memory",
+                "payload": {
+                    "type": "labels_listed",
+                    "payload": {
+                        "scope": "workspace",
+                        "labels": [{"label": "decision", "count": 2}]
+                    }
+                }
+            })
+        );
+
+        let metadata = serde_json::to_value(RuntimeEvent::Memory(MemoryEvent::MetadataQueried {
+            record_count: 3,
+            labels: vec![MemoryLabelSummary {
+                label: "fact".to_string(),
+                count: 1,
+            }],
+        }))
+        .unwrap();
+        assert_eq!(
+            metadata,
+            json!({
+                "type": "memory",
+                "payload": {
+                    "type": "metadata_queried",
+                    "payload": {
+                        "record_count": 3,
+                        "labels": [{"label": "fact", "count": 1}]
                     }
                 }
             })


### PR DESCRIPTION
## Summary

- execute protocol memory add/update/delete/list-label/metadata requests through `MemoryStore`
- publish structured memory runtime events for labels and metadata snapshots
- update the memory-records spec, todo checkpoint, and implementation journal

## Testing

- `cargo fmt --check`
- `cargo test protocol_sources --locked`
- `cargo test memory_label_and_metadata_events_use_structured_wire_shape --locked`

Note: the targeted test commands pass with existing repository warnings unrelated to this change.
