### PR TITLE
feat: emit protocol prompt source events

### DIFF
--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -207,6 +207,9 @@ workspace instructions and documentation, not in the default runtime system prom
   snapshotted sources remain active for every model request inside that query's
   agent loop. This keeps live protocol input on the normal prompt-runtime path
   instead of letting adapters edit final prompt text.
+- The registry emits lifecycle events for protocol prompt sources:
+  `Registered` when accepted, `Injected` when snapshotted into a user query, and
+  `Dropped` when a turn-limited source expires or is removed from the registry.
 
 ### 4) Agent Loop Integration
 

--- a/docs/journal/2026-05-09-protocol-prompt-source-events.md
+++ b/docs/journal/2026-05-09-protocol-prompt-source-events.md
@@ -1,0 +1,23 @@
+# Protocol Prompt Source Lifecycle Events
+
+## Context
+
+Live protocol prompt sources now flow from the shared registry into prompt
+runtime at the user-query boundary. External subscribers still needed a
+structured event that distinguishes registration from actual prompt injection.
+
+## Changes
+
+- Added `PromptSourceEvent::Injected`.
+- `PromptSourceRegistry::list_prompt_sources_for_query()` now emits `Injected`
+  for every source snapshotted into the query.
+- Turn-limited expiration still emits `Dropped` after the atomic query snapshot
+  removes expired sources from the registry.
+- Added focused registry coverage for `Registered` → `Injected` → `Dropped`
+  lifecycle events.
+
+## Remaining Work
+
+- Extend the same lifecycle-event pattern to protocol skill and hook visibility.
+- Surface protocol prompt-source lifecycle events in ACP/Wire subscribers once
+  those adapters expose typed prompt-source controls.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -50,7 +50,7 @@ Active backlog only. Keep this file small and current.
 - [x] Tests for workspace prompt-source discovery and cache invalidation (cwd changes, git branches, nested workspaces).
 - [x] Define `WorkspaceMemory` cache invalidation rules for prompt files and environment info (see `docs/features/workspace-memory-cache.md`).
 - [x] Unify `discover_prompt_sources()` and TUI `/status` source reporting.
-- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Protocol prompt sources now retain provenance, convert into prompt-runtime sources, and atomically snapshot from the live registry at the user-query boundary; next slice should add lifecycle events for injection/expiration and extend the same bridge to protocol skill/hook visibility.
+- [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Protocol prompt sources now retain provenance, convert into prompt-runtime sources, atomically snapshot from the live registry at the user-query boundary, and emit registered/injected/dropped lifecycle events; next slice should extend the same bridge to protocol skill/hook visibility.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.
 - [ ] Claude-style `verify` skill and `verifier-*` convention (see `docs/features/verify-skill.md`).
 - [ ] Evolve `SkillTool` to Codex/Claude contract (see `docs/features/skill-tool.md`): frontmatter, scopes, override visibility.

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -218,13 +218,12 @@ impl PromptSourceRegistry {
     /// turn-limited lifetimes under the same registry lock.
     pub async fn list_prompt_sources_for_query(&self) -> Vec<PromptSource> {
         let mut sources = self.sources.write().await;
-        let prompt_sources = sources
-            .values()
-            .map(ProtocolPromptSourceSnapshot::from)
-            .map(|snapshot| snapshot.to_prompt_source())
-            .collect();
+        let mut injected = Vec::with_capacity(sources.len());
+        let mut prompt_sources = Vec::with_capacity(sources.len());
         let mut expired = Vec::new();
         for (id, entry) in sources.iter_mut() {
+            injected.push(id.clone());
+            prompt_sources.push(ProtocolPromptSourceSnapshot::from(&*entry).to_prompt_source());
             if let Some(ref mut remaining) = entry.remaining_turns {
                 if *remaining <= 1 {
                     expired.push(id.clone());
@@ -237,6 +236,11 @@ impl PromptSourceRegistry {
             sources.remove(id);
         }
         drop(sources);
+        for id in injected {
+            let _ = self.event_bus.publish_control(RuntimeEvent::PromptSource(
+                PromptSourceEvent::Injected { source_id: id },
+            ));
+        }
         for id in expired {
             let _ = self.event_bus.publish_control(RuntimeEvent::PromptSource(
                 PromptSourceEvent::Dropped {
@@ -688,6 +692,48 @@ mod tests {
             prompt_sources[0].content,
             "Protocol context should keep provenance."
         );
+    }
+
+    #[tokio::test]
+    async fn prompt_source_registry_emits_injected_and_dropped_lifecycle_events() {
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let mut events = bus.subscribe_control();
+        let registry = PromptSourceRegistry::new(bus);
+
+        registry
+            .handle_control(&PromptSourceControlRequest::Register(
+                PromptSourceRegistration {
+                    source_id: "protocol-source-1".to_string(),
+                    scope: crate::runtime_control::SourceScope::Protocol,
+                    layer: crate::runtime_control::SourceLayer::User,
+                    budget_hint_tokens: Some(128),
+                    lifetime: PromptSourceLifetime::Turns(1),
+                    content: "Protocol context should emit lifecycle events.".to_string(),
+                },
+            ))
+            .await;
+        let registered = events.recv().await.expect("registered event");
+        assert!(matches!(
+            registered.event,
+            RuntimeEvent::PromptSource(PromptSourceEvent::Registered { source_id })
+                if source_id == "protocol-source-1"
+        ));
+
+        let prompt_sources = registry.list_prompt_sources_for_query().await;
+
+        assert_eq!(prompt_sources.len(), 1);
+        let injected = events.recv().await.expect("injected event");
+        assert!(matches!(
+            injected.event,
+            RuntimeEvent::PromptSource(PromptSourceEvent::Injected { source_id })
+                if source_id == "protocol-source-1"
+        ));
+        let dropped = events.recv().await.expect("dropped event");
+        assert!(matches!(
+            dropped.event,
+            RuntimeEvent::PromptSource(PromptSourceEvent::Dropped { source_id, reason })
+                if source_id == "protocol-source-1" && reason == "turn limit expired"
+        ));
     }
 
     #[tokio::test]

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -466,6 +466,7 @@ pub enum PlanEvent {
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PromptSourceEvent {
     Registered { source_id: String },
+    Injected { source_id: String },
     Unregistered { source_id: String },
     Dropped { source_id: String, reason: String },
 }


### PR DESCRIPTION
## Summary

- add `PromptSourceEvent::Injected`
- emit `Injected` when protocol prompt sources are snapshotted into a user query
- keep turn-limited expiration on the existing `Dropped` event
- document the lifecycle event contract and remaining adapter work

## Why

Protocol prompt sources now flow through the live registry into prompt runtime. Subscribers need to distinguish source registration from actual prompt injection, especially for ACP/Wire/appserver observability.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo metadata --locked --no-deps`

Local root-crate tests were not run because previous root test attempts repeatedly filled the local disk while compiling dependencies. CI should validate the added registry event test.
