### PR TITLE
chore: document terminal diagnostics contract

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -43,12 +43,17 @@ future appserver integrations can use.
 
 - `mcp-runtime.md`: source-aware MCP configuration, registry, status, refresh,
   reconnect, resource, and Tool Search contracts.
+- `support-acp-integration.md`: ACP client integration guidance boundary,
+  semantic input intents, output subscriptions, source registration, provenance,
+  and trust rules.
 - `bedrock-backend.md`: Bedrock SDK backend crate boundary and RARA adapter
   contract.
 - `file-search.md`: shared gitignore-aware file discovery and fuzzy path
   ranking crate for tools, TUI pickers, and context routing.
 - `retrieval-orchestration.md`: unified candidate-provider, ranking, dedupe,
   budget, and `/context` contract for memory/context retrieval.
+- `workspace-memory-cache.md`: prompt-source and workspace-memory cache
+  invalidation, ordering, and shared observability contract.
 - `thread-goals.md`: persistent `/goal` runtime, tool, continuation, budget,
   and compact TUI contracts aligned with Codex 0.129.
 

--- a/docs/features/support-acp-integration.md
+++ b/docs/features/support-acp-integration.md
@@ -1,0 +1,166 @@
+# Support ACP Integration
+
+## Problem
+
+RARA has an ACP surface and a `support-acp` skill, but the integration contract
+should not live only in the skill text. External IDEs, protocol clients, and
+future appserver adapters need a stable feature spec that explains what the
+skill is allowed to teach and which runtime-control contracts it depends on.
+
+Without that spec, the skill can drift into product-specific instructions while
+the runtime evolves independently.
+
+## Scope
+
+This spec covers the support material for third-party applications that connect
+to RARA through ACP or ACP-shaped adapters.
+
+In scope:
+
+- the purpose and boundary of the `support-acp` skill;
+- ACP startup and session lifecycle guidance;
+- semantic input intents for prompts, queued follow-ups, pending answers,
+  approvals, cancellation, and interruption;
+- output subscription and structured event expectations;
+- safe registration of prompt, skill, memory, MCP, and future hook sources;
+- control-plane provenance and trust expectations;
+- update rules that keep the skill aligned with runtime behavior.
+
+Out of scope:
+
+- replacing `docs/features/runtime-control-plane.md`;
+- defining the upstream ACP protocol;
+- promising that every future ACP client can bypass RARA's local approval,
+  sandbox, memory, or prompt-source policies;
+- documenting internal implementation details that are not visible to clients.
+
+## Architecture
+
+`support-acp` is a consumer-facing integration skill layered on top of RARA's
+runtime control plane.
+
+The layering is:
+
+1. `runtime-control-plane.md` defines RARA-owned request, event, provenance,
+   approval, source, and subscription contracts.
+2. ACP, Wire, TUI, CLI, and future appserver adapters translate their protocol
+   messages into those runtime-control contracts.
+3. `support-acp` explains the ACP-facing subset to external client authors.
+
+The skill is documentation, not an alternate runtime path. It must not describe
+direct prompt concatenation, direct LanceDB access, TUI key simulation, or
+adapter-specific state mutations as supported integration methods.
+
+## Contracts
+
+### Skill Placement
+
+The canonical skill entrypoint is:
+
+```text
+.agents/skills/support-acp/SKILL.md
+```
+
+The skill should stay in the repository skill tree so users and protocol client
+authors get the project-specific integration contract when they work inside
+RARA.
+
+### Semantic Input
+
+ACP clients should send semantic runtime intents instead of terminal events.
+
+Required intent mapping:
+
+| Client action | Runtime intent |
+| --- | --- |
+| submit a prompt | `InputControlRequest::SubmitUserPrompt` |
+| submit while a turn is busy | `InputControlRequest::SubmitFollowUp` |
+| answer a request-input prompt | `InputControlRequest::AnswerPendingInput` |
+| approve or deny a plan | `InputControlRequest::AnswerPlanApproval` |
+| approve or deny a shell command | `InputControlRequest::AnswerShellApproval` |
+| cancel the current turn | `SessionControlRequest::CancelCurrentTurn` |
+| request preemption | `SessionControlRequest::InterruptCurrentTurn` |
+
+Clients must not send raw keys such as `Esc` or rely on TUI overlay behavior.
+Queued follow-ups preserve input order. Cancellation and interruption are
+separate control requests and must not be implied by a follow-up.
+
+### Output Events
+
+ACP-facing output should be derived from structured runtime events, not parsed
+from TUI text.
+
+The support skill should document at least these event families:
+
+- assistant text;
+- reasoning or thinking;
+- tool lifecycle;
+- tool stdout, stderr, and system streams;
+- approvals;
+- request-input prompts;
+- plan and todo updates;
+- context and memory observability;
+- warnings, errors, cancellation, and completion.
+
+Plain text streaming is a presentation layer. The source of truth is the
+runtime-control event stream.
+
+### Source Registration
+
+External clients may contribute prompt-affecting material only through
+structured source objects.
+
+Supported source families:
+
+- prompt sources;
+- skill sources;
+- memory requests and memory records;
+- MCP resources, prompts, and tools;
+- hook declarations after the hook policy is enabled.
+
+Each source must carry provenance, source id, scope, lifetime, trust, authorship,
+and budget metadata where applicable. Sources that can affect the stable prompt
+prefix must be deterministic and ordered by runtime policy, not by client
+arrival race.
+
+### Trust And Approval
+
+ACP clients are untrusted unless the runtime explicitly marks a source or
+operation as trusted. Trust does not bypass:
+
+- sandbox policy;
+- shell approval policy;
+- memory mutation validation;
+- prompt-source provenance checks;
+- hook execution policy.
+
+If a client requests a privileged action, RARA should route it through the same
+approval and permission system used by the local TUI.
+
+## Validation Matrix
+
+- The support skill links back to runtime-control, prompt-source, memory, MCP,
+  and context specs rather than redefining incompatible contracts.
+- ACP client examples use semantic runtime intents, not TUI key events.
+- Output examples are event-based and do not require scraping rendered text.
+- Source registration examples include provenance and lifetime metadata.
+- Changes to runtime-control request or event shapes update the support skill
+  in the same PR.
+
+## Open Risks
+
+- ACP and Wire may expose different transport semantics. The skill should
+  describe RARA runtime intents first and only then show protocol-specific
+  mappings.
+- Some source families are scaffolds rather than complete runtime execution
+  paths. The skill should mark these clearly instead of implying support is
+  broader than the implementation.
+- Future appserver clients may need UI-control requests for overlays and
+  pickers. Those should remain separate from agent input intents.
+
+## Source Journals
+
+- [Runtime Control Plane](runtime-control-plane.md)
+- [MCP Runtime](mcp-runtime.md)
+- [Prompt Runtime](prompt-runtime.md)
+- [Memory Records](memory-records.md)

--- a/docs/features/terminal-environment.md
+++ b/docs/features/terminal-environment.md
@@ -82,9 +82,31 @@ The text status output uses the same view and names the fields with a
 `terminal_*` prefix. Future OTEL attributes should be derived from this view
 instead of reading environment variables again.
 
+The current diagnostic field set is:
+
+| Status text field | Source | Intended OTEL attribute |
+| --- | --- | --- |
+| `terminal_name` | `TerminalInfo::name` | `terminal.name` |
+| `terminal_user_agent` | `TerminalInfo::user_agent_token()` | `terminal.user_agent` |
+| `terminal_term` | `TerminalInfo::term` | `terminal.term` |
+| `terminal_term_program` | `TerminalInfo::term_program` | `terminal.term_program` |
+| `terminal_multiplexer` | `TerminalInfo::multiplexer` | `terminal.multiplexer` |
+| `terminal_remote` | `TerminalInfo::remote` | `terminal.remote` |
+| `terminal_history_mode` | TUI compatibility policy | `terminal.history_mode` |
+| `terminal_focused` | live TUI state | `terminal.focused` |
+| `terminal_width_columns` | live TUI state | `terminal.width_columns` |
+
+## Test Overrides
+
+Production terminal detection reads process environment once through
+`rara_terminal_detection::terminal_info()`. Tests that need SSH/local branches
+use a test-only guard under `tui::terminal_ui::test_env`. The guard sets a
+temporary SSH classification override before mutating `SSH_CONNECTION` and
+restores both on drop. This keeps parallel tests deterministic even though
+`TerminalInfo` itself is cached for production.
+
 ## Follow-Up
 
-- Add OTEL attributes from the same `TerminalInfo` shape.
 - Decide whether tmux client probing should be lazy, disabled by default, or
   never added.
 

--- a/docs/features/workspace-memory-cache.md
+++ b/docs/features/workspace-memory-cache.md
@@ -1,0 +1,166 @@
+# Workspace Memory Cache
+
+## Problem
+
+Workspace memory and prompt instruction files are stable context sources, but
+their discovery and cache behavior need a clear contract. Without one, prompt
+assembly, `/status`, `/context`, and future ACP/Wire clients can disagree about
+which files are active after cwd changes, branch changes, nested workspace
+changes, or environment updates.
+
+This is especially sensitive for provider prefix caches: workspace memory sits
+near the stable prompt prefix, so nondeterministic invalidation can turn small
+workspace changes into avoidable cache misses.
+
+## Scope
+
+This spec defines cache invalidation rules for workspace memory-like prompt
+sources.
+
+In scope:
+
+- user and project instruction files;
+- local memory files discovered as prompt sources;
+- environment-derived prompt-source metadata;
+- cwd, repository, branch, and nested workspace changes;
+- shared reporting for prompt runtime, `/status`, `/context`, and future
+  protocol subscribers.
+
+Out of scope:
+
+- retrieval ranking for volatile memory candidates;
+- LanceDB memory record storage;
+- session-shard search;
+- compaction summaries;
+- provider cache-edit APIs.
+
+## Architecture
+
+Workspace memory cache belongs to prompt-source discovery. It is upstream of
+retrieval orchestration and `MemorySelection`.
+
+The layering is:
+
+1. resolve workspace identity;
+2. discover prompt sources and local memory files in deterministic order;
+3. cache discovery results with an invalidation key;
+4. expose the resulting source manifest to prompt assembly, `/status`,
+   `/context`, and protocol output;
+5. let retrieval orchestration consume the manifest only as an input, not as a
+   separate discovery path.
+
+Stable prompt prefix order must remain:
+
+1. system prompt;
+2. tool schemas;
+3. stable skills and project memory;
+4. compacted history and carry-over;
+5. retrieval and volatile recent context;
+6. latest user input.
+
+Workspace memory cache invalidation must not reorder earlier prompt layers.
+
+## Contracts
+
+### Cache Key
+
+The workspace memory cache key should include:
+
+- resolved workspace root;
+- current cwd when it changes the instruction-file search path;
+- repository identity when available;
+- git branch or detached-head commit identity when available;
+- prompt-source file paths;
+- file metadata needed to detect content changes;
+- relevant environment-derived context fields that affect prompt sources.
+
+The cache key should not include volatile turn data such as latest user input,
+tool results, retrieval query text, pending approvals, or model output.
+
+### Invalidation Rules
+
+Invalidate cached workspace prompt-source discovery when any of these change:
+
+- cwd crosses into a different workspace root;
+- cwd moves into or out of a nested instruction scope;
+- git repository root changes;
+- git branch or detached-head identity changes;
+- a discovered prompt-source file is created, removed, renamed, or modified;
+- a parent directory that can contain prompt-source files changes;
+- the configured RARA home or workspace data directory changes;
+- environment metadata used by prompt-source rendering changes.
+
+Do not invalidate workspace memory cache for:
+
+- latest user message changes;
+- tool output changes;
+- retrieved-memory ranking changes;
+- compaction events;
+- model usage counters;
+- transient TUI focus or terminal width changes.
+
+Those belong to volatile context, compaction, status, or display views.
+
+### Ordering
+
+Cache rebuilds must produce deterministic ordering:
+
+1. user-level sources;
+2. repository-root sources;
+3. nested workspace sources from root toward cwd;
+4. protocol-registered stable sources ordered by runtime source policy;
+5. local memory sources in stable path order.
+
+Hash maps must not determine externally visible ordering.
+
+### Observability
+
+The runtime should expose a workspace source manifest with:
+
+- source id;
+- source kind;
+- display path or label;
+- scope;
+- provenance;
+- cache key fragment or version;
+- inclusion reason;
+- dropped or unavailable reason where applicable.
+
+`/status`, `/context`, and ACP/Wire subscribers should read the same manifest.
+They should not re-run independent discovery logic.
+
+### Relationship To MemorySelection
+
+Workspace memory cache answers "which stable workspace sources exist and are
+active." `MemorySelection` answers "which memory-like items are selected,
+available, or dropped for this turn."
+
+Stable workspace memory can appear in `MemorySelection` as a fixed selected
+item for explainability, but it must not compete with volatile retrieval
+candidates for discretionary retrieval budget.
+
+## Validation Matrix
+
+- cwd changes that do not cross instruction scope do not reorder stable sources.
+- cwd changes into a nested instruction scope add only the nested suffix.
+- git branch changes invalidate prompt-source discovery.
+- prompt-source file create/remove/modify invalidates discovery.
+- latest user input and tool output do not invalidate workspace memory cache.
+- `/status` and `/context` report the same prompt-source manifest.
+- tests assert deterministic ordering independent of hash-map iteration.
+
+## Open Risks
+
+- File watching may be platform-specific. The first implementation can use
+  explicit rebuild triggers and metadata checks before adding watchers.
+- Git branch detection can be expensive if done on every render path. Cache
+  invalidation should happen during runtime refresh, not TUI drawing.
+- Protocol-registered stable sources need clear lifetimes so they do not create
+  prefix churn across turns.
+
+## Source Journals
+
+- [Prompt Runtime](prompt-runtime.md)
+- [Context Architecture](context-architecture.md)
+- [Memory Selection](memory-selection.md)
+- [Retrieval Orchestration](retrieval-orchestration.md)

--- a/docs/journal/2026-05-09-spec-backlog-normalization.md
+++ b/docs/journal/2026-05-09-spec-backlog-normalization.md
@@ -1,0 +1,31 @@
+# 2026-05-09 Spec Backlog Normalization
+
+## Summary
+
+Captured two backlog items that had implementation or planning material but no
+stable feature-spec home:
+
+- `support-acp` integration guidance for third-party ACP clients;
+- `WorkspaceMemory` cache invalidation rules for prompt-source discovery.
+
+## Decisions
+
+- Keep `support-acp` as a repository skill for client authors, but define its
+  stable contract in `docs/features/support-acp-integration.md`.
+- Treat workspace memory cache invalidation as part of prompt-source discovery,
+  not retrieval ranking or `MemorySelection`.
+- Keep stable workspace memory near the stable prompt prefix while retrieval
+  candidates remain in the volatile suffix.
+
+## Validation
+
+- Documentation-only change.
+- `cargo fmt --check`
+- `git diff --check`
+
+## Follow-Up
+
+- Add focused prompt-source discovery tests for cwd, branch, and nested
+  workspace invalidation.
+- Move appserver/ACP/Wire input handling to the shared runtime input-control
+  bridge.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -33,7 +33,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add protocol-safe memory mutation/query scaffolding that creates memory records and selection views without bypassing `MemorySelection` (scaffold via protocol_sources.rs).
 - [x] Add hook declaration scaffolding for protocol and repo extensions; keep execution disabled until permission and sandbox policy are explicit.
 - [ ] Ensure every new skill, memory, prompt, hook, planning, approval, and output feature is control-plane-ready rather than TUI-only.
-- [ ] Add a `support-acp` integration skill for IDE and third-party app authors, covering ACP startup, runtime-control input intents, output event subscription, cancellation/preemption, approvals, MCP/tool-search expectations, and safe context-source registration.
+- [x] Add a `support-acp` integration skill for IDE and third-party app authors, covering ACP startup, runtime-control input intents, output event subscription, cancellation/preemption, approvals, MCP/tool-search expectations, and safe context-source registration (see `docs/features/support-acp-integration.md`).
 
 ## Configuration / Provider Surface
 
@@ -48,7 +48,7 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Add session-style incremental file search for TUI file pickers and context file routing on top of `crates/file-search`.
 - [ ] Tests for workspace prompt-source discovery and cache invalidation (cwd changes, git branches, nested workspaces).
-- [ ] Define `WorkspaceMemory` cache invalidation rules for prompt files and environment info.
+- [x] Define `WorkspaceMemory` cache invalidation rules for prompt files and environment info (see `docs/features/workspace-memory-cache.md`).
 - [ ] Unify `discover_prompt_sources()` and TUI `/status` source reporting.
 - [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.


### PR DESCRIPTION
## Summary

- document terminal diagnostics field-to-OTEL mapping
- document the test-only SSH override contract for cached terminal detection

## Testing

- `cargo fmt --check`
- `git diff --check`
