### PR TITLE
fix(tui): strip tool-call XML fragments from thinking text

### DIFF
--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -6,7 +6,8 @@ use self::helpers::{
     append_tool_progress, exploration_action_label, exploration_note_lines,
     exploration_result_note, format_tool_result, format_tool_use, is_exploration_tool_name,
     is_oauth_prompt_message, planning_action_label, planning_note_lines, planning_result_note,
-    scrub_internal_control_tokens, subagent_request_input, tool_action_label,
+    sanitize_thinking_text, scrub_internal_control_tokens, subagent_request_input,
+    tool_action_label,
 };
 use super::super::state::{RuntimePhase, TuiApp, TuiEvent, contains_structured_planning_output};
 use crate::agent::AgentEvent;
@@ -261,7 +262,7 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
         }),
         AgentEvent::AssistantThinkingDelta(text) => Some(TuiEvent::Transcript {
             role: "Agent Thinking Delta",
-            message: text,
+            message: sanitize_thinking_text(&text),
         }),
         AgentEvent::ToolUse { name, input } => {
             if name == crate::tools::todo::TODO_WRITE_TOOL_NAME {

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -1000,3 +1000,18 @@ pub(super) fn format_error_chain(err: &anyhow::Error) -> String {
     }
     lines.join("\n")
 }
+
+pub(super) fn sanitize_thinking_text(text: &str) -> String {
+    text.lines()
+        .filter(|line| {
+            let t = line.trim();
+            !t.starts_with("</")
+                && !t.starts_with("<parameter")
+                && !t.starts_with("</rara_invoke")
+                && !t.starts_with("</rara_tool_calls")
+                && !t.contains("string=\"true\"")
+                && !t.contains("string=\"false\"")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}


### PR DESCRIPTION
LLM reasoning output (AssistantThinkingDelta) can contain orphaned
XML close tags from the tool-calling prompt format, leaking into the
TUI and terminal.

Add sanitize_thinking_text() that filters lines containing:
- Orphaned close tags
- Open tag fragments with string attributes
- Tool-call parameter markup

Changes:
- src/tui/runtime/events/helpers.rs: add sanitize_thinking_text()
- src/tui/runtime/events.rs: apply sanitizer to ThinkingDelta events
