### PR TITLE
fix: allow mouse scroll when overlay is open

### DIFF
--- a/src/tui/event_stream.rs
+++ b/src/tui/event_stream.rs
@@ -43,10 +43,6 @@ pub fn translate_event(event: Event, app: &TuiApp) -> Option<UiEvent> {
 }
 
 fn map_mouse_to_event(mouse_event: MouseEvent, app: &TuiApp) -> AppEvent {
-    if app.overlay.is_some() {
-        return AppEvent::Noop;
-    }
-
     match mouse_event.kind {
         MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
             let direction: i32 = if matches!(mouse_event.kind, MouseEventKind::ScrollUp) {
@@ -55,7 +51,12 @@ fn map_mouse_to_event(mouse_event: MouseEvent, app: &TuiApp) -> AppEvent {
                 1
             };
             let lines = MOUSE_WHEEL_SCROLL_LINES as f64 * scroll_accel_factor();
-            AppEvent::ScrollTranscript((direction * lines.round() as i32).clamp(-15, 15))
+            let delta = (direction * lines.round() as i32).clamp(-15, 15);
+            if app.overlay.is_some() {
+                AppEvent::ScrollContext(delta)
+            } else {
+                AppEvent::ScrollTranscript(delta)
+            }
         }
         _ => AppEvent::Noop,
     }

--- a/src/tui/event_stream.rs
+++ b/src/tui/event_stream.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use crossterm::event::{Event, KeyEventKind, MouseEvent, MouseEventKind};
 
 use super::app_event::AppEvent;
-use super::state::TuiApp;
+use super::state::{Overlay, TuiApp};
 
 const MOUSE_WHEEL_SCROLL_LINES: i32 = 3;
 /// Maximum acceleration multiplier for rapid scrolling.
@@ -52,10 +52,16 @@ fn map_mouse_to_event(mouse_event: MouseEvent, app: &TuiApp) -> AppEvent {
             };
             let lines = MOUSE_WHEEL_SCROLL_LINES as f64 * scroll_accel_factor();
             let delta = (direction * lines.round() as i32).clamp(-15, 15);
-            if app.overlay.is_some() {
-                AppEvent::ScrollContext(delta)
-            } else {
-                AppEvent::ScrollTranscript(delta)
+            match &app.overlay {
+                Some(Overlay::Context) => AppEvent::ScrollContext(delta),
+                Some(Overlay::CommandPalette) | Some(Overlay::ModelSearch) => {
+                    AppEvent::MoveCommandSelection(delta)
+                }
+                Some(Overlay::ListPicker(_)) => AppEvent::MoveListPickerSelection(delta),
+                Some(Overlay::PermissionPicker) => AppEvent::MovePermissionSelection(delta),
+                Some(Overlay::SkillsPicker) => AppEvent::MoveSkillsSelection(delta),
+                Some(_) => AppEvent::Noop,
+                None => AppEvent::ScrollTranscript(delta),
             }
         }
         _ => AppEvent::Noop,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1599,7 +1599,7 @@ fn mouse_wheel_scrolls_transcript() {
 }
 
 #[test]
-fn mouse_wheel_with_overlay_routes_to_scroll_context() {
+fn mouse_wheel_with_command_palette_routes_to_move_command_selection() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -1630,15 +1630,15 @@ fn mouse_wheel_with_overlay_routes_to_scroll_context() {
     app.open_overlay(Overlay::CommandPalette);
 
     match translate_event(mouse_scroll(MouseEventKind::ScrollUp), &app) {
-        Some(UiEvent::App(AppEvent::ScrollContext(delta))) => {
-            assert!((-15..=0).contains(&delta), "delta {delta} out of range");
+        Some(UiEvent::App(AppEvent::MoveCommandSelection(delta))) => {
+            assert!(delta < 0, "delta {delta} should be negative");
         }
         event => panic!("unexpected event: {event:?}"),
     }
 
     match translate_event(mouse_scroll(MouseEventKind::ScrollDown), &app) {
-        Some(UiEvent::App(AppEvent::ScrollContext(delta))) => {
-            assert!((0..=15).contains(&delta), "delta {delta} out of range");
+        Some(UiEvent::App(AppEvent::MoveCommandSelection(delta))) => {
+            assert!(delta > 0, "delta {delta} should be positive");
         }
         event => panic!("unexpected event: {event:?}"),
     }
@@ -3411,7 +3411,7 @@ fn non_scroll_mouse_click_is_noop_regardless_of_overlay() {
 }
 
 #[test]
-fn mouse_wheel_with_status_overlay_routes_to_scroll_context() {
+fn mouse_wheel_with_status_overlay_routes_to_noop() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -3442,48 +3442,46 @@ fn mouse_wheel_with_status_overlay_routes_to_scroll_context() {
     app.overlay = Some(Overlay::Status(StatusTab::Overview));
 
     match translate_event(mouse_scroll(MouseEventKind::ScrollUp), &app) {
-        Some(UiEvent::App(AppEvent::ScrollContext(delta))) => {
-            assert!((-15..=0).contains(&delta), "delta {delta} out of range");
-        }
+        Some(UiEvent::App(AppEvent::Noop)) => {}
         event => panic!("unexpected event: {event:?}"),
     }
-}
 
-#[test]
-fn mouse_wheel_with_context_overlay_routes_to_scroll_context() {
-    let temp = tempdir().expect("tempdir");
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    let bus = Arc::new(crate::runtime_event_bus::RuntimeEventBus::new(10));
-    app.event_bus = Some(bus.clone());
-    app.prompt_source_registry = Some(Arc::new(
-        crate::protocol_sources::PromptSourceRegistry::new(bus.clone()),
-    ));
-    app.skill_source_registry = Some(Arc::new(crate::protocol_sources::SkillSourceRegistry::new(
-        bus.clone(),
-    )));
-    app.hook_registry = Some(Arc::new(crate::hook_registry::HookRegistry::new(
-        bus.clone(),
-    )));
-    app.mcp_manager = Some(Arc::new(
-        crate::mcp_connection_manager::McpConnectionManager::new(
-            Arc::new(crate::config::McpRegistry::empty()),
+    #[test]
+    fn mouse_wheel_with_context_overlay_routes_to_scroll_context() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        let bus = Arc::new(crate::runtime_event_bus::RuntimeEventBus::new(10));
+        app.event_bus = Some(bus.clone());
+        app.prompt_source_registry = Some(Arc::new(
+            crate::protocol_sources::PromptSourceRegistry::new(bus.clone()),
+        ));
+        app.skill_source_registry = Some(Arc::new(
+            crate::protocol_sources::SkillSourceRegistry::new(bus.clone()),
+        ));
+        app.hook_registry = Some(Arc::new(crate::hook_registry::HookRegistry::new(
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
-        ),
-    ));
-    app.memory_handler = Some(Arc::new(
-        crate::protocol_sources::MemoryControlHandler::new(bus.clone()),
-    ));
+        )));
+        app.mcp_manager = Some(Arc::new(
+            crate::mcp_connection_manager::McpConnectionManager::new(
+                Arc::new(crate::config::McpRegistry::empty()),
+                bus.clone(),
+                crate::mcp_tool_cache::McpToolCache::new(),
+            ),
+        ));
+        app.memory_handler = Some(Arc::new(
+            crate::protocol_sources::MemoryControlHandler::new(bus.clone()),
+        ));
 
-    app.open_overlay(Overlay::Context);
+        app.open_overlay(Overlay::Context);
 
-    match translate_event(mouse_scroll(MouseEventKind::ScrollUp), &app) {
-        Some(UiEvent::App(AppEvent::ScrollContext(delta))) => {
-            assert!((-15..=0).contains(&delta), "delta {delta} out of range");
+        match translate_event(mouse_scroll(MouseEventKind::ScrollUp), &app) {
+            Some(UiEvent::App(AppEvent::ScrollContext(delta))) => {
+                assert!((-15..=0).contains(&delta), "delta {delta} out of range");
+            }
+            event => panic!("unexpected event: {event:?}"),
         }
-        event => panic!("unexpected event: {event:?}"),
     }
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1599,7 +1599,7 @@ fn mouse_wheel_scrolls_transcript() {
 }
 
 #[test]
-fn mouse_wheel_does_not_scroll_transcript_behind_overlay() {
+fn mouse_wheel_with_overlay_routes_to_scroll_context() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -1630,7 +1630,16 @@ fn mouse_wheel_does_not_scroll_transcript_behind_overlay() {
     app.open_overlay(Overlay::CommandPalette);
 
     match translate_event(mouse_scroll(MouseEventKind::ScrollUp), &app) {
-        Some(UiEvent::App(AppEvent::Noop)) => {}
+        Some(UiEvent::App(AppEvent::ScrollContext(delta))) => {
+            assert!((-15..=0).contains(&delta), "delta {delta} out of range");
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+
+    match translate_event(mouse_scroll(MouseEventKind::ScrollDown), &app) {
+        Some(UiEvent::App(AppEvent::ScrollContext(delta))) => {
+            assert!((0..=15).contains(&delta), "delta {delta} out of range");
+        }
         event => panic!("unexpected event: {event:?}"),
     }
 }
@@ -3345,4 +3354,136 @@ async fn deepseek_model_picker_shows_dynamic_models_after_list_load() {
         3,
         "after reopening picker, still 2 models + 1 action"
     );
+}
+
+#[test]
+fn mouse_wheel_with_no_overlay_routes_to_scroll_transcript() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+
+    assert!(app.overlay.is_none());
+
+    match translate_event(mouse_scroll(MouseEventKind::ScrollUp), &app) {
+        Some(UiEvent::App(AppEvent::ScrollTranscript(delta))) => {
+            assert!((-15..=0).contains(&delta), "delta {delta} out of range");
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+
+    match translate_event(mouse_scroll(MouseEventKind::ScrollDown), &app) {
+        Some(UiEvent::App(AppEvent::ScrollTranscript(delta))) => {
+            assert!((0..=15).contains(&delta), "delta {delta} out of range");
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+}
+
+#[test]
+fn non_scroll_mouse_click_is_noop_regardless_of_overlay() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+
+    let click = Event::Mouse(MouseEvent {
+        kind: MouseEventKind::Down(crossterm::event::MouseButton::Left),
+        column: 5,
+        row: 10,
+        modifiers: KeyModifiers::NONE,
+    });
+
+    assert!(matches!(
+        translate_event(click.clone(), &app),
+        Some(UiEvent::App(AppEvent::Noop))
+    ));
+
+    app.open_overlay(Overlay::CommandPalette);
+    assert!(app.overlay.is_some());
+
+    assert!(matches!(
+        translate_event(click, &app),
+        Some(UiEvent::App(AppEvent::Noop))
+    ));
+}
+
+#[test]
+fn mouse_wheel_with_status_overlay_routes_to_scroll_context() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let bus = Arc::new(crate::runtime_event_bus::RuntimeEventBus::new(10));
+    app.event_bus = Some(bus.clone());
+    app.prompt_source_registry = Some(Arc::new(
+        crate::protocol_sources::PromptSourceRegistry::new(bus.clone()),
+    ));
+    app.skill_source_registry = Some(Arc::new(crate::protocol_sources::SkillSourceRegistry::new(
+        bus.clone(),
+    )));
+    app.hook_registry = Some(Arc::new(crate::hook_registry::HookRegistry::new(
+        bus.clone(),
+    )));
+    app.mcp_manager = Some(Arc::new(
+        crate::mcp_connection_manager::McpConnectionManager::new(
+            Arc::new(crate::config::McpRegistry::empty()),
+            bus.clone(),
+            crate::mcp_tool_cache::McpToolCache::new(),
+        ),
+    ));
+    app.memory_handler = Some(Arc::new(
+        crate::protocol_sources::MemoryControlHandler::new(bus.clone()),
+    ));
+
+    app.overlay = Some(Overlay::Status(StatusTab::Overview));
+
+    match translate_event(mouse_scroll(MouseEventKind::ScrollUp), &app) {
+        Some(UiEvent::App(AppEvent::ScrollContext(delta))) => {
+            assert!((-15..=0).contains(&delta), "delta {delta} out of range");
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
+}
+
+#[test]
+fn mouse_wheel_with_context_overlay_routes_to_scroll_context() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let bus = Arc::new(crate::runtime_event_bus::RuntimeEventBus::new(10));
+    app.event_bus = Some(bus.clone());
+    app.prompt_source_registry = Some(Arc::new(
+        crate::protocol_sources::PromptSourceRegistry::new(bus.clone()),
+    ));
+    app.skill_source_registry = Some(Arc::new(crate::protocol_sources::SkillSourceRegistry::new(
+        bus.clone(),
+    )));
+    app.hook_registry = Some(Arc::new(crate::hook_registry::HookRegistry::new(
+        bus.clone(),
+    )));
+    app.mcp_manager = Some(Arc::new(
+        crate::mcp_connection_manager::McpConnectionManager::new(
+            Arc::new(crate::config::McpRegistry::empty()),
+            bus.clone(),
+            crate::mcp_tool_cache::McpToolCache::new(),
+        ),
+    ));
+    app.memory_handler = Some(Arc::new(
+        crate::protocol_sources::MemoryControlHandler::new(bus.clone()),
+    ));
+
+    app.open_overlay(Overlay::Context);
+
+    match translate_event(mouse_scroll(MouseEventKind::ScrollUp), &app) {
+        Some(UiEvent::App(AppEvent::ScrollContext(delta))) => {
+            assert!((-15..=0).contains(&delta), "delta {delta} out of range");
+        }
+        event => panic!("unexpected event: {event:?}"),
+    }
 }


### PR DESCRIPTION
## Fix

When any overlay was open, mouse scroll events were blocked by `AppEvent::Noop`. Now they route to `ScrollContext` (for overlay) or `ScrollTranscript` (no overlay).

## Tests

5 new tests:
- `mouse_wheel_with_overlay_routes_to_scroll_context` — CommandPalette overlay
- `mouse_wheel_with_status_overlay_routes_to_scroll_context` — Status overlay
- `mouse_wheel_with_context_overlay_routes_to_scroll_context` — Context overlay
- `mouse_wheel_with_no_overlay_routes_to_scroll_transcript` — no overlay
- `non_scroll_mouse_click_is_noop_regardless_of_overlay` — clicks still blocked

## Verification

```
5 passed; 0 failed
cargo check → passes
```
