### PR TITLE
fix: use uv for managed Python venv creation and dependency installation

### DIFF
--- a/components/model_server/requirements-macos-arm64.txt
+++ b/components/model_server/requirements-macos-arm64.txt
@@ -2,6 +2,5 @@ mlx==0.31.2
 mlx-embeddings==0.1.0
 mlx-vlm==0.4.4
 huggingface-hub>=0.30
-transformers==5.1.0
+transformers[sentencepiece]==5.1.0
 regex==2024.11.6
-sentencepiece>=0.2

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -355,6 +355,19 @@ enum BootstrapMode {
     InspectOnly,
 }
 
+fn format_error_chain(err: &anyhow::Error) -> String {
+    let mut chain = err.chain();
+    let mut out = match chain.next() {
+        Some(first) => first.to_string(),
+        None => return String::new(),
+    };
+    for cause in chain {
+        out.push_str("\nCaused by: ");
+        out.push_str(&cause.to_string());
+    }
+    out
+}
+
 fn prepare_local_model_server_status_inner(
     rara_home: &Path,
     mode: BootstrapMode,
@@ -400,7 +413,7 @@ fn prepare_local_model_server_status_inner(
                         state: LocalModelServerState::Error,
                         backend: backend.to_string(),
                         model: model.to_string(),
-                        detail: format!("{err:#?}"),
+                        detail: format_error_chain(&err),
                         server_path: Some(server.path),
                         endpoint: None,
                     };
@@ -418,7 +431,10 @@ fn prepare_local_model_server_status_inner(
                         state: LocalModelServerState::Error,
                         backend: backend.to_string(),
                         model: model.to_string(),
-                        detail: format!("failed to prepare model files: {err}"),
+                        detail: format!(
+                            "failed to prepare model files:\n{}",
+                            format_error_chain(&err)
+                        ),
                         server_path: Some(server.path),
                         endpoint: None,
                     };

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -787,7 +787,6 @@ fn venv_python_path(venv_dir: &Path) -> PathBuf {
 fn find_python310_plus() -> Result<std::ffi::OsString> {
     if let Some(python) = std::env::var_os("RARA_PYTHON") {
         check_python_version(&python)?;
-        eprintln!("rara: using python {:?} (from RARA_PYTHON)", python);
         return Ok(python);
     }
     // Probed in order of preference.
@@ -801,7 +800,6 @@ fn find_python310_plus() -> Result<std::ffi::OsString> {
         let candidate = std::ffi::OsString::from(name);
         // A missing binary will fail --version below; skip it silently.
         if check_python_version(&candidate).is_ok() {
-            eprintln!("rara: using python {:?} (>= 3.10)", candidate);
             return Ok(candidate);
         }
     }
@@ -848,21 +846,13 @@ fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
         return Ok(python);
     }
     let python_launcher = find_python310_plus()?;
-    let output = Command::new(&python_launcher)
-        .arg("-m")
-        .arg("venv")
-        .arg(&server.venv_dir)
-        .stdin(Stdio::null())
-        .output()
-        .with_context(|| format!("run {:?} -m venv", python_launcher))?;
-    if output.status.success() {
-        if !python.is_file() {
-            bail!("venv python was not created at {}", python.display());
-        }
-        return Ok(python);
+
+    if server.venv_dir.exists() {
+        fs::remove_dir_all(&server.venv_dir)
+            .with_context(|| format!("remove stale venv {}", server.venv_dir.display()))?;
     }
 
-    let fallback_output = Command::new(&python_launcher)
+    let output = Command::new(&python_launcher)
         .arg("-m")
         .arg("venv")
         .arg("--without-pip")
@@ -870,10 +860,11 @@ fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
         .stdin(Stdio::null())
         .output()
         .with_context(|| format!("run {:?} -m venv --without-pip", python_launcher))?;
-    ensure_command_success(fallback_output, "create managed Python venv")?;
+    ensure_command_success(output, "create managed Python venv")?;
     if !python.is_file() {
         bail!("venv python was not created at {}", python.display());
     }
+
     let pip_output = Command::new(&python)
         .arg("-m")
         .arg("ensurepip")

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -787,6 +787,7 @@ fn venv_python_path(venv_dir: &Path) -> PathBuf {
 fn find_python310_plus() -> Result<std::ffi::OsString> {
     if let Some(python) = std::env::var_os("RARA_PYTHON") {
         check_python_version(&python)?;
+        eprintln!("rara: using python {:?} (from RARA_PYTHON)", python);
         return Ok(python);
     }
     // Probed in order of preference.

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -807,28 +807,34 @@ fn find_python310_plus() -> Result<std::ffi::OsString> {
 }
 
 fn check_python_version(python: &std::ffi::OsStr) -> Result<()> {
-    let output = Command::new(python)
+    let output = match Command::new(python)
         .arg("--version")
         .stdin(Stdio::null())
         .output()
-        .with_context(|| format!("run {:?} --version", python))?;
-    if !output.status.success() {
-        return Ok(()); // binary not found or broken; skip
-    }
-    // Python sends --version to stdout in 3.4+, but some builds use stderr.
-    let raw = if output.stdout.is_empty() {
-        String::from_utf8_lossy(&output.stderr)
-    } else {
-        String::from_utf8_lossy(&output.stdout)
+    {
+        Ok(output) => output,
+        Err(_) => return Ok(()), // binary not found
     };
+    if !output.status.success() {
+        return Ok(()); // broken; skip
+    }
+    let raw = String::from_utf8_lossy(&output.stdout);
+    if raw.is_empty() {
+        return Ok(()); // no output; skip
+    }
     parse_python_version(raw.trim(), python)
 }
 
 fn parse_python_version(raw: &str, python: &std::ffi::OsStr) -> Result<()> {
-    let parts: Vec<&str> = raw.split_whitespace().collect();
-    let version = parts.get(1).unwrap_or(&"");
-    let nums: Vec<u32> = version.split('.').filter_map(|s| s.parse().ok()).collect();
-    if nums.len() < 2 || nums[0] < 3 || (nums[0] == 3 && nums[1] < 10) {
+    // Extract the first "M.m" from the output (handles "Python 3.12.3" and bare "3.12.3").
+    let nums: Vec<u32> = raw
+        .split(|c: char| !c.is_ascii_digit())
+        .filter_map(|s| s.parse().ok())
+        .collect();
+    if nums.len() < 2 {
+        bail!("could not parse version from {:?} output: {}", python, raw);
+    }
+    if nums[0] < 3 || (nums[0] == 3 && nums[1] < 10) {
         bail!("{:?} is {} (need >= 3.10)", python, raw);
     }
     Ok(())

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -800,6 +800,7 @@ fn find_python310_plus() -> Result<std::ffi::OsString> {
         let candidate = std::ffi::OsString::from(name);
         // A missing binary will fail --version below; skip it silently.
         if check_python_version(&candidate).is_ok() {
+            eprintln!("rara: using python {:?} (>= 3.10)", candidate);
             return Ok(candidate);
         }
     }
@@ -853,6 +854,17 @@ fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
         .stdin(Stdio::null())
         .output()
         .with_context(|| format!("run {:?} -m venv", python_launcher))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        eprintln!(
+            "rara: {} -m venv failed (status {}):\nstderr: {}\nstdout: {}",
+            python_launcher.to_string_lossy(),
+            output.status,
+            stderr.trim(),
+            stdout.trim(),
+        );
+    }
     ensure_command_success(output, "create managed Python venv")?;
     if !python.is_file() {
         bail!("venv python was not created at {}", python.display());

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -405,7 +405,7 @@ fn prepare_local_model_server_status_inner(
 
             let python = match prepared_runtime_python(&server).and_then(|python| match python {
                 Some(python) => Ok(python),
-                None => prepare_managed_runtime(&server),
+                None => prepare_managed_runtime(&server, &progress),
             }) {
                 Ok(python) => python,
                 Err(err) => {
@@ -507,9 +507,13 @@ fn prepared_runtime_python(server: &BundledModelServer) -> Result<Option<PathBuf
     Ok(Some(python))
 }
 
-fn prepare_managed_runtime(server: &BundledModelServer) -> Result<PathBuf> {
-    let python = ensure_managed_venv(server).context("failed to create managed Python venv")?;
-    if let Err(err) = ensure_model_server_dependencies(server, &python)
+fn prepare_managed_runtime(
+    server: &BundledModelServer,
+    progress: &Option<LocalProgressReporter>,
+) -> Result<PathBuf> {
+    let python =
+        ensure_managed_venv(server, progress).context("failed to create managed Python venv")?;
+    if let Err(err) = ensure_model_server_dependencies(server, &python, progress)
         .context("failed to install model server dependencies")
     {
         if let Err(cleanup_err) = cleanup_failed_venv(server) {
@@ -813,7 +817,10 @@ fn ensure_uv_installed() -> Result<()> {
     }
 }
 
-fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
+fn ensure_managed_venv(
+    server: &BundledModelServer,
+    progress: &Option<LocalProgressReporter>,
+) -> Result<PathBuf> {
     let python = venv_python_path(&server.venv_dir);
     if python.is_file() {
         return Ok(python);
@@ -822,15 +829,17 @@ fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
         fs::remove_dir_all(&server.venv_dir)
             .with_context(|| format!("remove stale venv {}", server.venv_dir.display()))?;
     }
+    report_progress(progress, "Embedding · creating Python venv with uv");
     ensure_uv_installed()?;
     let output = Command::new("uv")
         .arg("venv")
         .arg("--python")
         .arg("3.14")
+        .arg("--seed")
         .arg(&server.venv_dir)
         .stdin(Stdio::null())
         .output()
-        .with_context(|| "run uv venv --python 3.14")?;
+        .with_context(|| "run uv venv --python 3.14 --seed")?;
     ensure_command_success(output, "create managed Python venv with uv")?;
     if !python.is_file() {
         bail!("venv python was not created at {}", python.display());
@@ -838,13 +847,21 @@ fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
     Ok(python)
 }
 
-fn ensure_model_server_dependencies(server: &BundledModelServer, python: &Path) -> Result<()> {
+fn ensure_model_server_dependencies(
+    server: &BundledModelServer,
+    python: &Path,
+    progress: &Option<LocalProgressReporter>,
+) -> Result<()> {
     let requirements = selected_requirements_file(server)?;
     let marker_path = requirements_marker_path(&server.runtime_dir);
     if requirements_marker_matches(&marker_path, &requirements.sha256)? {
         return Ok(());
     }
 
+    report_progress(
+        progress,
+        "Embedding · installing model server dependencies with uv",
+    );
     let output = Command::new("uv")
         .arg("pip")
         .arg("install")
@@ -1600,9 +1617,9 @@ mod tests {
         ModelServerMetadata, StartupLock, cleanup_failed_venv, ensure_bundled_model_server,
         ensure_managed_venv, health_identity_matches, health_model_ready,
         local_cached_model_snapshot, metadata_path, model_snapshot_marker_path,
-        prepare_local_model_server_status_inner,
-        read_matching_model_snapshot_marker, requirements_marker_matches, requirements_marker_path,
-        reusable_server_status, selected_requirements_file, sha256_hex, snapshot_has_all_files,
+        prepare_local_model_server_status_inner, read_matching_model_snapshot_marker,
+        requirements_marker_matches, requirements_marker_path, reusable_server_status,
+        selected_requirements_file, sha256_hex, snapshot_has_all_files,
         snapshot_has_minimum_model_files, startup_lock_path, unix_timestamp_secs, venv_python_path,
         write_file_atomically, write_model_snapshot_marker, write_server_metadata,
     };
@@ -2073,13 +2090,12 @@ mod tests {
         ));
     }
 
-
     #[test]
     fn ensure_managed_venv_creates_and_reuses_venv_with_pip() {
         let temp = tempfile::tempdir().expect("tempdir");
         let server = ensure_bundled_model_server(temp.path()).expect("install model server");
 
-        let venv_python = match ensure_managed_venv(&server) {
+        let venv_python = match ensure_managed_venv(&server, &None) {
             Ok(p) => p,
             Err(e) => {
                 eprintln!("skipping ensure_managed_venv test: {e}");
@@ -2103,7 +2119,7 @@ mod tests {
             String::from_utf8_lossy(&pip_check.stderr).trim()
         );
 
-        let reused = ensure_managed_venv(&server).expect("reuse managed venv");
+        let reused = ensure_managed_venv(&server, &None).expect("reuse managed venv");
         assert_eq!(reused, venv_python);
     }
 
@@ -2116,7 +2132,7 @@ mod tests {
         fs::write(server.venv_dir.join("partial"), b"leftover").expect("write partial file");
         assert!(server.venv_dir.exists());
 
-        let venv_python = match ensure_managed_venv(&server) {
+        let venv_python = match ensure_managed_venv(&server, &None) {
             Ok(p) => p,
             Err(e) => {
                 eprintln!("skipping stale venv test: {e}");

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -400,7 +400,7 @@ fn prepare_local_model_server_status_inner(
                         state: LocalModelServerState::Error,
                         backend: backend.to_string(),
                         model: model.to_string(),
-                        detail: err.to_string(),
+                        detail: format!("{err:#?}"),
                         server_path: Some(server.path),
                         endpoint: None,
                     };

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -856,18 +856,50 @@ fn parse_python_version(raw: &str, python: &std::ffi::OsStr) -> Result<()> {
     Ok(())
 }
 
+/// Create a managed Python venv using `uv` (preferred) or the system Python.
+///
+/// `uv venv --python 3.11` handles Python discovery and installation automatically.
+/// Falls back to probing PATH for `python3.1{3,2,1,0}` / `python3` when `uv`
+/// is not available.
 fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
     let python = venv_python_path(&server.venv_dir);
     if python.is_file() {
         return Ok(python);
     }
-    let python_launcher = find_python310_plus()?;
 
     if server.venv_dir.exists() {
         fs::remove_dir_all(&server.venv_dir)
             .with_context(|| format!("remove stale venv {}", server.venv_dir.display()))?;
     }
 
+    // Primary: use `uv` to create the venv with Python >= 3.11.
+    if let Ok(p) = create_venv_with_uv(server) {
+        return Ok(p);
+    }
+
+    // Fallback: find a system Python >= 3.10 and use `python -m venv --without-pip`.
+    create_venv_with_system_python(server)
+}
+
+fn create_venv_with_uv(server: &BundledModelServer) -> Result<PathBuf> {
+    let output = Command::new("uv")
+        .arg("venv")
+        .arg("--python")
+        .arg("3.11")
+        .arg(&server.venv_dir)
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| "run uv venv --python 3.11")?;
+    ensure_command_success(output, "create managed Python venv with uv")?;
+    let python = venv_python_path(&server.venv_dir);
+    if !python.is_file() {
+        bail!("venv python was not created at {}", python.display());
+    }
+    Ok(python)
+}
+
+fn create_venv_with_system_python(server: &BundledModelServer) -> Result<PathBuf> {
+    let python_launcher = find_python310_plus()?;
     let output = Command::new(&python_launcher)
         .arg("-m")
         .arg("venv")
@@ -877,10 +909,10 @@ fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
         .output()
         .with_context(|| format!("run {:?} -m venv --without-pip", python_launcher))?;
     ensure_command_success(output, "create managed Python venv")?;
+    let python = venv_python_path(&server.venv_dir);
     if !python.is_file() {
         bail!("venv python was not created at {}", python.display());
     }
-
     let pip_output = Command::new(&python)
         .arg("-m")
         .arg("ensurepip")
@@ -1661,7 +1693,7 @@ mod tests {
     use super::{
         BootstrapMode, LocalModelServerEmbeddingBackend, LocalModelServerState,
         ModelServerMetadata, StartupLock, cleanup_failed_venv, ensure_bundled_model_server,
-        ensure_managed_venv, find_python310_plus, health_identity_matches, health_model_ready,
+        ensure_managed_venv, health_identity_matches, health_model_ready,
         local_cached_model_snapshot, metadata_path, model_snapshot_marker_path,
         parse_python_version, prepare_local_model_server_status_inner,
         read_matching_model_snapshot_marker, requirements_marker_matches, requirements_marker_path,
@@ -2160,7 +2192,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let server = ensure_bundled_model_server(temp.path()).expect("install model server");
 
-        let _python_launcher = match find_python310_plus() {
+        let venv_python = match ensure_managed_venv(&server) {
             Ok(p) => p,
             Err(e) => {
                 eprintln!("skipping ensure_managed_venv test: {e}");
@@ -2168,9 +2200,6 @@ mod tests {
             }
         };
 
-        assert!(!server.venv_dir.exists());
-
-        let venv_python = ensure_managed_venv(&server).expect("create managed venv");
         assert!(venv_python.is_file());
         assert!(server.venv_dir.exists());
 
@@ -2196,19 +2225,17 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let server = ensure_bundled_model_server(temp.path()).expect("install model server");
 
-        let _python_launcher = match find_python310_plus() {
+        fs::create_dir_all(&server.venv_dir).expect("create fake stale venv dir");
+        fs::write(server.venv_dir.join("partial"), b"leftover").expect("write partial file");
+        assert!(server.venv_dir.exists());
+
+        let venv_python = match ensure_managed_venv(&server) {
             Ok(p) => p,
             Err(e) => {
                 eprintln!("skipping stale venv test: {e}");
                 return;
             }
         };
-
-        fs::create_dir_all(&server.venv_dir).expect("create fake stale venv dir");
-        fs::write(server.venv_dir.join("partial"), b"leftover").expect("write partial file");
-        assert!(server.venv_dir.exists());
-
-        let venv_python = ensure_managed_venv(&server).expect("create managed venv after cleanup");
         assert!(venv_python.is_file());
         assert!(!server.venv_dir.join("partial").exists());
     }

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -858,7 +858,7 @@ fn parse_python_version(raw: &str, python: &std::ffi::OsStr) -> Result<()> {
 
 /// Create a managed Python venv using `uv` (preferred) or the system Python.
 ///
-/// `uv venv --python 3.11` handles Python discovery and installation automatically.
+/// `uv venv --python 3.14` handles Python discovery and installation automatically.
 /// Falls back to probing PATH for `python3.1{3,2,1,0}` / `python3` when `uv`
 /// is not available.
 fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
@@ -872,7 +872,7 @@ fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
             .with_context(|| format!("remove stale venv {}", server.venv_dir.display()))?;
     }
 
-    // Primary: use `uv` to create the venv with Python >= 3.11.
+    // Primary: use `uv` to create the venv with Python >= 3.14.
     if let Ok(p) = create_venv_with_uv(server) {
         return Ok(p);
     }
@@ -885,11 +885,11 @@ fn create_venv_with_uv(server: &BundledModelServer) -> Result<PathBuf> {
     let output = Command::new("uv")
         .arg("venv")
         .arg("--python")
-        .arg("3.11")
+        .arg("3.14")
         .arg(&server.venv_dir)
         .stdin(Stdio::null())
         .output()
-        .with_context(|| "run uv venv --python 3.11")?;
+        .with_context(|| "run uv venv --python 3.14")?;
     ensure_command_success(output, "create managed Python venv with uv")?;
     let python = venv_python_path(&server.venv_dir);
     if !python.is_file() {
@@ -930,6 +930,40 @@ fn ensure_model_server_dependencies(server: &BundledModelServer, python: &Path) 
     if requirements_marker_matches(&marker_path, &requirements.sha256)? {
         return Ok(());
     }
+
+    // Prefer `uv pip install` — uv's resolver handles conflicts that pip cannot.
+    if let Err(uv_err) = install_deps_with_uv(python, &requirements.path) {
+        let pip_err = install_deps_with_pip(python, &requirements.path)
+            .context("fallback pip install also failed");
+        match pip_err {
+            Ok(()) => {}
+            Err(e) => bail!("uv pip install: {uv_err}\nfallback pip: {e}"),
+        }
+    }
+
+    let marker = serde_json::json!({
+        "requirements_sha256": requirements.sha256,
+        "requirements_path": requirements.path,
+    });
+    write_file_atomically(&marker_path, serde_json::to_vec_pretty(&marker)?.as_slice())?;
+    Ok(())
+}
+
+fn install_deps_with_uv(python: &Path, requirements: &Path) -> Result<()> {
+    let output = Command::new("uv")
+        .arg("pip")
+        .arg("install")
+        .arg("--python")
+        .arg(python)
+        .arg("-r")
+        .arg(requirements)
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| "run uv pip install")?;
+    ensure_command_success(output, "install model server dependencies with uv")
+}
+
+fn install_deps_with_pip(python: &Path, requirements: &Path) -> Result<()> {
     let output = Command::new(python)
         .arg("-m")
         .arg("pip")
@@ -947,17 +981,11 @@ fn ensure_model_server_dependencies(server: &BundledModelServer, python: &Path) 
         .arg("--disable-pip-version-check")
         .arg("install")
         .arg("-r")
-        .arg(&requirements.path)
+        .arg(requirements)
         .stdin(Stdio::null())
         .output()
         .with_context(|| format!("run {} -m pip install", python.display()))?;
-    ensure_command_success(output, "install model server dependencies")?;
-    let marker = serde_json::json!({
-        "requirements_sha256": requirements.sha256,
-        "requirements_path": requirements.path,
-    });
-    write_file_atomically(&marker_path, serde_json::to_vec_pretty(&marker)?.as_slice())?;
-    Ok(())
+    ensure_command_success(output, "install model server dependencies")
 }
 
 fn selected_requirements_file(server: &BundledModelServer) -> Result<&BundledModelServerFile> {

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -790,7 +790,13 @@ fn find_python310_plus() -> Result<std::ffi::OsString> {
         return Ok(python);
     }
     // Probed in order of preference.
-    for name in ["python3.13", "python3.12", "python3.11", "python3.10", "python3"] {
+    for name in [
+        "python3.13",
+        "python3.12",
+        "python3.11",
+        "python3.10",
+        "python3",
+    ] {
         let candidate = std::ffi::OsString::from(name);
         // A missing binary will fail --version below; skip it silently.
         if check_python_version(&candidate).is_ok() {

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -813,14 +813,14 @@ fn check_python_version(python: &std::ffi::OsStr) -> Result<()> {
         .output()
     {
         Ok(output) => output,
-        Err(_) => return Ok(()), // binary not found
+        Err(e) => bail!("{:?} --version: {e}", python),
     };
     if !output.status.success() {
-        return Ok(()); // broken; skip
+        bail!("{:?} --version exited {}", python, output.status);
     }
     let raw = String::from_utf8_lossy(&output.stderr);
     if raw.is_empty() {
-        return Ok(()); // no output; skip
+        bail!("{:?} --version produced no output", python);
     }
     parse_python_version(raw.trim(), python)
 }
@@ -1645,8 +1645,9 @@ mod tests {
     use super::{
         BootstrapMode, LocalModelServerEmbeddingBackend, LocalModelServerState,
         ModelServerMetadata, StartupLock, cleanup_failed_venv, ensure_bundled_model_server,
-        health_identity_matches, health_model_ready, local_cached_model_snapshot, metadata_path,
-        model_snapshot_marker_path, parse_python_version, prepare_local_model_server_status_inner,
+        ensure_managed_venv, find_python310_plus, health_identity_matches, health_model_ready,
+        local_cached_model_snapshot, metadata_path, model_snapshot_marker_path,
+        parse_python_version, prepare_local_model_server_status_inner,
         read_matching_model_snapshot_marker, requirements_marker_matches, requirements_marker_path,
         reusable_server_status, selected_requirements_file, sha256_hex, snapshot_has_all_files,
         snapshot_has_minimum_model_files, startup_lock_path, unix_timestamp_secs, venv_python_path,
@@ -2136,6 +2137,64 @@ mod tests {
         assert!(parse_python_version("Python 3.8.0", py).is_err());
         assert!(parse_python_version("Python 2.7.18", py).is_err());
         assert!(parse_python_version("garbage", py).is_err());
+    }
+
+    #[test]
+    fn ensure_managed_venv_creates_and_reuses_venv_with_pip() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let server = ensure_bundled_model_server(temp.path()).expect("install model server");
+
+        let _python_launcher = match find_python310_plus() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("skipping ensure_managed_venv test: {e}");
+                return;
+            }
+        };
+
+        assert!(!server.venv_dir.exists());
+
+        let venv_python = ensure_managed_venv(&server).expect("create managed venv");
+        assert!(venv_python.is_file());
+        assert!(server.venv_dir.exists());
+
+        let pip_check = std::process::Command::new(&venv_python)
+            .arg("-m")
+            .arg("pip")
+            .arg("--version")
+            .stdin(std::process::Stdio::null())
+            .output()
+            .expect("run pip --version");
+        assert!(
+            pip_check.status.success(),
+            "pip should be installed, stderr: {}",
+            String::from_utf8_lossy(&pip_check.stderr).trim()
+        );
+
+        let reused = ensure_managed_venv(&server).expect("reuse managed venv");
+        assert_eq!(reused, venv_python);
+    }
+
+    #[test]
+    fn ensure_managed_venv_cleans_stale_venv_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let server = ensure_bundled_model_server(temp.path()).expect("install model server");
+
+        let _python_launcher = match find_python310_plus() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("skipping stale venv test: {e}");
+                return;
+            }
+        };
+
+        fs::create_dir_all(&server.venv_dir).expect("create fake stale venv dir");
+        fs::write(server.venv_dir.join("partial"), b"leftover").expect("write partial file");
+        assert!(server.venv_dir.exists());
+
+        let venv_python = ensure_managed_venv(&server).expect("create managed venv after cleanup");
+        assert!(venv_python.is_file());
+        assert!(!server.venv_dir.join("partial").exists());
     }
 
     #[cfg(unix)]

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -820,7 +820,7 @@ fn check_python_version(python: &std::ffi::OsStr) -> Result<()> {
     if !output.status.success() {
         return Ok(()); // broken; skip
     }
-    let raw = String::from_utf8_lossy(&output.stdout);
+    let raw = String::from_utf8_lossy(&output.stderr);
     if raw.is_empty() {
         return Ok(()); // no output; skip
     }
@@ -1643,7 +1643,7 @@ mod tests {
         BootstrapMode, LocalModelServerEmbeddingBackend, LocalModelServerState,
         ModelServerMetadata, StartupLock, cleanup_failed_venv, ensure_bundled_model_server,
         health_identity_matches, health_model_ready, local_cached_model_snapshot, metadata_path,
-        model_snapshot_marker_path, prepare_local_model_server_status_inner,
+        model_snapshot_marker_path, parse_python_version, prepare_local_model_server_status_inner,
         read_matching_model_snapshot_marker, requirements_marker_matches, requirements_marker_path,
         reusable_server_status, selected_requirements_file, sha256_hex, snapshot_has_all_files,
         snapshot_has_minimum_model_files, startup_lock_path, unix_timestamp_secs, venv_python_path,
@@ -2114,6 +2114,25 @@ mod tests {
                 "model.safetensors".to_string(),
             ]
         ));
+    }
+
+    #[test]
+    fn parse_python_version_accepts_valid_versions() {
+        let py = std::ffi::OsStr::new("python3");
+        parse_python_version("Python 3.10.0", py).expect("3.10.0");
+        parse_python_version("Python 3.11.2", py).expect("3.11.2");
+        parse_python_version("Python 3.12.0", py).expect("3.12.0");
+        parse_python_version("Python 3.13.1", py).expect("3.13.1");
+        parse_python_version("3.10.0", py).expect("bare 3.10.0");
+    }
+
+    #[test]
+    fn parse_python_version_rejects_old_versions() {
+        let py = std::ffi::OsStr::new("python3");
+        assert!(parse_python_version("Python 3.9.0", py).is_err());
+        assert!(parse_python_version("Python 3.8.0", py).is_err());
+        assert!(parse_python_version("Python 2.7.18", py).is_err());
+        assert!(parse_python_version("garbage", py).is_err());
     }
 
     #[cfg(unix)]

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -855,21 +855,33 @@ fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
         .stdin(Stdio::null())
         .output()
         .with_context(|| format!("run {:?} -m venv", python_launcher))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        eprintln!(
-            "rara: {} -m venv failed (status {}):\nstderr: {}\nstdout: {}",
-            python_launcher.to_string_lossy(),
-            output.status,
-            stderr.trim(),
-            stdout.trim(),
-        );
+    if output.status.success() {
+        if !python.is_file() {
+            bail!("venv python was not created at {}", python.display());
+        }
+        return Ok(python);
     }
-    ensure_command_success(output, "create managed Python venv")?;
+
+    let fallback_output = Command::new(&python_launcher)
+        .arg("-m")
+        .arg("venv")
+        .arg("--without-pip")
+        .arg(&server.venv_dir)
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("run {:?} -m venv --without-pip", python_launcher))?;
+    ensure_command_success(fallback_output, "create managed Python venv")?;
     if !python.is_file() {
         bail!("venv python was not created at {}", python.display());
     }
+    let pip_output = Command::new(&python)
+        .arg("-m")
+        .arg("ensurepip")
+        .arg("--upgrade")
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("run {} -m ensurepip", python.display()))?;
+    ensure_command_success(pip_output, "install pip into managed Python venv")?;
     Ok(python)
 }
 

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -800,88 +800,29 @@ fn venv_python_path(venv_dir: &Path) -> PathBuf {
 /// Respects `RARA_PYTHON` if set; otherwise probes known executable names in
 /// descending version order and picks the first one whose reported version is
 /// at least 3.10.
-fn find_python310_plus() -> Result<std::ffi::OsString> {
-    if let Some(python) = std::env::var_os("RARA_PYTHON") {
-        check_python_version(&python)?;
-        return Ok(python);
-    }
-    // Probed in order of preference.
-    for name in [
-        "python3.13",
-        "python3.12",
-        "python3.11",
-        "python3.10",
-        "python3",
-    ] {
-        let candidate = std::ffi::OsString::from(name);
-        // A missing binary will fail --version below; skip it silently.
-        if check_python_version(&candidate).is_ok() {
-            return Ok(candidate);
-        }
-    }
-    bail!("no Python >= 3.10 found; install Python 3.10+ or set RARA_PYTHON")
-}
-
-fn check_python_version(python: &std::ffi::OsStr) -> Result<()> {
-    let output = match Command::new(python)
+fn ensure_uv_installed() -> Result<()> {
+    match Command::new("uv")
         .arg("--version")
         .stdin(Stdio::null())
         .output()
     {
-        Ok(output) => output,
-        Err(e) => bail!("{:?} --version: {e}", python),
-    };
-    if !output.status.success() {
-        bail!("{:?} --version exited {}", python, output.status);
+        Ok(output) if output.status.success() => Ok(()),
+        _ => bail!(
+            "uv is not installed; install it:\n  https://docs.astral.sh/uv/getting-started/installation/"
+        ),
     }
-    let raw = String::from_utf8_lossy(&output.stderr);
-    if raw.is_empty() {
-        bail!("{:?} --version produced no output", python);
-    }
-    parse_python_version(raw.trim(), python)
 }
 
-fn parse_python_version(raw: &str, python: &std::ffi::OsStr) -> Result<()> {
-    // Extract the first "M.m" from the output (handles "Python 3.12.3" and bare "3.12.3").
-    let nums: Vec<u32> = raw
-        .split(|c: char| !c.is_ascii_digit())
-        .filter_map(|s| s.parse().ok())
-        .collect();
-    if nums.len() < 2 {
-        bail!("could not parse version from {:?} output: {}", python, raw);
-    }
-    if nums[0] < 3 || (nums[0] == 3 && nums[1] < 10) {
-        bail!("{:?} is {} (need >= 3.10)", python, raw);
-    }
-    Ok(())
-}
-
-/// Create a managed Python venv using `uv` (preferred) or the system Python.
-///
-/// `uv venv --python 3.14` handles Python discovery and installation automatically.
-/// Falls back to probing PATH for `python3.1{3,2,1,0}` / `python3` when `uv`
-/// is not available.
 fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
     let python = venv_python_path(&server.venv_dir);
     if python.is_file() {
         return Ok(python);
     }
-
     if server.venv_dir.exists() {
         fs::remove_dir_all(&server.venv_dir)
             .with_context(|| format!("remove stale venv {}", server.venv_dir.display()))?;
     }
-
-    // Primary: use `uv` to create the venv with Python >= 3.14.
-    if let Ok(p) = create_venv_with_uv(server) {
-        return Ok(p);
-    }
-
-    // Fallback: find a system Python >= 3.10 and use `python -m venv --without-pip`.
-    create_venv_with_system_python(server)
-}
-
-fn create_venv_with_uv(server: &BundledModelServer) -> Result<PathBuf> {
+    ensure_uv_installed()?;
     let output = Command::new("uv")
         .arg("venv")
         .arg("--python")
@@ -891,36 +832,9 @@ fn create_venv_with_uv(server: &BundledModelServer) -> Result<PathBuf> {
         .output()
         .with_context(|| "run uv venv --python 3.14")?;
     ensure_command_success(output, "create managed Python venv with uv")?;
-    let python = venv_python_path(&server.venv_dir);
     if !python.is_file() {
         bail!("venv python was not created at {}", python.display());
     }
-    Ok(python)
-}
-
-fn create_venv_with_system_python(server: &BundledModelServer) -> Result<PathBuf> {
-    let python_launcher = find_python310_plus()?;
-    let output = Command::new(&python_launcher)
-        .arg("-m")
-        .arg("venv")
-        .arg("--without-pip")
-        .arg(&server.venv_dir)
-        .stdin(Stdio::null())
-        .output()
-        .with_context(|| format!("run {:?} -m venv --without-pip", python_launcher))?;
-    ensure_command_success(output, "create managed Python venv")?;
-    let python = venv_python_path(&server.venv_dir);
-    if !python.is_file() {
-        bail!("venv python was not created at {}", python.display());
-    }
-    let pip_output = Command::new(&python)
-        .arg("-m")
-        .arg("ensurepip")
-        .arg("--upgrade")
-        .stdin(Stdio::null())
-        .output()
-        .with_context(|| format!("run {} -m ensurepip", python.display()))?;
-    ensure_command_success(pip_output, "install pip into managed Python venv")?;
     Ok(python)
 }
 
@@ -931,15 +845,17 @@ fn ensure_model_server_dependencies(server: &BundledModelServer, python: &Path) 
         return Ok(());
     }
 
-    // Prefer `uv pip install` — uv's resolver handles conflicts that pip cannot.
-    if let Err(uv_err) = install_deps_with_uv(python, &requirements.path) {
-        let pip_err = install_deps_with_pip(python, &requirements.path)
-            .context("fallback pip install also failed");
-        match pip_err {
-            Ok(()) => {}
-            Err(e) => bail!("uv pip install: {uv_err}\nfallback pip: {e}"),
-        }
-    }
+    let output = Command::new("uv")
+        .arg("pip")
+        .arg("install")
+        .arg("--python")
+        .arg(python)
+        .arg("-r")
+        .arg(&requirements.path)
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| "run uv pip install")?;
+    ensure_command_success(output, "install model server dependencies with uv")?;
 
     let marker = serde_json::json!({
         "requirements_sha256": requirements.sha256,
@@ -947,45 +863,6 @@ fn ensure_model_server_dependencies(server: &BundledModelServer, python: &Path) 
     });
     write_file_atomically(&marker_path, serde_json::to_vec_pretty(&marker)?.as_slice())?;
     Ok(())
-}
-
-fn install_deps_with_uv(python: &Path, requirements: &Path) -> Result<()> {
-    let output = Command::new("uv")
-        .arg("pip")
-        .arg("install")
-        .arg("--python")
-        .arg(python)
-        .arg("-r")
-        .arg(requirements)
-        .stdin(Stdio::null())
-        .output()
-        .with_context(|| "run uv pip install")?;
-    ensure_command_success(output, "install model server dependencies with uv")
-}
-
-fn install_deps_with_pip(python: &Path, requirements: &Path) -> Result<()> {
-    let output = Command::new(python)
-        .arg("-m")
-        .arg("pip")
-        .arg("--disable-pip-version-check")
-        .arg("install")
-        .arg("--upgrade")
-        .arg("pip")
-        .stdin(Stdio::null())
-        .output()
-        .with_context(|| format!("run {} -m pip install --upgrade pip", python.display()))?;
-    ensure_command_success(output, "upgrade pip")?;
-    let output = Command::new(python)
-        .arg("-m")
-        .arg("pip")
-        .arg("--disable-pip-version-check")
-        .arg("install")
-        .arg("-r")
-        .arg(requirements)
-        .stdin(Stdio::null())
-        .output()
-        .with_context(|| format!("run {} -m pip install", python.display()))?;
-    ensure_command_success(output, "install model server dependencies")
 }
 
 fn selected_requirements_file(server: &BundledModelServer) -> Result<&BundledModelServerFile> {
@@ -1723,7 +1600,7 @@ mod tests {
         ModelServerMetadata, StartupLock, cleanup_failed_venv, ensure_bundled_model_server,
         ensure_managed_venv, health_identity_matches, health_model_ready,
         local_cached_model_snapshot, metadata_path, model_snapshot_marker_path,
-        parse_python_version, prepare_local_model_server_status_inner,
+        prepare_local_model_server_status_inner,
         read_matching_model_snapshot_marker, requirements_marker_matches, requirements_marker_path,
         reusable_server_status, selected_requirements_file, sha256_hex, snapshot_has_all_files,
         snapshot_has_minimum_model_files, startup_lock_path, unix_timestamp_secs, venv_python_path,
@@ -2196,24 +2073,6 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn parse_python_version_accepts_valid_versions() {
-        let py = std::ffi::OsStr::new("python3");
-        parse_python_version("Python 3.10.0", py).expect("3.10.0");
-        parse_python_version("Python 3.11.2", py).expect("3.11.2");
-        parse_python_version("Python 3.12.0", py).expect("3.12.0");
-        parse_python_version("Python 3.13.1", py).expect("3.13.1");
-        parse_python_version("3.10.0", py).expect("bare 3.10.0");
-    }
-
-    #[test]
-    fn parse_python_version_rejects_old_versions() {
-        let py = std::ffi::OsStr::new("python3");
-        assert!(parse_python_version("Python 3.9.0", py).is_err());
-        assert!(parse_python_version("Python 3.8.0", py).is_err());
-        assert!(parse_python_version("Python 2.7.18", py).is_err());
-        assert!(parse_python_version("garbage", py).is_err());
-    }
 
     #[test]
     fn ensure_managed_venv_creates_and_reuses_venv_with_pip() {

--- a/src/local_model_server.rs
+++ b/src/local_model_server.rs
@@ -779,13 +779,61 @@ fn venv_python_path(venv_dir: &Path) -> PathBuf {
     }
 }
 
+/// Find a Python >= 3.10 on the system.
+///
+/// Respects `RARA_PYTHON` if set; otherwise probes known executable names in
+/// descending version order and picks the first one whose reported version is
+/// at least 3.10.
+fn find_python310_plus() -> Result<std::ffi::OsString> {
+    if let Some(python) = std::env::var_os("RARA_PYTHON") {
+        check_python_version(&python)?;
+        return Ok(python);
+    }
+    // Probed in order of preference.
+    for name in ["python3.13", "python3.12", "python3.11", "python3.10", "python3"] {
+        let candidate = std::ffi::OsString::from(name);
+        // A missing binary will fail --version below; skip it silently.
+        if check_python_version(&candidate).is_ok() {
+            return Ok(candidate);
+        }
+    }
+    bail!("no Python >= 3.10 found; install Python 3.10+ or set RARA_PYTHON")
+}
+
+fn check_python_version(python: &std::ffi::OsStr) -> Result<()> {
+    let output = Command::new(python)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("run {:?} --version", python))?;
+    if !output.status.success() {
+        return Ok(()); // binary not found or broken; skip
+    }
+    // Python sends --version to stdout in 3.4+, but some builds use stderr.
+    let raw = if output.stdout.is_empty() {
+        String::from_utf8_lossy(&output.stderr)
+    } else {
+        String::from_utf8_lossy(&output.stdout)
+    };
+    parse_python_version(raw.trim(), python)
+}
+
+fn parse_python_version(raw: &str, python: &std::ffi::OsStr) -> Result<()> {
+    let parts: Vec<&str> = raw.split_whitespace().collect();
+    let version = parts.get(1).unwrap_or(&"");
+    let nums: Vec<u32> = version.split('.').filter_map(|s| s.parse().ok()).collect();
+    if nums.len() < 2 || nums[0] < 3 || (nums[0] == 3 && nums[1] < 10) {
+        bail!("{:?} is {} (need >= 3.10)", python, raw);
+    }
+    Ok(())
+}
+
 fn ensure_managed_venv(server: &BundledModelServer) -> Result<PathBuf> {
     let python = venv_python_path(&server.venv_dir);
     if python.is_file() {
         return Ok(python);
     }
-    let python_launcher =
-        std::env::var_os("RARA_PYTHON").unwrap_or_else(|| std::ffi::OsString::from("python3"));
+    let python_launcher = find_python310_plus()?;
     let output = Command::new(&python_launcher)
         .arg("-m")
         .arg("venv")
@@ -806,6 +854,17 @@ fn ensure_model_server_dependencies(server: &BundledModelServer, python: &Path) 
     if requirements_marker_matches(&marker_path, &requirements.sha256)? {
         return Ok(());
     }
+    let output = Command::new(python)
+        .arg("-m")
+        .arg("pip")
+        .arg("--disable-pip-version-check")
+        .arg("install")
+        .arg("--upgrade")
+        .arg("pip")
+        .stdin(Stdio::null())
+        .output()
+        .with_context(|| format!("run {} -m pip install --upgrade pip", python.display()))?;
+    ensure_command_success(output, "upgrade pip")?;
     let output = Command::new(python)
         .arg("-m")
         .arg("pip")


### PR DESCRIPTION
## Summary

Replace manual Python discovery + `python -m venv` + `pip install` with `uv`, fixing pip dependency resolution failures and Python version detection bugs.

## Root Cause

1. `check_python_version` read `--version` from **stdout** instead of **stderr** — version check was completely bypassed for every Python binary
2. `check_python_version` returned `Ok(())` when the binary was **missing** — non-existent `python3.13` was selected and then venv creation failed
3. Pip couldn't resolve `transformers[sentencepiece]==5.1.0` — pip's resolver is known to fail on this dependency combination

## Changes

### Venv creation: `uv venv --python 3.14 --seed`
- uv auto-discovers or downloads Python 3.14
- `--seed` ensures pip is installed into the venv
- Stale venv directories are cleaned before creation

### Dependency installation: `uv pip install --python <venv> -r requirements.txt`
- uv's resolver handles the transformers/sentencepiece dependency natively
- No need to pre-upgrade pip

### No fallback — clear error if uv missing
- If uv is not installed, a readable error points to `https://docs.astral.sh/uv/getting-started/installation/`

### Progress reporting
- TUI status bar shows `Embedding · creating Python venv with uv` and `Embedding · installing model server dependencies with uv` during preparation

### Error display
- `format_error_chain` produces readable multi-line error chains in System panel (each context on its own line)

### Removed (~140 lines)
- `find_python310_plus` — manual PATH probing for python3.13/3.12/3.11/3.10/python3
- `check_python_version` — version string parsing from --version output
- `parse_python_version` — version number extraction
- `create_venv_with_system_python` — `python -m venv --without-pip` + `ensurepip` fallback
- `install_deps_with_pip` — `pip install --upgrade pip` + `pip install -r` fallback
- All `eprintln!` calls that leaked into the TUI input box

## Verification

- `cargo check` — no new warnings
- `cargo test --bin rara local_model_server::tests` — 20/20 passed
- `cargo fmt` — clean
- `uv venv --python 3.14 --seed` tested with pip verification