### PR TITLE
feat: auto-prune idle PTY sessions

### DIFF
--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -110,28 +110,69 @@ impl PtySessionStore {
         }
         let now = Instant::now();
         let idle_cutoff = Duration::from_secs(PTY_IDLE_PRUNE_SECS);
-        let mut idle_ids: Vec<(String, Instant)> = sessions
+
+        // Collect (id, last_read, has_exited) for all sessions
+        let mut meta: Vec<(String, Instant, bool)> = sessions
             .iter()
-            .filter(|(_, s)| {
-                matches!(
+            .map(|(id, s)| {
+                let exited = !matches!(
                     *s.status.lock().expect("pty status lock"),
                     PtySessionStatus::Running
-                ) && now.duration_since(s.last_read) >= idle_cutoff
+                );
+                (id.clone(), s.last_read, exited)
             })
-            .map(|(id, s)| (id.clone(), s.last_read))
             .collect();
-        idle_ids.sort_by_key(|(_, last)| *last);
+
+        // Protect the 8 most recently read sessions
+        let mut by_recency = meta.clone();
+        by_recency.sort_by_key(|(_, last, _)| std::cmp::Reverse(*last));
+        let protected: std::collections::HashSet<&str> = by_recency
+            .iter()
+            .take(8)
+            .map(|(id, _, _)| id.as_str())
+            .collect();
+
+        // Idle = not read recently
+        let is_idle = |last: Instant| now.duration_since(last) >= idle_cutoff;
+
+        // Phase 1: prefer idle + exited
+        let mut by_lru = meta.clone();
+        by_lru.sort_by_key(|(_, last, _)| *last);
         let excess = count.saturating_sub(MAX_PTY_SESSIONS - 1);
-        idle_ids.truncate(excess);
-        let pruned = idle_ids.len();
-        drop(sessions);
-        for (id, _) in idle_ids {
-            let sessions = self.sessions.lock().expect("pty session store lock");
-            if let Some(session) = sessions.get(&id) {
-                let mut status = session.status.lock().expect("pty status lock");
-                if matches!(*status, PtySessionStatus::Running) {
-                    *status = PtySessionStatus::Killed;
+
+        let to_prune: Vec<String> = by_lru
+            .iter()
+            .filter(|(id, last, exited)| {
+                !protected.contains(id.as_str()) && *exited && is_idle(*last)
+            })
+            .take(excess)
+            .map(|(id, _, _)| id.clone())
+            .collect();
+
+        // Phase 2: if not enough exited, also prune idle running sessions
+        let to_prune = if to_prune.len() < excess {
+            let need_more = excess - to_prune.len();
+            let mut result = to_prune;
+            for (id, last, _) in &by_lru {
+                if result.len() >= excess {
+                    break;
                 }
+                if !protected.contains(id.as_str()) && is_idle(*last) && !result.contains(id) {
+                    result.push(id.clone());
+                }
+            }
+            result
+        } else {
+            to_prune
+        };
+
+        let pruned = to_prune.len();
+        drop(sessions);
+        for id in &to_prune {
+            let sessions = self.sessions.lock().expect("pty session store lock");
+            if let Some(session) = sessions.get(id) {
+                let mut status = session.status.lock().expect("pty status lock");
+                *status = PtySessionStatus::Killed;
             }
         }
         pruned

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -140,39 +140,37 @@ impl PtySessionStore {
         by_lru.sort_by_key(|(_, last, _)| *last);
         let excess = count.saturating_sub(MAX_PTY_SESSIONS - 1);
 
-        let to_prune: Vec<String> = by_lru
-            .iter()
-            .filter(|(id, last, exited)| {
-                !protected.contains(id.as_str()) && *exited && is_idle(*last)
-            })
-            .take(excess)
-            .map(|(id, _, _)| id.clone())
-            .collect();
+        let mut to_prune = Vec::with_capacity(excess);
+        let mut idle_running_candidates = Vec::new();
 
-        // Phase 2: if not enough exited, also prune idle running sessions
-        let to_prune = if to_prune.len() < excess {
-            let need_more = excess - to_prune.len();
-            let mut result = to_prune;
-            for (id, last, _) in &by_lru {
-                if result.len() >= excess {
-                    break;
-                }
-                if !protected.contains(id.as_str()) && is_idle(*last) && !result.contains(id) {
-                    result.push(id.clone());
+        for (id, last, exited) in &by_lru {
+            if !protected.contains(id.as_str()) && is_idle(*last) {
+                if *exited {
+                    to_prune.push(id.clone());
+                } else {
+                    idle_running_candidates.push(id.clone());
                 }
             }
-            result
+        }
+
+        if to_prune.len() < excess {
+            let needed = excess - to_prune.len();
+            to_prune.extend(idle_running_candidates.into_iter().take(needed));
         } else {
-            to_prune
-        };
+            to_prune.truncate(excess);
+        }
 
         let pruned = to_prune.len();
         drop(sessions);
-        for id in &to_prune {
-            let sessions = self.sessions.lock().expect("pty session store lock");
-            if let Some(session) = sessions.get(id) {
-                let mut status = session.status.lock().expect("pty status lock");
-                *status = PtySessionStatus::Killed;
+        if !to_prune.is_empty() {
+            if let Ok(sessions) = self.sessions.lock() {
+                for id in &to_prune {
+                    if let Some(session) = sessions.get(id) {
+                        if let Ok(mut status) = session.status.lock() {
+                            *status = PtySessionStatus::Killed;
+                        }
+                    }
+                }
             }
         }
         pruned

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -1280,6 +1280,7 @@ mod tests {
             child: Arc::new(Mutex::new(Box::new(FailingKillChild))),
             child_pid: None,
             status,
+            last_read: Instant::now(),
         };
         sessions
             .sessions

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -21,6 +21,8 @@ use crate::sandbox::{SandboxManager, WrappedCommand, sandbox_failure_hint};
 
 const PTY_START_QUICK_COMPLETION_TIMEOUT: Duration = Duration::from_millis(750);
 const PTY_START_QUICK_COMPLETION_POLL: Duration = Duration::from_millis(25);
+const MAX_PTY_SESSIONS: usize = 15;
+const PTY_IDLE_PRUNE_SECS: u64 = 120;
 
 pub struct PtyStartTool {
     pub sessions: Arc<PtySessionStore>,
@@ -69,6 +71,7 @@ struct PtySessionRecord {
     child: Arc<Mutex<Box<dyn portable_pty::Child + Send + Sync>>>,
     child_pid: Option<u32>,
     status: Arc<Mutex<PtySessionStatus>>,
+    last_read: Instant,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -99,6 +102,41 @@ impl PtySessionStore {
         })
     }
 
+    fn prune_idle_sessions(&self) -> usize {
+        let sessions = self.sessions.lock().expect("pty session store lock");
+        let count = sessions.len();
+        if count < MAX_PTY_SESSIONS {
+            return 0;
+        }
+        let now = Instant::now();
+        let idle_cutoff = Duration::from_secs(PTY_IDLE_PRUNE_SECS);
+        let mut idle_ids: Vec<(String, Instant)> = sessions
+            .iter()
+            .filter(|(_, s)| {
+                matches!(
+                    *s.status.lock().expect("pty status lock"),
+                    PtySessionStatus::Running
+                ) && now.duration_since(s.last_read) >= idle_cutoff
+            })
+            .map(|(id, s)| (id.clone(), s.last_read))
+            .collect();
+        idle_ids.sort_by_key(|(_, last)| *last);
+        let excess = count.saturating_sub(MAX_PTY_SESSIONS - 1);
+        idle_ids.truncate(excess);
+        let pruned = idle_ids.len();
+        drop(sessions);
+        for (id, _) in idle_ids {
+            let sessions = self.sessions.lock().expect("pty session store lock");
+            if let Some(session) = sessions.get(&id) {
+                let mut status = session.status.lock().expect("pty status lock");
+                if matches!(*status, PtySessionStatus::Running) {
+                    *status = PtySessionStatus::Killed;
+                }
+            }
+        }
+        pruned
+    }
+
     fn start(
         &self,
         command: String,
@@ -111,6 +149,7 @@ impl PtySessionStore {
     ) -> Result<PtySessionSnapshot, ToolError> {
         let id = format!("pty-{}", Uuid::new_v4());
         let output_path = self.dir.join(format!("{id}.log"));
+        self.prune_idle_sessions();
         let pty_system = NativePtySystem::default();
         let pair = pty_system
             .openpty(PtySize {
@@ -194,6 +233,7 @@ impl PtySessionStore {
             child,
             child_pid,
             status,
+            last_read: Instant::now(),
         };
         let snapshot = record.snapshot();
         self.sessions
@@ -207,8 +247,11 @@ impl PtySessionStore {
         self.sessions
             .lock()
             .expect("pty session store lock")
-            .get(id)
-            .map(PtySessionRecord::snapshot)
+            .get_mut(id)
+            .map(|record| {
+                record.last_read = Instant::now();
+                record.snapshot()
+            })
     }
 
     async fn wait_for_quick_completion(&self, id: &str, timeout: Duration) -> PtySessionSnapshot {


### PR DESCRIPTION
## Summary

Prevent fd exhaustion from leaked PTY sessions. Aligned with Codex's `prune_processes_if_needed` strategy.

### Algorithm

- **Hard cap**: 15 sessions
- **Phase 1**: prefer killing idle sessions whose child process has already exited
- **Phase 2**: kill idle running sessions if not enough exited ones
- **Protect 8 most recently read**: never prune recently-used sessions
- **Idle cutoff**: 120s without a read
- **Triggers on every pty_start**

### Verification

```
cargo check → passes (pre-existing warnings only)
```