### PR TITLE
feat: wire SystemMessageKind into production system message paths

### DIFF
--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use super::super::state::{
     GoalStatus, HelpTab, ListPickerKind, LocalCommand, LocalCommandKind, Overlay, PermissionMode,
-    PickerIntent, RalphGoal, RuntimePhase, StatusTab, TuiApp,
+    PickerIntent, RalphGoal, RuntimePhase, StatusTab, SystemMessageKind, TuiApp,
 };
 use super::tasks::{start_compact_task, start_rebuild_task, start_review_task};
 use crate::agent::{Agent, AgentEvent, AgentExecutionMode, BashApprovalMode};
@@ -401,7 +401,7 @@ fn handle_mcp_command(app: &mut TuiApp) {
         Ok(registry) => {
             let snapshot = McpStatusSnapshot::from_registry(&registry);
             publish_mcp_status_event(app, &snapshot);
-            app.push_entry("System", format_mcp_status(&snapshot));
+            app.push_system(format_mcp_status(&snapshot), SystemMessageKind::MCPStatus);
             app.bottom_pane.notice = Some("MCP status updated.".into());
             if let Some(cache) = app.mcp_tool_cache.as_ref() {
                 spawn_mcp_tool_cache_population(cache, &registry);
@@ -409,9 +409,9 @@ fn handle_mcp_command(app: &mut TuiApp) {
         }
         Err(err) => {
             publish_mcp_status_load_failed_event(app, &format!("{err:#}"));
-            app.push_entry(
-                "System",
+            app.push_system(
                 format!("MCP Servers\n\nFailed to load MCP configuration:\n{err:#}"),
+                SystemMessageKind::MCPStatus,
             );
             app.bottom_pane.notice = Some("MCP status failed.".into());
         }

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -8,7 +8,9 @@ use self::helpers::{
     is_oauth_prompt_message, planning_action_label, planning_note_lines, planning_result_note,
     scrub_internal_control_tokens, subagent_request_input, tool_action_label,
 };
-use super::super::state::{RuntimePhase, TuiApp, TuiEvent, contains_structured_planning_output};
+use super::super::state::{
+    RuntimePhase, SystemMessageKind, TuiApp, TuiEvent, contains_structured_planning_output,
+};
 use crate::agent::AgentEvent;
 use crate::memory_notice::{count_label, memory_notice};
 use crate::runtime_control::MemoryEvent;
@@ -167,7 +169,7 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                     app.set_runtime_phase(RuntimePhase::OAuthPollingDeviceCode, Some(detail));
                 } else if is_oauth_prompt_message(&message) {
                     let is_device_code = message.to_ascii_lowercase().contains("one-time code");
-                    app.push_entry("System", message);
+                    app.push_system(message, SystemMessageKind::OAuthPrompt);
                     if is_device_code {
                         app.set_runtime_phase(
                             RuntimePhase::OAuthDeviceCodePrompt,
@@ -200,7 +202,16 @@ pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                     app.set_runtime_phase(RuntimePhase::RebuildingBackend, Some(detail));
                 }
             }
-            app.push_entry(role, message)
+            if role == "System" {
+                let kind = if message.starts_with("Memory ·") {
+                    SystemMessageKind::Memory
+                } else {
+                    SystemMessageKind::Other
+                };
+                app.push_system(message, kind)
+            } else {
+                app.push_entry(role, message)
+            }
         }
         TuiEvent::Terminal(TerminalEvent::OutputDelta(event)) => {
             let name = match event.target {

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -20,7 +20,7 @@ use tokio::sync::mpsc;
 
 use super::super::state::{
     GoalStatus, ListPickerKind, OAuthLoginMode, PermissionMode, RalphGoal, RunningTask,
-    RuntimePhase, TaskCompletion, TaskKind, TuiApp, TuiEvent,
+    RuntimePhase, SystemMessageKind, TaskCompletion, TaskKind, TuiApp, TuiEvent,
 };
 use super::events::{
     apply_tui_event, convert_agent_event, format_error_chain, format_memory_event_notice,
@@ -81,6 +81,16 @@ Summarize the completed work, remaining blockers, and the next safest step for t
         goal_budget_label(goal),
         goal_remaining_label(goal)
     )
+}
+
+fn classify_system_warning(warning: &str, default_kind: SystemMessageKind) -> SystemMessageKind {
+    if warning.starts_with("embedding ·") || warning.starts_with("local embedding backend") {
+        SystemMessageKind::EmbeddingStatus
+    } else if warning.starts_with("Skill loading") {
+        SystemMessageKind::SkillLoading
+    } else {
+        default_kind
+    }
 }
 
 /// Forward `event` to the broadcast bus when there are active subscribers.
@@ -871,7 +881,7 @@ pub(crate) async fn finish_running_task_if_ready(
                             sanitize_url_for_display(base_url)
                         ));
                     }
-                    app.push_entry("System", message.clone());
+                    app.push_system(message.clone(), SystemMessageKind::Other);
                     app.push_notice(message);
                     try_start_queued_follow_up(app, agent_slot);
                 }
@@ -919,7 +929,7 @@ pub(crate) async fn finish_running_task_if_ready(
                     app.release_pending_follow_ups();
                     app.set_runtime_phase(RuntimePhase::Failed, Some("compact failed".into()));
                     let message = format!("Compaction failed:\n{}", format_error_chain(&err));
-                    app.push_entry("System", message.clone());
+                    app.push_system(message.clone(), SystemMessageKind::Other);
                     app.push_notice(message);
                 }
             }
@@ -954,6 +964,7 @@ pub(crate) async fn finish_running_task_if_ready(
                 app.memory_handler = Some(rebuilt.memory_handler);
                 app.local_model_server = rebuilt.local_model_server;
                 app.config_manager.save(&app.config)?;
+                let is_bootstrap = app.setup_status.is_none();
                 app.setup_status = Some(format!(
                     "Applied {} / {}",
                     app.config.provider,
@@ -966,10 +977,23 @@ pub(crate) async fn finish_running_task_if_ready(
                 }
                 app.close_overlay();
                 app.set_runtime_phase(RuntimePhase::BackendReady, Some("backend ready".into()));
-                app.push_entry("Runtime", app.setup_status.clone().unwrap_or_default());
+                app.push_system(
+                    app.setup_status.clone().unwrap_or_default(),
+                    if is_bootstrap {
+                        SystemMessageKind::BackendBootstrap
+                    } else {
+                        SystemMessageKind::BackendRebuild
+                    },
+                );
                 let warning_count = rebuilt.warnings.len();
+                let default_kind = if is_bootstrap {
+                    SystemMessageKind::BackendBootstrap
+                } else {
+                    SystemMessageKind::BackendRebuild
+                };
                 for warning in rebuilt.warnings {
-                    app.push_entry("System", warning);
+                    let kind = classify_system_warning(&warning, default_kind);
+                    app.push_system(warning, kind);
                 }
                 if warning_count > 0 {
                     let notice = if warning_count == 1 {
@@ -1020,7 +1044,7 @@ pub(crate) async fn finish_running_task_if_ready(
             Err(err) => {
                 app.set_runtime_phase(RuntimePhase::Failed, Some("oauth failed".into()));
                 let message = format!("OAuth failed:\n{}", format_error_chain(&err));
-                app.push_entry("System", message.clone());
+                app.push_system(message.clone(), SystemMessageKind::OAuth);
                 app.push_notice(message);
             }
         },
@@ -1058,7 +1082,7 @@ pub(crate) async fn finish_running_task_if_ready(
             Err(err) => {
                 app.set_runtime_phase(RuntimePhase::Failed, Some("google oauth failed".into()));
                 let message = format!("Google OAuth failed:\n{}", format_error_chain(&err));
-                app.push_entry("System", message.clone());
+                app.push_system(message.clone(), SystemMessageKind::OAuth);
                 app.push_notice(message);
             }
         },
@@ -1078,7 +1102,7 @@ pub(crate) async fn finish_running_task_if_ready(
                     "Failed to load DeepSeek models. Showing fallback list.\n{}",
                     format_error_chain(&err)
                 );
-                app.push_entry("System", message.clone());
+                app.push_system(message.clone(), SystemMessageKind::Other);
                 app.push_notice(message);
                 app.set_runtime_phase(RuntimePhase::Idle, Some("model list fallback".into()));
                 app.open_overlay(super::super::state::Overlay::ListPicker(
@@ -1102,7 +1126,7 @@ pub(crate) async fn finish_running_task_if_ready(
                     "Failed to load Kimi models. Showing fallback list.\n{}",
                     format_error_chain(&err)
                 );
-                app.push_entry("System", message.clone());
+                app.push_system(message.clone(), SystemMessageKind::Other);
                 app.push_notice(message);
                 app.set_runtime_phase(RuntimePhase::Idle, Some("model list fallback".into()));
                 app.open_overlay(super::super::state::Overlay::ListPicker(

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -487,7 +487,6 @@ pub enum SystemMessageKind {
     SkillLoading,
     BackendRebuild,
     BackendBootstrap,
-    ToolOutputCapture,
     MCPStatus,
     OAuthPrompt,
     Other,


### PR DESCRIPTION
## Summary

`SystemMessageKind` was defined but never used in production code — all system messages were pushed via `push_entry("System", ...)` without categorization. This PR wires all 9 `SystemMessageKind` variants into their corresponding production call sites.

## Changes

| File | Change |
|---|---|
| `tasks.rs` | All `push_entry("System", ...)` → `push_system(..., kind)` with classification. Added `classify_system_warning()` helper for warning-prefix matching. Detects first bootstrap vs rebuild via `setup_status.is_none()`. |
| `events.rs` | `TuiEvent::Transcript { role: "System" }` now routed to `push_system()`. Memory actions (`Memory ·` prefix) get `Memory` kind. OAuth prompts get `OAuthPrompt`. |
| `commands.rs` | MCP status/error messages routed to `push_system(..., MCPStatus)`. |
| `types.rs` | Removed `ToolOutputCapture` variant — doesn't map to RARA's architecture (tool output uses `Tool Progress`/`Tool Result` roles). |

## Variant coverage

All 9 variants now have production code callers:

| Variant | Trigger |
|---|---|
| `OAuthPrompt` | OAuth prompt in agent/runtime stream |
| `Memory` | Memory action events |
| `OAuth` | OAuth/GoogleOAuth task failure |
| `BackendRebuild` | Non-first backend rebuild warnings |
| `BackendBootstrap` | First backend startup |
| `EmbeddingStatus` | Warnings with "embedding ·" prefix |
| `SkillLoading` | Warnings with "Skill loading" prefix |
| `MCPStatus` | /mcp command status/errors |
| `Other` | Fallback for unclassified System messages |

## Verification

- `cargo check` — passes, no new warnings
- `cargo test --bin rara tui::render::cells` — 79 passed