### PR TITLE
feat(context): surface model routing

### DIFF
--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -305,6 +305,16 @@ reason when fallback occurred, token usage/cache metrics when available, and any
 be visible in `/status` or `/context`. TUI surfaces render those events; they must not infer routing
 or fallback behavior from display text.
 
+The first visible routing surface is intentionally read-only:
+
+- `/status` shows the effective main model, auxiliary model, source, and route.
+- `/context` shows the same main/auxiliary route near the context usage summary.
+- Explicit `auxiliary_model` config wins over inference.
+- DeepSeek OpenAI-compatible endpoints may conservatively infer `deepseek-v4-flash` from
+  `deepseek-v4-pro`.
+- Providers without an explicit or inferred helper route report `fallback`, meaning helper work uses
+  the main model.
+
 The parent agent should only apply the returned result through the post-compact assembly pipeline.
 The worker transcript must not be appended to the parent conversation. This keeps prefix order
 stable and preserves a clear boundary between main task history and compaction implementation

--- a/docs/journal/2026-05-09-model-routing-status-context.md
+++ b/docs/journal/2026-05-09-model-routing-status-context.md
@@ -1,0 +1,19 @@
+# Model Routing Status and Context Visibility
+
+RARA already supports an `auxiliary_model` config field and conservative DeepSeek lite-model
+inference for helper summarization paths, but the active routing decision was not visible in the TUI.
+That made later context-compression work harder to debug because users could not tell whether helper
+work would use the configured main model, an explicitly configured auxiliary model, or an inferred
+provider-lite model.
+
+This checkpoint adds a structured TUI model-routing view:
+
+- main model and source from the effective provider surface;
+- auxiliary model, source, and route;
+- explicit auxiliary config before provider inference;
+- conservative DeepSeek `deepseek-v4-pro` to `deepseek-v4-flash` inference;
+- fallback-to-main reporting for providers without a helper route.
+
+The `/status` overview, `/status` runtime text, and `/context` usage summary now render the same
+structured routing view. This keeps the visible model-routing surface aligned with the future
+auxiliary compression hook without starting the hook implementation yet.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -103,7 +103,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add terminal environment detection for TUI compatibility, diagnostics, and future OTEL attributes.
 - [ ] Surface terminal metadata in `/status` diagnostics and future OTEL attributes.
 - [ ] Add provider-gated cache-edit microcompact only for backends that explicitly declare cache-edit support.
-- [ ] Surface main model vs auxiliary model routing in `/status` and `/context`.
+- [x] Surface main model vs auxiliary model routing in `/status` and `/context`.
 - [ ] After context observability is complete, add an auxiliary-model compression hook for retrieval candidates without changing durable memory records.
 - [x] `ThreadStore` / `ThreadRecorder`: from façade over `SessionManager`+`StateDb` to true structured thread store.
 - [x] Thread-scoped and workspace-scoped `MemoryRecord` storage with promotion rules.

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -15,6 +15,7 @@ pub use self::gemini::GeminiBackend;
 pub use self::ollama::OllamaBackend;
 #[cfg(test)]
 pub(crate) use self::openai_compatible::context_window_error_for_test;
+pub(crate) use self::openai_compatible::infer_openai_compatible_auxiliary_model;
 pub(crate) use self::openai_compatible::is_context_window_error;
 pub use self::openai_compatible::{
     CodexBackend, OpenAiCompatibleBackend, fetch_model_context_window,

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -233,10 +233,15 @@ fn render_context_usage_summary(app: &TuiApp) -> String {
     let autocompact_buffer = window
         .map(|window| window.saturating_sub(app.snapshot.compact_threshold_tokens))
         .filter(|tokens| *tokens > 0);
+    let routing = app.model_routing_view();
 
     let mut lines = vec![
         "Context Usage".to_string(),
-        format!("  model: {}", app.current_model_label()),
+        format!("  model: {}", routing.main_model),
+        format!(
+            "  auxiliary: {} ({})",
+            routing.auxiliary_model, routing.auxiliary_route
+        ),
         format!(
             "  used: {}{} / {}",
             format_token_count(used_tokens),
@@ -536,6 +541,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
         "-"
     };
     let surface = app.config.effective_provider_surface();
+    let routing = app.model_routing_view();
     let reasoning_summary = surface
         .reasoning_summary
         .display_or(rara_config::DEFAULT_REASONING_SUMMARY);
@@ -579,12 +585,15 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
         ("remote".to_string(), "-".to_string())
     };
     format!(
-        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\ntodo={}\ndevice={}\ndtype={}\nfocused={}\nphase={}\ndetail={}",
+        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nauxiliary_model={}\nauxiliary_model_source={}\nauxiliary_route={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\ntodo={}\ndevice={}\ndtype={}\nfocused={}\nphase={}\ndetail={}",
         surface.provider,
         endpoint_profile,
         endpoint_kind,
-        surface.model.display_or(app.current_model_label()),
-        surface.model.source.label(),
+        routing.main_model,
+        routing.main_source,
+        routing.auxiliary_model,
+        routing.auxiliary_source,
+        routing.auxiliary_route,
         surface.base_url.display_or("-"),
         surface.base_url.source.label(),
         surface.revision.display_or("main"),

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -340,6 +340,9 @@ fn status_runtime_text_reports_effective_provider_surface_sources() {
 
     let rendered = status_runtime_text(&app);
     assert!(rendered.contains("model_source="));
+    assert!(rendered.contains("auxiliary_model="));
+    assert!(rendered.contains("auxiliary_model_source="));
+    assert!(rendered.contains("auxiliary_route="));
     assert!(rendered.contains("base_url_source="));
     assert!(rendered.contains("revision_source="));
     assert!(rendered.contains("reasoning_summary_source=legacy_global"));

--- a/src/tui/context_display.rs
+++ b/src/tui/context_display.rs
@@ -26,11 +26,17 @@ pub(crate) fn render_context_lines(app: &TuiApp, available_width: u16) -> Vec<Li
 
     // ── Context Usage ──
     section_header(&mut lines, "Context Usage");
+    let routing = app.model_routing_view();
+    kv(&mut lines, "model", &routing.main_model, Color::LightBlue);
     kv(
         &mut lines,
-        "model",
-        app.current_model_label(),
-        Color::LightBlue,
+        "auxiliary",
+        &format!("{} ({})", routing.auxiliary_model, routing.auxiliary_route),
+        if routing.auxiliary_uses_main_model {
+            TEXT_MUTED
+        } else {
+            Color::LightBlue
+        },
     );
     kv(
         &mut lines,

--- a/src/tui/render/snapshots/rara__tui__render__tests__context_overlay_typical_budget.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__context_overlay_typical_budget.snap
@@ -6,6 +6,7 @@ expression: rendered
 Context Usage
 
   model          anthropic/claude-sonnet-4
+  auxiliary      anthropic/claude-sonnet-4 (fallback)
   window         200.0K tokens
   ░░░░□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□
   10.2K / 200.0K  5.1% used

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -21,8 +21,8 @@ pub use self::types::current_unix_timestamp_secs;
 pub use self::types::{
     ActiveLiveEvent, ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
     AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, GoalHandle, GoalStatus,
-    HelpTab, InteractionKind, ListPickerKind, LocalCommand, LocalCommandKind, OAuthLoginMode,
-    OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot,
+    HelpTab, InteractionKind, ListPickerKind, LocalCommand, LocalCommandKind, ModelRoutingView,
+    OAuthLoginMode, OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot,
     PendingInteractionSnapshot, PermissionMode, ProviderFamily, RalphGoal, RebuildSuccess,
     RunningTask, RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab, TaskCompletion,
     TaskKind, TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent,
@@ -301,6 +301,56 @@ impl TuiApp {
 
     pub fn current_model_label(&self) -> &str {
         self.config.model.as_deref().unwrap_or("-")
+    }
+
+    pub fn model_routing_view(&self) -> ModelRoutingView {
+        let surface = self.config.effective_provider_surface();
+        let main_model = surface
+            .model
+            .value
+            .unwrap_or_else(|| self.current_model_label())
+            .to_string();
+        if let Some(auxiliary_model) = surface
+            .auxiliary_model
+            .value
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+        {
+            return ModelRoutingView {
+                main_model,
+                main_source: surface.model.source.label().to_string(),
+                auxiliary_model: auxiliary_model.to_string(),
+                auxiliary_source: surface.auxiliary_model.source.label().to_string(),
+                auxiliary_route: "configured".to_string(),
+                auxiliary_uses_main_model: false,
+            };
+        }
+
+        if let Some(auxiliary_model) = self.inferred_auxiliary_model(&main_model) {
+            return ModelRoutingView {
+                main_model,
+                main_source: surface.model.source.label().to_string(),
+                auxiliary_model,
+                auxiliary_source: "inferred".to_string(),
+                auxiliary_route: "provider_lite".to_string(),
+                auxiliary_uses_main_model: false,
+            };
+        }
+
+        ModelRoutingView {
+            auxiliary_model: main_model.clone(),
+            main_model,
+            main_source: surface.model.source.label().to_string(),
+            auxiliary_source: "main_model".to_string(),
+            auxiliary_route: "fallback".to_string(),
+            auxiliary_uses_main_model: true,
+        }
+    }
+
+    fn inferred_auxiliary_model(&self, main_model: &str) -> Option<String> {
+        let endpoint_kind = self.config.active_openai_profile_kind()?;
+        crate::llm::infer_openai_compatible_auxiliary_model(main_model, endpoint_kind)
+            .map(|model| model.into_owned())
     }
 
     pub fn repo_context_hint(&self) -> Option<String> {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -446,6 +446,47 @@ fn deepseek_catalog_options_keep_current_custom_model_selectable() {
 }
 
 #[test]
+fn model_routing_view_infers_deepseek_auxiliary_model() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+
+    app.config
+        .select_openai_profile("deepseek-default", "DeepSeek", OpenAiEndpointKind::Deepseek);
+    app.config.set_model(Some("deepseek-v4-pro".to_string()));
+
+    let routing = app.model_routing_view();
+
+    assert_eq!(routing.main_model, "deepseek-v4-pro");
+    assert_eq!(routing.auxiliary_model, "deepseek-v4-flash");
+    assert_eq!(routing.auxiliary_route, "provider_lite");
+    assert_eq!(routing.auxiliary_source, "inferred");
+    assert!(!routing.auxiliary_uses_main_model);
+}
+
+#[test]
+fn model_routing_view_falls_back_to_main_model_without_helper() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+
+    app.config.set_provider("ollama");
+    app.config.set_model(Some("qwen3".to_string()));
+
+    let routing = app.model_routing_view();
+
+    assert_eq!(routing.main_model, "qwen3");
+    assert_eq!(routing.auxiliary_model, "qwen3");
+    assert_eq!(routing.auxiliary_route, "fallback");
+    assert_eq!(routing.auxiliary_source, "main_model");
+    assert!(routing.auxiliary_uses_main_model);
+}
+
+#[test]
 fn codex_preset_keeps_the_codex_model_label() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -145,6 +145,16 @@ pub struct LocalCommand {
     pub arg: Option<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModelRoutingView {
+    pub main_model: String,
+    pub main_source: String,
+    pub auxiliary_model: String,
+    pub auxiliary_source: String,
+    pub auxiliary_route: String,
+    pub auxiliary_uses_main_model: bool,
+}
+
 pub struct CommandSpec {
     pub category: &'static str,
     pub name: &'static str,

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -23,8 +23,19 @@ pub(crate) fn render_status_lines(app: &TuiApp, tab: StatusTab) -> Vec<Line<'sta
 
 fn render_overview_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
     section_header(lines, "Provider & Model");
+    let routing = app.model_routing_view();
     kv(lines, "provider", &app.config.provider, Color::Cyan);
-    kv(lines, "model", app.current_model_label(), Color::LightBlue);
+    kv(lines, "model", &routing.main_model, Color::LightBlue);
+    kv(
+        lines,
+        "auxiliary",
+        &format!("{} ({})", routing.auxiliary_model, routing.auxiliary_route),
+        if routing.auxiliary_uses_main_model {
+            Color::DarkGray
+        } else {
+            Color::LightBlue
+        },
+    );
     if app.config.provider == "openai-compatible" {
         kv(
             lines,


### PR DESCRIPTION
## Summary

- add a structured TUI model routing view for main vs auxiliary helper models
- show the routing view in `/status`, `/context`, and status runtime text
- document the read-only visibility slice for future auxiliary compression work

## Testing

- `cargo fmt --check`
- `git diff --check`

Local focused `cargo test` attempts were blocked after a clean build by `No space left on device` while rebuilding DataFusion/LanceDB dependencies. CI should run the full checks on a clean runner.
