### PR TITLE
feat: enforce max_turns limit for sub-agents

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -650,6 +650,9 @@ impl Agent {
         loop {
             if let Some(max) = self.max_turns {
                 if *agentic_turns >= max {
+                    self.last_agent_turn_trace.loop_outcome = Some("stopped".to_string());
+                    self.last_agent_turn_trace.continuation_phase =
+                        Some("max_turns_reached".to_string());
                     report(AgentEvent::Status(format!(
                         "Agent reached max-turns limit ({max})",
                     )));

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -170,6 +170,7 @@ pub struct Agent {
     pub total_cache_hit_tokens: u32,
     pub total_cache_miss_tokens: u32,
     pub tool_result_store: ToolResultStore,
+    pub max_turns: Option<usize>,
     pub execution_mode: AgentExecutionMode,
     pub bash_approval_mode: BashApprovalMode,
     pub full_access_mode: bool,
@@ -255,6 +256,7 @@ impl Agent {
                 )
             }),
             execution_mode: AgentExecutionMode::Execute,
+            max_turns: None,
             bash_approval_mode: BashApprovalMode::Always,
             full_access_mode: false,
             current_plan: Vec::new(),
@@ -646,6 +648,14 @@ impl Agent {
     {
         let mut plan_exit_repair_attempts = 0usize;
         loop {
+            if let Some(max) = self.max_turns {
+                if *agentic_turns >= max {
+                    report(AgentEvent::Status(format!(
+                        "Agent reached max-turns limit ({max})",
+                    )));
+                    break;
+                }
+            }
             self.ensure_active_plan_step();
             let mut turn_output = self.run_model_turn(output_mode, report).await?;
             self.record_agent_turn_trace(&turn_output, *agentic_turns, None, None, false);

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -154,6 +154,10 @@ impl Agent {
         self.execution_mode = mode;
     }
 
+    pub fn set_max_turns(&mut self, max_turns: usize) {
+        self.max_turns = Some(max_turns);
+    }
+
     pub fn execution_mode_label(&self) -> &'static str {
         match self.execution_mode {
             AgentExecutionMode::Execute => "execute",

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -155,7 +155,11 @@ impl Agent {
     }
 
     pub fn set_max_turns(&mut self, max_turns: usize) {
-        self.max_turns = Some(max_turns);
+        self.max_turns = if max_turns == 0 {
+            None
+        } else {
+            Some(max_turns)
+        };
     }
 
     pub fn execution_mode_label(&self) -> &'static str {

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -239,7 +239,7 @@ fn builtin_agent_definition(name: &str) -> Option<AgentDefinition> {
             tools: vec!["Read".into(), "Glob".into(), "Grep".into()],
             disallowed_tools: vec!["Write".into(), "Edit".into(), "Bash".into()],
             model: None,
-            max_turns: 0,
+            max_turns: 50,
             permission_mode: None,
             plan_mode_required: false,
             hidden: false,
@@ -251,7 +251,7 @@ fn builtin_agent_definition(name: &str) -> Option<AgentDefinition> {
             tools: vec!["Read".into(), "Glob".into(), "Grep".into()],
             disallowed_tools: vec!["Write".into(), "Edit".into(), "Bash".into()],
             model: None,
-            max_turns: 0,
+            max_turns: 30,
             permission_mode: None,
             plan_mode_required: true,
             hidden: false,
@@ -1242,6 +1242,11 @@ async fn run_sub_agent(
         kind.execution_mode()
     });
     sub.set_prompt_config(append_subagent_prompt(prompt_config, kind.append_prompt()));
+    let def_max_turns = definition.map(|d| d.max_turns).unwrap_or(0);
+    if def_max_turns > 0 {
+        sub.set_max_turns(def_max_turns);
+    }
+
     sub.query_with_mode(
         instruction.to_string(),
         crate::agent::AgentOutputMode::Silent,

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -1216,3 +1216,21 @@ fn resolve_spawn_agent_definition_falls_back_for_unknown() {
     assert_eq!(def.name, "unknown-agent");
     assert!(!def.plan_mode_required);
 }
+
+#[test]
+fn explore_agent_definition_has_default_max_turns_50() {
+    let def = resolve_kind_definition(SubAgentKind::Explore);
+    assert_eq!(def.max_turns, 50);
+}
+
+#[test]
+fn plan_agent_definition_has_default_max_turns_30() {
+    let def = resolve_kind_definition(SubAgentKind::Plan);
+    assert_eq!(def.max_turns, 30);
+}
+
+#[test]
+fn general_agent_definition_has_unlimited_max_turns() {
+    let def = resolve_kind_definition(SubAgentKind::General);
+    assert_eq!(def.max_turns, 0);
+}


### PR DESCRIPTION
## Summary

Add `max_turns` enforcement to the agent loop, preventing sub-agents from looping indefinitely. Mirrors the Codex approach: check before each turn, break when limit reached.

- `Agent` struct gains `max_turns: Option\<usize\>` field + `set_max_turns()` setter
- Check in `run_agent_loop_with_limit` at start of each turn — emit status then break
- `run_sub_agent` passes `definition.max_turns` when \> 0
- Built-in defaults: Explore=50, Plan=30, General=unlimited (0)

## Verification

```
cargo check → passes (pre-existing warnings only)```

New tests:
- `explore_agent_definition_has_default_max_turns_50`
- `plan_agent_definition_has_default_max_turns_30`
- `general_agent_definition_has_unlimited_max_turns`
