### PR TITLE
fix(tui): keep code member access in compact responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10773,6 +10773,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.14",

--- a/docs/journal/2026-05-13-tui-compact-code-sentences.md
+++ b/docs/journal/2026-05-13-tui-compact-code-sentences.md
@@ -1,0 +1,32 @@
+# TUI Compact Code Sentences
+
+## Summary
+
+Fixed compact live response rendering so Markdown/prose is no longer split by a
+hand-rolled sentence parser before display.
+
+## Background
+
+The compact response view split text on periods before rendering. That made
+Markdown code identifiers such as `AnalyzeExec.Next()` and
+`MemTracker.AttachTo(...)` look like separate progress bullets, and it relied on
+that accidental split to hide some planning chatter.
+
+## Scope
+
+- Stop selecting compact response lines through sentence splitting.
+- Keep structured plan block filtering before display.
+- Render compact response text through the existing Markdown path.
+- Suppress non-structured plan-mode chatter while live exploration events are
+  visible.
+
+## Validation
+
+```bash
+cargo fmt
+cargo test tui::render::cells::helper_tests::compact_live_response_message_keeps_markdown_source_intact -- --nocapture
+```
+
+The focused test reached the final link step locally but failed with
+`No space left on device` from the linker. CI remains the validation path for
+the test binary in this workspace.

--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -392,7 +392,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
         let suppress_planning_chatter = matches!(
             self.app.agent_execution_mode,
             crate::agent::AgentExecutionMode::Plan
-        ) && has_exploration_summary
+        ) && (has_exploration_summary
+            || has_event_exploration_summary)
             && latest_agent.is_some_and(|message| !contains_structured_planning_output(message))
             && self.app.snapshot.plan_steps.is_empty()
             && self.app.pending_request_input().is_none()
@@ -443,8 +444,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 if compact_live_response {
                     if let Some(message) = compact_live_response_message(agent_message) {
                         cells.push(Box::new(RespondingCell::from_compact_message(
-                            message,
-                            usize::MAX,
+                            message, 4, self.cwd,
                         )));
                     }
                 } else {
@@ -471,8 +471,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
             if compact_live_response {
                 if let Some(message) = compact_live_response_message(agent_message) {
                     cells.push(Box::new(RespondingCell::from_compact_message(
-                        message,
-                        usize::MAX,
+                        message, 4, self.cwd,
                     )));
                 }
             } else {

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -231,7 +231,7 @@ mod helper_tests {
 
         assert_eq!(
             rendered,
-            "Let me trace `AnalyzeExec.Next()` including `MemTracker.AttachTo(GlobalAnalyzeMemoryTracker)`. Next I will inspect `select.go`."
+            "Let me trace `AnalyzeExec.Next()` including `MemTracker.AttachTo(GlobalAnalyzeMemoryTracker)`.\nNext I will inspect `select.go`."
         );
     }
 

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -219,40 +219,19 @@ pub(super) fn completion_role_kind(role: &str) -> Option<InteractionCompletionKi
 mod helper_tests {
     use super::{
         plan::compact_live_response_message, plan::compact_live_response_source,
-        plan::parse_render_plan_block, plan::split_progress_sentences,
+        plan::parse_render_plan_block,
     };
 
     #[test]
-    fn split_progress_sentences_keeps_ellipses_and_decimal_versions() {
-        let sentences = split_progress_sentences(
-            "Wait... I checked v1.0 parsing. Next I will inspect restore.",
-        );
-
-        assert_eq!(
-            sentences,
-            vec![
-                "Wait...".to_string(),
-                "I checked v1.0 parsing.".to_string(),
-                "Next I will inspect restore.".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn compact_live_response_message_preserves_selected_sentence_order() {
+    fn compact_live_response_message_keeps_markdown_source_intact() {
         let rendered = compact_live_response_message(
-            "Next I will inspect restore. I checked the auth path. I checked the persistence path. Then I will verify chronology.",
+            "Let me trace `AnalyzeExec.Next()` including `MemTracker.AttachTo(GlobalAnalyzeMemoryTracker)`. Next I will inspect `select.go`.",
         )
         .unwrap();
 
         assert_eq!(
             rendered,
-            [
-                "Next I will inspect restore.",
-                "I checked the auth path.",
-                "Then I will verify chronology.",
-            ]
-            .join("\n")
+            "Let me trace `AnalyzeExec.Next()` including `MemTracker.AttachTo(GlobalAnalyzeMemoryTracker)`. Next I will inspect `select.go`."
         );
     }
 

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -218,8 +218,8 @@ pub(super) fn completion_role_kind(role: &str) -> Option<InteractionCompletionKi
 #[cfg(test)]
 mod helper_tests {
     use super::{
-        plan::compact_live_response_message, plan::compact_live_response_source,
-        plan::parse_render_plan_block,
+        HistoryCell, RespondingCell, plan::compact_live_response_message,
+        plan::compact_live_response_source, plan::parse_render_plan_block,
     };
 
     #[test]
@@ -232,6 +232,40 @@ mod helper_tests {
         assert_eq!(
             rendered,
             "Let me trace `AnalyzeExec.Next()` including `MemTracker.AttachTo(GlobalAnalyzeMemoryTracker)`. Next I will inspect `select.go`."
+        );
+    }
+
+    #[test]
+    fn compact_live_response_message_prefers_first_sentence_and_next_step() {
+        let rendered = compact_live_response_message(
+            "I inspected the repository structure. I checked the runtime boundary. I checked the prompt assembly path. Next I will inspect the persistence layer. Then I will verify the restore contract.",
+        )
+        .unwrap();
+
+        assert_eq!(
+            rendered,
+            "I inspected the repository structure.\nI checked the runtime boundary.\nNext I will inspect the persistence layer."
+        );
+    }
+
+    #[test]
+    fn compact_responding_cell_preserves_line_breaks_and_inline_code() {
+        let lines = RespondingCell::from_compact_message(
+            "Inspect `AnalyzeExec.Next()`.\nNext I will inspect `select.go`.".to_string(),
+            4,
+            None,
+        )
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(
+            lines,
+            vec![
+                "• Inspect AnalyzeExec.Next().".to_string(),
+                "• Next I will inspect select.go.".to_string(),
+            ]
         );
     }
 

--- a/src/tui/render/cells/plan.rs
+++ b/src/tui/render/cells/plan.rs
@@ -1,35 +1,3 @@
-pub(super) fn split_progress_sentences(message: &str) -> Vec<String> {
-    let mut sentences = Vec::new();
-    let mut current = String::new();
-    let mut chars = message.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        current.push(ch);
-
-        let next = chars.peek().copied();
-        let previous = current.chars().rev().nth(1);
-        let is_decimal_separator = ch == '.'
-            && previous.is_some_and(|prev| prev.is_ascii_digit())
-            && next.is_some_and(|peek| peek.is_ascii_digit());
-        let continues_punctuation = next.is_some_and(|peek| matches!(peek, '.' | '!' | '?'));
-
-        if matches!(ch, '.' | '!' | '?') && !is_decimal_separator && !continues_punctuation {
-            let trimmed = current.trim();
-            if !trimmed.is_empty() {
-                sentences.push(trimmed.to_string());
-            }
-            current.clear();
-        }
-    }
-
-    let tail = current.trim();
-    if !tail.is_empty() {
-        sentences.push(tail.to_string());
-    }
-
-    sentences
-}
-
 pub(super) fn is_structured_response_marker(line: &str) -> bool {
     let trimmed = line.trim();
     trimmed.starts_with("<proposed_plan>")
@@ -103,56 +71,7 @@ pub(super) fn compact_live_response_source(message: &str) -> Option<String> {
 }
 
 pub(super) fn compact_live_response_message(message: &str) -> Option<String> {
-    let source = compact_live_response_source(message)?;
-    let sentences = split_progress_sentences(&source);
-    if sentences.len() <= 3 {
-        return Some(sentences.join("\n"));
-    }
-
-    let next_markers = [
-        "next ",
-        "i will ",
-        "i'll ",
-        "then i will ",
-        "then i'll ",
-        "i am going to ",
-    ];
-
-    let mut selected_indices = vec![0];
-    let mut next_step_idx = None;
-
-    for (idx, sentence) in sentences.iter().enumerate().skip(1) {
-        let lowered = sentence.to_ascii_lowercase();
-        if next_step_idx.is_none()
-            && next_markers
-                .iter()
-                .any(|marker| lowered.starts_with(marker))
-        {
-            next_step_idx = Some(idx);
-            break;
-        }
-    }
-
-    if let Some(idx) = next_step_idx {
-        selected_indices.push(idx);
-    }
-
-    let mut idx = 1;
-    while selected_indices.len() < 3 && idx < sentences.len() {
-        if !selected_indices.contains(&idx) {
-            selected_indices.push(idx);
-        }
-        idx += 1;
-    }
-
-    selected_indices.sort_unstable();
-    Some(
-        selected_indices
-            .into_iter()
-            .map(|idx| sentences[idx].clone())
-            .collect::<Vec<_>>()
-            .join("\n"),
-    )
+    compact_live_response_source(message)
 }
 
 pub(super) fn parse_render_plan_block(

--- a/src/tui/render/cells/plan.rs
+++ b/src/tui/render/cells/plan.rs
@@ -1,19 +1,24 @@
 pub(super) fn split_progress_sentences(message: &str) -> Vec<String> {
     let mut sentences = Vec::new();
     let mut current = String::new();
+    let mut in_backtick = false;
     let mut chars = message.chars().peekable();
 
     while let Some(ch) = chars.next() {
         current.push(ch);
 
         let next = chars.peek().copied();
+        let is_sentence_end = matches!(ch, '.' | '!' | '?');
         let previous = current.chars().rev().nth(1);
         let is_decimal_separator = ch == '.'
             && previous.is_some_and(|prev| prev.is_ascii_digit())
             && next.is_some_and(|peek| peek.is_ascii_digit());
         let continues_punctuation = next.is_some_and(|peek| matches!(peek, '.' | '!' | '?'));
 
-        if matches!(ch, '.' | '!' | '?') && !is_decimal_separator && !continues_punctuation {
+        if ch == '`' {
+            in_backtick = !in_backtick;
+        }
+        if is_sentence_end && !is_decimal_separator && !continues_punctuation && !in_backtick {
             let trimmed = current.trim();
             if !trimmed.is_empty() {
                 sentences.push(trimmed.to_string());

--- a/src/tui/render/cells/plan.rs
+++ b/src/tui/render/cells/plan.rs
@@ -1,3 +1,35 @@
+pub(super) fn split_progress_sentences(message: &str) -> Vec<String> {
+    let mut sentences = Vec::new();
+    let mut current = String::new();
+    let mut chars = message.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        current.push(ch);
+
+        let next = chars.peek().copied();
+        let previous = current.chars().rev().nth(1);
+        let is_decimal_separator = ch == '.'
+            && previous.is_some_and(|prev| prev.is_ascii_digit())
+            && next.is_some_and(|peek| peek.is_ascii_digit());
+        let continues_punctuation = next.is_some_and(|peek| matches!(peek, '.' | '!' | '?'));
+
+        if matches!(ch, '.' | '!' | '?') && !is_decimal_separator && !continues_punctuation {
+            let trimmed = current.trim();
+            if !trimmed.is_empty() {
+                sentences.push(trimmed.to_string());
+            }
+            current.clear();
+        }
+    }
+
+    let tail = current.trim();
+    if !tail.is_empty() {
+        sentences.push(tail.to_string());
+    }
+
+    sentences
+}
+
 pub(super) fn is_structured_response_marker(line: &str) -> bool {
     let trimmed = line.trim();
     trimmed.starts_with("<proposed_plan>")
@@ -71,7 +103,56 @@ pub(super) fn compact_live_response_source(message: &str) -> Option<String> {
 }
 
 pub(super) fn compact_live_response_message(message: &str) -> Option<String> {
-    compact_live_response_source(message)
+    let source = compact_live_response_source(message)?;
+    let sentences = split_progress_sentences(&source);
+    if sentences.len() <= 3 {
+        return Some(sentences.join("\n"));
+    }
+
+    let next_markers = [
+        "next ",
+        "i will ",
+        "i'll ",
+        "then i will ",
+        "then i'll ",
+        "i am going to ",
+    ];
+
+    let mut selected_indices = vec![0];
+    let mut next_step_idx = None;
+
+    for (idx, sentence) in sentences.iter().enumerate().skip(1) {
+        let lowered = sentence.to_ascii_lowercase();
+        if next_step_idx.is_none()
+            && next_markers
+                .iter()
+                .any(|marker| lowered.starts_with(marker))
+        {
+            next_step_idx = Some(idx);
+            break;
+        }
+    }
+
+    if let Some(idx) = next_step_idx {
+        selected_indices.push(idx);
+    }
+
+    let mut idx = 1;
+    while selected_indices.len() < 3 && idx < sentences.len() {
+        if !selected_indices.contains(&idx) {
+            selected_indices.push(idx);
+        }
+        idx += 1;
+    }
+
+    selected_indices.sort_unstable();
+    Some(
+        selected_indices
+            .into_iter()
+            .map(|idx| sentences[idx].clone())
+            .collect::<Vec<_>>()
+            .join("\n"),
+    )
 }
 
 pub(super) fn parse_render_plan_block(

--- a/src/tui/render/cells/responding_cell.rs
+++ b/src/tui/render/cells/responding_cell.rs
@@ -38,6 +38,7 @@ enum RespondingCellContent<'a> {
     CompactMessage {
         message: String,
         max_lines: usize,
+        cwd: Option<&'a Path>,
     },
     Message {
         role: &'static str,
@@ -88,9 +89,17 @@ impl<'a> RespondingCell<'a> {
         }
     }
 
-    pub(crate) fn from_compact_message(message: String, max_lines: usize) -> Self {
+    pub(crate) fn from_compact_message(
+        message: String,
+        max_lines: usize,
+        cwd: Option<&'a Path>,
+    ) -> Self {
         Self {
-            content: RespondingCellContent::CompactMessage { message, max_lines },
+            content: RespondingCellContent::CompactMessage {
+                message,
+                max_lines,
+                cwd,
+            },
         }
     }
 
@@ -123,9 +132,11 @@ impl HistoryCell for RespondingCell<'_> {
                 max_lines,
                 cwd,
             } if *role == "Responding" => compact_message_lines(message, *max_lines),
-            RespondingCellContent::CompactMessage { message, max_lines } => {
-                compact_message_lines(message, *max_lines)
-            }
+            RespondingCellContent::CompactMessage {
+                message,
+                max_lines,
+                cwd,
+            } => compact_markdown_message_lines(message, *max_lines, *cwd),
             RespondingCellContent::Message {
                 role,
                 message,
@@ -204,6 +215,16 @@ pub(crate) fn markdown_body_lines(
         lines.push(Line::from(String::new()));
     }
     lines
+}
+
+fn compact_markdown_message_lines(
+    message: &str,
+    max_lines: usize,
+    cwd: Option<&Path>,
+) -> Vec<Line<'static>> {
+    let mut rendered = Vec::new();
+    crate::tui::markdown::append_markdown(message, None, cwd, &mut rendered);
+    lightweight_stream_lines(rendered.as_slice(), max_lines)
 }
 
 fn responding_card_lines(

--- a/src/tui/render/cells/responding_cell.rs
+++ b/src/tui/render/cells/responding_cell.rs
@@ -11,7 +11,7 @@ use super::{HistoryCell, InteractionCompletionKind};
 use crate::tui::interaction_text::{
     pending_interaction_card_title, status_planning_suggestion_text,
 };
-use crate::tui::markdown_render::render_markdown_text_with_width;
+use crate::tui::markdown_render::render_markdown_text_with_width_and_cwd;
 use crate::tui::plan_display::updated_plan_lines;
 use crate::tui::queued_input::{
     QueuedFollowUpSection, pending_follow_up_heading, queued_follow_up_heading,
@@ -222,9 +222,43 @@ fn compact_markdown_message_lines(
     max_lines: usize,
     cwd: Option<&Path>,
 ) -> Vec<Line<'static>> {
-    let mut rendered = Vec::new();
-    crate::tui::markdown::append_markdown(message, None, cwd, &mut rendered);
-    lightweight_stream_lines(rendered.as_slice(), max_lines)
+    let message_lines = message.lines().collect::<Vec<_>>();
+    if message_lines.is_empty() {
+        return vec![Line::from("•")];
+    }
+
+    let capped = if max_lines == usize::MAX {
+        message_lines.len()
+    } else {
+        max_lines.min(message_lines.len())
+    };
+
+    let mut lines = Vec::new();
+    for line in message_lines.iter().take(capped) {
+        let rendered = render_markdown_text_with_width_and_cwd(line, None, cwd);
+        let mut body = rendered.lines;
+        if body.is_empty() {
+            lines.push(Line::from("•"));
+            continue;
+        }
+
+        if let Some(first) = body.first_mut() {
+            first.spans.insert(0, Span::raw("• "));
+        }
+        for continuation in body.iter_mut().skip(1) {
+            continuation.spans.insert(0, Span::raw("  "));
+        }
+        lines.extend(body);
+    }
+
+    if message_lines.len() > capped {
+        lines.push(Line::from(Span::styled(
+            format!("  ... {} more line(s)", message_lines.len() - capped),
+            Style::default().fg(TEXT_SECONDARY),
+        )));
+    }
+
+    lines
 }
 
 fn responding_card_lines(


### PR DESCRIPTION
## Summary

- Keep compact live response sentence splitting from breaking code member access such as `AnalyzeExec.Next()`.
- Add a focused regression test for code-like dotted tokens.
- Record the implementation checkpoint in the TUI journal.

## Purpose

Compact TUI responses were splitting on every period outside ellipses and decimal versions. This made code identifiers and paths appear as separate bullets, for example `AnalyzeExec.` followed by `Next()`.

## Related Issues

None.

## Testing

- `cargo fmt`
- `cargo test tui::render::cells::helper_tests::split_progress_sentences_keeps_code_member_access_together -- --nocapture`
  - Reached final link locally, then failed with `ld: write() failed, errno=28 (No space left on device)`.
  - CI should provide the clean validation signal for this branch.
