### PR TITLE
fix(provider): preserve empty deepseek reasoning history

### DIFF
--- a/docs/features/openai-compatible-model-config.md
+++ b/docs/features/openai-compatible-model-config.md
@@ -97,6 +97,17 @@ tool calls must replay the original `reasoning_content` without trimming or
 rewriting it, because DeepSeek requires thinking-mode tool-call turns to be
 sent back intact on later requests.
 
+For DeepSeek thinking-capable models, `reasoning_content` is a three-state
+history contract:
+
+- missing `reasoning_content` means the assistant turn is legacy history that
+  predates RARA's DeepSeek reasoning preservation and may need to be folded
+  into an internal context note;
+- `reasoning_content = ""` means the assistant turn is a known DeepSeek turn
+  whose reasoning slot was present but empty and must still be replayed with an
+  explicit empty field;
+- non-empty `reasoning_content` must be preserved byte-for-byte.
+
 ## Remembered Provider State
 
 RARA keeps provider-scoped remembered state in `RaraConfig.provider_states`.
@@ -164,6 +175,9 @@ fields in addition to standard `content` and `tool_calls`:
 
 - `reasoning_content` must be retained for the next request when DeepSeek
   returns it;
+- `reasoning_content = ""` must remain distinguishable from missing legacy
+  history and must be replayed as an explicit empty field on later DeepSeek
+  requests;
 - reasoning metadata must not be rendered as ordinary assistant prose in the
   committed transcript;
 - tool calls must still round-trip with their `id`, `name`, and `arguments`;

--- a/docs/journal/2026-05-13-deepseek-empty-reasoning-history.md
+++ b/docs/journal/2026-05-13-deepseek-empty-reasoning-history.md
@@ -25,6 +25,8 @@ construction to treat fresh assistant turns as legacy history.
 - Replay explicit empty `reasoning_content` back to DeepSeek assistant history.
 - Keep true legacy DeepSeek assistant history on the existing fold-to-context
   compatibility path.
+- Cover tool-call-only assistant turns so standard OpenAI `tool_calls` and
+  DeepSeek DSML tool calls also synthesize an explicit empty reasoning slot.
 - Add focused regression coverage for non-streaming, streaming, and DeepSeek V4
   history replay.
 
@@ -33,7 +35,9 @@ construction to treat fresh assistant turns as legacy history.
 - The request-side DeepSeek fold path now keys off field presence instead of
   non-empty content. Only truly missing `reasoning_content` counts as legacy.
 - Response parsing synthesizes empty DeepSeek reasoning metadata for assistant
-  turns that have visible text or tool calls but no explicit reasoning text.
+  turns that have visible text or tool calls but no explicit reasoning text,
+  including tool-call-only turns before those tool calls are appended into the
+  final content vector.
 - Reasoning-only assistant turns still stay off the replay path because
   request-side empty-assistant filtering continues to ignore metadata-only
   messages.
@@ -41,8 +45,13 @@ construction to treat fresh assistant turns as legacy history.
 ## Validation
 
 - `cargo test llm::tests::deepseek_visible_text_without_reasoning_content_synthesizes_empty_metadata -- --nocapture`
+- `cargo test llm::tests::deepseek_tool_call_only_turn_synthesizes_empty_reasoning_content -- --nocapture`
+- `cargo test llm::tests::deepseek_dsml_tool_call_only_turn_synthesizes_empty_reasoning_content -- --nocapture`
 - `cargo test llm::tests::deepseek_streaming_visible_text_without_reasoning_content_synthesizes_empty_metadata -- --nocapture`
+- `cargo test llm::tests::deepseek_streaming_tool_call_only_turn_synthesizes_empty_reasoning_content -- --nocapture`
+- `cargo test llm::tests::deepseek_streaming_dsml_tool_call_only_turn_synthesizes_empty_reasoning_content -- --nocapture`
 - `cargo test llm::tests::deepseek_v4_preserves_assistant_history_with_empty_reasoning_content -- --nocapture`
+- `cargo test deepseek_ -- --nocapture`
 - `cargo check`
 
 ## Follow-Ups

--- a/docs/journal/2026-05-13-deepseek-empty-reasoning-history.md
+++ b/docs/journal/2026-05-13-deepseek-empty-reasoning-history.md
@@ -1,0 +1,52 @@
+# DeepSeek Empty Reasoning History
+
+## Summary
+
+RARA now preserves DeepSeek `reasoning_content` as a three-state history slot
+for assistant turns:
+
+- missing means legacy history that predates DeepSeek reasoning preservation;
+- empty string means a known DeepSeek assistant turn with an explicit empty
+  reasoning slot;
+- non-empty string continues to round-trip byte-for-byte.
+
+## Background
+
+DeepSeek V4 and other thinking-capable DeepSeek models can require assistant
+history to keep a `reasoning_content` field even when the field is empty.
+RARA previously filtered out empty `reasoning_content`, which collapsed
+`missing` and `present-but-empty` into the same state and caused later request
+construction to treat fresh assistant turns as legacy history.
+
+## Scope
+
+- Preserve empty `deepseek.reasoning_content` metadata in the OpenAI-compatible
+  response parser.
+- Replay explicit empty `reasoning_content` back to DeepSeek assistant history.
+- Keep true legacy DeepSeek assistant history on the existing fold-to-context
+  compatibility path.
+- Add focused regression coverage for non-streaming, streaming, and DeepSeek V4
+  history replay.
+
+## Key Decisions
+
+- The request-side DeepSeek fold path now keys off field presence instead of
+  non-empty content. Only truly missing `reasoning_content` counts as legacy.
+- Response parsing synthesizes empty DeepSeek reasoning metadata for assistant
+  turns that have visible text or tool calls but no explicit reasoning text.
+- Reasoning-only assistant turns still stay off the replay path because
+  request-side empty-assistant filtering continues to ignore metadata-only
+  messages.
+
+## Validation
+
+- `cargo test llm::tests::deepseek_visible_text_without_reasoning_content_synthesizes_empty_metadata -- --nocapture`
+- `cargo test llm::tests::deepseek_streaming_visible_text_without_reasoning_content_synthesizes_empty_metadata -- --nocapture`
+- `cargo test llm::tests::deepseek_v4_preserves_assistant_history_with_empty_reasoning_content -- --nocapture`
+- `cargo check`
+
+## Follow-Ups
+
+- None for the request/response contract itself. Future DeepSeek protocol work
+  should extend the same three-state handling if additional assistant metadata
+  becomes replay-critical.

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -1212,6 +1212,12 @@ pub(super) fn parse_chat_completion_response(
             content.push(ContentBlock::Text { text });
         }
     }
+    let has_standard_tool_calls = choice
+        .get("tool_calls")
+        .and_then(Value::as_array)
+        .is_some_and(|tool_calls| !tool_calls.is_empty());
+    let should_synthesize_empty_reasoning_slot =
+        !content.is_empty() || !parsed_dsml_tool_calls.is_empty() || has_standard_tool_calls;
     if endpoint_kind == OpenAiEndpointKind::Deepseek {
         if let Some(reasoning_content) = choice.get("reasoning_content").and_then(Value::as_str) {
             content.push(ContentBlock::ProviderMetadata {
@@ -1219,12 +1225,7 @@ pub(super) fn parse_chat_completion_response(
                 key: "reasoning_content".to_string(),
                 value: Value::String(reasoning_content.to_string()),
             });
-        } else if content.iter().any(|block| {
-            matches!(
-                block,
-                ContentBlock::Text { .. } | ContentBlock::ToolUse { .. }
-            )
-        }) {
+        } else if should_synthesize_empty_reasoning_slot {
             content.push(ContentBlock::ProviderMetadata {
                 provider: "deepseek".to_string(),
                 key: "reasoning_content".to_string(),
@@ -1304,6 +1305,9 @@ pub(super) fn build_streaming_response_content(
         });
     }
 
+    let should_synthesize_empty_reasoning_slot = !content.is_empty()
+        || !parsed_dsml_tool_calls.is_empty()
+        || !streamed_tool_calls.is_empty();
     if endpoint_kind == OpenAiEndpointKind::Deepseek {
         if !streamed_reasoning_content.is_empty() {
             content.push(ContentBlock::ProviderMetadata {
@@ -1311,12 +1315,7 @@ pub(super) fn build_streaming_response_content(
                 key: "reasoning_content".to_string(),
                 value: Value::String(streamed_reasoning_content),
             });
-        } else if content.iter().any(|block| {
-            matches!(
-                block,
-                ContentBlock::Text { .. } | ContentBlock::ToolUse { .. }
-            )
-        }) {
+        } else if should_synthesize_empty_reasoning_slot {
             content.push(ContentBlock::ProviderMetadata {
                 provider: "deepseek".to_string(),
                 key: "reasoning_content".to_string(),

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -772,10 +772,7 @@ fn schema_is_object(schema: &Value) -> bool {
 fn fold_deepseek_legacy_reasoning_history(openai_messages: Vec<Value>) -> Vec<Value> {
     let Some(last_legacy_assistant_idx) = openai_messages.iter().rposition(|message| {
         message.get("role").and_then(Value::as_str) == Some("assistant")
-            && !message
-                .get("reasoning_content")
-                .and_then(Value::as_str)
-                .is_some_and(|reasoning| !reasoning.is_empty())
+            && !assistant_has_deepseek_reasoning_slot(message)
     }) else {
         return openai_messages;
     };
@@ -806,6 +803,12 @@ fn fold_deepseek_legacy_reasoning_history(openai_messages: Vec<Value>) -> Vec<Va
     }
     folded.extend(openai_messages.into_iter().skip(fold_end + 1));
     folded
+}
+
+fn assistant_has_deepseek_reasoning_slot(message: &Value) -> bool {
+    message
+        .get("reasoning_content")
+        .is_some_and(Value::is_string)
 }
 
 fn deepseek_history_requires_reasoning_content(
@@ -1113,9 +1116,7 @@ fn provider_metadata_string<'a>(content: &'a Value, provider: &str, key: &str) -
         if item.get("key").and_then(Value::as_str) != Some(key) {
             return None;
         }
-        item.get("value")
-            .and_then(Value::as_str)
-            .filter(|value| !value.is_empty())
+        item.get("value").and_then(Value::as_str)
     })
 }
 
@@ -1211,17 +1212,25 @@ pub(super) fn parse_chat_completion_response(
             content.push(ContentBlock::Text { text });
         }
     }
-    if endpoint_kind == OpenAiEndpointKind::Deepseek
-        && let Some(reasoning_content) = choice
-            .get("reasoning_content")
-            .and_then(Value::as_str)
-            .filter(|value| !value.is_empty())
-    {
-        content.push(ContentBlock::ProviderMetadata {
-            provider: "deepseek".to_string(),
-            key: "reasoning_content".to_string(),
-            value: Value::String(reasoning_content.to_string()),
-        });
+    if endpoint_kind == OpenAiEndpointKind::Deepseek {
+        if let Some(reasoning_content) = choice.get("reasoning_content").and_then(Value::as_str) {
+            content.push(ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: Value::String(reasoning_content.to_string()),
+            });
+        } else if content.iter().any(|block| {
+            matches!(
+                block,
+                ContentBlock::Text { .. } | ContentBlock::ToolUse { .. }
+            )
+        }) {
+            content.push(ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: Value::String(String::new()),
+            });
+        }
     }
     if let Some(tool_calls) = choice["tool_calls"].as_array() {
         for (idx, tc) in tool_calls.iter().enumerate() {
@@ -1295,12 +1304,25 @@ pub(super) fn build_streaming_response_content(
         });
     }
 
-    if endpoint_kind == OpenAiEndpointKind::Deepseek && !streamed_reasoning_content.is_empty() {
-        content.push(ContentBlock::ProviderMetadata {
-            provider: "deepseek".to_string(),
-            key: "reasoning_content".to_string(),
-            value: Value::String(streamed_reasoning_content),
-        });
+    if endpoint_kind == OpenAiEndpointKind::Deepseek {
+        if !streamed_reasoning_content.is_empty() {
+            content.push(ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: Value::String(streamed_reasoning_content),
+            });
+        } else if content.iter().any(|block| {
+            matches!(
+                block,
+                ContentBlock::Text { .. } | ContentBlock::ToolUse { .. }
+            )
+        }) {
+            content.push(ContentBlock::ProviderMetadata {
+                provider: "deepseek".to_string(),
+                key: "reasoning_content".to_string(),
+                value: Value::String(String::new()),
+            });
+        }
     }
 
     for (idx, tc) in streamed_tool_calls.iter().enumerate() {

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -1446,13 +1446,20 @@ fn parses_visible_text_before_dsml_tool_calls_for_deepseek() {
     )
     .expect("parse response");
 
-    assert_eq!(response.content.len(), 2);
+    assert_eq!(response.content.len(), 3);
     assert!(matches!(
         &response.content[0],
         ContentBlock::Text { text } if text.contains("inspect the file")
     ));
     assert!(matches!(
         &response.content[1],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
+    ));
+    assert!(matches!(
+        &response.content[2],
         ContentBlock::ToolUse { id, name, input }
             if id == "dsml-tool-1"
                 && name == "read_file"

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -287,6 +287,102 @@ fn deepseek_visible_text_without_reasoning_content_synthesizes_empty_metadata() 
 }
 
 #[test]
+fn deepseek_tool_call_only_turn_synthesizes_empty_reasoning_content() {
+    let response = parse_chat_completion_response(
+        &json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"Cargo.toml\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        }),
+        OpenAiEndpointKind::Deepseek,
+    )
+    .expect("parse response");
+
+    assert_eq!(response.content.len(), 2);
+    assert!(matches!(
+        &response.content[0],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
+    ));
+    assert!(matches!(
+        &response.content[1],
+        ContentBlock::ToolUse { id, name, input }
+            if id == "call-1" && name == "read_file" && input["path"] == "Cargo.toml"
+    ));
+
+    let messages = vec![Message {
+        role: "assistant".to_string(),
+        content: serde_json::to_value(&response.content).expect("content json"),
+    }];
+    let deepseek_messages =
+        to_openai_messages_for_endpoint(&messages, OpenAiEndpointKind::Deepseek);
+    assert_eq!(deepseek_messages[0]["reasoning_content"], "");
+    assert_eq!(deepseek_messages[0]["tool_calls"][0]["id"], "call-1");
+}
+
+#[test]
+fn deepseek_dsml_tool_call_only_turn_synthesizes_empty_reasoning_content() {
+    let response = parse_chat_completion_response(
+        &json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": concat!(
+                        "<｜DSML｜tool_calls>\n",
+                        "<｜DSML｜invoke name=\"read_file\">\n",
+                        "<｜DSML｜parameter name=\"path\" string=\"true\">Cargo.toml</｜DSML｜parameter>\n",
+                        "</｜DSML｜invoke>\n",
+                        "</｜DSML｜tool_calls>"
+                    )
+                },
+                "finish_reason": "tool_calls"
+            }]
+        }),
+        OpenAiEndpointKind::Deepseek,
+    )
+    .expect("parse response");
+
+    assert_eq!(response.content.len(), 2);
+    assert!(matches!(
+        &response.content[0],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
+    ));
+    assert!(matches!(
+        &response.content[1],
+        ContentBlock::ToolUse { id, name, input }
+            if id == "dsml-tool-1"
+                && name == "read_file"
+                && input["path"] == "Cargo.toml"
+    ));
+
+    let messages = vec![Message {
+        role: "assistant".to_string(),
+        content: serde_json::to_value(&response.content).expect("content json"),
+    }];
+    let deepseek_messages =
+        to_openai_messages_for_endpoint(&messages, OpenAiEndpointKind::Deepseek);
+    assert_eq!(deepseek_messages[0]["reasoning_content"], "");
+    assert_eq!(deepseek_messages[0]["tool_calls"][0]["id"], "dsml-tool-1");
+}
+
+#[test]
 fn deepseek_raw_leading_think_block_is_not_visible_text() {
     let response = parse_chat_completion_response(
         &json!({
@@ -556,6 +652,73 @@ fn deepseek_streaming_visible_text_without_reasoning_content_synthesizes_empty_m
             if provider == "deepseek"
                 && key == "reasoning_content"
                 && value == ""
+    ));
+}
+
+#[test]
+fn deepseek_streaming_tool_call_only_turn_synthesizes_empty_reasoning_content() {
+    let content = build_streaming_response_content(
+        OpenAiEndpointKind::Deepseek,
+        String::new(),
+        String::new(),
+        &[json!({
+            "id": "stream-call-1",
+            "function": {
+                "name": "read_file",
+                "arguments": "{\"path\":\"Cargo.toml\"}"
+            }
+        })],
+    )
+    .expect("build streaming content");
+
+    assert_eq!(content.len(), 2);
+    assert!(matches!(
+        &content[0],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
+    ));
+    assert!(matches!(
+        &content[1],
+        ContentBlock::ToolUse { id, name, input }
+            if id == "stream-call-1"
+                && name == "read_file"
+                && input["path"] == "Cargo.toml"
+    ));
+}
+
+#[test]
+fn deepseek_streaming_dsml_tool_call_only_turn_synthesizes_empty_reasoning_content() {
+    let content = build_streaming_response_content(
+        OpenAiEndpointKind::Deepseek,
+        concat!(
+            "<｜DSML｜tool_calls>\n",
+            "<｜DSML｜invoke name=\"read_file\">\n",
+            "<｜DSML｜parameter name=\"path\" string=\"true\">Cargo.toml</｜DSML｜parameter>\n",
+            "</｜DSML｜invoke>\n",
+            "</｜DSML｜tool_calls>"
+        )
+        .to_string(),
+        String::new(),
+        &[],
+    )
+    .expect("build streaming content");
+
+    assert_eq!(content.len(), 2);
+    assert!(matches!(
+        &content[0],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
+    ));
+    assert!(matches!(
+        &content[1],
+        ContentBlock::ToolUse { id, name, input }
+            if id == "dsml-tool-1"
+                && name == "read_file"
+                && input["path"] == "Cargo.toml"
     ));
 }
 

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -1576,9 +1576,16 @@ fn parses_dsml_tool_calls_from_text_content() {
     )
     .expect("parse response");
 
-    assert_eq!(response.content.len(), 1);
+    assert_eq!(response.content.len(), 2);
     assert!(matches!(
         &response.content[0],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
+    ));
+    assert!(matches!(
+        &response.content[1],
         ContentBlock::ToolUse { id, name, input }
             if id == "dsml-tool-1"
                 && name == "apply_patch"

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -248,6 +248,45 @@ fn deepseek_reasoning_content_roundtrips_as_provider_metadata() {
 }
 
 #[test]
+fn deepseek_visible_text_without_reasoning_content_synthesizes_empty_metadata() {
+    let response = parse_chat_completion_response(
+        &json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Visible answer"
+                },
+                "finish_reason": "stop"
+            }]
+        }),
+        OpenAiEndpointKind::Deepseek,
+    )
+    .expect("parse response");
+
+    assert_eq!(response.content.len(), 2);
+    assert!(matches!(
+        &response.content[0],
+        ContentBlock::Text { text } if text == "Visible answer"
+    ));
+    assert!(matches!(
+        &response.content[1],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
+    ));
+
+    let messages = vec![Message {
+        role: "assistant".to_string(),
+        content: serde_json::to_value(&response.content).expect("content json"),
+    }];
+    let deepseek_messages =
+        to_openai_messages_for_endpoint(&messages, OpenAiEndpointKind::Deepseek);
+    assert_eq!(deepseek_messages[0]["reasoning_content"], "");
+    assert_eq!(deepseek_messages[0]["content"], "Visible answer");
+}
+
+#[test]
 fn deepseek_raw_leading_think_block_is_not_visible_text() {
     let response = parse_chat_completion_response(
         &json!({
@@ -263,11 +302,18 @@ fn deepseek_raw_leading_think_block_is_not_visible_text() {
     )
     .expect("parse response");
 
-    assert_eq!(response.content.len(), 1);
+    assert_eq!(response.content.len(), 2);
     assert!(matches!(
         &response.content[0],
         ContentBlock::Text { text }
             if text.trim() == "Visible answer." && !text.contains("private reasoning")
+    ));
+    assert!(matches!(
+        &response.content[1],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
     ));
 }
 
@@ -287,10 +333,17 @@ fn deepseek_endpoint_preserves_literal_leading_think_without_control_evidence() 
     )
     .expect("parse response");
 
-    assert_eq!(response.content.len(), 1);
+    assert_eq!(response.content.len(), 2);
     assert!(matches!(
         &response.content[0],
         ContentBlock::Text { text } if text == "<think>inner</think> is an XML example."
+    ));
+    assert!(matches!(
+        &response.content[1],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
     ));
 }
 
@@ -483,6 +536,30 @@ fn deepseek_streaming_reasoning_content_preserves_exact_bytes() {
 }
 
 #[test]
+fn deepseek_streaming_visible_text_without_reasoning_content_synthesizes_empty_metadata() {
+    let content = build_streaming_response_content(
+        OpenAiEndpointKind::Deepseek,
+        "Visible answer".to_string(),
+        String::new(),
+        &[],
+    )
+    .expect("build streaming content");
+
+    assert_eq!(content.len(), 2);
+    assert!(matches!(
+        &content[0],
+        ContentBlock::Text { text } if text == "Visible answer"
+    ));
+    assert!(matches!(
+        &content[1],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
+    ));
+}
+
+#[test]
 fn deepseek_reasoner_defaults_preserve_standard_body() {
     let body = build_chat_completion_request_body(
         "deepseek-reasoner",
@@ -628,6 +705,39 @@ fn deepseek_v4_defaults_fold_legacy_tool_results_without_reasoning_content() {
             .as_str()
             .is_some_and(|content| content.contains("tool_results_available"))
     );
+}
+
+#[test]
+fn deepseek_v4_preserves_assistant_history_with_empty_reasoning_content() {
+    let body = build_chat_completion_request_body(
+        "deepseek-v4-pro",
+        &[
+            Message {
+                role: "assistant".to_string(),
+                content: json!([
+                    {"type":"text","text":"Visible answer"},
+                    {"type":"provider_metadata","provider":"deepseek","key":"reasoning_content","value":""}
+                ]),
+            },
+            Message {
+                role: "user".to_string(),
+                content: json!([{"type":"text","text":"Continue."}]),
+            },
+        ],
+        &[],
+        OpenAiEndpointKind::Deepseek,
+        None,
+        None,
+        LlmTurnMetadata::default(),
+    );
+
+    let messages = body["messages"].as_array().expect("messages");
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0]["role"], "assistant");
+    assert_eq!(messages[0]["content"], "Visible answer");
+    assert_eq!(messages[0]["reasoning_content"], "");
+    assert_eq!(messages[1]["role"], "user");
+    assert_eq!(messages[1]["content"], "Continue.");
 }
 
 #[test]
@@ -1189,11 +1299,18 @@ fn deepseek_streaming_raw_leading_think_block_is_not_visible_text() {
     )
     .expect("build streaming content");
 
-    assert_eq!(content.len(), 1);
+    assert_eq!(content.len(), 2);
     assert!(matches!(
         &content[0],
         ContentBlock::Text { text }
             if text.trim() == "Visible answer." && !text.contains("private reasoning")
+    ));
+    assert!(matches!(
+        &content[1],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
     ));
 }
 
@@ -1207,10 +1324,17 @@ fn deepseek_streaming_preserves_literal_leading_think_without_control_evidence()
     )
     .expect("build streaming content");
 
-    assert_eq!(content.len(), 1);
+    assert_eq!(content.len(), 2);
     assert!(matches!(
         &content[0],
         ContentBlock::Text { text } if text == "<think>inner</think> is an XML example."
+    ));
+    assert!(matches!(
+        &content[1],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
     ));
 }
 
@@ -1359,13 +1483,20 @@ fn parses_ascii_pipe_dsml_tool_calls_for_deepseek_pdf_compatibility() {
     )
     .expect("parse response");
 
-    assert_eq!(response.content.len(), 2);
+    assert_eq!(response.content.len(), 3);
     assert!(matches!(
         &response.content[0],
         ContentBlock::Text { text } if text.contains("inspect the directory")
     ));
     assert!(matches!(
         &response.content[1],
+        ContentBlock::ProviderMetadata { provider, key, value }
+            if provider == "deepseek"
+                && key == "reasoning_content"
+                && value == ""
+    ));
+    assert!(matches!(
+        &response.content[2],
         ContentBlock::ToolUse { id, name, input }
             if id == "dsml-tool-1" && name == "list_files" && input["path"] == "src"
     ));


### PR DESCRIPTION
## Summary

- preserve DeepSeek assistant `reasoning_content` as a three-state history slot
- replay explicit empty `reasoning_content: ""` back to DeepSeek requests
- keep true legacy DeepSeek assistant history on the existing fold-to-context path
- align the DSML parsing regression tests with the new empty-slot contract

## Why

RARA previously filtered out empty `reasoning_content`, which collapsed
`missing` and `present-but-empty` into the same state. For DeepSeek thinking
models this meant a fresh assistant turn with an explicit empty reasoning slot
could later be treated as legacy history during request replay.

This PR supersedes `#407`, which was opened from the wrong base branch and
accidentally included unrelated memory and embedding changes.

## Testing

- `cargo fmt --all`
- `cargo test parses_visible_text_before_dsml_tool_calls_for_deepseek -- --nocapture`
- `cargo test deepseek_ -- --nocapture`
- `cargo check`

## Docs

- update `docs/features/openai-compatible-model-config.md`
- add `docs/journal/2026-05-13-deepseek-empty-reasoning-history.md`
