### PR TITLE
feat(memory): add scope promotion rules

### DIFF
--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -164,6 +164,29 @@ The former `conversations` LanceDB table was an interim checkpoint path. Raw
 session-context checkpoints now write to per-session append shards under the
 rollout directory instead of the global memory index.
 
+## Scope Promotion Rules
+
+Promotion turns transient conversation or protocol input into durable
+`MemoryRecord`s. The record `scope` is the storage and index boundary. Provenance
+fields such as `session_id`, `thread_id`, and `source_span` explain where the
+memory came from, but they must not override the selected scope.
+
+The runtime promotion rules are:
+
+- `Workspace` promotion stores the record in the workspace bucket. It may keep
+  `session_id` and `thread_id` as provenance, but the LanceDB index key remains
+  `workspace`.
+- `Thread` promotion requires a non-empty `thread_id`. `session_id` is optional
+  provenance. The LanceDB index key is the `thread_id`.
+- `Session` promotion requires a non-empty `session_id`. It mirrors that id into
+  `thread_id` for compatibility with current session-thread provenance. The
+  LanceDB index key is the `session_id`.
+
+Protocol memory writes follow the same rules. A protocol client may add
+workspace-scoped memory without a thread id, but thread-scoped memory must pass
+`thread_id` in metadata so future control-plane clients cannot create ambiguous
+thread records.
+
 ## MemoryStore API
 
 - `insert(record) -> MemoryRecord` — persist with auto-embedding

--- a/docs/journal/2026-05-09-memory-scope-promotion-rules.md
+++ b/docs/journal/2026-05-09-memory-scope-promotion-rules.md
@@ -1,0 +1,27 @@
+# Memory Scope Promotion Rules
+
+## Checkpoint
+
+RARA now has a typed promotion boundary for durable memory records.
+`MemoryPromotionTarget` centralizes how thread, session, and workspace
+promotions become `NewMemoryRecord`s before they are inserted into
+`MemoryStore`.
+
+## Runtime Contract
+
+- Workspace memory may preserve session or thread provenance, but it indexes
+  under the workspace scope key.
+- Thread memory requires an explicit thread id and indexes under that thread id.
+- Session memory requires an explicit session id and indexes under that session
+  id.
+- Protocol memory writes use the same promotion rules as thread/session
+  distillation.
+
+This keeps the scope decision stable and visible before retrieval orchestration
+or `/context` explainability consume the record.
+
+## Follow-Up
+
+Periodic session-shard promotion still needs an explicit scheduler and policy
+gate. That work should reuse this promotion boundary instead of constructing
+memory records ad hoc.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -106,7 +106,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Surface main model vs auxiliary model routing in `/status` and `/context`.
 - [ ] After context observability is complete, add an auxiliary-model compression hook for retrieval candidates without changing durable memory records.
 - [x] `ThreadStore` / `ThreadRecorder`: from façade over `SessionManager`+`StateDb` to true structured thread store.
-- [ ] Thread-scoped and workspace-scoped `MemoryRecord` storage with promotion rules.
+- [x] Thread-scoped and workspace-scoped `MemoryRecord` storage with promotion rules.
 - [x] Initial retrieval orchestration layer from `docs/features/retrieval-orchestration.md`: typed candidates, orchestration view, richer `/context`, deterministic dedupe, and ACP/Wire event exposure.
 - [x] Add the first `RetrievalSourceProvider` boundary for current memory, session, thread-history, vector-slot, tool-result, and file-search candidates.
 - [ ] Add `RetrievalSourceProvider` implementations for MCP resource, hook, and graph sources after the current memory/session/file path is stable.

--- a/src/memory_store.rs
+++ b/src/memory_store.rs
@@ -90,6 +90,23 @@ pub struct NewMemoryRecord {
     pub source_span: Option<MemorySourceSpan>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MemoryPromotionTarget {
+    Workspace {
+        session_id: Option<String>,
+        thread_id: Option<String>,
+    },
+    Thread {
+        session_id: Option<String>,
+        thread_id: String,
+        source_span: Option<MemorySourceSpan>,
+    },
+    Session {
+        session_id: String,
+        source_span: Option<MemorySourceSpan>,
+    },
+}
+
 impl NewMemoryRecord {
     pub fn experience(content: impl Into<String>) -> Self {
         Self {
@@ -104,6 +121,55 @@ impl NewMemoryRecord {
             thread_id: None,
             source_span: None,
         }
+    }
+
+    pub fn promotion_base(source: MemorySource, target: MemoryPromotionTarget) -> Result<Self> {
+        let (scope, session_id, thread_id, source_span) = match target {
+            MemoryPromotionTarget::Workspace {
+                session_id,
+                thread_id,
+            } => (
+                MemoryScope::Workspace,
+                normalized_optional_id(session_id),
+                normalized_optional_id(thread_id),
+                None,
+            ),
+            MemoryPromotionTarget::Thread {
+                session_id,
+                thread_id,
+                source_span,
+            } => (
+                MemoryScope::Thread,
+                normalized_optional_id(session_id),
+                Some(required_memory_id(thread_id, "thread_id")?),
+                source_span,
+            ),
+            MemoryPromotionTarget::Session {
+                session_id,
+                source_span,
+            } => {
+                let session_id = required_memory_id(session_id, "session_id")?;
+                (
+                    MemoryScope::Session,
+                    Some(session_id.clone()),
+                    Some(session_id),
+                    source_span,
+                )
+            }
+        };
+
+        Ok(Self {
+            title: None,
+            content: String::new(),
+            labels: vec![MemoryLabel::Experience],
+            importance: 0.6,
+            pinned: false,
+            source,
+            scope,
+            session_id,
+            thread_id,
+            source_span,
+        })
     }
 }
 
@@ -300,10 +366,21 @@ impl MemoryStore {
 
 impl MemoryRecord {
     fn index_scope_key(&self) -> String {
-        self.session_id
-            .clone()
-            .or_else(|| self.thread_id.clone())
-            .unwrap_or_else(|| memory_scope_key(&self.scope).to_string())
+        match self.scope {
+            MemoryScope::Thread => self
+                .thread_id
+                .clone()
+                .or_else(|| self.session_id.clone())
+                .unwrap_or_else(|| memory_scope_key(&self.scope).to_string()),
+            MemoryScope::Session => self
+                .session_id
+                .clone()
+                .or_else(|| self.thread_id.clone())
+                .unwrap_or_else(|| memory_scope_key(&self.scope).to_string()),
+            MemoryScope::User | MemoryScope::Workspace | MemoryScope::Project => {
+                memory_scope_key(&self.scope).to_string()
+            }
+        }
     }
 
     pub fn is_protected_from_automatic_cleanup(&self) -> bool {
@@ -777,6 +854,14 @@ fn normalized_optional_id(value: Option<String>) -> Option<String> {
         .filter(|value| !value.is_empty())
 }
 
+fn required_memory_id(value: String, field: &str) -> Result<String> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        bail!("{field} is required for scoped memory promotion");
+    }
+    Ok(value)
+}
+
 fn clamp_importance(importance: f32) -> f32 {
     if importance.is_nan() {
         return DEFAULT_IMPORTANCE;
@@ -884,6 +969,79 @@ mod tests {
         assert_eq!(
             load_records_sync(&legacy_path).expect("load legacy records"),
             vec![record]
+        );
+    }
+
+    #[test]
+    fn memory_record_index_scope_key_respects_memory_scope() {
+        let mut workspace = test_memory_record(
+            "memory-workspace",
+            "Workspace-scoped records may carry thread provenance.",
+        );
+        workspace.scope = MemoryScope::Workspace;
+        workspace.session_id = Some("session-1".to_string());
+        workspace.thread_id = Some("thread-1".to_string());
+        assert_eq!(workspace.index_scope_key(), "workspace");
+
+        let mut thread = workspace.clone();
+        thread.scope = MemoryScope::Thread;
+        assert_eq!(thread.index_scope_key(), "thread-1");
+
+        let mut session = workspace.clone();
+        session.scope = MemoryScope::Session;
+        assert_eq!(session.index_scope_key(), "session-1");
+
+        let mut project = workspace;
+        project.scope = MemoryScope::Project;
+        assert_eq!(project.index_scope_key(), "project");
+    }
+
+    #[test]
+    fn memory_promotion_base_enforces_scope_rules() {
+        let workspace = NewMemoryRecord::promotion_base(
+            MemorySource::ProtocolWrite,
+            MemoryPromotionTarget::Workspace {
+                session_id: Some(" session-1 ".to_string()),
+                thread_id: Some(" thread-1 ".to_string()),
+            },
+        )
+        .expect("workspace promotion");
+        assert_eq!(workspace.scope, MemoryScope::Workspace);
+        assert_eq!(workspace.session_id.as_deref(), Some("session-1"));
+        assert_eq!(workspace.thread_id.as_deref(), Some("thread-1"));
+        assert_eq!(workspace.source_span, None);
+
+        let thread_err = NewMemoryRecord::promotion_base(
+            MemorySource::ThreadDistill,
+            MemoryPromotionTarget::Thread {
+                session_id: Some("session-1".to_string()),
+                thread_id: " ".to_string(),
+                source_span: None,
+            },
+        )
+        .expect_err("thread promotion needs a thread id");
+        assert!(thread_err.to_string().contains("thread_id is required"));
+
+        let session = NewMemoryRecord::promotion_base(
+            MemorySource::SessionDistill,
+            MemoryPromotionTarget::Session {
+                session_id: " session-2 ".to_string(),
+                source_span: Some(MemorySourceSpan {
+                    start_turn_index: 2,
+                    end_turn_index: 4,
+                }),
+            },
+        )
+        .expect("session promotion");
+        assert_eq!(session.scope, MemoryScope::Session);
+        assert_eq!(session.session_id.as_deref(), Some("session-2"));
+        assert_eq!(session.thread_id.as_deref(), Some("session-2"));
+        assert_eq!(
+            session.source_span,
+            Some(MemorySourceSpan {
+                start_turn_index: 2,
+                end_turn_index: 4,
+            })
         );
     }
 

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 use tokio::sync::RwLock;
 
 use crate::memory_store::{
-    MemoryLabel, MemoryLabelCount, MemoryRecord, MemoryRecordPatch,
+    MemoryLabel, MemoryLabelCount, MemoryPromotionTarget, MemoryRecord, MemoryRecordPatch,
     MemoryScope as StoreMemoryScope, MemorySource, MemoryStore, NewMemoryRecord,
 };
 use crate::runtime_control::{
@@ -364,24 +364,31 @@ fn new_memory_record_from_control(
     content: &str,
     metadata: &Value,
 ) -> Result<NewMemoryRecord> {
-    Ok(NewMemoryRecord {
-        title: metadata_string(metadata, "title"),
-        content: content.to_string(),
-        labels: metadata_labels(metadata)?,
-        importance: metadata
-            .get("importance")
-            .and_then(Value::as_f64)
-            .unwrap_or(0.5) as f32,
-        pinned: metadata
-            .get("pinned")
-            .and_then(Value::as_bool)
-            .unwrap_or(false),
-        source: MemorySource::ProtocolWrite,
-        scope: store_scope_from_control(scope.clone()),
-        session_id: metadata_string(metadata, "session_id"),
-        thread_id: metadata_string(metadata, "thread_id"),
-        source_span: None,
-    })
+    let target = match scope {
+        ControlMemoryScope::Workspace => MemoryPromotionTarget::Workspace {
+            session_id: metadata_string(metadata, "session_id"),
+            thread_id: metadata_string(metadata, "thread_id"),
+        },
+        ControlMemoryScope::Thread => MemoryPromotionTarget::Thread {
+            session_id: metadata_string(metadata, "session_id"),
+            thread_id: metadata_string(metadata, "thread_id")
+                .ok_or_else(|| anyhow::anyhow!("thread_id is required for thread memory scope"))?,
+            source_span: None,
+        },
+    };
+    let mut record = NewMemoryRecord::promotion_base(MemorySource::ProtocolWrite, target)?;
+    record.title = metadata_string(metadata, "title");
+    record.content = content.to_string();
+    record.labels = metadata_labels(metadata)?;
+    record.importance = metadata
+        .get("importance")
+        .and_then(Value::as_f64)
+        .unwrap_or(0.5) as f32;
+    record.pinned = metadata
+        .get("pinned")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    Ok(record)
 }
 
 fn memory_patch_from_control(patch: &MemoryRecordControlPatch) -> Result<MemoryRecordPatch> {
@@ -704,7 +711,7 @@ mod tests {
             memory_id: "protocol-memory-duplicate".to_string(),
             scope: ControlMemoryScope::Thread,
             content: "Duplicate protocol ids should not upsert.".to_string(),
-            metadata: json!({"labels": ["fact"]}),
+            metadata: json!({"labels": ["fact"], "thread_id": "thread-duplicate"}),
         };
 
         handler
@@ -717,5 +724,25 @@ mod tests {
             .expect_err("duplicate add should fail");
 
         assert!(err.to_string().contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn memory_control_thread_record_requires_thread_id() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let store = test_memory_store(temp.path());
+        let handler = MemoryControlHandler::with_store(bus, store);
+
+        let err = handler
+            .handle_control(&MemoryControlRequest::AddRecord {
+                memory_id: "protocol-memory-thread-missing-id".to_string(),
+                scope: ControlMemoryScope::Thread,
+                content: "Thread-scoped protocol writes need an explicit thread id.".to_string(),
+                metadata: json!({"labels": ["fact"]}),
+            })
+            .await
+            .expect_err("thread scope without thread_id should fail");
+
+        assert!(err.to_string().contains("thread_id is required"));
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -14,7 +14,7 @@ use crate::memory_distiller::{
     MemoryDistiller, dedupe_memory_drafts, new_memory_record_from_draft,
 };
 use crate::memory_store::{
-    MemoryLabel, MemoryRecord, MemoryScope, MemorySource, MemoryStore, NewMemoryRecord,
+    MemoryPromotionTarget, MemoryRecord, MemorySource, MemoryStore, NewMemoryRecord,
 };
 use crate::session_context::{self, SessionContextSearchHit};
 use crate::session_transcript;
@@ -188,21 +188,16 @@ impl SessionManager {
         let Some(last) = checkpoints.last() else {
             return Ok(Vec::new());
         };
-        let base = NewMemoryRecord {
-            title: None,
-            content: String::new(),
-            labels: vec![MemoryLabel::Experience],
-            importance: 0.6,
-            pinned: false,
-            source: MemorySource::SessionDistill,
-            scope: MemoryScope::Session,
-            session_id: Some(session_id.to_string()),
-            thread_id: Some(session_id.to_string()),
-            source_span: Some(crate::memory_store::MemorySourceSpan {
-                start_turn_index: first.turn_index,
-                end_turn_index: last.turn_index,
-            }),
-        };
+        let base = NewMemoryRecord::promotion_base(
+            MemorySource::SessionDistill,
+            MemoryPromotionTarget::Session {
+                session_id: session_id.to_string(),
+                source_span: Some(crate::memory_store::MemorySourceSpan {
+                    start_turn_index: first.turn_index,
+                    end_turn_index: last.turn_index,
+                }),
+            },
+        )?;
 
         let mut memories = Vec::with_capacity(drafts.len());
         for draft in drafts {

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -22,7 +22,7 @@ use crate::memory_distiller::{
     MemoryDistiller, dedupe_memory_drafts, new_memory_record_from_draft,
 };
 use crate::memory_store::{
-    MemoryLabel, MemoryRecord, MemoryScope, MemorySource, MemorySourceSpan, MemoryStore,
+    MemoryPromotionTarget, MemoryRecord, MemorySource, MemorySourceSpan, MemoryStore,
     NewMemoryRecord,
 };
 use crate::session::{
@@ -405,7 +405,7 @@ impl<'a> ThreadStore<'a> {
             existing_hits.push(memory_store.search(&draft.content, 5).await?);
         }
 
-        let base = thread_distilled_memory_base(&snapshot);
+        let base = thread_distilled_memory_base(&snapshot)?;
         let mut records = Vec::new();
         for draft in dedupe_memory_drafts(drafts, &existing_hits) {
             records.push(
@@ -1386,7 +1386,7 @@ fn thread_summary_memory_record(thread: &ThreadSnapshot) -> Option<NewMemoryReco
         .or_else(|| first_user_message(thread));
     let summary = summary?;
     let title = thread_title(thread);
-    let mut record = thread_distilled_memory_base(thread);
+    let mut record = thread_distilled_memory_base(thread).ok()?;
     record.title = Some(title);
     record.content = format!(
         concat!(
@@ -1409,23 +1409,19 @@ fn thread_summary_memory_record(thread: &ThreadSnapshot) -> Option<NewMemoryReco
     Some(record)
 }
 
-fn thread_distilled_memory_base(thread: &ThreadSnapshot) -> NewMemoryRecord {
+fn thread_distilled_memory_base(thread: &ThreadSnapshot) -> Result<NewMemoryRecord> {
     let end_turn_index = thread.history.len().saturating_sub(1) as u32;
-    NewMemoryRecord {
-        title: None,
-        content: String::new(),
-        labels: vec![MemoryLabel::Experience],
-        importance: 0.6,
-        pinned: false,
-        source: MemorySource::ThreadDistill,
-        scope: MemoryScope::Thread,
-        session_id: Some(thread.metadata.session_id.clone()),
-        thread_id: Some(thread.metadata.session_id.clone()),
-        source_span: Some(MemorySourceSpan {
-            start_turn_index: 0,
-            end_turn_index,
-        }),
-    }
+    NewMemoryRecord::promotion_base(
+        MemorySource::ThreadDistill,
+        MemoryPromotionTarget::Thread {
+            session_id: Some(thread.metadata.session_id.clone()),
+            thread_id: thread.metadata.session_id.clone(),
+            source_span: Some(MemorySourceSpan {
+                start_turn_index: 0,
+                end_turn_index,
+            }),
+        },
+    )
 }
 
 fn thread_title(thread: &ThreadSnapshot) -> String {


### PR DESCRIPTION
## Summary

- add typed memory promotion targets for workspace, thread, and session scopes
- make memory index scope keys follow the selected memory scope instead of provenance ids
- route session/thread distillation and protocol memory writes through the shared promotion rules
- document the scope promotion contract and close the matching TODO item

## Tests

- `cargo fmt`
- `cargo test memory_ -- --nocapture`
- `cargo test memory_record_index_scope_key_respects_memory_scope -- --nocapture`

Note: the test build still reports existing repository warnings; this change removed the new unused import it initially introduced.
