### PR TITLE
feat(providers): add Kimi as a first-class provider with model list support

### DIFF
--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -365,6 +365,7 @@ impl RaraConfig {
         match provider {
             "deepseek" => Some(DEFAULT_DEEPSEEK_BASE_URL),
             "gemini" => Some(DEFAULT_GEMINI_BASE_URL),
+            "kimi" => Some(DEFAULT_KIMI_BASE_URL),
             _ => None,
         }
     }

--- a/crates/provider-catalog/src/kimi.rs
+++ b/crates/provider-catalog/src/kimi.rs
@@ -1,0 +1,132 @@
+use anyhow::{Result, anyhow};
+use rara_config::DEFAULT_KIMI_BASE_URL;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+use crate::ModelCatalogRequest;
+use crate::redaction::{redact_known_secret, sanitize_url_for_display};
+
+const MODELS_TIMEOUT_SECS: u64 = 15;
+
+/// Model name → context window tokens (for budget calculation).
+/// Also serves as the fallback model list when the API is unavailable.
+pub const MODEL_WINDOWS: &[(&str, u32)] = &[
+    ("kimi-k2.6", 262_144),
+    ("kimi-k2.5", 262_144),
+    ("kimi-k2-0905-preview", 262_144),
+    ("kimi-k2-turbo-preview", 262_144),
+    ("kimi-k2-thinking", 262_144),
+    ("kimi-k2-thinking-turbo", 262_144),
+];
+
+pub const FALLBACK_MODELS: [&str; 6] = [
+    "kimi-k2.6",
+    "kimi-k2.5",
+    "kimi-k2-0905-preview",
+    "kimi-k2-turbo-preview",
+    "kimi-k2-thinking",
+    "kimi-k2-thinking-turbo",
+];
+
+#[derive(Deserialize)]
+struct ModelsResponse {
+    data: Vec<ModelEntry>,
+}
+
+#[derive(Deserialize)]
+struct ModelEntry {
+    id: String,
+}
+
+pub fn fallback_models() -> Vec<String> {
+    FALLBACK_MODELS
+        .iter()
+        .map(|model| (*model).to_string())
+        .collect()
+}
+
+pub fn models_url(base_url: Option<&str>) -> String {
+    let base_url = base_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(DEFAULT_KIMI_BASE_URL)
+        .trim_end_matches('/');
+    let root = base_url.strip_suffix("/v1").unwrap_or(base_url);
+    format!("{root}/models")
+}
+
+pub fn parse_models(body: &str) -> Result<Vec<String>> {
+    let response: ModelsResponse = serde_json::from_str(body)?;
+    let models = response
+        .data
+        .into_iter()
+        .map(|model| model.id.trim().to_string())
+        .filter(|id| !id.is_empty())
+        .collect::<Vec<_>>();
+    Ok(models)
+}
+
+pub async fn load_models(request: ModelCatalogRequest<'_>) -> Result<Vec<String>> {
+    let api_key = request
+        .api_key
+        .map(SecretString::expose_secret)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("Kimi API key is required to list models"))?;
+    let url = models_url(request.base_url);
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(MODELS_TIMEOUT_SECS))
+        .build()?;
+    let response = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .bearer_auth(api_key)
+        .send()
+        .await?;
+
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        return Err(anyhow!(
+            "Kimi model list request failed at {}: {}",
+            sanitize_url_for_display(&url),
+            redact_known_secret(&body, api_key)
+        ));
+    }
+    parse_models(&body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{models_url, parse_models};
+
+    #[test]
+    fn kimi_models_url_uses_root_models_endpoint() {
+        assert_eq!(
+            models_url(Some("https://api.moonshot.cn/v1")),
+            "https://api.moonshot.cn/models"
+        );
+        assert_eq!(
+            models_url(Some("https://api.moonshot.cn")),
+            "https://api.moonshot.cn/models"
+        );
+    }
+
+    #[test]
+    fn parses_kimi_models_in_provider_order() {
+        let models = parse_models(
+            r#"{
+                "object": "list",
+                "data": [
+                    {"id": "kimi-k2.6", "object": "model"},
+                    {"id": "kimi-k2.5", "object": "model"},
+                    {"id": "kimi-k2.5", "object": "model"},
+                    {"id": " ", "object": "model"}
+                ]
+            }"#,
+        )
+        .expect("parse models");
+
+        assert_eq!(models, vec!["kimi-k2.6", "kimi-k2.5", "kimi-k2.5"]);
+    }
+}

--- a/crates/provider-catalog/src/kimi.rs
+++ b/crates/provider-catalog/src/kimi.rs
@@ -42,8 +42,7 @@ pub fn models_url(base_url: Option<&str>) -> String {
         .filter(|value| !value.is_empty())
         .unwrap_or(DEFAULT_KIMI_BASE_URL)
         .trim_end_matches('/');
-    let root = base_url.strip_suffix("/v1").unwrap_or(base_url);
-    format!("{root}/models")
+    format!("{base_url}/models")
 }
 
 pub fn parse_models(body: &str) -> Result<Vec<String>> {
@@ -95,7 +94,7 @@ mod tests {
     fn kimi_models_url_uses_root_models_endpoint() {
         assert_eq!(
             models_url(Some("https://api.moonshot.cn/v1")),
-            "https://api.moonshot.cn/models"
+            "https://api.moonshot.cn/v1/models"
         );
         assert_eq!(
             models_url(Some("https://api.moonshot.cn")),

--- a/crates/provider-catalog/src/kimi.rs
+++ b/crates/provider-catalog/src/kimi.rs
@@ -19,14 +19,12 @@ pub const MODEL_WINDOWS: &[(&str, u32)] = &[
     ("kimi-k2-thinking-turbo", 262_144),
 ];
 
-pub const FALLBACK_MODELS: [&str; 6] = [
-    "kimi-k2.6",
-    "kimi-k2.5",
-    "kimi-k2-0905-preview",
-    "kimi-k2-turbo-preview",
-    "kimi-k2-thinking",
-    "kimi-k2-thinking-turbo",
-];
+pub fn fallback_models() -> Vec<String> {
+    MODEL_WINDOWS
+        .iter()
+        .map(|(model, _)| (*model).to_string())
+        .collect()
+}
 
 #[derive(Deserialize)]
 struct ModelsResponse {
@@ -36,13 +34,6 @@ struct ModelsResponse {
 #[derive(Deserialize)]
 struct ModelEntry {
     id: String,
-}
-
-pub fn fallback_models() -> Vec<String> {
-    FALLBACK_MODELS
-        .iter()
-        .map(|model| (*model).to_string())
-        .collect()
 }
 
 pub fn models_url(base_url: Option<&str>) -> String {

--- a/crates/provider-catalog/src/lib.rs
+++ b/crates/provider-catalog/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod deepseek;
+pub mod kimi;
 mod redaction;
 
 use anyhow::Result;
@@ -7,6 +8,7 @@ use secrecy::SecretString;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ModelCatalogProvider {
     DeepSeek,
+    Kimi,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -24,6 +26,7 @@ pub struct ModelCatalog {
 pub fn fallback_models(provider: ModelCatalogProvider) -> Vec<String> {
     match provider {
         ModelCatalogProvider::DeepSeek => deepseek::fallback_models(),
+        ModelCatalogProvider::Kimi => kimi::fallback_models(),
     }
 }
 
@@ -33,6 +36,7 @@ pub async fn load_model_catalog(
 ) -> Result<ModelCatalog> {
     let models = match provider {
         ModelCatalogProvider::DeepSeek => deepseek::load_models(request).await?,
+        ModelCatalogProvider::Kimi => kimi::load_models(request).await?,
     };
     Ok(ModelCatalog { provider, models })
 }

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -977,6 +977,7 @@ pub fn model_help_text(app: &TuiApp) -> String {
                         let shortcut = match family {
                             ProviderFamily::Codex
                             | ProviderFamily::DeepSeek
+                            | ProviderFamily::Kimi
                             | ProviderFamily::OpenAiCompatible
                             | ProviderFamily::Gemini
                             | ProviderFamily::CandleLocal

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -10,7 +10,10 @@ use super::provider_flow::{
     sync_codex_credential_from_auth_store,
 };
 use super::runtime::apply_permission_mode;
-use super::runtime::{start_deepseek_model_list_task, start_oauth_task, start_rebuild_task};
+use super::runtime::{
+    start_deepseek_model_list_task, start_kimi_model_list_task, start_oauth_task,
+    start_rebuild_task,
+};
 use super::session_restore::restore_thread_by_id;
 use super::state::{
     ActivePendingInteractionKind, ListPickerKind, OpenAiModelPickerAction, Overlay, PermissionMode,
@@ -234,6 +237,8 @@ pub(crate) async fn dispatch_event(
             } else if value.is_empty() && app.selected_provider_family() == ProviderFamily::DeepSeek
             {
                 app.push_notice("Enter a DeepSeek API key or press Esc to go back.");
+            } else if value.is_empty() && app.selected_provider_family() == ProviderFamily::Kimi {
+                app.push_notice("Enter a Kimi API key or press Esc to go back.");
             } else if value.is_empty() && app.openai_setup_keep_empty_api_key {
                 app.bottom_pane.notice =
                     Some("Kept existing API key for the current profile.".into());
@@ -252,6 +257,7 @@ pub(crate) async fn dispatch_event(
                 }
             } else {
                 let was_deepseek = app.selected_provider_family() == ProviderFamily::DeepSeek;
+                let was_kimi = app.selected_provider_family() == ProviderFamily::Kimi;
                 app.config.set_api_key(value.to_string());
                 if app.config.provider == "codex" {
                     app.codex_auth_mode = Some(SavedCodexAuthMode::ApiKey);
@@ -268,6 +274,10 @@ pub(crate) async fn dispatch_event(
                     app.bottom_pane.notice = Some("Saved DeepSeek API key. Loading models.".into());
                     app.close_overlay();
                     start_deepseek_model_list_task(app);
+                } else if was_kimi {
+                    app.bottom_pane.notice = Some("Saved Kimi API key. Loading models.".into());
+                    app.close_overlay();
+                    start_kimi_model_list_task(app);
                 } else {
                     app.bottom_pane.notice = Some("Saved API key for the current provider.".into());
                     if app.openai_setup_steps.is_empty() {
@@ -461,6 +471,15 @@ pub(crate) async fn dispatch_event(
                                 } else {
                                     app.open_overlay(Overlay::ApiKeyEditor);
                                 }
+                            } else if app.selected_provider_family() == ProviderFamily::Kimi {
+                                if app.selected_kimi_api_key_action() {
+                                    app.open_overlay(Overlay::ApiKeyEditor);
+                                } else if app.config.has_api_key() {
+                                    app.select_local_model(app.model_picker_idx);
+                                    start_rebuild_task(app);
+                                } else {
+                                    app.open_overlay(Overlay::ApiKeyEditor);
+                                }
                             } else {
                                 app.select_local_model(app.model_picker_idx);
                                 start_rebuild_task(app);
@@ -501,7 +520,9 @@ pub(crate) async fn dispatch_event(
                                 {
                                     app.begin_active_openai_profile_setup();
                                 }
-                                ProviderFamily::DeepSeek | ProviderFamily::Gemini
+                                ProviderFamily::DeepSeek
+                                | ProviderFamily::Kimi
+                                | ProviderFamily::Gemini
                                     if !app.config.has_api_key() =>
                                 {
                                     app.open_overlay(Overlay::ApiKeyEditor);

--- a/src/tui/provider_flow.rs
+++ b/src/tui/provider_flow.rs
@@ -157,11 +157,7 @@ pub(super) fn open_provider_connection(app: &mut TuiApp) {
     }
 
     match family {
-        ProviderFamily::DeepSeek => {
-            app.open_overlay(Overlay::ApiKeyEditor);
-            app.bottom_pane.notice = Some(format!("Enter your {label} API key."));
-        }
-        ProviderFamily::Kimi => {
+        ProviderFamily::DeepSeek | ProviderFamily::Kimi => {
             app.open_overlay(Overlay::ApiKeyEditor);
             app.bottom_pane.notice = Some(format!("Enter your {label} API key."));
         }

--- a/src/tui/provider_flow.rs
+++ b/src/tui/provider_flow.rs
@@ -161,6 +161,10 @@ pub(super) fn open_provider_connection(app: &mut TuiApp) {
             app.open_overlay(Overlay::ApiKeyEditor);
             app.bottom_pane.notice = Some(format!("Enter your {label} API key."));
         }
+        ProviderFamily::Kimi => {
+            app.open_overlay(Overlay::ApiKeyEditor);
+            app.bottom_pane.notice = Some(format!("Enter your {label} API key."));
+        }
         ProviderFamily::Gemini => {
             app.open_overlay(Overlay::ApiKeyEditor);
             app.bottom_pane.notice = Some(format!("Enter your {label} API key."));

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tui/render/tests.rs
+assertion_line: 875
 expression: rendered
 ---
 ── RARA ──────────────────────────────────────────────────
@@ -20,7 +21,7 @@ Prompt ideas│   [1] Codex (current)                                           
   · Explain │      Use Codex with browser login, device-code login, or a Codex API key.│
   · Find the│   [2] DeepSeek                                                           │
             │      Use DeepSeek with an API key and model list from api.deepseek.com.  │
-            │   [3] OpenAI-compatible                                                  │
-Warning  War│      Use OpenAI-compatible endpoint profiles such as Custom, Kimi, or Ope│
+            │   [3] Kimi                                                               │
+Warning  War│      Use Moonshot Kimi with an API key from api.moonshot.cn.             │
 › Ask about │                                                                          │
                           1-9 jump  Up/Down/jk move  Enter apply  Esc back

--- a/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tui/render/tests.rs
+assertion_line: 1240
 expression: rendered
 ---
 ── RARA ──────────────────────────────────────────────────
@@ -18,5 +19,5 @@ St│Select a model across all providers.                                      �
   │DeepSeek/deepseek-v4-flash                                                │
 Pr│DeepSeek/deepseek-v4-pro                                                  │
 Re│DeepSeek/deepseek-v4-preview                                              │
-› │My Custom GPT/gpt-custom                                                  │
+› │Kimi/kimi-k2.6                                                            │
                      Up/Down/jk move  Enter apply  Esc back

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -70,6 +70,10 @@ pub fn start_deepseek_model_list_task(app: &mut TuiApp) {
     tasks::start_deepseek_model_list_task(app);
 }
 
+pub fn start_kimi_model_list_task(app: &mut TuiApp) {
+    tasks::start_kimi_model_list_task(app);
+}
+
 pub async fn finish_running_task_if_ready(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -571,6 +571,45 @@ pub(super) fn start_deepseek_model_list_task(app: &mut TuiApp) {
     });
 }
 
+pub(super) fn start_kimi_model_list_task(app: &mut TuiApp) {
+    let (_sender, receiver) = mpsc::unbounded_channel();
+    let api_key = app.config.api_key.clone();
+    let base_url = Some(
+        app.config
+            .base_url
+            .clone()
+            .unwrap_or_else(|| crate::config::DEFAULT_KIMI_BASE_URL.to_string()),
+    );
+    app.bottom_pane.notice = Some("Loading Kimi models.".into());
+    app.set_runtime_phase(
+        RuntimePhase::RebuildingBackend,
+        Some("loading models".into()),
+    );
+
+    let handle = tokio::spawn(async move {
+        let result = load_model_catalog(
+            ModelCatalogProvider::Kimi,
+            ModelCatalogRequest {
+                api_key: api_key.as_ref(),
+                base_url: base_url.as_deref(),
+            },
+        )
+        .await
+        .map(|catalog| catalog.models);
+        TaskCompletion::KimiModels { result }
+    });
+
+    app.bottom_pane.running_task = Some(RunningTask {
+        kind: TaskKind::KimiModels,
+        receiver,
+        handle,
+        started_at: Instant::now(),
+        next_heartbeat_after_secs: u64::MAX,
+        cancellation_token: None,
+        cancellation_requested: false,
+    });
+}
+
 pub(super) fn request_running_task_cancellation(app: &mut TuiApp) {
     let Some(task) = app.bottom_pane.running_task.as_mut() else {
         app.bottom_pane.notice = Some("No running task to cancel.".into());
@@ -1013,6 +1052,30 @@ pub(crate) async fn finish_running_task_if_ready(
                 app.set_deepseek_model_options(fallback_models(ModelCatalogProvider::DeepSeek));
                 let message = format!(
                     "Failed to load DeepSeek models. Showing fallback list.\n{}",
+                    format_error_chain(&err)
+                );
+                app.push_entry("System", message.clone());
+                app.push_notice(message);
+                app.set_runtime_phase(RuntimePhase::Idle, Some("model list fallback".into()));
+                app.open_overlay(super::super::state::Overlay::ListPicker(
+                    ListPickerKind::Model,
+                ));
+            }
+        },
+        TaskCompletion::KimiModels { result } => match result {
+            Ok(models) => {
+                let count = models.len();
+                app.set_kimi_model_options(models);
+                app.bottom_pane.notice = Some(format!("Loaded {count} Kimi models."));
+                app.set_runtime_phase(RuntimePhase::Idle, Some("models loaded".into()));
+                app.open_overlay(super::super::state::Overlay::ListPicker(
+                    ListPickerKind::Model,
+                ));
+            }
+            Err(err) => {
+                app.set_kimi_model_options(fallback_models(ModelCatalogProvider::Kimi));
+                let message = format!(
+                    "Failed to load Kimi models. Showing fallback list.\n{}",
                     format_error_chain(&err)
                 );
                 app.push_entry("System", message.clone());

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -532,7 +532,7 @@ pub(super) fn start_google_oauth_task(
 
 pub(super) fn start_deepseek_model_list_task(app: &mut TuiApp) {
     let (_sender, receiver) = mpsc::unbounded_channel();
-    let api_key = app.config.api_key.clone();
+    let api_key = app.config.api_key_secret();
     let surface = app.config.effective_provider_surface();
     let base_url = Some(
         surface
@@ -573,12 +573,14 @@ pub(super) fn start_deepseek_model_list_task(app: &mut TuiApp) {
 
 pub(super) fn start_kimi_model_list_task(app: &mut TuiApp) {
     let (_sender, receiver) = mpsc::unbounded_channel();
-    let api_key = app.config.api_key.clone();
+    let api_key = app.config.api_key_secret();
+    let surface = app.config.effective_provider_surface();
     let base_url = Some(
-        app.config
+        surface
             .base_url
-            .clone()
-            .unwrap_or_else(|| crate::config::DEFAULT_KIMI_BASE_URL.to_string()),
+            .value
+            .unwrap_or(crate::config::DEFAULT_KIMI_BASE_URL)
+            .to_string(),
     );
     app.bottom_pane.notice = Some("Loading Kimi models.".into());
     app.set_runtime_phase(

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -64,6 +64,7 @@ pub fn is_provider_connected(app: &TuiApp, family: ProviderFamily) -> bool {
                 .and_then(|s| s.api_key.as_ref())
                 .is_some()
                 || std::env::var("KIMI_API_KEY").is_ok()
+                || std::env::var("MOONSHOT_API_KEY").is_ok()
         }
         ProviderFamily::Gemini => {
             std::env::var("GEMINI_API_KEY").is_ok()

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -58,13 +58,17 @@ pub fn is_provider_connected(app: &TuiApp, family: ProviderFamily) -> bool {
                 || std::env::var("DEEPSEEK_API_KEY").is_ok()
         }
         ProviderFamily::Kimi => {
-            config
+            let has_state = config
                 .provider_states
                 .get("kimi")
                 .and_then(|s| s.api_key.as_ref())
-                .is_some()
-                || std::env::var("KIMI_API_KEY").is_ok()
-                || std::env::var("MOONSHOT_API_KEY").is_ok()
+                .is_some();
+            let has_env =
+                std::env::var("KIMI_API_KEY").is_ok() || std::env::var("MOONSHOT_API_KEY").is_ok();
+            let has_profile = config.openai_profiles.values().any(|p| {
+                p.kind == crate::config::OpenAiEndpointKind::Kimi && p.api_key.as_ref().is_some()
+            });
+            has_state || has_env || has_profile
         }
         ProviderFamily::Gemini => {
             std::env::var("GEMINI_API_KEY").is_ok()
@@ -393,7 +397,11 @@ impl TuiApp {
                 }
                 ProviderFamily::Kimi => {
                     let has_key = self.config.provider == "kimi" && self.config.has_api_key();
-                    has_key
+                    let has_profile = self.config.openai_profiles.values().any(|p| {
+                        p.kind == crate::config::OpenAiEndpointKind::Kimi
+                            && p.api_key.as_ref().is_some()
+                    });
+                    has_key || has_profile
                 }
                 ProviderFamily::Gemini => {
                     let has_key = self.config.provider == "gemini" && self.config.has_api_key();

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -57,6 +57,14 @@ pub fn is_provider_connected(app: &TuiApp, family: ProviderFamily) -> bool {
                 .is_some()
                 || std::env::var("DEEPSEEK_API_KEY").is_ok()
         }
+        ProviderFamily::Kimi => {
+            config
+                .provider_states
+                .get("kimi")
+                .and_then(|s| s.api_key.as_ref())
+                .is_some()
+                || std::env::var("KIMI_API_KEY").is_ok()
+        }
         ProviderFamily::Gemini => {
             std::env::var("GEMINI_API_KEY").is_ok()
                 || config
@@ -305,6 +313,7 @@ impl TuiApp {
             openai_setup_keep_empty_api_key: false,
             codex_model_options: Vec::new(),
             deepseek_model_options: fallback_models(ModelCatalogProvider::DeepSeek),
+            kimi_model_options: fallback_models(ModelCatalogProvider::Kimi),
             recent_commands: Vec::new(),
             recent_threads: Vec::new(),
             resume_picker_idx: 0,
@@ -380,6 +389,10 @@ impl TuiApp {
                             && p.api_key.as_ref().is_some()
                     });
                     has_key || has_profile
+                }
+                ProviderFamily::Kimi => {
+                    let has_key = self.config.provider == "kimi" && self.config.has_api_key();
+                    has_key
                 }
                 ProviderFamily::Gemini => {
                     let has_key = self.config.provider == "gemini" && self.config.has_api_key();
@@ -571,6 +584,13 @@ impl TuiApp {
                 .position(|model| self.config.model.as_deref() == Some(model.as_str()))
                 .unwrap_or(0);
         }
+        if self.selected_provider_family() == ProviderFamily::Kimi {
+            return self
+                .kimi_model_options
+                .iter()
+                .position(|model| self.config.model.as_deref() == Some(model.as_str()))
+                .unwrap_or(0);
+        }
         selected_preset_idx_for_config(&self.config, self.provider_picker_idx)
     }
 
@@ -627,6 +647,31 @@ impl TuiApp {
                                 family: *family,
                                 provider_id: "deepseek".to_string(),
                                 provider_label: "DeepSeek".to_string(),
+                                model_id: model.clone(),
+                                model_label: model.clone(),
+                                status: None,
+                                context_window: None,
+                            });
+                        }
+                    }
+                }
+                ProviderFamily::Kimi => {
+                    if self.kimi_model_options.is_empty() {
+                        results.push(UnifiedModelPreset {
+                            family: *family,
+                            provider_id: "kimi".into(),
+                            provider_label: "Kimi".into(),
+                            model_id: "kimi-k2.6".into(),
+                            model_label: "kimi-k2.6".into(),
+                            status: None,
+                            context_window: None,
+                        });
+                    } else {
+                        for model in &self.kimi_model_options {
+                            results.push(UnifiedModelPreset {
+                                family: *family,
+                                provider_id: "kimi".to_string(),
+                                provider_label: "Kimi".to_string(),
                                 model_id: model.clone(),
                                 model_label: model.clone(),
                                 status: None,
@@ -852,6 +897,8 @@ impl TuiApp {
             self.codex_model_options.len()
         } else if self.selected_provider_family() == ProviderFamily::DeepSeek {
             self.deepseek_model_options.len() + 1
+        } else if self.selected_provider_family() == ProviderFamily::Kimi {
+            self.kimi_model_options.len() + 1
         } else if self.selected_provider_family() == ProviderFamily::OpenAiCompatible {
             self.openai_model_picker_profiles().len()
         } else {
@@ -866,6 +913,15 @@ impl TuiApp {
     pub fn selected_deepseek_api_key_action(&self) -> bool {
         self.selected_provider_family() == ProviderFamily::DeepSeek
             && self.model_picker_idx >= self.deepseek_api_key_action_idx()
+    }
+
+    pub fn kimi_api_key_action_idx(&self) -> usize {
+        self.kimi_model_options.len()
+    }
+
+    pub fn selected_kimi_api_key_action(&self) -> bool {
+        self.selected_provider_family() == ProviderFamily::Kimi
+            && self.model_picker_idx >= self.kimi_api_key_action_idx()
     }
 
     pub fn selected_codex_model(&self) -> Option<&CodexModelOption> {
@@ -940,6 +996,28 @@ impl TuiApp {
         options.sort();
         options.dedup();
         self.deepseek_model_options = options;
+        self.model_picker_idx = self.selected_preset_idx();
+    }
+
+    pub fn set_kimi_model_options(&mut self, options: Vec<String>) {
+        let mut options = if options.is_empty() {
+            fallback_models(ModelCatalogProvider::Kimi)
+        } else {
+            options
+        };
+        if let Some(current_model) = self
+            .config
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            && !options.iter().any(|model| model == current_model)
+        {
+            options.push(current_model.to_string());
+        }
+        options.sort();
+        options.dedup();
+        self.kimi_model_options = options;
         self.model_picker_idx = self.selected_preset_idx();
     }
 
@@ -1233,6 +1311,9 @@ impl TuiApp {
         if self.selected_provider_family() == ProviderFamily::DeepSeek {
             return None;
         }
+        if self.selected_provider_family() == ProviderFamily::Kimi {
+            return None;
+        }
         if self.selected_provider_family() == ProviderFamily::OpenAiCompatible {
             return None;
         }
@@ -1274,6 +1355,19 @@ impl TuiApp {
                 OpenAiEndpointKind::Deepseek,
             );
             self.config.set_provider("deepseek");
+            self.config.set_model(Some(model));
+            self.config.set_revision(None);
+            return;
+        }
+        if self.selected_provider_family() == ProviderFamily::Kimi {
+            let Some(model) = self.kimi_model_options.get(idx).cloned() else {
+                return;
+            };
+            self.config.select_openai_profile(
+                OpenAiEndpointKind::Kimi.default_profile_id(),
+                OpenAiEndpointKind::Kimi.label(),
+                OpenAiEndpointKind::Kimi,
+            );
             self.config.set_model(Some(model));
             self.config.set_revision(None);
             return;

--- a/src/tui/state/state_presets.rs
+++ b/src/tui/state/state_presets.rs
@@ -43,6 +43,8 @@ pub fn selected_provider_family_idx_for_config(config: &RaraConfig) -> usize {
         "openai-compatible" => {
             if config.active_openai_profile_kind() == Some(OpenAiEndpointKind::Deepseek) {
                 ProviderFamily::DeepSeek
+            } else if config.active_openai_profile_kind() == Some(OpenAiEndpointKind::Kimi) {
+                ProviderFamily::Kimi
             } else {
                 ProviderFamily::OpenAiCompatible
             }

--- a/src/tui/state/state_presets.rs
+++ b/src/tui/state/state_presets.rs
@@ -47,7 +47,8 @@ pub fn selected_provider_family_idx_for_config(config: &RaraConfig) -> usize {
                 ProviderFamily::OpenAiCompatible
             }
         }
-        "kimi" | "openrouter" => ProviderFamily::OpenAiCompatible,
+        "kimi" => ProviderFamily::Kimi,
+        "openrouter" => ProviderFamily::OpenAiCompatible,
         "gemini" | "gemini-code-assist" => ProviderFamily::Gemini,
         "ollama" | "ollama-native" | "ollama-openai" => ProviderFamily::Ollama,
         "bedrock" => ProviderFamily::Bedrock,
@@ -70,6 +71,7 @@ pub fn current_model_presets(
     match super::PROVIDER_FAMILIES[provider_picker_idx].0 {
         ProviderFamily::Codex => &CODEX_MODEL_PRESETS,
         ProviderFamily::DeepSeek => &[],
+        ProviderFamily::Kimi => &[],
         ProviderFamily::OpenAiCompatible => &OPENAI_COMPATIBLE_MODEL_PRESETS,
         ProviderFamily::Gemini => &[],
         ProviderFamily::CandleLocal => &LOCAL_MODEL_PRESETS,
@@ -129,7 +131,7 @@ mod tests {
             ..RaraConfig::default()
         };
 
-        assert_eq!(selected_provider_family_idx_for_config(&config), 2);
+        assert_eq!(selected_provider_family_idx_for_config(&config), 3);
     }
 
     #[test]
@@ -151,21 +153,29 @@ mod tests {
             ..RaraConfig::default()
         };
 
-        assert_eq!(selected_provider_family_idx_for_config(&local), 4);
-        assert_eq!(selected_provider_family_idx_for_config(&ollama), 5);
-        assert_eq!(selected_provider_family_idx_for_config(&ollama_native), 5);
-        assert_eq!(selected_provider_family_idx_for_config(&ollama_openai), 5);
+        assert_eq!(selected_provider_family_idx_for_config(&local), 5);
+        assert_eq!(selected_provider_family_idx_for_config(&ollama), 6);
+        assert_eq!(selected_provider_family_idx_for_config(&ollama_native), 6);
+        assert_eq!(selected_provider_family_idx_for_config(&ollama_openai), 6);
     }
 
     #[test]
     fn keeps_legacy_openai_endpoint_providers_in_openai_compatible_family() {
-        for provider in ["kimi", "openrouter"] {
-            let config = RaraConfig {
-                provider: provider.to_string(),
-                ..RaraConfig::default()
-            };
-            assert_eq!(selected_provider_family_idx_for_config(&config), 2);
-        }
+        let config = RaraConfig {
+            provider: "openrouter".to_string(),
+            ..RaraConfig::default()
+        };
+        assert_eq!(selected_provider_family_idx_for_config(&config), 3);
+    }
+
+    #[test]
+    fn routes_kimi_provider_to_dedicated_family() {
+        let config = RaraConfig {
+            provider: "kimi".to_string(),
+            ..RaraConfig::default()
+        };
+
+        assert_eq!(selected_provider_family_idx_for_config(&config), 2);
     }
 
     #[test]

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -81,6 +81,7 @@ pub enum ListPickerKind {
 pub enum ProviderFamily {
     Codex,
     DeepSeek,
+    Kimi,
     OpenAiCompatible,
     Gemini,
     CandleLocal,
@@ -336,6 +337,7 @@ pub enum TaskKind {
     OAuth,
     GoogleOAuth,
     DeepSeekModels,
+    KimiModels,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -365,6 +367,9 @@ pub enum TaskCompletion {
         result: anyhow::Result<crate::google_oauth::GoogleCredential>,
     },
     DeepSeekModels {
+        result: anyhow::Result<Vec<String>>,
+    },
+    KimiModels {
         result: anyhow::Result<Vec<String>>,
     },
 }
@@ -416,7 +421,7 @@ impl std::fmt::Debug for RunningTask {
     }
 }
 
-pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 7] = [
+pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 8] = [
     (
         ProviderFamily::Codex,
         "Codex",
@@ -426,6 +431,11 @@ pub const PROVIDER_FAMILIES: [(ProviderFamily, &str, &str); 7] = [
         ProviderFamily::DeepSeek,
         "DeepSeek",
         "Use DeepSeek with an API key and model list from api.deepseek.com.",
+    ),
+    (
+        ProviderFamily::Kimi,
+        "Kimi",
+        "Use Moonshot Kimi with an API key from api.moonshot.cn.",
     ),
     (
         ProviderFamily::OpenAiCompatible,
@@ -659,6 +669,7 @@ pub struct TuiApp {
     pub openai_setup_keep_empty_api_key: bool,
     pub codex_model_options: Vec<CodexModelOption>,
     pub deepseek_model_options: Vec<String>,
+    pub kimi_model_options: Vec<String>,
     pub recent_commands: Vec<String>,
     pub recent_threads: Vec<ThreadSummary>,
     pub resume_picker_idx: usize,


### PR DESCRIPTION
## What changed

Adds Moonshot Kimi (`kimi-k2.6`, `kimi-k2-*`) as a first-class provider in RARA, with its own `ProviderFamily::Kimi` variant, model-list fetching, and full TUI integration.

## Why

Kimi is an OpenAI-compatible provider that deserves dedicated provider-family treatment (like DeepSeek) rather than being hidden inside the generic OpenAI-compatible umbrella. This gives Kimi its own sidebar badge, `/connect` flow, model picker, and model-list caching.

## Key changes

| File | Change |
|------|--------|
| `crates/provider-catalog/src/kimi.rs` | New: Kimi model catalog (MODEL_WINDOWS, `load_models`, `parse_models`) |
| `crates/provider-catalog/src/lib.rs` | Add `Kimi` variant to `ModelCatalogProvider`, wire fallback/load |
| `src/tui/state/types.rs` | Add `ProviderFamily::Kimi`, `TaskKind::KimiModels`, `TaskCompletion::KimiModels`, `kimi_model_options` field |
| `src/tui/state/mod.rs` | All `TuiApp` Kimi branches (connection status, model presets, picker, model selection, `set_kimi_model_options`, API key action) |
| `src/tui/state/state_presets.rs` | Route `"kimi"` config to `ProviderFamily::Kimi`, update indices, add routing test |
| `src/tui/runtime/tasks.rs` | `start_kimi_model_list_task` + `handle_kimi_models_result` |
| `src/tui/runtime.rs` | Public wrapper `start_kimi_model_list_task` |
| `src/tui/event_dispatch.rs` | Kimi model selection handler, API key save flow |
| `src/tui/provider_flow.rs` | `/connect` Kimi → ApiKeyEditor |
| `src/tui/command/status.rs` | Shortcut match adds `ProviderFamily::Kimi` |
| `src/tui/render/snapshots/*.snap` | Updated provider-picker and model-picker snapshots |

## Verification

- `cargo check -p rara` — passes (pre-existing warnings only)
- `cargo test -p rara -- tui` — **477 passed; 0 failed**
- New `routes_kimi_provider_to_dedicated_family` test verifies Kimi routing
