### PR TITLE
feat(lsp): wire diagnostics runtime into TUI

### DIFF
--- a/docs/features/lsp-integration.md
+++ b/docs/features/lsp-integration.md
@@ -178,6 +178,20 @@ the LLM, not mediated through an MCP bridge.
 - Deduplicate and format diagnostic messages
 - Clear on agent turn boundary
 
+### Runtime status
+
+The runtime owns a per-workspace `LspManager` and shares it with the
+`lsp_diagnostics` tool and the TUI. The wide sidebar shows:
+
+- whether LSP is initialized, disabled, detected, idle, running, or missing;
+- detected server names for the current workspace markers;
+- the current cached diagnostic count;
+- the last startup or request error when one is available.
+
+Sidebar rendering must not spawn language-server availability checks. The
+status view only reports cached availability until a tool call needs to verify
+and start a server.
+
 ### Phase 3: Configuration (~50 lines)
 
 - Read `~/.rara/config.json` `lsp` section

--- a/docs/journal/2026-05-19-lsp-runtime-status.md
+++ b/docs/journal/2026-05-19-lsp-runtime-status.md
@@ -1,0 +1,31 @@
+# LSP Runtime Status
+
+## What changed
+
+- Wired a per-workspace `LspManager` into runtime bootstrap instead of leaving
+  it as an unused module.
+- Registered the built-in `lsp_diagnostics` tool with the shared manager.
+- Parsed `textDocument/publishDiagnostics` notifications into the diagnostics
+  cache used by the tool and prompt injection.
+- Shared the manager with the TUI and added a wide-sidebar LSP status section.
+
+## Design notes
+
+- The TUI reads a status snapshot from the shared manager rather than owning LSP
+  state. This keeps rendering separate from language-server lifecycle.
+- Sidebar status does not spawn language-server checks. Availability is cached
+  only after a tool call needs to detect or start a server.
+- `RARA_LSP=0`, `RARA_LSP=false`, and `RARA_LSP=off` disable the manager without
+  removing the tool surface; the tool reports a structured error payload.
+
+## Verification
+
+- `cargo fmt`
+- `cargo test lsp_manager -- --nocapture`
+- `cargo test push_lsp_status -- --nocapture`
+
+## Follow-up
+
+- Replace the initial sleep-based LSP initialize flow with response-aware
+  handshake handling.
+- Add config-file LSP server overrides after the config schema exists.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -41,8 +41,9 @@ Active backlog only. Keep this file small and current.
 - [ ] Wire plugin hook registration into runtime startup
 
 ### LSP (Phase 1)
-- [ ] rust-analyzer bridge: lazy spawn, JSON-RPC handshake, diagnostics parsing
-- [ ] `lsp_diagnostics` tool: return cached diagnostics for a file
+- [x] LSP runtime wiring: shared manager, lazy server startup, diagnostics parsing, sidebar status
+- [x] `lsp_diagnostics` tool: return cached diagnostics for a file
+- [ ] Replace sleep-based LSP initialization with response-aware handshake handling
 
 ### File Splits (P0)
 - [ ] `tools/bash.rs` (2315 lines) → by tool group

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -28,6 +28,7 @@ use crate::llm::{
     ContentBlock, EmbeddingBackend, EmbeddingInputKind, LlmBackend, LlmEmbeddingBackend,
     LlmStreamEvent, LlmTurnMetadata,
 };
+use crate::lsp_manager::LspManager;
 use crate::mcp_status::McpStatusSnapshot;
 use crate::memory_notice::{count_label, memory_notice};
 use crate::memory_store::MemoryStore;
@@ -206,6 +207,7 @@ pub struct Agent {
     prompt_config: PromptRuntimeConfig,
     prompt_source_registry: Option<Arc<PromptSourceRegistry>>,
     skill_source_registry: Option<Arc<SkillSourceRegistry>>,
+    lsp_manager: Option<Arc<LspManager>>,
     cancellation_token: Option<Arc<AtomicBool>>,
     last_interaction_time: std::time::Instant,
 }
@@ -316,6 +318,7 @@ impl Agent {
             prompt_config: PromptRuntimeConfig::default(),
             prompt_source_registry: None,
             skill_source_registry: None,
+            lsp_manager: None,
             cancellation_token: None,
             last_interaction_time: std::time::Instant::now(),
         }

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -5,6 +5,7 @@ use crate::context::{
     AssembledContext, AssembledTurnContext, ContextAssembler, RuntimeContextInputs,
     RuntimeInteractionInput,
 };
+use crate::prompt::{PromptSource, PromptSourceKind};
 use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 use crate::tool_result::ToolResultProjectionPolicy;
 
@@ -128,15 +129,34 @@ impl Agent {
         self.skill_source_registry = Some(skill_source_registry);
     }
 
+    pub fn set_lsp_manager(&mut self, lsp_manager: std::sync::Arc<crate::lsp_manager::LspManager>) {
+        self.lsp_manager = Some(lsp_manager);
+    }
+
     pub fn prompt_config(&self) -> &PromptRuntimeConfig {
         &self.prompt_config
     }
 
     pub(crate) async fn refresh_protocol_prompt_sources_for_query(&mut self) {
-        let Some(registry) = self.prompt_source_registry.as_ref() else {
-            return;
-        };
-        self.prompt_config.protocol_prompt_sources = registry.list_prompt_sources_for_query().await;
+        self.prompt_config.protocol_prompt_sources =
+            if let Some(registry) = self.prompt_source_registry.as_ref() {
+                registry.list_prompt_sources_for_query().await
+            } else {
+                Vec::new()
+            };
+        if let Some(lsp_manager) = self.lsp_manager.as_ref() {
+            let summary = lsp_manager.diagnostics_summary();
+            if !summary.trim().is_empty() {
+                self.prompt_config
+                    .protocol_prompt_sources
+                    .push(PromptSource {
+                        kind: PromptSourceKind::ProtocolPromptSource,
+                        label: "LSP Diagnostics".to_string(),
+                        display_path: "lsp://workspace".to_string(),
+                        content: summary,
+                    });
+            }
+        }
     }
 
     pub(crate) async fn refresh_protocol_skill_sources_for_query(&mut self) {

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -314,6 +314,7 @@ async fn run_tui_command(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
+        lsp_manager,
     ) = bootstrap.into_parts();
     let resumed_thread_id = crate::tui::run_tui(
         agent,
@@ -327,6 +328,7 @@ async fn run_tui_command(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
+        lsp_manager,
         initialize_local_embeddings,
     )
     .await?;

--- a/src/lsp_manager.rs
+++ b/src/lsp_manager.rs
@@ -15,10 +15,10 @@
 //! ```
 
 use std::collections::HashMap;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
@@ -37,7 +37,7 @@ pub enum DiagnosticSeverity {
 }
 
 /// A single diagnostic from an LSP server.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Diagnostic {
     pub file: String,
     pub line: u32,
@@ -56,6 +56,14 @@ pub enum ServerKind {
 }
 
 impl ServerKind {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::RustAnalyzer => "rust-analyzer",
+            Self::Gopls => "gopls",
+            Self::TypeScript => "typescript-language-server",
+        }
+    }
+
     fn command(&self) -> &'static [&'static str] {
         match self {
             Self::RustAnalyzer => &["rust-analyzer"],
@@ -79,6 +87,24 @@ impl ServerKind {
             Self::TypeScript => "package.json",
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LspServerStatus {
+    pub name: String,
+    pub detected: bool,
+    pub checked: bool,
+    pub available: bool,
+    pub running: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LspStatusSnapshot {
+    pub enabled: bool,
+    pub servers: Vec<LspServerStatus>,
+    pub diagnostic_file_count: usize,
+    pub diagnostic_count: usize,
+    pub last_error: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -110,8 +136,10 @@ struct JsonRpcNotification {
 /// Manages LSP server processes and diagnostics cache.
 pub struct LspManager {
     servers: Mutex<HashMap<ServerKind, Option<LspConnection>>>,
-    diagnostics: Mutex<HashMap<PathBuf, Vec<Diagnostic>>>,
+    diagnostics: Arc<Mutex<HashMap<PathBuf, Vec<Diagnostic>>>>,
+    last_error: Mutex<Option<String>>,
     workspace_root: PathBuf,
+    enabled: bool,
 }
 
 struct LspConnection {
@@ -127,20 +155,26 @@ impl LspManager {
     pub fn new(workspace_root: PathBuf) -> Self {
         Self {
             servers: Mutex::new(HashMap::new()),
-            diagnostics: Mutex::new(HashMap::new()),
+            diagnostics: Arc::new(Mutex::new(HashMap::new())),
+            last_error: Mutex::new(None),
             workspace_root,
+            enabled: lsp_enabled_from_env(),
         }
     }
 
     /// Returns diagnostics for a file. Starts the appropriate LSP server
     /// if needed (lazy initialization).
     pub fn diagnostics_for(&self, file_path: &Path) -> Result<Vec<Diagnostic>> {
-        let kind = self.detect_server(file_path)?;
+        if !self.enabled {
+            bail!("LSP is disabled by RARA_LSP");
+        }
+        let file_path = self.resolve_file_path(file_path);
+        let kind = self.detect_server(&file_path)?;
         self.ensure_server_running(kind)?;
-        self.sync_file(file_path, kind)?;
+        self.sync_file(&file_path, kind)?;
 
         let diags = self.diagnostics.lock().unwrap();
-        Ok(diags.get(file_path).cloned().unwrap_or_default())
+        Ok(diags.get(&file_path).cloned().unwrap_or_default())
     }
 
     /// Returns all current diagnostics formatted for System context injection.
@@ -150,7 +184,7 @@ impl LspManager {
             return String::new();
         }
         let mut lines = vec!["# LSP Diagnostics".to_string()];
-        for (path, file_diags) in diags.iter() {
+        for file_diags in diags.values() {
             for d in file_diags {
                 let sev = match d.severity {
                     DiagnosticSeverity::Error => "error",
@@ -177,6 +211,34 @@ impl LspManager {
         lines.join("\n")
     }
 
+    pub fn status_snapshot(&self) -> LspStatusSnapshot {
+        let servers = self.servers.lock().unwrap();
+        let diags = self.diagnostics.lock().unwrap();
+        let diagnostic_file_count = diags.len();
+        let diagnostic_count = diags.values().map(Vec::len).sum();
+        let server_statuses = all_server_kinds()
+            .iter()
+            .map(|kind| {
+                let detected = self.workspace_root.join(kind.detect_file()).exists();
+                let availability = server_available_cached(*kind);
+                LspServerStatus {
+                    name: kind.label().to_string(),
+                    detected,
+                    checked: availability.is_some(),
+                    available: detected && availability.unwrap_or(false),
+                    running: servers.get(kind).is_some_and(Option::is_some),
+                }
+            })
+            .collect();
+        LspStatusSnapshot {
+            enabled: self.enabled,
+            servers: server_statuses,
+            diagnostic_file_count,
+            diagnostic_count,
+            last_error: self.last_error.lock().unwrap().clone(),
+        }
+    }
+
     // ------------------------------------------------------------------
     // Internals
     // ------------------------------------------------------------------
@@ -188,16 +250,12 @@ impl LspManager {
             .map(|e| format!(".{e}"))
             .unwrap_or_default();
 
-        for kind in &[
-            ServerKind::RustAnalyzer,
-            ServerKind::Gopls,
-            ServerKind::TypeScript,
-        ] {
+        for kind in all_server_kinds() {
             if kind.extensions().contains(&ext.as_str()) {
                 let detect = self.workspace_root.join(kind.detect_file());
                 if detect.exists() {
-                    if server_available(*kind) {
-                        return Ok(*kind);
+                    if server_available(kind) {
+                        return Ok(kind);
                     }
                 }
             }
@@ -221,13 +279,10 @@ impl LspManager {
             .with_context(|| format!("spawn {:?}", cmd))?;
 
         let stdout = child.stdout.take().unwrap();
+        let diagnostics = self.diagnostics.clone();
+        let workspace_root = self.workspace_root.clone();
         let reader = std::thread::spawn(move || {
-            let reader = BufReader::new(stdout);
-            for line in reader.lines() {
-                if let Ok(line) = line {
-                    let _ = line; // parse notifications later
-                }
-            }
+            read_lsp_messages(stdout, diagnostics, workspace_root);
         });
 
         let stdin = child.stdin.take().unwrap();
@@ -248,12 +303,18 @@ impl LspManager {
                 }
             }
         });
-        let _ = conn.send_request("initialize", init_params);
+        if let Err(err) = conn.send_request("initialize", init_params) {
+            *self.last_error.lock().unwrap() = Some(err.to_string());
+            return Err(err);
+        }
         // Per LSP spec, initialized must be sent AFTER the initialize
         // response. Since we don't parse the response yet, sleep briefly
         // to let the server process the request before notifying.
         std::thread::sleep(std::time::Duration::from_millis(100));
-        let _ = conn.send_notification("initialized", serde_json::json!({}));
+        if let Err(err) = conn.send_notification("initialized", serde_json::json!({})) {
+            *self.last_error.lock().unwrap() = Some(err.to_string());
+            return Err(err);
+        }
 
         servers.insert(kind, Some(conn));
         Ok(())
@@ -288,6 +349,21 @@ impl LspManager {
         std::thread::sleep(std::time::Duration::from_millis(300));
 
         Ok(())
+    }
+
+    fn resolve_file_path<'a>(&'a self, file_path: &'a Path) -> PathBuf {
+        if file_path.is_absolute() {
+            file_path.to_path_buf()
+        } else {
+            self.workspace_root.join(file_path)
+        }
+    }
+}
+
+impl Drop for LspConnection {
+    fn drop(&mut self) {
+        let _ = self.process.kill();
+        let _ = self.process.wait();
     }
 }
 
@@ -326,21 +402,44 @@ impl LspConnection {
 /// Returns true if the LSP server command is available on PATH.
 /// Results are cached per-process via OnceLock.
 fn server_available(kind: ServerKind) -> bool {
+    *server_availability_lock(kind).get_or_init(|| {
+        let cmd = kind.command()[0];
+        Command::new(cmd).arg("--version").output().is_ok()
+    })
+}
+
+fn server_available_cached(kind: ServerKind) -> Option<bool> {
+    server_availability_lock(kind).get().copied()
+}
+
+fn server_availability_lock(kind: ServerKind) -> &'static std::sync::OnceLock<bool> {
     use std::sync::OnceLock;
     static RUST_ANALYZER_OK: OnceLock<bool> = OnceLock::new();
     static GOPLS_OK: OnceLock<bool> = OnceLock::new();
     static TS_OK: OnceLock<bool> = OnceLock::new();
 
-    let lock = match kind {
+    match kind {
         ServerKind::RustAnalyzer => &RUST_ANALYZER_OK,
         ServerKind::Gopls => &GOPLS_OK,
         ServerKind::TypeScript => &TS_OK,
-    };
+    }
+}
 
-    *lock.get_or_init(|| {
-        let cmd = kind.command()[0];
-        Command::new(cmd).arg("--version").output().is_ok()
-    })
+const fn all_server_kinds() -> [ServerKind; 3] {
+    [
+        ServerKind::RustAnalyzer,
+        ServerKind::Gopls,
+        ServerKind::TypeScript,
+    ]
+}
+
+fn lsp_enabled_from_env() -> bool {
+    std::env::var("RARA_LSP")
+        .map(|value| {
+            let value = value.trim().to_ascii_lowercase();
+            !(value == "0" || value == "false" || value == "off")
+        })
+        .unwrap_or(true)
 }
 
 fn kind_to_lang_id(kind: ServerKind) -> &'static str {
@@ -348,5 +447,158 @@ fn kind_to_lang_id(kind: ServerKind) -> &'static str {
         ServerKind::RustAnalyzer => "rust",
         ServerKind::Gopls => "go",
         ServerKind::TypeScript => "typescript",
+    }
+}
+
+fn read_lsp_messages(
+    stdout: impl Read,
+    diagnostics: Arc<Mutex<HashMap<PathBuf, Vec<Diagnostic>>>>,
+    workspace_root: PathBuf,
+) {
+    let mut reader = BufReader::new(stdout);
+    loop {
+        let Some(content_length) = read_content_length(&mut reader) else {
+            return;
+        };
+        let mut body = vec![0; content_length];
+        if reader.read_exact(&mut body).is_err() {
+            return;
+        }
+        let Ok(notification) = serde_json::from_slice::<JsonRpcNotification>(&body) else {
+            continue;
+        };
+        if notification.method.as_deref() == Some("textDocument/publishDiagnostics")
+            && let Some((path, file_diags)) =
+                parse_publish_diagnostics(notification.params, &workspace_root)
+        {
+            diagnostics.lock().unwrap().insert(path, file_diags);
+        }
+    }
+}
+
+fn read_content_length(reader: &mut impl BufRead) -> Option<usize> {
+    let mut content_length = None;
+    loop {
+        let mut line = String::new();
+        let read = reader.read_line(&mut line).ok()?;
+        if read == 0 {
+            return None;
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            return content_length;
+        }
+        if let Some(colon_pos) = trimmed.find(':') {
+            let (name, value) = trimmed.split_at(colon_pos);
+            if name.eq_ignore_ascii_case("Content-Length") {
+                content_length = value[1..].trim().parse().ok();
+            }
+        }
+    }
+}
+
+fn parse_publish_diagnostics(
+    params: Option<serde_json::Value>,
+    workspace_root: &Path,
+) -> Option<(PathBuf, Vec<Diagnostic>)> {
+    let params = params?;
+    let uri = params.get("uri")?.as_str()?;
+    let path = path_from_file_uri(uri)?;
+    let diagnostics = params.get("diagnostics")?.as_array()?;
+    let file = display_path_for_diagnostic(&path, workspace_root);
+    let parsed = diagnostics
+        .iter()
+        .filter_map(|item| parse_diagnostic(item, &file))
+        .collect::<Vec<_>>();
+    Some((path, parsed))
+}
+
+fn parse_diagnostic(value: &serde_json::Value, file: &str) -> Option<Diagnostic> {
+    let start = value.get("range")?.get("start")?;
+    let line = start.get("line")?.as_u64()? as u32;
+    let column = start.get("character")?.as_u64()? as u32;
+    let severity = match value.get("severity").and_then(serde_json::Value::as_u64) {
+        Some(1) => DiagnosticSeverity::Error,
+        Some(2) => DiagnosticSeverity::Warning,
+        Some(3) => DiagnosticSeverity::Information,
+        Some(4) | None => DiagnosticSeverity::Hint,
+        Some(_) => DiagnosticSeverity::Information,
+    };
+    let message = value.get("message")?.as_str()?.to_string();
+    let code = value.get("code").and_then(|code| match code {
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        _ => None,
+    });
+    Some(Diagnostic {
+        file: file.to_string(),
+        line,
+        column,
+        severity,
+        message,
+        code,
+    })
+}
+
+fn path_from_file_uri(uri: &str) -> Option<PathBuf> {
+    url::Url::parse(uri).ok()?.to_file_path().ok()
+}
+
+fn display_path_for_diagnostic(path: &Path, workspace_root: &Path) -> String {
+    path.strip_prefix(workspace_root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_publish_diagnostics_notification() {
+        let workspace = PathBuf::from("/repo");
+        let params = serde_json::json!({
+            "uri": "file:///repo/src/main.rs",
+            "diagnostics": [{
+                "range": { "start": { "line": 4, "character": 8 }, "end": { "line": 4, "character": 12 } },
+                "severity": 1,
+                "message": "cannot find value `x` in this scope",
+                "code": "E0425"
+            }]
+        });
+
+        let (path, diagnostics) = parse_publish_diagnostics(Some(params), &workspace).unwrap();
+
+        assert_eq!(path, PathBuf::from("/repo/src/main.rs"));
+        assert_eq!(
+            diagnostics,
+            vec![Diagnostic {
+                file: "src/main.rs".to_string(),
+                line: 4,
+                column: 8,
+                severity: DiagnosticSeverity::Error,
+                message: "cannot find value `x` in this scope".to_string(),
+                code: Some("E0425".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn reads_lsp_content_length_header() {
+        let body = r#"{"jsonrpc":"2.0"}"#;
+        let message = format!("Content-Length: {}\r\n\r\n{body}", body.len());
+        let mut reader = BufReader::new(message.as_bytes());
+
+        assert_eq!(read_content_length(&mut reader), Some(body.len()));
+    }
+
+    #[test]
+    fn reads_lsp_content_length_header_case_insensitively() {
+        let body = r#"{"jsonrpc":"2.0"}"#;
+        let message = format!("Content-length: {}\r\n\r\n{body}", body.len());
+        let mut reader = BufReader::new(message.as_bytes());
+
+        assert_eq!(read_content_length(&mut reader), Some(body.len()));
     }
 }

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -24,6 +24,7 @@ use crate::local_model_server::{
     LocalModelServerEmbeddingBackend, LocalModelServerStatus, inspect_local_model_server_status,
     prepare_local_model_server_status_with_progress,
 };
+use crate::lsp_manager::LspManager;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::mcp_tool_cache::McpToolCache;
 use crate::prompt::{PromptRuntimeConfig, PromptSkillSummary};
@@ -53,11 +54,12 @@ pub(crate) struct RuntimeBootstrap {
     pub goal_handle: GoalHandle,
     pub mcp_tool_cache: McpToolCache,
     pub mcp_manager: Arc<McpConnectionManager>,
+    pub lsp_manager: Arc<LspManager>,
 }
 
 impl RuntimeBootstrap {
     pub(crate) fn into_agent(self) -> Agent {
-        let (agent, _, _, _, _, _, _, _, _) = self.into_parts();
+        let (agent, _, _, _, _, _, _, _, _, _) = self.into_parts();
         agent
     }
 
@@ -73,6 +75,7 @@ impl RuntimeBootstrap {
         Arc<PromptSourceRegistry>,
         Arc<SkillSourceRegistry>,
         Arc<HookRegistry>,
+        Arc<LspManager>,
     ) {
         let mut agent = Agent::new_with_embedding_backend(
             self.tool_manager,
@@ -85,6 +88,7 @@ impl RuntimeBootstrap {
         agent.set_prompt_config(self.prompt_config);
         agent.set_prompt_source_registry(self.prompt_source_registry.clone());
         agent.set_skill_source_registry(self.skill_source_registry.clone());
+        agent.set_lsp_manager(self.lsp_manager.clone());
         (
             agent,
             self.warnings,
@@ -95,6 +99,7 @@ impl RuntimeBootstrap {
             self.prompt_source_registry,
             self.skill_source_registry,
             self.hook_registry,
+            self.lsp_manager,
         )
     }
 }
@@ -176,6 +181,7 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     let goal_handle: GoalHandle = Arc::new(std::sync::RwLock::new(None));
     let mcp_tool_cache = McpToolCache::new();
     mcp_tool_cache.clear();
+    let lsp_manager = Arc::new(LspManager::new(workspace.root.clone()));
 
     let config_manager = crate::config::ConfigManager::new()?;
     let mcp_registry = config_manager
@@ -215,6 +221,7 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
         sandbox_network_access.clone(),
         goal_handle.clone(),
         mcp_tool_cache.clone(),
+        lsp_manager.clone(),
     );
     let mut warnings = prompt_config.warnings.clone();
     warnings.extend(embedding_warnings);
@@ -236,6 +243,7 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
         goal_handle,
         mcp_tool_cache,
         mcp_manager,
+        lsp_manager,
     })
 }
 

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -12,6 +12,7 @@ use rara_tools::search::{GlobTool, GrepTool};
 use rara_tools::tool::ToolManager;
 
 use crate::llm::{EmbeddingBackend, LlmBackend};
+use crate::lsp_manager::LspManager;
 use crate::mcp_tool_cache::McpToolCache;
 use crate::prompt::PromptRuntimeConfig;
 use crate::sandbox::SandboxManager;
@@ -27,6 +28,7 @@ use crate::tools::bash::{
 };
 use crate::tools::context::RetrieveSessionContextTool;
 use crate::tools::goal::{CreateGoalTool, GetGoalTool, UpdateGoalTool};
+use crate::tools::lsp::LspDiagnosticsTool;
 use crate::tools::mcp_tool_search::McpToolSearch;
 use crate::tools::pty::{
     PtyKillTool, PtyListTool, PtyReadTool, PtySessionStore, PtyStartTool, PtyStatusTool,
@@ -55,6 +57,7 @@ pub(super) fn create_full_tool_manager(
     sandbox_network_access: Arc<AtomicBool>,
     goal_handle: GoalHandle,
     mcp_tool_cache: McpToolCache,
+    lsp_manager: Arc<LspManager>,
 ) -> ToolManager {
     let mut tm = ToolManager::new();
     let vector_db_uri = vector_db_uri_for_workspace(&workspace);
@@ -118,6 +121,7 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(WebSearchTool::from_env()));
     tm.register(Box::new(GlobTool));
     tm.register(Box::new(GrepTool));
+    tm.register(Box::new(LspDiagnosticsTool::new(lsp_manager)));
     tm.register(Box::new(McpToolSearch::new(mcp_tool_cache)));
     tm.register(Box::new(EnterPlanModeTool));
     tm.register(Box::new(ExitPlanModeTool));

--- a/src/tools/lsp.rs
+++ b/src/tools/lsp.rs
@@ -1,0 +1,67 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use rara_tools::tool::{Tool, ToolError};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::lsp_manager::LspManager;
+
+pub struct LspDiagnosticsTool {
+    manager: Arc<LspManager>,
+}
+
+impl LspDiagnosticsTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[derive(Deserialize)]
+struct LspDiagnosticsInput {
+    file: PathBuf,
+}
+
+#[async_trait]
+impl Tool for LspDiagnosticsTool {
+    fn name(&self) -> &str {
+        "lsp_diagnostics"
+    }
+
+    fn description(&self) -> &str {
+        "Return cached Language Server Protocol diagnostics for a source file. Starts the matching local language server lazily when available."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "file": {
+                    "type": "string",
+                    "description": "Path to the source file to check, relative to the workspace root or absolute."
+                }
+            },
+            "required": ["file"]
+        })
+    }
+
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let input: LspDiagnosticsInput = serde_json::from_value(input)
+            .map_err(|err| ToolError::InvalidInput(err.to_string()))?;
+        match self.manager.diagnostics_for(&input.file) {
+            Ok(diagnostics) => Ok(json!({
+                "file": input.file.display().to_string(),
+                "diagnostics": diagnostics,
+                "status": self.manager.status_snapshot(),
+            })),
+            Err(err) => Ok(json!({
+                "file": input.file.display().to_string(),
+                "diagnostics": [],
+                "error": err.to_string(),
+                "status": self.manager.status_snapshot(),
+            })),
+        }
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,6 +3,7 @@ pub mod bash;
 pub(crate) mod bash_readonly;
 pub mod context;
 pub mod goal;
+pub mod lsp;
 pub mod mcp_tool_search;
 pub mod pty;
 pub mod skill;

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -33,6 +33,7 @@ pub enum StartupResumeTarget {
 }
 
 use crate::hook_registry::HookRegistry;
+use crate::lsp_manager::LspManager;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 
@@ -48,6 +49,7 @@ pub async fn run_tui(
     prompt_source_registry: Arc<PromptSourceRegistry>,
     skill_source_registry: Arc<SkillSourceRegistry>,
     hook_registry: Arc<crate::hook_registry::HookRegistry>,
+    lsp_manager: Arc<LspManager>,
     initialize_local_embeddings: bool,
 ) -> anyhow::Result<Option<String>> {
     enable_raw_mode()?;
@@ -62,6 +64,7 @@ pub async fn run_tui(
     app.prompt_source_registry = Some(prompt_source_registry);
     app.skill_source_registry = Some(skill_source_registry);
     app.hook_registry = Some(hook_registry);
+    app.lsp_manager = Some(lsp_manager);
     app.memory_handler = Some(Arc::new(
         crate::protocol_sources::MemoryControlHandler::new(event_bus.clone()),
     ));

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -40,6 +40,8 @@ pub(crate) fn render_sidebar(f: &mut Frame, app: &TuiApp, area: Rect) {
     lines.push(Line::from(""));
     push_context_summary(&mut lines, app);
     lines.push(Line::from(""));
+    push_lsp_status(&mut lines, app);
+    lines.push(Line::from(""));
     if push_todo_section(&mut lines, app) {
         lines.push(Line::from(""));
     }
@@ -131,6 +133,90 @@ fn push_context_summary(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
         context_sidebar_summary(snap),
         Style::default().fg(TEXT_MUTED),
     )));
+}
+
+fn push_lsp_status(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
+    lines.push(Line::from(super::section_label("LSP", TEXT_SECONDARY)));
+    let Some(manager) = app.lsp_manager.as_ref() else {
+        lines.push(Line::from(Span::styled(
+            "not initialized",
+            Style::default().fg(TEXT_MUTED),
+        )));
+        return;
+    };
+
+    let snapshot = manager.status_snapshot();
+    if !snapshot.enabled {
+        lines.push(Line::from(Span::styled(
+            "disabled by RARA_LSP",
+            Style::default().fg(TEXT_MUTED),
+        )));
+        return;
+    }
+
+    let detected = snapshot
+        .servers
+        .iter()
+        .filter(|server| server.detected)
+        .collect::<Vec<_>>();
+    if detected.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "no project server detected",
+            Style::default().fg(TEXT_MUTED),
+        )));
+        return;
+    }
+
+    let running = detected.iter().filter(|server| server.running).count();
+    let available = detected.iter().filter(|server| server.available).count();
+    let status = if running > 0 {
+        format!(
+            "{} running · {} diagnostics",
+            running, snapshot.diagnostic_count
+        )
+    } else if available > 0 {
+        format!("idle · {available} available")
+    } else if detected.iter().any(|server| !server.checked) {
+        "detected · not started".to_string()
+    } else {
+        "server missing".to_string()
+    };
+    lines.push(Line::from(Span::styled(
+        status,
+        Style::default().fg(TEXT_MUTED),
+    )));
+
+    for server in detected.iter().take(3) {
+        let marker = if server.running {
+            "[>]"
+        } else if server.available {
+            "[ ]"
+        } else if !server.checked {
+            "[?]"
+        } else {
+            "[!]"
+        };
+        let style = if server.running {
+            Style::default().fg(INTERACTION_SUB_AGENT)
+        } else if server.available {
+            Style::default().fg(TEXT_SECONDARY)
+        } else if !server.checked {
+            Style::default().fg(TEXT_MUTED)
+        } else {
+            Style::default().fg(STATUS_WARNING)
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker} {}", server.name),
+            style,
+        )));
+    }
+
+    if let Some(error) = snapshot.last_error {
+        lines.push(Line::from(Span::styled(
+            format!("last error: {error}"),
+            Style::default().fg(STATUS_WARNING),
+        )));
+    }
 }
 
 fn push_todo_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bool {

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -2,8 +2,8 @@ use ratatui::{layout::Rect, style::Color, text::Line};
 use tempfile::tempdir;
 
 use super::{
-    push_child_sessions, push_context_summary, push_model_badge, push_session_info,
-    push_todo_section,
+    push_child_sessions, push_context_summary, push_lsp_status, push_model_badge,
+    push_session_info, push_todo_section,
 };
 use crate::config::ConfigManager;
 use crate::context::TodoContextView;
@@ -327,6 +327,49 @@ fn push_context_summary_no_context_window() {
             .any(|l| l.to_string().contains("600 · 5 turns")),
         "shows current-turn history tokens without context window"
     );
+}
+
+#[test]
+fn push_lsp_status_reports_not_initialized() {
+    let temp = tempdir().unwrap();
+    let app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+
+    let mut lines = Vec::new();
+    push_lsp_status(&mut lines, &app);
+
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("LSP"));
+    assert!(text.contains("not initialized"));
+}
+
+#[test]
+fn push_lsp_status_reports_no_detected_project_server() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.lsp_manager = Some(std::sync::Arc::new(crate::lsp_manager::LspManager::new(
+        temp.path().to_path_buf(),
+    )));
+
+    let mut lines = Vec::new();
+    push_lsp_status(&mut lines, &app);
+
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("LSP"));
+    assert!(text.contains("no project server detected"));
 }
 
 #[test]

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -982,6 +982,7 @@ pub(crate) async fn finish_running_task_if_ready(
                 app.goal = app.goal_handle.read().unwrap().clone();
                 app.mcp_tool_cache = Some(rebuilt.mcp_tool_cache);
                 app.mcp_manager = Some(rebuilt.mcp_manager);
+                app.lsp_manager = Some(rebuilt.lsp_manager);
                 app.prompt_source_registry = Some(rebuilt.prompt_source_registry);
                 app.skill_source_registry = Some(rebuilt.skill_source_registry);
                 app.memory_handler = Some(rebuilt.memory_handler);

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -26,6 +26,7 @@ pub(super) async fn rebuild_agent_with_progress(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
+        lsp_manager,
     ) = bootstrap.into_parts();
     let memory_handler = Arc::new(crate::protocol_sources::MemoryControlHandler::new(
         event_bus,
@@ -42,5 +43,6 @@ pub(super) async fn rebuild_agent_with_progress(
         skill_source_registry,
         hook_registry,
         memory_handler,
+        lsp_manager,
     })
 }

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -265,6 +265,9 @@ fn rebuild_success(
         )),
         hook_registry: Arc::new(crate::hook_registry::HookRegistry::new(bus.clone())),
         memory_handler: Arc::new(crate::protocol_sources::MemoryControlHandler::new(bus)),
+        lsp_manager: Arc::new(crate::lsp_manager::LspManager::new(
+            temp.path().to_path_buf(),
+        )),
     }
 }
 

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -346,6 +346,7 @@ impl TuiApp {
             state_db_status: None,
             local_model_server,
             mcp_manager: None,
+            lsp_manager: None,
             prompt_source_registry: None,
             skill_source_registry: None,
             hook_registry: None,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -21,6 +21,7 @@ use crate::context::{
 };
 use crate::control_tokens::{has_pending_internal_control_context, scrub_internal_control_tokens};
 use crate::hook_registry::HookRegistry;
+use crate::lsp_manager::LspManager;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::mcp_tool_cache::McpToolCache;
 use crate::oauth::SavedCodexAuthMode;
@@ -388,6 +389,7 @@ pub struct RebuildSuccess {
     pub skill_source_registry: Arc<SkillSourceRegistry>,
     pub hook_registry: Arc<HookRegistry>,
     pub memory_handler: Arc<MemoryControlHandler>,
+    pub lsp_manager: Arc<LspManager>,
 }
 
 pub enum TuiEvent {
@@ -714,6 +716,7 @@ pub struct TuiApp {
     pub state_db_status: Option<String>,
     pub local_model_server: crate::local_model_server::LocalModelServerStatus,
     pub mcp_manager: Option<Arc<McpConnectionManager>>,
+    pub lsp_manager: Option<Arc<LspManager>>,
     pub prompt_source_registry: Option<Arc<PromptSourceRegistry>>,
     pub skill_source_registry: Option<Arc<SkillSourceRegistry>>,
     pub hook_registry: Option<Arc<HookRegistry>>,


### PR DESCRIPTION
## Summary

- Wire a per-workspace `LspManager` into runtime bootstrap instead of leaving it unused.
- Register the built-in `lsp_diagnostics` tool with the shared manager.
- Parse `textDocument/publishDiagnostics` notifications into the diagnostics cache.
- Share LSP runtime state with the TUI and show status in the wide sidebar.
- Update the LSP feature spec, journal, and active TODO state.

## Motivation

`lsp_manager.rs` existed but was not instantiated anywhere, so the LSP path was effectively dead code: no manager, no tool registration, no configuration switch, and no runtime visibility. This change connects the existing LSP module to the agent runtime and makes its state visible in the sidebar.

## Implementation Notes

- `RARA_LSP=0`, `RARA_LSP=false`, and `RARA_LSP=off` disable the manager.
- Sidebar status uses a non-blocking status snapshot and does not spawn language-server availability checks during render.
- Language servers are still started lazily by `lsp_diagnostics`.
- The current initialize flow remains sleep-based; response-aware handshake handling is left as a documented follow-up.

## Related Issues

- None.

## Testing

- `cargo fmt`
- `cargo test lsp_manager -- --nocapture`
- `cargo test push_lsp_status -- --nocapture`
- `cargo check -p rara`
