### PR TITLE
feat: typed HookLifecycle + per-phase hook injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11996,6 +11996,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "rara-config",
+ "serde",
  "tempfile",
 ]
 

--- a/crates/instructions/Cargo.toml
+++ b/crates/instructions/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+serde = { workspace = true, features = ["derive"] }
 rara-config = { path = "../config" }
 
 [dev-dependencies]

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -6,6 +6,51 @@ use rara_config::RaraConfig;
 
 use crate::workspace::WorkspaceMemory;
 
+/// Agent lifecycle phase.  File-based hooks are tagged with this phase
+/// and only injected into the prompt when the assembler requests the
+/// matching phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum HookLifecycle {
+    SessionStart,
+    UserPromptSubmit,
+    PreToolUse,
+    PostToolUse,
+    Stop,
+    PreCompact,
+}
+
+impl HookLifecycle {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::SessionStart => "SessionStart",
+            Self::UserPromptSubmit => "UserPromptSubmit",
+            Self::PreToolUse => "PreToolUse",
+            Self::PostToolUse => "PostToolUse",
+            Self::Stop => "Stop",
+            Self::PreCompact => "PreCompact",
+        }
+    }
+
+    /// Parse from Claude-style hook file names, e.g. "pre-tool-use" → PreToolUse.
+    pub fn from_filename(name: &str) -> Option<Self> {
+        match name {
+            "session-start" | "session_start" => Some(Self::SessionStart),
+            "user-prompt-submit" | "user_prompt_submit" => Some(Self::UserPromptSubmit),
+            "pre-tool-use" | "pre_tool_use" => Some(Self::PreToolUse),
+            "post-tool-use" | "post_tool_use" => Some(Self::PostToolUse),
+            "stop" => Some(Self::Stop),
+            _ => None,
+        }
+    }
+}
+
+/// One file-based hook entry, tagged with its lifecycle phase.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookPromptEntry {
+    pub phase: HookLifecycle,
+    pub body: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PromptMode {
     Execute,
@@ -169,7 +214,10 @@ pub struct PromptRuntimeConfig {
     pub compact_prompt: Option<String>,
     pub protocol_prompt_sources: Vec<PromptSource>,
     pub available_skills: Vec<PromptSkillSummary>,
-    pub hook_prompt_text: Vec<String>,
+    /// Hook prompt entries, each tagged with its lifecycle phase.
+    /// Populated at startup from `.claude/hooks/*.md`.
+    pub hook_prompt_entries: Vec<HookPromptEntry>,
+
     pub warnings: Vec<String>,
 }
 
@@ -198,13 +246,28 @@ impl PromptRuntimeConfig {
             compact_prompt,
             protocol_prompt_sources: Vec::new(),
             available_skills: Vec::new(),
-            hook_prompt_text: Vec::new(),
+            hook_prompt_entries: Vec::new(),
             warnings,
         }
     }
 
-    pub fn hooks_prompt(&self) -> String {
-        self.hook_prompt_text.join("\n\n")
+    /// Return hook prompt text, optionally filtered to a specific lifecycle
+    /// phase. When `phase` is `None`, returns all hooks.
+    pub fn hooks_prompt(&self, phase: Option<HookLifecycle>) -> String {
+        if let Some(phase) = phase {
+            self.hook_prompt_entries
+                .iter()
+                .filter(|e| e.phase == phase)
+                .map(|e| e.body.as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n")
+        } else {
+            self.hook_prompt_entries
+                .iter()
+                .map(|e| e.body.as_str())
+                .collect::<Vec<_>>()
+                .join("\n\n")
+        }
     }
 
     pub fn as_sources(&self) -> Vec<PromptSource> {

--- a/src/context/assembler.rs
+++ b/src/context/assembler.rs
@@ -92,8 +92,9 @@ impl<'a> ContextAssembler<'a> {
         if !memory_section.is_empty() {
             context_sections.push(memory_section);
         }
-        if !self.runtime.hooks_prompt().is_empty() {
-            context_sections.push(format!("## Hooks\n\n{}", self.runtime.hooks_prompt()));
+        let hooks_text = self.runtime.hooks_prompt(None);
+        if !hooks_text.is_empty() {
+            context_sections.push(format!("## Hooks\n\n{}", hooks_text));
         }
         if !context_sections.is_empty() {
             prompt.text.push_str("\n\n");

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -11,58 +11,18 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
+/// Hook phases aligned with Claude Code's lifecycle events.
+use rara_instructions::HookLifecycle;
 use serde::Serialize;
 
-/// Hook phases aligned with Claude Code's lifecycle events.
-/// RARA may normalise Claude hook files into these phases.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum HookPhase {
-    /// When a new session begins.
-    SessionStart,
-    /// When the user sends a prompt.
-    UserPromptSubmit,
-    /// Before a tool is executed.
-    PreToolUse,
-    /// After a tool completes.
-    PostToolUse,
-    /// When the session stops.
-    Stop,
-}
-
-impl HookPhase {
-    /// Parse from Claude-style hook file names, e.g. "pre-tool-use" → PreToolUse.
-    pub fn from_filename(name: &str) -> Option<Self> {
-        match name {
-            "session-start" | "session_start" => Some(Self::SessionStart),
-            "user-prompt-submit" | "user_prompt_submit" => Some(Self::UserPromptSubmit),
-            "pre-tool-use" | "pre_tool_use" => Some(Self::PreToolUse),
-            "post-tool-use" | "post_tool_use" => Some(Self::PostToolUse),
-            "stop" => Some(Self::Stop),
-            _ => None,
-        }
-    }
-
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::SessionStart => "session_start",
-            Self::UserPromptSubmit => "user_prompt_submit",
-            Self::PreToolUse => "pre_tool_use",
-            Self::PostToolUse => "post_tool_use",
-            Self::Stop => "stop",
-        }
-    }
-}
-
 /// A discovered and normalised hook declaration.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct HookDefinition {
-    /// Unique id derived from source path.
     pub id: String,
     /// Repository-relative source path.
     pub source_path: String,
     /// Declared hook phase.
-    pub phase: HookPhase,
+    pub phase: HookLifecycle,
     /// Whether the hook could be fully parsed.
     pub parse_status: HookParseStatus,
     /// Hook body / handler content.
@@ -83,7 +43,7 @@ pub struct HookRegistry {
     pub hooks: BTreeMap<String, HookDefinition>,
     pub load_warnings: Vec<String>,
     /// All hook phases that have at least one registered hook.
-    pub active_phases: Vec<HookPhase>,
+    pub active_phases: Vec<HookLifecycle>,
 }
 
 impl HookRegistry {
@@ -118,7 +78,7 @@ impl HookRegistry {
             let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
                 continue;
             };
-            let Some(phase) = HookPhase::from_filename(stem) else {
+            let Some(phase) = HookLifecycle::from_filename(stem) else {
                 continue;
             };
 
@@ -174,7 +134,7 @@ impl HookRegistry {
     }
 
     fn refresh_active_phases(&mut self) {
-        let mut phases: Vec<HookPhase> = self
+        let mut phases: Vec<HookLifecycle> = self
             .hooks
             .values()
             .filter(|h| h.parse_status == HookParseStatus::Ok)
@@ -205,13 +165,14 @@ impl HookRegistry {
     }
 }
 
-fn phase_ordinal(phase: HookPhase) -> u8 {
+fn phase_ordinal(phase: HookLifecycle) -> u8 {
     match phase {
-        HookPhase::SessionStart => 0,
-        HookPhase::UserPromptSubmit => 1,
-        HookPhase::PreToolUse => 2,
-        HookPhase::PostToolUse => 3,
-        HookPhase::Stop => 4,
+        HookLifecycle::SessionStart => 0,
+        HookLifecycle::UserPromptSubmit => 1,
+        HookLifecycle::PreToolUse => 2,
+        HookLifecycle::PostToolUse => 3,
+        HookLifecycle::Stop => 4,
+        HookLifecycle::PreCompact => 5,
     }
 }
 
@@ -226,15 +187,18 @@ mod tests {
     #[test]
     fn parses_hook_phases_from_claude_filenames() {
         assert_eq!(
-            HookPhase::from_filename("pre-tool-use"),
-            Some(HookPhase::PreToolUse)
+            HookLifecycle::from_filename("pre-tool-use"),
+            Some(HookLifecycle::PreToolUse)
         );
         assert_eq!(
-            HookPhase::from_filename("session-start"),
-            Some(HookPhase::SessionStart)
+            HookLifecycle::from_filename("session-start"),
+            Some(HookLifecycle::SessionStart)
         );
-        assert_eq!(HookPhase::from_filename("stop"), Some(HookPhase::Stop));
-        assert_eq!(HookPhase::from_filename("unknown"), None);
+        assert_eq!(
+            HookLifecycle::from_filename("stop"),
+            Some(HookLifecycle::Stop)
+        );
+        assert_eq!(HookLifecycle::from_filename("unknown"), None);
     }
 
     #[test]
@@ -254,8 +218,8 @@ mod tests {
         registry.discover_from_dir(&hooks_dir);
 
         assert_eq!(registry.hooks.len(), 2);
-        assert!(registry.active_phases.contains(&HookPhase::PreToolUse));
-        assert!(registry.active_phases.contains(&HookPhase::Stop));
+        assert!(registry.active_phases.contains(&HookLifecycle::PreToolUse));
+        assert!(registry.active_phases.contains(&HookLifecycle::Stop));
     }
 
     #[test]

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -194,12 +194,14 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     if let Ok(cwd) = std::env::current_dir() {
         file_hooks.discover_repo_hooks(&cwd);
     }
-    prompt_config.hook_prompt_text = file_hooks
+    prompt_config.hook_prompt_entries = file_hooks
         .hooks
         .values()
-        .map(|h| format!("## {}\n\n{}", h.phase.as_str(), h.body))
+        .map(|h| rara_instructions::HookPromptEntry {
+            phase: h.phase,
+            body: format!("## {}\n\n{}", h.phase.as_str(), h.body),
+        })
         .collect();
-
     let tool_manager = create_full_tool_manager(
         backend.clone(),
         embedding_backend.clone(),


### PR DESCRIPTION
## Summary

Makes `HookLifecycle` a shared, serde-enabled type in the `instructions` crate,
replaces string-prefix matching with enum filtering, and enables per-phase
hook injection.

## Design

| Before | After |
|---|---|
| `HookLifecycle` in `runtime_control.rs` + `HookPhase` in `hooks.rs` (two types) | One `instructions::HookLifecycle` shared everywhere |
| `hook_prompt_text: Vec<String>` with `"PreToolUse:\n"` prefix | `hook_prompt_entries: Vec<HookPromptEntry>` with typed `phase` field |
| `hooks_prompt(phase: Option<&str>)` string-matched | `hooks_prompt(phase: Option<HookLifecycle>)` enum-matched |

## Changes

| File | Change |
|---|---|
| `crates/instructions/src/prompt.rs` | New `HookLifecycle` enum (with serde) + `HookPromptEntry` struct + `from_filename()` |
| `src/hooks.rs` | Removed duplicate `HookPhase`, uses `instructions::HookLifecycle` |
| `src/runtime_context.rs` | Creates `HookPromptEntry` with typed phase |
| `src/context/assembler.rs` | Calls `hooks_prompt(None)` (all hooks, backward compatible) |
| `crates/instructions/Cargo.toml` | Added `serde` for `HookLifecycle` derives |

## HookLifecycle variants

```
SessionStart | PreToolUse | PostToolUse | Stop | UserPromptSubmit | PreCompact
```

## Verification

- `cargo check` — passes
- `cargo test --bin rara tui::render::cells` — 79 passed