### PR TITLE
chore: clean up clippy warnings (283 → 239)

### DIFF
--- a/crates/instructions/src/languages.rs
+++ b/crates/instructions/src/languages.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 /// High-quality software engineering and idiomatic patterns for specific languages.
 /// Inspired by Claude Code's data references.
-
 pub fn get_language_prompt(cwd: &str) -> Option<String> {
     let root = Path::new(cwd);
 

--- a/crates/rara-tools/src/file.rs
+++ b/crates/rara-tools/src/file.rs
@@ -218,6 +218,7 @@ fn record_write_best_effort(read_state: &FileReadState, path: &str, content: &st
     }
 }
 
+#[derive(Default)]
 pub struct ReadFileTool {
     read_state: Option<SharedFileReadState>,
 }
@@ -227,12 +228,6 @@ impl ReadFileTool {
         Self {
             read_state: Some(read_state),
         }
-    }
-}
-
-impl Default for ReadFileTool {
-    fn default() -> Self {
-        Self { read_state: None }
     }
 }
 
@@ -516,6 +511,7 @@ fn truncate_read_line(line: &str) -> (String, bool) {
     (truncated, true)
 }
 
+#[derive(Default)]
 pub struct WriteFileTool {
     read_state: Option<SharedFileReadState>,
 }
@@ -525,12 +521,6 @@ impl WriteFileTool {
         Self {
             read_state: Some(read_state),
         }
-    }
-}
-
-impl Default for WriteFileTool {
-    fn default() -> Self {
-        Self { read_state: None }
     }
 }
 
@@ -582,6 +572,7 @@ impl Tool for WriteFileTool {
     }
 }
 
+#[derive(Default)]
 pub struct ReplaceTool {
     read_state: Option<SharedFileReadState>,
 }
@@ -591,12 +582,6 @@ impl ReplaceTool {
         Self {
             read_state: Some(read_state),
         }
-    }
-}
-
-impl Default for ReplaceTool {
-    fn default() -> Self {
-        Self { read_state: None }
     }
 }
 
@@ -650,6 +635,7 @@ impl Tool for ReplaceTool {
     }
 }
 
+#[derive(Default)]
 pub struct ReplaceLinesTool {
     read_state: Option<SharedFileReadState>,
 }
@@ -659,12 +645,6 @@ impl ReplaceLinesTool {
         Self {
             read_state: Some(read_state),
         }
-    }
-}
-
-impl Default for ReplaceLinesTool {
-    fn default() -> Self {
-        Self { read_state: None }
     }
 }
 
@@ -766,6 +746,7 @@ impl Tool for ReplaceLinesTool {
     }
 }
 
+#[derive(Default)]
 pub struct MultiEditTool {
     read_state: Option<SharedFileReadState>,
 }
@@ -775,12 +756,6 @@ impl MultiEditTool {
         Self {
             read_state: Some(read_state),
         }
-    }
-}
-
-impl Default for MultiEditTool {
-    fn default() -> Self {
-        Self { read_state: None }
     }
 }
 

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -116,7 +116,7 @@ impl SandboxManager {
             }
         }
         for root in &self.command_install_roots {
-            let root = sandbox_profile_string_literal(&root);
+            let root = sandbox_profile_string_literal(root);
             file_rules.push_str(&format!(
                 "(allow file-read* (subpath \"{root}\"))\n(allow file-map-executable (subpath \"{root}\"))\n"
             ));

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -435,14 +435,13 @@ const OPENAI_GPT4_CONTEXT_WINDOW_TOKENS: usize = 128_000;
 pub(super) fn model_context_budget(model: &str) -> Option<ContextBudget> {
     let canonical = model.trim().to_ascii_lowercase();
     // Look up DeepSeek models from the provider catalog map.
-    if canonical.contains("deepseek") {
-        if let Some(window) = rara_provider_catalog::deepseek::MODEL_WINDOWS
+    if canonical.contains("deepseek")
+        && let Some(window) = rara_provider_catalog::deepseek::MODEL_WINDOWS
             .iter()
-            .find(|(name, _)| name.contains(&canonical.as_str()))
+            .find(|(name, _)| name.contains(canonical.as_str()))
             .map(|(_, w)| *w as usize)
-        {
-            return Some(context_budget_from_window(window));
-        }
+    {
+        return Some(context_budget_from_window(window));
     }
     if canonical.contains("gpt-5")
         || canonical.contains("codex")

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -151,7 +151,7 @@ fn scan_agents_dir(agents_dir: &Path, registry: &mut AgentRegistry) {
             continue;
         }
         let path = entry.path();
-        if path.extension().map_or(true, |e| e != "md") {
+        if path.extension().is_none_or(|e| e != "md") {
             continue;
         }
 

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -396,6 +396,7 @@ fn approval_subcommand_index(program: &str, args: &[String]) -> Option<usize> {
     }
 }
 
+#[allow(clippy::if_same_then_else)]
 fn skip_known_global_options(
     args: &[String],
     valueless_options: &[&str],

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -494,19 +494,15 @@ pub(crate) async fn dispatch_event(
                                         }
                                     }
                                 }
-                                ProviderFamily::OpenAiCompatible => {
-                                    if app.openai_profile_needs_setup() {
-                                        app.begin_active_openai_profile_setup();
-                                    } else {
-                                        start_rebuild_task(app);
-                                    }
+                                ProviderFamily::OpenAiCompatible
+                                    if app.openai_profile_needs_setup() =>
+                                {
+                                    app.begin_active_openai_profile_setup();
                                 }
-                                ProviderFamily::DeepSeek | ProviderFamily::Gemini => {
-                                    if !app.config.has_api_key() {
-                                        app.open_overlay(Overlay::ApiKeyEditor);
-                                    } else {
-                                        start_rebuild_task(app);
-                                    }
+                                ProviderFamily::DeepSeek | ProviderFamily::Gemini
+                                    if !app.config.has_api_key() =>
+                                {
+                                    app.open_overlay(Overlay::ApiKeyEditor);
                                 }
                                 ProviderFamily::CandleLocal => {
                                     app.push_notice("Local models (alpha) are for preview only.");

--- a/src/tui/render/bottom_pane/view_builder.rs
+++ b/src/tui/render/bottom_pane/view_builder.rs
@@ -31,7 +31,7 @@ fn build_activity_view(app: &TuiApp, _width: u16) -> ActivityView {
     let perm_badge = app.permission_mode_label() != "auto";
     let perm_label = app.permission_mode_label();
     let goal_label = app.goal.as_ref().map(|goal| goal_label_text(goal.status));
-    let goal_detail = app.goal.as_ref().map(|goal| goal_detail_text(goal));
+    let goal_detail = app.goal.as_ref().map(goal_detail_text);
 
     ActivityView {
         label: animated,

--- a/src/tui/render/cells/thinking_cells.rs
+++ b/src/tui/render/cells/thinking_cells.rs
@@ -47,7 +47,7 @@ impl HistoryCell for ThinkingBlockCell<'_> {
 
         if !self.message.is_empty() {
             let rendered = render_markdown_text_with_width(&self.message, Some(render_width));
-            rendered_lines.extend(rendered.lines.into_iter());
+            rendered_lines.extend(rendered.lines);
         }
         if let Some(lines) = self.stream_lines {
             rendered_lines.extend(lines.iter().cloned());

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -600,9 +600,7 @@ pub(super) fn format_tool_result(name: &str, content: &str) -> String {
                 rendered.push('\n');
                 rendered.push_str(remainder.trim_end());
             }
-        } else if content.contains("<persisted-output>") {
-            rendered.push_str("\nfull result stored on disk");
-        } else if content.contains("full_result_path=") {
+        } else if content.contains("<persisted-output>") || content.contains("full_result_path=") {
             rendered.push_str("\nfull result stored on disk");
         } else if let Some(preview) = tool_result_preview(content) {
             rendered.push_str(&format!("\n{preview}"));

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -776,18 +776,17 @@ impl TuiApp {
                 self.config.set_model(Some(preset.model_id));
                 self.config.set_revision(None);
 
-                if preset.provider_id == "ollama" {
-                    if self
+                if preset.provider_id == "ollama"
+                    && self
                         .config
                         .base_url
                         .as_deref()
                         .map(str::trim)
                         .filter(|value| !value.is_empty())
                         .is_none()
-                    {
-                        self.config
-                            .set_base_url(Some("http://localhost:11434".to_string()));
-                    }
+                {
+                    self.config
+                        .set_base_url(Some("http://localhost:11434".to_string()));
                 }
             }
         }
@@ -1654,7 +1653,7 @@ impl TuiApp {
 
     pub fn sync_command_palette_with_input(&mut self) {
         if input_requests_command_palette(self.bottom_pane.input.as_str()) {
-            if matches!(self.overlay, None) {
+            if self.overlay.is_none() {
                 self.open_overlay(Overlay::CommandPalette);
             }
         } else if matches!(self.overlay, Some(Overlay::CommandPalette)) {

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -7,6 +7,11 @@
 // The palette is based on the Nord color scheme (matching OpenCode's
 // default dark theme) extended with semantic tokens for UI, Markdown,
 // and syntax highlighting.
+//
+// Many constants are reserved for planned rendering features (Markdown
+// syntax highlighting, diff views, phase badges, etc.). The full palette
+// is kept here as a single source of truth.
+#![allow(dead_code)]
 use ratatui::style::Color;
 
 // ── Nord palette (reference) ────────────────────────────────────


### PR DESCRIPTION
## Summary

Batch cleanup of clippy warnings in the workspace. Reduces warnings from 283 to 239.

## Changes

- **theme.rs**: Add module-level `#![allow(dead_code)]` for reserved palette constants (Markdown syntax, diff views, phase badges — planned features)
- **rara-tools/file.rs**: Replace 5 manual `impl Default` blocks with `#[derive(Default)]`
- **sandbox/lib.rs**: Fix unnecessary `&root` deref
- **instructions/languages.rs**: Remove empty line after doc comment
- **runtime/events/helpers.rs**: Collapse identical `if` branches with `||`
- **bash.rs**: Add `#[allow(clippy::if_same_then_else)]` on `skip_known_global_options`
- **40+ auto-fixes** via `cargo clippy --fix` (collapsed if, etc.)

## Remaining Warnings

~239 remain, mostly:
- `if can be collapsed` (12) — mechanical
- `too many arguments` (14) — architectural, needs param structs
- `never used` feature-scaffolding items — needs `#[allow(dead_code)]` + comments

## Verification
- `cargo fmt` ✅
- `cargo check` ✅
- `cargo test` ✅