### PR TITLE
fix(tui): command palette Enter fills input without auto-submit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10445,7 +10445,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -328,11 +328,9 @@ pub(crate) async fn dispatch_event(
             Some(Overlay::CommandPalette) => {
                 let query = app.command_query();
                 if let Some(spec) = palette_command_by_index(app, query, app.command_palette_idx) {
-                    app.set_input(spec.usage.to_string());
+                    app.input = spec.usage.to_string();
+                    app.input_cursor_offset = None;
                     app.close_overlay();
-                    if handle_submit(app, agent_slot, oauth_manager).await? {
-                        return Ok(true);
-                    }
                 }
             }
             Some(Overlay::BaseUrlEditor) => {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -399,8 +399,12 @@ async fn slash_palette_model_selection_opens_provider_picker_in_local_and_ssh() 
         .await
         .expect("apply command palette selection");
 
-        assert!(matches!(app.overlay, Some(Overlay::ListPicker(_))));
-        assert_eq!(app.notice.as_deref(), Some("Change the active model."));
+        assert!(app.overlay.is_none(), "palette closed after selection");
+        assert!(
+            app.input.contains("/model"),
+            "input filled with model command, got '{}'",
+            app.input
+        );
     }
 }
 


### PR DESCRIPTION
## Fix

Pressing Enter on a command in the Command Palette (e.g. `/model`) now fills the
composer with the command text and closes the palette, letting the user type
arguments before submitting manually.

### Before
`set_input()` → re-triggers `sync_command_palette_with_input()` (palette flicker open/close),
then immediately `handle_submit()` auto-submits the command without letting user edit.

### After
Set `input` / `input_cursor_offset` fields directly (bypassing palette sync),
close overlay, don't auto-submit. User types arguments and presses Enter to submit.

## Verification
- `cargo check` clean