### PR TITLE
feat: replace system message prefix matching with SystemMessageKind enum

### DIFF
--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -119,9 +119,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
         let latest_system = current_turn
             .iter()
             .rev()
-            .find(|entry| {
-                entry.role == "System" && is_renderable_system_message(entry.message.as_str())
-            })
+            .find(|entry| entry.role == "System" && is_renderable_system_message(entry))
             .map(|entry| entry.message.as_str());
         let latest_tool_result = current_turn
             .iter()

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -1568,7 +1568,7 @@ fn active_turn_cell_renders_device_code_prompt_system_message() {
     app.active_turn = TranscriptTurn {
         entries: vec![
             TranscriptEntry { role: "Runtime".into(), message: "Starting Codex device-code login flow.".into(), payload: None },
-            TranscriptEntry { role: "System".into(), message: "Open this URL in a browser and enter the one-time code:\nhttps://example.test\n\nCode: ABCD".into(), payload: None },
+            TranscriptEntry { role: "System".into(), message: "Open this URL in a browser and enter the one-time code:\nhttps://example.test\n\nCode: ABCD".into(), payload: Some(crate::tui::state::TranscriptEntryPayload::System(crate::tui::state::SystemMessageKind::OAuthPrompt)) },
         ],
     };
 

--- a/src/tui/render/cells/cells_tests/committed.rs
+++ b/src/tui/render/cells/cells_tests/committed.rs
@@ -106,7 +106,9 @@ fn committed_turn_cell_renders_memory_action_notices() {
         TranscriptEntry {
             role: "System".into(),
             message: "Memory · queried workspace memory: 2 candidates".into(),
-            payload: None,
+            payload: Some(crate::tui::state::TranscriptEntryPayload::System(
+                crate::tui::state::SystemMessageKind::Memory,
+            )),
         },
         TranscriptEntry {
             role: "Agent".into(),

--- a/src/tui/render/cells/committed_turn.rs
+++ b/src/tui/render/cells/committed_turn.rs
@@ -125,7 +125,7 @@ fn push_ordered_committed_activity<'a>(
         }
 
         if entry.role == "Agent"
-            || (entry.role == "System" && super::is_renderable_system_message(&entry.message))
+            || (entry.role == "System" && super::is_renderable_system_message(entry))
         {
             let max_lines = if entry.role == "Agent" { usize::MAX } else { 4 };
             cells.push(Box::new(MessageCell::new(

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -1,6 +1,6 @@
 use ratatui::{style::Color, text::Line};
 
-use crate::tui::state::TranscriptEntry;
+use crate::tui::state::{TranscriptEntry, TranscriptEntryPayload};
 
 #[path = "active_turn.rs"]
 mod active_turn;
@@ -331,32 +331,9 @@ mod helper_tests {
     }
 }
 
-const RENDERABLE_SYSTEM_MESSAGE_PREFIXES: &[&str] = &[
-    "query failed:",
-    "memory ·",
-    "compaction failed:",
-    "compact failed:",
-    "local embedding backend bootstrap reported:",
-    "skill loading failed:",
-    "oauth failed:",
-    "backend rebuild failed:",
-    "embedding ·",
-    "open this url in a browser and enter the one-time code:",
-    "starting codex browser login.",
-    "error:",
-];
-
-fn starts_with_ignore_ascii_case(s: &str, prefix: &str) -> bool {
-    s.len() >= prefix.len() && s[..prefix.len()].eq_ignore_ascii_case(prefix)
+pub(super) fn is_renderable_system_message(entry: &TranscriptEntry) -> bool {
+    matches!(entry.payload, Some(TranscriptEntryPayload::System(_)))
 }
-
-pub(super) fn is_renderable_system_message(message: &str) -> bool {
-    let trimmed = message.trim();
-    RENDERABLE_SYSTEM_MESSAGE_PREFIXES
-        .iter()
-        .any(|prefix| starts_with_ignore_ascii_case(trimmed, prefix))
-}
-
 #[cfg(test)]
 #[path = "cells_tests.rs"]
 mod tests; // #[path] set above

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -26,8 +26,8 @@ pub use self::types::{
     OAuthLoginMode, OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot,
     PendingInteractionSnapshot, PermissionMode, PickerIntent, ProviderFamily, RalphGoal,
     RebuildSuccess, RunningTask, RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab,
-    TaskCompletion, TaskKind, TerminalDiagnosticsView, TranscriptEntry, TranscriptEntryPayload,
-    TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
+    SystemMessageKind, TaskCompletion, TaskKind, TerminalDiagnosticsView, TranscriptEntry,
+    TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
 };
 use crate::google_oauth::GoogleOAuthManager;
 use crate::oauth::OAuthManager;

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -4,8 +4,8 @@ use rara_persistence::redaction::redact_secrets;
 use ratatui::text::Line;
 
 use super::{
-    ActiveLiveEvent, ActiveLiveSections, PendingFollowUpMessage, RuntimePhase, TranscriptEntry,
-    TranscriptTurn, TuiApp,
+    ActiveLiveEvent, ActiveLiveSections, PendingFollowUpMessage, RuntimePhase, SystemMessageKind,
+    TranscriptEntry, TranscriptTurn, TuiApp,
 };
 use crate::tui::terminal_event::TerminalEvent;
 
@@ -102,6 +102,13 @@ impl TuiApp {
         self.active_turn
             .entries
             .push(TranscriptEntry::terminal_event(event));
+        self.reset_transcript_scroll_if_following_tail();
+    }
+
+    pub fn push_system(&mut self, message: impl Into<String>, kind: SystemMessageKind) {
+        self.active_turn
+            .entries
+            .push(TranscriptEntry::system(message, kind));
         self.reset_transcript_scroll_if_following_tail();
     }
 

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -479,7 +479,7 @@ pub enum TranscriptEntryPayload {
     System(SystemMessageKind),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum SystemMessageKind {
     EmbeddingStatus,
     Memory,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -476,6 +476,21 @@ pub struct TranscriptEntry {
 #[derive(Clone, Debug)]
 pub enum TranscriptEntryPayload {
     Terminal(TerminalEvent),
+    System(SystemMessageKind),
+}
+
+#[derive(Clone, Debug)]
+pub enum SystemMessageKind {
+    EmbeddingStatus,
+    Memory,
+    OAuth,
+    SkillLoading,
+    BackendRebuild,
+    BackendBootstrap,
+    ToolOutputCapture,
+    MCPStatus,
+    OAuthPrompt,
+    Other,
 }
 
 impl TranscriptEntry {
@@ -492,6 +507,14 @@ impl TranscriptEntry {
             role: "Terminal Event".to_string(),
             message: event.to_transcript_message(),
             payload: Some(TranscriptEntryPayload::Terminal(event)),
+        }
+    }
+
+    pub fn system(message: impl Into<String>, kind: SystemMessageKind) -> Self {
+        Self {
+            role: "System".to_string(),
+            message: message.into(),
+            payload: Some(TranscriptEntryPayload::System(kind)),
         }
     }
 }


### PR DESCRIPTION
## Summary

Replaces the fragile string-prefix-based system message matching (`RENDERABLE_SYSTEM_MESSAGE_PREFIXES`) with a typed `SystemMessageKind` enum in `TranscriptEntryPayload`.

## Before

```rust
const PREFIXES: &[&str] = &["embedding ·", "memory ·", ...];
fn is_renderable_system_message(msg: &str) -> bool {
    PREFIXES.iter().any(|p| msg.starts_with(p))
}
```

## After

```rust
enum SystemMessageKind { EmbeddingStatus, Memory, BackendBootstrap, ... }
enum TranscriptEntryPayload { Terminal(...), System(SystemMessageKind) }

fn is_renderable_system_message(entry: &TranscriptEntry) -> bool {
    matches!(entry.payload, Some(TranscriptEntryPayload::System(_)))
}
```

## Changes

- Add `SystemMessageKind` enum with variants for all known system message types
- Add `TranscriptEntryPayload::System(SystemMessageKind)` variant
- Add `TranscriptEntry::system()` constructor and `Transcript::push_system()`
- Replace `is_renderable_system_message(&str)` with payload-based check
- Remove `RENDERABLE_SYSTEM_MESSAGE_PREFIXES`
- Warning-to-kind mapping deferred to follow-up

## Verification

- `cargo check` — no new warnings
- `cargo fmt` — clean