### PR TITLE
feat(memory): show memory action notices

### DIFF
--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -310,6 +310,13 @@ fail the request instead of being silently persisted.
 string fields and integer importance basis points so ACP/Wire adapters do not
 depend on internal Rust enums or floating-point formatting.
 
+Memory activity that affects the local agent turn must also produce a
+content-free TUI notice. Query notices may expose the operation and result
+count, and write notices may expose the operation and shortened record id, but
+they must not render stored memory content, query text, or titles in the
+transcript. Automatic workspace-memory retrieval and session checkpoint writes
+use the same notice style as protocol memory-control events.
+
 ### Hook Declaration
 
 External applications may declare hooks for lifecycle points such as:
@@ -511,6 +518,8 @@ adapters.
 - Permission and sandbox policy cannot be bypassed by third-party control.
 - Control events are the shared output surface for TUI, ACP, Wire, and headless
   evaluation.
+- TUI memory notices are transient transcript entries. They are observability
+  hints, not durable memory records.
 - Features that add user-visible state must define whether that state is
   persisted, compacted, or transient.
 
@@ -524,6 +533,8 @@ adapters.
 - Tests proving protocol skill sources follow normal precedence and override
   reporting.
 - Tests proving memory writes cannot bypass `MemorySelection`.
+- TUI tests proving memory action notices render without leaking record
+  content.
 - ACP adapter tests for prompt, cancellation, and output events once the adapter
   is wired.
 - Wire adapter tests should reuse the same control-plane fixtures.
@@ -544,3 +555,4 @@ adapters.
 - [2026-05-01-skilltool-and-verify-specs](../journal/2026-05-01-skilltool-and-verify-specs.md)
 - [2026-05-01-memory-selection-spec](../journal/2026-05-01-memory-selection-spec.md)
 - [2026-05-01-tui-modular-queued-follow-up](../journal/2026-05-01-tui-modular-queued-follow-up.md)
+- [2026-05-13-memory-action-notices](../journal/2026-05-13-memory-action-notices.md)

--- a/docs/journal/2026-05-13-memory-action-notices.md
+++ b/docs/journal/2026-05-13-memory-action-notices.md
@@ -1,0 +1,31 @@
+# Memory Action Notices
+
+## What changed
+
+- Added transient TUI notices for automatic workspace-memory retrieval before a
+  model turn.
+- Added a transient TUI notice after a session checkpoint is written to memory.
+- Mapped memory-control events to transcript notices for record writes, record
+  updates, record deletes, label listing, metadata queries, record queries, and
+  selection refreshes.
+- Kept memory notices content-free: they expose operation names and counts, not
+  stored memory content or query text.
+
+## Why
+
+Memory already affects prompt assembly and session continuity, but the TUI did
+not show when the runtime queried or wrote memory. A short action notice gives
+the operator the same kind of traceability as tool activity without treating
+memory operations as tool calls.
+
+## Trade-offs
+
+The notice text is intentionally small and transient. It is useful for local
+observability, but it is not a durable audit log and should not become the
+source of truth for memory state. Detailed memory state remains available
+through the memory store and control-plane events.
+
+## Remaining work
+
+- Consider grouping repeated memory notices if retrieval and write activity
+  becomes too noisy during multi-turn tool loops.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -107,6 +107,9 @@ pub enum AgentEvent {
         stream: ToolOutputStream,
         chunk: String,
     },
+    MemoryAction {
+        message: String,
+    },
     McpStatusUpdated(McpStatusSnapshot),
     McpStatusLoadFailed {
         message: String,
@@ -360,7 +363,17 @@ impl Agent {
             content: json!([{"type": "text", "text": prompt.clone()}]),
         });
         self.checkpoint_session()?;
+        report(AgentEvent::MemoryAction {
+            message: "Memory · querying workspace memory".to_string(),
+        });
         self.refresh_memory_retrieval_candidates().await;
+        report(AgentEvent::MemoryAction {
+            message: format!(
+                "Memory · queried workspace memory: {} {}",
+                self.retrieved_memory_candidates.len(),
+                memory_count_label("candidate", self.retrieved_memory_candidates.len())
+            ),
+        });
         self.refresh_file_search_candidates();
         self.refresh_protocol_prompt_sources_for_query().await;
         self.refresh_protocol_skill_sources_for_query().await;
@@ -404,7 +417,7 @@ impl Agent {
         {
             let session_manager = self.session_manager.clone();
             let session_id = self.session_id.clone();
-            let _ = tokio::task::spawn_blocking(move || {
+            let save_result = tokio::task::spawn_blocking(move || {
                 session_manager.save_session_context_checkpoint(
                     &session_id,
                     turn_start_idx as u32,
@@ -413,6 +426,11 @@ impl Agent {
                 )
             })
             .await;
+            if matches!(save_result, Ok(Ok(()))) {
+                report(AgentEvent::MemoryAction {
+                    message: "Memory · wrote session checkpoint".to_string(),
+                });
+            }
         }
         Ok(())
     }
@@ -1316,5 +1334,13 @@ fn recoverable_runtime_error_message(kind: &str, err: &anyhow::Error) -> Message
         content: json!([{"type": "text", "text": format!(
             "<agent_runtime_error>\nkind: {kind}\nerror:\n{error}\n\ninstructions:\n- Treat this as a recoverable local runtime or filesystem error from the previous step.\n- Explain the likely cause briefly, then choose the safest next action.\n- If the error came from disk space, sandboxing, or file permissions, inspect or suggest remediation instead of repeating the exact failing operation blindly.\n- Continue the same user task when it is safe to do so.\n</agent_runtime_error>"
         )}]),
+    }
+}
+
+fn memory_count_label(label: &str, count: usize) -> String {
+    if count == 1 {
+        label.to_string()
+    } else {
+        format!("{label}s")
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -29,6 +29,7 @@ use crate::llm::{
     LlmStreamEvent, LlmTurnMetadata,
 };
 use crate::mcp_status::McpStatusSnapshot;
+use crate::memory_notice::{count_label, memory_notice};
 use crate::memory_store::MemoryStore;
 use crate::prompt::{self, PromptMode, PromptRuntimeConfig};
 use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
@@ -364,15 +365,15 @@ impl Agent {
         });
         self.checkpoint_session()?;
         report(AgentEvent::MemoryAction {
-            message: "Memory · querying workspace memory".to_string(),
+            message: memory_notice("querying workspace memory"),
         });
         self.refresh_memory_retrieval_candidates().await;
         report(AgentEvent::MemoryAction {
-            message: format!(
-                "Memory · queried workspace memory: {} {}",
+            message: memory_notice(format!(
+                "queried workspace memory: {} {}",
                 self.retrieved_memory_candidates.len(),
-                memory_count_label("candidate", self.retrieved_memory_candidates.len())
-            ),
+                count_label("candidate", self.retrieved_memory_candidates.len())
+            )),
         });
         self.refresh_file_search_candidates();
         self.refresh_protocol_prompt_sources_for_query().await;
@@ -428,7 +429,7 @@ impl Agent {
             .await;
             if matches!(save_result, Ok(Ok(()))) {
                 report(AgentEvent::MemoryAction {
-                    message: "Memory · wrote session checkpoint".to_string(),
+                    message: memory_notice("wrote session checkpoint"),
                 });
             }
         }
@@ -1334,13 +1335,5 @@ fn recoverable_runtime_error_message(kind: &str, err: &anyhow::Error) -> Message
         content: json!([{"type": "text", "text": format!(
             "<agent_runtime_error>\nkind: {kind}\nerror:\n{error}\n\ninstructions:\n- Treat this as a recoverable local runtime or filesystem error from the previous step.\n- Explain the likely cause briefly, then choose the safest next action.\n- If the error came from disk space, sandboxing, or file permissions, inspect or suggest remediation instead of repeating the exact failing operation blindly.\n- Continue the same user task when it is safe to do so.\n</agent_runtime_error>"
         )}]),
-    }
-}
-
-fn memory_count_label(label: &str, count: usize) -> String {
-    if count == 1 {
-        label.to_string()
-    } else {
-        format!("{label}s")
     }
 }

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -113,6 +113,7 @@ fn lifecycle_for_event(event: &AgentEvent) -> Option<HookLifecycle> {
         | AgentEvent::AssistantDelta(_)
         | AgentEvent::AssistantThinkingDelta(_)
         | AgentEvent::ToolProgress { .. }
+        | AgentEvent::MemoryAction { .. }
         | AgentEvent::McpStatusUpdated(_)
         | AgentEvent::McpStatusLoadFailed { .. }
         | AgentEvent::TodoUpdated(_)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod mcp_connection_manager;
 mod mcp_status;
 mod mcp_tool_cache;
 mod memory_distiller;
+mod memory_notice;
 mod memory_store;
 mod oauth;
 mod plugin_middleware;

--- a/src/memory_notice.rs
+++ b/src/memory_notice.rs
@@ -1,0 +1,13 @@
+pub(crate) const MEMORY_NOTICE_PREFIX: &str = "Memory ·";
+
+pub(crate) fn memory_notice(action: impl AsRef<str>) -> String {
+    format!("{MEMORY_NOTICE_PREFIX} {}", action.as_ref())
+}
+
+pub(crate) fn count_label(label: &str, count: usize) -> String {
+    if count == 1 {
+        label.to_string()
+    } else {
+        format!("{label}s")
+    }
+}

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -554,6 +554,9 @@ pub enum MemoryEvent {
     RecordsQueried {
         records: Vec<MemoryRecordSummary>,
     },
+    ActionObserved {
+        message: String,
+    },
     SessionShardPromotionObserved {
         outcome: SessionShardPromotionOutcome,
     },
@@ -658,6 +661,9 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
             stream: stream.into(),
             chunk,
         }),
+        AgentEvent::MemoryAction { message } => {
+            RuntimeEvent::Memory(MemoryEvent::ActionObserved { message })
+        }
         AgentEvent::McpStatusUpdated(snapshot) => {
             RuntimeEvent::Mcp(McpEvent::StatusUpdated { snapshot })
         }

--- a/src/tui/render/cells/cells_tests/committed.rs
+++ b/src/tui/render/cells/cells_tests/committed.rs
@@ -96,6 +96,36 @@ fn committed_turn_cell_ignores_routine_system_notices() {
 }
 
 #[test]
+fn committed_turn_cell_renders_memory_action_notices() {
+    let entries = vec![
+        TranscriptEntry {
+            role: "You".into(),
+            message: "Review this repo".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "System".into(),
+            message: "Memory · queried workspace memory: 2 candidates".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Agent".into(),
+            message: "Final recommendation".into(),
+            payload: None,
+        },
+    ];
+
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Memory · queried workspace memory: 2 candidates"));
+}
+
+#[test]
 fn committed_turn_cell_renders_materialized_sidecar_sections() {
     let entries = vec![
         TranscriptEntry { role: "You".into(), message: "Review the workspace logic".into(), payload: None },

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -1,5 +1,6 @@
 use ratatui::{style::Color, text::Line};
 
+use crate::memory_notice::MEMORY_NOTICE_PREFIX;
 use crate::tui::state::TranscriptEntry;
 
 #[path = "active_turn.rs"]
@@ -320,8 +321,9 @@ mod helper_tests {
 
 pub(super) fn is_renderable_system_message(message: &str) -> bool {
     let lower = message.trim().to_ascii_lowercase();
+    let memory_notice_prefix = MEMORY_NOTICE_PREFIX.to_ascii_lowercase();
     lower.starts_with("query failed:")
-        || lower.starts_with("memory ·")
+        || lower.starts_with(&memory_notice_prefix)
         || lower.starts_with("compaction failed:")
         || lower.starts_with("compact failed:")
         || lower.starts_with("oauth failed:")

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -321,6 +321,7 @@ mod helper_tests {
 pub(super) fn is_renderable_system_message(message: &str) -> bool {
     let lower = message.trim().to_ascii_lowercase();
     lower.starts_with("query failed:")
+        || lower.starts_with("memory ·")
         || lower.starts_with("compaction failed:")
         || lower.starts_with("compact failed:")
         || lower.starts_with("oauth failed:")

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -10,6 +10,7 @@ use self::helpers::{
 };
 use super::super::state::{RuntimePhase, TuiApp, TuiEvent, contains_structured_planning_output};
 use crate::agent::AgentEvent;
+use crate::runtime_control::MemoryEvent;
 use crate::todo::format_todo_update;
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
@@ -311,6 +312,10 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
                     chunk,
                 })
             }),
+        AgentEvent::MemoryAction { message } => Some(TuiEvent::Transcript {
+            role: "System",
+            message,
+        }),
         AgentEvent::TodoUpdated(state) => Some(TuiEvent::Transcript {
             role: "Todo",
             message: format_todo_update(&state),
@@ -322,6 +327,61 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
         AgentEvent::AgentError { .. } => None,
         AgentEvent::ModelRequest { .. } => None,
         AgentEvent::ModelResponse { .. } => None,
+    }
+}
+
+pub(super) fn format_memory_event_notice(event: &MemoryEvent) -> String {
+    match event {
+        MemoryEvent::RecordAdded { memory_id } => {
+            format!("Memory · wrote record {}", short_memory_id(memory_id))
+        }
+        MemoryEvent::RecordUpdated { memory_id } => {
+            format!("Memory · updated record {}", short_memory_id(memory_id))
+        }
+        MemoryEvent::RecordDeleted { memory_id } => {
+            format!("Memory · deleted record {}", short_memory_id(memory_id))
+        }
+        MemoryEvent::LabelsListed { labels, .. } => {
+            format!(
+                "Memory · listed labels: {} {}",
+                labels.len(),
+                count_label("label", labels.len())
+            )
+        }
+        MemoryEvent::MetadataQueried { record_count, .. } => {
+            format!(
+                "Memory · queried metadata: {} {}",
+                record_count,
+                count_label("record", *record_count)
+            )
+        }
+        MemoryEvent::RecordsQueried { records } => {
+            format!(
+                "Memory · queried records: {} {}",
+                records.len(),
+                count_label("result", records.len())
+            )
+        }
+        MemoryEvent::ActionObserved { message } => message.clone(),
+        MemoryEvent::SessionShardPromotionObserved { outcome } => {
+            format!("Memory · observed session shard promotion: {outcome:?}")
+        }
+        MemoryEvent::SelectionUpdated => "Memory · refreshed selection snapshot".to_string(),
+    }
+}
+
+fn short_memory_id(memory_id: &str) -> &str {
+    memory_id
+        .char_indices()
+        .nth(12)
+        .map_or(memory_id, |(idx, _)| &memory_id[..idx])
+}
+
+fn count_label(label: &str, count: usize) -> String {
+    if count == 1 {
+        label.to_string()
+    } else {
+        format!("{label}s")
     }
 }
 

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -10,7 +10,11 @@ use self::helpers::{
 };
 use super::super::state::{RuntimePhase, TuiApp, TuiEvent, contains_structured_planning_output};
 use crate::agent::AgentEvent;
+use crate::memory_notice::{count_label, memory_notice};
 use crate::runtime_control::MemoryEvent;
+use crate::session_promotion::{
+    SessionShardPromotionDecision, SessionShardPromotionOutcome, SessionShardPromotionSkipReason,
+};
 use crate::todo::format_todo_update;
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
@@ -333,40 +337,62 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
 pub(super) fn format_memory_event_notice(event: &MemoryEvent) -> String {
     match event {
         MemoryEvent::RecordAdded { memory_id } => {
-            format!("Memory · wrote record {}", short_memory_id(memory_id))
+            memory_notice(format!("wrote record {}", short_memory_id(memory_id)))
         }
         MemoryEvent::RecordUpdated { memory_id } => {
-            format!("Memory · updated record {}", short_memory_id(memory_id))
+            memory_notice(format!("updated record {}", short_memory_id(memory_id)))
         }
         MemoryEvent::RecordDeleted { memory_id } => {
-            format!("Memory · deleted record {}", short_memory_id(memory_id))
+            memory_notice(format!("deleted record {}", short_memory_id(memory_id)))
         }
-        MemoryEvent::LabelsListed { labels, .. } => {
-            format!(
-                "Memory · listed labels: {} {}",
-                labels.len(),
-                count_label("label", labels.len())
-            )
-        }
-        MemoryEvent::MetadataQueried { record_count, .. } => {
-            format!(
-                "Memory · queried metadata: {} {}",
-                record_count,
-                count_label("record", *record_count)
-            )
-        }
-        MemoryEvent::RecordsQueried { records } => {
-            format!(
-                "Memory · queried records: {} {}",
-                records.len(),
-                count_label("result", records.len())
-            )
-        }
+        MemoryEvent::LabelsListed { labels, .. } => memory_notice(format!(
+            "listed labels: {} {}",
+            labels.len(),
+            count_label("label", labels.len())
+        )),
+        MemoryEvent::MetadataQueried { record_count, .. } => memory_notice(format!(
+            "queried metadata: {} {}",
+            record_count,
+            count_label("record", *record_count)
+        )),
+        MemoryEvent::RecordsQueried { records } => memory_notice(format!(
+            "queried records: {} {}",
+            records.len(),
+            count_label("result", records.len())
+        )),
         MemoryEvent::ActionObserved { message } => message.clone(),
         MemoryEvent::SessionShardPromotionObserved { outcome } => {
-            format!("Memory · observed session shard promotion: {outcome:?}")
+            memory_notice(format_session_shard_promotion_outcome(outcome))
         }
-        MemoryEvent::SelectionUpdated => "Memory · refreshed selection snapshot".to_string(),
+        MemoryEvent::SelectionUpdated => memory_notice("refreshed selection snapshot"),
+    }
+}
+
+fn format_session_shard_promotion_outcome(outcome: &SessionShardPromotionOutcome) -> String {
+    let checkpoint_count = outcome.plan.checkpoint_count;
+    match &outcome.plan.decision {
+        SessionShardPromotionDecision::Eligible => format!(
+            "promoted session shards: {} {} from {} {}",
+            outcome.promoted_count,
+            count_label("record", outcome.promoted_count),
+            checkpoint_count,
+            count_label("checkpoint", checkpoint_count)
+        ),
+        SessionShardPromotionDecision::Skipped { reason } => format!(
+            "skipped session shard promotion: {} with {} {}",
+            session_shard_skip_reason_label(reason),
+            checkpoint_count,
+            count_label("checkpoint", checkpoint_count)
+        ),
+    }
+}
+
+fn session_shard_skip_reason_label(reason: &SessionShardPromotionSkipReason) -> &'static str {
+    match reason {
+        SessionShardPromotionSkipReason::Disabled => "disabled",
+        SessionShardPromotionSkipReason::Empty => "no checkpoints",
+        SessionShardPromotionSkipReason::BelowMinCheckpoints => "below minimum checkpoints",
+        SessionShardPromotionSkipReason::MaxCheckpointsZero => "max checkpoints is zero",
     }
 }
 
@@ -375,14 +401,6 @@ fn short_memory_id(memory_id: &str) -> &str {
         .char_indices()
         .nth(12)
         .map_or(memory_id, |(idx, _)| &memory_id[..idx])
-}
-
-fn count_label(label: &str, count: usize) -> String {
-    if count == 1 {
-        label.to_string()
-    } else {
-        format!("{label}s")
-    }
 }
 
 pub(super) fn format_error_chain(err: &anyhow::Error) -> String {

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -7,10 +7,11 @@ use super::helpers::{
     format_tool_use, is_oauth_prompt_message, planning_note_lines, scrub_internal_control_tokens,
     subagent_request_input,
 };
-use super::{apply_tui_event, convert_agent_event};
+use super::{apply_tui_event, convert_agent_event, format_memory_event_notice};
 use crate::agent::{AgentEvent, AgentExecutionMode};
 use crate::config::ConfigManager;
 use crate::control_tokens::has_pending_internal_control_context;
+use crate::runtime_control::{MemoryEvent, MemoryRecordSummary};
 use crate::tui::state::{ActivePendingInteractionKind, TranscriptEntryPayload};
 use crate::tui::state::{RuntimePhase, TuiApp, TuiEvent};
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
@@ -30,6 +31,43 @@ fn parses_delegated_request_input_from_subagent_result() {
         parsed.note.as_deref(),
         Some("We need one product decision before editing.")
     );
+}
+
+#[test]
+fn memory_action_event_becomes_renderable_system_notice() {
+    let event = convert_agent_event(AgentEvent::MemoryAction {
+        message: "Memory · querying workspace memory".into(),
+    })
+    .expect("memory actions should be visible");
+
+    match event {
+        TuiEvent::Transcript { role, message } => {
+            assert_eq!(role, "System");
+            assert_eq!(message, "Memory · querying workspace memory");
+        }
+        _ => panic!("memory action should convert to transcript event"),
+    }
+}
+
+#[test]
+fn memory_query_notice_reports_count_without_record_content() {
+    let notice = format_memory_event_notice(&MemoryEvent::RecordsQueried {
+        records: vec![MemoryRecordSummary {
+            id: "memory-1234567890".into(),
+            title: "Useful title".into(),
+            content: "secret memory content".into(),
+            labels: vec!["project".into()],
+            importance_basis_points: 8000,
+            pinned: false,
+            scope: "workspace".into(),
+            session_id: None,
+            thread_id: None,
+        }],
+    });
+
+    assert_eq!(notice, "Memory · queried records: 1 result");
+    assert!(!notice.contains("secret memory content"));
+    assert!(!notice.contains("Useful title"));
 }
 
 #[test]

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -12,6 +12,10 @@ use crate::agent::{AgentEvent, AgentExecutionMode};
 use crate::config::ConfigManager;
 use crate::control_tokens::has_pending_internal_control_context;
 use crate::runtime_control::{MemoryEvent, MemoryRecordSummary};
+use crate::session_promotion::{
+    SessionShardPromotionDecision, SessionShardPromotionOutcome, SessionShardPromotionPlan,
+    SessionShardPromotionSkipReason, SessionShardPromotionTrigger,
+};
 use crate::tui::state::{ActivePendingInteractionKind, TranscriptEntryPayload};
 use crate::tui::state::{RuntimePhase, TuiApp, TuiEvent};
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
@@ -68,6 +72,31 @@ fn memory_query_notice_reports_count_without_record_content() {
     assert_eq!(notice, "Memory · queried records: 1 result");
     assert!(!notice.contains("secret memory content"));
     assert!(!notice.contains("Useful title"));
+}
+
+#[test]
+fn memory_promotion_notice_uses_readable_outcome() {
+    let notice = format_memory_event_notice(&MemoryEvent::SessionShardPromotionObserved {
+        outcome: SessionShardPromotionOutcome {
+            plan: SessionShardPromotionPlan {
+                session_id: "session-a".into(),
+                trigger: SessionShardPromotionTrigger::RuntimeControl,
+                checkpoint_count: 3,
+                min_checkpoints: 2,
+                max_checkpoints: 8,
+                decision: SessionShardPromotionDecision::Skipped {
+                    reason: SessionShardPromotionSkipReason::BelowMinCheckpoints,
+                },
+            },
+            promoted_count: 0,
+        },
+    });
+
+    assert_eq!(
+        notice,
+        "Memory · skipped session shard promotion: below minimum checkpoints with 3 checkpoints"
+    );
+    assert!(!notice.contains("SessionShardPromotionOutcome"));
 }
 
 #[test]

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -22,7 +22,9 @@ use super::super::state::{
     GoalStatus, ListPickerKind, OAuthLoginMode, PermissionMode, RalphGoal, RunningTask,
     RuntimePhase, TaskCompletion, TaskKind, TuiApp, TuiEvent,
 };
-use super::events::{apply_tui_event, convert_agent_event, format_error_chain};
+use super::events::{
+    apply_tui_event, convert_agent_event, format_error_chain, format_memory_event_notice,
+};
 use crate::agent::{Agent, AgentOutputMode, BashApprovalDecision};
 use crate::runtime_control::RuntimeProvenance;
 use crate::runtime_event_bus::RuntimeEventBus;
@@ -286,6 +288,13 @@ pub(super) fn start_input_control_task(
                     if let Some(tui_event) = convert_agent_event(agent_event) {
                         let _ = tx.send(tui_event);
                     }
+                } else if let crate::runtime_control::RuntimeEvent::Memory(me) =
+                    &control_event.event
+                {
+                    let _ = tx.send(TuiEvent::Transcript {
+                        role: "System",
+                        message: format_memory_event_notice(me),
+                    });
                 }
             },
         )


### PR DESCRIPTION
## Summary

- add content-free TUI notices for automatic memory query and session checkpoint writes
- surface memory control-plane events as transient transcript notices
- document the memory notice contract and add focused TUI coverage

## Purpose

Memory can affect prompt assembly and session continuity, but the TUI previously did not show when memory was queried or written. These notices make the behavior observable without leaking stored memory content, query text, or titles.

## Related Issue

None.

## Testing

- `cargo fmt`
- `git diff --check`
- Started focused `cargo test` runs for TUI event/render coverage; stopped before completion at the user's request and left full validation to CI.
