### PR TITLE
fix: harden git conflict prompt guidance

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -501,6 +501,8 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "When you encounter Git conflict markers such as '<<<<<<<', '=======', or '>>>>>>>', treat the file as unresolved until every marker has been removed.",
                     "Before resolving a conflict, inspect the current git state and read the conflicted file with enough surrounding context to understand both sides and the intended local change.",
                     "Do not blindly choose one side. Preserve both sides when they are complementary, remove obsolete code only when the inspected context proves it is obsolete, and keep imports, names, formatting, and control flow consistent after the merge.",
+                    "Do not use destructive git commands such as 'git reset --hard', 'git checkout --', 'git restore .', or 'git clean -fd' to escape conflicts unless the user explicitly requests that discard path.",
+                    "Avoid interactive git commands while resolving conflicts. Do not use 'git rebase -i' or 'git add -i', and supply commit messages with 'git commit -m' or 'git commit -F' instead of opening an editor.",
                     "Prefer structured edit tools or 'apply_patch' for the resolved hunks. Avoid full-file rewrites unless the file is small or the conflict truly requires rewriting the whole file.",
                     "After resolving conflicts, run a targeted marker scan such as 'rg \"<<<<<<<|=======|>>>>>>>\"' and the narrowest relevant formatter, test, build, or check command before claiming the conflict is resolved.",
                     "If the conflict semantics are ambiguous, state which side is verified, which side is inferred, and what validation remains instead of inventing intent.",
@@ -1312,6 +1314,9 @@ mod tests {
                 .contains("treat the file as unresolved until every marker has been removed")
         );
         assert!(effective.text.contains("Do not blindly choose one side"));
+        assert!(effective.text.contains("git reset --hard"));
+        assert!(effective.text.contains("git rebase -i"));
+        assert!(effective.text.contains("git commit -m"));
         assert!(effective.text.contains("rg \"<<<<<<<|=======|>>>>>>>\""));
         assert!(
             effective


### PR DESCRIPTION
## Summary

- harden the default Git conflict guidance against destructive conflict escape paths
- tell agents to avoid interactive Git commands during conflict resolution
- extend the existing prompt regression test for the added guidance

## Tests

- `cargo fmt`
- `cargo test -p rara-instructions default_system_prompt_includes_git_conflict_resolution_guidance --locked`
- `git diff --check origin/main...HEAD`
