### PR TITLE
feat: register mcp tool search

### DIFF
--- a/crates/rara-mcp-client/src/lib.rs
+++ b/crates/rara-mcp-client/src/lib.rs
@@ -21,6 +21,7 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// A single MCP tool record for caching.
 #[derive(Debug, Clone)]
 pub struct McpToolRecord {
+    pub server: String,
     pub name: String,
     pub display_name: String,
     pub description: String,
@@ -67,6 +68,7 @@ pub async fn list_stdio_tools(
         .tools
         .into_iter()
         .map(|t| McpToolRecord {
+            server: String::new(),
             name: t.name.to_string(),
             display_name: t.name.to_string(),
             description: t.description.map(|d| d.to_string()).unwrap_or_default(),

--- a/docs/features/mcp-tool-search.md
+++ b/docs/features/mcp-tool-search.md
@@ -6,26 +6,31 @@
 
 ## Design
 
-LanceDB 临时表 — 启动清空，退出清空。运行时 MCP server 连接后缓存 `tools/list` 结果。
+RARA keeps a volatile per-process cache of `tools/list` results. The cache is
+cleared on startup, refreshed from configured MCP servers, and searched on
+demand by the stable `mcp_tool_search` tool.
+
+The tool itself is registered in the normal `ToolManager` even when the cache is
+empty. This keeps the tool-schema prefix stable across turns; an empty cache
+returns a structured empty result instead of changing the visible tool list.
 
 ```
 session start
-  → drop mcp_tools table
+  → clear mcp tool cache
   → MCP servers connect
     → list_tools() per server
-    → insert tool { name, server, description, input_schema } into lance
-  → agent prompt: only mcp_tool_search tool visible
+    → insert tool { name, server, display_name, description, input_schema } into volatile cache
+  → agent prompt: stable mcp_tool_search tool visible
   → model calls mcp_tool_search("bash")
     → like-filter on name + description
     → return matching tool schemas
 session end
-  → drop mcp_tools table
+  → process exits; cache is discarded
 ```
 
-### LanceDB schema
+### Cache record
 
 ```rust
-#[derive(LanceTable)]
 struct McpToolRecord {
     name: String,          // tool name (searchable)
     server: String,        // which MCP server
@@ -51,12 +56,31 @@ Search query: `like('%{query}%', name) OR like('%{query}%', description)` — su
 
 ### Prompt injection
 
-When `mcp_tools` table is non-empty, inject only `mcp_tool_search` instead of full MCP tool list. After each search call, result tools are available for the current turn.
+`mcp_tool_search` is a stable tool entrypoint. Full MCP tool schemas should not
+be injected into every prompt; the search tool returns matching schemas only
+when needed. Keeping the entrypoint stable avoids cache-prefix churn when MCP
+servers connect, disconnect, or refresh.
 
 ## Implementation plan
 
-1. `src/mcp_tool_cache.rs` — LanceDB table create/insert/search/drop
-2. `src/tools/mcp_tool_search.rs` — tool definition, calls cache.search()
-3. Hook into MCP server connection lifecycle — refresh cache on connect
-4. Hook into session start/end — drop table on start/exit
-5. Update prompt builder — inject mcp_tool_search instead of full tool list when cache is populated
+1. `src/mcp_tool_cache.rs` — volatile cache insert/search/clear.
+2. `src/tools/mcp_tool_search.rs` — registered tool definition over cache.search().
+3. Runtime bootstrap — construct one shared cache and register the search tool.
+4. `/mcp` refresh path — repopulate the cache from configured stdio servers.
+5. Future lifecycle hooks — refresh on connection-manager events for dynamic
+   server changes.
+
+## Implementation checkpoint
+
+2026-05-09:
+
+- `McpToolCache` is cloneable and shared between runtime bootstrap, TUI refresh,
+  and the tool handler.
+- `McpToolRecord` carries `server` provenance; cache insertion normalizes
+  `display_name` as `server: tool`.
+- Search results are sorted by `(server, name)` before truncation so the same
+  cache contents produce deterministic output.
+- `mcp_tool_search` implements `Tool`, returns structured JSON, rejects empty
+  queries, and is registered by `create_full_tool_manager`.
+- Runtime initialization has a regression test that verifies the tool is visible
+  in the normal schema list.

--- a/docs/journal/2026-05-09-mcp-tool-search-registration.md
+++ b/docs/journal/2026-05-09-mcp-tool-search-registration.md
@@ -1,0 +1,29 @@
+# MCP Tool Search Registration
+
+## Context
+
+The MCP Tool Search files existed, but the tool was not part of the normal
+runtime tool set. That meant cached MCP tools could not be discovered by the
+agent even after `/mcp` populated the cache.
+
+## Changes
+
+- Registered `mcp_tool_search` through the standard `ToolManager`.
+- Shared one `McpToolCache` between runtime bootstrap, TUI MCP refresh, and the
+  tool handler.
+- Added server provenance to `McpToolRecord` and normalized display names as
+  `server: tool`.
+- Sorted search results by server and tool name to keep output deterministic.
+- Returned structured JSON from `mcp_tool_search` instead of a prose block.
+- Marked the MCP Tool Search TODO as implemented.
+
+## Verification
+
+- `cargo fmt --check`
+- `cargo test search_returns_stable_structured_tool_records --locked`
+- `cargo test initialize_rara_context_registers_mcp_tool_search --locked`
+
+## Follow-up
+
+Connection-manager driven MCP refresh can replace the current `/mcp`-triggered
+cache population once dynamic server lifecycle events are fully wired.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -27,7 +27,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add dynamic MCP tool/resource/prompt refresh through structured runtime events (scaffold via McpConnectionManager).
 - [x] Add bounded MCP auto-reconnect with manual reconnect command (scaffold via McpConnectionManager).
 - [x] Add MCP resource references as source objects visible in `/context`.
-- [ ] Add MCP Tool Search so large MCP tool sets are discovered on demand instead of injected into every prompt.
+- [x] Add MCP Tool Search so large MCP tool sets are discovered on demand instead of injected into every prompt.
 - [x] Support protocol-registered prompt sources with provenance, scope, budget hints, and `/context` visibility (scaffold via protocol_sources.rs).
 - [x] Support protocol-registered skill sources through the same `SkillRegistry` precedence and override reporting as local skills (scaffold via protocol_sources.rs).
 - [x] Add protocol-safe memory mutation/query scaffolding that creates memory records and selection views without bypassing `MemorySelection` (scaffold via protocol_sources.rs).

--- a/src/mcp_tool_cache.rs
+++ b/src/mcp_tool_cache.rs
@@ -15,6 +15,7 @@ use crate::config::McpServerTransport;
 
 /// In-memory cache of MCP tool records, keyed by server name.
 /// Wrapped in Arc<Mutex<...>> for shared access across tool handlers.
+#[derive(Clone)]
 pub struct McpToolCache {
     tools: Arc<Mutex<HashMap<String, Vec<McpToolRecord>>>>,
 }
@@ -29,6 +30,14 @@ impl McpToolCache {
     /// Replace the tool list for a given server (called on MCP connect).
     pub fn insert_server_tools(&self, server: String, tools: Vec<McpToolRecord>) {
         let mut map = self.tools.lock().unwrap();
+        let tools = tools
+            .into_iter()
+            .map(|mut tool| {
+                tool.server = server.clone();
+                tool.display_name = format!("{server}: {}", tool.name);
+                tool
+            })
+            .collect();
         map.insert(server, tools);
     }
 
@@ -46,6 +55,11 @@ impl McpToolCache {
                 }
             }
         }
+        results.sort_by(|left, right| {
+            left.server
+                .cmp(&right.server)
+                .then_with(|| left.name.cmp(&right.name))
+        });
         results.truncate(10);
         results
     }

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -119,6 +119,8 @@ pub(crate) async fn initialize_rara_context(
 
     let event_bus = Arc::new(RuntimeEventBus::new(256));
     let goal_handle: GoalHandle = Arc::new(std::sync::RwLock::new(None));
+    let mcp_tool_cache = McpToolCache::new();
+    mcp_tool_cache.clear();
 
     let tool_manager = create_full_tool_manager(
         backend.clone(),
@@ -131,10 +133,9 @@ pub(crate) async fn initialize_rara_context(
         Arc::new(shell_env.env),
         sandbox_network_access.clone(),
         goal_handle.clone(),
+        mcp_tool_cache.clone(),
     );
     let warnings = prompt_config.warnings.clone();
-    let mcp_tool_cache = McpToolCache::new();
-    mcp_tool_cache.clear();
 
     Ok(RuntimeBootstrap {
         backend,
@@ -353,6 +354,25 @@ mod tests {
                 .iter()
                 .any(|warning| warning.contains("system prompt"))
         );
+    }
+
+    #[tokio::test]
+    async fn initialize_rara_context_registers_mcp_tool_search() {
+        let config = RaraConfig {
+            provider: "mock".into(),
+            ..Default::default()
+        };
+
+        let bootstrap = initialize_rara_context(&config, None)
+            .await
+            .expect("bootstrap");
+        let schemas = bootstrap.tool_manager.get_schemas();
+        let names = schemas
+            .iter()
+            .filter_map(|schema| schema["name"].as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"mcp_tool_search"));
     }
 
     #[tokio::test]

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, atomic::AtomicBool};
 
 use crate::llm::LlmBackend;
+use crate::mcp_tool_cache::McpToolCache;
 use crate::prompt::PromptRuntimeConfig;
 use crate::sandbox::SandboxManager;
 use crate::session::SessionManager;
@@ -21,6 +22,7 @@ use crate::tools::file::{
     WriteFileTool,
 };
 use crate::tools::goal::{CreateGoalTool, GetGoalTool, UpdateGoalTool};
+use crate::tools::mcp_tool_search::McpToolSearch;
 use crate::tools::patch::ApplyPatchTool;
 use crate::tools::planning::{EnterPlanModeTool, ExitPlanModeTool};
 use crate::tools::pty::{
@@ -50,6 +52,7 @@ pub(super) fn create_full_tool_manager(
     shell_env: Arc<HashMap<String, String>>,
     sandbox_network_access: Arc<AtomicBool>,
     goal_handle: GoalHandle,
+    mcp_tool_cache: McpToolCache,
 ) -> ToolManager {
     let mut tm = ToolManager::new();
     let vector_db_uri = vector_db_uri_for_workspace(&workspace);
@@ -113,6 +116,7 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(WebSearchTool::from_env()));
     tm.register(Box::new(GlobTool));
     tm.register(Box::new(GrepTool));
+    tm.register(Box::new(McpToolSearch::new(mcp_tool_cache)));
     tm.register(Box::new(EnterPlanModeTool));
     tm.register(Box::new(ExitPlanModeTool));
     tm.register(Box::new(TodoWriteTool));

--- a/src/tools/mcp_tool_search.rs
+++ b/src/tools/mcp_tool_search.rs
@@ -1,7 +1,12 @@
 //! MCP tool search tool — lets the model discover MCP tools on demand
 //! instead of loading all tool schemas into every prompt.
 
+use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
+use serde_json::{Value, json};
+
 use crate::mcp_tool_cache::McpToolCache;
+use crate::tool::{Tool, ToolError};
 
 pub struct McpToolSearch {
     cache: McpToolCache,
@@ -12,21 +17,111 @@ impl McpToolSearch {
         Self { cache }
     }
 
-    /// Search cached MCP tools by keyword. Returns matching tool names,
-    /// descriptions, and input schemas.
-    pub fn search(&self, query: &str) -> String {
+    fn search_results(&self, query: &str) -> Value {
         let results = self.cache.search(query);
-        if results.is_empty() {
-            return format!("No MCP tools found matching '{query}'");
-        }
-        let mut output = String::new();
-        for tool in &results {
-            let schema = serde_json::to_string(&tool.input_schema).unwrap_or_default();
-            output.push_str(&format!(
-                "- {} — {}\n  Input schema: {}\n",
-                tool.display_name, tool.description, schema
-            ));
-        }
-        output
+        let tools = results
+            .into_iter()
+            .map(|tool| {
+                json!({
+                    "server": tool.server,
+                    "name": tool.name,
+                    "display_name": tool.display_name,
+                    "description": tool.description,
+                    "input_schema": tool.input_schema,
+                })
+            })
+            .collect::<Vec<_>>();
+        let is_empty = tools.is_empty();
+        json!({
+            "query": query,
+            "tools": tools,
+            "note": if is_empty {
+                Some("No cached MCP tools matched the query.")
+            } else {
+                None
+            },
+        })
+    }
+}
+
+#[tool_spec(
+    name = "mcp_tool_search",
+    description = "Search cached MCP tools by name or capability. Use this before asking for an MCP capability that may not be loaded directly in the prompt.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Tool name, server name, or capability keyword to search for."
+            }
+        },
+        "required": ["query"],
+        "additionalProperties": false
+    }
+)]
+#[async_trait]
+impl Tool for McpToolSearch {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let query = input["query"]
+            .as_str()
+            .map(str::trim)
+            .filter(|query| !query.is_empty())
+            .ok_or_else(|| ToolError::InvalidInput("query".into()))?;
+        Ok(self.search_results(query))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rara_mcp_client::McpToolRecord;
+    use serde_json::json;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn search_returns_stable_structured_tool_records() {
+        let cache = McpToolCache::new();
+        cache.insert_server_tools(
+            "zeta".to_string(),
+            vec![McpToolRecord {
+                server: String::new(),
+                name: "read_file".to_string(),
+                display_name: "read_file".to_string(),
+                description: "Read workspace files".to_string(),
+                input_schema: json!({"type": "object"}),
+            }],
+        );
+        cache.insert_server_tools(
+            "alpha".to_string(),
+            vec![McpToolRecord {
+                server: String::new(),
+                name: "read_doc".to_string(),
+                display_name: "read_doc".to_string(),
+                description: "Read docs".to_string(),
+                input_schema: json!({"type": "object"}),
+            }],
+        );
+
+        let tool = McpToolSearch::new(cache);
+        let result = tool
+            .call(json!({ "query": "read" }))
+            .await
+            .expect("search should succeed");
+        let tools = result["tools"].as_array().expect("tools array");
+
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["display_name"], "alpha: read_doc");
+        assert_eq!(tools[1]["display_name"], "zeta: read_file");
+    }
+
+    #[tokio::test]
+    async fn search_rejects_empty_query() {
+        let tool = McpToolSearch::new(McpToolCache::new());
+        let error = tool
+            .call(json!({ "query": " " }))
+            .await
+            .expect_err("empty query should fail");
+
+        assert!(error.to_string().contains("query"));
     }
 }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -706,6 +706,7 @@ command = "docs-server"
         cache.insert_server_tools(
             "stale".to_string(),
             vec![rara_mcp_client::McpToolRecord {
+                server: String::new(),
                 name: "old_tool".to_string(),
                 display_name: "old_tool".to_string(),
                 description: "stale cached tool".to_string(),


### PR DESCRIPTION
## Summary

- register `mcp_tool_search` in the normal runtime tool manager
- share one MCP tool cache between bootstrap, `/mcp` refresh, and the tool handler
- add server provenance, deterministic search ordering, structured JSON output, and focused tests
- update the MCP Tool Search spec, TODO, and implementation journal

## Testing

- `cargo fmt --check`
- `git diff --check`
- `cargo test mcp_tool_search --locked`
- `cargo test search_returns_stable_structured_tool_records --locked`
- `cargo test initialize_rara_context_registers_mcp_tool_search --locked`
