### PR TITLE
feat: show context window sizes in ModelSearch

### DIFF
--- a/docs/features/provider-connection-redesign.md
+++ b/docs/features/provider-connection-redesign.md
@@ -67,18 +67,20 @@ Model list: each row shows model name + context window size.
 
 ## Implementation Plan
 
-### Phase 1 — Connection state (P0)
-- Add `fn is_provider_connected(app: &TuiApp, family: ProviderFamily) -> bool`
-- Add green/red dot rendering to list picker items
-- Display connected providers in sidebar
+### Phase 1 — Connection state (P0) ✅ DONE (#362)
+- [x] Add `fn is_provider_connected(app: &TuiApp, family: ProviderFamily) -> bool`
+- [x] Add green/red dot rendering to list picker items
+- [x] ~~Display connected providers in sidebar~~ removed — too cluttered
 
-### Phase 2 — Refactor /connect (P0)
-- Remove forced config wizard
-- Provider picker → check credentials → auth if needed → list models
+### Phase 2 — Refactor /connect (P0) ✅ DONE (#365)
+- [x] Remove forced config wizard
+- [x] Connected → notice "Provider is connected ✓"
+- [x] Not-connected → auth overlay (ApiKeyEditor, AuthMode, Profile editor)
 
-### Phase 3 — Refactor /model (P1)
-- Two-step: provider picker → model list
-- Model list shows context window sizes from `MODEL_WINDOWS` map
+### Phase 3 — Refactor /model (P1) ✅ DONE (#362)
+- [x] ModelSearch overlay with input-driven filtering
+- [ ] **Remaining**: show context window sizes from `MODEL_WINDOWS` map in ModelSearch items
+- [ ] **Remaining**: model list from API (`/v1/models`) for connected providers, fallback to `MODEL_WINDOWS`
 
 ## Future
 - Custom provider support (arbitrary API endpoint + API key)

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -668,10 +668,18 @@ fn render_model_search(f: &mut Frame, app: &TuiApp, area: Rect) {
                 Style::default().add_modifier(Modifier::BOLD),
             );
             let family = Span::styled(
-                format!("  {}", p.provider_label.as_str()),
+                p.provider_label.as_str(),
                 Style::default().fg(TEXT_SECONDARY),
             );
-            ListItem::new(Line::from(vec![name, family]))
+            let window = if let Some(tokens) = p.context_window {
+                Span::styled(
+                    format!("  · {: >4.0} K", tokens as f64 / 1000.0),
+                    Style::default().fg(TEXT_MUTED),
+                )
+            } else {
+                Span::raw("")
+            };
+            ListItem::new(Line::from(vec![name, family, window]))
         })
         .collect();
 

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -593,6 +593,7 @@ impl TuiApp {
                             model_id: "gpt-4o".into(),
                             model_label: "gpt-4o".into(),
                             status: None,
+                            context_window: None,
                         });
                     } else {
                         for opt in &self.codex_model_options {
@@ -603,6 +604,7 @@ impl TuiApp {
                                 model_id: opt.id.clone(),
                                 model_label: opt.label.clone(),
                                 status: None,
+                                context_window: None,
                             });
                         }
                     }
@@ -617,6 +619,7 @@ impl TuiApp {
                             model_id: "deepseek-chat".into(),
                             model_label: "deepseek-chat".into(),
                             status: None,
+                            context_window: None,
                         });
                     } else {
                         for model in &self.deepseek_model_options {
@@ -627,6 +630,7 @@ impl TuiApp {
                                 model_id: model.clone(),
                                 model_label: model.clone(),
                                 status: None,
+                                context_window: None,
                             });
                         }
                     }
@@ -646,6 +650,7 @@ impl TuiApp {
                             model_id: model_id.clone(),
                             model_label: model_id,
                             status: None,
+                            context_window: None,
                         });
                     }
 
@@ -660,6 +665,7 @@ impl TuiApp {
                                 model_id: preset.2.to_string(),
                                 model_label: preset.0.to_string(),
                                 status: None,
+                                context_window: None,
                             });
                         }
                     }
@@ -673,6 +679,7 @@ impl TuiApp {
                             model_id: preset.2.to_string(),
                             model_label: preset.0.to_string(),
                             status: Some("alpha".to_string()),
+                            context_window: None,
                         });
                     }
                 }
@@ -685,6 +692,7 @@ impl TuiApp {
                             model_id: preset.2.to_string(),
                             model_label: preset.0.to_string(),
                             status: None,
+                            context_window: None,
                         });
                     }
                 }
@@ -697,6 +705,7 @@ impl TuiApp {
                             model_id: preset.2.to_string(),
                             model_label: preset.0.to_string(),
                             status: None,
+                            context_window: None,
                         });
                     }
                 }
@@ -708,11 +717,25 @@ impl TuiApp {
                         model_id: "gemini-3-flash".to_string(),
                         model_label: "Gemini 3 Flash".to_string(),
                         status: None,
+                        context_window: None,
                     });
                 }
             }
         }
+        for p in &mut results {
+            p.context_window = Self::resolve_context_window(&p.model_id);
+        }
         results
+    }
+
+    /// Look up context window tokens for a model from provider catalogs.
+    fn resolve_context_window(model_id: &str) -> Option<u32> {
+        for &(name, tokens) in rara_provider_catalog::deepseek::MODEL_WINDOWS {
+            if model_id == name {
+                return Some(tokens);
+            }
+        }
+        None
     }
 
     pub fn select_unified_model(&mut self, idx: usize) {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -120,6 +120,8 @@ pub struct UnifiedModelPreset {
     pub model_id: String,
     pub model_label: String,
     pub status: Option<String>,
+    /// Context window in tokens, if known.
+    pub context_window: Option<u32>,
 }
 
 impl PermissionMode {


### PR DESCRIPTION
## Summary

ModelSearch overlay now shows context window size for each model:

- Adds `context_window: Option<u32>` to `UnifiedModelPreset`
- `resolve_context_window()` looks up the `MODEL_WINDOWS` map from the DeepSeek catalog
- Each model item displays: **model-name**  `provider`  `· 64 K`

| Changes |
|---|
| `src/tui/state/types.rs` — add field |
| `src/tui/state/mod.rs` — lookup + populate |
| `src/tui/render/overlay.rs` — display |

Example output:
```
deepseek-chat       DeepSeek  ·   64 K
deepseek-v4-pro     DeepSeek  · 1024 K
```