### PR TITLE
feat(tui): optimize sidebar layout to align with OpenCode

### DIFF
--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -1,14 +1,14 @@
 // Wide-screen sidebar (≥120 cols) rendered alongside the main transcript pane.
 // Layout draws a 38-column panel on the left split by a vertical border,
 // showing session identity, model badge, context summary, files access, and status.
+use std::collections::BTreeSet;
+
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
-
-use std::collections::BTreeSet;
 
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::TuiApp;
@@ -93,10 +93,7 @@ fn push_session_info(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
 }
 
 fn push_model_badge(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
-    lines.push(Line::from(super::section_label(
-        "Model",
-        TEXT_SECONDARY,
-    )));
+    lines.push(Line::from(super::section_label("Model", TEXT_SECONDARY)));
 
     let provider = &app.config.provider;
     let provider = provider.as_str();
@@ -130,10 +127,7 @@ fn push_model_badge(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
 }
 
 fn push_context_summary(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
-    lines.push(Line::from(super::section_label(
-        "Context",
-        TEXT_SECONDARY,
-    )));
+    lines.push(Line::from(super::section_label("Context", TEXT_SECONDARY)));
 
     let snap = &app.snapshot;
 
@@ -221,6 +215,12 @@ fn push_files_in_context(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
                 }
             } else if let Some(path) = msg.strip_prefix("write_file ") {
                 changed_files.insert(path.trim().to_string());
+            } else if let Some(path) = msg.strip_prefix("replace ") {
+                changed_files.insert(path.trim().to_string());
+            } else if let Some(path) = msg.strip_prefix("multi_edit ") {
+                changed_files.insert(path.trim().to_string());
+            } else if let Some(path) = msg.strip_prefix("replace_lines ") {
+                changed_files.insert(path.trim().to_string());
             }
         }
     }
@@ -229,10 +229,7 @@ fn push_files_in_context(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
         return;
     }
 
-    lines.push(Line::from(super::section_label(
-        "Files",
-        TEXT_SECONDARY,
-    )));
+    lines.push(Line::from(super::section_label("Files", TEXT_SECONDARY)));
 
     // Files read.
     if !read_files.is_empty() {

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -1,12 +1,14 @@
 // Wide-screen sidebar (≥120 cols) rendered alongside the main transcript pane.
 // Layout draws a 38-column panel on the left split by a vertical border,
-// showing session identity, model badge, context budget bar, and status.
+// showing session identity, model badge, context summary, files access, and status.
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
+
+use std::collections::BTreeSet;
 
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::TuiApp;
@@ -38,11 +40,11 @@ pub(crate) fn render_sidebar(f: &mut Frame, app: &TuiApp, area: Rect) {
     lines.push(Line::from(""));
     push_model_badge(&mut lines, app);
     lines.push(Line::from(""));
-    push_budget_bar(&mut lines, app, body_area.width);
+    push_context_summary(&mut lines, app);
     lines.push(Line::from(""));
     push_child_sessions(&mut lines, app);
     lines.push(Line::from(""));
-    push_context_summary(&mut lines, app);
+    push_files_in_context(&mut lines, app);
 
     f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), body_area);
 
@@ -57,7 +59,7 @@ fn push_session_info(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
     let title = if app.snapshot.session_id.is_empty() {
         "RARA".to_string()
     } else {
-        // Shorten session id for display: first 12 chars.
+        // Shorten session id for display.
         let session_id = &app.snapshot.session_id;
         if session_id.len() > 14 {
             format!(
@@ -77,20 +79,25 @@ fn push_session_info(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
             .add_modifier(Modifier::BOLD),
     )));
 
+    // Compact cwd (+ branch if available) on a single line.
+    let cwd = super::display_directory_for_startup(app);
+    let location = if app.snapshot.branch.is_empty() {
+        cwd
+    } else {
+        format!("{} :: {}", cwd, app.snapshot.branch)
+    };
     lines.push(Line::from(Span::styled(
-        format!("cwd  {}", super::display_directory_for_startup(app)),
-        Style::default().fg(TEXT_SECONDARY),
+        location,
+        Style::default().fg(TEXT_MUTED),
     )));
-
-    if !app.snapshot.branch.is_empty() {
-        lines.push(Line::from(Span::styled(
-            format!("branch  {}", app.snapshot.branch),
-            Style::default().fg(TEXT_SECONDARY),
-        )));
-    }
 }
 
 fn push_model_badge(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
+    lines.push(Line::from(super::section_label(
+        "Model",
+        TEXT_SECONDARY,
+    )));
+
     let provider = &app.config.provider;
     let provider = provider.as_str();
 
@@ -115,148 +122,165 @@ fn push_model_badge(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
         let effort = effort.trim();
         if !effort.is_empty() {
             lines.push(Line::from(Span::styled(
-                format!("  reasoning  {}", effort),
+                format!("  reasoning  {effort}"),
                 Style::default().fg(TEXT_MUTED),
             )));
         }
     }
 }
 
-fn push_budget_bar(lines: &mut Vec<Line<'static>>, app: &TuiApp, width: u16) {
-    let snap = &app.snapshot;
-    let Some(context_window) = snap.context_window_tokens else {
-        return;
-    };
-
-    let bar_width = width.saturating_sub(2).max(10) as usize;
-
-    // Collect budget segments: (label, tokens, color)
-    struct Segment {
-        label: &'static str,
-        tokens: usize,
-        color: Color,
-    }
-
-    let segments = [
-        Segment {
-            label: "sys",
-            tokens: snap.stable_instructions_budget,
-            color: BUDGET_SYSTEM,
-        },
-        Segment {
-            label: "ws",
-            tokens: snap.workspace_prompt_budget,
-            color: BUDGET_WORKSPACE,
-        },
-        Segment {
-            label: "act",
-            tokens: snap.active_turn_budget,
-            color: BUDGET_ACTIVE,
-        },
-        Segment {
-            label: "hist",
-            tokens: snap.compacted_history_budget,
-            color: BUDGET_HISTORY,
-        },
-        Segment {
-            label: "mem",
-            tokens: snap.retrieved_memory_budget,
-            color: BUDGET_MEMORY,
-        },
-    ];
-
-    let used: usize = segments.iter().map(|s| s.tokens).sum();
-    let free = context_window.saturating_sub(used);
-
-    let all_widths: Vec<(usize, Color)> = segments
-        .iter()
-        .map(|s| (s.tokens, s.color))
-        .chain(std::iter::once((free, BUDGET_FREE)))
-        .collect();
-
-    // Build a single-line bar from colored spans.
-    let mut spans: Vec<Span<'static>> = Vec::new();
-
-    // Scale each segment by bar_width relative to context_window.
-    let mut drawn = 0usize;
-    for (idx, (tokens, color)) in all_widths.iter().enumerate() {
-        let seg_width = if idx == all_widths.len() - 1 {
-            // last segment (free) takes remaining space
-            bar_width.saturating_sub(drawn)
-        } else {
-            ((*tokens as f64 / context_window as f64) * bar_width as f64).round() as usize
-        };
-        if seg_width == 0 {
-            continue;
-        }
-        let bar = "█".repeat(seg_width.min(bar_width.saturating_sub(drawn)));
-        spans.push(Span::styled(bar, Style::default().fg(*color)));
-        drawn += seg_width;
-    }
-
-    let bar_line = Line::from(spans);
-    lines.push(bar_line);
-
-    // Legend line.
-    let legend_items: Vec<String> = segments
-        .iter()
-        .map(|s| format!("{} {}", s.label, format_token_count(s.tokens)))
-        .collect();
-    let legend = legend_items.join("  ");
-
-    let remaining_str = snap
-        .remaining_input_budget
-        .map(|r| format!("  free {}", format_token_count(r as usize)))
-        .unwrap_or_default();
-
-    lines.push(Line::from(Span::styled(
-        format!("{}{}", legend, remaining_str),
-        Style::default().fg(TEXT_MUTED),
+fn push_context_summary(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
+    lines.push(Line::from(super::section_label(
+        "Context",
+        TEXT_SECONDARY,
     )));
 
+    let snap = &app.snapshot;
+
+    let total_tokens = snap.total_input_tokens as usize + snap.total_output_tokens as usize;
+    let mut parts: Vec<String> = Vec::new();
+
+    // Token usage: "8.1k/16k"
+    if let Some(ctx) = snap.context_window_tokens {
+        parts.push(format!(
+            "{}/{} tokens",
+            format_token_count(total_tokens),
+            format_token_count(ctx)
+        ));
+    } else {
+        parts.push(format!("{} tokens", format_token_count(total_tokens)));
+    }
+
+    // History turns
+    parts.push(format!("{} turns", snap.history_len));
+
+    // Compaction
+    if snap.compaction_count > 0 {
+        parts.push(format!("compacted {}×", snap.compaction_count));
+    }
+
+    let summary = parts.join(" · ");
     lines.push(Line::from(Span::styled(
-        format!(
-            "ctx {}  in/out {}/{}  cache hit {}  miss {}",
-            format_token_count(context_window),
-            format_token_count(snap.total_input_tokens as usize),
-            format_token_count(snap.total_output_tokens as usize),
-            format_token_count(snap.total_cache_hit_tokens as usize),
-            format_token_count(snap.total_cache_miss_tokens as usize),
-        ),
+        summary,
         Style::default().fg(TEXT_MUTED),
     )));
 }
 
 fn push_child_sessions(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
-    // Child / sub-agent sessions if any.
     let child_count = app.snapshot.pending_interactions.len();
-    if child_count > 0 {
-        lines.push(Line::from(Span::styled(
-            format!("sub-agents  {child_count} active"),
-            Style::default()
-                .fg(INTERACTION_SUB_AGENT)
-                .add_modifier(Modifier::BOLD),
-        )));
+    if child_count == 0 {
+        return;
     }
-}
 
-fn push_context_summary(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
-    lines.push(Line::from(Span::styled(
-        format!("history  {} turns", app.snapshot.history_len),
-        Style::default().fg(TEXT_SECONDARY),
+    lines.push(Line::from(super::section_label(
+        "Sub-agents",
+        TEXT_SECONDARY,
     )));
 
-    if app.snapshot.compaction_count > 0 {
+    // Show running sub-agents up to 5.
+    for pi in app.snapshot.pending_interactions.iter().take(5) {
+        let label = format!("  {} (running)", pi.title);
         lines.push(Line::from(Span::styled(
-            format!("compacted  {} times", app.snapshot.compaction_count),
+            label,
+            Style::default().fg(INTERACTION_SUB_AGENT),
+        )));
+    }
+
+    if child_count > 5 {
+        lines.push(Line::from(Span::styled(
+            format!("  ... and {} more", child_count - 5),
             Style::default().fg(TEXT_MUTED),
         )));
     }
 }
 
+fn push_files_in_context(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
+    let mut read_files: BTreeSet<String> = BTreeSet::new();
+    let mut changed_files: BTreeSet<String> = BTreeSet::new();
+
+    let all_turns = app
+        .committed_turns
+        .iter()
+        .chain(std::iter::once(&app.active_turn));
+
+    for turn in all_turns {
+        for entry in &turn.entries {
+            if entry.role != "Tool" {
+                continue;
+            }
+            let msg = entry.message.trim();
+
+            if let Some(path) = msg.strip_prefix("read_file ") {
+                read_files.insert(path.trim().to_string());
+            } else if let Some(rest) = msg.strip_prefix("apply_patch ") {
+                for part in rest.split(',') {
+                    let p = part.trim();
+                    if !p.is_empty() {
+                        changed_files.insert(p.to_string());
+                    }
+                }
+            } else if let Some(path) = msg.strip_prefix("write_file ") {
+                changed_files.insert(path.trim().to_string());
+            }
+        }
+    }
+
+    if read_files.is_empty() && changed_files.is_empty() {
+        return;
+    }
+
+    lines.push(Line::from(super::section_label(
+        "Files",
+        TEXT_SECONDARY,
+    )));
+
+    // Files read.
+    if !read_files.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "Read:",
+            Style::default().fg(TEXT_MUTED),
+        )));
+        for path in read_files.iter().take(5) {
+            lines.push(Line::from(Span::styled(
+                format!("  {path}"),
+                Style::default().fg(TEXT_SECONDARY),
+            )));
+        }
+        if read_files.len() > 5 {
+            lines.push(Line::from(Span::styled(
+                format!("  ... and {} more", read_files.len() - 5),
+                Style::default().fg(TEXT_MUTED),
+            )));
+        }
+    }
+
+    // Files changed.
+    if !changed_files.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "Changed:",
+            Style::default().fg(TEXT_MUTED),
+        )));
+        for path in changed_files.iter().take(5) {
+            lines.push(Line::from(Span::styled(
+                format!("  {path}"),
+                Style::default().fg(INTERACTION_SUB_AGENT),
+            )));
+        }
+        if changed_files.len() > 5 {
+            lines.push(Line::from(Span::styled(
+                format!("  ... and {} more", changed_files.len() - 5),
+                Style::default().fg(TEXT_MUTED),
+            )));
+        }
+    }
+}
+
 fn version_footer_line() -> Span<'static> {
     let version = option_env!("CARGO_PKG_VERSION").unwrap_or("dev");
-    Span::styled(format!("rara v{version}"), Style::default().fg(TEXT_MUTED))
+    Span::styled(
+        format!("• rara v{version}"),
+        Style::default().fg(TEXT_MUTED),
+    )
 }
 
 /// Format a token count for human-readable display.

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -551,7 +551,10 @@ fn push_files_in_context_detects_replace() {
         .map(|l| l.to_string())
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(text.contains("Changed:"), "replace should be a changed file");
+    assert!(
+        text.contains("Changed:"),
+        "replace should be a changed file"
+    );
     assert!(text.contains("src/main.rs"), "should show replaced path");
 }
 
@@ -573,8 +576,14 @@ fn push_files_in_context_detects_multi_edit() {
         .map(|l| l.to_string())
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(text.contains("Changed:"), "multi_edit should be a changed file");
-    assert!(text.contains("crates/lib.rs"), "should show multi_edit path");
+    assert!(
+        text.contains("Changed:"),
+        "multi_edit should be a changed file"
+    );
+    assert!(
+        text.contains("crates/lib.rs"),
+        "should show multi_edit path"
+    );
 }
 
 #[test]
@@ -585,7 +594,10 @@ fn push_files_in_context_detects_replace_lines() {
     })
     .expect("build tui app");
     app.committed_turns = vec![TranscriptTurn {
-        entries: vec![TranscriptEntry::new("Tool", "replace_lines src/tui/sidebar.rs")],
+        entries: vec![TranscriptEntry::new(
+            "Tool",
+            "replace_lines src/tui/sidebar.rs",
+        )],
     }];
 
     let mut lines = Vec::new();
@@ -595,8 +607,14 @@ fn push_files_in_context_detects_replace_lines() {
         .map(|l| l.to_string())
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(text.contains("Changed:"), "replace_lines should be a changed file");
-    assert!(text.contains("src/tui/sidebar.rs"), "should show replace_lines path");
+    assert!(
+        text.contains("Changed:"),
+        "replace_lines should be a changed file"
+    );
+    assert!(
+        text.contains("src/tui/sidebar.rs"),
+        "should show replace_lines path"
+    );
 }
 
 // ── PendingInteractionSnapshot default helper ───────────────────────

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -2,11 +2,14 @@ use ratatui::{layout::Rect, style::Color, text::Line};
 use tempfile::tempdir;
 
 use super::{
-    format_token_count, push_budget_bar, push_child_sessions, push_context_summary,
+    format_token_count, push_child_sessions, push_context_summary, push_files_in_context,
     push_model_badge, push_session_info,
 };
 use crate::config::ConfigManager;
-use crate::tui::state::{PendingInteractionSnapshot, RuntimeSnapshot, TuiApp};
+use crate::tui::state::{
+    InteractionKind, PendingInteractionSnapshot, RuntimeSnapshot, TranscriptEntry, TranscriptTurn,
+    TuiApp,
+};
 
 // ── format_token_count ──────────────────────────────────────────────
 
@@ -31,9 +34,10 @@ fn format_token_count_mega() {
 }
 
 // ── push_session_info ───────────────────────────────────────────────
+// Now merges cwd + branch into a single compact line.
 
 #[test]
-fn push_session_info_shows_id_cwd_branch() {
+fn push_session_info_shows_id_and_location() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -58,8 +62,10 @@ fn push_session_info_shows_id_cwd_branch() {
         text.contains("abcdefgh…5678"),
         "should contain shortened session id"
     );
-    assert!(text.contains("/home/user/project"), "should contain cwd");
-    assert!(text.contains("main"), "should contain branch");
+    assert!(
+        text.contains("/home/user/project :: main"),
+        "should show cwd :: branch on one line"
+    );
 }
 
 #[test]
@@ -86,6 +92,30 @@ fn push_session_info_empty_session_shows_rara() {
 }
 
 #[test]
+fn push_session_info_no_branch_shows_cwd_only() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot = RuntimeSnapshot {
+        cwd: "/home/user/project".into(),
+        branch: String::new(),
+        ..RuntimeSnapshot::default()
+    };
+
+    let mut lines = Vec::new();
+    push_session_info(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("/home/user/project"), "should show cwd");
+    assert!(!text.contains("::"), "no branch separator when branch empty");
+}
+
+#[test]
 fn push_session_info_short_session_id_not_truncated() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
@@ -109,6 +139,7 @@ fn push_session_info_short_session_id_not_truncated() {
 }
 
 // ── push_model_badge ────────────────────────────────────────────────
+// Now includes "# Model" section header.
 
 #[test]
 fn push_model_badge_shows_provider_and_model() {
@@ -128,6 +159,7 @@ fn push_model_badge_shows_provider_and_model() {
         .map(|l| l.to_string())
         .collect::<Vec<_>>()
         .join("\n");
+    assert!(text.contains("Model"), "should show # Model section label");
     assert!(text.contains("openai"), "should show provider");
     assert!(text.contains("gpt-4o"), "should show model");
 }
@@ -202,10 +234,70 @@ fn push_model_badge_no_reasoning_effort_when_none() {
     );
 }
 
-// ── push_budget_bar ─────────────────────────────────────────────────
+// ── push_context_summary ────────────────────────────────────────────
+// Replaces push_budget_bar. Shows tokens, turns, compaction in one line.
 
 #[test]
-fn push_budget_bar_skips_when_no_context_window() {
+fn push_context_summary_shows_tokens_turns_compaction() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot = RuntimeSnapshot {
+        context_window_tokens: Some(16000),
+        total_input_tokens: 8200,
+        total_output_tokens: 1200,
+        history_len: 42,
+        compaction_count: 3,
+        ..RuntimeSnapshot::default()
+    };
+
+    let mut lines = Vec::new();
+    push_context_summary(&mut lines, &app);
+
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("Context"), "should show # Context section label");
+    assert!(
+        text.contains("9.4k/16.0k tokens"),
+        "should show token usage: 9.4k/16.0k"
+    );
+    assert!(text.contains("42 turns"), "should show turn count");
+    assert!(text.contains("compacted 3×"), "should show compaction count");
+}
+
+#[test]
+fn push_context_summary_no_compaction() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot = RuntimeSnapshot {
+        context_window_tokens: Some(16000),
+        total_input_tokens: 1000,
+        total_output_tokens: 500,
+        history_len: 1,
+        compaction_count: 0,
+        ..RuntimeSnapshot::default()
+    };
+
+    let mut lines = Vec::new();
+    push_context_summary(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(!text.contains("compacted"), "no compaction mention when 0");
+}
+
+#[test]
+fn push_context_summary_no_context_window() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -213,184 +305,281 @@ fn push_budget_bar_skips_when_no_context_window() {
     .expect("build tui app");
     app.snapshot = RuntimeSnapshot {
         context_window_tokens: None,
+        total_input_tokens: 500,
+        total_output_tokens: 100,
+        history_len: 5,
         ..RuntimeSnapshot::default()
     };
-
-    let mut lines = Vec::new();
-    push_budget_bar(&mut lines, &app, 30);
-    assert!(lines.is_empty(), "should be empty when no context window");
-}
-
-#[test]
-fn push_budget_bar_renders_segments_and_stats() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.snapshot = RuntimeSnapshot {
-        context_window_tokens: Some(32768),
-        stable_instructions_budget: 2000,
-        workspace_prompt_budget: 500,
-        active_turn_budget: 10000,
-        compacted_history_budget: 4000,
-        retrieved_memory_budget: 1500,
-        remaining_input_budget: Some(14768),
-        total_input_tokens: 222,
-        total_output_tokens: 44,
-        total_cache_hit_tokens: 100,
-        total_cache_miss_tokens: 10,
-        ..RuntimeSnapshot::default()
-    };
-
-    let mut lines = Vec::new();
-    push_budget_bar(&mut lines, &app, 38);
-
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    // Budget bar uses unicode block chars — just check labels appear.
-    assert!(text.contains("sys"), "should show sys label");
-    assert!(text.contains("ws"), "should show ws label");
-    assert!(text.contains("act"), "should show act label");
-    assert!(text.contains("hist"), "should show hist label");
-    assert!(text.contains("mem"), "should show mem label");
-    assert!(text.contains("free"), "should show free label");
-
-    // Token stats
-    assert!(text.contains("32.8k"), "should show context window size");
-    assert!(text.contains("222"), "should show input tokens");
-    assert!(text.contains("44"), "should show output tokens");
-    assert!(text.contains("100"), "should show cache hit tokens");
-    assert!(text.contains("10"), "should show cache miss tokens");
-}
-
-#[test]
-fn push_budget_bar_no_remaining_input_budget() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.snapshot = RuntimeSnapshot {
-        context_window_tokens: Some(16384),
-        remaining_input_budget: None,
-        ..RuntimeSnapshot::default()
-    };
-
-    let mut lines = Vec::new();
-    push_budget_bar(&mut lines, &app, 38);
-
-    // Should still render without free label (no remaining_input_budget).
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(!text.is_empty(), "should render budget bar");
-}
-
-// ── push_child_sessions ─────────────────────────────────────────────
-
-#[test]
-fn push_child_sessions_empty_when_no_children() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-
-    let mut lines = Vec::new();
-    push_child_sessions(&mut lines, &app);
-    assert!(lines.is_empty(), "no output when zero children");
-}
-
-#[test]
-fn push_child_sessions_shows_count() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.snapshot.pending_interactions = vec![
-        PendingInteractionSnapshot {
-            kind: crate::tui::state::InteractionKind::RequestInput,
-            title: "sub-1".into(),
-            summary: "".into(),
-            options: vec![("ok".into(), "OK".into())],
-            note: None,
-            approval: None,
-            source: None,
-        },
-        PendingInteractionSnapshot {
-            kind: crate::tui::state::InteractionKind::RequestInput,
-            title: "sub-2".into(),
-            summary: "".into(),
-            options: vec![("ok".into(), "OK".into())],
-            note: None,
-            approval: None,
-            source: None,
-        },
-    ];
-
-    let mut lines = Vec::new();
-    push_child_sessions(&mut lines, &app);
-
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(text.contains("2 active"), "should show sub-agent count");
-}
-
-// ── push_context_summary ────────────────────────────────────────────
-
-#[test]
-fn push_context_summary_shows_turns() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.snapshot.history_len = 12;
 
     let mut lines = Vec::new();
     push_context_summary(&mut lines, &app);
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.to_string().contains("600 tokens")),
+        "shows total tokens without context window"
+    );
+}
 
+// ── push_child_sessions ─────────────────────────────────────────────
+// Now shows "# Sub-agents" section header + each title (running).
+
+#[test]
+fn push_child_sessions_shows_titles_running() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot = RuntimeSnapshot {
+        pending_interactions: vec![
+            PendingInteractionSnapshot {
+                kind: InteractionKind::Approval,
+                title: "explore-sidebar".into(),
+                ..Default::default()
+            },
+            PendingInteractionSnapshot {
+                kind: InteractionKind::PlanApproval,
+                title: "plan-refactor".into(),
+                ..Default::default()
+            },
+        ],
+        ..RuntimeSnapshot::default()
+    };
+
+    let mut lines = Vec::new();
+    push_child_sessions(&mut lines, &app);
     let text: String = lines
         .iter()
         .map(|l| l.to_string())
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(text.contains("12 turns"), "should show turn count");
     assert!(
-        !text.contains("compacted"),
-        "should not show compaction when zero"
+        text.contains("Sub-agents"),
+        "should show # Sub-agents section label"
+    );
+    assert!(
+        text.contains("explore-sidebar (running)"),
+        "should show sub-agent title + (running)"
     );
 }
 
 #[test]
-fn push_context_summary_shows_compaction() {
+fn push_child_sessions_skip_when_empty() {
+    let temp = tempdir().unwrap();
+    let app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let mut lines = Vec::new();
+    push_child_sessions(&mut lines, &app);
+    assert!(lines.is_empty(), "empty when no pending interactions");
+}
+
+// ── push_files_in_context ───────────────────────────────────────────
+// Extracts read_file / apply_patch / write_file paths from transcript.
+
+#[test]
+fn push_files_in_context_empty_when_no_file_tools() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
     })
     .expect("build tui app");
-    app.snapshot.history_len = 8;
-    app.snapshot.compaction_count = 3;
+    app.committed_turns = vec![TranscriptTurn {
+        entries: vec![TranscriptEntry::new(
+            "Assistant",
+            "Let me think about this.",
+        )],
+    }];
 
     let mut lines = Vec::new();
+    push_files_in_context(&mut lines, &app);
+    assert!(lines.is_empty(), "empty when no file-tool entries");
+}
+
+#[test]
+fn push_files_in_context_shows_read_and_changed() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.committed_turns = vec![TranscriptTurn {
+        entries: vec![
+            TranscriptEntry::new("Tool", "read_file src/main.rs"),
+            TranscriptEntry::new("Tool", "read_file crates/lib.rs"),
+            TranscriptEntry::new("Tool", "apply_patch src/main.rs"),
+            TranscriptEntry::new("Tool", "write_file docs/new.md"),
+        ],
+    }];
+
+    let mut lines = Vec::new();
+    push_files_in_context(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("Files"), "should show # Files section label");
+    assert!(text.contains("Read:"), "should have Read subsection");
+    assert!(text.contains("src/main.rs"), "should show read file");
+    assert!(text.contains("crates/lib.rs"), "should show read file");
+    assert!(text.contains("Changed:"), "should have Changed subsection");
+    assert!(text.contains("docs/new.md"), "should show changed file");
+}
+
+#[test]
+fn push_files_in_context_deduplicates() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.committed_turns = vec![TranscriptTurn {
+        entries: vec![
+            TranscriptEntry::new("Tool", "read_file src/main.rs"),
+            TranscriptEntry::new("Tool", "read_file src/main.rs"),
+        ],
+    }];
+
+    let mut lines = Vec::new();
+    push_files_in_context(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    // Only one occurrence of src/main.rs
+    let count = text.matches("src/main.rs").count();
+    assert_eq!(count, 1, "duplicate file paths are collapsed");
+}
+
+#[test]
+fn push_files_in_context_truncates_at_five() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let files: Vec<_> = (1..=8)
+        .map(|i| TranscriptEntry::new("Tool", format!("read_file src/file{i}.rs")))
+        .collect();
+    app.committed_turns = vec![TranscriptTurn { entries: files }];
+
+    let mut lines = Vec::new();
+    push_files_in_context(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        text.contains("... and 3 more"),
+        "should truncate at 5 with overflow count"
+    );
+}
+
+#[test]
+fn push_files_in_context_read_only_no_changed() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.committed_turns = vec![TranscriptTurn {
+        entries: vec![TranscriptEntry::new("Tool", "read_file src/main.rs")],
+    }];
+
+    let mut lines = Vec::new();
+    push_files_in_context(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("Read:"));
+    assert!(!text.contains("Changed:"));
+}
+
+#[test]
+fn push_files_in_context_includes_active_turn() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.active_turn = TranscriptTurn {
+        entries: vec![TranscriptEntry::new("Tool", "read_file crates/tool.rs")],
+    };
+
+    let mut lines = Vec::new();
+    push_files_in_context(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        text.contains("crates/tool.rs"),
+        "should include files from active turn"
+    );
+}
+
+// ── PendingInteractionSnapshot default helper ───────────────────────
+
+impl Default for PendingInteractionSnapshot {
+    fn default() -> Self {
+        Self {
+            kind: InteractionKind::RequestInput,
+            title: String::new(),
+            summary: String::new(),
+            options: Vec::new(),
+            note: None,
+            approval: None,
+            source: None,
+        }
+    }
+}
+
+// ─── Section header check ───────────────────────────────────────────
+
+#[test]
+fn section_header_appears_in_sidebar() {
+    // Verify the sidebar calls section_label for each area.
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot = RuntimeSnapshot {
+        session_id: "sess1".into(),
+        cwd: "/tmp".into(),
+        ..RuntimeSnapshot::default()
+    };
+    app.config.provider = "test".into();
+    app.config.model = Some("m".into());
+
+    // Collect all sidebar lines by calling each push fn.
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    push_session_info(&mut lines, &app);
+    lines.push(Line::from(""));
+    push_model_badge(&mut lines, &app);
+    lines.push(Line::from(""));
     push_context_summary(&mut lines, &app);
+    lines.push(Line::from(""));
+    push_child_sessions(&mut lines, &app);
+    lines.push(Line::from(""));
+    push_files_in_context(&mut lines, &app);
 
     let text: String = lines
         .iter()
         .map(|l| l.to_string())
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(text.contains("8 turns"), "should show turn count");
-    assert!(text.contains("compacted"), "should show compaction");
-    assert!(text.contains("3 times"), "should show compaction count");
+
+    // Model, Context, and Files sections should exist.
+    assert!(text.contains("Model"), "sidebar has Model section");
+    assert!(text.contains("Context"), "sidebar has Context section");
+    // Files only appears when there are file-tool entries; in this test none.
 }

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -112,7 +112,10 @@ fn push_session_info_no_branch_shows_cwd_only() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(text.contains("/home/user/project"), "should show cwd");
-    assert!(!text.contains("::"), "no branch separator when branch empty");
+    assert!(
+        !text.contains("::"),
+        "no branch separator when branch empty"
+    );
 }
 
 #[test]
@@ -261,13 +264,19 @@ fn push_context_summary_shows_tokens_turns_compaction() {
         .map(|l| l.to_string())
         .collect::<Vec<_>>()
         .join("\n");
-    assert!(text.contains("Context"), "should show # Context section label");
+    assert!(
+        text.contains("Context"),
+        "should show # Context section label"
+    );
     assert!(
         text.contains("9.4k/16.0k tokens"),
         "should show token usage: 9.4k/16.0k"
     );
     assert!(text.contains("42 turns"), "should show turn count");
-    assert!(text.contains("compacted 3×"), "should show compaction count");
+    assert!(
+        text.contains("compacted 3×"),
+        "should show compaction count"
+    );
 }
 
 #[test]
@@ -314,9 +323,7 @@ fn push_context_summary_no_context_window() {
     let mut lines = Vec::new();
     push_context_summary(&mut lines, &app);
     assert!(
-        lines
-            .iter()
-            .any(|l| l.to_string().contains("600 tokens")),
+        lines.iter().any(|l| l.to_string().contains("600 tokens")),
         "shows total tokens without context window"
     );
 }
@@ -524,6 +531,72 @@ fn push_files_in_context_includes_active_turn() {
         text.contains("crates/tool.rs"),
         "should include files from active turn"
     );
+}
+
+#[test]
+fn push_files_in_context_detects_replace() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.committed_turns = vec![TranscriptTurn {
+        entries: vec![TranscriptEntry::new("Tool", "replace src/main.rs")],
+    }];
+
+    let mut lines = Vec::new();
+    push_files_in_context(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("Changed:"), "replace should be a changed file");
+    assert!(text.contains("src/main.rs"), "should show replaced path");
+}
+
+#[test]
+fn push_files_in_context_detects_multi_edit() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.committed_turns = vec![TranscriptTurn {
+        entries: vec![TranscriptEntry::new("Tool", "multi_edit crates/lib.rs")],
+    }];
+
+    let mut lines = Vec::new();
+    push_files_in_context(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("Changed:"), "multi_edit should be a changed file");
+    assert!(text.contains("crates/lib.rs"), "should show multi_edit path");
+}
+
+#[test]
+fn push_files_in_context_detects_replace_lines() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.committed_turns = vec![TranscriptTurn {
+        entries: vec![TranscriptEntry::new("Tool", "replace_lines src/tui/sidebar.rs")],
+    }];
+
+    let mut lines = Vec::new();
+    push_files_in_context(&mut lines, &app);
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("Changed:"), "replace_lines should be a changed file");
+    assert!(text.contains("src/tui/sidebar.rs"), "should show replace_lines path");
 }
 
 // ── PendingInteractionSnapshot default helper ───────────────────────


### PR DESCRIPTION
## Summary

Restructure the wide-screen sidebar to align with OpenCode's cleaner, section-based layout.

## Changes

- **Session info**: merge cwd/branch into one compact line
- **# Model**: add section header before provider/model badge
- **# Context**: replace detailed budget bar + token stats with one-line summary
- **# Files**: new section showing read files and changed files from transcript
- **# Sub-agents**: add section header, show each title + running status
- **Footer**: change to OpenCode format
- Remove push_budget_bar entirely

## Validation

- 23/23 tests pass
- 0 new clippy warnings