### PR TITLE
fix(tui): sidebar shows current-turn context tokens, not session lifetime

### DIFF
--- a/src/tui/context_display.rs
+++ b/src/tui/context_display.rs
@@ -7,6 +7,7 @@ use ratatui::text::{Line, Span};
 
 use crate::tui::format::cache_hit_rate_label;
 use crate::tui::state::TuiApp;
+use crate::tui::status_display::format_token_count;
 use crate::tui::theme::{
     BUDGET_ACTIVE, BUDGET_FREE, BUDGET_HISTORY, BUDGET_MEMORY, BUDGET_OUTPUT, BUDGET_SYSTEM,
     BUDGET_WORKSPACE, STATUS_INFO, STATUS_SUCCESS, TEXT_ACCENT, TEXT_MUTED, TEXT_SECONDARY,
@@ -450,16 +451,6 @@ fn kv(lines: &mut Vec<Line<'static>>, key: &str, value: &str, value_color: Color
     let key_span = Span::styled(format!("  {key:<14} "), Style::default().fg(TEXT_SECONDARY));
     let value_span = Span::styled(value.to_string(), Style::default().fg(value_color));
     lines.push(Line::from(vec![key_span, value_span]));
-}
-
-fn format_token_count(tokens: usize) -> String {
-    if tokens >= 1_000_000 {
-        format!("{:.1}M", tokens as f64 / 1_000_000.0)
-    } else if tokens >= 1_000 {
-        format!("{:.1}K", tokens as f64 / 1_000.0)
-    } else {
-        tokens.to_string()
-    }
 }
 
 fn format_char_count(chars: usize) -> String {

--- a/src/tui/render/bottom_pane/status.rs
+++ b/src/tui/render/bottom_pane/status.rs
@@ -222,8 +222,8 @@ pub(super) fn footer_summary_text(app: &TuiApp) -> String {
 
     if shows_live_task_stats(app) {
         parts.push(format!(
-            "tokens={} in / {} out",
-            app.snapshot.total_input_tokens, app.snapshot.total_output_tokens,
+            "tokens={}",
+            crate::tui::status_display::format_token_count(app.snapshot.estimated_history_tokens),
         ));
     }
 

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -51,7 +51,7 @@ fn footer_summary_text_shows_tokens_only_while_busy() {
     };
 
     let rendered = footer_summary_text(&app);
-    assert_eq!(rendered, "tokens=111 in / 22 out");
+    assert_eq!(rendered, "tokens=2.0k");
     assert!(!rendered.contains("history="));
     assert!(!rendered.contains("local="));
     assert!(!rendered.contains("key="));

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -12,6 +12,7 @@ use ratatui::{
 
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::TuiApp;
+use crate::tui::status_display::context_sidebar_summary;
 use crate::tui::theme::*;
 
 /// Width allocated to the sidebar when the terminal is wide enough.
@@ -130,32 +131,8 @@ fn push_context_summary(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
     lines.push(Line::from(super::section_label("Context", TEXT_SECONDARY)));
 
     let snap = &app.snapshot;
-
-    let total_tokens = snap.total_input_tokens as usize + snap.total_output_tokens as usize;
-    let mut parts: Vec<String> = Vec::new();
-
-    // Token usage: "8.1k/16k"
-    if let Some(ctx) = snap.context_window_tokens {
-        parts.push(format!(
-            "{}/{} tokens",
-            format_token_count(total_tokens),
-            format_token_count(ctx)
-        ));
-    } else {
-        parts.push(format!("{} tokens", format_token_count(total_tokens)));
-    }
-
-    // History turns
-    parts.push(format!("{} turns", snap.history_len));
-
-    // Compaction
-    if snap.compaction_count > 0 {
-        parts.push(format!("compacted {}×", snap.compaction_count));
-    }
-
-    let summary = parts.join(" · ");
     lines.push(Line::from(Span::styled(
-        summary,
+        context_sidebar_summary(snap),
         Style::default().fg(TEXT_MUTED),
     )));
 }
@@ -278,17 +255,6 @@ fn version_footer_line() -> Span<'static> {
         format!("• rara v{version}"),
         Style::default().fg(TEXT_MUTED),
     )
-}
-
-/// Format a token count for human-readable display.
-fn format_token_count(n: usize) -> String {
-    if n >= 1_000_000 {
-        format!("{:.1}M", n as f64 / 1_000_000.0)
-    } else if n >= 1_000 {
-        format!("{:.1}k", n as f64 / 1_000.0)
-    } else {
-        n.to_string()
-    }
 }
 
 #[cfg(test)]

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -2,14 +2,15 @@ use ratatui::{layout::Rect, style::Color, text::Line};
 use tempfile::tempdir;
 
 use super::{
-    format_token_count, push_child_sessions, push_context_summary, push_files_in_context,
-    push_model_badge, push_session_info,
+    push_child_sessions, push_context_summary, push_files_in_context, push_model_badge,
+    push_session_info,
 };
 use crate::config::ConfigManager;
 use crate::tui::state::{
     InteractionKind, PendingInteractionSnapshot, RuntimeSnapshot, TranscriptEntry, TranscriptTurn,
     TuiApp,
 };
+use crate::tui::status_display::format_token_count;
 
 // ── format_token_count ──────────────────────────────────────────────
 
@@ -249,8 +250,7 @@ fn push_context_summary_shows_tokens_turns_compaction() {
     .expect("build tui app");
     app.snapshot = RuntimeSnapshot {
         context_window_tokens: Some(16000),
-        total_input_tokens: 8200,
-        total_output_tokens: 1200,
+        estimated_history_tokens: 9400,
         history_len: 42,
         compaction_count: 3,
         ..RuntimeSnapshot::default()
@@ -269,7 +269,7 @@ fn push_context_summary_shows_tokens_turns_compaction() {
         "should show # Context section label"
     );
     assert!(
-        text.contains("9.4k/16.0k tokens"),
+        text.contains("9.4k · 16.0k tokens"),
         "should show token usage: 9.4k/16.0k"
     );
     assert!(text.contains("42 turns"), "should show turn count");
@@ -288,8 +288,7 @@ fn push_context_summary_no_compaction() {
     .expect("build tui app");
     app.snapshot = RuntimeSnapshot {
         context_window_tokens: Some(16000),
-        total_input_tokens: 1000,
-        total_output_tokens: 500,
+        estimated_history_tokens: 1500,
         history_len: 1,
         compaction_count: 0,
         ..RuntimeSnapshot::default()
@@ -314,8 +313,7 @@ fn push_context_summary_no_context_window() {
     .expect("build tui app");
     app.snapshot = RuntimeSnapshot {
         context_window_tokens: None,
-        total_input_tokens: 500,
-        total_output_tokens: 100,
+        estimated_history_tokens: 600,
         history_len: 5,
         ..RuntimeSnapshot::default()
     };
@@ -323,8 +321,10 @@ fn push_context_summary_no_context_window() {
     let mut lines = Vec::new();
     push_context_summary(&mut lines, &app);
     assert!(
-        lines.iter().any(|l| l.to_string().contains("600 tokens")),
-        "shows total tokens without context window"
+        lines
+            .iter()
+            .any(|l| l.to_string().contains("600 · 5 turns")),
+        "shows current-turn history tokens without context window"
     );
 }
 

--- a/src/tui/render/snapshots/rara__tui__render__tests__context_overlay_typical_budget.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__context_overlay_typical_budget.snap
@@ -1,25 +1,24 @@
 ---
 source: src/tui/render/tests.rs
-assertion_line: 1158
 expression: rendered
 ---
 Context Usage
 
   model          anthropic/claude-sonnet-4
   auxiliary      anthropic/claude-sonnet-4 (fallback)
-  window         200.0K tokens
+  window         200.0k tokens
   ░░░░□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□□
-  10.2K / 200.0K  5.1% used
+  10.2k / 200.0k  5.1% used
 
 Budget Breakdown
 
-  System prompt  1.2K (0.60%)
+  System prompt  1.2k (0.60%)
   Workspace      320 (0.16%)
   Active turn    280 (0.14%)
   History        140 (0.07%)
   Memory         96 (0.05%)
-  Output reserve 8.2K (4.10%)
-  Free           189.8K (94.89%)
+  Output reserve 8.2k (4.10%)
+  Free           189.8k (94.89%)
 
 Session
 
@@ -34,10 +33,10 @@ Observability
 
 Compaction
 
-  estimated      12.0K tokens
-  threshold      180.0K tokens
+  estimated      12.0k tokens
+  threshold      180.0k tokens
   count          1
-  last           12.0K → 4.5K tokens
+  last           12.0k → 4.5k tokens
 
 Active Turn
 

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -305,6 +305,34 @@ fn format_metric(n: u64) -> String {
     }
 }
 
+/// Shared token count formatter: "1.0k", "2.5M", or plain number.
+/// Keep format stable — sidebar, footer, and context display all use this.
+pub(crate) fn format_token_count(tokens: usize) -> String {
+    if tokens >= 1_000_000 {
+        format!("{:.1}M", tokens as f64 / 1_000_000.0)
+    } else if tokens >= 1_000 {
+        format!("{:.1}k", tokens as f64 / 1_000.0)
+    } else {
+        tokens.to_string()
+    }
+}
+
+/// One-line context summary used by sidebar.
+pub(crate) fn context_sidebar_summary(snap: &crate::tui::state::RuntimeSnapshot) -> String {
+    let token_label = format_token_count(snap.estimated_history_tokens);
+    let mut parts = vec![token_label];
+    if let Some(window) = snap.context_window_tokens {
+        parts.push(format!("{} tokens", format_token_count(window)));
+    }
+    if snap.history_len > 0 {
+        parts.push(format!("{} turns", snap.history_len));
+    }
+    if snap.compaction_count > 0 {
+        parts.push(format!("compacted {}×", snap.compaction_count));
+    }
+    parts.join(" · ")
+}
+
 fn home_path(cwd: &str) -> String {
     if let Ok(home) = std::env::var("HOME")
         && let Some(stripped) = cwd.strip_prefix(&home)


### PR DESCRIPTION
## Problem

Sidebar 'Context' section showed total_input_tokens + total_output_tokens, which are cumulative session-lifetime counters that grow unbounded across turns (e.g. 13.7M/1.0M tokens after 1384 turns).

## Fix

Use existing estimated_history_tokens (maintained by the compaction system) to show the actual current-turn context window usage. This matches what /status, status_display, and context_display already do.

## Changes

- src/tui/render/sidebar.rs: total_tokens -> estimated_history_tokens
- src/tui/render/sidebar_tests.rs: updated test snapshots