### PR TITLE
fix(tui): context window 128k default + allow /model /status /help during agent rebuild

### DIFF
--- a/src/tui/input_control.rs
+++ b/src/tui/input_control.rs
@@ -47,7 +47,9 @@ pub(crate) fn submit_user_prompt(
     }
 
     let Some(agent) = agent_slot.take() else {
-        app.push_notice("Agent is not ready for input.");
+        app.push_notice("Agent not ready. Starting rebuild — try again in a moment.");
+        // Auto-recover: trigger agent rebuild so the slot is refilled.
+        super::runtime::start_rebuild_task(app);
         return InputControlOutcome::Rejected;
     };
 

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -323,8 +323,8 @@ fn push_context_summary_no_context_window() {
     assert!(
         lines
             .iter()
-            .any(|l| l.to_string().contains("600 · 5 turns")),
-        "shows current-turn history tokens without context window"
+            .any(|l| l.to_string().contains("600 · 128.0k tokens · 5 turns")),
+        "shows current-turn history tokens with default 128k context window"
     );
 }
 

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -203,14 +203,12 @@ fn render_context_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
         &format!("{} tokens", snap.estimated_history_tokens),
         Color::DarkGray,
     );
-    if let Some(window) = snap.context_window_tokens {
-        kv(
-            lines,
-            "window",
-            &format_metric(window as u64),
-            Color::LightBlue,
-        );
-    }
+    kv(
+        lines,
+        "window",
+        &format_metric(snap.context_window_tokens.unwrap_or(128_000) as u64),
+        Color::LightBlue,
+    );
     if let Some(remaining) = snap.remaining_input_budget {
         kv(
             lines,
@@ -321,9 +319,8 @@ pub(crate) fn format_token_count(tokens: usize) -> String {
 pub(crate) fn context_sidebar_summary(snap: &crate::tui::state::RuntimeSnapshot) -> String {
     let token_label = format_token_count(snap.estimated_history_tokens);
     let mut parts = vec![token_label];
-    if let Some(window) = snap.context_window_tokens {
-        parts.push(format!("{} tokens", format_token_count(window)));
-    }
+    let window = snap.context_window_tokens.unwrap_or(128_000);
+    parts.push(format!("{} tokens", format_token_count(window)));
     if snap.history_len > 0 {
         parts.push(format!("{} turns", snap.history_len));
     }

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -363,3 +363,39 @@ fn sandbox_label(_app: &TuiApp) -> String {
     }
     .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::config::ConfigManager;
+    use crate::tui::state::RuntimeSnapshot;
+
+    #[test]
+    fn context_status_shows_128k_when_window_unknown() {
+        let temp = tempdir().unwrap();
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.snapshot = RuntimeSnapshot {
+            context_window_tokens: None,
+            estimated_history_tokens: 5000,
+            ..RuntimeSnapshot::default()
+        };
+
+        let mut lines = Vec::new();
+        render_context_status(&app, &mut lines);
+        let text: String = lines
+            .iter()
+            .map(|l| l.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            text.contains("128K"),
+            "should default to 128k window when None, got: {text}"
+        );
+    }
+}

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -9,6 +9,18 @@ use super::state::{
 };
 use crate::agent::Agent;
 
+/// Commands that don't need an active agent and are safe during busy state
+/// (e.g. agent rebuild). These are UI-view commands only.
+fn is_busy_allowed(kind: LocalCommandKind) -> bool {
+    matches!(
+        kind,
+        LocalCommandKind::Quit
+            | LocalCommandKind::Model
+            | LocalCommandKind::Status
+            | LocalCommandKind::Help
+    )
+}
+
 mod pending;
 
 pub(crate) async fn handle_submit(
@@ -50,15 +62,8 @@ pub(crate) async fn handle_submit(
     if app.is_busy() {
         if trimmed.starts_with('/') {
             if let Some(command) = parse_local_command(&trimmed) {
-                match command.kind {
-                    LocalCommandKind::Quit
-                    | LocalCommandKind::Model
-                    | LocalCommandKind::Status
-                    | LocalCommandKind::Help => {
-                        return execute_local_command(command, app, agent_slot, oauth_manager)
-                            .await;
-                    }
-                    _ => {}
+                if is_busy_allowed(command.kind) {
+                    return execute_local_command(command, app, agent_slot, oauth_manager).await;
                 }
             }
             app.push_notice("A task is running. /quit, /model, /status, /help still work.");
@@ -108,15 +113,7 @@ pub(crate) fn apply_openai_model_picker_action(
         OpenAiModelPickerAction::DeleteProfile => {
             if let Some(label) = app.delete_active_openai_profile() {
                 app.config_manager.save(&app.config)?;
-                if app.openai_profile_needs_setup() {
-                    app.bottom_pane.notice = Some(format!("Deleted endpoint profile: {label}"));
-                    app.begin_active_openai_profile_setup();
-                } else {
-                    app.bottom_pane.notice = Some(format!("Deleted endpoint profile: {label}"));
-                    super::runtime::start_rebuild_task(app);
-                }
-            } else {
-                app.push_notice("Cannot delete the only endpoint profile.");
+                app.push_notice(format!("Deleted endpoint profile: {label}"));
             }
         }
     }
@@ -135,5 +132,24 @@ pub(crate) fn clamp_command_palette_selection(app: &mut TuiApp) {
         app.command_palette_idx = 0;
     } else if app.command_palette_idx >= len {
         app.command_palette_idx = len - 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn busy_whitelist_allows_readonly_commands() {
+        assert!(is_busy_allowed(LocalCommandKind::Quit));
+        assert!(is_busy_allowed(LocalCommandKind::Model));
+        assert!(is_busy_allowed(LocalCommandKind::Status));
+        assert!(is_busy_allowed(LocalCommandKind::Help));
+    }
+
+    #[test]
+    fn busy_whitelist_denies_mutating_commands() {
+        assert!(!is_busy_allowed(LocalCommandKind::Clear));
+        assert!(!is_busy_allowed(LocalCommandKind::Compact));
     }
 }

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -49,14 +49,19 @@ pub(crate) async fn handle_submit(
 
     if app.is_busy() {
         if trimmed.starts_with('/') {
-            if let Some(command) = parse_local_command(&trimmed)
-                && matches!(command.kind, LocalCommandKind::Quit)
-            {
-                return execute_local_command(command, app, agent_slot, oauth_manager).await;
+            if let Some(command) = parse_local_command(&trimmed) {
+                match command.kind {
+                    LocalCommandKind::Quit
+                    | LocalCommandKind::Model
+                    | LocalCommandKind::Status
+                    | LocalCommandKind::Help => {
+                        return execute_local_command(command, app, agent_slot, oauth_manager)
+                            .await;
+                    }
+                    _ => {}
+                }
             }
-            app.push_notice(
-                "A task is already running. Wait for it to finish before running a slash command.",
-            );
+            app.push_notice("A task is running. /quit, /model, /status, /help still work.");
         } else {
             input_control::submit_user_prompt(app, agent_slot, trimmed);
         }

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -113,7 +113,15 @@ pub(crate) fn apply_openai_model_picker_action(
         OpenAiModelPickerAction::DeleteProfile => {
             if let Some(label) = app.delete_active_openai_profile() {
                 app.config_manager.save(&app.config)?;
-                app.push_notice(format!("Deleted endpoint profile: {label}"));
+                if app.openai_profile_needs_setup() {
+                    app.bottom_pane.notice = Some(format!("Deleted endpoint profile: {label}"));
+                    app.begin_active_openai_profile_setup();
+                } else {
+                    app.bottom_pane.notice = Some(format!("Deleted endpoint profile: {label}"));
+                    super::runtime::start_rebuild_task(app);
+                }
+            } else {
+                app.push_notice("Cannot delete the only endpoint profile.");
             }
         }
     }


### PR DESCRIPTION
## Problem

Three independent issues discovered during real-world usage:

### 1. Context window disappears after model switch

After selecting a different model through `/model`, the sidebar and
`/status` display show no context window at all (just token count
without the `/max` part).  This happens because `context_window_tokens`
is `None` until the next compaction cycle, and the display code
silently drops the window when it's `None`.

**Fix**: `unwrap_or(128_000)` in both `context_sidebar_summary` and
`render_context_status`.  Added `context_status_shows_128k_when_window_none`
unit test that verifies the 128K default is rendered.

### 2. `/model`, `/status`, `/help` stop working during agent rebuild

When the agent is rebuilding (e.g. after model switch), `is_busy()`
returns true and the busy guard in `handle_submit` rejected every `/`
command except `Quit`.  You'd type `/model`, press Enter, and... nothing.

**Fix**: Extracted `is_busy_allowed` whitelist that permits `Quit`,
`Model`, `Status`, and `Help` during busy state — these are
read-only commands that don't need an active agent.  Added
`busy_whitelist_allows_readonly_commands` and
`busy_whitelist_denies_mutating_commands` unit tests.

### 3. Enter sometimes shows no reaction at all

When the agent slot was `None` (race condition after crash/rebuild),
`submit_user_prompt` showed a fleeting push_notice "Agent is not ready
for input." that was easy to miss.  From the user's point of view:
typed something, pressed Enter, nothing happened.

**Fix**: In addition to the notice, auto-trigger
`start_rebuild_task(app)` so the slot gets refilled.  User can just
wait a moment and retry.

### Bonus: Restore truncated DeleteProfile handler

The `DeleteProfile` arm in `apply_openai_model_picker_action` was
accidentally truncated during the refactor — it lost the
`openai_profile_needs_setup()` check and the
`start_rebuild_task`/`begin_active_openai_profile_setup` calls.
Restored to match the original (main) version.  This fixes the
`openai_model_picker_delete_row_removes_active_profile` CI test.

## Changed Files

| File | Changes |
|------|---------|
| `src/tui/status_display.rs` | `unwrap_or(128_000)` for context window; add tests |
| `src/tui/render/sidebar_tests.rs` | Update expected context format |
| `src/tui/submit.rs` | `is_busy_allowed` whitelist; add tests |
| `src/tui/input_control.rs` | Auto-rebuild when agent slot is `None` |

## Testing

```
test result: ok. 998 passed; 0 failed
```