### PR TITLE
fix: remove double saturating_sub(1) in viewport visible_rows

### DIFF
--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -629,7 +629,7 @@ fn transcript_viewport_visible_window_slices_to_visible_rows() {
         80,
     );
 
-    // height=3 reserves 1 bottom row, giving 2 visible content rows.
+    // height=3 gives 3 visible content rows.
     let (lines, inner_scroll) = viewport.visible_window(80, 3);
     let rendered = lines
         .into_iter()
@@ -637,7 +637,7 @@ fn transcript_viewport_visible_window_slices_to_visible_rows() {
         .collect::<Vec<_>>();
 
     assert_eq!(inner_scroll, 0);
-    assert_eq!(rendered, vec!["• Second", "  Third"]);
+    assert_eq!(rendered, vec!["• Second", "  Third", "  Fourth"]);
 }
 
 #[test]

--- a/src/tui/render/viewport.rs
+++ b/src/tui/render/viewport.rs
@@ -90,7 +90,7 @@ impl TranscriptViewport {
 
         // Reserve one bottom row as breathing room so content isn't
         // visually flush against the input bar at any scroll position.
-        let visible_rows = usize::from(height.saturating_sub(1).max(1));
+        let visible_rows = usize::from(height.max(1));
         let target_start = usize::from(self.scroll_offset);
         let target_end = target_start.saturating_add(visible_rows);
 

--- a/src/tui/render/viewport.rs
+++ b/src/tui/render/viewport.rs
@@ -88,9 +88,9 @@ impl TranscriptViewport {
             return (Vec::new(), 0);
         }
 
-        // Reserve one bottom row as breathing room so content isn't
-        // visually flush against the input bar at any scroll position.
-        let visible_rows = usize::from(height.max(1));
+        // Breathing room is handled by the caller (transcript_viewport)
+        // when computing scroll_offset.
+        let visible_rows = usize::from(height);
         let target_start = usize::from(self.scroll_offset);
         let target_end = target_start.saturating_add(visible_rows);
 


### PR DESCRIPTION
## Fix

`visible_window` was subtracting 1 from `height` after `transcript_viewport` had already subtracted 1 from `viewport_height`. Net: rendered `viewport_height - 2` rows instead of `viewport_height - 1`.

When a soft-wrapped line pushed `inner_scroll > 0` (partial line offset), the available visible rows were too few to fill the viewport, leaving black gaps at the bottom. Manually scrolling up forced a recomputation that fixed it.

## Test

Updated `transcript_viewport_visible_window_slices_to_visible_rows` to expect 3 rows (matching `height=3`).