### PR TITLE
fix: add background contrast to shell approval card command text

### DIFF
--- a/src/tui/render/cells/interaction_cells.rs
+++ b/src/tui/render/cells/interaction_cells.rs
@@ -25,6 +25,7 @@ use crate::tui::render::{
 use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
 use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;
 use crate::tui::theme::*;
+use crate::tui::theme::{PENDING_CARD_BG, PENDING_CARD_FG};
 
 pub(crate) struct TerminalCell {
     command: String,
@@ -244,11 +245,12 @@ impl ApprovalCell {
 
 impl HistoryCell for ApprovalCell {
     fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
+        let card_style = Style::default().fg(PENDING_CARD_FG).bg(PENDING_CARD_BG);
         let mut lines = vec![Line::from(section_label(self.title, self.color))];
         lines.extend(
             self.lines
                 .iter()
-                .map(|line| Line::from(format!("  {line}"))),
+                .map(|line| Line::from(Span::styled(format!("  {line}"), card_style))),
         );
         lines
     }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -93,6 +93,10 @@ pub(crate) const BADGE_FG_LIGHT: Color = NORD0;
 // ── Interaction ─────────────────────────────────────────────────
 pub(crate) const INTERACTION_SUB_AGENT: Color = NORD13;
 
+// ── Pending interaction card background ───────────────────────────
+pub(crate) const PENDING_CARD_FG: Color = NORD5;
+pub(crate) const PENDING_CARD_BG: Color = NORD1;
+
 // ── Tool output ─────────────────────────────────────────────────
 pub(crate) const TOOL_STDERR_BG: Color = NORD11;
 pub(crate) const TOOL_STDERR_FG: Color = NORD6;


### PR DESCRIPTION
## Problem

Shell approval dialogs show the command (e.g. `cargo check -p rara 2>&1 | tail -3`)
with default styling, making the text blend into the terminal background.
Hard to read.

## Fix

- Add `PENDING_CARD_FG` (NORD5) and `PENDING_CARD_BG` (NORD1) theme constants
- Apply them as styled card background to approval cell command lines

This gives the shell command text a subtle dark background with light
foreground, providing clear visual separation from surrounding content.

## Verification
- `cargo fmt` ✅
- `cargo check` ✅ (no new warnings)