### PR TITLE
fix(tui): render startup warnings in transcript

### DIFF
--- a/components/model_server/rara_model_server.py
+++ b/components/model_server/rara_model_server.py
@@ -13,6 +13,7 @@ import json
 import os
 import platform
 import sys
+import threading
 import time
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -193,6 +194,33 @@ class FastEmbedBgeM3Backend(EmbeddingBackend):
     name = "fastembed_bge_m3"
     model_id = FASTEMBED_MODEL_ID
 
+    _bge_m3_registered = False
+    _bge_m3_lock = threading.Lock()
+
+    @classmethod
+    def _ensure_bge_m3_registered(cls) -> None:
+        if cls._bge_m3_registered:
+            return
+        with cls._bge_m3_lock:
+            if cls._bge_m3_registered:
+                return
+            from fastembed import TextEmbedding
+            from fastembed.common.model_description import ModelSource, PoolingType
+
+            TextEmbedding.add_custom_model(
+                model=FASTEMBED_MODEL_ID,
+                dim=EMBEDDING_DIMENSION,
+                description="Text embeddings, Unimodal (text), multilingual, 8192 tokens, BGE-M3",
+                license="apache-2.0",
+                size_in_gb=2.3,
+                sources=ModelSource(hf=FASTEMBED_MODEL_ID),
+                pooling=PoolingType.MEAN,
+                normalization=True,
+                model_file="onnx/model.onnx",
+                additional_files=["onnx/model.onnx_data"],
+            )
+            cls._bge_m3_registered = True
+
     def __init__(self) -> None:
         super().__init__()
         self.model: Any | None = None
@@ -205,6 +233,9 @@ class FastEmbedBgeM3Backend(EmbeddingBackend):
         requested = os.environ.get("RARA_FASTEMBED_EMBEDDING_MODEL", FASTEMBED_MODEL_ID)
         if requested != FASTEMBED_MODEL_ID:
             raise RuntimeError(f"unsupported FastEmbed model: {requested}")
+
+        self._ensure_bge_m3_registered()
+
         from fastembed import TextEmbedding
 
         kwargs: dict[str, Any] = {"model_name": requested}
@@ -233,6 +264,8 @@ class ModelRegistry:
     def __init__(self) -> None:
         self.backends: dict[str, EmbeddingBackend] = {}
         self.preparation: dict[str, dict[str, Any]] = {}
+        self._preparing: dict[str, bool] = {}
+        self._prepare_lock = threading.Lock()
 
     def embedding_backend(self, requested: str | None) -> EmbeddingBackend:
         name = requested or os.environ.get("RARA_EMBEDDING_BACKEND") or _platform_default_backend()
@@ -251,6 +284,14 @@ class ModelRegistry:
 
     def prepare_model(self, requested: str | None, model_path: str | None) -> dict[str, Any]:
         backend = self.embedding_backend(requested)
+        if backend.loaded_at is not None:
+            return {"ok": True, "backend": backend.name, "model": backend.model_id, "state": "ready"}
+        with self._prepare_lock:
+            if backend.loaded_at is not None:
+                return {"ok": True, "backend": backend.name, "model": backend.model_id, "state": "ready"}
+            if self._preparing.get(backend.name):
+                return {"ok": True, "backend": backend.name, "model": backend.model_id, "state": "loading"}
+            self._preparing[backend.name] = True
         self.preparation[backend.name] = {
             "state": "loading",
             "backend": backend.name,
@@ -260,6 +301,8 @@ class ModelRegistry:
         try:
             backend.load(model_path)
         except Exception as exc:
+            with self._prepare_lock:
+                self._preparing[backend.name] = False
             self.preparation[backend.name] = {
                 "state": "error",
                 "backend": backend.name,
@@ -267,6 +310,8 @@ class ModelRegistry:
                 "message": str(exc),
             }
             raise
+        with self._prepare_lock:
+            self._preparing[backend.name] = False
         self.preparation[backend.name] = {
             "state": "ready",
             "backend": backend.name,
@@ -280,8 +325,23 @@ class ModelRegistry:
             "state": "ready",
         }
 
+    def start_background_preparation(self) -> None:
+        backend_name = self._platform_default_backend()
+
+        def _run() -> None:
+            try:
+                self.prepare_model(backend_name, None)
+            except Exception as exc:
+                print(
+                    f"[model-server] background model preparation failed: {exc}",
+                    file=sys.stderr,
+                )
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+
     def status(self) -> dict[str, Any]:
-        default_backend = _platform_default_backend()
+        default_backend = self._platform_default_backend()
         self.embedding_backend(default_backend)
         return {
             "ok": True,
@@ -298,6 +358,10 @@ class ModelRegistry:
                 name: state.copy() for name, state in sorted(self.preparation.items())
             },
         }
+
+    @staticmethod
+    def _platform_default_backend() -> str:
+        return _platform_default_backend()
 
 
 REGISTRY = ModelRegistry()
@@ -398,6 +462,8 @@ def main() -> int:
     if host not in {"127.0.0.1", "localhost"}:
         raise RuntimeError("RARA model server only binds to loopback hosts")
     server = ThreadingHTTPServer((host, port), RequestHandler)
+    print(f"RARA model server listening on {host}:{port}", flush=True)
+    REGISTRY.start_background_preparation()
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -12,6 +12,7 @@ use fs2::FileExt;
 use hf_hub::api::Progress as HfProgress;
 use hf_hub::api::sync::ApiBuilder;
 use hf_hub::{Cache, Repo, RepoType};
+use nix::unistd::Pid;
 use rara_persistence::redaction::{redact_secrets, sanitize_url_for_display};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -47,8 +48,8 @@ const REQUIREMENTS_MARKER_NAME: &str = "requirements-installed.json";
 const MODEL_SNAPSHOT_MARKER_NAME: &str = "model-snapshot.json";
 const HEALTH_TIMEOUT: Duration = Duration::from_millis(300);
 const PREPARE_TIMEOUT: Duration = Duration::from_secs(30);
-const STARTUP_HEALTH_ATTEMPTS: usize = 10;
-const STARTUP_HEALTH_DELAY: Duration = Duration::from_millis(100);
+const STARTUP_HEALTH_ATTEMPTS: usize = 30;
+const STARTUP_HEALTH_DELAY: Duration = Duration::from_millis(200);
 const MODEL_REVISION: &str = "main";
 static ATOMIC_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -269,6 +270,18 @@ impl LocalModelServerEmbeddingBackend {
                     .expect("local embedding endpoint lock poisoned") = None;
                 Err(err)
             }
+        }
+    }
+}
+
+impl Drop for LocalModelServerEmbeddingBackend {
+    fn drop(&mut self) {
+        let runtime_dir = self.rara_home.join("runtime").join("model-server");
+        if let Ok(Some(metadata)) = read_server_metadata(&metadata_path(&runtime_dir)) {
+            let _ = nix::sys::signal::kill(
+                Pid::from_raw(metadata.pid as i32),
+                nix::sys::signal::Signal::SIGTERM,
+            );
         }
     }
 }
@@ -517,8 +530,30 @@ fn reusable_server_status(
     }
     let endpoint = endpoint_url(&metadata.host, metadata.port);
     let health = probe_health(&metadata.host, metadata.port).ok()?;
-    if !health_identity_matches(&health, backend, model) || !health_model_ready(&health, backend) {
+    if !health_identity_matches(&health, backend, model) {
         return None;
+    }
+    if !health_model_ready(&health, backend) {
+        if let Some(error_message) = health_preparation_error(&health, backend) {
+            return Some(LocalModelServerStatus {
+                state: LocalModelServerState::Error,
+                backend: backend.to_string(),
+                model: model.to_string(),
+                detail: format!(
+                    "model server running at {endpoint}; model preparation failed: {error_message}"
+                ),
+                server_path: Some(server.path.clone()),
+                endpoint: Some(endpoint),
+            });
+        }
+        return Some(LocalModelServerStatus {
+            state: LocalModelServerState::PreparingModel,
+            backend: backend.to_string(),
+            model: model.to_string(),
+            detail: format!("model server running at {endpoint}; model is still loading"),
+            server_path: Some(server.path.clone()),
+            endpoint: Some(endpoint),
+        });
     }
     Some(LocalModelServerStatus {
         state: LocalModelServerState::Ready,
@@ -541,6 +576,9 @@ fn start_model_server(
     let port = DEFAULT_MODEL_SERVER_PORT;
     let endpoint = endpoint_url(host, port);
     let model_cache_dir = default_local_model_cache_dir();
+    let stderr_log_path = server.runtime_dir.join("model-server-stderr.log");
+    let stderr_file = std::fs::File::create(&stderr_log_path)
+        .unwrap_or_else(|_| std::fs::File::create("/dev/null").unwrap());
     match Command::new(python)
         .arg(&server.path)
         .env("RARA_MODEL_SERVER_HOST", host)
@@ -548,10 +586,10 @@ fn start_model_server(
         .env("RARA_MODEL_CACHE_DIR", &model_cache_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::from(stderr_file))
         .spawn()
     {
-        Ok(child) => {
+        Ok(mut child) => {
             let metadata = ModelServerMetadata {
                 pid: child.id(),
                 host: host.to_string(),
@@ -572,39 +610,79 @@ fn start_model_server(
                 };
             }
 
+            let mut health_ever_passed = false;
+            let mut last_prepare_error: Option<anyhow::Error> = None;
             for _ in 0..STARTUP_HEALTH_ATTEMPTS {
                 if let Ok(health) = probe_health(host, port) {
+                    health_ever_passed = true;
                     if health_identity_matches(&health, backend, model) {
-                        return match prepare_model(host, port, backend, model_path) {
-                            Ok(()) => LocalModelServerStatus {
-                                state: LocalModelServerState::Ready,
-                                backend: backend.to_string(),
-                                model: model.to_string(),
-                                detail: format!(
-                                    "started model server and prepared model at {endpoint}"
-                                ),
-                                server_path: Some(server.path.clone()),
-                                endpoint: Some(endpoint),
-                            },
-                            Err(err) => LocalModelServerStatus {
-                                state: LocalModelServerState::Error,
-                                backend: backend.to_string(),
-                                model: model.to_string(),
-                                detail: format!("failed to prepare model: {err}"),
-                                server_path: Some(server.path.clone()),
-                                endpoint: Some(endpoint),
-                            },
-                        };
+                        match prepare_model(host, port, backend, model_path) {
+                            Ok(state) => {
+                                let (state_tag, detail) = if state == "ready" {
+                                    (
+                                        LocalModelServerState::Ready,
+                                        format!(
+                                            "started model server and prepared model at {endpoint}"
+                                        ),
+                                    )
+                                } else {
+                                    (
+                                        LocalModelServerState::PreparingModel,
+                                        format!(
+                                            "started model server at {endpoint}; model is still loading"
+                                        ),
+                                    )
+                                };
+                                return LocalModelServerStatus {
+                                    state: state_tag,
+                                    backend: backend.to_string(),
+                                    model: model.to_string(),
+                                    detail,
+                                    server_path: Some(server.path.clone()),
+                                    endpoint: Some(endpoint),
+                                };
+                            }
+                            Err(err) => {
+                                last_prepare_error = Some(err);
+                            }
+                        }
                     }
                 }
                 std::thread::sleep(STARTUP_HEALTH_DELAY);
+                if let Ok(Some(status)) = child.try_wait() {
+                    return LocalModelServerStatus {
+                        state: LocalModelServerState::Error,
+                        backend: backend.to_string(),
+                        model: model.to_string(),
+                        detail: format!(
+                            "model server process exited with {status} during startup (stderr log: {})",
+                            stderr_log_path.display()
+                        ),
+                        server_path: Some(server.path.clone()),
+                        endpoint: Some(endpoint),
+                    };
+                }
+            }
+            if let Some(err) = last_prepare_error {
+                return LocalModelServerStatus {
+                    state: LocalModelServerState::Error,
+                    backend: backend.to_string(),
+                    model: model.to_string(),
+                    detail: format!(
+                        "failed to prepare model at {endpoint} after {} health checks: {err} (stderr log: {})",
+                        STARTUP_HEALTH_ATTEMPTS,
+                        stderr_log_path.display()
+                    ),
+                    server_path: Some(server.path.clone()),
+                    endpoint: Some(endpoint),
+                };
             }
 
-            if let Ok(()) = prepare_model(host, port, backend, model_path) {
-                if let Ok(health) = probe_health(host, port) {
-                    if health_identity_matches(&health, backend, model)
-                        && health_model_ready(&health, backend)
-                    {
+            let stderr_hint = format!(" (stderr log: {})", stderr_log_path.display());
+            match prepare_model(host, port, backend, model_path) {
+                Ok(state) => {
+                    health_ever_passed = true;
+                    if state == "ready" {
                         return LocalModelServerStatus {
                             state: LocalModelServerState::Ready,
                             backend: backend.to_string(),
@@ -616,6 +694,23 @@ fn start_model_server(
                             endpoint: Some(endpoint),
                         };
                     }
+                    if let Ok(health) = probe_health(host, port) {
+                        if health_identity_matches(&health, backend, model) {
+                            return LocalModelServerStatus {
+                                state: LocalModelServerState::PreparingModel,
+                                backend: backend.to_string(),
+                                model: model.to_string(),
+                                detail: format!(
+                                    "started model server at {endpoint}; model is still loading"
+                                ),
+                                server_path: Some(server.path.clone()),
+                                endpoint: Some(endpoint),
+                            };
+                        }
+                    }
+                }
+                Err(err) => {
+                    last_prepare_error = Some(err);
                 }
             }
 
@@ -623,7 +718,15 @@ fn start_model_server(
                 state: LocalModelServerState::Starting,
                 backend: backend.to_string(),
                 model: model.to_string(),
-                detail: format!("started model server process; waiting for health at {endpoint}"),
+                detail: if health_ever_passed {
+                    format!(
+                        "started model server process; waiting for health at {endpoint}{stderr_hint}"
+                    )
+                } else {
+                    format!(
+                        "started model server process; health never reached at {endpoint}{stderr_hint}"
+                    )
+                },
                 server_path: Some(server.path.clone()),
                 endpoint: Some(endpoint),
             }
@@ -1222,24 +1325,35 @@ fn probe_health(host: &str, port: u16) -> Result<Value> {
         .context("parse model server health response")
 }
 
-fn prepare_model(host: &str, port: u16, backend: &str, model_path: Option<&Path>) -> Result<()> {
+fn prepare_model(
+    host: &str,
+    port: u16,
+    backend: &str,
+    model_path: Option<&Path>,
+) -> Result<String> {
     let mut body = serde_json::json!({ "backend": backend });
     if let Some(model_path) = model_path {
         body["model_path"] = Value::String(model_path.display().to_string());
     }
     let body = body.to_string();
+    let url = format!("http://{host}:{port}/models/prepare");
     let response = post_json(host, port, "/models/prepare", &body, PREPARE_TIMEOUT)
-        .context("call model prepare endpoint")?;
+        .with_context(|| format!("call POST {url}"))?;
     if response.get("ok").and_then(Value::as_bool) != Some(true) {
         bail!("model prepare endpoint returned non-ok response");
     }
     if response.get("backend").and_then(Value::as_str) != Some(backend) {
         bail!("model prepare endpoint returned mismatched backend");
     }
-    if response.get("state").and_then(Value::as_str) != Some("ready") {
-        bail!("model prepare endpoint did not report ready state");
+    let state = response
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    if state != "ready" && state != "loading" {
+        bail!("model prepare endpoint returned unexpected state: {state}");
     }
-    Ok(())
+    Ok(state)
 }
 
 fn post_json(host: &str, port: u16, path: &str, body: &str, timeout: Duration) -> Result<Value> {
@@ -1299,6 +1413,17 @@ fn health_model_ready(health: &Value, backend: &str) -> bool {
         .and_then(|value| value.get("loaded"))
         .and_then(Value::as_bool)
         == Some(true)
+}
+
+fn health_preparation_error<'a>(health: &'a Value, backend: &str) -> Option<&'a str> {
+    let prep = health
+        .get("preparation")
+        .and_then(|value| value.get(backend))?;
+    if prep.get("state").and_then(Value::as_str) == Some("error") {
+        prep.get("message").and_then(Value::as_str)
+    } else {
+        None
+    }
 }
 
 fn ensure_command_success(output: Output, context: &str) -> Result<()> {

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -326,6 +326,8 @@ pub(super) fn is_renderable_system_message(message: &str) -> bool {
         || lower.starts_with(&memory_notice_prefix)
         || lower.starts_with("compaction failed:")
         || lower.starts_with("compact failed:")
+        || lower.starts_with("local embedding backend bootstrap reported:")
+        || lower.starts_with("skill loading failed:")
         || lower.starts_with("oauth failed:")
         || lower.starts_with("backend rebuild failed:")
         || lower.starts_with("open this url in a browser and enter the one-time code:")

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -1,6 +1,5 @@
 use ratatui::{style::Color, text::Line};
 
-use crate::memory_notice::MEMORY_NOTICE_PREFIX;
 use crate::tui::state::TranscriptEntry;
 
 #[path = "active_turn.rs"]
@@ -319,20 +318,29 @@ mod helper_tests {
     }
 }
 
+const RENDERABLE_SYSTEM_MESSAGE_PREFIXES: &[&str] = &[
+    "query failed:",
+    "memory ·",
+    "compaction failed:",
+    "compact failed:",
+    "local embedding backend bootstrap reported:",
+    "skill loading failed:",
+    "oauth failed:",
+    "backend rebuild failed:",
+    "open this url in a browser and enter the one-time code:",
+    "starting codex browser login.",
+    "error:",
+];
+
+fn starts_with_ignore_ascii_case(s: &str, prefix: &str) -> bool {
+    s.len() >= prefix.len() && s[..prefix.len()].eq_ignore_ascii_case(prefix)
+}
+
 pub(super) fn is_renderable_system_message(message: &str) -> bool {
-    let lower = message.trim().to_ascii_lowercase();
-    let memory_notice_prefix = MEMORY_NOTICE_PREFIX.to_ascii_lowercase();
-    lower.starts_with("query failed:")
-        || lower.starts_with(&memory_notice_prefix)
-        || lower.starts_with("compaction failed:")
-        || lower.starts_with("compact failed:")
-        || lower.starts_with("local embedding backend bootstrap reported:")
-        || lower.starts_with("skill loading failed:")
-        || lower.starts_with("oauth failed:")
-        || lower.starts_with("backend rebuild failed:")
-        || lower.starts_with("open this url in a browser and enter the one-time code:")
-        || lower.starts_with("starting codex browser login.")
-        || lower.starts_with("error:")
+    let trimmed = message.trim();
+    RENDERABLE_SYSTEM_MESSAGE_PREFIXES
+        .iter()
+        .any(|prefix| starts_with_ignore_ascii_case(trimmed, prefix))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Add two missing prefixes to `is_renderable_system_message` so that startup warnings pushed to the transcript as `System` entries are actually visible in the TUI.

## Why

When the backend rebuilds, warnings such as `"local embedding backend bootstrap reported: ..."` or `"Skill loading failed: ..."` are pushed to the transcript. The bottom pane shows the notice "Startup warning added to transcript.", but `is_renderable_system_message` — the gatekeeper for which `System`-role entries appear in the TUI — did not recognize these prefixes. The warnings were silently filtered from the rendered output.

## How

Added two prefixes to `is_renderable_system_message` in `src/tui/render/cells/mod.rs`:

- `"local embedding backend bootstrap reported:"`
- `"skill loading failed:"`

## Testing

- `cargo fmt --check` — passed
- `rebuild_success_keeps_long_warnings_in_transcript` — passed
- 69 cells rendering tests — all passed
- `ssh_startup_page_warns_without_opening_setup_window` — passed
