### PR TITLE
fix: remove [Thinking] prefix, adopt OpenCode-style dimmed thinking display

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -502,15 +502,8 @@ impl Agent {
                         report(AgentEvent::AssistantDelta(delta));
                     }
                     LlmStreamEvent::ReasoningDelta(delta) => {
-                        let non_empty = !delta.trim().is_empty();
-                        if non_empty {
-                            if !streamed_any_reasoning_delta {
-                                streamed_any_reasoning_delta = true;
-                                report(AgentEvent::AssistantDelta(format!("[Thinking] {delta}")));
-                            } else {
-                                report(AgentEvent::AssistantDelta(delta));
-                            }
-                        }
+                        streamed_any_reasoning_delta = true;
+                        report(AgentEvent::AssistantThinkingDelta(delta));
                     }
                 }
             })

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -1080,8 +1080,7 @@ fn active_turn_cell_shows_live_thinking_stream() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("▾ Thinking ·"));
-    assert!(rendered.contains("checking runtime events"));
+    assert!(rendered.contains("┊ checking runtime events"));
 }
 
 #[test]
@@ -1122,7 +1121,8 @@ fn active_turn_cell_flattens_thinking_and_running_events_in_order() {
     assert!(first_thinking < first_running);
     assert!(first_running < second_thinking);
     assert!(second_thinking < second_running);
-    assert_eq!(rendered.matches("▾ Thinking ·").count(), 2);
+    assert!(rendered.contains("┊ first reasoning block"));
+    assert!(rendered.contains("┊ second reasoning block"));
     assert_eq!(rendered.matches("# Running").count(), 2);
 }
 
@@ -1160,7 +1160,8 @@ fn active_turn_cell_places_streaming_thinking_after_latest_progress_event() {
 
     assert!(first_thinking < running);
     assert!(running < second_thinking);
-    assert_eq!(rendered.matches("▾ Thinking ·").count(), 2);
+    assert!(rendered.contains("┊ first reasoning block"));
+    assert!(rendered.contains("┊ second reasoning block"));
     assert_eq!(rendered.matches("# Running").count(), 1);
 }
 
@@ -1198,7 +1199,8 @@ fn active_turn_cell_places_streaming_thinking_after_latest_exploration_event() {
 
     assert!(first_thinking < exploring);
     assert!(exploring < second_thinking);
-    assert_eq!(rendered.matches("▾ Thinking ·").count(), 2);
+    assert!(rendered.contains("┊ first reasoning block"));
+    assert!(rendered.contains("┊ second reasoning block"));
     assert_eq!(rendered.matches("# Exploring").count(), 1);
 }
 
@@ -1233,7 +1235,7 @@ fn active_turn_cell_groups_consecutive_thinking_events_with_stream() {
     let second_thinking = rendered.find("second reasoning block").unwrap();
 
     assert!(first_thinking < second_thinking);
-    assert_eq!(rendered.matches("▾ Thinking ·").count(), 1);
+    assert!(rendered.contains("┊ first reasoning block"));
 }
 
 #[test]
@@ -1262,7 +1264,7 @@ fn active_turn_cell_preserves_flushed_thinking_leading_indentation() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("      let value = 1;"));
+    assert!(rendered.contains("┊     let value = 1;"));
 }
 
 #[test]
@@ -1408,11 +1410,10 @@ fn active_turn_cell_shows_live_thinking_tail_without_cloning_full_body() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("▾ Thinking ·"));
-    assert!(rendered.contains("... 1 more line(s)"));
-    assert!(!rendered.contains("line 1"));
-    assert!(rendered.contains("line 2"));
-    assert!(rendered.contains("line 5"));
+    assert!(rendered.contains("┊  ... 1 more lines"));
+    assert!(!rendered.contains("┊ line 1"));
+    assert!(rendered.contains("┊ line 2"));
+    assert!(rendered.contains("┊ line 5"));
 }
 
 #[test]

--- a/src/tui/render/cells/cells_tests/committed.rs
+++ b/src/tui/render/cells/cells_tests/committed.rs
@@ -180,7 +180,9 @@ fn committed_turn_cell_keeps_progress_segments_and_terminal_output() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let thinking_idx = rendered.find("▸ Thinking ·").unwrap();
+    let thinking_idx = rendered
+        .find("┊ I should run the focused test first.")
+        .unwrap();
     let progress_idx = rendered.find("Run cargo test active_turn_cell").unwrap();
     let terminal_idx = rendered.find("running 38 tests").unwrap();
     let agent_idx = rendered.find("• The focused tests passed.").unwrap();

--- a/src/tui/render/cells/thinking_cells.rs
+++ b/src/tui/render/cells/thinking_cells.rs
@@ -4,25 +4,18 @@ use ratatui::{
 };
 
 use super::HistoryCell;
-use super::responding_cell::markdown_body_lines;
 use crate::tui::markdown_render::render_markdown_text_with_width;
-use crate::tui::theme::{TEXT_MUTED, TEXT_SECONDARY};
+use crate::tui::theme::TEXT_MUTED;
 
-/// Renders a thinking block with collapsible display.
+/// Renders thinking content as dimmed lines with a ┊ accent prefix.
 ///
-/// Streaming (live): ▾ Thinking · N lines → content with ┊ accent bars
-/// Committed:          ▸ Thinking · N lines (≈T tokens) → summary only
-///
-/// Design blends Claude Code's collapsed-summary pattern and OpenCode's
-/// ┊ border-left accent for expanded content.
-///
-/// NOTE: committed turns are always collapsed in this version. An `expanded`
-/// field independent of `is_streaming` would enable Enter-key toggle (follow-up).
+/// Design follows OpenCode: no header label, no toggle, no token count.
+/// Every line is prefixed with ┊ and colored TEXT_MUTED for a subdued
+/// "inner monologue" visual layer between # You and # Agent sections.
 pub(crate) struct ThinkingBlockCell<'a> {
     message: String,
     stream_lines: Option<&'a [Line<'static>]>,
     max_lines: usize,
-    is_streaming: bool,
 }
 
 impl<'a> ThinkingBlockCell<'a> {
@@ -31,7 +24,6 @@ impl<'a> ThinkingBlockCell<'a> {
             message: message.to_string(),
             stream_lines: None,
             max_lines,
-            is_streaming: false,
         }
     }
 
@@ -44,74 +36,43 @@ impl<'a> ThinkingBlockCell<'a> {
             message,
             stream_lines,
             max_lines,
-            is_streaming: true,
         }
     }
 }
 
 impl HistoryCell for ThinkingBlockCell<'_> {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
-        // Raw line count (from newlines + stream lines) for collapsed summary.
-        // Avoids expensive markdown rendering in the committed path.
-        let raw_line_count =
-            self.message.lines().count() + self.stream_lines.map_or(0, |l| l.len());
+        let render_width = usize::from(width.saturating_sub(2));
+        let mut rendered_lines: Vec<Line<'static>> = Vec::new();
 
-        if self.is_streaming {
-            // --- Expanded: render markdown, show with ┊ accent bars ---
-            let render_width = usize::from(width.saturating_sub(2));
-            let mut rendered_lines: Vec<Line<'static>> = Vec::new();
-            if !self.message.is_empty() {
-                let rendered = render_markdown_text_with_width(&self.message, Some(render_width));
-                rendered_lines.extend(rendered.lines.into_iter());
-            }
-            if let Some(lines) = self.stream_lines {
-                rendered_lines.extend(lines.iter().cloned());
-            }
-            let total_line_count = rendered_lines.len();
-
-            let header = Line::from(Span::styled(
-                format!("▾ Thinking · {total_line_count} line(s)"),
-                Style::default().fg(TEXT_SECONDARY),
-            ));
-            let start = total_line_count.saturating_sub(self.max_lines);
-            let body = markdown_body_lines(&rendered_lines[start..], self.max_lines);
-            let mut lines = vec![header];
-            if start > 0 {
-                lines.push(Line::from(Span::styled(
-                    format!("┊  ... {start} more line(s)"),
-                    Style::default().fg(TEXT_MUTED),
-                )));
-            }
-            for line in body {
-                let mut accented = Line::from(Span::styled("┊ ", Style::default().fg(TEXT_MUTED)));
-                for span in line.spans {
-                    accented.push_span(Span::styled(
-                        span.content.to_string(),
-                        span.style.fg(TEXT_MUTED),
-                    ));
-                }
-                lines.push(accented);
-            }
-            lines
-        } else {
-            // --- Collapsed: summary only, no markdown render ---
-            let token_estimate = thinking_token_estimate(&self.message, self.stream_lines);
-            vec![Line::from(Span::styled(
-                format!("▸ Thinking · {raw_line_count} line(s) (≈{token_estimate} tokens)"),
-                Style::default().fg(TEXT_SECONDARY),
-            ))]
+        if !self.message.is_empty() {
+            let rendered = render_markdown_text_with_width(&self.message, Some(render_width));
+            rendered_lines.extend(rendered.lines.into_iter());
         }
-    }
-}
-
-/// Rough token estimate from thinking text and stream lines.
-fn thinking_token_estimate(message: &str, stream_lines: Option<&[Line<'_>]>) -> usize {
-    let mut chars: usize = message.chars().count();
-    if let Some(lines) = stream_lines {
-        for line in lines {
-            chars += line.width();
+        if let Some(lines) = self.stream_lines {
+            rendered_lines.extend(lines.iter().cloned());
         }
+
+        let start = rendered_lines.len().saturating_sub(self.max_lines);
+        let tail = &rendered_lines[start..];
+
+        let mut lines = Vec::with_capacity(tail.len());
+        if start > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("┊  ... {start} more lines"),
+                Style::default().fg(TEXT_MUTED),
+            )));
+        }
+        for line in tail {
+            let mut accented = Line::from(Span::styled("┊ ", Style::default().fg(TEXT_MUTED)));
+            for span in &line.spans {
+                accented.push_span(Span::styled(
+                    span.content.to_string(),
+                    span.style.patch(Style::default().fg(TEXT_MUTED)),
+                ));
+            }
+            lines.push(accented);
+        }
+        lines
     }
-    // Rough heuristic: ~4 chars per token for English text
-    chars / 4
 }


### PR DESCRIPTION
## Summary

Fixes the lingering `[Thinking]` prefix that was not addressed in #367.

**Root cause:** `agent.rs` was routing `ReasoningDelta` through `AssistantDelta` 
with a hardcoded `[Thinking] ` prefix instead of using the existing 
`AssistantThinkingDelta` event channel. This bypassed the TUI's 
`ThinkingBlockCell` renderer entirely.

## Changes

- **agent.rs**: Route `ReasoningDelta` through `AssistantThinkingDelta` 
  (the correct thinking event channel) instead of wrapping in 
  `[Thinking]` prefix with `AssistantDelta`
- **thinking_cells.rs**: Switch to OpenCode-style display — no header label, 
  no toggle, no token count. Every line gets a `┊` accent prefix 
  with `TEXT_MUTED` color for a subdued inner-monologue layer
- **Tests**: Update 9 assertions from `▾/▸ Thinking ·` header matching 
  to `┊` content matching

## Before / After

```
# Before (broken)
[Thinking] The user said 你好...

# After
┊ The user said 你好 which is Hello...
┊ This is a simple greeting...
┊ I should respond naturally and briefly.
```

## Verification
- `cargo fmt` ✅
- `cargo clippy` ✅ (0 new errors)
- `cargo test tui::render::cells::tests` — **66/66 passed**