### PR TITLE
chore: update development plan

### DIFF
--- a/.agents/skills/add_tests/SKILL.md
+++ b/.agents/skills/add_tests/SKILL.md
@@ -38,6 +38,47 @@ For a non-trivial change, choose the narrowest useful test surface:
    - Use `tempdir()` and isolate filesystem state.
    - Never rely on the current working directory or developer-local paths.
 
+## Non-Negotiable Expectations
+
+### Bugfixes Need Regression Coverage
+
+Behavior fixes should normally include a focused automated test that reproduces
+the fixed behavior or locks the regression boundary.
+
+Manual verification alone is acceptable only when an automated test is not
+practical, such as terminal-only behavior that cannot be isolated without
+fragile infrastructure. In that case, record the reason in the PR or final
+summary.
+
+### Prefer The Narrowest Meaningful Surface
+
+Do not default to the whole suite when one focused module proves the change.
+
+Examples:
+
+- TUI state transition:
+  - `cargo test tui::state::<test_name> -- --nocapture`
+- TUI render contract:
+  - focused `src/tui/render/*` test or snapshot
+- provider request construction:
+  - focused `llm::tests::<test_name>`
+- agent-loop behavior:
+  - focused `agent::tests::<test_name>`
+- crate boundary or broad Rust type impact:
+  - focused test plus `cargo check`
+
+### Classify CI Failures
+
+When a PR goes red, classify the failure before changing tests:
+
+- implementation bug
+- test bug
+- workflow/config bug
+- unrelated flaky infrastructure
+
+Do not weaken a test to hide an implementation regression. If the test is
+wrong, fix the fixture or assertion while preserving the regression intent.
+
 ## Repository-Specific Guidance
 
 ### Assertion Style
@@ -140,6 +181,9 @@ cargo check
 ```
 
 If a change only affects one rendering contract, prefer one focused test target plus `cargo check`.
+
+For documentation-only or skill-only changes, Rust tests are usually not
+needed; run `git diff --check` and inspect the rendered markdown shape instead.
 
 ## Heuristics For Choosing Assertions
 

--- a/.agents/skills/project-github-titles/SKILL.md
+++ b/.agents/skills/project-github-titles/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: project-github-titles
+description: Use when preparing commit messages, pull request titles, or first-line summaries for the RARA repository. Enforces the repo's short conventional title subset using feat, fix, chore, or test.
+---
+
+# Project GitHub Titles
+
+Use this skill when writing commit titles, pull request titles, or the first
+summary line in PR/commentary text for this repository.
+
+## Title Format
+
+Use one of:
+
+- `type: subject`
+- `type(scope): subject`
+
+Never prefix titles with `[codex]`.
+
+Keep title text in English, concise, and specific. Do not end the subject with a
+period.
+
+## Allowed Types
+
+RARA intentionally uses a small subset:
+
+- `feat`: user-visible feature or capability
+- `fix`: bug fix or behavior correction
+- `chore`: maintenance, dependency, tooling, docs, or non-user-facing cleanup
+- `test`: test-only changes
+
+Do not use unlisted types such as `docs`, `refactor`, or `style`. Map those to
+the closest allowed type, usually `chore` for docs or maintenance.
+
+Do not use `!` breaking-change markers in titles. Describe compatibility impact
+in the PR body instead.
+
+## Scope Rules
+
+Use a scope only when it clarifies the primary touched area. Keep it short and
+lower-case.
+
+Useful scopes in this repository include:
+
+- `agent`
+- `tui`
+- `tools`
+- `memory`
+- `context`
+- `provider`
+- `plugins`
+- `skills`
+- `acp`
+- `wire`
+- `ci`
+
+Prefer stable product or domain scopes over file names.
+
+## Subject Rules
+
+- Describe the main effect, not the mechanics.
+- Prefer imperative or result-oriented phrasing.
+- Avoid vague subjects such as `update stuff` or `misc cleanup`.
+- Use lower-case unless a proper noun or code identifier requires otherwise.
+
+Good examples:
+
+- `fix(tui): keep approval overlay above transcript`
+- `feat(memory): add local embedding prototype`
+- `chore(skills): add RARA journal writing skill`
+- `test(agent): cover duplicate tool call warning`
+
+## PR Body
+
+PR descriptions should use markdown and include:
+
+- summary of changes
+- purpose or motivation
+- related issue, if any
+- testing or validation
+
+For documentation-only changes, `Testing: Not run; documentation-only change.`
+is acceptable.

--- a/.agents/skills/rara-docs-journal/SKILL.md
+++ b/.agents/skills/rara-docs-journal/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: rara-docs-journal
+description: Use when creating, updating, or reviewing RARA implementation journals under docs/journal/. Applies to dated rollout notes, implementation checkpoints, validation evidence, and deciding what belongs in a journal versus a feature spec or docs/todo.md.
+---
+
+# RARA Journal Writing
+
+Use this skill when writing or reviewing `docs/journal/YYYY-MM-DD-topic.md`
+files in this repository.
+
+## Goal
+
+Keep journals as concise implementation records:
+
+- what changed
+- why it changed
+- what was validated
+- what remains open
+
+Journals are not canonical specs and should not become scratch-note dumps.
+
+## Surface Rules
+
+- Journal files live under `docs/journal/`.
+- Filenames use `YYYY-MM-DD-topic.md`.
+- Use one topic per file; append to an existing journal when the follow-up is
+  part of the same rollout.
+- Stable contracts belong in `docs/features/`.
+- Open follow-up work belongs in `docs/todo.md`.
+
+## Structure
+
+A normal journal should use these sections when they fit:
+
+- `Summary`
+- `Background`
+- `Scope`
+- `Key Decisions`
+- `Validation`
+- `Follow-Ups`
+
+For small checkpoints, shorter headings are fine if the entry still records the
+post-change truth and the remaining work.
+
+## Writing Rules
+
+### Record Post-Change Truth
+
+Do not leave pre-fix wording in place after the same PR already changed the
+code or docs. If a step landed, mark it as done or remove it from remaining
+work.
+
+### Keep TODO And Journal Aligned
+
+If `docs/todo.md` references a journal decision, both files must agree on:
+
+- scope
+- priority
+- whether the item is done or still open
+- any effort or rollout estimate
+
+### Make Validation Concrete
+
+List commands or checks that support the entry.
+
+Good examples:
+
+```bash
+cargo test tui::render::tests::bottom_pane_grows_for_multiline_input -- --nocapture
+cargo check
+gh pr checks 395 | cat
+```
+
+Avoid vague validation such as `tested locally` or `CI should pass`.
+
+### Keep Follow-Ups Narrow
+
+Follow-ups should describe remaining work only. If a broad item was partly
+completed, rewrite the follow-up as the unresolved tail instead of repeating the
+old broad task.
+
+## Before Finishing
+
+Check:
+
+- filename date matches the implementation date
+- stable contract changes also updated `docs/features/`
+- open work is visible in `docs/todo.md`
+- validation commands are explicit
+- wording matches the actual post-change state

--- a/.agents/skills/rara-docs-spec/SKILL.md
+++ b/.agents/skills/rara-docs-spec/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: rara-docs-spec
+description: Use when creating, revising, or reviewing RARA canonical feature specs under docs/features/. Applies to stable runtime, TUI, protocol, memory, provider, skill, plugin, and tool contracts, including scope boundaries and validation matrices.
+---
+
+# RARA Feature Spec Writing
+
+Use this skill when writing or reviewing `docs/features/*.md` files in this
+repository.
+
+## Goal
+
+Keep feature specs as the stable source of truth for:
+
+- product and engineering scope
+- runtime, TUI, protocol, or tool contracts
+- architecture boundaries
+- validation expectations
+- known operational risks
+
+Feature specs are not date-stamped rollout notes and should not read like a
+PR-by-PR changelog.
+
+## Surface Rules
+
+- Canonical specs live under `docs/features/`.
+- Filenames are topic-oriented kebab-case.
+- Do not use date prefixes in `docs/features/`.
+- Chronological implementation notes belong in `docs/journal/`.
+- Open rollout tails belong in `docs/todo.md`.
+
+## Structure
+
+Prefer these sections for active specs:
+
+- `Problem`
+- `Scope`
+- `Non-Goals`
+- `Architecture`
+- `Contracts`
+- `Validation Matrix`
+- `Operational Notes`
+- `Open Risks`
+- `Source Journals`
+
+If a section is intentionally short, keep it short, but do not silently drop
+scope, non-goals, contracts, or validation.
+
+## Writing Rules
+
+### Capture Stable Contracts
+
+A spec should answer what behavior is intended, what boundary is canonical, and
+what downstream consumers can rely on.
+
+Avoid:
+
+- temporary debugging notes
+- CI chatter
+- file-by-file implementation inventory with no contract value
+- broad brainstorming that has not been accepted as a target
+
+### Keep Scope Explicit
+
+Do not let a spec silently expand into adjacent surfaces. If a capability is
+deferred, put it in `Non-Goals` or `Open Risks` instead of implying it is
+already part of the contract.
+
+### Distinguish Canonical And Compatibility Paths
+
+When a transition exists, identify the canonical path and the compatibility
+path separately. Do not describe both as equally primary unless they truly are.
+
+### Make Validation Product-Aware
+
+The validation matrix should name focused checks that prove the contract:
+
+- Rust unit or integration tests
+- TUI render or snapshot tests
+- protocol/control-plane tests
+- typecheck, lint, or build gates
+- browser or MCP verification when the user-visible surface requires it
+
+## Compaction Guidance
+
+When multiple journals describe the same area:
+
+1. Move durable conclusions into the feature spec.
+2. Leave rollout evidence and CI notes in journals.
+3. Point `docs/todo.md` follow-ups at the canonical spec.
+4. Remove or rewrite stale spec text that contradicts the current design.
+
+## Before Finishing
+
+Check:
+
+- filename is topic-oriented, not date-oriented
+- scope and non-goals are explicit
+- contracts describe the post-change canonical behavior
+- validation matrix is concrete
+- source journals link implementation evidence
+- remaining work is not buried only in prose

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ It is the baseline index for future implementation and evolution.
 - [4. Current Key Decisions](#4-current-key-decisions)
 - [5. Documentation Rules](#5-documentation-rules)
 - [6. Near-Term Focus](#6-near-term-focus)
-- [7. Commit Rules](#7-commit-rules)
+- [7. Repository Skills](#7-repository-skills)
+- [8. Commit Rules](#8-commit-rules)
 
 ### Docs
 - [docs/features/](docs/features/README.md) — engineering specs and contracts (28 files)
@@ -123,7 +124,23 @@ The current product direction is to make local inference a first-class path inst
 - Stronger local-model prompt formatting and stop-sequence handling.
 - A real embedding backend for local memory retrieval quality.
 
-## 7. Commit Rules
+## 7. Repository Skills
+
+Repo-local skills live under `.agents/skills/`. Use them as focused workflow
+guides instead of expanding this charter with long procedural detail:
+
+- `add_tests`: choose and write focused RARA test coverage.
+- `context-cache-management`: update context compression, memory placement, or
+  provider cache behavior while preserving stable prompt prefixes.
+- `support-acp`: integrate or debug ACP clients and control-plane behavior.
+- `rara-docs-journal`: write or review dated implementation journals under
+  `docs/journal/`.
+- `rara-docs-spec`: write or review canonical feature specs under
+  `docs/features/`.
+- `project-github-titles`: write RARA commit and PR titles using the allowed
+  project title format.
+
+## 8. Commit Rules
 
 - Always run `cargo fmt` before every commit to ensure consistent formatting.
 - Use short project-specific conventional commit titles. This is an intentional

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -253,6 +253,30 @@ Matchers are parsed but not evaluated in the first slice (matching is deferred).
 | `discover_plugins` skips non-directories | unit test |
 | `discover_plugins` de-dupes by name | unit test |
 
+## Implementation Status
+
+Implemented in the first merged slice:
+
+- `crates/rara-plugins` exists with loader, executor, and shared types.
+- `.claude-plugin/plugin.json` and `hooks/hooks.json` are parsed.
+- Command hooks can be executed with stdin JSON, timeout handling, exit-code
+  reporting, and stdout parsing.
+- A middleware bridge exists in `src/plugin_middleware.rs`, but it is not yet
+  part of the runtime startup path.
+- The current discovery API scans one plugin directory at a time; the target
+  user/project/CLI precedence and dedupe contract remains to be implemented.
+
+Next implementation slices:
+
+1. Register discovered plugin hooks during runtime bootstrap and make the path
+   work for TUI, CLI, ACP, and Wire surfaces.
+2. Fix lifecycle parity gaps before user-facing rollout: `SessionEnd` mapping,
+   matcher evaluation, blocking hook results, and hook output observability.
+3. Add `rara plugin install/list/remove` with explicit trust copy and git/local
+   source handling.
+4. Feed plugin `.mcp.json`, commands, skills, and agents into the same
+   structured extension-source registries used by native RARA features.
+
 ## Open Risks
 
 - Hook scripts may `require` Node modules that aren't installed in the user's
@@ -267,4 +291,5 @@ Matchers are parsed but not evaluated in the first slice (matching is deferred).
 
 ## Source Journals
 
-- `docs/journal/2026-05-12-claude-plugin-runtime.md` (to be written)
+- `docs/journal/2026-05-12-claude-plugin-runtime.md`
+- `docs/journal/2026-05-12-main-sync-development-plan.md`

--- a/docs/features/provider-connection-redesign.md
+++ b/docs/features/provider-connection-redesign.md
@@ -82,6 +82,14 @@ Model list: each row shows model name + context window size.
 - [ ] **Remaining**: show context window sizes from `MODEL_WINDOWS` map in ModelSearch items
 - [ ] **Remaining**: model list from API (`/v1/models`) for connected providers, fallback to `MODEL_WINDOWS`
 
+### Phase 4 — Model Catalog And API-List Polish (P1)
+- [x] Add Kimi as a first-class provider with catalog-backed model windows.
+- [x] Add DeepSeek v4 model-window metadata to the provider catalog.
+- [ ] Generalize ModelSearch display so every provider with catalog metadata
+      shows context windows consistently.
+- [ ] Add provider API model-list loading for connected API-key providers, with
+      catalog metadata as fallback and enrichment.
+
 ## Future
 - Custom provider support (arbitrary API endpoint + API key)
 - Model list caching with manual `/refresh`

--- a/docs/journal/2026-05-12-main-sync-development-plan.md
+++ b/docs/journal/2026-05-12-main-sync-development-plan.md
@@ -36,11 +36,11 @@ another independent feature line:
    durable local embedding backend.
 6. Audit Codex and Claude Code system prompts and migrate only the parts that
    fit RARA's stable prompt-runtime contract.
-7. Port reusable AgentHub `.agents/skills` patterns into RARA skills. The
-   reusable pieces are docs journal/spec writing, focused testing guidance, and
-   project title conventions. AgentHub ACP rendering and backend agent debug
-   skills should stay source material only unless RARA grows equivalent
-   domain-specific ACP/TUI/debug workflows.
+7. Port reusable AgentHub `.agents/skills` patterns into RARA skills. This
+   landed as `rara-docs-journal`, `rara-docs-spec`, `project-github-titles`,
+   and an `add_tests` update for focused testing guidance. AgentHub ACP
+   rendering and backend agent debug skills should stay source material only
+   unless RARA grows equivalent domain-specific ACP/TUI/debug workflows.
 8. Keep web/source-reporting, auxiliary-model routing, cross-process sub-agent
    reattach, Terminal-Bench readiness, and release packaging as follow-up lanes.
 

--- a/docs/journal/2026-05-12-main-sync-development-plan.md
+++ b/docs/journal/2026-05-12-main-sync-development-plan.md
@@ -36,7 +36,12 @@ another independent feature line:
    durable local embedding backend.
 6. Audit Codex and Claude Code system prompts and migrate only the parts that
    fit RARA's stable prompt-runtime contract.
-7. Keep web/source-reporting, auxiliary-model routing, cross-process sub-agent
+7. Port reusable AgentHub `.agents/skills` patterns into RARA skills. The
+   reusable pieces are docs journal/spec writing, focused testing guidance, and
+   project title conventions. AgentHub ACP rendering and backend agent debug
+   skills should stay source material only unless RARA grows equivalent
+   domain-specific ACP/TUI/debug workflows.
+8. Keep web/source-reporting, auxiliary-model routing, cross-process sub-agent
    reattach, Terminal-Bench readiness, and release packaging as follow-up lanes.
 
 ## Trade-offs

--- a/docs/journal/2026-05-12-main-sync-development-plan.md
+++ b/docs/journal/2026-05-12-main-sync-development-plan.md
@@ -1,0 +1,52 @@
+# 2026-05-12 Main Sync Development Plan
+
+## What Changed On Main
+
+Synchronized `main` from `5a6f6ae` to `608986f`. The recent changes move RARA
+forward in several areas:
+
+- Claude Code plugin compatibility: new `rara-plugins` crate, command-hook
+  parsing/execution, and an initial middleware bridge.
+- Memory and prompt sources: auto-memory extraction and directory-walking
+  `.rara/rules/*.md` prompt sources.
+- Provider/model surface: Kimi catalog support, DeepSeek model-window metadata,
+  provider labels, and connection-flow cleanup.
+- TUI: bottom-pane state extraction, paste-burst handling, overlay scrolling,
+  collapsible thinking display, and status formatting.
+- Agent reliability: sub-agent limits/progress/timeout behavior, duplicate
+  tool-call detection, and anti-spin prompt guidance.
+
+## Plan Update
+
+The next development plan should prioritize integration gaps over starting
+another independent feature line:
+
+1. Finish plugin runtime integration before expanding plugin feature scope.
+   The crate exists, but runtime startup, blocking semantics, matcher
+   evaluation, MCP launch integration, install/list/remove, and source
+   visibility are still the real product boundary.
+2. Complete provider/model catalog and API-list polish. The next visible slice
+   is context-window display in ModelSearch plus provider API model listing
+   with catalog fallback.
+3. Continue TUI cleanup by completing the `BottomPaneModel` migration and then
+   moving pending-interaction flows into a bottom-pane view stack.
+4. Add observability and controls around auto-memory extraction before making it
+   more aggressive.
+5. Keep web/source-reporting, auxiliary-model routing, cross-process sub-agent
+   reattach, Terminal-Bench readiness, and release packaging as follow-up lanes.
+
+## Trade-offs
+
+Plugin integration is now the highest-leverage lane because it intersects hooks,
+MCP, skills, agents, permissions, and control-plane readiness. Starting prompt
+hooks or marketplace features before command hooks are fully observable would
+increase the permission and debugging surface too early.
+
+Provider and TUI work remain important, but they are more incremental and can
+be sliced after the plugin runtime has a working end-to-end path.
+
+## Updated Artifacts
+
+- `docs/todo.md`
+- `docs/features/claude-plugin-runtime.md`
+- `docs/features/provider-connection-redesign.md`

--- a/docs/journal/2026-05-12-main-sync-development-plan.md
+++ b/docs/journal/2026-05-12-main-sync-development-plan.md
@@ -32,7 +32,11 @@ another independent feature line:
    moving pending-interaction flows into a bottom-pane view stack.
 4. Add observability and controls around auto-memory extraction before making it
    more aggressive.
-5. Keep web/source-reporting, auxiliary-model routing, cross-process sub-agent
+5. Prototype local embedding models for memory retrieval before committing to a
+   durable local embedding backend.
+6. Audit Codex and Claude Code system prompts and migrate only the parts that
+   fit RARA's stable prompt-runtime contract.
+7. Keep web/source-reporting, auxiliary-model routing, cross-process sub-agent
    reattach, Terminal-Bench readiness, and release packaging as follow-up lanes.
 
 ## Trade-offs

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -67,6 +67,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Audit Codex and Claude Code system prompts, then migrate applicable prompt guidance into RARA's default prompt family without reordering stable prompt sections.
 - [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Protocol prompt sources now retain provenance, convert into prompt-runtime sources, atomically snapshot from the live registry at the user-query boundary, and emit registered/injected/dropped lifecycle events; next slice should extend the same bridge to protocol skill/hook visibility.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.
+- [ ] Port reusable AgentHub `.agents/skills` patterns into RARA repo skills: docs journal/spec writing, project title rules, and focused testing guidance; do not copy AgentHub-specific ACP rendering/debug skills directly.
 - [ ] Claude-style `verify` skill and `verifier-*` convention (see `docs/features/verify-skill.md`).
 - [ ] Evolve `SkillTool` to Codex/Claude contract (see `docs/features/skill-tool.md`): frontmatter, scopes, override visibility.
 - [ ] Surface skill precedence/override across home, repo, nested roots.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -67,7 +67,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Audit Codex and Claude Code system prompts, then migrate applicable prompt guidance into RARA's default prompt family without reordering stable prompt sections.
 - [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Protocol prompt sources now retain provenance, convert into prompt-runtime sources, atomically snapshot from the live registry at the user-query boundary, and emit registered/injected/dropped lifecycle events; next slice should extend the same bridge to protocol skill/hook visibility.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.
-- [ ] Port reusable AgentHub `.agents/skills` patterns into RARA repo skills: docs journal/spec writing, project title rules, and focused testing guidance; do not copy AgentHub-specific ACP rendering/debug skills directly.
+- [x] Port reusable AgentHub `.agents/skills` patterns into RARA repo skills: docs journal/spec writing, project title rules, and focused testing guidance; do not copy AgentHub-specific ACP rendering/debug skills directly.
 - [ ] Claude-style `verify` skill and `verifier-*` convention (see `docs/features/verify-skill.md`).
 - [ ] Evolve `SkillTool` to Codex/Claude contract (see `docs/features/skill-tool.md`): frontmatter, scopes, override visibility.
 - [ ] Surface skill precedence/override across home, repo, nested roots.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -64,6 +64,7 @@ Active backlog only. Keep this file small and current.
 - [x] Unify `discover_prompt_sources()` and TUI `/status` source reporting.
 - [x] Add directory-walking `.rara/rules/*.md` prompt sources from CWD to repo root.
 - [ ] Define and implement `.rara/local.md` semantics, scope, precedence, and visibility before enabling it as a prompt source.
+- [ ] Audit Codex and Claude Code system prompts, then migrate applicable prompt guidance into RARA's default prompt family without reordering stable prompt sections.
 - [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Protocol prompt sources now retain provenance, convert into prompt-runtime sources, atomically snapshot from the live registry at the user-query boundary, and emit registered/injected/dropped lifecycle events; next slice should extend the same bridge to protocol skill/hook visibility.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.
 - [ ] Claude-style `verify` skill and `verifier-*` convention (see `docs/features/verify-skill.md`).
@@ -104,6 +105,7 @@ Active backlog only. Keep this file small and current.
 - [x] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.
 - [x] Auto-memory extraction: background LLM-driven fact extraction after every 5 turns, inserted into LanceDB via MemoryStore (PR #375).
 - [x] Directory-walking rules layer: `.rara/rules/*.md` discovered from CWD to repo root (PR #375).
+- [ ] Prototype local embedding models for memory retrieval, comparing local inference quality/latency against the current remote or fallback embedding path before choosing a durable backend.
 - [ ] Add auto-memory extraction controls and observability: enable/disable config, last-run status, error reporting, dedupe metrics, and bounded background concurrency.
 - [ ] Define cross-process background sub-agent restart/reattach semantics.
 - [x] Compaction as first-class lifecycle event: persist summaries, token counters, metadata ownership.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,14 +4,14 @@ Active backlog only. Keep this file small and current.
 
 ## Suggested Rollout Order
 
-1. Runtime control plane and ACP/Wire-ready context contracts
-2. Runtime bootstrap and source-object unification
-3. Configuration and provider-surface cleanup
-4. Workspace / skill observability and cache correctness
-5. Memory / retrieval / thread persistence
-6. TUI transcript parity and command-surface polish
-7. Terminal-Bench evaluation readiness
-8. Release distribution and package-manager adapters
+1. Claude plugin runtime integration and extension-source unification
+2. Provider/model connection polish and `reasoning_summary` completion
+3. TUI bottom-pane/view-stack cleanup and transcript rendering parity
+4. Web/source-reporting and auxiliary-model routing
+5. Cross-process sub-agent durability and Terminal-Bench readiness
+6. Security, sandbox policy provenance, and secret handling
+7. Release distribution and package-manager adapters
+8. Oversized-module cleanup and docs/spec hygiene
 
 ## Runtime Control Plane / ACP / Wire
 
@@ -35,6 +35,16 @@ Active backlog only. Keep this file small and current.
 - [ ] Ensure every new skill, memory, prompt, hook, planning, approval, and output feature is control-plane-ready rather than TUI-only.
 - [x] Add a `support-acp` integration skill for IDE and third-party app authors, covering ACP startup, runtime-control input intents, output event subscription, cancellation/preemption, approvals, MCP/tool-search expectations, and safe context-source registration (see `docs/features/support-acp-integration.md`).
 
+## Plugins / Extension Runtime
+
+- [x] Add the first `rara-plugins` crate for Claude Code plugin discovery, `plugin.json` parsing, `hooks/hooks.json` parsing, command-hook execution, timeouts, and tests.
+- [ ] Wire plugin hook registration into runtime startup so discovered command hooks actually fire through `HookRuntime` for TUI, CLI, ACP, and Wire entrypoints.
+- [ ] Fix plugin lifecycle parity gaps before broader rollout: `SessionEnd` mapping, matcher evaluation, hook stdout/stderr observability, and blocking `{ "continue": false }` semantics.
+- [ ] Add `rara plugin install/list/remove` with local-path and git-source support, plus explicit trust/sandbox copy.
+- [ ] Parse plugin `.mcp.json` into the existing MCP registry and launch lifecycle instead of leaving MCP config as inert metadata.
+- [ ] Register plugin-provided commands, skills, and agents as structured extension sources with precedence and `/context` visibility.
+- [ ] Design prompt/http/agent hook support only after command hooks have runtime integration, observability, and permission boundaries.
+
 ## Configuration / Provider Surface
 
 - [ ] Complete `reasoning_summary` rollout across backend requests, switching flows, and status surfaces; retire remaining `thinking`-only behavior outside migration fallback.
@@ -42,6 +52,8 @@ Active backlog only. Keep this file small and current.
 - [ ] Study Gemini/Codex-style multi-model routing for top-tier + flash/fast model pairing.
 - [ ] Deepen provider-surface continuity after hot-swap: auth-mode/endpoint alignment, provenance reporting.
 - [ ] Align Codex endpoint selection with auth mode (ChatGPT/Codex login vs API key).
+- [ ] Show provider-catalog context windows in ModelSearch items for DeepSeek/Kimi/OpenAI/Codex where known.
+- [ ] Load model lists from provider APIs for connected providers, with provider-catalog windows as fallback metadata.
 - [ ] Split Codex-specific persisted auth/config to `~/.codex`, keep RARA config under `~/.rara`.
 
 ## Workspace / Skills / Prompt Sources
@@ -50,6 +62,8 @@ Active backlog only. Keep this file small and current.
 - [x] Tests for workspace prompt-source discovery and cache invalidation (cwd changes, git branches, nested workspaces).
 - [x] Define `WorkspaceMemory` cache invalidation rules for prompt files and environment info (see `docs/features/workspace-memory-cache.md`).
 - [x] Unify `discover_prompt_sources()` and TUI `/status` source reporting.
+- [x] Add directory-walking `.rara/rules/*.md` prompt sources from CWD to repo root.
+- [ ] Define and implement `.rara/local.md` semantics, scope, precedence, and visibility before enabling it as a prompt source.
 - [ ] New prompt inputs through structured source objects, `MemorySelection`, lifecycle events, and runtime-control provenance — not ad hoc text. Protocol prompt sources now retain provenance, convert into prompt-runtime sources, atomically snapshot from the live registry at the user-query boundary, and emit registered/injected/dropped lifecycle events; next slice should extend the same bridge to protocol skill/hook visibility.
 - [ ] Project-scoped extension surface for `.claude/agents/`, `.claude/hooks/`, `.agents/skills/` with precedence rules.
 - [ ] Claude-style `verify` skill and `verifier-*` convention (see `docs/features/verify-skill.md`).
@@ -90,6 +104,7 @@ Active backlog only. Keep this file small and current.
 - [x] Durable in-turn checkpoints: persist after each message/tool-result batch, atomic writes, crash-tolerant `SessionManager`.
 - [x] Auto-memory extraction: background LLM-driven fact extraction after every 5 turns, inserted into LanceDB via MemoryStore (PR #375).
 - [x] Directory-walking rules layer: `.rara/rules/*.md` discovered from CWD to repo root (PR #375).
+- [ ] Add auto-memory extraction controls and observability: enable/disable config, last-run status, error reporting, dedupe metrics, and bounded background concurrency.
 - [ ] Define cross-process background sub-agent restart/reattach semantics.
 - [x] Compaction as first-class lifecycle event: persist summaries, token counters, metadata ownership.
 - [x] Add prompt-too-long retry for compaction by dropping oldest API-round groups.
@@ -120,7 +135,7 @@ Active backlog only. Keep this file small and current.
 - [x] Remove crossterm history write path, unify all rendering through Ratatui (PR #272).
 - [x] Decouple overlays from transcript layout (pure top layer, no viewport perturbation).
 - [x] Split the bottom pane into composable activity, composer, queued-preview, and footer modules (PR #366).
-- [ ] Introduce a `BottomPaneModel` so bottom-pane rendering consumes structured view data instead of reading broad `TuiApp` state directly.
+- [ ] Complete `BottomPaneModel` migration: activity/footer now use structured view data, but composer and sizing still read broad `TuiApp` state directly.
 - [ ] Move approval, request-input, command-palette, and picker flows toward a Codex-style bottom-pane view stack after the rendering split is stable.
 - [ ] Post-exit resume hint (e.g. `rara resume --last`).
 - [x] Claude-style repo context hints beneath input area (GitHub PR link).
@@ -131,6 +146,7 @@ Active backlog only. Keep this file small and current.
 - [x] Tool-action summaries more source-aware and file-aware.
 - [ ] Live `bash` transcript: lifecycle framing, streamed stdout/stderr, long-output folding.
 - [ ] High-fidelity render pass for `write/update`, inline diffs, approval cards, message-card hierarchy.
+- [ ] Add committed thinking expand/collapse interaction and elapsed-time summary after the first collapsible thinking display slice.
 - [ ] Strengthen terminal Markdown rendering parity: GitHub-flavored Markdown coverage, local file-link rendering, fenced code blocks, list wrapping, and focused snapshot coverage.
 - [ ] Expand TUI snapshot coverage.
 - [ ] Keep transcript and pending-interaction state backed by structured events that ACP/Wire output subscribers can reuse.


### PR DESCRIPTION
## Summary

- Sync the active development plan after the latest `main` updates.
- Add a plugin/extension runtime backlog focused on runtime integration gaps.
- Update plugin and provider specs with current implementation status and next slices.
- Add a dated journal note for the main-sync planning checkpoint.

## Purpose

Recent `main` changes added plugin scaffolding, auto-memory extraction, provider catalog updates, TUI bottom-pane work, thinking display changes, and agent reliability improvements. The backlog needed to reflect those landed pieces and prioritize the next integration work instead of carrying stale ordering.

## Related Issues

None.

## Testing

- Not run; documentation-only change.
