### PR TITLE
feat: add action safety prompt section

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -510,6 +510,22 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
             ),
         ),
         PromptSection::new(
+            "action_safety",
+            section(
+                "Action Safety And Care",
+                &[
+                    "Carefully consider the reversibility and blast radius of every action.",
+                    "Freely take local, reversible actions: editing tracked files, running tests, formatting code.",
+                    "Before any hard-to-reverse or shared-state action, confirm with the user: destructive operations (rm -rf, git reset --hard, deleting branches), shared-state changes (git push, creating/closing PRs, commenting on issues), or anything visible to others.",
+                    "A user approving an action once does NOT mean blanket approval. Unless authorized in durable instructions like AGENTS.md, re-confirm each time.",
+                    "When you encounter an obstacle, do not use destructive actions as a shortcut. Investigate root causes instead of bypassing safety checks (e.g. --no-verify).",
+                    "If you discover unexpected state (unfamiliar files, branches, lock files), investigate before deleting or overwriting — it may represent in-progress user work.",
+                    "Match the scope of your actions to what was actually requested. Do not expand the blast radius beyond the task.",
+                    "When in doubt, ask before acting. The cost of pausing to confirm is low; the cost of an unwanted action is very high.",
+                ],
+            ),
+        ),
+        PromptSection::new(
             "task_workflow",
             section(
                 "Task Workflow",


### PR DESCRIPTION
## Summary

Add `action_safety` prompt section based on Claude Code's "Executing actions with care".

- Warn against destructive ops (rm -rf, git reset --hard, deleting branches)
- Require confirmation before shared-state changes (push, PRs, comments)
- Re-confirmation rule: one approval is not blanket authorization
- No bypassing safety checks as shortcuts to obstacles

## Context

Codex `gpt_5_codex_prompt.md` and Claude Code `executing-actions-with-care.md` both have this. RARA previously had no action-safety guidance.

Existing `coding_standards` section already covers "no unnecessary error handling" and "no compatibility hacks" — those were not duplicated.

## Verification

```
cargo check → passes (pre-existing warnings only)
```