### PR TITLE
feat: Claude Code-style goal evaluator loop

### DIFF
--- a/docs/features/goal-evaluator-loop.md
+++ b/docs/features/goal-evaluator-loop.md
@@ -1,122 +1,41 @@
-# `/goal` Evaluator Loop (Claude Code-style)
+# `/goal` Evaluator Loop
 
-## Motivation
-
-Claude Code's `/goal` is a runtime loop: after every turn, a lightweight
-evaluator assesses whether the goal condition is met.  If not, the loop
-continues automatically with the evaluator's feedback as context.
-
-This differs from Codex's hidden-prompt-injection approach.  The agent
-doesn't know it's in a goal — it only sees the evaluator's "not yet"
-message at the start of each continuation turn.
+## Status
+- [x] Evaluator placeholder wired into agent turn cycle
+- [ ] Real LLM evaluator call (small model, yes/no output)
+- [ ] `GoalCreated` / `GoalCompleted` hook phases
 
 ## Design
 
 ### Flow
-
 ```
 User: /goal "run cargo test && all 14 pass"
 
 Loop:
   1. Agent runs normally (tools + reasoning)
   2. Turn completes
-  3. Evaluator (small model) checks condition:
-     "Is 'run cargo test && all 14 pass' satisfied?"
-     → "no: 3 of 14 tests still fail"  → loop back to 1
-     → "yes: all 14 tests pass"        → set Complete, return to user
+  3. Evaluator pushes "no: goal not yet complete — ..." as System message
+  4. Agent sees evaluator context on next turn → continues working
+  5. Agent eventually calls `update_goal(status=Complete)` or user stops
 ```
 
-### Evaluator
+### Implementation
+- `RalphGoal.condition: Option<String>` set from objective at create_goal time
+- Evaluator placeholder injected in `tasks.rs` Ralph loop after budget check
+- Uses `app.push_system()` to push evaluator context as System message
+- Agent loop continues via existing `start_query_task()` with next_goal_prompt
 
-The evaluator is a lightweight LLM call with a fixed prompt:
-
+### Evaluator (future)
+The real evaluator will call a lightweight LLM with:
 ```
-The goal is: {objective}
-
+The goal is: {condition}
 Based on the work done in the last turn, is the goal satisfied?
 Answer ONLY "yes" or "no: <one-sentence reason>".
 ```
+- "yes" → mark Complete, push notice
+- "no: reason" → push reason as System message, continue loop
 
-- Uses `LlmBackend::complete()` with a small, fast model
-- Max ~100 tokens output
-- Result parsed: starts with "yes" → Complete; starts with "no:" → continue
-
-### State Machine
-
-`RalphGoal` gains a `condition: Option<String>` field.
-
-| GoalStatus | Set when |
-|---|---|
-| `Pursuing` | Goal created, evaluator running |
-| `Complete` | Evaluator returns "yes" |
-
-`Paused` and `BudgetLimited` are removed (Claude Code has no budget tracking).
-
-### Agent Loop Integration
-
-In the main turn loop (`tasks.rs`), after a turn completes:
-
-```
-if let Some(goal) = app.goal_handle.read().unwrap().as_ref()
-    && goal.status == Pursuing
-{
-    let evaluator_result = run_evaluator(&llm, &goal.condition).await?;
-    match evaluator_result {
-        EvaluatorResult::Satisfied => {
-            app.goal_handle.write().unwrap().as_mut().unwrap().status = Complete;
-            app.push_notice("Goal completed");
-            break; // return control to user
-        }
-        EvaluatorResult::NotSatisfied(reason) => {
-            // Continue loop — evaluator's reason becomes context
-            app.push_entry("System", reason);
-            continue;
-        }
-    }
-}
-```
-
-### Prompt
-
-The evaluator's "not yet" reason is pushed as a System message:
-```
-System: no: 3 of 14 tests still fail — check src/auth.rs:42
-```
-
-This becomes the agent's context for the next turn. The agent sees it
-and continues working, same as if a user said "3 tests still fail".
-
-### `create_goal` Tool
-
-```
-create_goal(objective: "run cargo test && all 14 pass")
-```
-
-Creates `RalphGoal { status: Pursuing, condition: Some("run cargo test && all 14 pass") }`.
-
-### `update_goal` Tool
-
-```
-update_goal(status: Complete)
-```
-
-Explicitly marks the goal complete (user can also force-complete).
-
-## Integration Points
-
-- `agent.rs` — evaluator loop called at turn end
-- `runtime_context.rs` — creates evaluator LLM instance (separate from main LLM)
-- `tui/state/types.rs` — `RalphGoal.condition: Option<String>`
-- `tools/goal.rs` — `create_goal` sets condition
-
-## What's NOT included
-
-- Prompt injection (no `<goal>` fragments)
-- Token budget tracking
-- `Paused` / `BudgetLimited` states
-- `with_goal()` builder on ContextAssembler
-
-## Verification
-
-- Manual: `/goal "echo hello"` → agent runs echo → evaluator says yes → complete
-- Manual: `/goal "run cargo test && all 14 pass"` with broken tests → loops until fixed
+### What's NOT included
+- Real LLM evaluation (placeholder always returns "not yet")
+- Goal lifecycle hook phases (GoalCreated / GoalCompleted)
+- Prompt injection (evaluator context is a transcript message, not a prompt fragment)

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -809,6 +809,24 @@ pub(crate) async fn finish_running_task_if_ready(
                                 start_query_task(app, next_goal_prompt, agent);
                                 return Ok(());
                             }
+                            // Claude Code-style evaluator: check whether the
+                            // goal condition is satisfied.
+                            let condition = app
+                                .goal
+                                .as_ref()
+                                .and_then(|g| g.condition.clone())
+                                .unwrap_or_default();
+                            if !condition.is_empty() {
+                                // TODO: call evaluator LLM to get real yes/no.
+                                // Placeholder: always "not yet" so the loop
+                                // continues until the model marks complete.
+                                let eval_reason =
+                                    format!("no: goal not yet complete — {condition}");
+                                app.push_system(
+                                    eval_reason,
+                                    crate::tui::state::SystemMessageKind::Other,
+                                );
+                            }
                             // finalize_active_turn closes the current turn's transcript
                             // before start_query_task begins a new one.
                             app.finalize_active_turn();

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -702,7 +702,7 @@ pub(crate) async fn finish_running_task_if_ready(
     }
     match completion {
         TaskCompletion::Query { agent, result } => {
-            let agent = agent;
+            let mut agent = agent;
             let query_started_in_plan_mode = matches!(
                 app.agent_execution_mode,
                 crate::agent::AgentExecutionMode::Plan
@@ -809,12 +809,11 @@ pub(crate) async fn finish_running_task_if_ready(
                                 start_query_task(app, next_goal_prompt, agent);
                                 return Ok(());
                             }
-                            // Claude Code-style evaluator: check whether the
-                            // goal condition is satisfied.
+                            // Evaluator: check whether the goal condition is satisfied.
                             let condition = app
                                 .goal
                                 .as_ref()
-                                .and_then(|g| g.condition.clone())
+                                .and_then(|g| g.condition.as_deref())
                                 .unwrap_or_default();
                             if !condition.is_empty() {
                                 // TODO: call evaluator LLM to get real yes/no.
@@ -823,9 +822,15 @@ pub(crate) async fn finish_running_task_if_ready(
                                 let eval_reason =
                                     format!("no: goal not yet complete — {condition}");
                                 app.push_system(
-                                    eval_reason,
+                                    eval_reason.clone(),
                                     crate::tui::state::SystemMessageKind::Other,
                                 );
+                                // Also push to agent history so the model
+                                // sees the evaluator's feedback on the next turn.
+                                agent.push_history_message(crate::agent::Message {
+                                    role: "system".into(),
+                                    content: serde_json::Value::String(eval_reason),
+                                });
                             }
                             // finalize_active_turn closes the current turn's transcript
                             // before start_query_task begins a new one.

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1296,3 +1296,35 @@ fn clearing_slash_closes_palette() {
     assert_eq!(app.command_palette_idx, 0);
     assert!(app.bottom_pane.input.is_empty());
 }
+
+#[test]
+fn ralph_goal_sets_condition_from_objective() {
+    let goal = crate::tui::state::RalphGoal::new("run tests".into(), None);
+    assert_eq!(goal.objective, "run tests");
+    assert_eq!(goal.condition, Some("run tests".into()));
+    assert_eq!(goal.status, crate::tui::state::GoalStatus::Pursuing);
+    assert_eq!(goal.tokens_used, 0);
+}
+
+#[test]
+fn ralph_goal_condition_populated_after_construction() {
+    let mut goal = crate::tui::state::RalphGoal::new("test".into(), Some(100));
+    assert!(goal.condition.is_some());
+    // condition can be updated independently
+    goal.condition = Some("different condition".into());
+    assert_eq!(goal.condition, Some("different condition".into()));
+}
+
+#[test]
+fn ralph_goal_budget_defaults_to_none() {
+    let goal = crate::tui::state::RalphGoal::new("objective".into(), None);
+    assert!(goal.token_budget.is_none());
+    assert!(!goal.token_budget.is_some_and(|b| goal.tokens_used >= b));
+
+    let limited = crate::tui::state::RalphGoal::new("obj".into(), Some(0));
+    assert!(
+        limited
+            .token_budget
+            .is_some_and(|b| limited.tokens_used >= b)
+    );
+}

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -765,6 +765,9 @@ pub enum GoalStatus {
 pub struct RalphGoal {
     /// The objective text set by `/goal <objective>`.
     pub objective: String,
+    /// Condition string used by the evaluator to check completion.
+    /// Defaults to the objective if not explicitly set.
+    pub condition: Option<String>,
     /// Current lifecycle status.
     pub status: GoalStatus,
     /// Optional token budget (input tokens). None = unlimited.
@@ -780,7 +783,8 @@ pub struct RalphGoal {
 impl RalphGoal {
     pub fn new(objective: String, token_budget: Option<u32>) -> Self {
         Self {
-            objective,
+            objective: objective.clone(),
+            condition: Some(objective),
             status: GoalStatus::Pursuing,
             token_budget,
             tokens_used: 0,


### PR DESCRIPTION
## Summary

Implements evaluator loop for `/goal`. After each agent turn, when a goal
is pursuing, the evaluator pushes a `no: ...` message into the transcript
so the agent sees the evaluator's context on the next turn.

## Flow

```
1. Agent turn completes
2. Goal is Pursuing + agent had tools → track tokens
3. Budget OK → evaluator pushes System: "no: goal not yet complete — ..."
4. finalize_active_turn() + start_query_task() → agent sees evaluator context
5. Repeat until model calls update_goal(status=Complete)
```

## Changes

- `RalphGoal.condition: Option<String>` set from objective at create_goal time
- Evaluator placeholder wired in `tasks.rs` Ralph loop after budget check
- Uses `app.push_system()` to push evaluator context as System message
- Spec updated: `docs/features/goal-evaluator-loop.md`

## What's next

- Real LLM evaluator call (small model, yes/no output)
- Goal lifecycle hook phases (GoalCreated / GoalCompleted)

## Verification

- `cargo check` — passes
- `cargo test --bin rara tui` — 490 passed