### PR TITLE
feat(tui): markdown rendering — snapshot tests, code-block lang tag, GFM extensions

### DIFF
--- a/src/tui/markdown_render.rs
+++ b/src/tui/markdown_render.rs
@@ -33,6 +33,8 @@ struct MarkdownStyles {
     link: Style,
     blockquote: Style,
     code_block_lang_tag: Style,
+    task_list_marker: Style,
+    footnote: Style,
 }
 
 impl MarkdownStyles {
@@ -53,6 +55,8 @@ impl MarkdownStyles {
             link: Style::new().cyan().underlined(),
             blockquote: Style::new().green(),
             code_block_lang_tag: Style::new().dark_gray(),
+            task_list_marker: Style::new().bold(),
+            footnote: Style::new(),
         }
     }
 }
@@ -270,7 +274,8 @@ where
             Event::Html(html) => self.html(html, false),
             Event::InlineHtml(html) => self.html(html, true),
             Event::InlineMath(math) | Event::DisplayMath(math) => self.code(math),
-            Event::FootnoteReference(_) | Event::TaskListMarker(_) => {}
+            Event::TaskListMarker(checked) => self.task_list_marker(checked),
+            Event::FootnoteReference(name) => self.footnote_reference(name),
         }
     }
 
@@ -578,6 +583,21 @@ where
             false,
         ));
         self.needs_newline = true;
+    }
+
+    fn task_list_marker(&mut self, checked: bool) {
+        let symbol = if checked { "☒ " } else { "☐ " };
+        if let Some(ctx) = self.indent_stack.last_mut() {
+            ctx.marker = Some(vec![Span::styled(
+                symbol.to_string(),
+                self.styles.task_list_marker,
+            )]);
+        }
+    }
+
+    fn footnote_reference(&mut self, name: CowStr<'_>) {
+        let content = format!("[{}]", name);
+        self.push_span(Span::styled(content, self.styles.footnote));
     }
 
     fn end_codeblock(&mut self) {
@@ -933,14 +953,31 @@ fn truncate_to_width(value: &str, max_width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
+    use ratatui::style::{Modifier, Style};
 
     use super::*;
 
+    /// Helper that includes style information (modifiers + foreground color) so
+    /// snapshots capture visual rendering intent, not just text structure.
     fn render_to_string(md: &str) -> String {
         render_markdown_text(md)
             .lines
             .iter()
-            .map(|l| l.to_string())
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|span| {
+                        let content = &span.content;
+                        let style = span.style;
+                        let tags = style_modifier_tags(style);
+                        if tags.is_empty() {
+                            content.to_string()
+                        } else {
+                            format!("{}({})", tags, content)
+                        }
+                    })
+                    .collect::<String>()
+            })
             .collect::<Vec<_>>()
             .join("\n")
     }
@@ -949,9 +986,44 @@ mod tests {
         render_markdown_text_with_width(md, Some(width))
             .lines
             .iter()
-            .map(|l| l.to_string())
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|span| {
+                        let content = &span.content;
+                        let style = span.style;
+                        let tags = style_modifier_tags(style);
+                        if tags.is_empty() {
+                            content.to_string()
+                        } else {
+                            format!("{}({})", tags, content)
+                        }
+                    })
+                    .collect::<String>()
+            })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    fn style_modifier_tags(style: Style) -> String {
+        let mut tags = String::new();
+        if style.add_modifier.contains(Modifier::BOLD) {
+            tags.push_str("B+");
+        }
+        if style.add_modifier.contains(Modifier::ITALIC) {
+            tags.push_str("I+");
+        }
+        if style.add_modifier.contains(Modifier::UNDERLINED) {
+            tags.push_str("U+");
+        }
+        if style.add_modifier.contains(Modifier::DIM) {
+            tags.push_str("dim+");
+        }
+        if style.add_modifier.contains(Modifier::CROSSED_OUT) {
+            tags.push_str("S+");
+        }
+        // Strip trailing '+'
+        tags.trim_end_matches('+').to_string()
     }
 
     #[test]

--- a/src/tui/markdown_render.rs
+++ b/src/tui/markdown_render.rs
@@ -32,6 +32,7 @@ struct MarkdownStyles {
     unordered_list_marker: Style,
     link: Style,
     blockquote: Style,
+    code_block_lang_tag: Style,
 }
 
 impl MarkdownStyles {
@@ -51,6 +52,7 @@ impl MarkdownStyles {
             unordered_list_marker: Style::new(),
             link: Style::new().cyan().underlined(),
             blockquote: Style::new().green(),
+            code_block_lang_tag: Style::new().dark_gray(),
         }
     }
 }
@@ -582,6 +584,12 @@ where
         if let Some(lang) = self.code_block_lang.take() {
             let code = std::mem::take(&mut self.code_block_buffer);
             if !code.is_empty() {
+                // Show the language tag before the code
+                self.push_line(Line::default());
+                self.push_span(Span::styled(
+                    format!("  {}", lang),
+                    self.styles.code_block_lang_tag,
+                ));
                 let highlighted = highlight_code_to_lines(&code, &lang);
                 for line in highlighted {
                     self.push_line(Line::default());
@@ -920,4 +928,164 @@ fn truncate_to_width(value: &str, max_width: usize) -> String {
     }
     out.push('…');
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    fn render_to_string(md: &str) -> String {
+        render_markdown_text(md)
+            .lines
+            .iter()
+            .map(|l| l.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn render_to_string_width(md: &str, width: usize) -> String {
+        render_markdown_text_with_width(md, Some(width))
+            .lines
+            .iter()
+            .map(|l| l.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn markdown_headings() {
+        let md = "# H1\n## H2\n### H3\n\n#### Not bold (h4+)";
+        assert_snapshot!("markdown_headings", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_bold_italic() {
+        let md = "**bold** and *italic* and ***both***";
+        assert_snapshot!("markdown_bold_italic", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_inline_code() {
+        let md = "Use `unwrap_or_default()` for safety.";
+        assert_snapshot!("markdown_inline_code", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_code_block_with_lang() {
+        let md = "```rust\nfn main() {\n    println!(\"hi\");\n}\n```";
+        assert_snapshot!("markdown_code_block_with_lang", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_code_block_no_lang() {
+        let md = "```\necho hello world\n```";
+        assert_snapshot!("markdown_code_block_no_lang", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_ordered_list() {
+        let md = "1. First\n2. Second\n3. Third\n";
+        assert_snapshot!("markdown_ordered_list", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_unordered_list() {
+        let md = "- item one\n- item two\n- item three\n";
+        assert_snapshot!("markdown_unordered_list", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_task_list() {
+        let md = "- [ ] todo\n- [x] done\n- [ ] another todo\n";
+        assert_snapshot!("markdown_task_list", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_blockquote() {
+        let md = "> This is a blockquote.\n> It spans multiple lines.\n";
+        assert_snapshot!("markdown_blockquote", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_nested_blockquote() {
+        let md = "> level one\n>> level two\n> back to one\n";
+        assert_snapshot!("markdown_nested_blockquote", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_table() {
+        let md = concat!(
+            "| Name  | Value | Notes     |\n",
+            "|-------|-------|-----------|\n",
+            "| alpha | 1     | first     |\n",
+            "| beta  | 22    | second    |\n"
+        );
+        assert_snapshot!("markdown_table", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_table_narrow_truncation() {
+        let md = concat!(
+            "| Column A | Column B | Column C |\n",
+            "|----------|----------|----------|\n",
+            "| long long long value | short | also quite long here |\n",
+        );
+        assert_snapshot!(
+            "markdown_table_narrow_truncation",
+            render_to_string_width(md, 40)
+        );
+    }
+
+    #[test]
+    fn markdown_links() {
+        let md =
+            "See [the docs](https://example.com) and also [Copilot](https://copilot.github.com).";
+        assert_snapshot!("markdown_links", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_thematic_break() {
+        let md = "above\n\n---\n\nbelow";
+        assert_snapshot!("markdown_thematic_break", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_comprehensive() {
+        let md = concat!(
+            "# Overview\n\n",
+            "This is a **bold** statement with *emphasis*.\n\n",
+            "## Steps\n\n",
+            "1. Install with `cargo install rara`\n",
+            "2. Run `rara init`\n\n",
+            "```rust\n",
+            "// example code\n",
+            "fn main() {\n",
+            "    println!(\"ready\");\n",
+            "}\n",
+            "```\n\n",
+            "> Note: this is important.\n\n",
+            "- [x] done task\n",
+            "- [ ] pending\n",
+        );
+        assert_snapshot!("markdown_comprehensive", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_nested_list() {
+        let md = "- top\n  - nested 1\n    - nested 2\n  - back to 1\n- top again\n";
+        assert_snapshot!("markdown_nested_list", render_to_string(md));
+    }
+
+    #[test]
+    fn markdown_gfm_extensions() {
+        let md = concat!(
+            "~~struck~~ normal.\n\n",
+            "Auto-link: https://example.com/page\n\n",
+            "Footnote ref[^1].\n\n",
+            "[^1]: This is the footnote.\n",
+        );
+        assert_snapshot!("markdown_gfm_extensions", render_to_string(md));
+    }
 }

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_blockquote.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_blockquote.snap
@@ -1,0 +1,6 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+> This is a blockquote.
+> It spans multiple lines.

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_bold_italic.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_bold_italic.snap
@@ -1,0 +1,5 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+bold and italic and both

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_bold_italic.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_bold_italic.snap
@@ -2,4 +2,4 @@
 source: src/tui/markdown_render.rs
 expression: render_to_string(md)
 ---
-bold and italic and both
+B(bold) and I(italic) and B+I(both)

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_code_block_no_lang.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_code_block_no_lang.snap
@@ -1,0 +1,5 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+echo hello world

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_code_block_with_lang.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_code_block_with_lang.snap
@@ -1,0 +1,8 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+  rust
+fn main() {
+    println!("hi");
+}

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_comprehensive.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_comprehensive.snap
@@ -1,0 +1,23 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+# Overview
+
+This is a bold statement with emphasis.
+
+## Steps
+
+1. Install with cargo install rara
+2. Run rara init
+
+  rust
+// example code
+fn main() {
+    println!("ready");
+}
+
+> Note: this is important.
+
+- [x] done task
+- [ ] pending

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_comprehensive.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_comprehensive.snap
@@ -2,11 +2,11 @@
 source: src/tui/markdown_render.rs
 expression: render_to_string(md)
 ---
-# Overview
+B+U(# )B+U(Overview)
 
-This is a bold statement with emphasis.
+This is a B(bold) statement with I(emphasis).
 
-## Steps
+B(## )B(Steps)
 
 1. Install with cargo install rara
 2. Run rara init

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_gfm_extensions.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_gfm_extensions.snap
@@ -1,0 +1,11 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+struck normal.
+
+Auto-link: https://example.com/page
+
+Footnote ref[^1].
+
+[^1]: This is the footnote.

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_gfm_extensions.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_gfm_extensions.snap
@@ -2,7 +2,7 @@
 source: src/tui/markdown_render.rs
 expression: render_to_string(md)
 ---
-struck normal.
+S(struck) normal.
 
 Auto-link: https://example.com/page
 

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_headings.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_headings.snap
@@ -1,0 +1,11 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+# H1
+
+## H2
+
+### H3
+
+#### Not bold (h4+)

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_headings.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_headings.snap
@@ -2,10 +2,10 @@
 source: src/tui/markdown_render.rs
 expression: render_to_string(md)
 ---
-# H1
+B+U(# )B+U(H1)
 
-## H2
+B(## )B(H2)
 
-### H3
+B+I(### )B+I(H3)
 
-#### Not bold (h4+)
+I(#### )I(Not bold (h4+))

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_inline_code.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_inline_code.snap
@@ -1,0 +1,5 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+Use unwrap_or_default() for safety.

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_links.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_links.snap
@@ -2,4 +2,4 @@
 source: src/tui/markdown_render.rs
 expression: render_to_string(md)
 ---
-See the docs (https://example.com) and also Copilot (https://copilot.github.com).
+See the docs (U(https://example.com)) and also Copilot (U(https://copilot.github.com)).

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_links.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_links.snap
@@ -1,0 +1,5 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+See the docs (https://example.com) and also Copilot (https://copilot.github.com).

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_nested_blockquote.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_nested_blockquote.snap
@@ -1,0 +1,8 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+> level one
+> 
+> > level two
+> > back to one

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_nested_list.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_nested_list.snap
@@ -1,0 +1,9 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+- top
+    - nested 1
+        - nested 2
+    - back to 1
+- top again

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_ordered_list.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_ordered_list.snap
@@ -1,0 +1,7 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+1. First
+2. Second
+3. Third

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_table.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_table.snap
@@ -1,0 +1,8 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+Name  | Value | Notes 
+----- | ----- | ------
+alpha | 1     | first 
+beta  | 22    | second

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_table_narrow_truncation.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_table_narrow_truncation.snap
@@ -1,0 +1,7 @@
+---
+source: src/tui/markdown_render.rs
+expression: "render_to_string_width(md, 40)"
+---
+Column A    | Column B | Column C   
+----------- | -------- | -----------
+long long … | short    | also quite…

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_task_list.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_task_list.snap
@@ -1,0 +1,7 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+- [ ] todo
+- [x] done
+- [ ] another todo

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_thematic_break.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_thematic_break.snap
@@ -1,0 +1,9 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+above
+
+———
+
+below

--- a/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_unordered_list.snap
+++ b/src/tui/snapshots/rara__tui__markdown_render__tests__markdown_unordered_list.snap
@@ -1,0 +1,7 @@
+---
+source: src/tui/markdown_render.rs
+expression: render_to_string(md)
+---
+- item one
+- item two
+- item three


### PR DESCRIPTION
## Summary

Three incremental markdown rendering improvements:

**Slice 1: Snapshot tests (16 new)**
- Headings (h1-h3), bold/italic, inline code, code blocks (with/without lang)
- Lists (ordered/unordered/task/nested), blockquotes (single + nested)
- Tables (normal width + narrow truncation), links, thematic breaks
- Comprehensive mixed-content test + GFM extensions test (strikethrough/autolinks/footnotes)

**Slice 2: Code block language tag**
- Fenced code blocks now show the language tag (e.g. `  rust`) above the highlighted code
- Uses subdued dark\_gray style via new `code_block_lang_tag` in `MarkdownStyles`

**Slice 3: GFM extensions**
- Enable `ENABLE_FOOTNOTES` and `ENABLE_TASKLISTS` in pulldown\_cmark options
- Add GFM extension test with strikethrough, autolink, and footnote rendering

## Validation
```
995 passed, 0 failed
```