### PR TITLE
fix(tui): command palette Esc cleanup, provider descriptions, and bottom pane highlight

### DIFF
--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -32,7 +32,14 @@ pub(crate) async fn dispatch_event(
     match event {
         AppEvent::Noop => {}
         AppEvent::OpenOverlay(overlay) => app.open_overlay(overlay),
-        AppEvent::CloseOverlay => app.close_overlay(),
+        AppEvent::CloseOverlay => {
+            // Clear palette query when Esc from command palette.
+            if matches!(app.overlay, Some(Overlay::CommandPalette)) {
+                app.input.clear();
+                app.command_palette_idx = 0;
+            }
+            app.close_overlay();
+        }
         AppEvent::CancelRunningTask => {
             input_control::handle_session_control(app, SessionControlRequest::CancelCurrentTurn);
         }

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -117,19 +117,21 @@ impl ListPickerKind {
         PROVIDER_FAMILIES
             .iter()
             .enumerate()
-            .map(|(idx, (family, label, _desc))| {
-                let status = if app.selected_provider_family() == *family {
+            .map(|(idx, (_family, label, desc))| {
+                let status = if app.selected_provider_family() == PROVIDER_FAMILIES[idx].0 {
                     " (current)"
                 } else {
                     ""
                 };
-                ListItem::new(vec![ratatui::text::Line::from(format!(
-                    "[{}] {}{}",
-                    idx + 1,
-                    label,
-                    status
-                ))])
-                .style(Self::selected_style(idx, selected))
+                let name_line = ratatui::text::Line::from(vec![ratatui::text::Span::styled(
+                    format!("[{}] {}{}", idx + 1, label, status),
+                    Style::default().add_modifier(Modifier::BOLD),
+                )]);
+                let desc_line = ratatui::text::Line::from(ratatui::text::Span::styled(
+                    format!("    {}", desc),
+                    Style::default().fg(TEXT_MUTED),
+                ));
+                ListItem::new(vec![name_line, desc_line]).style(Self::selected_style(idx, selected))
             })
             .collect()
     }

--- a/src/tui/render/bottom_pane.rs
+++ b/src/tui/render/bottom_pane.rs
@@ -2,7 +2,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Wrap},
+    widgets::{Block, Paragraph, Wrap},
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -46,23 +46,19 @@ pub(crate) fn desired_bottom_pane_height(app: &TuiApp, width: u16, rows: u16) ->
 }
 
 pub(super) fn render_bottom_pane(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)> {
-    // Highlight the bottom pane border when a pending interaction needs attention.
-    if let Some(pending) = app.active_pending_interaction() {
+    // Highlight the bottom pane background when a pending interaction needs attention.
+    let style = if let Some(pending) = app.active_pending_interaction() {
         let color = match pending.kind {
             ActivePendingInteractionKind::ShellApproval => STATUS_WARNING,
             ActivePendingInteractionKind::PlanApproval => TEXT_ACCENT,
             _ => STATUS_SUCCESS,
         };
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(color).add_modifier(Modifier::BOLD));
-        let inner = block.inner(area);
-        f.render_widget(block, area);
-        render_bottom_pane_inner(f, app, inner)
+        Style::default().bg(color).fg(Color::Black)
     } else {
-        f.render_widget(Block::default().style(bottom_pane_style()), area);
-        render_bottom_pane_inner(f, app, area)
-    }
+        bottom_pane_style()
+    };
+    f.render_widget(Block::default().style(style), area);
+    render_bottom_pane_inner(f, app, area)
 }
 
 fn render_bottom_pane_inner(f: &mut Frame, app: &TuiApp, area: Rect) -> Option<(u16, u16)> {

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -10,15 +10,15 @@ Ready.        ┌ Provider ─────────────────�
 ──            │Select a provider family.                                             │
 Type a message└──────────────────────────────────────────────────────────────────────┘
               │[1] Codex (current)                                                   │
-Start with:   │[2] DeepSeek                                                          │
-  /help    bro│[3] OpenAI-compatible                                                 │
-  /model   cho│[4] Gemini                                                            │
-  /status  ins│[5] Candle Local                                                      │
-  /quit    lea│[6] Ollama                                                            │
-              │[7] Bedrock                                                           │
-Prompt ideas: │                                                                      │
-  · Explain th│                                                                      │
-  · Find the m│                                                                      │
+Start with:   │    Use Codex with browser login, device-code login, or a Codex API ke│
+  /help    bro│[2] DeepSeek                                                          │
+  /model   cho│    Use DeepSeek with an API key and model list from api.deepseek.com.│
+  /status  ins│[3] OpenAI-compatible                                                 │
+  /quit    lea│    Use OpenAI-compatible endpoint profiles such as Custom, Kimi, or O│
+              │[4] Gemini                                                            │
+Prompt ideas: │    Use Google Gemini via AI Studio (API key) or Code Assist (OAuth). │
+  · Explain th│[5] Candle Local                                                      │
+  · Find the m│    Run local Candle models directly in-process.                      │
               │                                                                      │
                           1-9 jump  Up/Down/jk move  Enter apply  Esc back
 Ready  waiting


### PR DESCRIPTION
## Summary

Follow-up fixes on top of merged #308 (dialog stack, palette UX, /connect, sidebar toggle).

### Changes

| Commit | Content |
|--------|---------|
| `fix(tui): clear input on Esc...` | Esc from command palette now clears the leftover `/abc` query text. Provider list picker now shows two-line items: name (bold) + description (muted), like OpenCode. Updated snapshot. |
| `fix(tui): replace bottom pane border...` | Pending-interaction highlight uses background color instead of border — avoids consuming 2 rows of layout and hiding shell approval options. |

### How to test

1. `/` → type `/model` → Esc: input should clear
2. `/connect` or `/model` → provider list should show descriptions
3. Shell approval (eg `bash` with approval required) → options "1 allow once 2 allow prefix..." should be visible

### Verification

`cargo test` — 980 passed, 0 failed.