### PR TITLE
feat(tools): preserve read_file metadata after compaction and add grep context_lines

### DIFF
--- a/crates/rara-tools/src/search.rs
+++ b/crates/rara-tools/src/search.rs
@@ -71,15 +71,15 @@ impl Tool for GrepTool {
         {
             if entry.file_type().is_file() {
                 if let Ok(c) = fs::read_to_string(entry.path()) {
-                    let all_lines: Vec<&str> = c.lines().collect();
-                    for (line_idx, line) in all_lines.iter().enumerate() {
-                        if re.is_match(line) {
-                            let mut entry_json = json!({
-                                "file": entry.path().display().to_string(),
-                                "line": line_idx + 1,
-                                "content": line.trim()
-                            });
-                            if context_lines > 0 {
+                    if context_lines > 0 {
+                        let all_lines: Vec<&str> = c.lines().collect();
+                        for (line_idx, line) in all_lines.iter().enumerate() {
+                            if re.is_match(line) {
+                                let mut entry_json = json!({
+                                    "file": entry.path().display().to_string(),
+                                    "line": line_idx + 1,
+                                    "content": line.trim()
+                                });
                                 let start = line_idx.saturating_sub(context_lines);
                                 let end = (line_idx + context_lines + 1).min(all_lines.len());
                                 let context: Vec<serde_json::Value> = (start..end)
@@ -91,8 +91,18 @@ impl Tool for GrepTool {
                                     })
                                     .collect();
                                 entry_json["context"] = json!(context);
+                                results.push(entry_json);
                             }
-                            results.push(entry_json);
+                        }
+                    } else {
+                        for (line_idx, line) in c.lines().enumerate() {
+                            if re.is_match(line) {
+                                results.push(json!({
+                                    "file": entry.path().display().to_string(),
+                                    "line": line_idx + 1,
+                                    "content": line.trim()
+                                }));
+                            }
                         }
                     }
                 }

--- a/crates/rara-tools/src/search.rs
+++ b/crates/rara-tools/src/search.rs
@@ -44,7 +44,8 @@ pub struct GrepTool;
         "properties": {
             "pattern": { "type": "string" },
             "path": { "type": "string", "default": "." },
-            "include_ignored": { "type": "boolean", "default": false }
+            "include_ignored": { "type": "boolean", "default": false },
+            "context_lines": { "type": "integer", "minimum": 0, "default": 0, "description": "Number of surrounding context lines to include per match." }
         },
         "required": ["pattern"]
     }
@@ -60,6 +61,7 @@ impl Tool for GrepTool {
             .get("include_ignored")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let context_lines = i.get("context_lines").and_then(Value::as_u64).unwrap_or(0) as usize;
         let re = Regex::new(p).map_err(|e| ToolError::InvalidInput(e.to_string()))?;
         let mut results = Vec::new();
         for entry in walkdir::WalkDir::new(search_path)
@@ -69,9 +71,28 @@ impl Tool for GrepTool {
         {
             if entry.file_type().is_file() {
                 if let Ok(c) = fs::read_to_string(entry.path()) {
-                    for (line_idx, line) in c.lines().enumerate() {
+                    let all_lines: Vec<&str> = c.lines().collect();
+                    for (line_idx, line) in all_lines.iter().enumerate() {
                         if re.is_match(line) {
-                            results.push(json!({ "file": entry.path().display().to_string(), "line": line_idx + 1, "content": line.trim() }));
+                            let mut entry_json = json!({
+                                "file": entry.path().display().to_string(),
+                                "line": line_idx + 1,
+                                "content": line.trim()
+                            });
+                            if context_lines > 0 {
+                                let start = line_idx.saturating_sub(context_lines);
+                                let end = (line_idx + context_lines + 1).min(all_lines.len());
+                                let context: Vec<serde_json::Value> = (start..end)
+                                    .map(|i| {
+                                        json!({
+                                            "line": i + 1,
+                                            "text": all_lines[i]
+                                        })
+                                    })
+                                    .collect();
+                                entry_json["context"] = json!(context);
+                            }
+                            results.push(entry_json);
                         }
                     }
                 }

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -533,11 +533,51 @@ fn compact_read_file(input: &Value, result: &Value) -> String {
     let total_chars = content.chars().count();
     let preview = truncate_text(content, INLINE_CHAR_BUDGET.min(LARGE_PREVIEW_HEAD));
     let summary = summarize_tool_result("read_file", input, result);
-    if preview.chars().count() < total_chars {
-        format!("{summary}\nContent preview:\n{preview}\n... truncated.")
+    let metadata = read_file_metadata_line(result);
+    let body = if preview.chars().count() < total_chars {
+        format!("Content preview:\n{preview}\n... truncated.")
     } else {
-        format!("{summary}\nContent:\n{preview}")
-    }
+        format!("Content:\n{preview}")
+    };
+    format!("{summary}\n{metadata}\n{body}")
+}
+
+fn read_file_metadata_line(result: &Value) -> String {
+    let start = result
+        .get("start_line")
+        .and_then(Value::as_u64)
+        .unwrap_or(1);
+    let end = result.get("end_line").and_then(Value::as_u64).unwrap_or(0);
+    let next = result
+        .get("next_offset")
+        .and_then(Value::as_u64)
+        .map(|n| format!("{n}"))
+        .unwrap_or_else(|| "none".to_string());
+    let total = if result
+        .get("total_lines_exact")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        format!(
+            "{}",
+            result
+                .get("total_lines")
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        )
+    } else {
+        format!(
+            "{}",
+            result
+                .get("observed_lines")
+                .and_then(Value::as_u64)
+                .map(|n| format!("{n}+"))
+                .unwrap_or_else(|| "?".to_string())
+        )
+    };
+    format!(
+        "[file size] start_line={start}, end_line={end}, next_offset={next}, total_lines={total}"
+    )
 }
 
 fn compact_glob(result: &Value) -> String {
@@ -582,7 +622,15 @@ fn compact_grep(result: &Value) -> String {
                 .get("content")
                 .and_then(Value::as_str)
                 .unwrap_or_default();
-            format!("{file}:{line}: {content}")
+            let ctx_hint = entry
+                .get("context")
+                .and_then(Value::as_array)
+                .filter(|a| !a.is_empty())
+                .map(|a| format!(" (+{} context lines)", a.len()));
+            format!(
+                "{file}:{line}: {content}{}",
+                ctx_hint.as_deref().unwrap_or("")
+            )
         })
         .collect::<Vec<_>>()
         .join("\n");

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -298,7 +298,7 @@ pub fn project_tool_results_for_context(
         if content == MICROCOMPACT_CLEARED_MESSAGE {
             continue;
         }
-        let replacement = microcompact_cleared_tool_result(&candidate.tool_name);
+        let replacement = microcompact_cleared_tool_result(&candidate.tool_name, content);
         projected_chars = projected_chars
             .saturating_sub(candidate.chars)
             .saturating_add(replacement.chars().count());
@@ -399,10 +399,50 @@ fn is_microcompactable_tool(name: &str) -> bool {
     )
 }
 
-fn microcompact_cleared_tool_result(tool_name: &str) -> String {
-    format!(
-        "{MICROCOMPACT_CLEARED_MESSAGE}\ntool={tool_name}\nreason=older compactable tool results exceeded the per-request projection budget; original transcript remains unchanged"
-    )
+fn microcompact_cleared_tool_result(tool_name: &str, original_content: &str) -> String {
+    let mut lines = vec![
+        format!("{MICROCOMPACT_CLEARED_MESSAGE}"),
+        format!("tool={tool_name}"),
+        "reason=older compactable tool results exceeded the per-request projection budget; original transcript remains unchanged".to_string(),
+    ];
+    if tool_name == "read_file" {
+        if let Some(meta) = read_file_marker_lines(original_content) {
+            lines.push(meta);
+        }
+    }
+    lines.join("\n")
+}
+
+fn read_file_marker_lines(raw_json: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(raw_json).ok()?;
+    let start = v.get("start_line").and_then(|x| x.as_u64()).unwrap_or(1);
+    let end = v.get("end_line").and_then(|x| x.as_u64()).unwrap_or(0);
+    let next = v
+        .get("next_offset")
+        .and_then(|x| x.as_u64())
+        .map(|n| format!("{n}"))
+        .unwrap_or_else(|| "none".to_string());
+    let total = if v
+        .get("total_lines_exact")
+        .and_then(|x| x.as_bool())
+        .unwrap_or(false)
+    {
+        format!(
+            "{}",
+            v.get("total_lines").and_then(|x| x.as_u64()).unwrap_or(0)
+        )
+    } else {
+        format!(
+            "{}",
+            v.get("observed_lines")
+                .and_then(|x| x.as_u64())
+                .map(|n| format!("{n}+"))
+                .unwrap_or_else(|| "?".to_string())
+        )
+    };
+    Some(format!(
+        "[file size] start_line={start}, end_line={end}, next_offset={next}, total_lines={total}"
+    ))
 }
 
 #[derive(Debug)]

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -406,43 +406,14 @@ fn microcompact_cleared_tool_result(tool_name: &str, original_content: &str) -> 
         "reason=older compactable tool results exceeded the per-request projection budget; original transcript remains unchanged".to_string(),
     ];
     if tool_name == "read_file" {
-        if let Some(meta) = read_file_marker_lines(original_content) {
-            lines.push(meta);
+        if let Some(meta) = original_content
+            .lines()
+            .find(|l| l.starts_with("[file size]"))
+        {
+            lines.push(meta.to_string());
         }
     }
     lines.join("\n")
-}
-
-fn read_file_marker_lines(raw_json: &str) -> Option<String> {
-    let v: serde_json::Value = serde_json::from_str(raw_json).ok()?;
-    let start = v.get("start_line").and_then(|x| x.as_u64()).unwrap_or(1);
-    let end = v.get("end_line").and_then(|x| x.as_u64()).unwrap_or(0);
-    let next = v
-        .get("next_offset")
-        .and_then(|x| x.as_u64())
-        .map(|n| format!("{n}"))
-        .unwrap_or_else(|| "none".to_string());
-    let total = if v
-        .get("total_lines_exact")
-        .and_then(|x| x.as_bool())
-        .unwrap_or(false)
-    {
-        format!(
-            "{}",
-            v.get("total_lines").and_then(|x| x.as_u64()).unwrap_or(0)
-        )
-    } else {
-        format!(
-            "{}",
-            v.get("observed_lines")
-                .and_then(|x| x.as_u64())
-                .map(|n| format!("{n}+"))
-                .unwrap_or_else(|| "?".to_string())
-        )
-    };
-    Some(format!(
-        "[file size] start_line={start}, end_line={end}, next_offset={next}, total_lines={total}"
-    ))
 }
 
 #[derive(Debug)]
@@ -596,7 +567,7 @@ fn read_file_metadata_line(result: &Value) -> String {
     let total = if result
         .get("total_lines_exact")
         .and_then(Value::as_bool)
-        .unwrap_or(false)
+        .unwrap_or(true)
     {
         format!(
             "{}",


### PR DESCRIPTION
## Summary

Two tool-layer optimizations that reduce round-trips between the model and the
runtime, aligning with Codex and Claude Code patterns.

## Changes

### 1. read_file metadata survives microcompact

Before: when the microcompact projection cleared a `read_file` result, the
model lost all line-range metadata:

```
[tool result cleared]
tool=read_file
reason=older compactable tool results exceeded budget
```

The model had to re-read with blind offset guesses.

After: metadata is extracted before replacement and appended:

```
[tool result cleared]
tool=read_file
reason=older compactable tool results exceeded budget
[file size] start_line=401, end_line=600, next_offset=601, total_lines=1287
```

This matches Codex and Claude Code patterns where structural metadata survives
compaction.

Both paths are fixed:
- `compact_read_file` (ToolResultStore stored-result summary)
- `microcompact_cleared_tool_result` (per-request projection)

### 2. GrepTool gains optional `context_lines` parameter

When `context_lines > 0`, each match result includes surrounding source lines
in a `context` array, removing the need for a follow-up `read_file` to
understand the match site.

```json
{ "file": "src/agent.rs", "line": 1159, "content": "...", "context": [{"line": 1154, "text": "..."}, ...] }
```

`compact_grep` shows a context-line count hint when context is present.

## Files

| File | Change |
|---|---|
| `crates/rara-tools/src/search.rs` | +27, GrepTool context_lines |
| `src/tool_result.rs` | +108, compact_read_file and microcompact metadata |

## Verification

- `cargo check -p rara-tools` — passed (only pre-existing dead_code warnings)
- `cargo fmt` — passed