### PR TITLE
fix: allow mouse scroll when overlay is open

### DIFF
--- a/src/tui/event_stream.rs
+++ b/src/tui/event_stream.rs
@@ -43,10 +43,6 @@ pub fn translate_event(event: Event, app: &TuiApp) -> Option<UiEvent> {
 }
 
 fn map_mouse_to_event(mouse_event: MouseEvent, app: &TuiApp) -> AppEvent {
-    if app.overlay.is_some() {
-        return AppEvent::Noop;
-    }
-
     match mouse_event.kind {
         MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
             let direction: i32 = if matches!(mouse_event.kind, MouseEventKind::ScrollUp) {
@@ -55,8 +51,14 @@ fn map_mouse_to_event(mouse_event: MouseEvent, app: &TuiApp) -> AppEvent {
                 1
             };
             let lines = MOUSE_WHEEL_SCROLL_LINES as f64 * scroll_accel_factor();
-            AppEvent::ScrollTranscript((direction * lines.round() as i32).clamp(-15, 15))
+            let delta = (direction * lines.round() as i32).clamp(-15, 15);
+            if app.overlay.is_some() {
+                AppEvent::ScrollContext(delta)
+            } else {
+                AppEvent::ScrollTranscript(delta)
+            }
         }
+        // All other mouse events: ignore when overlay is open
         _ => AppEvent::Noop,
     }
 }


### PR DESCRIPTION
## Problem

When any overlay was open (model selector, help dialog, etc.), mouse scroll events were swallowed by a return AppEvent::Noop gate. The transcript/content was unresponsive to scrolling.

## Fix

- Removed the blanket Noop early-return that blocked all mouse events during overlay
- Mouse scroll now routes to ScrollContext when overlay is active (scrolls overlay content)
- Mouse scroll routes to ScrollTranscript when no overlay (scrolls main transcript)
- Non-scroll mouse events still ignored during overlay to prevent accidental clicks

## Verification

cargo check passes (pre-existing warnings only)
