### PR TITLE
feat: show embedding backend/model/state in System panel

### DIFF
--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -285,6 +285,11 @@ fn build_embedding_backends(
                     "local embedding backend bootstrap reported: {}",
                     status.detail
                 ));
+            } else {
+                warnings.push(format!(
+                    "embedding · {} · {} · {:?}",
+                    status.backend, status.model, status.state
+                ));
             }
             let embedding_backend: Arc<dyn EmbeddingBackend> = Arc::new(
                 LocalModelServerEmbeddingBackend::from_initial_status(rara_home, status)?,

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -340,6 +340,7 @@ const RENDERABLE_SYSTEM_MESSAGE_PREFIXES: &[&str] = &[
     "skill loading failed:",
     "oauth failed:",
     "backend rebuild failed:",
+    "embedding ·",
     "open this url in a browser and enter the one-time code:",
     "starting codex browser login.",
     "error:",


### PR DESCRIPTION
## Summary

After bootstrap completes (successfully or with an error), the embedding backend, model, and state are now displayed in the TUI System panel.

## Before

System panel only showed errors:
```
local embedding backend bootstrap reported: failed to create managed Python venv
```

## After

On success:
```
embedding · sentence-transformers/all-MiniLM-L6-v2 · all-MiniLM-L6-v2 · prepared_stopped
```

On error (unchanged):
```
local embedding backend bootstrap reported: <error detail>
```

## Changes

- `src/tui/render/cells/mod.rs`: add `"embedding ·"` to `RENDERABLE_SYSTEM_MESSAGE_PREFIXES`
- `src/runtime_context.rs`: push embedding status message (`backend · model · state`) on non-error bootstrap

## Verification

- `cargo check` — no new warnings
- `cargo test --bin rara local_model_server::tests` — 20/20 passed
- `cargo fmt` — clean