### PR TITLE
feat: retain protocol prompt provenance

### DIFF
--- a/docs/journal/2026-05-09-protocol-prompt-source-provenance.md
+++ b/docs/journal/2026-05-09-protocol-prompt-source-provenance.md
@@ -1,0 +1,29 @@
+# 2026-05-09 Protocol Prompt Source Provenance
+
+## Summary
+
+Closed the first control-plane gap for protocol-registered prompt sources:
+registrations now retain the `RuntimeControlEnvelope` provenance instead of
+storing only the prompt-source payload.
+
+## Changes
+
+- Added `PromptSourceRegistry::handle_control_with_provenance`.
+- Added `ProtocolPromptSourceSnapshot` so future prompt-runtime integration can
+  consume registration, lifetime, and provenance from one stable object.
+- Updated `control_plane::dispatch` to pass envelope provenance into prompt
+  source registration.
+- Added a focused regression test for provenance retention.
+
+## Remaining Work
+
+Protocol prompt sources still need to be converted into prompt-runtime
+`PromptSource` entries and surfaced through `/context` as active or available
+prompt inputs. This follow-up should consume the snapshot object added here
+instead of re-reading protocol registry internals.
+
+## Validation
+
+- `cargo test protocol_sources::tests::prompt_source_registry_preserves_control_plane_provenance`
+- `cargo fmt --check`
+- `git diff --check`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -50,7 +50,7 @@ Active backlog only. Keep this file small and current.
 - [x] Tests for workspace prompt-source discovery and cache invalidation (cwd changes, git branches, nested workspaces).
 - [x] Define `WorkspaceMemory` cache invalidation rules for prompt files and environment info (see `docs/features/workspace-memory-cache.md`).
 - [x] Unify `discover_prompt_sources()` and TUI `/status` source reporting.
-- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text.
+- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Prompt-source provenance is now retained in `PromptSourceRegistry`; next slice should feed protocol prompt-source snapshots into prompt runtime and `/context`.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.
 - [ ] Claude-style `verify` skill and `verifier-*` convention (see `docs/features/verify-skill.md`).
 - [ ] Evolve `SkillTool` to Codex/Claude contract (see `docs/features/skill-tool.md`): frontmatter, scopes, override visibility.

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -37,7 +37,9 @@ where
             Ok(())
         }
         RuntimeControlRequest::PromptSource(prompt_request) => {
-            prompt_registry.handle_control(prompt_request).await;
+            prompt_registry
+                .handle_control_with_provenance(prompt_request, envelope.provenance.clone())
+                .await;
             Ok(())
         }
         RuntimeControlRequest::SkillSource(skill_request) => {

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -29,7 +29,7 @@ use crate::runtime_control::{
     MemoryControlRequest, MemoryEvent, MemoryLabelSummary, MemoryRecordControlPatch,
     MemoryRecordSummary, MemoryScope as ControlMemoryScope, PromptSourceControlRequest,
     PromptSourceEvent, PromptSourceLifetime, PromptSourceRegistration, RuntimeEvent,
-    SkillSourceControlRequest,
+    RuntimeProvenance, SkillSourceControlRequest,
 };
 use crate::runtime_event_bus::RuntimeEventBus;
 
@@ -39,8 +39,16 @@ use crate::runtime_event_bus::RuntimeEventBus;
 #[derive(Clone, Debug)]
 struct PromptSourceEntry {
     registration: PromptSourceRegistration,
+    provenance: RuntimeProvenance,
     /// Remaining turn count (only meaningful for `Turns` lifetime).
     remaining_turns: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProtocolPromptSourceSnapshot {
+    pub registration: PromptSourceRegistration,
+    pub provenance: RuntimeProvenance,
+    pub remaining_turns: Option<u32>,
 }
 
 /// Registry for protocol-registered prompt sources.
@@ -58,6 +66,15 @@ impl PromptSourceRegistry {
     }
 
     pub async fn handle_control(&self, request: &PromptSourceControlRequest) {
+        self.handle_control_with_provenance(request, RuntimeProvenance::runtime(None))
+            .await;
+    }
+
+    pub async fn handle_control_with_provenance(
+        &self,
+        request: &PromptSourceControlRequest,
+        provenance: RuntimeProvenance,
+    ) {
         match request {
             PromptSourceControlRequest::Register(registration) => {
                 let mut sources = self.sources.write().await;
@@ -69,6 +86,7 @@ impl PromptSourceRegistry {
                     registration.source_id.clone(),
                     PromptSourceEntry {
                         registration: registration.clone(),
+                        provenance,
                         remaining_turns: turns,
                     },
                 );
@@ -132,6 +150,19 @@ impl PromptSourceRegistry {
             .await
             .values()
             .map(|e| e.registration.clone())
+            .collect()
+    }
+
+    pub async fn list_source_snapshots(&self) -> Vec<ProtocolPromptSourceSnapshot> {
+        self.sources
+            .read()
+            .await
+            .values()
+            .map(|entry| ProtocolPromptSourceSnapshot {
+                registration: entry.registration.clone(),
+                provenance: entry.provenance.clone(),
+                remaining_turns: entry.remaining_turns,
+            })
             .collect()
     }
 }
@@ -524,6 +555,38 @@ mod tests {
             )),
             root.join("memories").join("records.json"),
         ))
+    }
+
+    #[tokio::test]
+    async fn prompt_source_registry_preserves_control_plane_provenance() {
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let registry = PromptSourceRegistry::new(bus);
+        let provenance = RuntimeProvenance::protocol(
+            crate::runtime_control::RuntimeControllerKind::Acp,
+            "acp",
+            Some("session-1".to_string()),
+            Some("protocol-source-1".to_string()),
+        );
+
+        registry
+            .handle_control_with_provenance(
+                &PromptSourceControlRequest::Register(PromptSourceRegistration {
+                    source_id: "protocol-source-1".to_string(),
+                    scope: crate::runtime_control::SourceScope::Protocol,
+                    layer: crate::runtime_control::SourceLayer::User,
+                    budget_hint_tokens: Some(128),
+                    lifetime: PromptSourceLifetime::Turns(2),
+                    content: "Protocol context should keep provenance.".to_string(),
+                }),
+                provenance.clone(),
+            )
+            .await;
+
+        let snapshots = registry.list_source_snapshots().await;
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].registration.source_id, "protocol-source-1");
+        assert_eq!(snapshots[0].provenance, provenance);
+        assert_eq!(snapshots[0].remaining_turns, Some(2));
     }
 
     #[tokio::test]

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -44,11 +44,26 @@ struct PromptSourceEntry {
     remaining_turns: Option<u32>,
 }
 
+/// Stable snapshot of a protocol-registered prompt source.
+///
+/// Unlike `list_sources`, this keeps the control-plane provenance and the
+/// current turn-lifetime state that prompt runtime and `/context` integration
+/// need for explainable source injection.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProtocolPromptSourceSnapshot {
     pub registration: PromptSourceRegistration,
     pub provenance: RuntimeProvenance,
     pub remaining_turns: Option<u32>,
+}
+
+impl From<&PromptSourceEntry> for ProtocolPromptSourceSnapshot {
+    fn from(entry: &PromptSourceEntry) -> Self {
+        Self {
+            registration: entry.registration.clone(),
+            provenance: entry.provenance.clone(),
+            remaining_turns: entry.remaining_turns,
+        }
+    }
 }
 
 /// Registry for protocol-registered prompt sources.
@@ -70,6 +85,8 @@ impl PromptSourceRegistry {
             .await;
     }
 
+    /// Handle a prompt source control request while explicitly recording the
+    /// provenance of the runtime-control envelope that carried it.
     pub async fn handle_control_with_provenance(
         &self,
         request: &PromptSourceControlRequest,
@@ -153,16 +170,13 @@ impl PromptSourceRegistry {
             .collect()
     }
 
+    /// Return all registered sources with provenance and remaining lifetime.
     pub async fn list_source_snapshots(&self) -> Vec<ProtocolPromptSourceSnapshot> {
         self.sources
             .read()
             .await
             .values()
-            .map(|entry| ProtocolPromptSourceSnapshot {
-                registration: entry.registration.clone(),
-                provenance: entry.provenance.clone(),
-                remaining_turns: entry.remaining_turns,
-            })
+            .map(ProtocolPromptSourceSnapshot::from)
             .collect()
     }
 }


### PR DESCRIPTION
## Summary

- preserve `RuntimeControlEnvelope` provenance when protocol prompt sources are registered
- add `ProtocolPromptSourceSnapshot` as the stable bridge for later prompt-runtime and `/context` integration
- document the remaining prompt-source injection follow-up in TODO and journal

## Testing

- `cargo fmt --check`
- `git diff --check`
- `cargo test protocol_sources::tests::prompt_source_registry_preserves_control_plane_provenance` attempted locally, but the machine ran out of disk while rebuilding dependencies after `cargo clean`; CI should validate on a clean runner
