### PR TITLE
feat(tui): add transcript copy selection

### DIFF
--- a/docs/features/mouse-text-selection.md
+++ b/docs/features/mouse-text-selection.md
@@ -2,72 +2,93 @@
 
 ## Problem
 
-When `EnableMouseCapture` is active (added in PR #317 for scroll acceleration),
-the terminal sends all mouse events to the application. Native text selection
-(drag-to-select, double-click to select word) is blocked at the terminal layer.
-Users cannot select text from the transcript or input area with the mouse.
+RARA enables terminal mouse capture so the TUI can receive wheel events and keep
+transcript scrolling inside the application. That disables terminal-native
+drag-to-select behavior for the visible transcript.
 
-This is inherent in all terminal applications that enable mouse reporting; it
-is not a Ratatui limitation. The trade-off is:
+Codex avoids this by keeping transcript history in terminal scrollback and not
+capturing mouse events by default. RARA intentionally keeps the application-owned
+transcript viewport for now, so copy-friendly selection must be implemented at
+the TUI layer.
 
-- Mouse reporting ON  → scroll acceleration, click-to-interact, but no text selection
-- Mouse reporting OFF → native text selection, but no mouse-driven scroll/click
+## Scope
 
-## Solution: Shift-Toggle Mouse Passthrough
+The canonical behavior is application-owned selection for the visible transcript
+area only:
 
-Hold `Shift` to temporarily disable mouse capture while the key is held,
-allowing native text selection. When `Shift` is released, mouse capture resumes.
-
-### Implementation
-
-1. Detect `Shift` key press/release in the key event handler
-2. On `Shift` press: `DisableMouseCapture`
-3. On `Shift` release: `EnableMouseCapture`
-
-```rust
-// event_dispatch.rs
-AppEvent::Key(KeyEvent { code: KeyCode::Key(..), modifiers, kind }) => {
-    if kind == KeyEventKind::Press && modifiers.intersects(KeyModifiers::SHIFT) {
-        execute!(backend, DisableMouseCapture)?;
-    } else if kind == KeyEventKind::Release && !modifiers.intersects(KeyModifiers::SHIFT) {
-        execute!(backend, EnableMouseCapture)?;
-    }
-}
-```
-
-### Detection
-
-`crossterm` exposes `KeyModifiers::SHIFT` for regular keys. For standalone
-Shift press, terminals may send different key events. The reliable approach is
-to track `SHIFT` modifier on keyboard events rather than detecting a standalone
-Shift press. When ANY key is pressed with Shift held, enter selection mode.
-
-Simultaneously, scan for `MouseEventKind::Down` events and if they occur without
-a registered TUI interaction target, treat them as selection start.
-
-### Behavior Matrix
-
-| State | Mouse scroll | Text selection | Mouse click |
-|-------|-------------|----------------|-------------|
-| Normal (mouse capture ON) | ✅ scroll acceleration | ❌ blocked | ✅ interact with TUI |
-| Shift held (mouse capture OFF) | ❌ terminal handles | ✅ native selection | ❌ ignored |
-
-### Constraints
-
-- The backend reference must be accessible from `event_dispatch`. Currently
-  `event_dispatch` receives `&mut TuiApp` and `agent_slot`. We need to add
-  `&mut Terminal<CrosstermBackend<Stdout>>` or a channel to send capture
-  toggle commands.
-- `DisableMouseCapture`/`EnableMouseCapture` must be called on the same
-  backend that owns the terminal output handle.
+- left-button drag starts and updates a transcript selection;
+- selected cells are highlighted by RARA while dragging;
+- releasing the left button copies the selected plain text;
+- dragging at the top or bottom edge autoscrolls the transcript and extends the
+  selection;
+- normal wheel scrolling remains available outside active drag selection.
 
 ## Non-Goals
 
-- Per-pixel mouse selection precision (inherently limited by terminal cell grid).
-- Copy-to-clipboard integration (use terminal's native copy: Cmd+C / Ctrl+Shift+C).
+- Selecting text in the composer.
+- Selecting text in overlays such as `/help`, `/status`, pickers, or context
+  inspection.
+- Selecting text from the wide-screen sidebar.
+- Selecting off-screen terminal scrollback rows outside the transcript model.
+- Preserving rich styles in the copied text.
 
-## Verification
+## Architecture
 
-- Manual: open RARA, hold Shift, drag mouse over transcript text → text should
-  be highlighted by the terminal.
-- Release Shift, scroll with mouse wheel → scroll acceleration should resume.
+RARA keeps `EnableMouseCapture` enabled and routes left-button mouse events into
+`TranscriptSelection`.
+
+The render path owns the authoritative visible transcript snapshot. Each frame:
+
+1. builds the transcript viewport;
+2. computes the visible wrapped rows for the current scroll offset;
+3. stores the screen-area-to-text mapping in `TuiApp.transcript_selection`;
+4. renders the transcript;
+5. applies selection highlight over the rendered buffer.
+
+Mouse handling uses that latest snapshot to map screen coordinates back to
+wrapped transcript rows. The tick loop drives edge autoscroll while dragging.
+
+Clipboard output first emits OSC 52 so SSH sessions can copy to the local
+terminal clipboard when the terminal permits it. Platform clipboard commands are
+best-effort fallbacks for local sessions.
+
+## Contracts
+
+- Selection only starts when there is no active overlay and the mouse down event
+  lands inside the transcript snapshot.
+- Dragging outside the transcript area clamps to the nearest visible transcript
+  row.
+- A zero-width selection does not copy anything.
+- Copied text is plain text reconstructed from visible wrapped transcript rows.
+- Edge autoscroll uses the same transcript scroll direction as wheel and
+  keyboard scrolling.
+- Clipboard failures must not terminate the TUI; they surface as notices.
+
+## Validation Matrix
+
+| Behavior | Validation |
+| --- | --- |
+| Wrapped text range extraction | Unit tests for `TranscriptSelection` |
+| Autoscroll selection extension | Unit tests for non-zero scroll offset |
+| Mouse event routing | Existing TUI event tests plus focused selection events |
+| Clipboard fallback safety | Manual SSH/local verification |
+| Render highlight | Manual TUI verification; future snapshot if styling changes |
+
+## Operational Notes
+
+OSC 52 depends on terminal policy. Some terminals disable remote clipboard
+writes by default, and tmux/screen may require passthrough support. RARA still
+attempts native clipboard fallback, but over SSH that fallback writes the remote
+machine clipboard rather than the user's local desktop clipboard.
+
+## Open Risks
+
+- The first implementation reconstructs copied text from wrapped visual rows,
+  so extremely wide Unicode grapheme clusters may not match terminal emulator
+  selection exactly.
+- The transcript snapshot is frame-based. If a mouse event arrives before the
+  first transcript frame, selection start is ignored.
+
+## Source Journals
+
+- [2026-05-13-transcript-copy-selection](../journal/2026-05-13-transcript-copy-selection.md)

--- a/docs/features/mouse-text-selection.md
+++ b/docs/features/mouse-text-selection.md
@@ -19,8 +19,8 @@ area only:
 - left-button drag starts and updates a transcript selection;
 - selected cells are highlighted by RARA while dragging;
 - releasing the left button copies the selected plain text;
-- dragging at the top or bottom edge autoscrolls the transcript and extends the
-  selection;
+- dragging outside the top or bottom edge autoscrolls the transcript and
+  extends the selection;
 - normal wheel scrolling remains available outside active drag selection.
 
 ## Non-Goals
@@ -45,6 +45,11 @@ The render path owns the authoritative visible transcript snapshot. Each frame:
 4. renders the transcript;
 5. applies selection highlight over the rendered buffer.
 
+Snapshot rebuilding is guarded by a lightweight key derived from the viewport
+area, scroll offset, transcript size, and transcript edge content. Unchanged
+frames reuse the previous screen-area-to-text mapping instead of reallocating
+wrapped rows.
+
 Mouse handling uses that latest snapshot to map screen coordinates back to
 wrapped transcript rows. The tick loop drives edge autoscroll while dragging.
 
@@ -60,8 +65,8 @@ best-effort fallbacks for local sessions.
   row.
 - A zero-width selection does not copy anything.
 - Copied text is plain text reconstructed from visible wrapped transcript rows.
-- Edge autoscroll uses the same transcript scroll direction as wheel and
-  keyboard scrolling.
+- Edge autoscroll only starts once the cursor leaves the transcript viewport and
+  uses the same transcript scroll direction as wheel and keyboard scrolling.
 - Clipboard failures must not terminate the TUI; they surface as notices.
 
 ## Validation Matrix

--- a/docs/journal/2026-05-13-transcript-copy-selection.md
+++ b/docs/journal/2026-05-13-transcript-copy-selection.md
@@ -1,0 +1,42 @@
+# Transcript Copy Selection
+
+## What Changed
+
+RARA now treats mouse drag selection as an application-owned transcript feature
+instead of trying to temporarily restore terminal-native selection.
+
+The implementation is intentionally scoped to the visible transcript area:
+
+- left-button drag starts and updates selection;
+- selected transcript cells are highlighted in the rendered buffer;
+- left-button release copies selected plain text;
+- dragging at the transcript top or bottom edge autoscrolls and extends the
+  selection;
+- overlays, composer, and sidebar are out of scope.
+
+## Why
+
+RARA captures mouse events to support transcript wheel scrolling. That prevents
+the terminal from performing native drag-to-select. Codex avoids the conflict by
+using terminal scrollback for transcript history, while opencode-style TUIs keep
+mouse capture and simulate selection inside the app.
+
+The selected direction keeps RARA's existing transcript viewport and adds a
+copy-friendly path without giving up mouse scrolling.
+
+## Trade-Offs
+
+The copied text is reconstructed from RARA's rendered transcript model rather
+than from the terminal emulator. This is more predictable for application-owned
+content but does not cover terminal scrollback or UI surfaces outside the
+transcript.
+
+Clipboard writes first use OSC 52 for SSH compatibility, then best-effort local
+platform commands. Remote clipboard behavior still depends on terminal and
+multiplexer policy.
+
+## Remaining Work
+
+- Add an opt-out config if users prefer no copy-on-select behavior.
+- Consider extending selection tests for wide Unicode grapheme behavior.
+- Manually verify OSC 52 behavior under tmux and common terminals.

--- a/docs/journal/2026-05-13-transcript-copy-selection.md
+++ b/docs/journal/2026-05-13-transcript-copy-selection.md
@@ -10,8 +10,8 @@ The implementation is intentionally scoped to the visible transcript area:
 - left-button drag starts and updates selection;
 - selected transcript cells are highlighted in the rendered buffer;
 - left-button release copies selected plain text;
-- dragging at the transcript top or bottom edge autoscrolls and extends the
-  selection;
+- dragging outside the transcript top or bottom edge autoscrolls and extends
+  the selection;
 - overlays, composer, and sidebar are out of scope.
 
 ## Why
@@ -35,8 +35,12 @@ Clipboard writes first use OSC 52 for SSH compatibility, then best-effort local
 platform commands. Remote clipboard behavior still depends on terminal and
 multiplexer policy.
 
+Snapshot rebuilds are keyed by viewport and transcript metadata so stable frames
+reuse the previous mapping. This keeps the selection path out of the hot render
+loop unless the transcript, size, or scroll position changes.
+
 ## Remaining Work
 
 - Add an opt-out config if users prefer no copy-on-select behavior.
 - Consider extending selection tests for wide Unicode grapheme behavior.
-- Manually verify OSC 52 behavior under tmux and common terminals.
+- Manually verify OSC 52 behavior under tmux, GNU Screen, and common terminals.

--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -1,3 +1,4 @@
+use super::selection::ScreenPosition;
 use super::state::{HelpTab, Overlay, StatusTab};
 
 #[derive(Debug, Clone)]
@@ -18,6 +19,9 @@ pub enum AppEvent {
     MoveCursorDown,
     NavigateInputHistory(i32),
     ScrollTranscript(i32),
+    StartTranscriptSelection(ScreenPosition),
+    DragTranscriptSelection(ScreenPosition),
+    FinishTranscriptSelection(ScreenPosition),
     ScrollContext(i32),
     MoveCommandSelection(i32),
     MovePermissionSelection(i32),

--- a/src/tui/clipboard.rs
+++ b/src/tui/clipboard.rs
@@ -1,0 +1,56 @@
+use std::io::{self, Write};
+use std::process::{Command, Stdio};
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+
+pub(crate) fn copy_text(text: &str) -> io::Result<()> {
+    write_osc52(text)?;
+    try_native_clipboard(text);
+    Ok(())
+}
+
+fn write_osc52(text: &str) -> io::Result<()> {
+    let encoded = STANDARD.encode(text.as_bytes());
+    let sequence = if std::env::var_os("TMUX").is_some() || std::env::var_os("STY").is_some() {
+        format!("\x1bPtmux;\x1b\x1b]52;c;{encoded}\x07\x1b\\")
+    } else {
+        format!("\x1b]52;c;{encoded}\x07")
+    };
+    let mut stdout = io::stdout();
+    stdout.write_all(sequence.as_bytes())?;
+    stdout.flush()
+}
+
+fn try_native_clipboard(text: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = pipe_to_command("pbcopy", &[], text);
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if std::env::var_os("WAYLAND_DISPLAY").is_some()
+            && pipe_to_command("wl-copy", &[], text).is_ok()
+        {
+            return;
+        }
+        if pipe_to_command("xclip", &["-selection", "clipboard"], text).is_ok() {
+            return;
+        }
+        let _ = pipe_to_command("xsel", &["--clipboard", "--input"], text);
+    }
+}
+
+fn pipe_to_command(program: &str, args: &[&str], text: &str) -> io::Result<()> {
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin.write_all(text.as_bytes())?;
+    }
+    let _ = child.wait();
+    Ok(())
+}

--- a/src/tui/clipboard.rs
+++ b/src/tui/clipboard.rs
@@ -11,8 +11,10 @@ pub(crate) fn copy_text(text: &str) -> io::Result<()> {
 
 fn write_osc52(text: &str) -> io::Result<()> {
     let encoded = STANDARD.encode(text.as_bytes());
-    let sequence = if std::env::var_os("TMUX").is_some() || std::env::var_os("STY").is_some() {
+    let sequence = if std::env::var_os("TMUX").is_some() {
         format!("\x1bPtmux;\x1b\x1b]52;c;{encoded}\x07\x1b\\")
+    } else if std::env::var_os("STY").is_some() {
+        format!("\x1bP\x1b]52;c;{encoded}\x07\x1b\\")
     } else {
         format!("\x1b]52;c;{encoded}\x07")
     };
@@ -48,9 +50,9 @@ fn pipe_to_command(program: &str, args: &[&str], text: &str) -> io::Result<()> {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
-    if let Some(stdin) = child.stdin.as_mut() {
+    if let Some(mut stdin) = child.stdin.take() {
         stdin.write_all(text.as_bytes())?;
     }
-    let _ = child.wait();
+    child.wait()?;
     Ok(())
 }

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -106,6 +106,22 @@ pub(crate) async fn dispatch_event(
             app.navigate_input_history(delta);
         }
         AppEvent::ScrollTranscript(delta) => app.scroll_transcript(delta),
+        AppEvent::StartTranscriptSelection(position) => {
+            app.transcript_selection.start(position);
+        }
+        AppEvent::DragTranscriptSelection(position) => {
+            app.transcript_selection.drag(position);
+        }
+        AppEvent::FinishTranscriptSelection(position) => {
+            if let Some(text) = app.transcript_selection.finish(position) {
+                match crate::tui::clipboard::copy_text(text.as_str()) {
+                    Ok(()) => app.push_notice("Copied transcript selection to clipboard."),
+                    Err(err) => {
+                        app.push_notice(format!("Failed to copy transcript selection: {err}"))
+                    }
+                }
+            }
+        }
         AppEvent::ScrollContext(delta) => app.scroll_context(delta),
         AppEvent::MoveCommandSelection(delta) => {
             if matches!(app.overlay, Some(Overlay::ModelSearch)) {

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -130,6 +130,9 @@ pub async fn run_tui(
 
         tokio::select! {
             _ = tick.tick() => {
+                if let Some(delta) = app.transcript_selection.autoscroll_delta() {
+                    app.scroll_transcript(delta);
+                }
                 needs_redraw = true;
             }
             maybe_event = events.next() => {

--- a/src/tui/event_stream.rs
+++ b/src/tui/event_stream.rs
@@ -1,9 +1,10 @@
 use std::sync::Mutex;
 use std::time::Instant;
 
-use crossterm::event::{Event, KeyEventKind, MouseEvent, MouseEventKind};
+use crossterm::event::{Event, KeyEventKind, MouseButton, MouseEvent, MouseEventKind};
 
 use super::app_event::AppEvent;
+use super::selection::ScreenPosition;
 use super::state::{Overlay, TuiApp};
 
 const MOUSE_WHEEL_SCROLL_LINES: i32 = 3;
@@ -44,7 +45,28 @@ pub fn translate_event(event: Event, app: &TuiApp) -> Option<UiEvent> {
 
 fn map_mouse_to_event(mouse_event: MouseEvent, app: &TuiApp) -> AppEvent {
     match mouse_event.kind {
+        MouseEventKind::Down(MouseButton::Left) if app.overlay.is_none() => {
+            AppEvent::StartTranscriptSelection(ScreenPosition::new(
+                mouse_event.column,
+                mouse_event.row,
+            ))
+        }
+        MouseEventKind::Drag(MouseButton::Left) if app.overlay.is_none() => {
+            AppEvent::DragTranscriptSelection(ScreenPosition::new(
+                mouse_event.column,
+                mouse_event.row,
+            ))
+        }
+        MouseEventKind::Up(MouseButton::Left) if app.overlay.is_none() => {
+            AppEvent::FinishTranscriptSelection(ScreenPosition::new(
+                mouse_event.column,
+                mouse_event.row,
+            ))
+        }
         MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+            if app.transcript_selection.is_dragging() {
+                return AppEvent::Noop;
+            }
             let direction: i32 = if matches!(mouse_event.kind, MouseEventKind::ScrollUp) {
                 -1
             } else {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,7 @@
 mod app_command;
 mod app_event;
 mod auth_mode_picker;
+mod clipboard;
 mod command;
 mod constants;
 mod context_display;
@@ -27,6 +28,7 @@ mod provider_flow;
 mod queued_input;
 mod render;
 pub(super) mod runtime;
+mod selection;
 mod session_restore;
 pub(crate) mod state;
 mod status_display;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -118,9 +118,10 @@ fn shows_startup_header(app: &TuiApp) -> bool {
         && !app.has_pending_planning_suggestion()
 }
 
-fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
+fn render_transcript(f: &mut Frame, app: &mut TuiApp, area: Rect) {
     let viewport = transcript_viewport(app, area.width, area.height);
     if !app.has_any_transcript() && viewport.lines.is_empty() {
+        app.transcript_selection.clear_snapshot();
         let lines = vec![
             Line::from("Ready."),
             Line::from(Span::styled("──", Style::default().fg(TEXT_SECONDARY))),
@@ -146,7 +147,15 @@ fn render_transcript(f: &mut Frame, app: &TuiApp, area: Rect) {
         return;
     }
 
+    app.transcript_selection.update_snapshot(
+        viewport.lines.as_slice(),
+        area,
+        area.width,
+        viewport.scroll_offset,
+    );
     viewport.render(f, area);
+    app.transcript_selection
+        .highlight_visible_range(f.buffer_mut());
 }
 
 pub(crate) fn transcript_viewport(

--- a/src/tui/selection.rs
+++ b/src/tui/selection.rs
@@ -1,3 +1,8 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+};
+
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -25,6 +30,7 @@ pub(crate) struct TranscriptSelection {
     last_mouse: Option<ScreenPosition>,
     dragging: bool,
     snapshot: TranscriptSelectionSnapshot,
+    snapshot_key: Option<TranscriptSelectionSnapshotKey>,
 }
 
 impl TranscriptSelection {
@@ -39,13 +45,19 @@ impl TranscriptSelection {
         width: u16,
         scroll_offset: u16,
     ) {
+        let key = TranscriptSelectionSnapshotKey::from_lines(lines, area, width, scroll_offset);
+        if self.snapshot_key == Some(key) {
+            return;
+        }
         self.snapshot =
             TranscriptSelectionSnapshot::from_lines(lines, area, width, usize::from(scroll_offset));
+        self.snapshot_key = Some(key);
         self.clamp_points_to_snapshot();
     }
 
     pub(crate) fn clear_snapshot(&mut self) {
         self.snapshot = TranscriptSelectionSnapshot::default();
+        self.snapshot_key = None;
         self.clear();
     }
 
@@ -105,13 +117,12 @@ impl TranscriptSelection {
         }
         let last = self.last_mouse?;
         let area = self.snapshot.area;
-        let bottom = area.bottom().saturating_sub(1);
-        if last.y <= area.y && self.snapshot.visible_start > 0 {
+        if last.y < area.y && self.snapshot.visible_start > 0 {
             let next_row = self.snapshot.visible_start.saturating_sub(1);
             self.focus = Some(self.snapshot.point_for_row_and_x(next_row, last.x));
             return Some(-1);
         }
-        if last.y >= bottom && self.snapshot.visible_end < self.snapshot.rows.len() {
+        if last.y >= area.bottom() && self.snapshot.visible_end < self.snapshot.rows.len() {
             let next_row = self.snapshot.visible_end.min(self.snapshot.rows.len() - 1);
             self.focus = Some(self.snapshot.point_for_row_and_x(next_row, last.x));
             return Some(1);
@@ -196,6 +207,48 @@ struct TranscriptSelectionSnapshot {
     rows: Vec<VisualRow>,
     visible_start: usize,
     visible_end: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TranscriptSelectionSnapshotKey {
+    area: Rect,
+    width: u16,
+    scroll_offset: u16,
+    line_count: usize,
+    span_count: usize,
+    text_len: usize,
+    edge_hash: u64,
+}
+
+impl TranscriptSelectionSnapshotKey {
+    fn from_lines(lines: &[Line<'static>], area: Rect, width: u16, scroll_offset: u16) -> Self {
+        let mut span_count = 0usize;
+        let mut text_len = 0usize;
+        for line in lines {
+            span_count = span_count.saturating_add(line.spans.len());
+            for span in &line.spans {
+                text_len = text_len.saturating_add(span.content.len());
+            }
+        }
+
+        let mut hasher = DefaultHasher::new();
+        if let Some(first) = lines.first() {
+            hash_line(first, &mut hasher);
+        }
+        if let Some(last) = lines.last() {
+            hash_line(last, &mut hasher);
+        }
+
+        Self {
+            area,
+            width,
+            scroll_offset,
+            line_count: lines.len(),
+            span_count,
+            text_len,
+            edge_hash: hasher.finish(),
+        }
+    }
 }
 
 impl TranscriptSelectionSnapshot {
@@ -371,6 +424,12 @@ fn slice_display_cols(text: &str, start: usize, end: usize) -> String {
     out
 }
 
+fn hash_line(line: &Line<'static>, hasher: &mut DefaultHasher) {
+    for span in &line.spans {
+        span.content.hash(hasher);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ratatui::{layout::Rect, text::Line};
@@ -406,7 +465,22 @@ mod tests {
         assert!(selection.start(ScreenPosition::new(0, 2)));
         assert!(selection.drag(ScreenPosition::new(0, 1)));
 
+        assert_eq!(selection.autoscroll_delta(), None);
+        assert!(selection.drag(ScreenPosition::new(0, 0)));
         assert_eq!(selection.autoscroll_delta(), Some(-1));
         assert_eq!(selection.selected_text().as_deref(), Some("one\ntwo"));
+    }
+
+    #[test]
+    fn snapshot_cache_refreshes_when_transcript_edges_change() {
+        let mut selection = TranscriptSelection::default();
+        let area = Rect::new(0, 0, 10, 2);
+        selection.update_snapshot(&[Line::from("one")], area, 10, 0);
+        assert!(selection.start(ScreenPosition::new(0, 0)));
+        assert!(selection.drag(ScreenPosition::new(3, 0)));
+        assert_eq!(selection.selected_text().as_deref(), Some("one"));
+
+        selection.update_snapshot(&[Line::from("two")], area, 10, 0);
+        assert_eq!(selection.selected_text().as_deref(), Some("two"));
     }
 }

--- a/src/tui/selection.rs
+++ b/src/tui/selection.rs
@@ -1,0 +1,412 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::Line,
+};
+use unicode_width::UnicodeWidthChar;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ScreenPosition {
+    pub(crate) x: u16,
+    pub(crate) y: u16,
+}
+
+impl ScreenPosition {
+    pub(crate) fn new(x: u16, y: u16) -> Self {
+        Self { x, y }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TranscriptSelection {
+    anchor: Option<SelectionPoint>,
+    focus: Option<SelectionPoint>,
+    last_mouse: Option<ScreenPosition>,
+    dragging: bool,
+    snapshot: TranscriptSelectionSnapshot,
+}
+
+impl TranscriptSelection {
+    pub(crate) fn is_dragging(&self) -> bool {
+        self.dragging
+    }
+
+    pub(crate) fn update_snapshot(
+        &mut self,
+        lines: &[Line<'static>],
+        area: Rect,
+        width: u16,
+        scroll_offset: u16,
+    ) {
+        self.snapshot =
+            TranscriptSelectionSnapshot::from_lines(lines, area, width, usize::from(scroll_offset));
+        self.clamp_points_to_snapshot();
+    }
+
+    pub(crate) fn clear_snapshot(&mut self) {
+        self.snapshot = TranscriptSelectionSnapshot::default();
+        self.clear();
+    }
+
+    pub(crate) fn start(&mut self, position: ScreenPosition) -> bool {
+        let Some(point) = self
+            .snapshot
+            .point_for_position(position, PointClamp::InsideOnly)
+        else {
+            return false;
+        };
+        self.anchor = Some(point);
+        self.focus = Some(point);
+        self.last_mouse = Some(position);
+        self.dragging = true;
+        true
+    }
+
+    pub(crate) fn drag(&mut self, position: ScreenPosition) -> bool {
+        if !self.dragging {
+            return false;
+        }
+        self.last_mouse = Some(position);
+        if let Some(point) = self
+            .snapshot
+            .point_for_position(position, PointClamp::ClampToArea)
+        {
+            self.focus = Some(point);
+        }
+        true
+    }
+
+    pub(crate) fn finish(&mut self, position: ScreenPosition) -> Option<String> {
+        if !self.dragging {
+            return None;
+        }
+        let _ = self.drag(position);
+        let selected = self.selected_text();
+        self.clear();
+        selected
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.anchor = None;
+        self.focus = None;
+        self.last_mouse = None;
+        self.dragging = false;
+    }
+
+    pub(crate) fn selected_text(&self) -> Option<String> {
+        let (start, end) = self.normalized_range()?;
+        self.snapshot.text_for_range(start, end)
+    }
+
+    pub(crate) fn autoscroll_delta(&mut self) -> Option<i32> {
+        if !self.dragging || self.snapshot.rows.is_empty() {
+            return None;
+        }
+        let last = self.last_mouse?;
+        let area = self.snapshot.area;
+        let bottom = area.bottom().saturating_sub(1);
+        if last.y <= area.y && self.snapshot.visible_start > 0 {
+            let next_row = self.snapshot.visible_start.saturating_sub(1);
+            self.focus = Some(self.snapshot.point_for_row_and_x(next_row, last.x));
+            return Some(-1);
+        }
+        if last.y >= bottom && self.snapshot.visible_end < self.snapshot.rows.len() {
+            let next_row = self.snapshot.visible_end.min(self.snapshot.rows.len() - 1);
+            self.focus = Some(self.snapshot.point_for_row_and_x(next_row, last.x));
+            return Some(1);
+        }
+        None
+    }
+
+    pub(crate) fn highlight_visible_range(&self, buffer: &mut Buffer) {
+        let Some((start, end)) = self.normalized_range() else {
+            return;
+        };
+        let style = Style::default().add_modifier(Modifier::REVERSED);
+        for (row_index, row) in self.snapshot.visible_rows().iter().enumerate() {
+            let row_start = if row.global_row == start.row {
+                start.col
+            } else {
+                0
+            };
+            let row_end = if row.global_row == end.row {
+                end.col
+            } else {
+                display_width(row.text)
+            };
+            if row.global_row < start.row || row.global_row > end.row || row_start >= row_end {
+                continue;
+            }
+            let y = self.snapshot.area.y.saturating_add(row_index as u16);
+            if y >= self.snapshot.area.bottom() {
+                break;
+            }
+            let x_start = self
+                .snapshot
+                .area
+                .x
+                .saturating_add(row_start.min(u16::MAX as usize) as u16);
+            let x_end = self
+                .snapshot
+                .area
+                .x
+                .saturating_add(row_end.min(usize::from(self.snapshot.area.width)) as u16)
+                .min(self.snapshot.area.right());
+            for x in x_start..x_end {
+                if let Some(cell) = buffer.cell_mut((x, y)) {
+                    cell.set_style(cell.style().patch(style));
+                }
+            }
+        }
+    }
+
+    fn normalized_range(&self) -> Option<(SelectionPoint, SelectionPoint)> {
+        let anchor = self.anchor?;
+        let focus = self.focus?;
+        if anchor == focus {
+            return None;
+        }
+        if anchor <= focus {
+            Some((anchor, focus))
+        } else {
+            Some((focus, anchor))
+        }
+    }
+
+    fn clamp_points_to_snapshot(&mut self) {
+        if self.snapshot.rows.is_empty() {
+            self.clear();
+            return;
+        }
+        self.anchor = self.anchor.map(|point| self.snapshot.clamp_point(point));
+        self.focus = self.focus.map(|point| self.snapshot.clamp_point(point));
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct SelectionPoint {
+    row: usize,
+    col: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TranscriptSelectionSnapshot {
+    area: Rect,
+    rows: Vec<VisualRow>,
+    visible_start: usize,
+    visible_end: usize,
+}
+
+impl TranscriptSelectionSnapshot {
+    fn from_lines(lines: &[Line<'static>], area: Rect, width: u16, scroll_offset: usize) -> Self {
+        let wrap_width = usize::from(width.max(1));
+        let mut rows = Vec::new();
+        for line in lines {
+            let text = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>();
+            let wrapped = wrap_text_rows(text.as_str(), wrap_width);
+            rows.extend(wrapped.into_iter().map(|text| VisualRow { text }));
+        }
+
+        let visible_start = scroll_offset.min(rows.len());
+        let visible_end = rows
+            .len()
+            .min(visible_start.saturating_add(usize::from(area.height)));
+        Self {
+            area,
+            rows,
+            visible_start,
+            visible_end,
+        }
+    }
+
+    fn visible_rows(&self) -> Vec<VisibleRow<'_>> {
+        self.rows[self.visible_start.min(self.rows.len())..self.visible_end.min(self.rows.len())]
+            .iter()
+            .enumerate()
+            .map(|(idx, row)| VisibleRow {
+                global_row: self.visible_start + idx,
+                text: row.text.as_str(),
+            })
+            .collect()
+    }
+
+    fn point_for_position(
+        &self,
+        position: ScreenPosition,
+        clamp: PointClamp,
+    ) -> Option<SelectionPoint> {
+        if self.rows.is_empty() || self.area.width == 0 || self.area.height == 0 {
+            return None;
+        }
+        let inside = position.x >= self.area.x
+            && position.x < self.area.right()
+            && position.y >= self.area.y
+            && position.y < self.area.bottom();
+        if !inside && matches!(clamp, PointClamp::InsideOnly) {
+            return None;
+        }
+        let local_y = position
+            .y
+            .saturating_sub(self.area.y)
+            .min(self.area.height.saturating_sub(1));
+        let row = (self.visible_start + usize::from(local_y)).min(self.rows.len() - 1);
+        Some(self.point_for_row_and_x(row, position.x))
+    }
+
+    fn point_for_row_and_x(&self, row: usize, x: u16) -> SelectionPoint {
+        let row = row.min(self.rows.len().saturating_sub(1));
+        let local_x = x.saturating_sub(self.area.x);
+        let col = usize::from(local_x).min(display_width(self.rows[row].text.as_str()));
+        SelectionPoint { row, col }
+    }
+
+    fn clamp_point(&self, point: SelectionPoint) -> SelectionPoint {
+        let row = point.row.min(self.rows.len().saturating_sub(1));
+        let col = point.col.min(display_width(self.rows[row].text.as_str()));
+        SelectionPoint { row, col }
+    }
+
+    fn text_for_range(&self, start: SelectionPoint, end: SelectionPoint) -> Option<String> {
+        if start == end || self.rows.is_empty() {
+            return None;
+        }
+        let mut selected = Vec::new();
+        for row_index in start.row..=end.row {
+            let row = self.rows.get(row_index)?;
+            let row_width = display_width(row.text.as_str());
+            let start_col = if row_index == start.row { start.col } else { 0 };
+            let end_col = if row_index == end.row {
+                end.col
+            } else {
+                row_width
+            };
+            selected.push(slice_display_cols(
+                row.text.as_str(),
+                start_col.min(row_width),
+                end_col.min(row_width),
+            ));
+        }
+        while selected.first().is_some_and(String::is_empty) {
+            selected.remove(0);
+        }
+        while selected.last().is_some_and(String::is_empty) {
+            selected.pop();
+        }
+        let text = selected.join("\n");
+        (!text.is_empty()).then_some(text)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PointClamp {
+    InsideOnly,
+    ClampToArea,
+}
+
+#[derive(Clone, Debug)]
+struct VisualRow {
+    text: String,
+}
+
+#[derive(Clone, Copy)]
+struct VisibleRow<'a> {
+    global_row: usize,
+    text: &'a str,
+}
+
+fn wrap_text_rows(text: &str, width: usize) -> Vec<String> {
+    if text.is_empty() {
+        return vec![String::new()];
+    }
+    let mut rows = Vec::new();
+    let mut current = String::new();
+    let mut current_width = 0usize;
+    for ch in text.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if current_width > 0 && ch_width > 0 && current_width + ch_width > width {
+            rows.push(std::mem::take(&mut current));
+            current_width = 0;
+        }
+        current.push(ch);
+        current_width = current_width.saturating_add(ch_width);
+        if current_width >= width && !current.is_empty() {
+            rows.push(std::mem::take(&mut current));
+            current_width = 0;
+        }
+    }
+    if !current.is_empty() {
+        rows.push(current);
+    }
+    rows
+}
+
+fn display_width(text: &str) -> usize {
+    text.chars()
+        .map(|ch| UnicodeWidthChar::width(ch).unwrap_or(0))
+        .sum()
+}
+
+fn slice_display_cols(text: &str, start: usize, end: usize) -> String {
+    if start >= end {
+        return String::new();
+    }
+    let mut out = String::new();
+    let mut col = 0usize;
+    for ch in text.chars() {
+        let width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        let next = col.saturating_add(width);
+        if next > start && col < end {
+            out.push(ch);
+        }
+        col = next;
+        if col >= end {
+            break;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::{layout::Rect, text::Line};
+
+    use super::{ScreenPosition, TranscriptSelection};
+
+    #[test]
+    fn selection_extracts_wrapped_visible_text() {
+        let mut selection = TranscriptSelection::default();
+        selection.update_snapshot(
+            &[Line::from("abcdef"), Line::from("gh")],
+            Rect::new(0, 0, 3, 3),
+            3,
+            0,
+        );
+
+        assert!(selection.start(ScreenPosition::new(1, 0)));
+        assert!(selection.drag(ScreenPosition::new(2, 1)));
+
+        assert_eq!(selection.selected_text().as_deref(), Some("bc\nde"));
+    }
+
+    #[test]
+    fn autoscroll_extends_selection_beyond_visible_area() {
+        let mut selection = TranscriptSelection::default();
+        selection.update_snapshot(
+            &[Line::from("one"), Line::from("two"), Line::from("three")],
+            Rect::new(0, 1, 10, 2),
+            10,
+            1,
+        );
+
+        assert!(selection.start(ScreenPosition::new(0, 2)));
+        assert!(selection.drag(ScreenPosition::new(0, 1)));
+
+        assert_eq!(selection.autoscroll_delta(), Some(-1));
+        assert_eq!(selection.selected_text().as_deref(), Some("one\ntwo"));
+    }
+}

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -325,6 +325,7 @@ impl TuiApp {
             committed_render_generation: 0,
             committed_render_cache: RefCell::new(CommittedTranscriptRenderCache::default()),
             transcript_scroll: 0,
+            transcript_selection: crate::tui::selection::TranscriptSelection::default(),
             context_scroll: 0,
             terminal_width: 80,
             agent_markdown_stream: None,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -29,6 +29,7 @@ use crate::runtime_event_bus::RuntimeEventBus;
 use crate::thread_store::ThreadSummary;
 use crate::tools::bash::BashCommandInput;
 use crate::tui::display_sanitize::sanitize_display_text;
+use crate::tui::selection::TranscriptSelection;
 use crate::tui::terminal_event::TerminalEvent;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -676,6 +677,7 @@ pub struct TuiApp {
     pub committed_render_generation: u64,
     pub committed_render_cache: RefCell<CommittedTranscriptRenderCache>,
     pub transcript_scroll: usize,
+    pub(crate) transcript_selection: TranscriptSelection,
     pub context_scroll: u16,
     pub terminal_width: u16,
     pub agent_markdown_stream: Option<AgentMarkdownStreamState>,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3382,7 +3382,7 @@ fn mouse_wheel_with_no_overlay_routes_to_scroll_transcript() {
 }
 
 #[test]
-fn non_scroll_mouse_click_is_noop_regardless_of_overlay() {
+fn left_mouse_drag_routes_to_transcript_selection_without_overlay() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -3398,7 +3398,8 @@ fn non_scroll_mouse_click_is_noop_regardless_of_overlay() {
 
     assert!(matches!(
         translate_event(click.clone(), &app),
-        Some(UiEvent::App(AppEvent::Noop))
+        Some(UiEvent::App(AppEvent::StartTranscriptSelection(position)))
+            if position.x == 5 && position.y == 10
     ));
 
     app.open_overlay(Overlay::CommandPalette);


### PR DESCRIPTION
## Summary

- add app-owned mouse text selection for the visible transcript area
- copy selected transcript text on mouse release with OSC 52 first, then native clipboard fallbacks
- support edge autoscroll while dragging and document the interaction contract

## Purpose

RARA captures mouse events for its TUI, so terminal-native drag selection is unavailable in the transcript. This change adds an application-level selection path similar to opencode's copy-on-select behavior while keeping selection scoped to the transcript viewport.

## Related Issue

None.

## Testing

- `cargo fmt`
- `cargo test --bin rara selection::tests -- --nocapture`
- `cargo check`
- `git diff --check`

`cargo check` still reports existing repository warnings.
