### PR TITLE
feat: promote session shards into memory records

### DIFF
--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -17,9 +17,9 @@ and vector search live in one table, while context assembly still goes through
 This spec describes the target product contract. The current implementation
 slices provide the LanceDB-backed index, retrieval tools, a runtime
 `MemoryStore` facade, ranked `MemorySelection` candidates, pinned retention
-metadata, update/delete/list-label scaffolding, and LLM-assisted thread
-distillation into multiple durable records. Background promotion and richer
-filtering remain follow-up work.
+metadata, update/delete/list-label scaffolding, LLM-assisted thread
+distillation into multiple durable records, and an explicit session-shard
+promotion API. Periodic scheduling and richer filtering remain follow-up work.
 
 ## Six Design Laws (Cross-Industry Consensus)
 
@@ -120,6 +120,7 @@ Importance scale:
 | Memory delete | User or control-plane request can delete records with audit-safe semantics. | Partial. `MemoryStore::delete` removes the domain record and search rehydration filters stale indexed rows; physical LanceDB row cleanup remains future work. |
 | Memory retention | Pinned, user-created, and high-importance memories are protected from automatic cleanup; explicit delete remains possible with provenance. | Implemented as a domain guard on `MemoryRecord`; no automatic cleanup path exists yet. |
 | Thread distillation | Thread history can be distilled into 2-8 durable memory records. | Implemented for loaded threads through `ThreadStore::distill_thread_memories`, with LLM-assisted extraction, batch/existing-memory deduplication, and thread provenance. Long-thread chunking remains future work. |
+| Session-shard promotion | Session context shards can be promoted into durable memory records without writing raw checkpoints to the global index by default. | Partial. `SessionManager::promote_session_context_memories` explicitly distills selected shard checkpoints into `MemoryRecord`s with session provenance; periodic scheduling remains future work. |
 | Context injection | Ranked memory candidates pass through `MemorySelection` before prompt injection. | Partial. LanceDB-backed memory and session search now produce direct ranked `MemorySelection` candidates; retention, deduplication, and protocol mutation remain future work. |
 | Graph retrieval | Entity and relationship traversal complements vector recall. | Future work. |
 | Working memory | Daily or session briefing summarizes recent and important memories. | Future work. |
@@ -255,6 +256,10 @@ Current implementation checkpoint:
   promoting one summary-style record.
 - `ThreadStore::distill_thread_memories` promotes a loaded thread into 2-8
   independently useful `MemoryRecord`s using `MemoryDistiller`.
+- `SessionManager::promote_session_context_memories` explicitly promotes
+  selected per-session context checkpoints into durable `MemoryRecord`s using
+  the same `MemoryDistiller` and duplicate suppression path as thread
+  distillation. The runtime does not schedule background promotion yet.
 - The distillation prompt treats older memory and prior conclusions as
   historical context, not current truth. If the inspected thread proves the
   current design is stale or poor, the distiller should extract the corrected
@@ -292,7 +297,8 @@ Current implementation checkpoint:
     extraction with deduplication is available through `distill_thread_memories`.
 11. Move raw session checkpoints out of the global `conversations` LanceDB table
    into per-session append shards. Done.
-12. Add periodic promotion from session shards into global `MemoryRecord`s.
+12. Add explicit promotion from session shards into global `MemoryRecord`s.
+    Done for API-triggered promotion; periodic scheduling remains future work.
 13. Deprecate `VectorDB`.
 14. Remove `VectorDB`.
 

--- a/docs/journal/2026-05-09-session-shard-memory-promotion.md
+++ b/docs/journal/2026-05-09-session-shard-memory-promotion.md
@@ -1,0 +1,27 @@
+# Session Shard Memory Promotion
+
+## Context
+
+Session context checkpoints already live in per-session `context.jsonl` shards
+and are searchable for recall. The remaining gap was a controlled path for
+turning durable takeaways from those shards into real `MemoryRecord`s without
+writing every raw checkpoint into the global memory index.
+
+## Implementation
+
+- Added a public session-shard loader that returns latest-per-turn checkpoints
+  in turn order.
+- Added `SessionManager::promote_session_context_memories`, an explicit
+  promotion API that:
+  - reads a bounded tail of session context checkpoints;
+  - formats them as distillation input;
+  - reuses `MemoryDistiller` and existing-memory deduplication;
+  - writes promoted records through `MemoryStore`;
+  - preserves `session_id`, `thread_id`, and source-span provenance.
+- Added `MemorySource::SessionDistill` so promoted shard memories are
+  distinguishable from direct agent-turn writes and thread distillation.
+
+## Boundaries
+
+This is not a background scheduler. Periodic promotion still needs policy gates,
+observability, and user/provider controls before it should run automatically.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -85,7 +85,8 @@ Active backlog only. Keep this file small and current.
 - [x] Add append-only parent/child spawn-edge rollout metadata for foreground sub-agent calls.
 - [x] Index parent/child spawn-edge metadata in `StateDb` for resume/listing queries.
 - [x] Add in-process background sub-agent resume/stop over the sidechain transcript contract.
-- [ ] Add periodic promotion from session shards into global `MemoryRecord`s.
+- [x] Add an explicit promotion API from session context shards into global `MemoryRecord`s.
+- [ ] Add scheduler/policy gates for periodic session-shard promotion so background writes are opt-in and observable.
 - [x] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.
 - [ ] Define cross-process background sub-agent restart/reattach semantics.
 - [x] Compaction as first-class lifecycle event: persist summaries, token counters, metadata ownership.

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -34,6 +34,7 @@ pub enum MemorySource {
     AgentTurn,
     UserCreated,
     ThreadDistill,
+    SessionDistill,
     FileImport,
     ProtocolWrite,
 }

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -449,12 +449,12 @@ fn memory_label_name(label: &MemoryLabel) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use rara_memory::vectordb::VectorDB;
     use serde_json::json;
 
     use super::*;
     use crate::llm::MockLlm;
     use crate::runtime_control::RuntimeEvent;
-    use crate::vectordb::VectorDB;
 
     fn test_memory_store(root: &std::path::Path) -> Arc<MemoryStore> {
         Arc::new(MemoryStore::new_with_record_path(

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,6 +10,12 @@ use rara_state::thread_rollout_log;
 use serde::{Deserialize, Serialize};
 
 use crate::agent::Message;
+use crate::memory_distiller::{
+    MemoryDistiller, dedupe_memory_drafts, new_memory_record_from_draft,
+};
+use crate::memory_store::{
+    MemoryLabel, MemoryRecord, MemoryScope, MemorySource, MemoryStore, NewMemoryRecord,
+};
 use crate::session_context::{self, SessionContextSearchHit};
 use crate::session_transcript;
 use crate::todo::TodoState;
@@ -148,6 +154,65 @@ impl SessionManager {
         limit: usize,
     ) -> Result<Vec<SessionContextSearchHit>> {
         session_context::search_context_shards(&self.storage_dir, query, query_vector, limit)
+    }
+
+    pub async fn promote_session_context_memories(
+        &self,
+        memory_store: &MemoryStore,
+        session_id: &str,
+        max_checkpoints: usize,
+    ) -> Result<Vec<MemoryRecord>> {
+        if max_checkpoints == 0 {
+            return Ok(Vec::new());
+        }
+        let mut checkpoints =
+            session_context::load_session_context_checkpoints(&self.storage_dir, session_id)?;
+        if checkpoints.is_empty() {
+            return Ok(Vec::new());
+        }
+        if checkpoints.len() > max_checkpoints {
+            checkpoints = checkpoints.split_off(checkpoints.len().saturating_sub(max_checkpoints));
+        }
+
+        let markdown = session_context_promotion_markdown(session_id, &checkpoints);
+        let distiller = MemoryDistiller::new(memory_store.backend());
+        let drafts = distiller.distill_thread_markdown(&markdown).await?;
+        let mut existing_hits = Vec::with_capacity(drafts.len());
+        for draft in &drafts {
+            existing_hits.push(memory_store.search(&draft.content, 3).await?);
+        }
+        let drafts = dedupe_memory_drafts(drafts, &existing_hits);
+        let Some(first) = checkpoints.first() else {
+            return Ok(Vec::new());
+        };
+        let Some(last) = checkpoints.last() else {
+            return Ok(Vec::new());
+        };
+        let base = NewMemoryRecord {
+            title: None,
+            content: String::new(),
+            labels: vec![MemoryLabel::Experience],
+            importance: 0.6,
+            pinned: false,
+            source: MemorySource::SessionDistill,
+            scope: MemoryScope::Session,
+            session_id: Some(session_id.to_string()),
+            thread_id: Some(session_id.to_string()),
+            source_span: Some(crate::memory_store::MemorySourceSpan {
+                start_turn_index: first.turn_index,
+                end_turn_index: last.turn_index,
+            }),
+        };
+
+        let mut memories = Vec::with_capacity(drafts.len());
+        for draft in drafts {
+            memories.push(
+                memory_store
+                    .insert(new_memory_record_from_draft(draft, base.clone()))
+                    .await?,
+            );
+        }
+        Ok(memories)
     }
 
     pub fn plan_file_path(&self, session_id: &str) -> PathBuf {
@@ -481,6 +546,25 @@ impl SessionManager {
     }
 }
 
+fn session_context_promotion_markdown(
+    session_id: &str,
+    checkpoints: &[session_context::SessionContextCheckpoint],
+) -> String {
+    let mut lines = vec![
+        format!("# Session Context {session_id}"),
+        String::new(),
+        "Extract only durable takeaways from these session context checkpoints.".to_string(),
+        "Do not preserve transient command progress or stale intermediate conclusions.".to_string(),
+        String::new(),
+    ];
+    for checkpoint in checkpoints {
+        lines.push(format!("## Turn {}", checkpoint.turn_index));
+        lines.push(checkpoint.text.trim().to_string());
+        lines.push(String::new());
+    }
+    lines.join("\n")
+}
+
 #[cfg(unix)]
 fn sync_parent_dir_best_effort(parent: &std::path::Path) {
     if let Ok(dir) = fs::File::open(parent) {
@@ -515,9 +599,16 @@ fn transcript_is_shorter_than_snapshot_prefix(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use rara_memory::vectordb::VectorDB;
+    use serde_json::Value;
     use tempfile::tempdir;
 
     use super::*;
+    use crate::llm::{ContentBlock, LlmBackend, LlmResponse, TokenUsage};
+    use crate::memory_store::{MemoryLabel, MemoryScope, MemorySource, MemoryStore};
     use crate::session_transcript::{
         SessionTranscriptEntry, load_transcript, main_transcript_path, model_visible_messages,
     };
@@ -946,5 +1037,98 @@ mod tests {
             } if *event_index == 2 && summary == "second"
         ));
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn promote_session_context_memories_distills_shard_into_records() -> Result<()> {
+        let temp = tempdir()?;
+        let rara_dir = temp.path().join(".rara");
+        let session_manager = SessionManager::new_for_rara_dir(rara_dir.clone())?;
+        session_manager.save_session_context_checkpoint(
+            "session-promote",
+            1,
+            "Use session shards first, then promote durable takeaways into MemoryRecords."
+                .to_string(),
+            vec![0.2; 128],
+        )?;
+        session_manager.save_session_context_checkpoint(
+            "session-promote",
+            2,
+            "Promotion records must keep session_id and source span provenance.".to_string(),
+            vec![0.3; 128],
+        )?;
+        let memory_store = MemoryStore::new(
+            Arc::new(SessionPromotionMockLlm),
+            Arc::new(VectorDB::new(
+                rara_dir.join("lancedb").to_str().expect("utf8 path"),
+            )),
+        );
+
+        let memories = session_manager
+            .promote_session_context_memories(&memory_store, "session-promote", 8)
+            .await?;
+
+        assert_eq!(memories.len(), 2);
+        assert!(memories.iter().all(|memory| {
+            memory.source == MemorySource::SessionDistill
+                && memory.scope == MemoryScope::Session
+                && memory.session_id.as_deref() == Some("session-promote")
+                && memory.thread_id.as_deref() == Some("session-promote")
+                && memory
+                    .source_span
+                    .as_ref()
+                    .is_some_and(|span| span.start_turn_index == 1 && span.end_turn_index == 2)
+        }));
+        assert!(
+            memories
+                .iter()
+                .any(|memory| memory.title == "Session shard promotion")
+        );
+        let labels = memory_store.list_labels(Some(MemoryScope::Session)).await?;
+        assert!(
+            labels
+                .iter()
+                .any(|label| label.label == MemoryLabel::Decision)
+        );
+        Ok(())
+    }
+
+    struct SessionPromotionMockLlm;
+
+    #[async_trait]
+    impl LlmBackend for SessionPromotionMockLlm {
+        async fn ask(&self, _messages: &[Message], _tools: &[Value]) -> Result<LlmResponse> {
+            Ok(LlmResponse {
+                content: vec![ContentBlock::Text {
+                    text: serde_json::json!({
+                        "memories": [
+                            {
+                                "title": "Session shard promotion",
+                                "content": "Use session shards as raw recall first, then promote durable takeaways into MemoryRecords.",
+                                "labels": ["decision"],
+                                "importance": 0.8
+                            },
+                            {
+                                "title": "Promotion provenance",
+                                "content": "Session-shard promotion records must preserve session_id, thread_id, and source span provenance.",
+                                "labels": ["procedure"],
+                                "importance": 0.7
+                            }
+                        ]
+                    })
+                    .to_string(),
+                }],
+                stop_reason: Some("end_turn".to_string()),
+                usage: Some(TokenUsage::default()),
+            })
+        }
+
+        async fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.1; 128])
+        }
+
+        async fn summarize(&self, _messages: &[Message], _instruction: &str) -> Result<String> {
+            Ok("summary".to_string())
+        }
     }
 }

--- a/src/session_context.rs
+++ b/src/session_context.rs
@@ -138,6 +138,27 @@ pub fn search_context_shards(
     Ok(hits)
 }
 
+pub fn load_session_context_checkpoints(
+    root_dir: &Path,
+    session_id: &str,
+) -> Result<Vec<SessionContextCheckpoint>> {
+    let path = context_shard_path(root_dir, session_id);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let mut latest_by_turn = HashMap::<u32, SessionContextCheckpoint>::new();
+    for checkpoint in load_context_checkpoint_file_cached(&path)? {
+        latest_by_turn.insert(checkpoint.turn_index, checkpoint);
+    }
+    let mut checkpoints = latest_by_turn.into_values().collect::<Vec<_>>();
+    checkpoints.sort_by(|left, right| {
+        left.turn_index
+            .cmp(&right.turn_index)
+            .then_with(|| left.recorded_at.cmp(&right.recorded_at))
+    });
+    Ok(checkpoints)
+}
+
 fn load_all_context_checkpoints(root_dir: &Path) -> Result<Vec<SessionContextCheckpoint>> {
     let mut checkpoints = Vec::new();
     if !root_dir.exists() {
@@ -335,6 +356,40 @@ mod tests {
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].checkpoint.text, "new checkpoint text");
+        Ok(())
+    }
+
+    #[test]
+    fn loads_session_context_checkpoints_sorted_with_latest_duplicate() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        append_context_checkpoint(
+            temp.path(),
+            "session-a",
+            2,
+            "second checkpoint".to_string(),
+            vec![0.0, 1.0],
+        )?;
+        append_context_checkpoint(
+            temp.path(),
+            "session-a",
+            1,
+            "old first checkpoint".to_string(),
+            vec![1.0, 0.0],
+        )?;
+        append_context_checkpoint(
+            temp.path(),
+            "session-a",
+            1,
+            "new first checkpoint".to_string(),
+            vec![1.0, 0.0],
+        )?;
+
+        let checkpoints = load_session_context_checkpoints(temp.path(), "session-a")?;
+
+        assert_eq!(checkpoints.len(), 2);
+        assert_eq!(checkpoints[0].turn_index, 1);
+        assert_eq!(checkpoints[0].text, "new first checkpoint");
+        assert_eq!(checkpoints[1].turn_index, 2);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- add an explicit session-shard promotion API that distills bounded session context checkpoints into durable `MemoryRecord`s
- preserve session provenance with `session_id`, `thread_id`, `MemorySource::SessionDistill`, and source turn span metadata
- document the implementation checkpoint and keep periodic background promotion as a future opt-in policy item

## Tests

- `cargo fmt`
- `cargo check --locked`
- `cargo test loads_session_context_checkpoints_sorted_with_latest_duplicate --locked`
- `cargo test promote_session_context_memories_distills_shard_into_records --locked`
- `git diff --check`

## Notes

This PR intentionally does not add a background scheduler. Automatic promotion still needs policy gates, observability, and user/provider controls before it should run periodically.
