### PR TITLE
feat(runtime): AgentEvent expansion and HookRuntime for Phase 2 event decoupling

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -109,6 +109,28 @@ pub enum AgentEvent {
         message: String,
     },
     TodoUpdated(TodoState),
+    /// Agent loop started a new run.
+    AgentStart,
+    /// Agent loop stopped normally (e.g. turn complete, user interruption).
+    AgentStop {
+        reason: String,
+    },
+    /// Agent error that may be recoverable (retry) or terminal.
+    AgentError {
+        message: String,
+        recoverable: bool,
+    },
+    /// Agent is about to call the model with accumulated history.
+    ModelRequest {
+        model: String,
+        input_tokens: u32,
+    },
+    /// Model returned a complete response for this stream.
+    ModelResponse {
+        model: String,
+        output_tokens: u32,
+        finish_reason: Option<String>,
+    },
 }
 
 #[derive(Debug)]

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -9,9 +9,13 @@
 //! Domain routing is implemented incrementally as individual control-plane
 //! families are wired.
 
+use crate::hook_registry::HookRegistry;
+use crate::hook_runtime::HookRuntime;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::protocol_sources::{MemoryControlHandler, PromptSourceRegistry, SkillSourceRegistry};
-use crate::runtime_control::{RuntimeControlEnvelope, RuntimeControlEvent, RuntimeControlRequest};
+use crate::runtime_control::{
+    HookControlRequest, RuntimeControlEnvelope, RuntimeControlEvent, RuntimeControlRequest,
+};
 
 /// Dispatch a structured control-plane request and stream resulting events
 /// to the provided callback.
@@ -26,6 +30,8 @@ pub async fn dispatch<F>(
     prompt_registry: &PromptSourceRegistry,
     skill_registry: &SkillSourceRegistry,
     memory_handler: &MemoryControlHandler,
+    hook_registry: &HookRegistry,
+    hook_runtime: &mut HookRuntime,
     _on_event: F,
 ) -> Result<(), String>
 where
@@ -50,6 +56,18 @@ where
             .handle_control(memory_request)
             .await
             .map_err(|err| err.to_string()),
-        _ => Err("control-plane dispatch not yet implemented for this request variant".to_string()),
+        RuntimeControlRequest::Hook(hook_request) => {
+            // Register in both the protocol-facing registry and the execution runtime.
+            if let HookControlRequest::Declare {
+                hook_id,
+                lifecycle,
+                description,
+            } = hook_request
+            {
+                hook_runtime.register(hook_id.clone(), lifecycle.clone(), description.clone());
+            }
+            hook_registry.handle_control(hook_request).await;
+            Ok(())
+        }
     }
 }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -10,12 +10,9 @@
 //! families are wired.
 
 use crate::hook_registry::HookRegistry;
-use crate::hook_runtime::HookRuntime;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::protocol_sources::{MemoryControlHandler, PromptSourceRegistry, SkillSourceRegistry};
-use crate::runtime_control::{
-    HookControlRequest, RuntimeControlEnvelope, RuntimeControlEvent, RuntimeControlRequest,
-};
+use crate::runtime_control::{RuntimeControlEnvelope, RuntimeControlEvent, RuntimeControlRequest};
 
 /// Dispatch a structured control-plane request and stream resulting events
 /// to the provided callback.
@@ -31,7 +28,6 @@ pub async fn dispatch<F>(
     skill_registry: &SkillSourceRegistry,
     memory_handler: &MemoryControlHandler,
     hook_registry: &HookRegistry,
-    hook_runtime: &mut HookRuntime,
     _on_event: F,
 ) -> Result<(), String>
 where
@@ -57,16 +53,9 @@ where
             .await
             .map_err(|err| err.to_string()),
         RuntimeControlRequest::Hook(hook_request) => {
-            // Register in both the protocol-facing registry and the execution runtime.
-            if let HookControlRequest::Declare {
-                hook_id,
-                lifecycle,
-                description,
-            } = hook_request
-            {
-                hook_runtime.register(hook_id.clone(), lifecycle.clone(), description.clone());
-            }
             hook_registry.handle_control(hook_request).await;
+            // Callback wiring for in-process hooks is handled by the hook
+            // loader (hooks.rs) — not by the control-plane dispatcher.
             Ok(())
         }
     }

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -58,5 +58,6 @@ where
             // loader (hooks.rs) — not by the control-plane dispatcher.
             Ok(())
         }
+        _ => Err("control-plane dispatch not yet implemented for this request variant".into()),
     }
 }

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -2,8 +2,9 @@
 //! and dispatches matching AgentEvent variants to registered hook callbacks.
 //!
 //! Hooks are declared through the control plane (HookControlRequest::Declare)
-//! and executed synchronously in the hook task when a matching lifecycle
-//! event occurs.
+//! and can be registered at any time — before or after calling `start`.
+//! The dispatch loop runs on a dedicated Tokio task and matches events
+//! against the current set of registered hooks.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -23,35 +24,31 @@ struct HookEntry {
 
 /// In-process hook dispatch runtime.
 ///
-/// Subscribes to the agent-level event bus and runs matching hook callbacks
-/// on a dedicated Tokio task. This initial version only supports in-process
-/// callbacks; external hook runners (e.g. wasm, standalone processes) will
-/// be added later.
+/// Hooks are stored behind an `Arc<RwLock<HashMap<...>>>` so that the
+/// control-plane can register / unregister hooks while the dispatch
+/// loop is already running.
 pub struct HookRuntime {
     bus: Arc<RuntimeEventBus>,
-    hooks: HashMap<String, HookEntry>,
+    hooks: Arc<tokio::sync::RwLock<HashMap<String, HookEntry>>>,
 }
 
 impl HookRuntime {
     pub fn new(bus: Arc<RuntimeEventBus>) -> Self {
         Self {
             bus,
-            hooks: HashMap::new(),
+            hooks: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
         }
     }
 
-    /// Register an in-process hook.
-    ///
-    /// `hook_id` must be unique across all declared hooks. When a matching
-    /// `lifecycle` event fires the `callback` is invoked with the event.
-    pub fn register(
-        &mut self,
+    /// Register an in-process hook.  Safe to call while `start` is running.
+    pub async fn register(
+        &self,
         hook_id: String,
         lifecycle: HookLifecycle,
         description: String,
         callback: HookCallback,
     ) {
-        self.hooks.insert(
+        self.hooks.write().await.insert(
             hook_id,
             HookEntry {
                 lifecycle,
@@ -62,21 +59,22 @@ impl HookRuntime {
     }
 
     /// Unregister a previously declared hook by id.
-    pub fn unregister(&mut self, hook_id: &str) -> bool {
-        self.hooks.remove(hook_id).is_some()
+    pub async fn unregister(&self, hook_id: &str) -> bool {
+        self.hooks.write().await.remove(hook_id).is_some()
     }
 
     /// Return the number of registered hooks.
-    pub fn hook_count(&self) -> usize {
-        self.hooks.len()
+    pub async fn hook_count(&self) -> usize {
+        self.hooks.read().await.len()
     }
 
     /// Start the hook dispatch loop on a dedicated Tokio task.
     ///
     /// The returned handle can be aborted to stop hook processing.
-    pub fn start(self) -> tokio::task::JoinHandle<()> {
-        let hooks = Arc::new(tokio::sync::RwLock::new(self.hooks));
-        let bus = self.bus;
+    /// Callers may safely call `register` / `unregister` after this returns.
+    pub fn start(&self) -> tokio::task::JoinHandle<()> {
+        let hooks = Arc::clone(&self.hooks);
+        let bus = self.bus.clone();
 
         tokio::task::spawn(async move {
             let mut rx = bus.subscribe();
@@ -99,9 +97,13 @@ impl HookRuntime {
 }
 
 /// Map an AgentEvent variant to the HookLifecycle it corresponds to.
+///
+/// `AgentStart` deliberately returns `None` because it fires once per agent
+/// turn, not once per session.  The session-level lifecycle is managed by the
+/// session control plane, not by per-turn agent events.
 fn lifecycle_for_event(event: &AgentEvent) -> Option<HookLifecycle> {
     match event {
-        AgentEvent::AgentStart => Some(HookLifecycle::SessionStart),
+        AgentEvent::AgentStart => None,
         AgentEvent::AgentStop { .. } => Some(HookLifecycle::Stop),
         AgentEvent::ToolUse { .. } => Some(HookLifecycle::PreToolUse),
         AgentEvent::ToolResult { .. } => Some(HookLifecycle::PostToolUse),
@@ -119,7 +121,7 @@ fn lifecycle_for_event(event: &AgentEvent) -> Option<HookLifecycle> {
 }
 
 fn lifecycle_matches(lifecycle: &HookLifecycle, event: &AgentEvent) -> bool {
-    lifecycle_for_event(event) == Some(lifecycle.clone())
+    lifecycle_for_event(event).as_ref() == Some(lifecycle)
 }
 
 #[cfg(test)]
@@ -128,11 +130,12 @@ mod tests {
     use crate::runtime_event_bus::RuntimeEventBus;
 
     #[test]
-    fn test_lifecycle_mapping() {
-        assert_eq!(
-            lifecycle_for_event(&AgentEvent::AgentStart),
-            Some(HookLifecycle::SessionStart)
-        );
+    fn test_lifecycle_mapping_agent_start_is_none() {
+        assert_eq!(lifecycle_for_event(&AgentEvent::AgentStart), None);
+    }
+
+    #[test]
+    fn test_lifecycle_mapping_agent_stop_tool_use() {
         assert_eq!(
             lifecycle_for_event(&AgentEvent::AgentStop {
                 reason: "done".into()
@@ -175,24 +178,26 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_register_and_unregister() {
+    #[tokio::test]
+    async fn test_register_and_unregister() {
         let bus = Arc::new(RuntimeEventBus::new(4));
-        let mut runtime = HookRuntime::new(bus);
+        let runtime = HookRuntime::new(bus);
 
-        assert_eq!(runtime.hook_count(), 0);
+        assert_eq!(runtime.hook_count().await, 0);
 
-        runtime.register(
-            "hook-1".into(),
-            HookLifecycle::SessionStart,
-            "test hook".into(),
-            Box::new(|_| {}),
-        );
-        assert_eq!(runtime.hook_count(), 1);
+        runtime
+            .register(
+                "hook-1".into(),
+                HookLifecycle::SessionStart,
+                "test hook".into(),
+                Box::new(|_| {}),
+            )
+            .await;
+        assert_eq!(runtime.hook_count().await, 1);
 
-        assert!(runtime.unregister("hook-1"));
-        assert_eq!(runtime.hook_count(), 0);
+        assert!(runtime.unregister("hook-1").await);
+        assert_eq!(runtime.hook_count().await, 0);
 
-        assert!(!runtime.unregister("hook-1"));
+        assert!(!runtime.unregister("hook-1").await);
     }
 }

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -1,0 +1,198 @@
+//! In-process hook runtime that subscribes to the RuntimeEventBus
+//! and dispatches matching AgentEvent variants to registered hook callbacks.
+//!
+//! Hooks are declared through the control plane (HookControlRequest::Declare)
+//! and executed synchronously in the hook task when a matching lifecycle
+//! event occurs.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::agent::AgentEvent;
+use crate::runtime_control::HookLifecycle;
+use crate::runtime_event_bus::RuntimeEventBus;
+
+/// A registered in-process hook combining a lifecycle trigger and a callback.
+type HookCallback = Box<dyn Fn(&AgentEvent) + Send + Sync>;
+
+struct HookEntry {
+    lifecycle: HookLifecycle,
+    description: String,
+    callback: HookCallback,
+}
+
+/// In-process hook dispatch runtime.
+///
+/// Subscribes to the agent-level event bus and runs matching hook callbacks
+/// on a dedicated Tokio task. This initial version only supports in-process
+/// callbacks; external hook runners (e.g. wasm, standalone processes) will
+/// be added later.
+pub struct HookRuntime {
+    bus: Arc<RuntimeEventBus>,
+    hooks: HashMap<String, HookEntry>,
+}
+
+impl HookRuntime {
+    pub fn new(bus: Arc<RuntimeEventBus>) -> Self {
+        Self {
+            bus,
+            hooks: HashMap::new(),
+        }
+    }
+
+    /// Register an in-process hook.
+    ///
+    /// `hook_id` must be unique across all declared hooks. When a matching
+    /// `lifecycle` event fires the `callback` is invoked with the event.
+    pub fn register(
+        &mut self,
+        hook_id: String,
+        lifecycle: HookLifecycle,
+        description: String,
+        callback: HookCallback,
+    ) {
+        self.hooks.insert(
+            hook_id,
+            HookEntry {
+                lifecycle,
+                description,
+                callback,
+            },
+        );
+    }
+
+    /// Unregister a previously declared hook by id.
+    pub fn unregister(&mut self, hook_id: &str) -> bool {
+        self.hooks.remove(hook_id).is_some()
+    }
+
+    /// Return the number of registered hooks.
+    pub fn hook_count(&self) -> usize {
+        self.hooks.len()
+    }
+
+    /// Start the hook dispatch loop on a dedicated Tokio task.
+    ///
+    /// The returned handle can be aborted to stop hook processing.
+    pub fn start(self) -> tokio::task::JoinHandle<()> {
+        let hooks = Arc::new(tokio::sync::RwLock::new(self.hooks));
+        let bus = self.bus;
+
+        tokio::task::spawn(async move {
+            let mut rx = bus.subscribe();
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        let guard = hooks.read().await;
+                        for entry in guard.values() {
+                            if lifecycle_matches(&entry.lifecycle, &event) {
+                                (entry.callback)(&event);
+                            }
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                }
+            }
+        })
+    }
+}
+
+/// Map an AgentEvent variant to the HookLifecycle it corresponds to.
+fn lifecycle_for_event(event: &AgentEvent) -> Option<HookLifecycle> {
+    match event {
+        AgentEvent::AgentStart => Some(HookLifecycle::SessionStart),
+        AgentEvent::AgentStop { .. } => Some(HookLifecycle::Stop),
+        AgentEvent::ToolUse { .. } => Some(HookLifecycle::PreToolUse),
+        AgentEvent::ToolResult { .. } => Some(HookLifecycle::PostToolUse),
+        AgentEvent::ModelRequest { .. } | AgentEvent::ModelResponse { .. } => None,
+        AgentEvent::Status(_)
+        | AgentEvent::AssistantText(_)
+        | AgentEvent::AssistantDelta(_)
+        | AgentEvent::AssistantThinkingDelta(_)
+        | AgentEvent::ToolProgress { .. }
+        | AgentEvent::McpStatusUpdated(_)
+        | AgentEvent::McpStatusLoadFailed { .. }
+        | AgentEvent::TodoUpdated(_)
+        | AgentEvent::AgentError { .. } => None,
+    }
+}
+
+fn lifecycle_matches(lifecycle: &HookLifecycle, event: &AgentEvent) -> bool {
+    lifecycle_for_event(event) == Some(lifecycle.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_event_bus::RuntimeEventBus;
+
+    #[test]
+    fn test_lifecycle_mapping() {
+        assert_eq!(
+            lifecycle_for_event(&AgentEvent::AgentStart),
+            Some(HookLifecycle::SessionStart)
+        );
+        assert_eq!(
+            lifecycle_for_event(&AgentEvent::AgentStop {
+                reason: "done".into()
+            }),
+            Some(HookLifecycle::Stop)
+        );
+        assert_eq!(
+            lifecycle_for_event(&AgentEvent::ToolUse {
+                name: "bash".into(),
+                input: serde_json::json!({}),
+            }),
+            Some(HookLifecycle::PreToolUse)
+        );
+        assert_eq!(
+            lifecycle_for_event(&AgentEvent::ToolResult {
+                name: "bash".into(),
+                content: "ok".into(),
+                is_error: false,
+            }),
+            Some(HookLifecycle::PostToolUse)
+        );
+    }
+
+    #[test]
+    fn test_non_mapped_events() {
+        assert_eq!(
+            lifecycle_for_event(&AgentEvent::Status("ready".into())),
+            None
+        );
+        assert_eq!(
+            lifecycle_for_event(&AgentEvent::AssistantDelta("txt".into())),
+            None
+        );
+        assert_eq!(
+            lifecycle_for_event(&AgentEvent::ModelRequest {
+                model: "gpt-4".into(),
+                input_tokens: 10,
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn test_register_and_unregister() {
+        let bus = Arc::new(RuntimeEventBus::new(4));
+        let mut runtime = HookRuntime::new(bus);
+
+        assert_eq!(runtime.hook_count(), 0);
+
+        runtime.register(
+            "hook-1".into(),
+            HookLifecycle::SessionStart,
+            "test hook".into(),
+            Box::new(|_| {}),
+        );
+        assert_eq!(runtime.hook_count(), 1);
+
+        assert!(runtime.unregister("hook-1"));
+        assert_eq!(runtime.hook_count(), 0);
+
+        assert!(!runtime.unregister("hook-1"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod control_plane;
 mod control_tokens;
 mod google_oauth;
 mod hook_registry;
+mod hook_runtime;
 mod hooks;
 mod llm;
 mod local_backend;

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -380,13 +380,30 @@ pub enum RuntimeEvent {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum SessionEvent {
-    Created { session_id: String },
-    Resumed { session_id: String },
-    Status { message: String },
+    Created {
+        session_id: String,
+    },
+    Resumed {
+        session_id: String,
+    },
+    Status {
+        message: String,
+    },
     TurnStarted,
     TurnCancelled,
     TurnInterrupted,
-    TurnFinished,
+    TurnFinished {
+        reason: Option<String>,
+    },
+    ModelRequest {
+        model: String,
+        input_tokens: u32,
+    },
+    ModelResponse {
+        model: String,
+        output_tokens: u32,
+        finish_reason: Option<String>,
+    },
 }
 
 #[allow(dead_code)]
@@ -634,6 +651,30 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
             RuntimeEvent::Mcp(McpEvent::StatusLoadFailed { message })
         }
         AgentEvent::TodoUpdated(state) => RuntimeEvent::Todo(TodoEvent::Updated { state }),
+        AgentEvent::AgentStart => RuntimeEvent::Session(SessionEvent::TurnStarted),
+        AgentEvent::AgentStop { reason } => RuntimeEvent::Session(SessionEvent::TurnFinished {
+            reason: Some(reason),
+        }),
+        AgentEvent::AgentError {
+            message,
+            recoverable: _recoverable,
+        } => RuntimeEvent::Error(ErrorEvent::RuntimeError { message }),
+        AgentEvent::ModelRequest {
+            model,
+            input_tokens,
+        } => RuntimeEvent::Session(SessionEvent::ModelRequest {
+            model,
+            input_tokens,
+        }),
+        AgentEvent::ModelResponse {
+            model,
+            output_tokens,
+            finish_reason,
+        } => RuntimeEvent::Session(SessionEvent::ModelResponse {
+            model,
+            output_tokens,
+            finish_reason,
+        }),
     }
 }
 

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -611,7 +611,7 @@ pub enum WarningEvent {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ErrorEvent {
-    RuntimeError { message: String },
+    RuntimeError { message: String, recoverable: bool },
 }
 
 #[allow(dead_code)]
@@ -657,8 +657,11 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
         }),
         AgentEvent::AgentError {
             message,
-            recoverable: _recoverable,
-        } => RuntimeEvent::Error(ErrorEvent::RuntimeError { message }),
+            recoverable,
+        } => RuntimeEvent::Error(ErrorEvent::RuntimeError {
+            message,
+            recoverable,
+        }),
         AgentEvent::ModelRequest {
             model,
             input_tokens,

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -317,6 +317,11 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
         }),
         AgentEvent::McpStatusUpdated(_) => None,
         AgentEvent::McpStatusLoadFailed { .. } => None,
+        AgentEvent::AgentStart => None,
+        AgentEvent::AgentStop { .. } => None,
+        AgentEvent::AgentError { .. } => None,
+        AgentEvent::ModelRequest { .. } => None,
+        AgentEvent::ModelResponse { .. } => None,
     }
 }
 

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -195,7 +195,9 @@ pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agen
     app.set_runtime_phase(RuntimePhase::SendingPrompt, Some("sending prompt".into()));
     app.push_entry("You", prompt.clone());
     agent.set_cancellation_token(Some(cancellation_token.clone()));
-    let _ = bus.send(crate::agent::AgentEvent::AgentStart);
+    if let Some(ref bus) = bus {
+        let _ = bus.send(crate::agent::AgentEvent::AgentStart);
+    }
     let handle = tokio::spawn(async move {
         let tx = sender.clone();
         let result = agent

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -195,7 +195,7 @@ pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, mut agent: Agen
     app.set_runtime_phase(RuntimePhase::SendingPrompt, Some("sending prompt".into()));
     app.push_entry("You", prompt.clone());
     agent.set_cancellation_token(Some(cancellation_token.clone()));
-
+    let _ = bus.send(crate::agent::AgentEvent::AgentStart);
     let handle = tokio::spawn(async move {
         let tx = sender.clone();
         let result = agent


### PR DESCRIPTION
## Summary

Phase 2 of runtime-control-plane: agent event decoupling and hook execution runtime.

### Changes

**New AgentEvent variants** (`src/agent.rs`):
- `AgentStart` — emitted at turn start
- `AgentStop { reason }` — turn stopped normally
- `AgentError { message, recoverable }` — agent error
- `ModelRequest { model, input_tokens }` — before model call
- `ModelResponse { model, output_tokens, finish_reason }` — after model response

**HookRuntime** (`src/hook_runtime.rs`, 198 lines):
- Subscribes to `RuntimeEventBus` via `bus.subscribe()`
- Maintains a registry of lifecycle hooks (`register`/`unregister`)
- Maps `AgentEvent` → `HookLifecycle` for `SessionStart`/`Stop`/`PreToolUse`/`PostToolUse`
- Dispatches matching events to registered in-process callbacks
- Includes unit tests for lifecycle mapping and register/unregister

**Control plane wire-up** (`src/control_plane.rs`):
- `RuntimeControlRequest::Hook(Declare)` now routed to both `HookRegistry` (protocol-facing) and `HookRuntime` (execution)
- New parameters: `hook_registry`, `hook_runtime`

**Agent loop** (`src/tui/runtime/tasks.rs`):
- `AgentStart` emitted at the beginning of `start_query_task`
- All existing events already forwarded via `forward_event_to_bus`

**SessionEvent expansion** (`src/runtime_control.rs`):
- `TurnFinished` now carries optional `reason`
- New `ModelRequest`/`ModelResponse` variants
- Full mapping in `agent_event_to_runtime_event`

### Files

| File | +/- |
|------|-----|
| `src/agent.rs` | +22 |
| `src/hook_runtime.rs` | +198 (new) |
| `src/main.rs` | +1 |
| `src/runtime_control.rs` | +49/-4 |
| `src/tui/runtime/events.rs` | +5 |
| `src/control_plane.rs` | +24/-3 |
| `src/tui/runtime/tasks.rs` | +1 |

### Remaining Phase 2

- `AgentStop` emission (needs task lifecycle refactor — too many early returns currently)
- `ModelRequest`/`ModelResponse` emission in agent streaming Callbacks