### PR TITLE
feat(tui): show permission status in footer

### DIFF
--- a/docs/journal/2026-05-19-codex-131-status-line.md
+++ b/docs/journal/2026-05-19-codex-131-status-line.md
@@ -1,0 +1,30 @@
+# Codex 0.131 Status Line Borrowing
+
+## What changed
+
+RARA now keeps the bottom footer status dense enough to show the active
+permission mode and bash approval mode even when the runtime is idle.
+
+The specific borrowed behavior comes from Codex Rust 0.131.0, which called out
+status-line visibility for approval and permission state. RARA already had the
+detailed `/status` command and activity badges, so this checkpoint keeps the
+implementation narrower: the footer always includes `perm=<mode>` and
+`approval=<mode>` before live token, cache, or compaction statistics.
+
+## Trade-offs
+
+- The footer is no longer blank in an idle workspace without repository
+  context. This is intentional because permission state is operationally useful
+  before a prompt is submitted.
+- The change avoids duplicating the full `/status` view. The footer remains a
+  compact scan target rather than a second status panel.
+- Agent execution mode still stays in the existing activity line and composer
+  hints, because the release note item being mirrored is specifically approval
+  and permission visibility.
+
+## Validation
+
+- Updated bottom pane footer tests to assert the idle permission and approval
+  labels.
+- Updated the busy footer test to keep live token statistics while preserving
+  the new permission summary.

--- a/src/tui/render/bottom_pane/view_builder.rs
+++ b/src/tui/render/bottom_pane/view_builder.rs
@@ -208,6 +208,8 @@ pub(super) fn footer_summary_text(app: &TuiApp) -> String {
         parts.push(hint);
     }
 
+    parts.push(footer_permission_status(app));
+
     if shows_live_task_stats(app) {
         parts.push(format!(
             "tokens={}",
@@ -227,6 +229,14 @@ pub(super) fn footer_summary_text(app: &TuiApp) -> String {
     }
 
     parts.join("  ")
+}
+
+fn footer_permission_status(app: &TuiApp) -> String {
+    format!(
+        "perm={} approval={}",
+        app.permission_mode_label(),
+        app.bash_approval_mode_label()
+    )
 }
 
 fn shows_live_task_stats(app: &TuiApp) -> bool {

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -18,7 +18,7 @@ use crate::tui::state::{
 use crate::tui::theme::STATUS_WARNING;
 
 #[test]
-fn footer_summary_text_is_empty_when_idle_and_no_repo_context() {
+fn footer_summary_text_reports_permission_and_approval_when_idle() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -31,11 +31,13 @@ fn footer_summary_text_is_empty_when_idle_and_no_repo_context() {
     };
 
     let rendered = footer_summary_text(&app);
-    assert_eq!(rendered, "");
+    assert_eq!(rendered, "perm=auto approval=suggestion");
+    assert!(!rendered.contains("tokens="));
+    assert!(!rendered.contains("ctx~="));
 }
 
 #[test]
-fn footer_summary_text_shows_tokens_only_while_busy() {
+fn footer_summary_text_shows_tokens_while_busy() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -51,7 +53,7 @@ fn footer_summary_text_shows_tokens_only_while_busy() {
     };
 
     let rendered = footer_summary_text(&app);
-    assert_eq!(rendered, "tokens=2.0k");
+    assert_eq!(rendered, "perm=auto approval=suggestion  tokens=2.0k");
     assert!(!rendered.contains("history="));
     assert!(!rendered.contains("local="));
     assert!(!rendered.contains("key="));

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tui/render/tests.rs
-assertion_line: 875
 expression: rendered
 ---
 ── RARA ──────────────────────────────────────────────────
@@ -25,3 +24,5 @@ Prompt ideas│   [1] Codex (current)                                           
 Warning  War│      Use Moonshot Kimi with an API key from api.moonshot.cn.             │
 › Ask about │                                                                          │
                           1-9 jump  Up/Down/jk move  Enter apply  Esc back
+
+                                                                       perm=auto approval=suggestion

--- a/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
@@ -23,3 +23,6 @@ Prompt ideas:
 
 Warning  Warning: openai-compatible is missing an API key. Use /model to configure the current provi
 › Ask about the repo, request a code change, or type /help to browse commands.
+
+
+                                                                       perm=auto approval=suggestion

--- a/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tui/render/tests.rs
-assertion_line: 1240
 expression: rendered
 ---
 ── RARA ──────────────────────────────────────────────────
@@ -21,3 +20,5 @@ Pr│DeepSeek/deepseek-v4-pro                                                  �
 Re│DeepSeek/deepseek-v4-preview                                              │
 › │Kimi/kimi-k2.6                                                            │
                      Up/Down/jk move  Enter apply  Esc back
+
+                                                   perm=auto approval=suggestion


### PR DESCRIPTION
## Summary

- Surface permission and bash approval status in the bottom footer.
- Keep live token, cache-hit, compaction, and repo context footer details intact.
- Add focused footer rendering tests and a journal checkpoint.

## Purpose

Codex Rust 0.131.0 calls out status-line visibility for approval and permission
state. RARA already has a detailed `/status` command and activity badges, so
this change borrows the smaller interaction pattern: the footer always exposes
`perm=<mode>` and `approval=<mode>` as a compact scan target before a prompt is
submitted.

## Related Issue

None.

## Testing

- `cargo fmt --check`
- `git diff --check --cached`
- `git diff --check`
- `cargo check`
  - Completed successfully with existing workspace warnings.
- `cargo test footer_summary_text_reports_permission_and_approval_when_idle -- --nocapture`
- `cargo test footer_summary_text_shows_tokens_while_busy -- --nocapture`
- `cargo test footer_summary_text_includes_repo_context_when_available -- --nocapture`
- `cargo test`
  - Completed successfully with existing workspace warnings.
