### PR TITLE
feat: add protocol prompt runtime sources

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -34,6 +34,7 @@ pub enum PromptSourceKind {
     UserInstruction,
     ProjectInstruction,
     LocalMemory,
+    ProtocolPromptSource,
     CustomSystemPrompt,
     AppendSystemPrompt,
     CompactPrompt,
@@ -53,6 +54,7 @@ impl PromptSource {
             PromptSourceKind::UserInstruction => "user_instruction",
             PromptSourceKind::ProjectInstruction => "project_instruction",
             PromptSourceKind::LocalMemory => "local_memory",
+            PromptSourceKind::ProtocolPromptSource => "protocol_prompt_source",
             PromptSourceKind::CustomSystemPrompt => "custom_system_prompt",
             PromptSourceKind::AppendSystemPrompt => "append_system_prompt",
             PromptSourceKind::CompactPrompt => "compact_prompt",
@@ -68,6 +70,9 @@ impl PromptSource {
                 format!("project instruction: {}", self.display_path)
             }
             PromptSourceKind::LocalMemory => format!("local memory: {}", self.display_path),
+            PromptSourceKind::ProtocolPromptSource => {
+                format!("protocol prompt source: {}", self.display_path)
+            }
             PromptSourceKind::CustomSystemPrompt => {
                 format!("custom system prompt: {}", self.display_path)
             }
@@ -88,6 +93,9 @@ impl PromptSource {
             }
             PromptSourceKind::LocalMemory => {
                 "included as durable workspace memory from the local RARA memory file"
+            }
+            PromptSourceKind::ProtocolPromptSource => {
+                "included as a structured protocol-registered prompt source with runtime-control provenance"
             }
             PromptSourceKind::CustomSystemPrompt => "included as the configured base system prompt",
             PromptSourceKind::AppendSystemPrompt => {
@@ -157,6 +165,7 @@ pub struct PromptRuntimeConfig {
     pub system_prompt: Option<String>,
     pub append_system_prompt: Option<String>,
     pub compact_prompt: Option<String>,
+    pub protocol_prompt_sources: Vec<PromptSource>,
     pub available_skills: Vec<PromptSkillSummary>,
     pub warnings: Vec<String>,
 }
@@ -184,6 +193,7 @@ impl PromptRuntimeConfig {
             system_prompt,
             append_system_prompt,
             compact_prompt,
+            protocol_prompt_sources: Vec::new(),
             available_skills: Vec::new(),
             warnings,
         }
@@ -199,6 +209,7 @@ impl PromptRuntimeConfig {
                 content: content.clone(),
             });
         }
+        sources.extend(self.protocol_prompt_sources.iter().cloned());
         if let Some(content) = &self.append_system_prompt {
             sources.push(PromptSource {
                 kind: PromptSourceKind::AppendSystemPrompt,
@@ -675,11 +686,13 @@ fn dynamic_system_prompt_sections(
         .iter()
         .find(|source| matches!(source.kind, PromptSourceKind::LocalMemory))
         .map(|memory| format!("## {}\n{}", memory.label, memory.content));
+    let protocol_prompt_sources_block = render_protocol_prompt_sources_section(sources);
     let skills_block = render_available_skills_section(available_skills);
 
     vec![
         PromptSection::optional("instructions", instruction_block),
         PromptSection::optional("memory", memory_block),
+        PromptSection::optional("protocol_prompt_sources", protocol_prompt_sources_block),
         PromptSection::optional("skills", skills_block),
         PromptSection::new("runtime_context", render_environment_context(&cwd, &branch)),
         PromptSection::optional(
@@ -691,6 +704,27 @@ fn dynamic_system_prompt_sections(
             matches!(mode, PromptMode::Review).then(review_mode_prompt),
         ),
     ]
+}
+
+fn render_protocol_prompt_sources_section(sources: &[PromptSource]) -> Option<String> {
+    let sections = sources
+        .iter()
+        .filter(|source| matches!(source.kind, PromptSourceKind::ProtocolPromptSource))
+        .map(|source| {
+            format!(
+                "### {}\nSource: {}\n\n{}",
+                source.label, source.display_path, source.content
+            )
+        })
+        .collect::<Vec<_>>();
+    if sections.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "## Protocol Prompt Sources\n\n{}",
+            sections.join("\n\n")
+        ))
+    }
 }
 
 fn render_environment_context(cwd: &str, branch: &str) -> String {
@@ -885,7 +919,7 @@ mod tests {
     use std::fs;
 
     use super::{
-        PromptMode, PromptRuntimeConfig, PromptSkillSummary, PromptSourceKind,
+        PromptMode, PromptRuntimeConfig, PromptSkillSummary, PromptSource, PromptSourceKind,
         build_compact_instruction, build_effective_prompt, build_system_prompt,
         discover_prompt_sources, render_skill_listing,
     };
@@ -934,6 +968,41 @@ mod tests {
             sources
                 .iter()
                 .any(|source| matches!(source.kind, PromptSourceKind::AppendSystemPrompt))
+        );
+    }
+
+    #[test]
+    fn build_effective_prompt_includes_protocol_prompt_sources() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = root.join(".rara");
+        fs::create_dir_all(&rara_dir).expect("mkdir .rara");
+        let workspace = WorkspaceMemory::from_paths(root, rara_dir);
+        let runtime = PromptRuntimeConfig {
+            protocol_prompt_sources: vec![PromptSource {
+                kind: PromptSourceKind::ProtocolPromptSource,
+                label: "Protocol Prompt Source acp-note".to_string(),
+                display_path: "protocol:acp:test:acp-note".to_string(),
+                content: "Use the active editor selection as extra context.".to_string(),
+            }],
+            ..Default::default()
+        };
+
+        let effective = build_effective_prompt(&workspace, &runtime, PromptMode::Execute);
+
+        assert!(effective.section_keys.contains(&"protocol_prompt_sources"));
+        assert!(effective.text.contains("## Protocol Prompt Sources"));
+        assert!(effective.text.contains("Protocol Prompt Source acp-note"));
+        assert!(
+            effective
+                .text
+                .contains("Use the active editor selection as extra context.")
+        );
+        assert!(
+            effective
+                .sources
+                .iter()
+                .any(|source| matches!(source.kind, PromptSourceKind::ProtocolPromptSource))
         );
     }
 

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -191,6 +191,15 @@ workspace instructions and documentation, not in the default runtime system prom
   prompt or rename top-level prompt sections.
 - `/context`, `/status`, and protocol output subscribers must be able to inspect
   the same prompt source objects.
+- `ProtocolPromptSourceSnapshot` is the registry-to-runtime bridge. It converts
+  into a `PromptSourceKind::ProtocolPromptSource` entry before prompt assembly,
+  preserving the source id in the label, protocol provenance in the display
+  path, and adapter-provided content as the source body.
+- Protocol prompt sources are rendered in a dedicated dynamic
+  `protocol_prompt_sources` section. This keeps workspace instructions,
+  workspace memory, skills, runtime environment, and append prompts in their
+  existing relative order while still making protocol input visible in the
+  effective prompt and prompt-source context view.
 
 ### 4) Agent Loop Integration
 

--- a/docs/journal/2026-05-09-protocol-prompt-runtime-sources.md
+++ b/docs/journal/2026-05-09-protocol-prompt-runtime-sources.md
@@ -1,0 +1,28 @@
+# Protocol Prompt Runtime Sources
+
+## Context
+
+Protocol prompt-source registration already retained runtime-control
+provenance in `PromptSourceRegistry`, but the prompt runtime still had no
+typed source variant for adapter-provided prompt material.
+
+## Changes
+
+- Added `PromptSourceKind::ProtocolPromptSource`.
+- Added `PromptRuntimeConfig::protocol_prompt_sources` as the structured
+  runtime input slot for protocol-managed prompt material.
+- Render protocol prompt sources in a dedicated dynamic
+  `protocol_prompt_sources` section so the existing workspace instruction,
+  workspace memory, skills, runtime environment, and append-prompt ordering
+  stays stable.
+- Added `ProtocolPromptSourceSnapshot::to_prompt_source()` and
+  `PromptSourceRegistry::list_prompt_sources()` to bridge registry snapshots
+  into prompt-runtime source objects without exposing registry internals.
+- Added focused tests for prompt rendering and registry-to-runtime conversion.
+
+## Remaining Work
+
+- Wire live `PromptSourceRegistry` snapshots into agent request assembly so
+  ACP/Wire/appserver prompt-source registrations automatically populate
+  `PromptRuntimeConfig::protocol_prompt_sources`.
+- Add lifecycle events around snapshot injection once the live bridge exists.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -50,7 +50,7 @@ Active backlog only. Keep this file small and current.
 - [x] Tests for workspace prompt-source discovery and cache invalidation (cwd changes, git branches, nested workspaces).
 - [x] Define `WorkspaceMemory` cache invalidation rules for prompt files and environment info (see `docs/features/workspace-memory-cache.md`).
 - [x] Unify `discover_prompt_sources()` and TUI `/status` source reporting.
-- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Prompt-source provenance is now retained in `PromptSourceRegistry`; next slice should feed protocol prompt-source snapshots into prompt runtime and `/context`.
+- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Prompt-source provenance is now retained in `PromptSourceRegistry`, and snapshots can now convert into prompt-runtime sources visible through `EffectivePrompt` and `/context`; next slice should wire live registry snapshots into agent/runtime config during request assembly.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.
 - [ ] Claude-style `verify` skill and `verifier-*` convention (see `docs/features/verify-skill.md`).
 - [ ] Evolve `SkillTool` to Codex/Claude contract (see `docs/features/skill-tool.md`): frontmatter, scopes, override visibility.

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -25,6 +25,7 @@ use crate::memory_store::{
     MemoryLabel, MemoryLabelCount, MemoryPromotionTarget, MemoryRecord, MemoryRecordPatch,
     MemoryScope as StoreMemoryScope, MemorySource, MemoryStore, NewMemoryRecord,
 };
+use crate::prompt::{PromptSource, PromptSourceKind};
 use crate::runtime_control::{
     MemoryControlRequest, MemoryEvent, MemoryLabelSummary, MemoryRecordControlPatch,
     MemoryRecordSummary, MemoryScope as ControlMemoryScope, PromptSourceControlRequest,
@@ -62,6 +63,30 @@ impl From<&PromptSourceEntry> for ProtocolPromptSourceSnapshot {
             registration: entry.registration.clone(),
             provenance: entry.provenance.clone(),
             remaining_turns: entry.remaining_turns,
+        }
+    }
+}
+
+impl ProtocolPromptSourceSnapshot {
+    pub fn to_prompt_source(&self) -> PromptSource {
+        PromptSource {
+            kind: PromptSourceKind::ProtocolPromptSource,
+            label: format!("Protocol Prompt Source {}", self.registration.source_id),
+            display_path: self.display_path(),
+            content: self.registration.content.clone(),
+        }
+    }
+
+    fn display_path(&self) -> String {
+        let controller = format!("{:?}", self.provenance.controller).to_lowercase();
+        match self.provenance.adapter.as_deref() {
+            Some(adapter) if !adapter.trim().is_empty() => {
+                format!(
+                    "protocol:{controller}:{adapter}:{}",
+                    self.registration.source_id
+                )
+            }
+            _ => format!("protocol:{controller}:{}", self.registration.source_id),
         }
     }
 }
@@ -177,6 +202,15 @@ impl PromptSourceRegistry {
             .await
             .values()
             .map(ProtocolPromptSourceSnapshot::from)
+            .collect()
+    }
+
+    /// Return active protocol sources in the prompt-runtime source format.
+    pub async fn list_prompt_sources(&self) -> Vec<PromptSource> {
+        self.list_source_snapshots()
+            .await
+            .iter()
+            .map(ProtocolPromptSourceSnapshot::to_prompt_source)
             .collect()
     }
 }
@@ -601,6 +635,25 @@ mod tests {
         assert_eq!(snapshots[0].registration.source_id, "protocol-source-1");
         assert_eq!(snapshots[0].provenance, provenance);
         assert_eq!(snapshots[0].remaining_turns, Some(2));
+
+        let prompt_sources = registry.list_prompt_sources().await;
+        assert_eq!(prompt_sources.len(), 1);
+        assert_eq!(
+            prompt_sources[0].kind,
+            PromptSourceKind::ProtocolPromptSource
+        );
+        assert_eq!(
+            prompt_sources[0].label,
+            "Protocol Prompt Source protocol-source-1"
+        );
+        assert_eq!(
+            prompt_sources[0].display_path,
+            "protocol:acp:acp:protocol-source-1"
+        );
+        assert_eq!(
+            prompt_sources[0].content,
+            "Protocol context should keep provenance."
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add `ProtocolPromptSource` as a first-class prompt-runtime source kind
- add `PromptRuntimeConfig::protocol_prompt_sources` and render them in a dedicated dynamic prompt section
- bridge `ProtocolPromptSourceSnapshot` into `PromptSource` for future live registry injection
- document the prompt-runtime contract and remaining live assembly wiring

## Why

Protocol prompt-source registration already preserved runtime-control provenance, but the prompt runtime had no typed source slot for adapter-provided prompt material. This keeps protocol prompt input as structured source objects instead of ad hoc text concatenation, and makes those sources visible through `EffectivePrompt` and `/context` source views.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo metadata --locked --no-deps`
- `cargo test -p rara-instructions build_effective_prompt_includes_protocol_prompt_sources`

Local root-crate focused tests were attempted, but the machine ran out of disk while compiling dependencies under `target/debug`; CI should validate the root-crate registry test.
