### PR TITLE
chore: strengthen documentation rules and engineering principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,13 +100,21 @@ The current product direction is to make local inference a first-class path inst
   - derive an implementation plan and concrete task breakdown from that specification;
   - align implementation against that specification;
   - record the resulting implementation checkpoint and any remaining follow-up work.
+- **Every non-trivial change must leave documentation.** No implementation PR
+  that touches behavior, contracts, or architecture should be merged without
+  the corresponding spec or journal update.
 - `docs/features/` stores stable engineering specs and contracts.
 - `docs/journal/` stores dated implementation notes and checkpoints.
 - `docs/todo.md` stores active follow-up work only.
-- Non-trivial changes should update:
+- Non-trivial changes MUST update:
   - the relevant feature spec when a contract or behavior changed;
   - a dated journal note for the implementation checkpoint;
   - `docs/todo.md` only when open follow-up work remains.
+- When creating or revising feature specs, follow the patterns in existing
+  `docs/features/*.md` files (motivation, design, integration points, TUI
+  display if applicable, verification).
+- Dated journal notes (`docs/journal/YYYY-MM-DD-<slug>.md`) should include:
+  what was built, why, what trade-offs were made, and what remains.
 
 ## 6. Near-Term Focus
 

--- a/docs/journal/2026-05-10-agenthub-agents-port.md
+++ b/docs/journal/2026-05-10-agenthub-agents-port.md
@@ -1,0 +1,23 @@
+# 2026-05-10 — AGENTS.md updated from AgentHub review
+
+## What was done
+
+Reviewed `/home/hawkingrei/devel/opensource/agenthub/AGENTS.md` and ported the
+following rules to RARA's `AGENTS.md`:
+
+1. **Fix obvious local issues** (Section 3 Architecture Constraints)
+   - Unused imports, stale names, dead code, and compile warnings in the
+     touched area should be fixed in the same change, not left for later.
+
+2. **Strengthened Documentation Rules** (Section 5)
+   - Changed "Non-trivial changes should update" to "Non-trivial changes MUST
+     update".
+   - Added: "Every non-trivial change must leave documentation" (matching
+     AgentHub's "Every meaningful change should leave tracked documentation").
+   - Added patterns for creating feature specs and journal notes.
+
+## What remains
+
+- Create `docs-feature` and `docs-journal` skills (like AgentHub's
+  `agenthub-docs-spec` / `agenthub-docs-journal` skills) to automate spec and
+  journal creation.

--- a/docs/journal/2026-05-10-agenthub-agents-port.md
+++ b/docs/journal/2026-05-10-agenthub-agents-port.md
@@ -1,9 +1,6 @@
-# 2026-05-10 — AGENTS.md updated from AgentHub review
+# 2026-05-10 — AGENTS.md strengthened documentation rules
 
 ## What was done
-
-Reviewed `/home/hawkingrei/devel/opensource/agenthub/AGENTS.md` and ported the
-following rules to RARA's `AGENTS.md`:
 
 1. **Fix obvious local issues** (Section 3 Architecture Constraints)
    - Unused imports, stale names, dead code, and compile warnings in the
@@ -12,12 +9,10 @@ following rules to RARA's `AGENTS.md`:
 2. **Strengthened Documentation Rules** (Section 5)
    - Changed "Non-trivial changes should update" to "Non-trivial changes MUST
      update".
-   - Added: "Every non-trivial change must leave documentation" (matching
-     AgentHub's "Every meaningful change should leave tracked documentation").
+   - Added: "Every non-trivial change must leave documentation."
    - Added patterns for creating feature specs and journal notes.
 
 ## What remains
 
-- Create `docs-feature` and `docs-journal` skills (like AgentHub's
-  `agenthub-docs-spec` / `agenthub-docs-journal` skills) to automate spec and
+- Create `docs-feature` and `docs-journal` skills to automate spec and
   journal creation.


### PR DESCRIPTION
## Summary

1. **Fix obvious local issues** — unused imports, stale names, dead code, compile warnings in the touched area → fix in the same change (Section 3)

2. **Stronger documentation enforcement** — changed "should update" to "MUST update" for spec/journal/todo. Every non-trivial change must leave documentation. (Section 5)

3. **Added patterns** for creating feature specs and journal notes

## Journal

`docs/journal/2026-05-10-agenthub-agents-port.md`