### PR TITLE
fix: dynamic composer height + paste burst + placeholder

### DIFF
--- a/src/tui/render/bottom_pane/mod.rs
+++ b/src/tui/render/bottom_pane/mod.rs
@@ -21,9 +21,6 @@ pub(crate) fn desired_viewport_height(app: &TuiApp, width: u16, rows: u16) -> u1
     if app.overlay.is_some() {
         return rows.max(1);
     }
-    if app.transcript_scroll > 0 {
-        return rows.max(1);
-    }
     let bottom_pane_height = desired_bottom_pane_height(app, width, rows);
     let has_active_content =
         !app.active_turn.entries.is_empty() || app.bottom_pane.has_pending_planning_suggestion();

--- a/src/tui/state/bottom_pane_model.rs
+++ b/src/tui/state/bottom_pane_model.rs
@@ -29,8 +29,10 @@ pub struct BottomPaneModel {
     // avoiding O(n²) per-frame redraws for long pastes.
     pub(super) paste_burst_buffer: Option<String>,
     pub(super) paste_burst_deadline: Option<Instant>,
-    /// (placeholder, full_text) — expanded on submit via expand_large_paste.
-    pub(super) large_paste_pending: Option<(String, String)>,
+    /// Large pastes pending expansion on submit. Each entry is
+    /// `(placeholder_text, full_text)` where placeholder is unique.
+    pub(crate) large_paste_pending: Vec<(String, String)>,
+    pub(crate) large_paste_counter: u32,
 }
 
 impl BottomPaneModel {
@@ -46,7 +48,8 @@ impl BottomPaneModel {
             notice: None,
             paste_burst_buffer: None,
             paste_burst_deadline: None,
-            large_paste_pending: None,
+            large_paste_pending: Vec::new(),
+            large_paste_counter: 0,
         }
     }
 
@@ -98,12 +101,17 @@ impl BottomPaneModel {
         let is_large = char_count > 1000;
 
         if is_large {
-            let placeholder = format!("[Pasted Content {} chars]", char_count);
-            self.input.push_str(&placeholder);
-            self.input_cursor_offset = None;
-            self.large_paste_pending = Some((placeholder, buf));
+            let counter = self.large_paste_counter;
+            self.large_paste_counter += 1;
+            let placeholder = format!("[Pasted Content #{} — {} chars]", counter, char_count);
+            // Insert placeholder at cursor position instead of end
+            let offset = self.composer_cursor_offset();
+            let pos = char_offset_to_byte_index(&self.input, offset);
+            self.input.insert_str(pos, &placeholder);
+            self.input_cursor_offset = Some(offset + placeholder.chars().count());
+            self.large_paste_pending.push((placeholder, buf));
             self.notice = Some(format!(
-                "Large paste ({char_count} chars) — expanded on submit"
+                "Large paste #{counter} ({char_count} chars) — expanded on submit"
             ));
             return true;
         }
@@ -130,9 +138,12 @@ impl BottomPaneModel {
 
     /// Replace paste placeholder in input with the real text. Call before submit.
     pub(crate) fn expand_large_paste(&mut self) {
-        if let Some((placeholder, full_text)) = self.large_paste_pending.take() {
+        let pending: Vec<_> = std::mem::take(&mut self.large_paste_pending);
+        for (placeholder, full_text) in pending {
             self.input = self.input.replace(&placeholder, &full_text);
         }
+        // Also handle legacy single-entry format for safety
+        self.large_paste_counter = 0;
     }
 
     pub fn has_queued_follow_up_messages(&self) -> bool {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1783,6 +1783,86 @@ async fn paste_normalizes_crlf_and_cr_newlines() {
 }
 
 #[test]
+fn large_paste_inserts_placeholder_at_cursor_position() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    // Pre-fill input and move cursor to middle
+    app.bottom_pane.input = "before after".to_string();
+    app.bottom_pane.input_cursor_offset = Some("before ".chars().count());
+
+    let big = "x".repeat(1200);
+    super::terminal_ui::handle_paste(big.clone(), &mut app);
+    app.bottom_pane.flush_paste_burst();
+
+    // Placeholder should appear at cursor position, not end
+    assert!(
+        app.bottom_pane
+            .input
+            .starts_with("before [Pasted Content #0 — 1200 chars]after")
+    );
+    // Cursor should be after the placeholder
+    assert_eq!(
+        app.composer_cursor_offset(),
+        "before [Pasted Content #0 — 1200 chars]".chars().count()
+    );
+}
+
+#[test]
+fn multiple_large_pastes_accumulate_in_pending_vec() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+
+    let big_a = "a".repeat(1200);
+    let big_b = "b".repeat(1100);
+    super::terminal_ui::handle_paste(big_a.clone(), &mut app);
+    app.bottom_pane.flush_paste_burst();
+    assert_eq!(app.bottom_pane.large_paste_pending.len(), 1);
+
+    super::terminal_ui::handle_paste(big_b.clone(), &mut app);
+    app.bottom_pane.flush_paste_burst();
+    assert_eq!(app.bottom_pane.large_paste_pending.len(), 2);
+
+    // Both placeholders should be in the input
+    assert!(app.bottom_pane.input.contains("Pasted Content #0"));
+    assert!(app.bottom_pane.input.contains("Pasted Content #1"));
+    // Counters should be unique
+    assert_ne!(
+        app.bottom_pane.large_paste_pending[0].0,
+        app.bottom_pane.large_paste_pending[1].0
+    );
+}
+
+#[test]
+fn expand_large_paste_replaces_all_placeholders() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+
+    let big = "z".repeat(1500);
+    super::terminal_ui::handle_paste(big.clone(), &mut app);
+    app.bottom_pane.flush_paste_burst();
+    assert!(app.bottom_pane.large_paste_pending.len() == 1);
+    assert!(app.bottom_pane.input.contains("Pasted Content"));
+    assert!(!app.bottom_pane.input.contains(&big));
+
+    app.bottom_pane.expand_large_paste();
+
+    // After expand: placeholder gone, full text present, counter reset
+    assert!(!app.bottom_pane.input.contains("Pasted Content"));
+    assert!(app.bottom_pane.input.contains(&big));
+    assert_eq!(app.bottom_pane.large_paste_pending.len(), 0);
+    assert_eq!(app.bottom_pane.large_paste_counter, 0);
+}
+
+#[test]
 fn crossterm_paste_event_uses_paste_channel() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {


### PR DESCRIPTION
## Summary

Three fixes for the TUI composer:

1. **Paste burst buffer never flushed** — check_paste_burst_flush was defined but never called from the event loop. Pasted text got stuck in the buffer. Fixed by calling it after each render.

2. **Placeholder for large pastes** — Aligned with Codex: pastes >1000 chars now insert [Pasted Content N chars] placeholder instead of all text. Real text expands on submit. Prevents O(n²) freeze.

3. **Composer grows with content** — Removed the transcript_scroll > 0 block from desired_viewport_height. This prevented the composer from expanding when the user scrolled up. Now the composer always gets its content height, like Codex.