### PR TITLE
feat(memory): gate session shard promotion

### DIFF
--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -187,6 +187,26 @@ workspace-scoped memory without a thread id, but thread-scoped memory must pass
 `thread_id` in metadata so future control-plane clients cannot create ambiguous
 thread records.
 
+## Periodic Promotion Policy Gate
+
+Periodic session-shard promotion must be opt-in. The explicit API
+`SessionManager::promote_session_context_memories` remains available for manual
+or control-plane-triggered promotion, but scheduler-style callers should use the
+policy-gated path:
+
+- `SessionShardPromotionPolicy` defaults to disabled.
+- `min_checkpoints` avoids promoting tiny or accidental shards.
+- `max_checkpoints` bounds the tail of context checkpoints passed to
+  distillation.
+- `SessionShardPromotionTrigger` records whether the attempt came from a
+  periodic scheduler, shutdown hook, or runtime-control request.
+- `SessionShardPromotionOutcome` reports eligible/skipped state and promoted
+  count so `/context`, ACP/Wire, and future OTEL exporters can observe promotion
+  attempts without parsing logs.
+
+The first gated path does not install a timer. It provides the contract that any
+future scheduler must call before writing durable memory in the background.
+
 ## MemoryStore API
 
 - `insert(record) -> MemoryRecord` — persist with auto-embedding
@@ -321,9 +341,12 @@ Current implementation checkpoint:
 11. Move raw session checkpoints out of the global `conversations` LanceDB table
    into per-session append shards. Done.
 12. Add explicit promotion from session shards into global `MemoryRecord`s.
-    Done for API-triggered promotion; periodic scheduling remains future work.
-13. Deprecate `VectorDB`.
-14. Remove `VectorDB`.
+    Done for API-triggered promotion.
+13. Add scheduler/policy gates for periodic session-shard promotion.
+    Done for opt-in policy evaluation and observable outcomes; a real periodic
+    timer remains future work.
+14. Deprecate `VectorDB`.
+15. Remove `VectorDB`.
 
 ## Source Journals
 

--- a/docs/journal/2026-05-09-session-shard-promotion-policy.md
+++ b/docs/journal/2026-05-09-session-shard-promotion-policy.md
@@ -1,0 +1,23 @@
+# Session Shard Promotion Policy Gate
+
+## Checkpoint
+
+Periodic session-shard promotion now has an explicit opt-in policy gate. The
+existing manual promotion API remains unchanged, while scheduler-style callers
+can evaluate a `SessionShardPromotionPolicy` before writing durable memory.
+
+## Runtime Contract
+
+- Default policy is disabled, so background promotion cannot write memory by
+  accident.
+- Enabled policy requires enough checkpoints and a non-zero maximum checkpoint
+  window.
+- Promotion attempts return a structured `SessionShardPromotionOutcome` with
+  trigger, checkpoint counts, decision, skip reason, and promoted count.
+- Runtime memory events can carry that outcome without depending on logs.
+
+## Follow-Up
+
+The policy gate does not install a timer. A future scheduler can call the gated
+API from a runtime task once configuration, status display, and operator controls
+are ready.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -86,7 +86,7 @@ Active backlog only. Keep this file small and current.
 - [x] Index parent/child spawn-edge metadata in `StateDb` for resume/listing queries.
 - [x] Add in-process background sub-agent resume/stop over the sidechain transcript contract.
 - [x] Add an explicit promotion API from session context shards into global `MemoryRecord`s.
-- [ ] Add scheduler/policy gates for periodic session-shard promotion so background writes are opt-in and observable.
+- [x] Add scheduler/policy gates for periodic session-shard promotion so background writes are opt-in and observable.
 - [x] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.
 - [ ] Define cross-process background sub-agent restart/reattach semantics.
 - [x] Compaction as first-class lifecycle event: persist summaries, token counters, metadata ownership.

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod runtime_event_bus;
 mod sandbox;
 mod session;
 mod session_context;
+mod session_promotion;
 mod session_transcript;
 mod shell_env;
 mod skill;

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use crate::agent::{AgentEvent, BashApprovalDecision};
 use crate::context::{ContextObservabilityView, RetrievalOrchestrationView};
 use crate::mcp_status::{McpConnectionState, McpStatusSnapshot};
+use crate::session_promotion::SessionShardPromotionOutcome;
 use crate::todo::TodoState;
 use crate::tool::ToolOutputStream;
 
@@ -523,6 +524,9 @@ pub enum MemoryEvent {
     },
     RecordsQueried {
         records: Vec<MemoryRecordSummary>,
+    },
+    SessionShardPromotionObserved {
+        outcome: SessionShardPromotionOutcome,
     },
     SelectionUpdated,
 }
@@ -1301,6 +1305,50 @@ mod tests {
                             "session_id": "session-1",
                             "thread_id": null
                         }]
+                    }
+                }
+            })
+        );
+
+        let promotion = serde_json::to_value(RuntimeEvent::Memory(
+            MemoryEvent::SessionShardPromotionObserved {
+                outcome: crate::session_promotion::SessionShardPromotionOutcome {
+                    plan: crate::session_promotion::SessionShardPromotionPlan {
+                        session_id: "session-1".to_string(),
+                        trigger: crate::session_promotion::SessionShardPromotionTrigger::Periodic,
+                        checkpoint_count: 2,
+                        min_checkpoints: 2,
+                        max_checkpoints: 8,
+                        decision: crate::session_promotion::SessionShardPromotionDecision::Skipped {
+                            reason: crate::session_promotion::SessionShardPromotionSkipReason::Disabled,
+                        },
+                    },
+                    promoted_count: 0,
+                },
+            },
+        ))
+        .unwrap();
+        assert_eq!(
+            promotion,
+            json!({
+                "type": "memory",
+                "payload": {
+                    "type": "session_shard_promotion_observed",
+                    "payload": {
+                        "outcome": {
+                            "plan": {
+                                "session_id": "session-1",
+                                "trigger": "periodic",
+                                "checkpoint_count": 2,
+                                "min_checkpoints": 2,
+                                "max_checkpoints": 8,
+                                "decision": {
+                                    "status": "skipped",
+                                    "reason": "disabled"
+                                }
+                            },
+                            "promoted_count": 0
+                        }
                     }
                 }
             })

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,6 +17,10 @@ use crate::memory_store::{
     MemoryPromotionTarget, MemoryRecord, MemorySource, MemoryStore, NewMemoryRecord,
 };
 use crate::session_context::{self, SessionContextSearchHit};
+use crate::session_promotion::{
+    SessionShardPromotionOutcome, SessionShardPromotionPlan, SessionShardPromotionPolicy,
+    SessionShardPromotionTrigger,
+};
 use crate::session_transcript;
 use crate::todo::TodoState;
 
@@ -208,6 +212,46 @@ impl SessionManager {
             );
         }
         Ok(memories)
+    }
+
+    pub fn plan_session_context_memory_promotion(
+        &self,
+        session_id: &str,
+        policy: SessionShardPromotionPolicy,
+        trigger: SessionShardPromotionTrigger,
+    ) -> Result<SessionShardPromotionPlan> {
+        let checkpoints =
+            session_context::load_session_context_checkpoints(&self.storage_dir, session_id)?;
+        Ok(policy.evaluate(session_id.to_string(), trigger, checkpoints.len()))
+    }
+
+    pub async fn promote_session_context_memories_with_policy(
+        &self,
+        memory_store: &MemoryStore,
+        session_id: &str,
+        policy: SessionShardPromotionPolicy,
+        trigger: SessionShardPromotionTrigger,
+    ) -> Result<(SessionShardPromotionOutcome, Vec<MemoryRecord>)> {
+        let plan = self.plan_session_context_memory_promotion(session_id, policy, trigger)?;
+        if !plan.is_eligible() {
+            return Ok((
+                SessionShardPromotionOutcome {
+                    plan,
+                    promoted_count: 0,
+                },
+                Vec::new(),
+            ));
+        }
+
+        let max_checkpoints = plan.max_checkpoints;
+        let memories = self
+            .promote_session_context_memories(memory_store, session_id, max_checkpoints)
+            .await?;
+        let outcome = SessionShardPromotionOutcome {
+            plan,
+            promoted_count: memories.len(),
+        };
+        Ok((outcome, memories))
     }
 
     pub fn plan_file_path(&self, session_id: &str) -> PathBuf {
@@ -604,6 +648,9 @@ mod tests {
     use super::*;
     use crate::llm::{ContentBlock, LlmBackend, LlmResponse, TokenUsage};
     use crate::memory_store::{MemoryLabel, MemoryScope, MemorySource, MemoryStore};
+    use crate::session_promotion::{
+        SessionShardPromotionDecision, SessionShardPromotionSkipReason,
+    };
     use crate::session_transcript::{
         SessionTranscriptEntry, load_transcript, main_transcript_path, model_visible_messages,
     };
@@ -1085,6 +1132,98 @@ mod tests {
                 .iter()
                 .any(|label| label.label == MemoryLabel::Decision)
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn session_context_promotion_policy_skips_background_writes_by_default() -> Result<()> {
+        let temp = tempdir()?;
+        let rara_dir = temp.path().join(".rara");
+        let session_manager = SessionManager::new_for_rara_dir(rara_dir.clone())?;
+        session_manager.save_session_context_checkpoint(
+            "session-policy-disabled",
+            1,
+            "This checkpoint should not be promoted unless the policy enables writes.".to_string(),
+            vec![0.2; 128],
+        )?;
+        session_manager.save_session_context_checkpoint(
+            "session-policy-disabled",
+            2,
+            "Default policy keeps periodic promotion disabled.".to_string(),
+            vec![0.3; 128],
+        )?;
+        let memory_store = MemoryStore::new(
+            Arc::new(SessionPromotionMockLlm),
+            Arc::new(VectorDB::new(
+                rara_dir.join("lancedb").to_str().expect("utf8 path"),
+            )),
+        );
+
+        let (outcome, memories) = session_manager
+            .promote_session_context_memories_with_policy(
+                &memory_store,
+                "session-policy-disabled",
+                SessionShardPromotionPolicy::default(),
+                SessionShardPromotionTrigger::Periodic,
+            )
+            .await?;
+
+        assert!(memories.is_empty());
+        assert_eq!(outcome.promoted_count, 0);
+        assert_eq!(
+            outcome.plan.decision,
+            SessionShardPromotionDecision::Skipped {
+                reason: SessionShardPromotionSkipReason::Disabled,
+            }
+        );
+        assert_eq!(memory_store.record_count().await?, 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn session_context_promotion_policy_promotes_when_enabled() -> Result<()> {
+        let temp = tempdir()?;
+        let rara_dir = temp.path().join(".rara");
+        let session_manager = SessionManager::new_for_rara_dir(rara_dir.clone())?;
+        session_manager.save_session_context_checkpoint(
+            "session-policy-enabled",
+            1,
+            "Use policy gates before periodic session shard promotion.".to_string(),
+            vec![0.2; 128],
+        )?;
+        session_manager.save_session_context_checkpoint(
+            "session-policy-enabled",
+            2,
+            "Eligible policy runs bounded distillation into MemoryRecords.".to_string(),
+            vec![0.3; 128],
+        )?;
+        let memory_store = MemoryStore::new(
+            Arc::new(SessionPromotionMockLlm),
+            Arc::new(VectorDB::new(
+                rara_dir.join("lancedb").to_str().expect("utf8 path"),
+            )),
+        );
+
+        let (outcome, memories) = session_manager
+            .promote_session_context_memories_with_policy(
+                &memory_store,
+                "session-policy-enabled",
+                SessionShardPromotionPolicy {
+                    enabled: true,
+                    min_checkpoints: 2,
+                    max_checkpoints: 8,
+                },
+                SessionShardPromotionTrigger::Periodic,
+            )
+            .await?;
+
+        assert_eq!(
+            outcome.plan.decision,
+            SessionShardPromotionDecision::Eligible
+        );
+        assert_eq!(outcome.promoted_count, memories.len());
+        assert_eq!(memories.len(), 2);
+        assert_eq!(memory_store.record_count().await?, 2);
         Ok(())
     }
 

--- a/src/session_promotion.rs
+++ b/src/session_promotion.rs
@@ -1,0 +1,104 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionShardPromotionTrigger {
+    Periodic,
+    Shutdown,
+    RuntimeControl,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SessionShardPromotionPolicy {
+    pub enabled: bool,
+    pub min_checkpoints: usize,
+    pub max_checkpoints: usize,
+}
+
+impl Default for SessionShardPromotionPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            min_checkpoints: 2,
+            max_checkpoints: 8,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionShardPromotionSkipReason {
+    Disabled,
+    Empty,
+    BelowMinCheckpoints,
+    MaxCheckpointsZero,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SessionShardPromotionDecision {
+    Eligible,
+    Skipped {
+        reason: SessionShardPromotionSkipReason,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionShardPromotionPlan {
+    pub session_id: String,
+    pub trigger: SessionShardPromotionTrigger,
+    pub checkpoint_count: usize,
+    pub min_checkpoints: usize,
+    pub max_checkpoints: usize,
+    pub decision: SessionShardPromotionDecision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionShardPromotionOutcome {
+    pub plan: SessionShardPromotionPlan,
+    pub promoted_count: usize,
+}
+
+impl SessionShardPromotionPolicy {
+    pub fn evaluate(
+        self,
+        session_id: impl Into<String>,
+        trigger: SessionShardPromotionTrigger,
+        checkpoint_count: usize,
+    ) -> SessionShardPromotionPlan {
+        let decision = if !self.enabled {
+            SessionShardPromotionDecision::Skipped {
+                reason: SessionShardPromotionSkipReason::Disabled,
+            }
+        } else if self.max_checkpoints == 0 {
+            SessionShardPromotionDecision::Skipped {
+                reason: SessionShardPromotionSkipReason::MaxCheckpointsZero,
+            }
+        } else if checkpoint_count == 0 {
+            SessionShardPromotionDecision::Skipped {
+                reason: SessionShardPromotionSkipReason::Empty,
+            }
+        } else if checkpoint_count < self.min_checkpoints {
+            SessionShardPromotionDecision::Skipped {
+                reason: SessionShardPromotionSkipReason::BelowMinCheckpoints,
+            }
+        } else {
+            SessionShardPromotionDecision::Eligible
+        };
+
+        SessionShardPromotionPlan {
+            session_id: session_id.into(),
+            trigger,
+            checkpoint_count,
+            min_checkpoints: self.min_checkpoints,
+            max_checkpoints: self.max_checkpoints,
+            decision,
+        }
+    }
+}
+
+impl SessionShardPromotionPlan {
+    pub fn is_eligible(&self) -> bool {
+        matches!(self.decision, SessionShardPromotionDecision::Eligible)
+    }
+}


### PR DESCRIPTION
## Summary

- add a typed `SessionShardPromotionPolicy` gate for periodic/session-shard memory promotion
- keep the default policy disabled so background promotion cannot write durable memory unless explicitly enabled
- return structured promotion outcomes with trigger, checkpoint counts, decision, skip reason, and promoted count
- expose the outcome through structured memory runtime events for `/context`, ACP/Wire, and future OTEL use
- document the promotion policy contract and close the matching TODO item

## Tests

- `cargo fmt`
- `cargo test session_context_promotion_policy -- --nocapture`
- `cargo test memory_label_and_metadata_events_use_structured_wire_shape -- --nocapture`

Note: the test build still reports existing repository warnings; this change does not add a new warning after the `is_eligible` call path was wired.
