### PR TITLE
chore(tui): remove files read/changed section from sidebar

### DIFF
--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -1,8 +1,5 @@
 // Wide-screen sidebar (≥120 cols) rendered alongside the main transcript pane.
 // Layout draws a 38-column panel on the left split by a vertical border,
-// showing session identity, model badge, context summary, todo progress,
-// files access, and status.
-use std::collections::BTreeSet;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -48,7 +45,6 @@ pub(crate) fn render_sidebar(f: &mut Frame, app: &TuiApp, area: Rect) {
     }
     push_child_sessions(&mut lines, app);
     lines.push(Line::from(""));
-    push_files_in_context(&mut lines, app);
 
     f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), body_area);
 
@@ -220,90 +216,6 @@ fn push_child_sessions(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
             format!("  ... and {} more", child_count - 5),
             Style::default().fg(TEXT_MUTED),
         )));
-    }
-}
-
-fn push_files_in_context(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
-    let mut read_files: BTreeSet<String> = BTreeSet::new();
-    let mut changed_files: BTreeSet<String> = BTreeSet::new();
-
-    let all_turns = app
-        .committed_turns
-        .iter()
-        .chain(std::iter::once(&app.active_turn));
-
-    for turn in all_turns {
-        for entry in &turn.entries {
-            if entry.role != "Tool" {
-                continue;
-            }
-            let msg = entry.message.trim();
-
-            if let Some(path) = msg.strip_prefix("read_file ") {
-                read_files.insert(path.trim().to_string());
-            } else if let Some(rest) = msg.strip_prefix("apply_patch ") {
-                for part in rest.split(',') {
-                    let p = part.trim();
-                    if !p.is_empty() {
-                        changed_files.insert(p.to_string());
-                    }
-                }
-            } else if let Some(path) = msg.strip_prefix("write_file ") {
-                changed_files.insert(path.trim().to_string());
-            } else if let Some(path) = msg.strip_prefix("replace ") {
-                changed_files.insert(path.trim().to_string());
-            } else if let Some(path) = msg.strip_prefix("multi_edit ") {
-                changed_files.insert(path.trim().to_string());
-            } else if let Some(path) = msg.strip_prefix("replace_lines ") {
-                changed_files.insert(path.trim().to_string());
-            }
-        }
-    }
-
-    if read_files.is_empty() && changed_files.is_empty() {
-        return;
-    }
-
-    lines.push(Line::from(super::section_label("Files", TEXT_SECONDARY)));
-
-    // Files read.
-    if !read_files.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "Read:",
-            Style::default().fg(TEXT_MUTED),
-        )));
-        for path in read_files.iter().take(5) {
-            lines.push(Line::from(Span::styled(
-                format!("  {path}"),
-                Style::default().fg(TEXT_SECONDARY),
-            )));
-        }
-        if read_files.len() > 5 {
-            lines.push(Line::from(Span::styled(
-                format!("  ... and {} more", read_files.len() - 5),
-                Style::default().fg(TEXT_MUTED),
-            )));
-        }
-    }
-
-    // Files changed.
-    if !changed_files.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "Changed:",
-            Style::default().fg(TEXT_MUTED),
-        )));
-        for path in changed_files.iter().take(5) {
-            lines.push(Line::from(Span::styled(
-                format!("  {path}"),
-                Style::default().fg(INTERACTION_SUB_AGENT),
-            )));
-        }
-        if changed_files.len() > 5 {
-            lines.push(Line::from(Span::styled(
-                format!("  ... and {} more", changed_files.len() - 5),
-                Style::default().fg(TEXT_MUTED),
-            )));
-        }
     }
 }
 

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -2,8 +2,8 @@ use ratatui::{layout::Rect, style::Color, text::Line};
 use tempfile::tempdir;
 
 use super::{
-    push_child_sessions, push_context_summary, push_files_in_context, push_model_badge,
-    push_session_info, push_todo_section,
+    push_child_sessions, push_context_summary, push_model_badge, push_session_info,
+    push_todo_section,
 };
 use crate::config::ConfigManager;
 use crate::context::TodoContextView;
@@ -445,240 +445,6 @@ fn push_child_sessions_skip_when_empty() {
     assert!(lines.is_empty(), "empty when no pending interactions");
 }
 
-// ── push_files_in_context ───────────────────────────────────────────
-// Extracts read_file / apply_patch / write_file paths from transcript.
-
-#[test]
-fn push_files_in_context_empty_when_no_file_tools() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.committed_turns = vec![TranscriptTurn {
-        entries: vec![TranscriptEntry::new(
-            "Assistant",
-            "Let me think about this.",
-        )],
-    }];
-
-    let mut lines = Vec::new();
-    push_files_in_context(&mut lines, &app);
-    assert!(lines.is_empty(), "empty when no file-tool entries");
-}
-
-#[test]
-fn push_files_in_context_shows_read_and_changed() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.committed_turns = vec![TranscriptTurn {
-        entries: vec![
-            TranscriptEntry::new("Tool", "read_file src/main.rs"),
-            TranscriptEntry::new("Tool", "read_file crates/lib.rs"),
-            TranscriptEntry::new("Tool", "apply_patch src/main.rs"),
-            TranscriptEntry::new("Tool", "write_file docs/new.md"),
-        ],
-    }];
-
-    let mut lines = Vec::new();
-    push_files_in_context(&mut lines, &app);
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(text.contains("Files"), "should show # Files section label");
-    assert!(text.contains("Read:"), "should have Read subsection");
-    assert!(text.contains("src/main.rs"), "should show read file");
-    assert!(text.contains("crates/lib.rs"), "should show read file");
-    assert!(text.contains("Changed:"), "should have Changed subsection");
-    assert!(text.contains("docs/new.md"), "should show changed file");
-}
-
-#[test]
-fn push_files_in_context_deduplicates() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.committed_turns = vec![TranscriptTurn {
-        entries: vec![
-            TranscriptEntry::new("Tool", "read_file src/main.rs"),
-            TranscriptEntry::new("Tool", "read_file src/main.rs"),
-        ],
-    }];
-
-    let mut lines = Vec::new();
-    push_files_in_context(&mut lines, &app);
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    // Only one occurrence of src/main.rs
-    let count = text.matches("src/main.rs").count();
-    assert_eq!(count, 1, "duplicate file paths are collapsed");
-}
-
-#[test]
-fn push_files_in_context_truncates_at_five() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    let files: Vec<_> = (1..=8)
-        .map(|i| TranscriptEntry::new("Tool", format!("read_file src/file{i}.rs")))
-        .collect();
-    app.committed_turns = vec![TranscriptTurn { entries: files }];
-
-    let mut lines = Vec::new();
-    push_files_in_context(&mut lines, &app);
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(
-        text.contains("... and 3 more"),
-        "should truncate at 5 with overflow count"
-    );
-}
-
-#[test]
-fn push_files_in_context_read_only_no_changed() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.committed_turns = vec![TranscriptTurn {
-        entries: vec![TranscriptEntry::new("Tool", "read_file src/main.rs")],
-    }];
-
-    let mut lines = Vec::new();
-    push_files_in_context(&mut lines, &app);
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(text.contains("Read:"));
-    assert!(!text.contains("Changed:"));
-}
-
-#[test]
-fn push_files_in_context_includes_active_turn() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.active_turn = TranscriptTurn {
-        entries: vec![TranscriptEntry::new("Tool", "read_file crates/tool.rs")],
-    };
-
-    let mut lines = Vec::new();
-    push_files_in_context(&mut lines, &app);
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(
-        text.contains("crates/tool.rs"),
-        "should include files from active turn"
-    );
-}
-
-#[test]
-fn push_files_in_context_detects_replace() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.committed_turns = vec![TranscriptTurn {
-        entries: vec![TranscriptEntry::new("Tool", "replace src/main.rs")],
-    }];
-
-    let mut lines = Vec::new();
-    push_files_in_context(&mut lines, &app);
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(
-        text.contains("Changed:"),
-        "replace should be a changed file"
-    );
-    assert!(text.contains("src/main.rs"), "should show replaced path");
-}
-
-#[test]
-fn push_files_in_context_detects_multi_edit() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.committed_turns = vec![TranscriptTurn {
-        entries: vec![TranscriptEntry::new("Tool", "multi_edit crates/lib.rs")],
-    }];
-
-    let mut lines = Vec::new();
-    push_files_in_context(&mut lines, &app);
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(
-        text.contains("Changed:"),
-        "multi_edit should be a changed file"
-    );
-    assert!(
-        text.contains("crates/lib.rs"),
-        "should show multi_edit path"
-    );
-}
-
-#[test]
-fn push_files_in_context_detects_replace_lines() {
-    let temp = tempdir().unwrap();
-    let mut app = TuiApp::new(ConfigManager {
-        path: temp.path().join("config.json"),
-    })
-    .expect("build tui app");
-    app.committed_turns = vec![TranscriptTurn {
-        entries: vec![TranscriptEntry::new(
-            "Tool",
-            "replace_lines src/tui/sidebar.rs",
-        )],
-    }];
-
-    let mut lines = Vec::new();
-    push_files_in_context(&mut lines, &app);
-    let text: String = lines
-        .iter()
-        .map(|l| l.to_string())
-        .collect::<Vec<_>>()
-        .join("\n");
-    assert!(
-        text.contains("Changed:"),
-        "replace_lines should be a changed file"
-    );
-    assert!(
-        text.contains("src/tui/sidebar.rs"),
-        "should show replace_lines path"
-    );
-}
-
 // ── PendingInteractionSnapshot default helper ───────────────────────
 
 impl Default for PendingInteractionSnapshot {
@@ -722,8 +488,6 @@ fn section_header_appears_in_sidebar() {
     push_context_summary(&mut lines, &app);
     lines.push(Line::from(""));
     push_child_sessions(&mut lines, &app);
-    lines.push(Line::from(""));
-    push_files_in_context(&mut lines, &app);
 
     let text: String = lines
         .iter()
@@ -731,7 +495,5 @@ fn section_header_appears_in_sidebar() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    // Context section should exist.
     assert!(text.contains("Context"), "sidebar has Context section");
-    // Files only appears when there are file-tool entries; in this test none.
 }


### PR DESCRIPTION
## Summary

Remove the "Files" section from the left sidebar that showed Read and Changed file lists.

## Changes

- Remove `push_files_in_context` function and its call from sidebar renderer
- Remove all 8 related test functions
- Remove now-unused `BTreeSet` import

## Verification

- `cargo fmt` passes
- All 18 sidebar tests pass (`cargo test sidebar`)