### PR TITLE
feat: sub-agent timeout guard and progress tracking

### DIFF
--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -925,6 +925,9 @@ impl BackgroundSubAgentStore {
         record.finished_at = Some(unix_timestamp_secs());
         match result {
             Ok(result) => {
+                record.progress.total_input_tokens = result.total_input_tokens as usize;
+                record.progress.total_output_tokens = result.total_output_tokens as usize;
+                record.progress.tool_use_count = result.total_input_tokens as usize; // approximate
                 record.status = result.status;
                 record.summary = Some(result.summary);
                 record.persistence_error = result.persistence_error;
@@ -983,9 +986,11 @@ impl BackgroundSubAgentRecord {
             "name": self.name,
             "model": self.model,
             "progress": {
-                "name": self.progress.subagent_name,
                 "tool_use_count": self.progress.tool_use_count,
+                "tool_use_total": self.progress.tool_use_total,
                 "latest_activity": self.progress.latest_activity(),
+                "total_input_tokens": self.progress.total_input_tokens,
+                "total_output_tokens": self.progress.total_output_tokens,
                 "total_tokens": self.progress.total_tokens(),
             },
             "kind": self.kind,
@@ -1214,6 +1219,8 @@ struct SubAgentResult {
     plan: Option<Vec<PlanStep>>,
     plan_explanation: Option<String>,
     request_user_input: Option<PendingUserInput>,
+    total_input_tokens: u32,
+    total_output_tokens: u32,
 }
 
 async fn run_sub_agent(
@@ -1265,9 +1272,11 @@ async fn run_sub_agent(
 
     tokio::time::timeout(Duration::from_secs(SUBAGENT_TIMEOUT_SECS), query_fut)
         .await
-        .map_err(|_| {
+        .map_err(|_elapsed| {
             ToolError::ExecutionFailed(format!(
-                "sub-agent timed out after {} seconds",
+                "sub-agent {} ({}) timed out after {} seconds",
+                agent_id,
+                kind.label(),
                 SUBAGENT_TIMEOUT_SECS
             ))
         })?
@@ -1294,6 +1303,8 @@ async fn run_sub_agent(
     Ok(SubAgentResult {
         agent_id: agent_id.to_string(),
         session_id: sub.session_id.clone(),
+        total_input_tokens: sub.total_input_tokens,
+        total_output_tokens: sub.total_output_tokens,
         status,
         summary,
         persistence_error,

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -927,7 +927,6 @@ impl BackgroundSubAgentStore {
             Ok(result) => {
                 record.progress.total_input_tokens = result.total_input_tokens as usize;
                 record.progress.total_output_tokens = result.total_output_tokens as usize;
-                record.progress.tool_use_count = result.total_input_tokens as usize; // approximate
                 record.status = result.status;
                 record.summary = Some(result.summary);
                 record.persistence_error = result.persistence_error;

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -6,7 +6,7 @@ use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, Ordering},
 };
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use futures::stream::{self, StreamExt, TryStreamExt};
@@ -305,6 +305,7 @@ impl SubagentProgress {
 
 const TEAM_CREATE_MAX_TASKS: usize = 8;
 const TEAM_CREATE_CONCURRENCY_LIMIT: usize = 4;
+const SUBAGENT_TIMEOUT_SECS: u64 = 300;
 
 macro_rules! strict_read_only_subagent_prompt {
     () => {
@@ -782,6 +783,7 @@ struct BackgroundSubAgentRecord {
     session_id: String,
     name: Option<String>,
     model: Option<String>,
+    progress: SubagentProgress,
     kind: &'static str,
     parent_session_id: Option<String>,
     status: &'static str,
@@ -804,6 +806,9 @@ impl BackgroundSubAgentStore {
             session_id: session_id.clone(),
             name: start.name.clone(),
             model: start.definition.model.clone(),
+            progress: SubagentProgress::new(
+                start.name.clone().unwrap_or_else(|| "sub-agent".into()),
+            ),
             kind: start.kind.label(),
             parent_session_id: start.parent_session_id.clone(),
             status: "running",
@@ -977,6 +982,12 @@ impl BackgroundSubAgentRecord {
             "session_id": self.session_id,
             "name": self.name,
             "model": self.model,
+            "progress": {
+                "name": self.progress.subagent_name,
+                "tool_use_count": self.progress.tool_use_count,
+                "latest_activity": self.progress.latest_activity(),
+                "total_tokens": self.progress.total_tokens(),
+            },
             "kind": self.kind,
             "parent_session_id": self.parent_session_id,
             "status": self.status,
@@ -1247,12 +1258,20 @@ async fn run_sub_agent(
         sub.set_max_turns(def_max_turns);
     }
 
-    sub.query_with_mode(
+    let query_fut = sub.query_with_mode(
         instruction.to_string(),
         crate::agent::AgentOutputMode::Silent,
-    )
-    .await
-    .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+    );
+
+    tokio::time::timeout(Duration::from_secs(SUBAGENT_TIMEOUT_SECS), query_fut)
+        .await
+        .map_err(|_| {
+            ToolError::ExecutionFailed(format!(
+                "sub-agent timed out after {} seconds",
+                SUBAGENT_TIMEOUT_SECS
+            ))
+        })?
+        .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
 
     let status = kind.result_status();
     let summary = latest_assistant_text(&sub).unwrap_or_else(|| "Sub-agent finished.".to_string());

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -838,6 +838,7 @@ fn background_subagent_store_prunes_old_completed_records() {
                     session_id: format!("session-{idx}"),
                     name: None,
                     model: None,
+                    progress: SubagentProgress::new("test".into()),
                     kind: "general",
                     parent_session_id: None,
                     status: "done",

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -15,10 +15,10 @@ use tokio::time::{Duration, sleep};
 
 use super::{
     AgentDefinition, BACKGROUND_SUBAGENT_COMPLETED_RETENTION, BackgroundSubAgentRecord,
-    BackgroundSubAgentStore, SubAgentKind, TEAM_CREATE_CONCURRENCY_LIMIT, append_subagent_prompt,
-    build_filtered_tool_manager, build_read_only_tool_manager, build_subagent_tool_manager,
-    latest_assistant_text_from_history, parse_team_task_kind, resolve_kind_definition,
-    resolve_spawn_agent_definition,
+    BackgroundSubAgentStore, SubAgentKind, SubagentProgress, TEAM_CREATE_CONCURRENCY_LIMIT,
+    append_subagent_prompt, build_filtered_tool_manager, build_read_only_tool_manager,
+    build_subagent_tool_manager, latest_assistant_text_from_history, parse_team_task_kind,
+    resolve_kind_definition, resolve_spawn_agent_definition,
 };
 use crate::agent::Message;
 use crate::llm::{ContentBlock, LlmBackend, LlmResponse, MockLlm};

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -838,7 +838,7 @@ fn background_subagent_store_prunes_old_completed_records() {
                     session_id: format!("session-{idx}"),
                     name: None,
                     model: None,
-                    progress: SubagentProgress::new("test".into()),
+                    progress: SubagentProgress::new("test".to_string()),
                     kind: "general",
                     parent_session_id: None,
                     status: "done",


### PR DESCRIPTION
## Summary

- **Timeout guard**: 300s `tokio::time::timeout` wrapping `sub.query_with_mode`, prevents hung sub-agents
- **Progress tracking**: `BackgroundSubAgentRecord` now includes a `SubagentProgress` field auto-initialized on spawn, serialized in the JSON status response for TUI/resume inspection

## Verification

```
cargo check → passes (pre-existing warnings only)
```