### PR TITLE
feat(status): show terminal diagnostics

### DIFF
--- a/docs/features/terminal-environment.md
+++ b/docs/features/terminal-environment.md
@@ -67,9 +67,23 @@ login warnings, but now comes from `TerminalInfo::is_remote_session()`.
 4. `TERM` fallback;
 5. unknown.
 
+## Status Diagnostics
+
+The `/status` diagnostics surface now consumes the same `TerminalInfo` data model
+through a `TerminalDiagnosticsView`. It reports:
+
+- detected terminal name and sanitized user-agent token;
+- `TERM` and `TERM_PROGRAM` when present;
+- multiplexer and remote-session classification;
+- selected history insertion compatibility mode;
+- current TUI focus and terminal width.
+
+The text status output uses the same view and names the fields with a
+`terminal_*` prefix. Future OTEL attributes should be derived from this view
+instead of reading environment variables again.
+
 ## Follow-Up
 
-- Surface terminal metadata in diagnostics once `/status` has a suitable tab.
 - Add OTEL attributes from the same `TerminalInfo` shape.
 - Decide whether tmux client probing should be lazy, disabled by default, or
   never added.

--- a/docs/journal/2026-05-09-terminal-status-diagnostics.md
+++ b/docs/journal/2026-05-09-terminal-status-diagnostics.md
@@ -1,0 +1,16 @@
+# Terminal Status Diagnostics
+
+Terminal detection already lived behind the `rara-terminal-detection` crate, but `/status` still
+reported only the TUI focus flag. That left terminal compatibility decisions hard to inspect and
+made future OTEL fields likely to drift from the runtime behavior.
+
+This checkpoint adds a `TerminalDiagnosticsView` on `TuiApp` and routes status rendering through it:
+
+- detected terminal name and sanitized user-agent token;
+- optional `TERM` and `TERM_PROGRAM`;
+- multiplexer and remote-session classification;
+- selected history insertion mode;
+- current TUI focus and terminal width.
+
+The `/status` config tab and status runtime text now read the same structured view. Future OTEL
+attributes should reuse this view instead of reading process environment variables directly.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -101,7 +101,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add per-request microcompact observability to `/context`.
 - [x] Add an OTEL-ready context observability event model for compaction, microcompact projection, cache usage, and memory retrieval.
 - [x] Add terminal environment detection for TUI compatibility, diagnostics, and future OTEL attributes.
-- [ ] Surface terminal metadata in `/status` diagnostics and future OTEL attributes.
+- [x] Surface terminal metadata in `/status` diagnostics and future OTEL attributes.
 - [ ] Add provider-gated cache-edit microcompact only for backends that explicitly declare cache-edit support.
 - [x] Surface main model vs auxiliary model routing in `/status` and `/context`.
 - [ ] After context observability is complete, add an auxiliary-model compression hook for retrieval candidates without changing durable memory records.

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -542,6 +542,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
     };
     let surface = app.config.effective_provider_surface();
     let routing = app.model_routing_view();
+    let terminal = app.terminal_diagnostics_view();
     let reasoning_summary = surface
         .reasoning_summary
         .display_or(rara_config::DEFAULT_REASONING_SUMMARY);
@@ -585,7 +586,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
         ("remote".to_string(), "-".to_string())
     };
     format!(
-        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nauxiliary_model={}\nauxiliary_model_source={}\nauxiliary_route={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\ntodo={}\ndevice={}\ndtype={}\nfocused={}\nphase={}\ndetail={}",
+        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nauxiliary_model={}\nauxiliary_model_source={}\nauxiliary_route={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\ntodo={}\ndevice={}\ndtype={}\nterminal_name={}\nterminal_user_agent={}\nterminal_term={}\nterminal_term_program={}\nterminal_multiplexer={}\nterminal_remote={}\nterminal_history_mode={}\nterminal_focused={}\nterminal_width_columns={}\nphase={}\ndetail={}",
         surface.provider,
         endpoint_profile,
         endpoint_kind,
@@ -615,7 +616,15 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
         todo_summary_line(app),
         device,
         dtype,
-        app.terminal_focused,
+        terminal.name,
+        terminal.user_agent,
+        terminal.term.as_deref().unwrap_or("-"),
+        terminal.term_program.as_deref().unwrap_or("-"),
+        terminal.multiplexer,
+        terminal.remote,
+        terminal.history_mode,
+        terminal.focused,
+        terminal.width_columns,
         phase,
         detail,
     )

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -345,6 +345,10 @@ fn status_runtime_text_reports_effective_provider_surface_sources() {
     assert!(rendered.contains("auxiliary_route="));
     assert!(rendered.contains("base_url_source="));
     assert!(rendered.contains("revision_source="));
+    assert!(rendered.contains("terminal_name="));
+    assert!(rendered.contains("terminal_user_agent="));
+    assert!(rendered.contains("terminal_history_mode="));
+    assert!(rendered.contains("terminal_width_columns="));
     assert!(rendered.contains("reasoning_summary_source=legacy_global"));
 }
 

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -25,7 +25,8 @@ pub use self::types::{
     OAuthLoginMode, OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot,
     PendingInteractionSnapshot, PermissionMode, ProviderFamily, RalphGoal, RebuildSuccess,
     RunningTask, RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab, TaskCompletion,
-    TaskKind, TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent,
+    TaskKind, TerminalDiagnosticsView, TranscriptEntry, TranscriptEntryPayload, TranscriptTurn,
+    TuiApp, TuiEvent,
 };
 
 const OPENAI_PROFILE_SETUP_KINDS: [OpenAiEndpointKind; 3] = [
@@ -37,6 +38,27 @@ pub(super) const INPUT_HISTORY_LIMIT: usize = 200;
 
 pub fn openai_profile_setup_kinds() -> &'static [OpenAiEndpointKind] {
     &OPENAI_PROFILE_SETUP_KINDS
+}
+
+fn terminal_multiplexer_label(
+    multiplexer: Option<&rara_terminal_detection::Multiplexer>,
+) -> String {
+    match multiplexer {
+        Some(rara_terminal_detection::Multiplexer::Tmux { version }) => version
+            .as_ref()
+            .filter(|value| !value.is_empty())
+            .map(|version| format!("tmux/{version}"))
+            .unwrap_or_else(|| "tmux".to_string()),
+        Some(rara_terminal_detection::Multiplexer::Zellij) => "zellij".to_string(),
+        None => "-".to_string(),
+    }
+}
+
+fn terminal_remote_label(remote: Option<&rara_terminal_detection::RemoteSession>) -> &'static str {
+    match remote {
+        Some(rara_terminal_detection::RemoteSession::Ssh) => "ssh",
+        None => "local",
+    }
 }
 
 use rara_persistence::redaction::redact_secrets;
@@ -351,6 +373,25 @@ impl TuiApp {
         let endpoint_kind = self.config.active_openai_profile_kind()?;
         crate::llm::infer_openai_compatible_auxiliary_model(main_model, endpoint_kind)
             .map(|model| model.into_owned())
+    }
+
+    pub fn terminal_diagnostics_view(&self) -> TerminalDiagnosticsView {
+        let info = rara_terminal_detection::terminal_info();
+        TerminalDiagnosticsView {
+            name: format!("{:?}", info.name),
+            user_agent: info.user_agent_token(),
+            term_program: info.term_program.clone(),
+            term: info.term.clone(),
+            multiplexer: terminal_multiplexer_label(info.multiplexer.as_ref()),
+            remote: terminal_remote_label(info.remote.as_ref()).to_string(),
+            history_mode: if info.is_zellij() {
+                "zellij-fallback-insert".to_string()
+            } else {
+                "scroll-region".to_string()
+            },
+            focused: self.terminal_focused,
+            width_columns: self.terminal_width,
+        }
     }
 
     pub fn repo_context_hint(&self) -> Option<String> {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -487,6 +487,25 @@ fn model_routing_view_falls_back_to_main_model_without_helper() {
 }
 
 #[test]
+fn terminal_diagnostics_view_uses_live_tui_dimensions() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+
+    app.terminal_width = 123;
+    app.terminal_focused = false;
+
+    let terminal = app.terminal_diagnostics_view();
+
+    assert_eq!(terminal.width_columns, 123);
+    assert!(!terminal.focused);
+    assert!(!terminal.user_agent.is_empty());
+    assert!(!terminal.history_mode.is_empty());
+}
+
+#[test]
 fn codex_preset_keeps_the_codex_model_label() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -155,6 +155,19 @@ pub struct ModelRoutingView {
     pub auxiliary_uses_main_model: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TerminalDiagnosticsView {
+    pub name: String,
+    pub user_agent: String,
+    pub term_program: Option<String>,
+    pub term: Option<String>,
+    pub multiplexer: String,
+    pub remote: String,
+    pub history_mode: String,
+    pub focused: bool,
+    pub width_columns: u16,
+}
+
 pub struct CommandSpec {
     pub category: &'static str,
     pub name: &'static str,

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -159,6 +159,39 @@ fn render_config_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
             Color::LightGreen
         },
     );
+
+    section_spacer(lines);
+    section_header(lines, "Terminal");
+    let terminal = app.terminal_diagnostics_view();
+    kv(lines, "name", &terminal.name, Color::LightBlue);
+    kv(lines, "user_agent", &terminal.user_agent, Color::DarkGray);
+    kv(
+        lines,
+        "term",
+        terminal.term.as_deref().unwrap_or("-"),
+        Color::DarkGray,
+    );
+    kv(
+        lines,
+        "term_program",
+        terminal.term_program.as_deref().unwrap_or("-"),
+        Color::DarkGray,
+    );
+    kv(lines, "multiplexer", &terminal.multiplexer, Color::DarkGray);
+    kv(lines, "remote", &terminal.remote, Color::DarkGray);
+    kv(lines, "history", &terminal.history_mode, Color::DarkGray);
+    kv(
+        lines,
+        "focused",
+        if terminal.focused { "true" } else { "false" },
+        Color::DarkGray,
+    );
+    kv(
+        lines,
+        "width",
+        &format!("{} columns", terminal.width_columns),
+        Color::DarkGray,
+    );
 }
 
 fn render_context_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {

--- a/src/tui/terminal_ui.rs
+++ b/src/tui/terminal_ui.rs
@@ -81,6 +81,10 @@ fn viewport_area(width: u16, height: u16, viewport_height: u16) -> Rect {
 }
 
 pub(crate) fn is_ssh_session() -> bool {
+    #[cfg(test)]
+    if let Some(is_ssh) = test_env::ssh_session_override() {
+        return is_ssh;
+    }
     rara_terminal_detection::is_remote_session()
 }
 
@@ -90,18 +94,28 @@ pub(crate) mod test_env {
     use std::sync::{LazyLock, Mutex, MutexGuard};
 
     static SSH_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    static SSH_SESSION_OVERRIDE: LazyLock<Mutex<Option<bool>>> = LazyLock::new(|| Mutex::new(None));
 
     pub(crate) struct SshEnvGuard {
         old_ssh_connection: Option<OsString>,
         old_ssh_tty: Option<OsString>,
+        old_override: Option<bool>,
         _lock: MutexGuard<'static, ()>,
     }
 
     impl SshEnvGuard {
         pub(crate) fn set(is_ssh: bool) -> SshEnvGuard {
-            let lock = SSH_ENV_LOCK.lock().unwrap();
+            let lock = SSH_ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
             let old_ssh_connection = std::env::var_os("SSH_CONNECTION");
             let old_ssh_tty = std::env::var_os("SSH_TTY");
+            let old_override = {
+                let mut override_guard = SSH_SESSION_OVERRIDE
+                    .lock()
+                    .unwrap_or_else(|poison| poison.into_inner());
+                override_guard.replace(is_ssh)
+            };
             if is_ssh {
                 unsafe {
                     std::env::set_var("SSH_CONNECTION", "1");
@@ -117,6 +131,7 @@ pub(crate) mod test_env {
             SshEnvGuard {
                 old_ssh_connection,
                 old_ssh_tty,
+                old_override,
                 _lock: lock,
             }
         }
@@ -124,6 +139,12 @@ pub(crate) mod test_env {
 
     impl Drop for SshEnvGuard {
         fn drop(&mut self) {
+            {
+                let mut override_guard = SSH_SESSION_OVERRIDE
+                    .lock()
+                    .unwrap_or_else(|poison| poison.into_inner());
+                *override_guard = self.old_override;
+            }
             if let Some(ref val) = self.old_ssh_connection {
                 unsafe {
                     std::env::set_var("SSH_CONNECTION", val);
@@ -148,6 +169,12 @@ pub(crate) mod test_env {
     /// Convenience wrapper; returns a guard that auto-restores env on drop.
     pub(crate) fn set_ssh_session(is_ssh: bool) -> SshEnvGuard {
         SshEnvGuard::set(is_ssh)
+    }
+
+    pub(crate) fn ssh_session_override() -> Option<bool> {
+        *SSH_SESSION_OVERRIDE
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Summary

- add a structured `TerminalDiagnosticsView` over terminal detection metadata
- show terminal metadata in `/status` config diagnostics and status runtime text
- update the terminal environment spec and TODO checkpoint

## Testing

- `cargo fmt --check`
- `git diff --check`

Local cargo test/check is currently blocked by low disk space after rebuilding heavy DataFusion/LanceDB dependencies; CI should run the full validation on a clean runner.
