### PR TITLE
feat: time-based trigger for more aggressive tool result projection (Claude Code style)

### DIFF
--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::*;
 use crate::context::{
     AssembledContext, AssembledTurnContext, ContextAssembler, RuntimeContextInputs,
@@ -80,12 +82,20 @@ impl Agent {
         let mut policy = ToolResultProjectionPolicy::default()
             .for_provider_cache_edit(self.llm_backend.cache_profile().cache_edit);
 
-        // Time-based trigger (Claude Code style):
-        // If the session has been idle for a while, the provider cache is likely cold.
-        // We can disable cache-edit eligibility to allow more aggressive microcompaction
-        // since we'll pay the cache-miss penalty anyway.
+        // Time-based trigger (Claude Code microcompact style):
+        // When the gap since the last interaction exceeds 60 minutes, the
+        // provider prompt cache has expired (typical TTL is ~1 hour).
+        // We tighten keep_recent to send a smaller payload — we're paying
+        // the cache-miss cost anyway, so there's no benefit to preserving
+        // old tool results for cache stability.
         let idle_duration = self.last_interaction_time.elapsed();
-        if idle_duration > std::time::Duration::from_secs(300) {
+        const CACHE_TTL_IDLE_THRESHOLD: Duration = Duration::from_secs(3600);
+        const CACHE_EDIT_IDLE_THRESHOLD: Duration = Duration::from_secs(300);
+
+        if idle_duration > CACHE_TTL_IDLE_THRESHOLD {
+            policy.keep_recent = 2;
+            policy.cache_edit_eligible = false;
+        } else if idle_duration > CACHE_EDIT_IDLE_THRESHOLD {
             policy.cache_edit_eligible = false;
         }
 


### PR DESCRIPTION
## Summary

Adds time-based microcompact trigger, matching Claude Code's
`maybeTimeBasedMicrocompact` behavior.

When the gap since the last user interaction exceeds **60 minutes**,
the provider prompt cache has expired (~1h TTL). We tighten
`keep_recent` from 6 → 2 to send a smaller payload —
since we'll pay the cache-miss cost anyway, there's no benefit
to keeping old tool results.

### Two-tier logic

| Idle time | Action |
|---|---|
| `> 60 min` | `keep_recent = 2` (clear aggressively) |
| `> 5 min` | `cache_edit_eligible = false` (existing) |

### Reference

Claude Code `src/services/compact/microCompact.ts`:
- `evaluateTimeBasedTrigger()` detects gap > threshold
- When triggered, clears `compactableIds` except last N
- Same motivation: "cache TTL is ~1h, so we can clear more aggressively"

### Diff
1 file, +9 −5 lines in `src/agent/prompting.rs`

### Verification
`cargo test` — **1012 passed, 0 failed**