### PR TITLE
fix: correct provider label for DeepSeek models

### DIFF
--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -638,6 +638,14 @@ impl TuiApp {
                 ProviderFamily::OpenAiCompatible => {
                     let mut found_profile = false;
                     for (profile_id, profile) in &self.config.openai_profiles {
+                        // Skip profiles whose kind already has a dedicated
+                        // provider family (these show up via their own branch).
+                        if matches!(
+                            profile.kind,
+                            OpenAiEndpointKind::Deepseek | OpenAiEndpointKind::Kimi
+                        ) {
+                            continue;
+                        }
                         found_profile = true;
                         let model_id = profile
                             .model
@@ -769,6 +777,7 @@ impl TuiApp {
                     OpenAiEndpointKind::Deepseek.label(),
                     OpenAiEndpointKind::Deepseek,
                 );
+                self.config.set_provider("deepseek");
                 self.config.set_model(Some(preset.model_id));
                 self.config.set_revision(None);
             }
@@ -1264,6 +1273,7 @@ impl TuiApp {
                 OpenAiEndpointKind::Deepseek.label(),
                 OpenAiEndpointKind::Deepseek,
             );
+            self.config.set_provider("deepseek");
             self.config.set_model(Some(model));
             self.config.set_revision(None);
             return;


### PR DESCRIPTION
## Root cause

select_openai_profile sets config.provider = "openai-compatible" regardless. When DeepSeek is saved, provider stays openai-compatible.

## Fix

- set_provider("deepseek") after select_openai_profile (2 call sites)
- Filter OpenAiCompatible profiles with kind=Deepseek|Kimi from all_unified_model_presets (already have own family branch)

## Result
- Sidebar: deepseek / deepseek-v4-pro (was openai-compatible / ...)
- ModelSearch: no gpt-4o-mini or duplicate entries under DeepSeek
- 476 tests passed