### PR TITLE
feat: tighten todo verification workflow

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -27,4 +27,4 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
-        run: cargo clippy --all-targets --no-deps
+        run: cargo clippy --locked --all-targets --no-deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,4 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
  "candle-kernels",
  "candle-metal-kernels",
  "candle-ug",
- "cudarc 0.19.4",
+ "cudarc 0.19.6",
  "float8",
  "gemm 0.19.0",
  "half",
@@ -2805,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.4"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
+checksum = "83be2fd94791d2580692ced87ea19e9728102ce75582543b82765dbe3e884557"
 dependencies = [
  "float8",
  "half",
@@ -4829,7 +4829,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -6332,7 +6332,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -6724,7 +6724,7 @@ dependencies = [
  "socket2 0.6.3",
  "widestring",
  "windows-registry",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 
@@ -10773,6 +10773,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.14",
@@ -13989,7 +13990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -14000,7 +14001,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -14009,11 +14023,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -14022,9 +14036,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -14032,6 +14057,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14061,7 +14097,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
 ]
 
@@ -14072,8 +14108,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -14083,6 +14128,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -431,6 +431,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "Report outcomes faithfully. If tests fail, checks are pending, output is partial, truncated, or work is incomplete, state that directly with the relevant evidence. Never claim tests or checks passed unless the observed output shows that they passed.",
                     "When output is truncated, do not infer the missing result from the visible tail or from what usually happens. Re-run a narrower command, inspect a saved full log, or use targeted search until the relevant evidence is visible.",
                     "If an approach fails, diagnose why before switching tactics: read the error, check your assumptions, and try a focused fix. Do not retry the identical action blindly.",
+                    "If a tool call, sandboxed command, or escalated command request is denied, treat that denial as new information. Do not immediately repeat the exact same call; adjust the command, choose another local path, or explain why the blocked capability is essential.",
                 ],
             ),
         ),
@@ -567,6 +568,8 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "Prefer multiple parallel tool calls when reading or searching independent files — it reduces turnaround time.",
                     "When a tool fails, read the exact error, update the working hypothesis, and try the narrowest corrective action that preserves the user's constraints.",
                     "Do not abandon the task after a transient tool, sandbox, network, or filesystem error when a safe local fallback is available.",
+                    "Especially for tests, builds, and checks, treat sandbox denials as a routing problem: inspect the exact failure, retry with a narrower command when possible, or ask for escalated permissions instead of declaring verification impossible.",
+                    "If a command or escalation request was denied, do not blindly re-run the same denied call. Narrow the command, switch to another local evidence path, or report the exact blocked permission you still need.",
                     "When output is truncated, narrow the query, read a smaller range, inspect saved full output, or use a targeted search before asking the user for the missing content.",
                     "When command output may be large, prefer targeted commands, exact tests, log files plus search, or smaller ranges over arbitrary tailing of the last few lines.",
                     "For long-running commands, prefer background task or PTY tools when available; after starting one, use list/status/stop tools to keep the task observable and controllable.",
@@ -610,7 +613,11 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "Choose validation based on the risk of the change. A narrow unit test is enough for a local helper; state, rendering, or workflow changes need tests at the nearest behavioral boundary.",
                     "Prefer regression tests that would fail on the old behavior and pass for the intended behavior.",
                     "Run the smallest relevant test first, then broaden only when the touched path or risk justifies it.",
+                    "For bug fixes, close the loop in order when practical: reproduce or characterize the original failure, implement the fix, run the focused regression test, then check nearby behavior for side effects.",
+                    "Treat build/test output as necessary evidence, not the whole story. When user-visible state, runtime workflow, or tool behavior changed, also inspect the changed surface or structured runtime result.",
                     "Inspect the real command output before claiming success. A command that exits successfully with warnings should be reported as passed with warnings when the warnings matter.",
+                    "If sandbox or permission limits block a needed validation command, do not stop at the first denial. Read the exact error, try the narrowest equivalent command or other local evidence path, and request escalated permissions only when the sandbox is the real blocker.",
+                    "If the runtime or user denies an escalated validation command, do not re-submit the exact same denied request immediately. Keep the verification work open, use other local evidence if available, or explain the specific permission that still blocks completion.",
                     "If tests cannot be run because of environment, time, sandbox, network, or missing dependency constraints, report that exact limitation and the next best validation.",
                     "Do not update snapshots, fixtures, or recorded outputs blindly. Verify that the new output represents the intended behavior.",
                     "Do not treat formatting as validation for behavior. Formatting is useful, but behavior needs tests, checks, or direct inspection.",
@@ -739,6 +746,10 @@ fn dynamic_system_prompt_sections(
         PromptSection::optional("skills", skills_block),
         PromptSection::optional("language_best_practices", language_prompt),
         PromptSection::new("runtime_context", render_environment_context(&cwd, &branch)),
+        PromptSection::optional(
+            "execute_mode",
+            matches!(mode, PromptMode::Execute).then(execute_mode_prompt),
+        ),
         PromptSection::optional(
             "plan_mode",
             matches!(mode, PromptMode::Plan).then(plan_mode_prompt),
@@ -921,6 +932,21 @@ fn plan_mode_prompt() -> String {
     prompt
 }
 
+fn execute_mode_prompt() -> String {
+    section(
+        "Execute Mode",
+        &[
+            "For complex multi-step execution, keep mutable task state current with 'todo_write' instead of tracking progress only in prose.",
+            "Use 'todo_write' proactively once work has multiple concrete steps, and refresh the full list when new requirements, blockers, or validation work changes the working set.",
+            "Update todo state as soon as a step changes: mark completed items promptly, keep at most one item in progress, and do not batch status changes until the end.",
+            "For non-trivial code changes, keep reproduction, regression-test, or verification work visible in the todo list when it is still pending, and do not treat the implementation as effectively done while the relevant validation item is still pending or failing.",
+            "When a needed test, build, or check is blocked by sandbox permissions, keep pushing on verification: inspect the exact denial, try the narrowest viable alternative, or request escalated permissions with concrete justification rather than stopping at 'sandbox blocked'.",
+            "If a validation command or escalation request is denied, keep the relevant verification todo item pending and describe the blocked capability instead of marking the task effectively done.",
+            "When the next safe local step is obvious from the inspected code and transcript, take it instead of stopping with optional suggestions about what could be done next.",
+        ],
+    )
+}
+
 fn review_mode_prompt() -> String {
     REVIEW_MODE_PROMPT.clone()
 }
@@ -1074,6 +1100,49 @@ mod tests {
     }
 
     #[test]
+    fn build_system_prompt_includes_execute_mode_guidance_only_in_execute_mode() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().join("workspace");
+        let rara_dir = root.join(".rara");
+        fs::create_dir_all(&rara_dir).expect("mkdir .rara");
+        let workspace = WorkspaceMemory::from_paths(root, rara_dir);
+
+        let execute = build_effective_prompt(
+            &workspace,
+            &PromptRuntimeConfig::default(),
+            PromptMode::Execute,
+        );
+        assert!(execute.section_keys.contains(&"execute_mode"));
+        assert!(execute.text.contains("# Execute Mode"));
+        assert!(execute.text.contains("todo_write"));
+        assert!(execute.text.contains("refresh the full list"));
+        assert!(
+            execute
+                .text
+                .contains("do not batch status changes until the end")
+        );
+        assert!(
+            execute
+                .text
+                .contains("relevant validation item is still pending or failing")
+        );
+        assert!(execute.text.contains("stopping at 'sandbox blocked'"));
+        assert!(
+            execute
+                .text
+                .contains("keep the relevant verification todo item pending")
+        );
+
+        let plan = build_effective_prompt(
+            &workspace,
+            &PromptRuntimeConfig::default(),
+            PromptMode::Plan,
+        );
+        assert!(!plan.section_keys.contains(&"execute_mode"));
+        assert!(!plan.text.contains("# Execute Mode"));
+    }
+
+    #[test]
     fn build_system_prompt_includes_language_best_practices_for_rust_project() {
         let temp = tempfile::tempdir().expect("tempdir");
         let root = temp.path().join("rust-project");
@@ -1131,6 +1200,11 @@ mod tests {
             effective
                 .text
                 .contains("When output is truncated, do not infer the missing result")
+        );
+        assert!(
+            effective
+                .text
+                .contains("Do not immediately repeat the exact same call")
         );
     }
 
@@ -1313,9 +1387,12 @@ mod tests {
         assert!(prompt.contains("list/status/stop tools"));
         assert!(prompt.contains("available GitHub tools or the 'gh' CLI"));
         assert!(prompt.contains("never rewrite history"));
+        assert!(prompt.contains("Especially for tests, builds, and checks"));
+        assert!(prompt.contains("do not blindly re-run the same denied call"));
         assert!(prompt.contains("evidence-backed conclusion"));
         assert!(prompt.contains("Do not assume durable vector recall exists"));
         assert!(prompt.contains("Use 'spawn_agent' or 'team_create'"));
+        assert!(prompt.contains("todo_write"));
     }
 
     #[test]
@@ -1427,6 +1504,22 @@ mod tests {
             effective
                 .text
                 .contains("Prefer regression tests that would fail on the old behavior")
+        );
+        assert!(
+            effective
+                .text
+                .contains("close the loop in order when practical")
+        );
+        assert!(
+            effective
+                .text
+                .contains("Treat build/test output as necessary evidence")
+        );
+        assert!(effective.text.contains("do not stop at the first denial"));
+        assert!(
+            effective
+                .text
+                .contains("do not re-submit the exact same denied request immediately")
         );
         assert!(
             effective

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -50,7 +50,7 @@ The effective prompt is assembled in this order:
 2. dynamic instruction sources;
 3. memory sources;
 4. runtime context;
-5. mode-specific addenda such as plan mode;
+5. mode-specific addenda such as execute mode, plan mode, and review mode;
 6. append prompt.
 
 ### 3.1) Built-In Engineering Workflow Guidance
@@ -63,7 +63,8 @@ The default base prompt includes source-grounded engineering workflow guidance f
 - external-source and web-search selection, including when to prefer local source, GitHub tooling,
   MCP resources, upstream open-source documentation, or fetched web evidence;
 - structured tool use, including edit-tool discipline and unfiltered command-output inspection;
-- reviewable implementation workflow, focused validation, and PR hygiene;
+- reviewable implementation workflow, focused validation, sandbox-persistent verification, and PR
+  hygiene;
 - Git conflict resolution when conflict markers are present.
 
 Software-engineering task interpretation is adapted from Claude-style task framing. In a repository,
@@ -83,6 +84,15 @@ Git conflict guidance is intentionally conservative. It tells the model to inspe
 state and conflicted file, preserve complementary changes instead of blindly choosing one side, use
 structured edits where practical, scan for remaining conflict markers, and run the narrowest relevant
 validation before claiming the conflict is resolved.
+
+Testing and verification guidance is split between the always-on base prompt, execute-mode addenda,
+and tool descriptions. The default prompt should require the agent to reproduce or characterize bug
+failures before changing code when practical, prefer focused regression tests, inspect the changed
+runtime surface when user-visible or workflow behavior changed, and treat sandbox denials as a
+diagnostic or escalation path rather than a reason to abandon validation. A denied validation call
+or denied escalation request should be treated as new routing information: do not retry it
+verbatim, either narrow the command, use another local evidence path, or explain the exact blocked
+capability that still requires approval.
 
 Large-write guidance follows the same edit-tool boundary:
 
@@ -119,9 +129,14 @@ Prompt guidance is intentionally split by responsibility:
 
 - Runtime system prompt: behavior that materially affects task completion, correctness, safety,
   evidence quality, memory staleness, and agent-loop continuation.
+- Execute-mode addenda: execution-only workflow rules that depend on mutable task progress, such as
+  keeping multi-step work current with `todo_write`, carrying pending verification items, and
+  biasing toward the next safe local step.
+- Plan/review-mode addenda: read-only contracts, approval flow, and output-shape rules that apply
+  only in those modes.
 - Tool descriptions and input schemas: call-time constraints such as shell-vs-PTY selection,
-  dedicated file/edit tool preference, `cwd` handling, background task controls, and stdout/stderr
-  handling.
+  dedicated file/edit tool preference, `cwd` handling, background task controls, stdout/stderr
+  handling, and sandbox-escalation discipline for validation commands.
 - Workspace instruction files such as `AGENTS.md`: repository-maintenance conventions, Rust API
   style, TUI module boundaries, snapshot expectations, commit rules, and documentation workflow.
 - Skills: deeper task-specific workflows that should be loaded only when relevant.
@@ -131,6 +146,31 @@ New always-on prompt text should be rare, additive, and placed near related sect
 reordering existing prompt sections, because stable prefixes matter for provider prompt-cache reuse.
 RARA-specific documentation conventions such as SDD, journals, and TODO hygiene belong in
 workspace instructions and documentation, not in the default runtime system prompt.
+
+Prompt locality is a contract, not only a style preference:
+
+- place a rule at the narrowest layer that still guarantees the behavior;
+- do not move an execution-only rule into the always-on base prompt just because Claude or Codex has
+  a nearby sentence in its own runtime;
+- when borrowing from other agents, migrate the behavioral contract, not the exact prompt text or
+  provider-specific wrapper structure.
+
+Examples:
+
+- irreversible-action confirmation belongs in always-on runtime safety guidance because it applies
+  across tasks and tools;
+- `todo_write` usage belongs in execute-mode guidance because it is meaningless in read-only plan or
+  review turns;
+- `todo_write` replacement semantics and completion discipline belong in the tool description because
+  the model needs them when deciding what todo payload to send;
+- stale-read recovery and file-write boundaries belong in edit-tool descriptions because the model
+  needs those rules at the tool-choice point;
+- sandbox-escalation behavior for tests, builds, and checks belongs in the bash tool description as
+  well as the always-on validation guidance because the model needs that rule when choosing whether
+  to retry, narrow the command, or request approval, and because denied calls should not be retried
+  verbatim;
+- repository-specific engineering rules remain in `AGENTS.md` or skills instead of bloating the
+  default runtime prompt.
 
 ### 4) Compact Prompt
 
@@ -256,4 +296,6 @@ workspace instructions and documentation, not in the default runtime system prom
 - [2026-04-25-context-assembly-stage1](../journal/2026-04-25-context-assembly-stage1.md)
 - [2026-05-02-git-conflict-prompt-guidance](../journal/2026-05-02-git-conflict-prompt-guidance.md)
 - [2026-05-07-engineering-guidance-placement](../journal/2026-05-07-engineering-guidance-placement.md)
+- [2026-05-13-claude-prompt-locality](../journal/2026-05-13-claude-prompt-locality.md)
+- [2026-05-14-sandbox-denial-escalation-guidance](../journal/2026-05-14-sandbox-denial-escalation-guidance.md)
 - [Runtime Control Plane](runtime-control-plane.md)

--- a/docs/features/todo-runtime.md
+++ b/docs/features/todo-runtime.md
@@ -15,7 +15,8 @@ session restore without polluting `plan.md` with transient status.
 
 - A session-scoped todo artifact for the current execution working set.
 - A tool surface that lets the agent create, update, complete, and inspect todo items.
-- Runtime and TUI state that can display todo progress when it changes.
+- Runtime and TUI state that can display todo progress when it changes and keep the active working
+  set visible from status surfaces.
 - Context assembly support so compacted or resumed turns can recover the current todo state.
 - Clear separation between approved plan state and mutable todo state.
 
@@ -82,6 +83,16 @@ to RARA's runtime:
 The tool should update the whole todo list atomically rather than patching individual fields. This
 keeps the model contract simple and makes it easy to validate status transitions.
 
+The tool description and execute-mode prompt should also teach the working discipline around that
+contract:
+
+- use `todo_write` proactively for complex multi-step execution, not for trivial one-step work;
+- resend the full working set when statuses, blockers, order, or validation work changes;
+- keep at most one `in_progress` item unless multi-agent ownership exists later;
+- prefer concrete execution items such as bug reproduction, focused tests, or final verification;
+- do not treat implementation as effectively complete while the relevant verification item is still
+  pending or failing.
+
 A later `todo_read` tool is optional. In the first implementation, todo state can be provided through
 runtime context and `/context`/`/status`, so a separate read tool is not required unless models need
 an explicit recall action.
@@ -106,6 +117,8 @@ Todo progress should be displayed only when it changes or when explicitly reques
 surfaces:
 
 - `todo_write` results may render a compact `Todo Updated` card.
+- the wide-screen sidebar may show a bounded `Todo` section with progress, active item, and a short
+  checklist preview while todo state exists.
 - `/context` should show the current todo artifact and active item.
 - `/status` may show a brief count summary.
 - Completed todo state should not stay pinned as a permanent bottom card after it becomes stale.
@@ -141,6 +154,15 @@ This keeps Todo visible as execution state without turning it into persistent tr
 - If todo state is too large for the active context budget, inject counts and the active item first,
   then omit completed items before omitting pending items.
 
+### Execution Guidance
+
+- The execute-mode prompt should tell the agent to keep todo state current for complex multi-step
+  execution instead of tracking mutable progress only in prose.
+- When a task changes non-trivial behavior, the todo list should normally preserve a focused
+  reproduction, regression-test, or verification item until that validation has actually happened.
+- Sidebar, `/status`, and `/context` should all project from the same structured todo state instead
+  of keeping separate UI-only copies.
+
 ## Validation Matrix
 
 - Unit tests for todo state validation and normalization.
@@ -175,6 +197,8 @@ conversion:
   clearer ownership model.
 - The UI should avoid permanent todo cards; stale completed lists can become visual noise in long
   sessions.
+- Sidebar todo previews must stay bounded so they remain useful instead of pushing out more stable
+  context information.
 - Future context compaction should decide whether to carry the active todo only or a bounded pending
   projection.
 
@@ -182,3 +206,4 @@ conversion:
 
 - [2026-05-01-todo-and-review-specs](../journal/2026-05-01-todo-and-review-specs.md)
 - [2026-05-03-todo-write-runtime](../journal/2026-05-03-todo-write-runtime.md)
+- [2026-05-13-todo-verification-runtime-guidance](../journal/2026-05-13-todo-verification-runtime-guidance.md)

--- a/docs/journal/2026-05-13-claude-prompt-locality.md
+++ b/docs/journal/2026-05-13-claude-prompt-locality.md
@@ -1,0 +1,41 @@
+# 2026-05-13 Claude Prompt Locality
+
+## Summary
+
+Migrated a small Claude prompt slice into RARA by adding execute-only
+task-tracking guidance and documenting prompt locality as a first-class runtime
+contract.
+
+## Background
+
+RARA's default prompt already covered most of the obvious Claude/Codex
+engineering guidance. The remaining gap was narrower:
+
+- execute-only workflow guidance such as mutable todo tracking was not
+  expressed as a mode-local rule;
+- prompt locality existed as an implicit preference, but not yet as an explicit
+  spec contract.
+
+## Scope
+
+- Added an execute-only dynamic prompt section that tells the model to use
+  `todo_write` for complex multi-step execution and keep that state current.
+- Updated the prompt-runtime spec to describe locality and rule placement more
+  explicitly.
+
+## Key Decisions
+
+- Keep mutable execution workflow rules in an `execute_mode` addendum instead of
+  the shared base prompt so plan/review turns stay narrower.
+- Treat locality as part of cache-stable prompt architecture: preserve section
+  order, keep dynamic rules behind the existing boundary, and avoid copying
+  provider-specific prompt wrappers from Claude Code.
+
+## Validation
+
+- `cargo fmt`
+- `cargo test -p rara-instructions`
+
+## Follow-Ups
+
+- No new follow-up was opened by this slice.

--- a/docs/journal/2026-05-13-todo-verification-runtime-guidance.md
+++ b/docs/journal/2026-05-13-todo-verification-runtime-guidance.md
@@ -1,0 +1,51 @@
+# Todo, Verification, And Sidebar Guidance
+
+## Context
+
+RARA already had the first slice of Claude-style `todo_write` support: session persistence, runtime
+events, transcript cards, and `/context`/`/status` reporting. The next gap was behavioral rather
+than structural:
+
+- the default prompt did not push hard enough on bugfix verification and sandbox-persistent testing;
+- `todo_write` did not teach the model when to use it or how to keep verification visible;
+- the wide-screen sidebar still hid todo state behind a generic context summary instead of showing a
+  durable working-set preview.
+
+Claude Code spreads those expectations across `TodoWrite`, testing/verification guidance, and the
+verification agent. RARA now mirrors the contract in its own locality model.
+
+## Implemented
+
+- Strengthened execute-mode guidance so complex multi-step work must use `todo_write` proactively,
+  keep the full working set current, preserve pending verification items, and continue validation
+  even when sandbox permissions block the first command.
+- Tightened the default testing/validation prompt so bugfixes follow a reproduce-or-characterize ->
+  fix -> focused regression test -> nearby side-effect check loop when practical.
+- Added stronger always-on tool-workflow guidance that sandbox denials during tests/builds/checks
+  are a routing problem to diagnose, narrow, or escalate rather than a reason to stop.
+- Expanded the `todo_write` tool description and schema text so the call site itself teaches:
+  complex-task usage, full-list replacement semantics, prompt status updates, and verification-aware
+  completion discipline.
+- Expanded the `bash` tool description so validation commands keep pushing through sandbox denials by
+  inspecting the exact failure and requesting escalation only when the sandbox is proven to be the
+  blocker.
+- Added a bounded `Todo` section to the wide-screen sidebar with progress, active item, and a short
+  checklist preview inspired by OpenCode's persistent session todo surface, but adapted to RARA's
+  existing left-sidebar layout instead of adding a separate dock.
+
+## Trade-Offs
+
+- RARA still does not enforce verification items structurally inside `todo_write`; the stronger
+  contract remains prompt-and-tool-description guidance rather than schema rejection. That keeps the
+  tool simple while making the expected workflow much harder for the model to miss.
+- The sidebar preview is intentionally bounded to avoid crowding out more stable context. Full todo
+  detail stays in `/context` and `/status`.
+- Sandbox persistence is expressed in both the always-on prompt and the `bash` tool description. The
+  overlap is deliberate because the rule matters both at workflow level and at tool-choice time.
+
+## Validation
+
+- `cargo fmt`
+- `cargo test -p rara-instructions`
+- `cargo test todo_write`
+- `cargo test sidebar`

--- a/docs/journal/2026-05-14-sandbox-denial-escalation-guidance.md
+++ b/docs/journal/2026-05-14-sandbox-denial-escalation-guidance.md
@@ -1,0 +1,61 @@
+# Sandbox Denial Escalation Guidance
+
+## Summary
+
+Strengthened RARA's runtime prompt and `bash` tool guidance so sandbox-denied
+validation work follows the same contract Claude Code uses: treat denials as
+new information, do not blindly repeat the exact same call, and escalate with
+concrete justification when the blocked capability is essential.
+
+## Background
+
+RARA already told the model not to give up on tests, builds, or checks just
+because the first sandboxed command failed. In practice that still left one
+important gap: the model could see a denial, report it, and then stall without
+either narrowing the command or requesting `require_escalated`.
+
+Claude Code spreads the missing behavior across its harness and denied-tool
+prompts:
+
+- a denied tool call is not something to repeat verbatim;
+- the model should adjust its approach based on why the call was denied;
+- when the blocked capability is necessary, the model should explain that need
+  and request the required permission.
+
+This change ports that contract into RARA's own prompt-locality model instead
+of copying Claude-specific wrappers.
+
+## Scope
+
+- Added always-on prompt guidance that denied tool calls, denied sandboxed
+  commands, and denied escalation requests must not be retried verbatim.
+- Added execute-mode guidance that verification todos stay pending when
+  validation remains blocked by denied commands or denied escalation.
+- Expanded the `bash` tool description and input schema so the call site itself
+  teaches: inspect the denial, narrow the command, and prefer
+  `require_escalated` over repeating an already denied essential validation
+  command.
+- Tightened CI lockfile discipline by running the existing `clippy` and `test`
+  workflows with `--locked`, so lockfile drift fails normal PR validation
+  instead of showing up only in release jobs or local hooks.
+- Updated the prompt-runtime spec to document denied-call handling as part of
+  sandbox-escalation locality.
+
+## Key Decisions
+
+- Keep the broad "denials are routing information" rule in the always-on prompt
+  because it applies beyond any single tool.
+- Repeat the sandbox-specific escalation rule in `bash` because the model needs
+  it at the exact moment it chooses whether to retry or request approval.
+- Tie denied validation back to `todo_write` only in execute mode so plan and
+  review turns stay read-only and narrower.
+
+## Validation
+
+- `cargo fmt --all`
+- `cargo test -p rara-instructions`
+- `cargo test bash_tool_schema_guides_command_discipline`
+
+## Follow-Ups
+
+- No new follow-up was opened by this slice.

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -643,13 +643,13 @@ fn command_env_for_wrapped(
 
 #[tool_spec(
     name = "bash",
-    description = "Run a shell command in the sandbox for commands that need process execution. Use the cwd field for the working directory; do not prefix commands with cd. Prefer dedicated RARA tools for file search, file reads, and file edits. Edit files with apply_patch, replace, replace_lines, or write_file; do not use shell redirection, sed -i, awk, perl, heredocs, or ad-hoc scripts to edit files when direct edit tools can do the job. Avoid newline-separated command chaining. If commands are independent and can run in parallel, make multiple bash tool calls in one assistant turn instead of joining them with &&, ;, or pipelines. Do not add 2>&1, head, tail, or grep only to reduce displayed output; RARA preserves stdout/stderr and provides bounded model-facing previews. Commands must be non-interactive: do not start editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, always supply the message with git commit -m or git commit -F; never run bare git commit and wait for an editor. Keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop.",
+    description = "Run a shell command in the sandbox for commands that need process execution. Use the cwd field for the working directory; do not prefix commands with cd. Prefer dedicated RARA tools for file search, file reads, and file edits. Edit files with apply_patch, replace, replace_lines, or write_file; do not use shell redirection, sed -i, awk, perl, heredocs, or ad-hoc scripts to edit files when direct edit tools can do the job. Avoid newline-separated command chaining. If commands are independent and can run in parallel, make multiple bash tool calls in one assistant turn instead of joining them with &&, ;, or pipelines. Do not add 2>&1, head, tail, or grep only to reduce displayed output; RARA preserves stdout/stderr and provides bounded model-facing previews. Commands must be non-interactive: do not start editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, always supply the message with git commit -m or git commit -F; never run bare git commit and wait for an editor. Keep commands sandboxed unless require_escalated is justified by user request or clear sandbox failure evidence. If a needed test, build, or check is blocked by sandbox limits, inspect the exact denial, try the narrowest viable command, and request require_escalated only when that evidence shows the sandbox is the blocker; do not stop verification just because the first command was denied. Do not re-run the exact same denied sandboxed validation command; either narrow it or switch to require_escalated with a concrete justification when the blocked capability is essential. Use run_in_background for long-running non-interactive commands, then inspect or stop them with background_task_status, background_task_list, and background_task_stop.",
     input_schema = {
         "type": "object",
         "properties": {
             "command": {
                 "type": "string",
-                "description": "Legacy shell command string. Do not prefix this command with cd; set the cwd field instead. Prefer program+args for new calls. Avoid newline-separated command chaining. Do not join independent validation commands with &&, ;, or pipelines just to run them together; make multiple bash tool calls instead. Do not add 2>&1, head, tail, or grep only to trim output for the model. Do not run interactive editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, use git commit -m or git commit -F, never bare git commit. Do not use this field for file edits when apply_patch, replace, replace_lines, or write_file can do the job; avoid sed -i, awk, perl, shell redirection, and heredocs for edits."
+                "description": "Legacy shell command string. Do not prefix this command with cd; set the cwd field instead. Prefer program+args for new calls. Avoid newline-separated command chaining. Do not join independent validation commands with &&, ;, or pipelines just to run them together; make multiple bash tool calls instead. Do not add 2>&1, head, tail, or grep only to trim output for the model. Do not run interactive editors, pagers, REPLs, prompts, or TUI programs from bash. For git commits, use git commit -m or git commit -F, never bare git commit. Do not use this field for file edits when apply_patch, replace, replace_lines, or write_file can do the job; avoid sed -i, awk, perl, shell redirection, and heredocs for edits. If a validation command is denied by the sandbox, inspect the exact failure and either narrow the command or request escalated permissions instead of giving up. Do not repeat the exact same denied sandboxed validation call."
             },
             "program": {
                 "type": "string",
@@ -683,11 +683,11 @@ fn command_env_for_wrapped(
                 "type": "string",
                 "enum": ["use_default", "require_escalated"],
                 "default": "use_default",
-                "description": "Sandbox permissions for the command. Defaults to use_default. Set to require_escalated only when the user asked for it or sandbox failure evidence shows the command cannot work inside the sandbox."
+                "description": "Sandbox permissions for the command. Defaults to use_default. Set to require_escalated only when the user asked for it or sandbox failure evidence shows the command cannot work inside the sandbox. For tests, builds, and checks, first confirm that the denial is actually caused by sandbox restrictions. If the same essential validation command was already denied for sandbox reasons, prefer require_escalated over repeating the denied sandboxed call."
             },
             "justification": {
                 "type": "string",
-                "description": "Only set if sandbox_permissions is require_escalated. Ask the user a short question explaining why this command needs to run outside the sandbox."
+                "description": "Only set if sandbox_permissions is require_escalated. Ask the user a short question explaining why this command needs to run outside the sandbox and which blocked validation or capability requires it."
             },
             "prefix_rule": {
                 "type": "array",
@@ -1513,6 +1513,11 @@ mod tests {
         assert!(description.contains("Commands must be non-interactive"));
         assert!(description.contains("git commit -m"));
         assert!(description.contains("require_escalated"));
+        assert!(description.contains("do not stop verification"));
+        assert!(
+            description
+                .contains("Do not re-run the exact same denied sandboxed validation command")
+        );
         assert!(description.contains("background_task_status"));
 
         let schema = tool.input_schema().to_string();
@@ -1520,8 +1525,13 @@ mod tests {
         assert!(schema.contains("Do not prefix this command with cd"));
         assert!(schema.contains("apply_patch, replace, replace_lines"));
         assert!(schema.contains("never bare git commit"));
+        assert!(schema.contains("request escalated permissions instead of giving up"));
+        assert!(schema.contains("Do not repeat the exact same denied sandboxed validation call"));
         assert!(schema.contains("Use this instead of prefixing the command with cd"));
         assert!(schema.contains("sandbox failure evidence"));
+        assert!(
+            schema.contains("prefer require_escalated over repeating the denied sandboxed call")
+        );
         assert!(schema.contains("Do not suggest broad prefixes"));
     }
 

--- a/src/tools/todo.rs
+++ b/src/tools/todo.rs
@@ -11,13 +11,13 @@ pub struct TodoWriteTool;
 
 #[tool_spec(
     name = "todo_write",
-    description = "Create or replace the session todo list for complex multi-step execution. Use this to track mutable execution progress, not to request plan approval.",
+    description = "Create or replace the session todo list for complex multi-step execution. Use this proactively once work has multiple concrete steps or verification work worth tracking; do not use it for trivial one-step tasks or to request plan approval. Re-send the full working set whenever statuses, order, blockers, or validation steps change. Keep at most one item in_progress, update statuses promptly, and prefer concrete execution items such as reproducing a bug, running a focused test, or final verification. Do not mark an item completed until the underlying implementation or validation is actually done.",
     input_schema = {
         "type": "object",
         "properties": {
             "todos": {
                 "type": "array",
-                "description": "Complete replacement list of todo items for the current session.",
+                "description": "Complete replacement list of todo items for the current session. Re-send the entire working set whenever items, order, statuses, blockers, or verification work changes.",
                 "items": {
                     "type": "object",
                     "properties": {
@@ -27,12 +27,12 @@ pub struct TodoWriteTool;
                         },
                         "content": {
                             "type": "string",
-                            "description": "Imperative description of the task."
+                            "description": "Short imperative task description. Prefer concrete work items such as 'Reproduce failing behavior' or 'Run focused regression test'."
                         },
                         "status": {
                             "type": "string",
                             "enum": ["pending", "in_progress", "completed", "cancelled"],
-                            "description": "Current task status. Keep at most one item in_progress."
+                            "description": "Current task status. Keep at most one item in_progress, and do not mark completed until the relevant implementation or verification work is actually done."
                         }
                     },
                     "required": ["content", "status"],
@@ -89,5 +89,21 @@ mod tests {
             schema["properties"]["todos"]["items"]["additionalProperties"],
             false
         );
+    }
+
+    #[test]
+    fn todo_write_description_guides_execution_and_verification() {
+        let tool = TodoWriteTool;
+        let description = tool.description();
+        assert!(description.contains("multiple concrete steps"));
+        assert!(description.contains("verification work worth tracking"));
+        assert!(description.contains("Re-send the full working set"));
+        assert!(description.contains("running a focused test"));
+        assert!(description.contains("underlying implementation or validation"));
+
+        let schema = tool.input_schema().to_string();
+        assert!(schema.contains("entire working set"));
+        assert!(schema.contains("Reproduce failing behavior"));
+        assert!(schema.contains("relevant implementation or verification work"));
     }
 }

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -1,6 +1,7 @@
 // Wide-screen sidebar (≥120 cols) rendered alongside the main transcript pane.
 // Layout draws a 38-column panel on the left split by a vertical border,
-// showing session identity, model badge, context summary, files access, and status.
+// showing session identity, model badge, context summary, todo progress,
+// files access, and status.
 use std::collections::BTreeSet;
 
 use ratatui::{
@@ -42,6 +43,9 @@ pub(crate) fn render_sidebar(f: &mut Frame, app: &TuiApp, area: Rect) {
     lines.push(Line::from(""));
     push_context_summary(&mut lines, app);
     lines.push(Line::from(""));
+    if push_todo_section(&mut lines, app) {
+        lines.push(Line::from(""));
+    }
     push_child_sessions(&mut lines, app);
     lines.push(Line::from(""));
     push_files_in_context(&mut lines, app);
@@ -131,6 +135,64 @@ fn push_context_summary(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
         context_sidebar_summary(snap),
         Style::default().fg(TEXT_MUTED),
     )));
+}
+
+fn push_todo_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bool {
+    let todo = &app.snapshot.todo;
+    if todo.summary.total == 0 {
+        return false;
+    }
+
+    lines.push(Line::from(super::section_label("Todo", TEXT_SECONDARY)));
+    let open = todo.summary.pending + todo.summary.in_progress;
+    lines.push(Line::from(Span::styled(
+        format!(
+            "{}/{} done · {} open",
+            todo.summary.completed, todo.summary.total, open
+        ),
+        Style::default().fg(TEXT_MUTED),
+    )));
+
+    if let Some(active) = todo.summary.active_item.as_deref() {
+        lines.push(Line::from(Span::styled(
+            format!("Active: {active}"),
+            Style::default().fg(INTERACTION_SUB_AGENT),
+        )));
+    }
+
+    for (_, status, content) in todo.items.iter().take(4) {
+        lines.push(Line::from(Span::styled(
+            format!("{} {}", todo_status_marker(status), content.trim()),
+            todo_status_style(status),
+        )));
+    }
+
+    if todo.items.len() > 4 {
+        lines.push(Line::from(Span::styled(
+            format!("... and {} more", todo.items.len() - 4),
+            Style::default().fg(TEXT_MUTED),
+        )));
+    }
+
+    true
+}
+
+fn todo_status_marker(status: &str) -> &'static str {
+    match status {
+        "in_progress" => "[>]",
+        "completed" => "[x]",
+        "cancelled" => "[-]",
+        _ => "[ ]",
+    }
+}
+
+fn todo_status_style(status: &str) -> Style {
+    match status {
+        "in_progress" => Style::default().fg(INTERACTION_SUB_AGENT),
+        "completed" => Style::default().fg(STATUS_SUCCESS),
+        "cancelled" => Style::default().fg(TEXT_MUTED),
+        _ => Style::default().fg(TEXT_SECONDARY),
+    }
 }
 
 fn push_child_sessions(lines: &mut Vec<Line<'static>>, app: &TuiApp) {

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -3,9 +3,11 @@ use tempfile::tempdir;
 
 use super::{
     push_child_sessions, push_context_summary, push_files_in_context, push_model_badge,
-    push_session_info,
+    push_session_info, push_todo_section,
 };
 use crate::config::ConfigManager;
+use crate::context::TodoContextView;
+use crate::todo::TodoSummary;
 use crate::tui::state::{
     InteractionKind, PendingInteractionSnapshot, RuntimeSnapshot, TranscriptEntry, TranscriptTurn,
     TuiApp,
@@ -325,6 +327,67 @@ fn push_context_summary_no_context_window() {
             .any(|l| l.to_string().contains("600 · 5 turns")),
         "shows current-turn history tokens without context window"
     );
+}
+
+#[test]
+fn push_todo_section_shows_progress_and_items() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot = RuntimeSnapshot {
+        todo: TodoContextView {
+            summary: TodoSummary {
+                total: 4,
+                pending: 1,
+                in_progress: 1,
+                completed: 1,
+                cancelled: 1,
+                active_item: Some("Run focused regression test".into()),
+            },
+            updated_at: Some(1_777_584_000),
+            items: vec![
+                (
+                    "todo-1".into(),
+                    "completed".into(),
+                    "Reproduce failing behavior".into(),
+                ),
+                (
+                    "todo-2".into(),
+                    "in_progress".into(),
+                    "Run focused regression test".into(),
+                ),
+                (
+                    "todo-3".into(),
+                    "pending".into(),
+                    "Check nearby side effects".into(),
+                ),
+                (
+                    "todo-4".into(),
+                    "cancelled".into(),
+                    "Broader cleanup".into(),
+                ),
+            ],
+        },
+        ..RuntimeSnapshot::default()
+    };
+
+    let mut lines = Vec::new();
+    assert!(push_todo_section(&mut lines, &app));
+
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("Todo"));
+    assert!(text.contains("1/4 done · 2 open"));
+    assert!(text.contains("Active: Run focused regression test"));
+    assert!(text.contains("[x] Reproduce failing behavior"));
+    assert!(text.contains("[>] Run focused regression test"));
+    assert!(text.contains("[ ] Check nearby side effects"));
+    assert!(text.contains("[-] Broader cleanup"));
 }
 
 // ── push_child_sessions ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- strengthen prompt and bash guidance for sandbox-denied validation and denied escalation requests
- keep verification work visible in `todo_write` and execute-mode guidance until it is actually resolved
- show bounded todo progress in the wide sidebar and document the related runtime contracts
- run the existing `clippy` and `test` CI jobs with `--locked` so lockfile drift fails PR validation

## Purpose

- prevent the agent from dropping verification after the first sandbox denial
- make pending validation work explicit in both runtime guidance and the TUI

## Related issue

- None

## Testing

- `cargo fmt --all`
- `cargo test -p rara-instructions`
- `cargo test bash_tool_schema_guides_command_discipline`
- `cargo test todo_write`
- `cargo test sidebar`
