### PR TITLE
feat: refresh live protocol prompt sources

### DIFF
--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -200,6 +200,13 @@ workspace instructions and documentation, not in the default runtime system prom
   workspace memory, skills, runtime environment, and append prompts in their
   existing relative order while still making protocol input visible in the
   effective prompt and prompt-source context view.
+- Runtime bootstrap owns the live `PromptSourceRegistry` and attaches it to the
+  agent. At the start of each user query, the agent atomically snapshots
+  turn-active registry entries into `PromptRuntimeConfig::protocol_prompt_sources`
+  and advances turn-limited lifetimes under the same registry lock. The
+  snapshotted sources remain active for every model request inside that query's
+  agent loop. This keeps live protocol input on the normal prompt-runtime path
+  instead of letting adapters edit final prompt text.
 
 ### 4) Agent Loop Integration
 

--- a/docs/journal/2026-05-09-live-protocol-prompt-sources.md
+++ b/docs/journal/2026-05-09-live-protocol-prompt-sources.md
@@ -1,0 +1,29 @@
+# Live Protocol Prompt Sources
+
+## Context
+
+Protocol prompt sources could be registered and converted into prompt-runtime
+source objects, but the agent did not yet refresh the live registry during
+request assembly.
+
+## Changes
+
+- Runtime bootstrap now owns a shared `PromptSourceRegistry` backed by the
+  runtime event bus.
+- Agents can attach that registry through `set_prompt_source_registry`.
+- At the start of each user query, the agent atomically refreshes registry
+  snapshots into `PromptRuntimeConfig::protocol_prompt_sources`.
+- Turn-limited prompt sources are advanced under the same registry lock as the
+  snapshot, so a `Turns(1)` source participates in one complete user query and
+  is then expired without racing later registrations.
+- Added regression coverage that verifies protocol prompt sources appear in the
+  effective prompt and `/context` prompt-source view, remain available for the
+  current query after expiration from the registry, then disappear on the next
+  query refresh.
+
+## Remaining Work
+
+- Publish structured lifecycle events for prompt-source injection and
+  expiration.
+- Wire external appserver/ACP/Wire prompt-source controls to the shared runtime
+  registry once those adapters expose typed prompt-source requests.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -50,7 +50,7 @@ Active backlog only. Keep this file small and current.
 - [x] Tests for workspace prompt-source discovery and cache invalidation (cwd changes, git branches, nested workspaces).
 - [x] Define `WorkspaceMemory` cache invalidation rules for prompt files and environment info (see `docs/features/workspace-memory-cache.md`).
 - [x] Unify `discover_prompt_sources()` and TUI `/status` source reporting.
-- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Prompt-source provenance is now retained in `PromptSourceRegistry`, and snapshots can now convert into prompt-runtime sources visible through `EffectivePrompt` and `/context`; next slice should wire live registry snapshots into agent/runtime config during request assembly.
+- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Protocol prompt sources now retain provenance, convert into prompt-runtime sources, and atomically snapshot from the live registry at the user-query boundary; next slice should add lifecycle events for injection/expiration and extend the same bridge to protocol skill/hook visibility.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.
 - [ ] Claude-style `verify` skill and `verifier-*` convention (see `docs/features/verify-skill.md`).
 - [ ] Evolve `SkillTool` to Codex/Claude contract (see `docs/features/skill-tool.md`): frontmatter, scopes, override visibility.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -27,6 +27,7 @@ use crate::llm::{ContentBlock, LlmBackend, LlmStreamEvent, LlmTurnMetadata};
 use crate::mcp_status::McpStatusSnapshot;
 use crate::memory_store::MemoryStore;
 use crate::prompt::{self, PromptMode, PromptRuntimeConfig};
+use crate::protocol_sources::PromptSourceRegistry;
 use crate::session::SessionManager;
 use crate::thread_store::ThreadRecorder;
 use crate::todo::TodoState;
@@ -169,6 +170,7 @@ pub struct Agent {
     last_turn_had_tool_calls: bool,
     pending_plan_exit_tool_id: Option<String>,
     prompt_config: PromptRuntimeConfig,
+    prompt_source_registry: Option<Arc<PromptSourceRegistry>>,
     cancellation_token: Option<Arc<AtomicBool>>,
     consecutive_reasoning_only_turns: usize,
 }
@@ -248,6 +250,7 @@ impl Agent {
             last_turn_had_tool_calls: false,
             pending_plan_exit_tool_id: None,
             prompt_config: PromptRuntimeConfig::default(),
+            prompt_source_registry: None,
             cancellation_token: None,
             consecutive_reasoning_only_turns: 0,
         }
@@ -297,6 +300,7 @@ impl Agent {
         self.checkpoint_session()?;
         self.refresh_memory_retrieval_candidates().await;
         self.refresh_file_search_candidates();
+        self.refresh_protocol_prompt_sources_for_query().await;
 
         match self
             .run_agent_loop_with_limit(output_mode, &mut report, &mut agentic_turns)

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -3,6 +3,7 @@ use crate::context::{
     AssembledContext, AssembledTurnContext, ContextAssembler, RuntimeContextInputs,
     RuntimeInteractionInput,
 };
+use crate::protocol_sources::PromptSourceRegistry;
 use crate::tool_result::ToolResultProjectionPolicy;
 
 impl Agent {
@@ -85,8 +86,22 @@ impl Agent {
         self.prompt_config = prompt_config;
     }
 
+    pub fn set_prompt_source_registry(
+        &mut self,
+        prompt_source_registry: std::sync::Arc<PromptSourceRegistry>,
+    ) {
+        self.prompt_source_registry = Some(prompt_source_registry);
+    }
+
     pub fn prompt_config(&self) -> &PromptRuntimeConfig {
         &self.prompt_config
+    }
+
+    pub(crate) async fn refresh_protocol_prompt_sources_for_query(&mut self) {
+        let Some(registry) = self.prompt_source_registry.as_ref() else {
+            return;
+        };
+        self.prompt_config.protocol_prompt_sources = registry.list_prompt_sources_for_query().await;
     }
 
     pub fn set_cancellation_token(

--- a/src/agent/tests/context_view.rs
+++ b/src/agent/tests/context_view.rs
@@ -9,6 +9,12 @@ use crate::agent::{Agent, AgentExecutionMode, Message, PlanStep, PlanStepStatus}
 use crate::llm::{ContentBlock, LlmResponse};
 use crate::memory_store::{MemoryLabel, MemoryScope, MemorySource, MemoryStore, NewMemoryRecord};
 use crate::prompt::PromptRuntimeConfig;
+use crate::protocol_sources::PromptSourceRegistry;
+use crate::runtime_control::{
+    PromptSourceControlRequest, PromptSourceLifetime, PromptSourceRegistration, SourceLayer,
+    SourceScope,
+};
+use crate::runtime_event_bus::RuntimeEventBus;
 
 #[test]
 fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
@@ -399,6 +405,88 @@ fn assemble_turn_context_matches_prompt_and_runtime_views() {
         Some("appendix")
     );
     assert_eq!(assembled.runtime.plan.execution_mode, "plan");
+}
+
+#[tokio::test]
+async fn protocol_prompt_registry_feeds_prompt_runtime_for_query() {
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::Text {
+            text: "ok".to_string(),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: None,
+    }]));
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new(
+            &rara_dir.join("lancedb").display().to_string(),
+        )),
+        session_manager,
+        workspace,
+    );
+    let registry = Arc::new(PromptSourceRegistry::new(Arc::new(RuntimeEventBus::new(8))));
+    registry
+        .handle_control(&PromptSourceControlRequest::Register(
+            PromptSourceRegistration {
+                source_id: "editor-selection".to_string(),
+                scope: SourceScope::Protocol,
+                layer: SourceLayer::User,
+                budget_hint_tokens: Some(64),
+                lifetime: PromptSourceLifetime::Turns(1),
+                content: "The active editor selection is src/main.rs.".to_string(),
+            },
+        ))
+        .await;
+    agent.set_prompt_source_registry(registry.clone());
+
+    agent.refresh_protocol_prompt_sources_for_query().await;
+
+    let effective = agent.effective_prompt();
+    assert!(effective.section_keys.contains(&"protocol_prompt_sources"));
+    assert!(effective.text.contains("## Protocol Prompt Sources"));
+    assert!(
+        effective
+            .text
+            .contains("### Protocol Prompt Source editor-selection")
+    );
+    assert!(
+        effective
+            .text
+            .contains("The active editor selection is src/main.rs.")
+    );
+    assert!(
+        agent
+            .shared_runtime_context()
+            .prompt
+            .source_entries
+            .iter()
+            .any(|entry| {
+                entry.kind == "protocol_prompt_source"
+                    && entry.display_path == "protocol:runtime:editor-selection"
+            })
+    );
+    assert!(
+        registry.list_prompt_sources().await.is_empty(),
+        "turn-limited source should be consumed after one user query"
+    );
+    assert!(
+        agent
+            .effective_prompt()
+            .section_keys
+            .contains(&"protocol_prompt_sources"),
+        "the current query keeps the snapshotted source for every model request"
+    );
+
+    agent.refresh_protocol_prompt_sources_for_query().await;
+
+    assert!(
+        !agent
+            .effective_prompt()
+            .section_keys
+            .contains(&"protocol_prompt_sources")
+    );
 }
 
 #[tokio::test]

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -167,7 +167,7 @@ impl PromptSourceRegistry {
         let mut expired = Vec::new();
         for (id, entry) in sources.iter_mut() {
             if let Some(ref mut remaining) = entry.remaining_turns {
-                if *remaining == 0 {
+                if *remaining <= 1 {
                     expired.push(id.clone());
                 } else {
                     *remaining -= 1;
@@ -212,6 +212,40 @@ impl PromptSourceRegistry {
             .iter()
             .map(ProtocolPromptSourceSnapshot::to_prompt_source)
             .collect()
+    }
+
+    /// Atomically snapshot active prompt sources for one query and advance
+    /// turn-limited lifetimes under the same registry lock.
+    pub async fn list_prompt_sources_for_query(&self) -> Vec<PromptSource> {
+        let mut sources = self.sources.write().await;
+        let prompt_sources = sources
+            .values()
+            .map(ProtocolPromptSourceSnapshot::from)
+            .map(|snapshot| snapshot.to_prompt_source())
+            .collect();
+        let mut expired = Vec::new();
+        for (id, entry) in sources.iter_mut() {
+            if let Some(ref mut remaining) = entry.remaining_turns {
+                if *remaining <= 1 {
+                    expired.push(id.clone());
+                } else {
+                    *remaining -= 1;
+                }
+            }
+        }
+        for id in &expired {
+            sources.remove(id);
+        }
+        drop(sources);
+        for id in expired {
+            let _ = self.event_bus.publish_control(RuntimeEvent::PromptSource(
+                PromptSourceEvent::Dropped {
+                    source_id: id,
+                    reason: "turn limit expired".into(),
+                },
+            ));
+        }
+        prompt_sources
     }
 }
 

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -20,6 +20,7 @@ use crate::llm::{
 use crate::local_backend::{LocalLlmBackend, LocalProgressReporter};
 use crate::mcp_tool_cache::McpToolCache;
 use crate::prompt::{PromptRuntimeConfig, PromptSkillSummary};
+use crate::protocol_sources::PromptSourceRegistry;
 use crate::runtime_event_bus::RuntimeEventBus;
 use crate::sandbox::SandboxManager;
 use crate::session::SessionManager;
@@ -38,6 +39,7 @@ pub(crate) struct RuntimeBootstrap {
     pub warnings: Vec<String>,
     pub sandbox_network_access: Arc<AtomicBool>,
     pub event_bus: Arc<RuntimeEventBus>,
+    pub prompt_source_registry: Arc<PromptSourceRegistry>,
     pub goal_handle: GoalHandle,
     pub mcp_tool_cache: McpToolCache,
 }
@@ -65,6 +67,7 @@ impl RuntimeBootstrap {
             self.workspace,
         );
         agent.set_prompt_config(self.prompt_config);
+        agent.set_prompt_source_registry(self.prompt_source_registry);
         (
             agent,
             self.warnings,
@@ -118,6 +121,7 @@ pub(crate) async fn initialize_rara_context(
     ));
 
     let event_bus = Arc::new(RuntimeEventBus::new(256));
+    let prompt_source_registry = Arc::new(PromptSourceRegistry::new(event_bus.clone()));
     let goal_handle: GoalHandle = Arc::new(std::sync::RwLock::new(None));
     let mcp_tool_cache = McpToolCache::new();
     mcp_tool_cache.clear();
@@ -147,6 +151,7 @@ pub(crate) async fn initialize_rara_context(
         warnings,
         sandbox_network_access,
         event_bus,
+        prompt_source_registry,
         goal_handle,
         mcp_tool_cache,
     })


### PR DESCRIPTION
## Summary

- attach a shared `PromptSourceRegistry` during runtime bootstrap
- refresh protocol prompt source snapshots into the agent prompt config before model request assembly
- expire turn-limited protocol prompt sources at the same assembly boundary
- add a focused regression test for effective prompt and `/context` prompt-source visibility

## Why

The previous slice made protocol prompt-source snapshots convertible into prompt-runtime sources. This change wires the live registry into the agent so registered protocol prompt sources participate in normal prompt assembly instead of remaining registry-only state.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo metadata --locked --no-deps`

Attempted:

- `cargo test agent::tests::context_view::protocol_prompt_registry_feeds_prompt_runtime_for_model_turn`

The focused root-crate test did not complete locally because dependency compilation filled the local disk under `target/debug` with `No space left on device`. CI should validate the new root-crate test.
