### PR TITLE
feat(tui): color-block popup design with adaptive sizing

### DIFF
--- a/docs/journal/2026-05-20-tui-popup-color-block.md
+++ b/docs/journal/2026-05-20-tui-popup-color-block.md
@@ -1,0 +1,68 @@
+# TUI Popup Color-Block Redesign
+
+## Motivation
+
+All overlay popups (help, status, context, command palette, model search,
+setup editors, pickers) previously used wireframe `Borders::ALL` /
+`Borders::LEFT|RIGHT` blocks on the default terminal background. This created
+a dated "DOS dialog" look with visible line-drawing characters around every
+pane and input.
+
+[opencode](https://github.com/sst/opencode)'s TUI dialogs use a color-block
+approach: a full-screen semi-transparent dimmer behind a solid
+`backgroundPanel` color block with no visible borders. This checkpoint mirrors
+that design language in RARA.
+
+## What changed
+
+### Theme
+- `POPUP_BG` (NORD1 `#3B4252`) — popup content area background
+- `POPUP_DIMMER_BG` (NORD0 `#2E3440`) — full-screen dimmer behind centered popups
+
+### Positioning (adaptive sizing)
+- `popup_rect(area, max_width, max_height_pct)` replaces `centered_rect`:
+  horizontal center, vertical offset at `height / 4` (opencode-style).
+  Width/height clamped to `area - 4` so popups never exceed the visible
+  terminal.
+- `render_dimmer(f, area)` — fills the given area with `POPUP_DIMMER_BG`
+  before rendering popup content, creating a visual depth layer.
+- `popup_block()` — styled `Block` with `POPUP_BG` background and 1-char
+  horizontal padding, no borders.
+
+### Style (border removal)
+- All `Block::default().borders(Borders::ALL)` → styled with
+  `UI_ELEMENT_BG` / `POPUP_BG` backgrounds + padding
+- All `.block(Block::default().borders(Borders::LEFT | Borders::RIGHT))`
+  removed from list and paragraph widgets — content flows naturally within
+  the panel area
+- `command_palette_rect` and `bottom_picker_rect` kept their bottom-anchored
+  positioning but got the same color-block treatment
+
+### Files
+- `src/tui/theme.rs` — `POPUP_BG`, `POPUP_DIMMER_BG`
+- `src/tui/render/overlay.rs` — `popup_rect()`, `render_dimmer()`,
+  `popup_block()`; all modal renderers updated
+- `src/tui/render/overlay_setup.rs` — all editor/setup modals updated
+- `src/tui/list_picker.rs` — picker modals updated
+
+## Trade-offs
+
+- The dimmer overlay is rendered as a full-area color fill, not a true
+  transparency. NORD0 is already the main UI background, so the dimmer
+  "darkens" the area behind the popup but doesn't show through the prior
+  content.
+- Snapshot tests were not updated in this change. The visual diff is large
+  enough that snapshots should be reviewed and accepted in a follow-up
+  after the design direction is confirmed.
+- `Borders` type is no longer imported in `overlay`, `overlay_setup`, or
+  `list_picker` — any future bordered UI element will need to add the import
+  back.
+
+## Remaining
+
+- Update snapshot tests (`cargo insta review`) after design approval
+- Consider a thin separator line (NORD3) between sections inside large popups
+  if the pure color-block approach loses too much structure
+- Command palette and model search still use `command_palette_rect` instead of
+  the centered `popup_rect` — evaluate whether these should also become
+  centered overlays

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -9,7 +9,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    widgets::{Block, List, ListItem, ListState, Padding, Paragraph},
 };
 
 use super::app_event::AppEvent;
@@ -498,14 +498,15 @@ pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, are
         .split(area);
 
     f.render_widget(
-        Paragraph::new(kind.description())
-            .block(Block::default().borders(Borders::ALL).title(kind.title())),
+        Paragraph::new(kind.description()).block(
+            Block::default()
+                .style(Style::default().bg(UI_ELEMENT_BG))
+                .padding(Padding::horizontal(1))
+                .title(kind.title()),
+        ),
         chunks[0],
     );
-    f.render_widget(
-        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-    );
+    f.render_widget(List::new(items), chunks[1]);
     f.render_widget(
         Paragraph::new(kind.help_text()).alignment(Alignment::Center),
         chunks[2],
@@ -549,7 +550,8 @@ fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_widget(
         Paragraph::new(vec![search_line, status_line]).block(
             Block::default()
-                .borders(Borders::ALL)
+                .style(Style::default().bg(UI_ELEMENT_BG))
+                .padding(Padding::horizontal(1))
                 .title(ListPickerKind::Resume.title()),
         ),
         chunks[0],
@@ -562,8 +564,7 @@ fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_stateful_widget(
         List::new(items)
             .highlight_style(Style::default().fg(TEXT_ACCENT))
-            .highlight_symbol("› ")
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
+            .highlight_symbol("› "),
         chunks[1],
         &mut state,
     );

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -477,6 +477,16 @@ fn resume_compaction_detail(summary: &ThreadSummary) -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
+// Popup color-block helper (mirrors `popup_block()` in overlay.rs)
+// ---------------------------------------------------------------------------
+
+fn popup_block() -> Block<'static> {
+    Block::default()
+        .style(Style::default().bg(POPUP_BG))
+        .padding(Padding::horizontal(1))
+}
+
+// ---------------------------------------------------------------------------
 // Unified render — one function for all ListPicker variants
 // ---------------------------------------------------------------------------
 
@@ -488,6 +498,9 @@ pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, are
 
     let items = kind.render_items(app);
 
+    let block = popup_block();
+    let inner = block.inner(area);
+    f.render_widget(block, area);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -495,7 +508,7 @@ pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, are
             Constraint::Min(6),
             Constraint::Length(2),
         ])
-        .split(area);
+        .split(inner);
 
     f.render_widget(
         Paragraph::new(kind.description()).block(
@@ -515,6 +528,9 @@ pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, are
 
 fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
     let items = ListPickerKind::Resume.render_items(app);
+    let block = popup_block();
+    let inner = block.inner(area);
+    f.render_widget(block, area);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -522,7 +538,7 @@ fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
             Constraint::Min(8),
             Constraint::Length(1),
         ])
-        .split(area);
+        .split(inner);
 
     let query = if app.resume_search_query.is_empty() {
         "type to filter".to_string()

--- a/src/tui/render/cells/interaction_cells.rs
+++ b/src/tui/render/cells/interaction_cells.rs
@@ -26,7 +26,6 @@ use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
 use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;
 use crate::tui::terminal_event::TerminalStream;
 use crate::tui::theme::*;
-use crate::tui::theme::{PENDING_CARD_BG, PENDING_CARD_FG};
 
 pub(crate) struct TerminalCell {
     command: String,
@@ -267,7 +266,10 @@ impl ApprovalCell {
 
 impl HistoryCell for ApprovalCell {
     fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
-        let card_style = Style::default().fg(PENDING_CARD_FG).bg(PENDING_CARD_BG);
+        // Deliberately no special background: the card content (command output, etc.)
+        // renders on the main terminal background so text is always readable.
+        // The section label provides the only visual framing.
+        let card_style = Style::default().fg(PENDING_CARD_FG);
         let mut lines = vec![Line::from(section_label(self.title, self.color))];
         lines.extend(
             self.lines

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -6,7 +6,8 @@ use ratatui::{
     layout::{Alignment, Constraint, Direction, Flex, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Tabs, Wrap},
+    widgets::Padding,
+    widgets::{Block, Clear, List, ListItem, ListState, Paragraph, Tabs, Wrap},
 };
 
 use self::overlay_setup::{
@@ -28,7 +29,8 @@ use crate::tui::status_display::render_status_lines;
 pub(super) fn render_overlay(f: &mut Frame, app: &TuiApp, overlay: Overlay) -> Option<(u16, u16)> {
     match overlay {
         Overlay::Help(tab) => {
-            let popup = centered_rect(78, 70, f.area());
+            let popup = popup_rect(f.area(), 80, 60);
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             render_help_modal(f, app, popup, tab);
             None
@@ -46,55 +48,64 @@ pub(super) fn render_overlay(f: &mut Frame, app: &TuiApp, overlay: Overlay) -> O
             None
         }
         Overlay::Status(tab) => {
-            let popup = centered_rect(78, 70, f.area());
+            let popup = popup_rect(f.area(), 80, 60);
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             render_status_modal(f, app, popup, tab);
             None
         }
         Overlay::Context => {
-            let popup = centered_rect(78, 70, f.area());
+            let popup = popup_rect(f.area(), 80, 60);
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             render_context_modal(f, app, popup);
             None
         }
         Overlay::ListPicker(kind) => {
             let popup = if kind == super::super::state::ListPickerKind::Resume {
-                centered_rect(96, 92, f.area())
+                popup_rect(f.area(), 96, 80)
             } else {
                 bottom_picker_rect(f.area())
             };
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             super::super::list_picker::render_list_picker(f, app, kind, popup);
             None
         }
         Overlay::PermissionPicker => {
-            let popup = centered_rect(72, 70, f.area());
+            let popup = popup_rect(f.area(), 72, 60);
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             render_permission_picker_modal(f, app, popup);
             None
         }
         Overlay::BaseUrlEditor => {
             let popup = setup_flow_rect(f.area());
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             render_base_url_editor_modal(f, app, popup)
         }
         Overlay::ApiKeyEditor => {
             let popup = setup_flow_rect(f.area());
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             render_api_key_editor_modal(f, app, popup)
         }
         Overlay::ModelNameEditor => {
             let popup = setup_flow_rect(f.area());
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             render_model_name_editor_modal(f, app, popup)
         }
         Overlay::OpenAiProfileLabelEditor => {
             let popup = setup_flow_rect(f.area());
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             render_openai_profile_label_editor_modal(f, app, popup)
         }
         Overlay::SkillsPicker => {
             let popup = setup_flow_rect(f.area());
+            render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             render_skills_picker_modal(f, app, popup);
             None
@@ -103,14 +114,17 @@ pub(super) fn render_overlay(f: &mut Frame, app: &TuiApp, overlay: Overlay) -> O
 }
 
 fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
+    let block = popup_block();
+    let inner = block.inner(area);
+    f.render_widget(block, area);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),
+            Constraint::Length(2),
             Constraint::Min(10),
             Constraint::Length(2),
         ])
-        .split(area);
+        .split(inner);
     let titles = ["General", "Commands", "Runtime"]
         .into_iter()
         .map(Line::from)
@@ -122,7 +136,6 @@ fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
     };
     f.render_widget(
         Tabs::new(titles)
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
             .select(selected)
             .style(Style::default().fg(TEXT_SECONDARY))
             .highlight_style(help_selected_tab_style()),
@@ -132,7 +145,6 @@ fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
         HelpTab::General => {
             f.render_widget(
                 Paragraph::new(panel_text("general", general_help_text()))
-                    .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
                     .wrap(Wrap { trim: false }),
                 chunks[1],
             );
@@ -147,8 +159,7 @@ fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
             f.render_stateful_widget(
                 List::new(items)
                     .highlight_style(command_list_highlight_style())
-                    .highlight_symbol("› ")
-                    .block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
+                    .highlight_symbol("› "),
                 chunks[1],
                 &mut state,
             );
@@ -172,13 +183,11 @@ fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
                 .split(inner[1]);
             f.render_widget(
                 Paragraph::new(panel_text("runtime", &status_runtime_text(app)))
-                    .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
                     .wrap(Wrap { trim: false }),
                 left[0],
             );
             f.render_widget(
                 Paragraph::new(panel_text("workspace", &status_workspace_text(app)))
-                    .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
                     .wrap(Wrap { trim: false }),
                 left[1],
             );
@@ -187,13 +196,11 @@ fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
                     "prompt sources",
                     &status_prompt_sources_text(app),
                 ))
-                .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
                 .wrap(Wrap { trim: false }),
                 left[2],
             );
             f.render_widget(
                 Paragraph::new(panel_text("metrics", &status_metrics_text(app)))
-                    .block(Block::default().borders(Borders::RIGHT))
                     .wrap(Wrap { trim: false }),
                 right[0],
             );
@@ -206,7 +213,6 @@ fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
                         recent_transcript_preview(app, 4)
                     ),
                 ))
-                .block(Block::default().borders(Borders::RIGHT))
                 .wrap(Wrap { trim: false }),
                 right[1],
             );
@@ -228,15 +234,12 @@ fn render_command_palette(f: &mut Frame, app: &TuiApp, area: Rect) {
     };
 
     let mut state = command_palette_list_state(app.command_palette_idx);
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(TEXT_MUTED))
-        .title_top(Line::from(Span::styled(
-            " Command Palette ",
-            Style::default()
-                .fg(BADGE_FG_DARK)
-                .add_modifier(Modifier::BOLD),
-        )));
+    let block = popup_block().title_top(Line::from(Span::styled(
+        " Command Palette ",
+        Style::default()
+            .fg(TEXT_ACCENT)
+            .add_modifier(Modifier::BOLD),
+    )));
     let inner = block.inner(area);
     f.render_widget(block, area);
 
@@ -355,27 +358,26 @@ fn help_selected_tab_style() -> Style {
 
 fn render_status_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: StatusTab) {
     let lines = render_status_lines(app, tab);
+    let block = popup_block();
+    let inner = block.inner(area);
+    f.render_widget(block, area);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),
+            Constraint::Length(2),
             Constraint::Fill(1),
             Constraint::Length(1),
         ])
-        .split(area);
+        .split(inner);
     let titles = status_tab_titles();
     f.render_widget(
         Tabs::new(titles)
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
             .select(status_tab_index(tab))
             .style(Style::default().fg(TEXT_SECONDARY))
             .highlight_style(help_selected_tab_style()),
         chunks[0],
     );
-    f.render_widget(
-        Paragraph::new(lines).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-    );
+    f.render_widget(Paragraph::new(lines), chunks[1]);
     f.render_widget(
         Paragraph::new("Esc close  1 overview  2 config  3 context  <-> switch")
             .style(Style::default().fg(Color::DarkGray))
@@ -401,14 +403,16 @@ fn status_tab_index(tab: StatusTab) -> usize {
 
 fn render_context_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     let lines = render_context_lines(app, area.width);
+    let block = popup_block();
+    let inner = block.inner(area);
+    f.render_widget(block, area);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(8), Constraint::Length(2)])
-        .split(area);
+        .split(inner);
 
     f.render_widget(
         Paragraph::new(lines)
-            .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
             .wrap(Wrap { trim: false })
             .scroll((app.context_scroll, 0)),
         chunks[0],
@@ -419,8 +423,6 @@ fn render_context_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     );
 }
 
-/// Bottom-anchored compact popup for list pickers (model, provider, etc.).
-/// OpenCode-style: anchored near the input area, not full-screen.
 fn bottom_picker_rect(area: Rect) -> Rect {
     // OpenCode-style bottom-anchored compact popup
     let width = area.width.min(76).max(32).clamp(10, area.width);
@@ -434,25 +436,38 @@ fn bottom_picker_rect(area: Rect) -> Rect {
     Rect::new(x, y.max(area.y), width, height)
 }
 
-fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let vertical = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage((100 - percent_y) / 2),
-            Constraint::Percentage(percent_y),
-            Constraint::Percentage((100 - percent_y) / 2),
-        ])
-        .split(area);
-    let horizontal = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage((100 - percent_x) / 2),
-            Constraint::Percentage(percent_x),
-            Constraint::Percentage((100 - percent_x) / 2),
-        ])
-        .flex(Flex::Center)
-        .split(vertical[1]);
-    horizontal[1]
+/// Centered popup rect with adaptive sizing.
+///
+/// Horizontally centered; vertically offset from top by ~1/4 of screen
+/// height (opencode style). Width and height are clamped so the popup
+/// never exceeds the visible area.
+fn popup_rect(area: Rect, max_width: u16, max_height_pct: u16) -> Rect {
+    let width = max_width.min(area.width.saturating_sub(4)).max(20);
+    let max_height = (area.height as u32 * max_height_pct as u32 / 100) as u16;
+    let height = max_height.min(area.height.saturating_sub(4)).max(8);
+    let top_offset = area.height / 4;
+    let x = area
+        .x
+        .saturating_add((area.width.saturating_sub(width)) / 2);
+    let y = (area.y.saturating_add(top_offset))
+        .min(area.y.saturating_add(area.height.saturating_sub(height)));
+    Rect::new(x, y, width, height)
+}
+
+/// Fill the given area with the dimmer background behind popups.
+fn render_dimmer(f: &mut Frame, area: Rect) {
+    f.render_widget(
+        Paragraph::new("").style(Style::default().bg(POPUP_DIMMER_BG)),
+        area,
+    );
+}
+
+/// Styled block for popup content areas: solid panel background, no borders,
+/// 1-char horizontal padding (opencode color-block style).
+fn popup_block() -> Block<'static> {
+    Block::default()
+        .style(Style::default().bg(POPUP_BG))
+        .padding(Padding::horizontal(1))
 }
 
 fn setup_flow_rect(area: Rect) -> Rect {
@@ -629,15 +644,12 @@ fn render_model_search(f: &mut Frame, app: &TuiApp, area: Rect) {
         app.model_search_idx.min(filtered.len().saturating_sub(1)),
     ));
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(TEXT_MUTED))
-        .title_top(Line::from(Span::styled(
-            " Model Search ",
-            Style::default()
-                .fg(BADGE_FG_DARK)
-                .add_modifier(Modifier::BOLD),
-        )));
+    let block = popup_block().title_top(Line::from(Span::styled(
+        " Model Search ",
+        Style::default()
+            .fg(BADGE_FG_DARK)
+            .add_modifier(Modifier::BOLD),
+    )));
     let inner = block.inner(area);
     f.render_widget(block, area);
 

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -423,6 +423,8 @@ fn render_context_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     );
 }
 
+/// Bottom-anchored compact popup for list pickers (model, provider, etc.).
+/// OpenCode-style: anchored near the input area, not full-screen.
 fn bottom_picker_rect(area: Rect) -> Rect {
     // OpenCode-style bottom-anchored compact popup
     let width = area.width.min(76).max(32).clamp(10, area.width);
@@ -442,9 +444,13 @@ fn bottom_picker_rect(area: Rect) -> Rect {
 /// height (opencode style). Width and height are clamped so the popup
 /// never exceeds the visible area.
 fn popup_rect(area: Rect, max_width: u16, max_height_pct: u16) -> Rect {
-    let width = max_width.min(area.width.saturating_sub(4)).max(20);
+    let width = max_width
+        .min(area.width.saturating_sub(4))
+        .max(20.min(area.width));
     let max_height = (area.height as u32 * max_height_pct as u32 / 100) as u16;
-    let height = max_height.min(area.height.saturating_sub(4)).max(8);
+    let height = max_height
+        .min(area.height.saturating_sub(4))
+        .max(8.min(area.height));
     let top_offset = area.height / 4;
     let x = area
         .x
@@ -647,7 +653,7 @@ fn render_model_search(f: &mut Frame, app: &TuiApp, area: Rect) {
     let block = popup_block().title_top(Line::from(Span::styled(
         " Model Search ",
         Style::default()
-            .fg(BADGE_FG_DARK)
+            .fg(TEXT_ACCENT)
             .add_modifier(Modifier::BOLD),
     )));
     let inner = block.inner(area);

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -6,7 +6,7 @@ use ratatui::{
     style::{Modifier, Style},
     text::Line,
     widgets::{
-        Block, Borders, Cell, List, ListItem, ListState, Paragraph, Row, Table, TableState, Wrap,
+        Block, Cell, List, ListItem, ListState, Padding, Paragraph, Row, Table, TableState, Wrap,
     },
 };
 use secrecy::ExposeSecret;
@@ -80,16 +80,14 @@ pub(super) fn render_provider_picker_modal(f: &mut Frame, app: &TuiApp, area: Re
         Paragraph::new(intro)
             .block(
                 Block::default()
-                    .borders(Borders::ALL)
+                    .style(Style::default().bg(UI_ELEMENT_BG))
+                    .padding(Padding::horizontal(1))
                     .title(" Provider Menu "),
             )
             .wrap(Wrap { trim: false }),
         chunks[0],
     );
-    f.render_widget(
-        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-    );
+    f.render_widget(List::new(items), chunks[1]);
     f.render_widget(
         Paragraph::new("number jump  up/down move  enter choose  esc close")
             .alignment(Alignment::Center),
@@ -256,15 +254,13 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
     f.render_widget(
         Paragraph::new(help).block(
             Block::default()
-                .borders(Borders::ALL)
+                .style(Style::default().bg(UI_ELEMENT_BG))
+                .padding(Padding::horizontal(1))
                 .title(" Model Picker "),
         ),
         chunks[0],
     );
-    f.render_widget(
-        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-    );
+    f.render_widget(List::new(items), chunks[1]);
     f.render_widget(
         Paragraph::new(if provider_label == "Codex" {
             "1-9 jump  Up/Down move  Enter choose level  Esc close"
@@ -303,7 +299,8 @@ fn render_openai_profile_manager_modal(f: &mut Frame, app: &TuiApp, area: Rect) 
         Paragraph::new(help)
             .block(
                 Block::default()
-                    .borders(Borders::ALL)
+                    .style(Style::default().bg(UI_ELEMENT_BG))
+                    .padding(Padding::horizontal(1))
                     .title(" Model Profiles "),
             )
             .wrap(Wrap { trim: false }),
@@ -336,7 +333,6 @@ fn render_openai_profile_manager_modal(f: &mut Frame, app: &TuiApp, area: Rect) 
         ],
     )
     .header(header)
-    .block(Block::default().borders(Borders::LEFT | Borders::RIGHT))
     .column_spacing(1)
     .highlight_symbol("› ")
     .row_highlight_style(
@@ -457,15 +453,13 @@ pub(super) fn render_openai_profile_picker_modal(f: &mut Frame, app: &TuiApp, ar
         ))
         .block(
             Block::default()
-                .borders(Borders::ALL)
+                .style(Style::default().bg(UI_ELEMENT_BG))
+                .padding(Padding::horizontal(1))
                 .title(" Endpoint Profiles "),
         ),
         chunks[0],
     );
-    f.render_widget(
-        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-    );
+    f.render_widget(List::new(items), chunks[1]);
     f.render_widget(
         Paragraph::new("Up/Down move  Enter choose  Esc back").alignment(Alignment::Center),
         chunks[2],
@@ -527,16 +521,14 @@ pub(super) fn render_openai_endpoint_kind_picker_modal(f: &mut Frame, app: &TuiA
         Paragraph::new(intro)
             .block(
                 Block::default()
-                    .borders(Borders::ALL)
+                    .style(Style::default().bg(UI_ELEMENT_BG))
+                    .padding(Padding::horizontal(1))
                     .title(" Endpoint Kind "),
             )
             .wrap(Wrap { trim: false }),
         chunks[0],
     );
-    f.render_widget(
-        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-    );
+    f.render_widget(List::new(items), chunks[1]);
     f.render_widget(
         Paragraph::new("1-4 jump  Up/Down move  Enter choose  Esc back")
             .alignment(Alignment::Center),
@@ -580,13 +572,10 @@ pub(super) fn render_reasoning_effort_picker_modal(f: &mut Frame, app: &TuiApp, 
         .split(area);
     f.render_widget(
         Paragraph::new("Select the reasoning level for the chosen Codex model. Enter persists both the model and the level.")
-            .block(Block::default().borders(Borders::ALL).title(title)),
+            .block(Block::default().style(Style::default().bg(UI_ELEMENT_BG)).padding(Padding::horizontal(1)).title(title)),
         chunks[0],
     );
-    f.render_widget(
-        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-    );
+    f.render_widget(List::new(items), chunks[1]);
     f.render_widget(
         Paragraph::new("1-5 jump  Up/Down move  Enter apply  Esc back")
             .alignment(Alignment::Center),
@@ -659,13 +648,10 @@ pub(super) fn render_permission_picker_modal(f: &mut Frame, app: &TuiApp, area: 
         .split(area);
     f.render_widget(
         Paragraph::new("Choose how RARA handles file edits, commands, and network access. Press Enter to apply the selected mode.")
-            .block(Block::default().borders(Borders::ALL).title(title)),
+            .block(Block::default().style(Style::default().bg(UI_ELEMENT_BG)).padding(Padding::horizontal(1)).title(title)),
         chunks[0],
     );
-    f.render_widget(
-        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-    );
+    f.render_widget(List::new(items), chunks[1]);
     f.render_widget(
         Paragraph::new("1-4 jump  Up/Down move  Enter apply  Esc back")
             .alignment(Alignment::Center),
@@ -697,10 +683,19 @@ pub(super) fn render_base_url_editor_modal(
         ])
         .split(area);
     let intro = Paragraph::new(intro_text)
-        .block(Block::default().borders(Borders::ALL).title(" Base URL "))
+        .block(
+            Block::default()
+                .style(Style::default().bg(UI_ELEMENT_BG))
+                .padding(Padding::horizontal(1))
+                .title(" Base URL "),
+        )
         .wrap(Wrap { trim: false });
-    let editor = Paragraph::new(app.base_url_input.as_str())
-        .block(Block::default().borders(Borders::ALL).title(" Value "));
+    let editor = Paragraph::new(app.base_url_input.as_str()).block(
+        Block::default()
+            .style(Style::default().bg(UI_ELEMENT_BG))
+            .padding(Padding::horizontal(1))
+            .title(" Value "),
+    );
     let footer =
         Paragraph::new("Enter save  Esc back to model picker").alignment(Alignment::Center);
     f.render_widget(intro, chunks[0]);
@@ -728,7 +723,12 @@ pub(super) fn render_skills_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect
 
     f.render_widget(
         Paragraph::new(intro)
-            .block(Block::default().borders(Borders::ALL).title(title.as_str()))
+            .block(
+                Block::default()
+                    .style(Style::default().bg(UI_ELEMENT_BG))
+                    .padding(Padding::horizontal(1))
+                    .title(title.as_str()),
+            )
             .wrap(Wrap { trim: false }),
         chunks[0],
     );
@@ -762,11 +762,7 @@ pub(super) fn render_skills_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect
         list_state.select(Some(app.skill_picker_idx));
     }
 
-    f.render_stateful_widget(
-        List::new(items).block(Block::default().borders(Borders::LEFT | Borders::RIGHT)),
-        chunks[1],
-        &mut list_state,
-    );
+    f.render_stateful_widget(List::new(items), chunks[1], &mut list_state);
 
     let footer = if app.skill_picker_entries.is_empty() {
         "Esc close"
@@ -794,7 +790,8 @@ pub(super) fn render_auth_mode_picker_modal(f: &mut Frame, app: &TuiApp, area: R
         Paragraph::new(view.intro)
             .block(
                 Block::default()
-                    .borders(Borders::ALL)
+                    .style(Style::default().bg(UI_ELEMENT_BG))
+                    .padding(Padding::horizontal(1))
                     .title(" Codex Login "),
             )
             .wrap(Wrap { trim: false }),
@@ -804,7 +801,8 @@ pub(super) fn render_auth_mode_picker_modal(f: &mut Frame, app: &TuiApp, area: R
     let body = Paragraph::new(view.lines.join("\n"))
         .block(
             Block::default()
-                .borders(Borders::LEFT | Borders::RIGHT)
+                .style(Style::default().bg(UI_ELEMENT_BG))
+                .padding(Padding::horizontal(1))
                 .title(" Details "),
         )
         .wrap(Wrap { trim: false });
@@ -848,10 +846,19 @@ pub(super) fn render_api_key_editor_modal(
         ])
         .split(area);
     let intro = Paragraph::new(intro_text)
-        .block(Block::default().borders(Borders::ALL).title(title))
+        .block(
+            Block::default()
+                .style(Style::default().bg(UI_ELEMENT_BG))
+                .padding(Padding::horizontal(1))
+                .title(title),
+        )
         .wrap(Wrap { trim: false });
-    let editor = Paragraph::new(app.api_key_input.as_str())
-        .block(Block::default().borders(Borders::ALL).title(" Value "));
+    let editor = Paragraph::new(app.api_key_input.as_str()).block(
+        Block::default()
+            .style(Style::default().bg(UI_ELEMENT_BG))
+            .padding(Padding::horizontal(1))
+            .title(" Value "),
+    );
     let footer = Paragraph::new(footer_text).alignment(Alignment::Center);
     f.render_widget(intro, chunks[0]);
     f.render_widget(editor, chunks[1]);
@@ -879,10 +886,19 @@ pub(super) fn render_model_name_editor_modal(
         ])
         .split(area);
     let intro = Paragraph::new(intro_text)
-        .block(Block::default().borders(Borders::ALL).title(" Model Name "))
+        .block(
+            Block::default()
+                .style(Style::default().bg(UI_ELEMENT_BG))
+                .padding(Padding::horizontal(1))
+                .title(" Model Name "),
+        )
         .wrap(Wrap { trim: false });
-    let editor = Paragraph::new(app.model_name_input.as_str())
-        .block(Block::default().borders(Borders::ALL).title(" Value "));
+    let editor = Paragraph::new(app.model_name_input.as_str()).block(
+        Block::default()
+            .style(Style::default().bg(UI_ELEMENT_BG))
+            .padding(Padding::horizontal(1))
+            .title(" Value "),
+    );
     let footer =
         Paragraph::new("Enter save  Esc back to model picker").alignment(Alignment::Center);
     f.render_widget(intro, chunks[0]);
@@ -919,12 +935,17 @@ pub(super) fn render_openai_profile_label_editor_modal(
     let intro = Paragraph::new(intro_text)
         .block(
             Block::default()
-                .borders(Borders::ALL)
+                .style(Style::default().bg(UI_ELEMENT_BG))
+                .padding(Padding::horizontal(1))
                 .title(" New Endpoint Profile "),
         )
         .wrap(Wrap { trim: false });
-    let editor = Paragraph::new(app.openai_profile_label_input.as_str())
-        .block(Block::default().borders(Borders::ALL).title(" Label "));
+    let editor = Paragraph::new(app.openai_profile_label_input.as_str()).block(
+        Block::default()
+            .style(Style::default().bg(UI_ELEMENT_BG))
+            .padding(Padding::horizontal(1))
+            .title(" Label "),
+    );
     let footer = Paragraph::new("Enter create  Esc back to profiles").alignment(Alignment::Center);
     f.render_widget(intro, chunks[0]);
     f.render_widget(editor, chunks[1]);

--- a/src/tui/render/snapshots/rara__tui__render__tests__api_key_editor_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__api_key_editor_standard_terminal.snap
@@ -1,12 +1,11 @@
 ---
 source: src/tui/render/tests.rs
-assertion_line: 592
 expression: rendered
 ---
-┌ API Key ─────────────────────────────────────────────────────────────────────────────────────────┐
-│Paste the API key for the selected OpenAI-compatible endpoint profile.                            │
-└──────────────────────────────────────────────────────────────────────────────────────────────────┘
-┌ Value ───────────────────────────────────────────────────────────────────────────────────────────┐
-│                                                                                                  │
-└──────────────────────────────────────────────────────────────────────────────────────────────────┘
+ API Key
+ Paste the API key for the selected OpenAI-compatible endpoint profile.
+
+ Value
+
+
                                 Enter save  Esc back to model picker

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -13,16 +13,16 @@ Type a message to start a task or run a local command.
 Start with:
   /help    browse built-in commands and runtime hints
   /model   choose provider first, then switch models
-  /status  i┌ Provider ────────────────────────────────────────────────────────────────┐
-  /quit    l│Select a provider family.                                                 │
-            └──────────────────────────────────────────────────────────────────────────┘
-Prompt ideas│   [1] Codex (current)                                                    │
-  · Explain │      Use Codex with browser login, device-code login, or a Codex API key.│
-  · Find the│   [2] DeepSeek                                                           │
-            │      Use DeepSeek with an API key and model list from api.deepseek.com.  │
-            │   [3] Kimi                                                               │
-Warning  War│      Use Moonshot Kimi with an API key from api.moonshot.cn.             │
-› Ask about │                                                                          │
+  /status  i Provider
+  /quit    l Select a provider family.
+
+Prompt ideas   [1] Codex (current)
+  · Explain       Use Codex with browser login, device-code login, or a Codex API key.
+  · Find the   [2] DeepSeek
+                  Use DeepSeek with an API key and model list from api.deepseek.com.
+               [3] Kimi
+Warning  War      Use Moonshot Kimi with an API key from api.moonshot.cn.
+› Ask about
                           1-9 jump  Up/Down/jk move  Enter apply  Esc back
 
                                                                        perm=auto approval=suggestion

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -13,15 +13,15 @@ Type a message to start a task or run a local command.
 Start with:
   /help    browse built-in commands and runtime hints
   /model   choose provider first, then switch models
-  /status  i Provider
-  /quit    l Select a provider family.
+  /status  i  Provider
+  /quit    l  Select a provider family.
 
-Prompt ideas   [1] Codex (current)
-  · Explain       Use Codex with browser login, device-code login, or a Codex API key.
-  · Find the   [2] DeepSeek
-                  Use DeepSeek with an API key and model list from api.deepseek.com.
-               [3] Kimi
-Warning  War      Use Moonshot Kimi with an API key from api.moonshot.cn.
+Prompt ideas    [1] Codex (current)
+  · Explain        Use Codex with browser login, device-code login, or a Codex API key.
+  · Find the    [2] DeepSeek
+                   Use DeepSeek with an API key and model list from api.deepseek.com.
+                [3] Kimi
+Warning  War       Use Moonshot Kimi with an API key from api.moonshot.cn.
 › Ask about
                           1-9 jump  Up/Down/jk move  Enter apply  Esc back
 

--- a/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
@@ -9,16 +9,16 @@ dir   · /workspace/rara
 Ready.
 ──
 Type a message to start a task or run a local command.
-  ┌ All Models ──────────────────────────────────────────────────────────────┐
-St│Select a model across all providers.                                      │
-  └──────────────────────────────────────────────────────────────────────────┘
-  │Codex/gpt-4o                                                              │
-  │DeepSeek/deepseek-chat                                                    │
-  │DeepSeek/deepseek-reasoner                                                │
-  │DeepSeek/deepseek-v4-flash                                                │
-Pr│DeepSeek/deepseek-v4-pro                                                  │
-Re│DeepSeek/deepseek-v4-preview                                              │
-› │Kimi/kimi-k2.6                                                            │
+   All Models
+St Select a model across all providers.
+
+  Codex/gpt-4o
+  DeepSeek/deepseek-chat
+  DeepSeek/deepseek-reasoner
+  DeepSeek/deepseek-v4-flash
+PrDeepSeek/deepseek-v4-pro
+ReDeepSeek/deepseek-v4-preview
+› Kimi/kimi-k2.6
                      Up/Down/jk move  Enter apply  Esc back
 
                                                    perm=auto approval=suggestion

--- a/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
@@ -9,16 +9,16 @@ dir   · /workspace/rara
 Ready.
 ──
 Type a message to start a task or run a local command.
-   All Models
-St Select a model across all providers.
+    All Models
+St  Select a model across all providers.
 
-  Codex/gpt-4o
-  DeepSeek/deepseek-chat
-  DeepSeek/deepseek-reasoner
-  DeepSeek/deepseek-v4-flash
-PrDeepSeek/deepseek-v4-pro
-ReDeepSeek/deepseek-v4-preview
-› Kimi/kimi-k2.6
+   Codex/gpt-4o
+   DeepSeek/deepseek-chat
+   DeepSeek/deepseek-reasoner
+   DeepSeek/deepseek-v4-flash
+Pr DeepSeek/deepseek-v4-pro
+Re DeepSeek/deepseek-v4-preview
+›  Kimi/kimi-k2.6
                      Up/Down/jk move  Enter apply  Esc back
 
                                                    perm=auto approval=suggestion

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -100,7 +100,6 @@ pub(crate) const INTERACTION_SUB_AGENT: Color = NORD13;
 
 // ── Pending interaction card background ───────────────────────────
 pub(crate) const PENDING_CARD_FG: Color = NORD5;
-pub(crate) const PENDING_CARD_BG: Color = NORD1;
 
 // ── Tool output ─────────────────────────────────────────────────
 pub(crate) const TOOL_STDERR_BG: Color = NORD11;

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -56,6 +56,11 @@ pub(crate) const UI_ELEMENT_BG: Color = NORD2;
 pub(crate) const UI_BORDER: Color = NORD3;
 pub(crate) const UI_BORDER_ACTIVE: Color = NORD8;
 
+// ── Popup / overlay surfaces ────────────────────────────────────
+pub(crate) const POPUP_BG: Color = NORD1;
+/// Full-screen dimmer behind centered popups (matches UI_BG).
+pub(crate) const POPUP_DIMMER_BG: Color = NORD0;
+
 // ── Text ────────────────────────────────────────────────────────
 pub(crate) const TEXT_PRIMARY: Color = NORD4;
 pub(crate) const TEXT_SECONDARY: Color = NORD3;


### PR DESCRIPTION
## Summary

Replace wireframe borders with color-block panel design across all overlay popups and modals, taking inspiration from [opencode](https://github.com/sst/opencode)'s dialog styling.

## Changes

### Style (color-block design language)
- **Popup background**: Solid `UI_PANEL_BG` (NORD1) instead of wireframe `Borders::ALL`
- **Dimmer overlay**: Full-screen `POPUP_DIMMER_BG` (NORD0) behind centered popups for visual depth
- **Input/editor fields**: `UI_ELEMENT_BG` (NORD2) background with 1-char horizontal padding, no borders
- **Lists/paragraphs**: No wrapping block — content flows naturally within the panel area
- New theme constants: `POPUP_BG`, `POPUP_DIMMER_BG`

### Positioning (adaptive sizing)
- `popup_rect()` replaces `centered_rect()`: horizontal center, vertical offset at height/4 (opencode-style)
- Width/height clamped to `area - 4` to ensure popups never exceed the visible terminal
- `render_dimmer()` fills the full screen with dimmer background before rendering popup content

### Files changed
- `src/tui/theme.rs` — add `POPUP_BG`, `POPUP_DIMMER_BG` constants
- `src/tui/render/overlay.rs` — `popup_rect()`, `render_dimmer()`, `popup_block()` helpers; update all modal renderers
- `src/tui/render/overlay_setup.rs` — replace all `Borders::ALL` / `Borders::LEFT|RIGHT` with styled blocks
- `src/tui/list_picker.rs` — same border → color-block replacement