### PR TITLE
feat(tui): improve resume picker and status line

### DIFF
--- a/docs/journal/2026-05-18-resume-picker-information.md
+++ b/docs/journal/2026-05-18-resume-picker-information.md
@@ -1,0 +1,59 @@
+# Resume Picker Information
+
+## Summary
+
+The resume picker now uses a dedicated Codex-aligned picker surface instead of
+only changing the row text inside the generic bottom list:
+
+- the modal is expanded to a near-full-screen picker instead of a small bottom
+  slice;
+- sessions can be searched by preview, id, cwd, branch, provider, model, mode,
+  or approval policy;
+- the toolbar exposes cwd/all filtering and updated/created sorting;
+- the list loads up to 200 recent sessions and scrolls the selected row;
+- each row keeps the preview-first metadata hierarchy while using a dense
+  two-line layout, with a third line only when compaction details exist.
+
+## Background
+
+Codex's resume picker is not just a richer row renderer. It is a dedicated
+selection surface with filtering and sorting controls, so users can narrow a
+large persisted session list before resuming. RARA already stored enough
+metadata for that shape, but the previous `/resume` route used the generic
+bottom list picker, loaded only a small fixed set, and had no visible search or
+filter surface.
+
+## Scope
+
+This checkpoint keeps the existing `Overlay::ListPicker(ListPickerKind::Resume)`
+route and adds the missing resume-specific behavior there. It also removes the
+unused legacy `render_resume_picker_modal` path from `overlay_setup.rs` so there
+is only one resume picker implementation to maintain. The row layout is kept
+dense enough for repeated resume workflows: preview on the first line, runtime,
+workspace, identifiers, and counts on the second line, and optional compaction
+details on the third line.
+
+The change does not add Codex's async transcript preview expansion, pagination,
+or dense/comfortable view toggle.
+
+## Validation
+
+```bash
+cargo test tui::list_picker::tests::resume_summary_lines_surface_runtime_location_and_compaction_metadata -- --nocapture
+cargo test tui::list_picker::tests::resume_picker_key_event_treats_printable_keys_as_search_input -- --nocapture
+cargo test tui::state::tests::resume_picker_refreshes_recent_threads_on_open -- --nocapture
+cargo test tui::state::tests::resume_picker_loads_more_than_legacy_twenty_thread_cap -- --nocapture
+cargo test tui::state::tests::resume_picker_search_filters_and_clear_restores_threads -- --nocapture
+cargo fmt --check
+cargo check
+```
+
+`cargo check` completed successfully with existing workspace warnings. The
+focused tests above cover the row metadata contract, resume-specific key
+handling, refresh-on-open behavior, the larger recent-session cap, and search
+clearing.
+
+## Follow-Ups
+
+- Decide separately whether RARA should add transcript expansion, pagination, and
+  density toggles to match the rest of Codex's picker behavior.

--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -46,6 +46,7 @@ pub enum AppEvent {
     ApplyOverlaySelection,
     CycleResumeFilter,
     CycleResumeSort,
+    ClearResumeSearch,
     CancelRunningTask,
     ClearComposer,
     ToggleSidebar,

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -39,6 +39,12 @@ pub(crate) async fn dispatch_event(
             if matches!(app.overlay, Some(Overlay::ModelSearch)) {
                 app.model_search_query.clear();
             }
+            if matches!(
+                app.overlay,
+                Some(Overlay::ListPicker(ListPickerKind::Resume))
+            ) {
+                app.clear_resume_search();
+            }
             app.close_overlay();
         }
         AppEvent::CancelRunningTask => {
@@ -69,6 +75,13 @@ pub(crate) async fn dispatch_event(
                 app.model_search_idx = 0;
                 return Ok(false);
             }
+            if matches!(
+                app.overlay,
+                Some(Overlay::ListPicker(ListPickerKind::Resume))
+            ) {
+                app.push_resume_search_char(c);
+                return Ok(false);
+            }
             if app.bottom_pane.input.is_empty() {
                 app.transcript_scroll = 0;
             }
@@ -77,6 +90,13 @@ pub(crate) async fn dispatch_event(
         AppEvent::Backspace => {
             if matches!(app.overlay, Some(Overlay::ModelSearch)) {
                 app.model_search_query.pop();
+                return Ok(false);
+            }
+            if matches!(
+                app.overlay,
+                Some(Overlay::ListPicker(ListPickerKind::Resume))
+            ) {
+                app.pop_resume_search_char();
                 return Ok(false);
             }
             app.backspace_active_input();
@@ -385,6 +405,17 @@ pub(crate) async fn dispatch_event(
         }
         AppEvent::CycleResumeSort => {
             app.cycle_resume_sort();
+        }
+        AppEvent::ClearResumeSearch => {
+            if matches!(
+                app.overlay,
+                Some(Overlay::ListPicker(ListPickerKind::Resume))
+            ) && !app.resume_search_query.is_empty()
+            {
+                app.clear_resume_search();
+            } else {
+                app.close_overlay();
+            }
         }
 
         AppEvent::ApplyOverlaySelection => match app.overlay {

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -8,13 +8,15 @@ use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
-    widgets::{Block, Borders, List, ListItem, Paragraph},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
 };
 
 use super::app_event::AppEvent;
 use super::custom_terminal::Frame;
 use super::state::{ListPickerKind, TuiApp};
 use super::theme::*;
+use crate::thread_store::ThreadSummary;
 
 impl ListPickerKind {
     /// Return the 0-based index of the highlighted item.
@@ -296,27 +298,13 @@ impl ListPickerKind {
         if app.recent_threads.is_empty() {
             return vec![ListItem::new("No threads available.")];
         }
+        let now = current_unix_time_secs();
         app.recent_threads
             .iter()
             .enumerate()
             .map(|(idx, summary)| {
-                let preview = if summary.preview.is_empty() {
-                    "(no preview)"
-                } else {
-                    summary.preview.as_str()
-                };
-                ListItem::new(vec![
-                    ratatui::text::Line::from(format!(
-                        "[{}] {} / {}  branch={}",
-                        idx + 1,
-                        summary.metadata.session_id,
-                        summary.metadata.provider,
-                        summary.metadata.branch,
-                    )),
-                    ratatui::text::Line::from(format!("     {}", preview)),
-                    ratatui::text::Line::from(""),
-                ])
-                .style(Self::selected_style(idx, selected))
+                ListItem::new(render_resume_summary_lines(idx, summary, now))
+                    .style(Self::selected_style(idx, selected))
             })
             .collect()
     }
@@ -370,11 +358,118 @@ impl ListPickerKind {
     }
 }
 
+fn render_resume_summary_lines(
+    idx: usize,
+    summary: &ThreadSummary,
+    now: u64,
+) -> Vec<Line<'static>> {
+    let preview = normalized_resume_preview(summary);
+    let metadata = &summary.metadata;
+    let workspace = resume_workspace_label(&metadata.cwd);
+    let updated = format_resume_age(metadata.updated_at, now);
+    let counts = format!(
+        "hist={} trans={} compact={}",
+        metadata.history_len, metadata.transcript_len, summary.compaction.compaction_count
+    );
+    let compaction = resume_compaction_detail(summary);
+
+    let title = Line::from(vec![
+        Span::raw(format!("[{}] ", idx + 1)),
+        Span::styled(preview, Style::default().add_modifier(Modifier::BOLD)),
+    ]);
+    let metadata = Line::from(format!(
+        "     {updated}  {}/{}  mode={} approval={}  cwd={} branch={} id={}  {counts}",
+        metadata.provider,
+        metadata.model,
+        metadata.agent_mode,
+        metadata.bash_approval,
+        workspace,
+        metadata.branch,
+        metadata.session_id
+    ));
+
+    let mut lines = vec![title, metadata];
+    if let Some(compaction) = compaction {
+        lines.push(Line::from(format!("     {compaction}")));
+    }
+    lines
+}
+
+fn normalized_resume_preview(summary: &ThreadSummary) -> String {
+    let preview = summary.preview.replace('\n', " ");
+    let preview = preview.trim();
+    if preview.is_empty() {
+        "(no transcript preview)".to_string()
+    } else {
+        preview.to_string()
+    }
+}
+
+fn resume_workspace_label(cwd: &str) -> String {
+    std::path::Path::new(cwd)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| cwd.to_string())
+}
+
+fn current_unix_time_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn format_resume_age(updated_at: i64, now: u64) -> String {
+    if updated_at <= 0 {
+        return "updated unknown".to_string();
+    }
+    let age = now.saturating_sub(updated_at as u64);
+    let label = if age < 60 {
+        "just now".to_string()
+    } else if age < 3600 {
+        format!("{}m ago", age / 60)
+    } else if age < 86400 {
+        format!("{}h ago", age / 3600)
+    } else {
+        format!("{}d ago", age / 86400)
+    };
+    format!("updated {label}")
+}
+
+fn resume_compaction_detail(summary: &ThreadSummary) -> Option<String> {
+    let compaction = &summary.compaction;
+    if compaction.compaction_count == 0 {
+        return None;
+    }
+    let mut parts = Vec::new();
+    if let Some(version) = compaction.boundary_version {
+        parts.push(format!("boundary=v{version}"));
+    }
+    if let Some(count) = compaction.recent_file_count {
+        parts.push(format!("recent_files={count}"));
+    }
+    if let (Some(before), Some(after)) = (compaction.before_tokens, compaction.after_tokens) {
+        parts.push(format!("tokens={before}->{after}"));
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(format!("compact {}", parts.join(" ")))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Unified render — one function for all ListPicker variants
 // ---------------------------------------------------------------------------
 
 pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, area: Rect) {
+    if kind == ListPickerKind::Resume {
+        render_resume_picker(f, app, area);
+        return;
+    }
+
     let items = kind.render_items(app);
 
     let chunks = Layout::default()
@@ -401,11 +496,89 @@ pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, are
     );
 }
 
+fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
+    let items = ListPickerKind::Resume.render_items(app);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(4),
+            Constraint::Min(8),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    let query = if app.resume_search_query.is_empty() {
+        "type to filter".to_string()
+    } else {
+        app.resume_search_query.clone()
+    };
+    let filter_status = if app.resume_filter_cwd {
+        "filter=[cwd] all"
+    } else {
+        "filter=cwd [all]"
+    };
+    let sort_status = if app.resume_sort_by_created {
+        "sort=updated [created]"
+    } else {
+        "sort=[updated] created"
+    };
+    let total = app.recent_threads.len();
+    let current = if total == 0 {
+        0
+    } else {
+        app.resume_picker_idx + 1
+    };
+    let search_line = Line::from(vec![
+        Span::styled("Search: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(query),
+        Span::raw(format!("  showing {current}/{total}")),
+    ]);
+    let status_line = Line::from(format!(
+        "{filter_status}  {sort_status}  tab cwd/all  left/right sort"
+    ));
+
+    f.render_widget(
+        Paragraph::new(vec![search_line, status_line]).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(ListPickerKind::Resume.title()),
+        ),
+        chunks[0],
+    );
+
+    let mut state = ListState::default();
+    if total > 0 {
+        state.select(Some(app.resume_picker_idx));
+    }
+    f.render_stateful_widget(
+        List::new(items)
+            .highlight_style(Style::default().fg(TEXT_ACCENT))
+            .highlight_symbol("› ")
+            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
+        chunks[1],
+        &mut state,
+    );
+
+    let footer = if app.resume_search_query.is_empty() {
+        "type search  tab cwd/all  left/right sort  up/down move  enter resume  esc close"
+    } else {
+        "type search  backspace edit  esc clear search  enter resume"
+    };
+    f.render_widget(
+        Paragraph::new(footer).alignment(Alignment::Center),
+        chunks[2],
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Key handling — shared for all ListPicker variants
 // ---------------------------------------------------------------------------
 
 pub fn list_picker_key_event(kind: ListPickerKind, code: KeyCode) -> AppEvent {
+    if kind == ListPickerKind::Resume {
+        return resume_picker_key_event(code);
+    }
+
     match code {
         KeyCode::Esc => AppEvent::CloseOverlay,
         KeyCode::Up | KeyCode::Char('k') => AppEvent::MoveListPickerSelection(-1),
@@ -437,13 +610,97 @@ pub fn list_picker_key_event(kind: ListPickerKind, code: KeyCode) -> AppEvent {
         KeyCode::Char('9') if kind != ListPickerKind::UnifiedModel => {
             AppEvent::SetListPickerSelection(8)
         }
-        KeyCode::Tab if kind == ListPickerKind::Resume => AppEvent::CycleResumeFilter,
-        KeyCode::BackTab if kind == ListPickerKind::Resume => AppEvent::CycleResumeSort,
-        KeyCode::Left | KeyCode::Right if kind == ListPickerKind::Resume => {
-            AppEvent::CycleResumeSort
-        }
-
         KeyCode::Enter => AppEvent::ApplyOverlaySelection,
         _ => AppEvent::Noop,
+    }
+}
+
+fn resume_picker_key_event(code: KeyCode) -> AppEvent {
+    match code {
+        KeyCode::Esc => AppEvent::ClearResumeSearch,
+        KeyCode::Up => AppEvent::MoveListPickerSelection(-1),
+        KeyCode::Down => AppEvent::MoveListPickerSelection(1),
+        KeyCode::Tab => AppEvent::CycleResumeFilter,
+        KeyCode::BackTab | KeyCode::Left | KeyCode::Right => AppEvent::CycleResumeSort,
+        KeyCode::Backspace => AppEvent::Backspace,
+        KeyCode::Enter => AppEvent::ApplyOverlaySelection,
+        KeyCode::Char(c) if !c.is_control() => AppEvent::InputChar(c),
+        _ => AppEvent::Noop,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::thread_store::{CompactionRecord, ThreadMetadata};
+
+    #[test]
+    fn resume_summary_lines_surface_runtime_location_and_compaction_metadata() {
+        let summary = ThreadSummary {
+            metadata: ThreadMetadata {
+                session_id: "thread-123".to_string(),
+                cwd: "/Users/test/projects/rara".to_string(),
+                branch: "feature/resume-picker".to_string(),
+                provider: "codex".to_string(),
+                model: "gpt-5.2".to_string(),
+                base_url: None,
+                agent_mode: "execute".to_string(),
+                bash_approval: "suggestion".to_string(),
+                created_at: 0,
+                origin_kind: "direct".to_string(),
+                forked_from_thread_id: None,
+                history_len: 8,
+                transcript_len: 5,
+                updated_at: 0,
+            },
+            preview: "User: improve resume picker".to_string(),
+            compaction: CompactionRecord {
+                compaction_count: 2,
+                before_tokens: Some(12_000),
+                after_tokens: Some(4_000),
+                recent_file_count: Some(3),
+                boundary_version: Some(1),
+                replaced_start: None,
+                replaced_end: None,
+                metadata_owner: None,
+                recent_files: Vec::new(),
+                summary: None,
+            },
+        };
+
+        let rendered = render_resume_summary_lines(0, &summary, 0)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("[1] User: improve resume picker"));
+        assert!(rendered.contains("updated unknown  codex/gpt-5.2"));
+        assert!(rendered.contains("mode=execute approval=suggestion"));
+        assert!(rendered.contains("cwd=rara branch=feature/resume-picker id=thread-123"));
+        assert!(rendered.contains("hist=8 trans=5 compact=2"));
+        assert!(rendered.contains("compact boundary=v1 recent_files=3 tokens=12000->4000"));
+        assert!(!rendered.contains("compaction runs=2"));
+        assert_eq!(rendered.lines().count(), 3);
+    }
+
+    #[test]
+    fn resume_picker_key_event_treats_printable_keys_as_search_input() {
+        assert!(matches!(
+            list_picker_key_event(ListPickerKind::Resume, KeyCode::Char('1')),
+            AppEvent::InputChar('1')
+        ));
+        assert!(matches!(
+            list_picker_key_event(ListPickerKind::Resume, KeyCode::Char('j')),
+            AppEvent::InputChar('j')
+        ));
+        assert!(matches!(
+            list_picker_key_event(ListPickerKind::Resume, KeyCode::Up),
+            AppEvent::MoveListPickerSelection(-1)
+        ));
+        assert!(matches!(
+            list_picker_key_event(ListPickerKind::Resume, KeyCode::Tab),
+            AppEvent::CycleResumeFilter
+        ));
     }
 }

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -58,7 +58,11 @@ pub(super) fn render_overlay(f: &mut Frame, app: &TuiApp, overlay: Overlay) -> O
             None
         }
         Overlay::ListPicker(kind) => {
-            let popup = bottom_picker_rect(f.area());
+            let popup = if kind == super::super::state::ListPickerKind::Resume {
+                centered_rect(96, 92, f.area())
+            } else {
+                bottom_picker_rect(f.area())
+            };
             f.render_widget(Clear, popup);
             super::super::list_picker::render_list_picker(f, app, kind, popup);
             None

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -1,6 +1,5 @@
 // Items reserved for planned overlay migration.
 #![allow(dead_code)]
-use std::path::Path;
 
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -96,131 +95,6 @@ pub(super) fn render_provider_picker_modal(f: &mut Frame, app: &TuiApp, area: Re
             .alignment(Alignment::Center),
         chunks[2],
     );
-}
-
-pub(super) fn render_resume_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
-    let intro = if app.recent_threads.is_empty() {
-        "No persisted threads found yet."
-    } else {
-        "Choose a recent thread to restore its transcript, plan state, and interaction cards."
-    };
-    let intro_height = wrapped_text_height(intro, area.width);
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(intro_height),
-            Constraint::Min(8),
-            Constraint::Length(2),
-        ])
-        .split(area);
-    f.render_widget(
-        Paragraph::new(intro)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(" Resume Thread "),
-            )
-            .wrap(Wrap { trim: false }),
-        chunks[0],
-    );
-    let items = if app.recent_threads.is_empty() {
-        vec![ListItem::new("No threads available.")]
-    } else {
-        app.recent_threads
-            .iter()
-            .enumerate()
-            .map(|(idx, session)| {
-                let style = if idx == app.resume_picker_idx {
-                    Style::default()
-                        .fg(TEXT_ACCENT)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default()
-                };
-                let when = if session.metadata.updated_at > 0 {
-                    let secs = session.metadata.updated_at;
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_secs())
-                        .unwrap_or(secs as u64);
-                    let age = now.saturating_sub(secs as u64);
-                    if age < 60 {
-                        "just now".to_string()
-                    } else if age < 3600 {
-                        format!("{}m ago", age / 60)
-                    } else if age < 86400 {
-                        format!("{}h ago", age / 3600)
-                    } else {
-                        format!("{}d ago", age / 86400)
-                    }
-                } else {
-                    "unknown".to_string()
-                };
-                let msg_count = session.metadata.history_len;
-                let preview = if session.preview.is_empty() {
-                    "(empty)".to_string()
-                } else {
-                    session.preview.replace('\n', " ")
-                };
-                let workspace = Path::new(&session.metadata.cwd)
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .filter(|name| !name.is_empty())
-                    .unwrap_or("-");
-                ListItem::new(vec![
-                    Line::from(format!(
-                        "{}  {}  {}  msgs={}",
-                        session.metadata.session_id, session.metadata.model, workspace, msg_count,
-                    )),
-                    Line::from(format!(
-                        "  {when}  {}/{}",
-                        session.metadata.provider, session.metadata.agent_mode,
-                    )),
-                    Line::from(format!("  {preview}")),
-                ])
-                .style(style)
-            })
-            .collect::<Vec<_>>()
-    };
-    f.render_widget(
-        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-    );
-    let total = app.recent_threads.len();
-    let current = if total > 0 {
-        app.resume_picker_idx + 1
-    } else {
-        0
-    };
-    let pct = if total > 0 {
-        (current * 100) / total
-    } else {
-        0
-    };
-    let footer = format!(
-        "enter resume   esc exit   ctrl+c exit   ↑/↓ browse   {current} / {total} · {pct}%"
-    );
-    f.render_widget(
-        Paragraph::new(footer).alignment(Alignment::Center),
-        chunks[2],
-    );
-}
-
-fn resume_compaction_label(compaction: &crate::thread_store::CompactionRecord) -> String {
-    if compaction.compaction_count == 0 {
-        return "compact=0".to_string();
-    }
-    let mut parts = vec![format!("compact={}", compaction.compaction_count)];
-    if let Some(version) = compaction.boundary_version {
-        parts.push(format!("boundary=v{version}"));
-    }
-    if let (Some(start), Some(end)) = (compaction.replaced_start, compaction.replaced_end) {
-        parts.push(format!("range={start}..{end}"));
-    }
-    if let (Some(before), Some(after)) = (compaction.before_tokens, compaction.after_tokens) {
-        parts.push(format!("tokens={before}->{after}"));
-    }
-    parts.join(" ")
 }
 
 pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
@@ -1060,27 +934,4 @@ pub(super) fn render_openai_profile_label_editor_modal(
         app.openai_profile_label_cursor_offset(),
         chunks[1],
     ))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn resume_compaction_label_includes_boundary_range_and_tokens() {
-        let label = resume_compaction_label(&crate::thread_store::CompactionRecord {
-            compaction_count: 2,
-            before_tokens: Some(12_000),
-            after_tokens: Some(4_000),
-            recent_file_count: Some(3),
-            boundary_version: Some(1),
-            replaced_start: Some(0),
-            replaced_end: Some(8),
-            metadata_owner: Some("runtime.compaction".to_string()),
-            recent_files: vec![],
-            summary: Some("summary".to_string()),
-        });
-
-        assert_eq!(label, "compact=2 boundary=v1 range=0..8 tokens=12000->4000");
-    }
 }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -331,6 +331,7 @@ impl TuiApp {
             resume_picker_idx: 0,
             resume_filter_cwd: true,
             resume_sort_by_created: false,
+            resume_search_query: String::new(),
             committed_render_generation: 0,
             committed_render_cache: RefCell::new(CommittedTranscriptRenderCache::default()),
             transcript_scroll: 0,

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -9,6 +9,8 @@ use serde_json::json;
 use super::{InteractionKind, StateDb, TranscriptTurn, TuiApp, state_db_status_error};
 use crate::thread_store::{ThreadRecorder, ThreadRuntimeState, ThreadStore};
 
+const RESUME_PICKER_THREAD_LIMIT: usize = 200;
+
 impl TuiApp {
     pub(super) fn refresh_recent_threads(&mut self) {
         let Some(state_db) = self.state_db.as_ref() else {
@@ -16,7 +18,8 @@ impl TuiApp {
             return;
         };
         self.recent_threads =
-            ThreadStore::list_recent_threads_for_db(state_db, 20).unwrap_or_default();
+            ThreadStore::list_recent_threads_for_db(state_db, RESUME_PICKER_THREAD_LIMIT)
+                .unwrap_or_default();
     }
 
     pub(super) fn refresh_recent_threads_for_resume_picker(&mut self) {
@@ -27,6 +30,11 @@ impl TuiApp {
                 .unwrap_or_default();
             self.recent_threads
                 .retain(|t| t.metadata.cwd == current_cwd);
+        }
+        let query = self.resume_search_query.trim().to_ascii_lowercase();
+        if !query.is_empty() {
+            self.recent_threads
+                .retain(|thread| resume_thread_matches_query(thread, query.as_str()));
         }
         self.recent_threads.sort_by(|a, b| {
             if self.resume_sort_by_created {
@@ -49,6 +57,24 @@ impl TuiApp {
 
     pub(crate) fn cycle_resume_sort(&mut self) {
         self.resume_sort_by_created = !self.resume_sort_by_created;
+        self.refresh_recent_threads_for_resume_picker();
+    }
+
+    pub(crate) fn push_resume_search_char(&mut self, c: char) {
+        self.resume_search_query.push(c);
+        self.resume_picker_idx = 0;
+        self.refresh_recent_threads_for_resume_picker();
+    }
+
+    pub(crate) fn pop_resume_search_char(&mut self) {
+        self.resume_search_query.pop();
+        self.resume_picker_idx = 0;
+        self.refresh_recent_threads_for_resume_picker();
+    }
+
+    pub(crate) fn clear_resume_search(&mut self) {
+        self.resume_search_query.clear();
+        self.resume_picker_idx = 0;
         self.refresh_recent_threads_for_resume_picker();
     }
 
@@ -252,4 +278,20 @@ impl TuiApp {
                 Some(state_db_status_error("turn write failed", err.to_string()));
         }
     }
+}
+
+fn resume_thread_matches_query(thread: &crate::thread_store::ThreadSummary, query: &str) -> bool {
+    let metadata = &thread.metadata;
+    [
+        thread.preview.as_str(),
+        metadata.session_id.as_str(),
+        metadata.cwd.as_str(),
+        metadata.branch.as_str(),
+        metadata.provider.as_str(),
+        metadata.model.as_str(),
+        metadata.agent_mode.as_str(),
+        metadata.bash_approval.as_str(),
+    ]
+    .into_iter()
+    .any(|value| value.to_ascii_lowercase().contains(query))
 }

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -849,6 +849,99 @@ fn resume_picker_refreshes_recent_threads_on_open() {
 }
 
 #[test]
+fn resume_picker_loads_more_than_legacy_twenty_thread_cap() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    let state_db = StateDb::new_for_root_dir(dir.path().join(".rara")).expect("state db");
+    app.attach_state_db(std::sync::Arc::new(state_db));
+
+    for idx in 0..25 {
+        app.state_db
+            .as_ref()
+            .expect("state db")
+            .upsert_session(
+                format!("thread-{idx:02}").as_str(),
+                "/tmp/workspace",
+                "main",
+                "ollama",
+                "qwen3",
+                None,
+                "execute",
+                "always",
+                None,
+                &PersistedPromptRuntimeState::default(),
+                1,
+                0,
+                &PersistedCompactState::default(),
+            )
+            .expect("upsert thread");
+    }
+
+    app.resume_filter_cwd = false;
+    app.open_overlay(Overlay::ListPicker(ListPickerKind::Resume));
+
+    assert_eq!(app.recent_threads.len(), 25);
+}
+
+#[test]
+fn resume_picker_search_filters_and_clear_restores_threads() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    let state_db = StateDb::new_for_root_dir(dir.path().join(".rara")).expect("state db");
+    app.attach_state_db(std::sync::Arc::new(state_db));
+
+    for (thread_id, branch, model) in [
+        ("thread-alpha", "feature/resume-search", "qwen3"),
+        ("thread-beta", "main", "gpt-5.2"),
+    ] {
+        app.state_db
+            .as_ref()
+            .expect("state db")
+            .upsert_session(
+                thread_id,
+                "/tmp/workspace",
+                branch,
+                "codex",
+                model,
+                None,
+                "execute",
+                "always",
+                None,
+                &PersistedPromptRuntimeState::default(),
+                1,
+                0,
+                &PersistedCompactState::default(),
+            )
+            .expect("upsert thread");
+    }
+
+    app.resume_filter_cwd = false;
+    app.open_overlay(Overlay::ListPicker(ListPickerKind::Resume));
+    assert_eq!(app.recent_threads.len(), 2);
+
+    for c in "resume-search".chars() {
+        app.push_resume_search_char(c);
+    }
+
+    assert_eq!(app.resume_search_query, "resume-search");
+    assert_eq!(app.resume_picker_idx, 0);
+    assert_eq!(app.recent_threads.len(), 1);
+    assert_eq!(app.recent_threads[0].metadata.session_id, "thread-alpha");
+
+    app.clear_resume_search();
+
+    assert!(app.resume_search_query.is_empty());
+    assert_eq!(app.resume_picker_idx, 0);
+    assert_eq!(app.recent_threads.len(), 2);
+}
+
+#[test]
 fn finalize_agent_stream_updates_latest_committed_turn_when_final_text_arrives_late() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -699,6 +699,7 @@ pub struct TuiApp {
     pub resume_picker_idx: usize,
     pub resume_filter_cwd: bool,
     pub resume_sort_by_created: bool,
+    pub resume_search_query: String,
     pub committed_render_generation: u64,
     pub committed_render_cache: RefCell<CommittedTranscriptRenderCache>,
     pub transcript_scroll: usize,


### PR DESCRIPTION
## Summary

- Replace the generic bottom `/resume` list with a near-full-screen resume-specific picker surface.
- Add visible search, cwd/all filtering, updated/created sorting, and stateful list scrolling.
- Load up to 200 recent sessions for the picker instead of the old 20-session cap.
- Keep the preview-first metadata rows, but compress each session into a dense two-line layout with an optional compaction detail line.
- Remove the unused legacy resume picker modal from `overlay_setup.rs`.
- Surface permission and bash approval status in the bottom footer, borrowing the Codex Rust 0.131.0 status-line visibility improvement.
- Record the checkpoints in `docs/journal/2026-05-18-resume-picker-information.md` and `docs/journal/2026-05-19-codex-131-status-line.md`.

## Purpose

Codex's resume picker is a dedicated browsing surface, not just richer row text.
RARA's `/resume` path still used the generic compact bottom list, so users could
only see a small slice of resumable sessions and had no way to narrow the list.
This change keeps the existing `ListPickerKind::Resume` route but gives it the
search/filter/sort behavior needed to scan many sessions.

Codex Rust 0.131.0 also calls out status-line visibility for approval and
permission state. RARA already has a detailed `/status` command, so this PR
keeps that borrowed behavior intentionally small by making the footer always
show `perm=<mode>` and `approval=<mode>`.

## Related Issue

None.

## Testing

- `cargo fmt --check`
- `git diff --check`
- `cargo check`
  - Completed successfully with existing workspace warnings.
- `cargo test tui::list_picker::tests::resume_summary_lines_surface_runtime_location_and_compaction_metadata -- --nocapture`
- `cargo test tui::list_picker::tests::resume_picker_key_event_treats_printable_keys_as_search_input -- --nocapture`
- `cargo test tui::state::tests::resume_picker_refreshes_recent_threads_on_open -- --nocapture`
- `cargo test tui::state::tests::resume_picker_loads_more_than_legacy_twenty_thread_cap -- --nocapture`
- `cargo test tui::state::tests::resume_picker_search_filters_and_clear_restores_threads -- --nocapture`
- `cargo test footer_summary_text_reports_permission_and_approval_when_idle -- --nocapture`
- `cargo test footer_summary_text_shows_tokens_while_busy -- --nocapture`
- `cargo test footer_summary_text_includes_repo_context_when_available -- --nocapture`
