### PR TITLE
chore: clarify retrieval provider backlog

### DIFF
--- a/docs/features/retrieval-orchestration.md
+++ b/docs/features/retrieval-orchestration.md
@@ -340,9 +340,10 @@ The display should keep details compact and path/URI-like fields visible.
 - Add durable source ids and dedupe keys for future providers.
 - Add tests for duplicate memory/file/session candidates.
 
-### Phase 5: Graph/MCP/Hook Sources
+### Phase 5: Graph/Hook Sources
 
-- Status: partially implemented for MCP resource references.
+- Status: MCP resource references are implemented; hook and graph candidates
+  remain pending.
 - MCP resource references now normalize into the shared `RetrievalCandidate`
   boundary and appear in `/context` provider/candidate views.
 - Resource body loading and excerpt selection remain out of scope for this

--- a/docs/journal/2026-05-09-retrieval-provider-scope-audit.md
+++ b/docs/journal/2026-05-09-retrieval-provider-scope-audit.md
@@ -1,0 +1,28 @@
+# 2026-05-09 Retrieval Provider Scope Audit
+
+## Summary
+
+Audited the remaining retrieval-provider TODO after MCP resource references were
+implemented.
+
+## Evidence
+
+- `src/context/retrieval_provider.rs` has `PrecomputedMcpResourceProvider`.
+- `mcp_resource_candidate(...)` normalizes MCP resource references into
+  `RetrievalCandidate`.
+- `provider_boundary_collects_current_sources_in_stable_order` asserts MCP
+  resource candidates are collected after file-search candidates and remain
+  non-selectable until a resource body loader exists.
+- `src/context/retrieval_view.rs` exposes MCP resource references in the
+  provider view used by `/context`.
+
+## Decision
+
+MCP resource references should no longer be tracked as missing from the
+retrieval-provider boundary. The remaining work is hook output candidates and
+graph candidates, both of which need source-specific runtime producers before
+they can become selectable retrieval inputs.
+
+## Validation
+
+- `rg -n "PrecomputedMcpResourceProvider|mcp_resource_candidate|provider_boundary_collects_current_sources_in_stable_order" src/context`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -109,7 +109,7 @@ Active backlog only. Keep this file small and current.
 - [x] Thread-scoped and workspace-scoped `MemoryRecord` storage with promotion rules.
 - [x] Initial retrieval orchestration layer from `docs/features/retrieval-orchestration.md`: typed candidates, orchestration view, richer `/context`, deterministic dedupe, and ACP/Wire event exposure.
 - [x] Add the first `RetrievalSourceProvider` boundary for current memory, session, thread-history, vector-slot, tool-result, and file-search candidates.
-- [ ] Add `RetrievalSourceProvider` implementations for MCP resource, hook, and graph sources after the current memory/session/file path is stable.
+- [ ] Add `RetrievalSourceProvider` implementations for hook output and graph sources after the current memory/session/file/MCP path is stable.
 - [x] Initialize LanceDB and wire FTS/vector/hybrid search paths behind the existing memory index façade.
 - [x] Make memory mutation/query control-plane-ready so ACP/Wire can inspect and add memory without directly editing prompt text.
 


### PR DESCRIPTION
## Summary

- clarify that MCP resource references already use the retrieval provider boundary
- narrow the remaining retrieval provider TODO to hook output and graph candidates
- add a journal audit with the code evidence for the MCP provider path

## Testing

- `cargo fmt --check`
- `git diff --check`
