### PR TITLE
feat(tui): render LSP diagnostics results

### DIFF
--- a/docs/features/lsp-integration.md
+++ b/docs/features/lsp-integration.md
@@ -95,6 +95,9 @@ Per-project override via `AGENTS.md` or `.rara/lsp.json`.
 |------|-----------|-------------|
 | `lsp_diagnostics` | `(file: Path)` → `Vec<Diagnostic>` | Current LSP diagnostics for a file |
 
+The tool result keeps a JSON payload in the transcript so the TUI can render it
+with a dedicated diagnostics cell instead of showing generic formatted JSON.
+
 ```rust
 struct Diagnostic {
     file: PathBuf,
@@ -192,6 +195,10 @@ The runtime owns a per-workspace `LspManager` and shares it with the
 Sidebar rendering must not spawn language-server availability checks. The
 status view only reports cached availability until a tool call needs to verify
 and start a server.
+
+`lsp_diagnostics` tool results render as a structured TUI cell with the target
+file, diagnostic count, severity, source location, optional diagnostic code,
+message preview, cached runtime count, and startup/request error when present.
 
 ### Phase 3: Configuration (~50 lines)
 

--- a/docs/journal/2026-05-19-lsp-runtime-status.md
+++ b/docs/journal/2026-05-19-lsp-runtime-status.md
@@ -21,12 +21,17 @@
   sending `initialized`; reader threads route response messages through a
   connection-local channel while keeping diagnostics notification handling in
   the shared cache.
+- `lsp_diagnostics` compact results keep their JSON payload parseable for the
+  TUI. The transcript renderer recognizes that payload and renders a dedicated
+  diagnostics cell instead of a generic text preview.
 
 ## Verification
 
 - `cargo fmt`
 - `cargo test lsp_manager -- --nocapture`
 - `cargo test push_lsp_status -- --nocapture`
+- `cargo test lsp_diagnostics -- --nocapture`
+- `cargo test formats_lsp_diagnostics_tool_result_as_parseable_payload -- --nocapture`
 - `cargo check -p rara`
 
 ## Follow-up

--- a/src/tool_result.rs
+++ b/src/tool_result.rs
@@ -104,6 +104,7 @@ impl ToolResultStore {
             "grep" => compact_grep(result),
             "web_fetch" => compact_web_fetch(input, result),
             "web_search" => compact_web_search(input, result),
+            "lsp_diagnostics" => compact_lsp_diagnostics(result),
             _ => compact_generic(&summary, result),
         };
         let full_rendered =
@@ -1216,6 +1217,21 @@ fn summarize_tool_result(tool_name: &str, input: &Value, result: &Value) -> Stri
                 "Replaced lines {start_line}-{end_line} in {path}: {inserted_lines} inserted line(s)."
             )
         }
+        "lsp_diagnostics" => {
+            let file = result
+                .get("file")
+                .and_then(Value::as_str)
+                .unwrap_or("<unknown>");
+            let total = result
+                .get("diagnostics")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len);
+            if let Some(error) = result.get("error").and_then(Value::as_str) {
+                format!("LSP diagnostics for {file} failed: {error}")
+            } else {
+                format!("LSP diagnostics for {file}: {total} diagnostic(s).")
+            }
+        }
         _ => {
             let keys = result
                 .as_object()
@@ -1225,6 +1241,10 @@ fn summarize_tool_result(tool_name: &str, input: &Value, result: &Value) -> Stri
             format!("Tool {tool_name} completed with {keys}.")
         }
     }
+}
+
+fn compact_lsp_diagnostics(result: &Value) -> String {
+    serde_json::to_string_pretty(result).unwrap_or_else(|_| result.to_string())
 }
 
 fn truncate_text(text: &str, max_chars: usize) -> String {

--- a/src/tui/render/cells/committed_turn.rs
+++ b/src/tui/render/cells/committed_turn.rs
@@ -8,7 +8,8 @@ use super::progress::{ProgressRole, progress_entry_message_lines, push_progress_
 use super::terminal::terminal_cell_from_entries;
 use super::user_startup::UserCell;
 use super::{
-    HistoryCell, InteractionCompletionKind, is_progress_stack_title, trim_trailing_empty_lines,
+    HistoryCell, InteractionCompletionKind, LspDiagnosticsCell, is_progress_stack_title,
+    trim_trailing_empty_lines,
 };
 use crate::tui::state::{TranscriptEntry, TranscriptEntryPayload};
 
@@ -106,6 +107,12 @@ fn push_ordered_committed_activity<'a>(
             entry.role.as_str(),
             "Tool" | "Tool Result" | "Tool Error" | "Tool Progress"
         ) {
+            if matches!(entry.role.as_str(), "Tool Result" | "Tool Error")
+                && let Some(cell) = LspDiagnosticsCell::from_message(&entry.message)
+            {
+                cells.push(Box::new(cell));
+                continue;
+            }
             cells.push(Box::new(MessageCell::new_tail(
                 &entry.role,
                 &entry.message,

--- a/src/tui/render/cells/lsp_diagnostics.rs
+++ b/src/tui/render/cells/lsp_diagnostics.rs
@@ -1,0 +1,275 @@
+use ratatui::{
+    style::{Modifier, Style},
+    text::{Line, Span},
+};
+use serde::Deserialize;
+
+use super::HistoryCell;
+use crate::tui::theme::{
+    STATUS_ERROR, STATUS_INFO, STATUS_SUCCESS, STATUS_WARNING, TEXT_MUTED, TEXT_SECONDARY,
+};
+
+const MAX_VISIBLE_DIAGNOSTICS: usize = 4;
+
+pub(crate) struct LspDiagnosticsCell {
+    file: String,
+    diagnostics: Vec<LspDiagnostic>,
+    error: Option<String>,
+    status: Option<LspStatus>,
+}
+
+#[derive(Deserialize)]
+struct LspDiagnosticsPayload {
+    file: String,
+    #[serde(default)]
+    diagnostics: Vec<LspDiagnostic>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    status: Option<LspStatus>,
+}
+
+#[derive(Deserialize)]
+struct LspDiagnostic {
+    file: String,
+    line: u32,
+    column: u32,
+    severity: String,
+    message: String,
+    #[serde(default)]
+    code: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct LspStatus {
+    #[serde(default)]
+    diagnostic_count: usize,
+    #[serde(default)]
+    servers: Vec<LspServerStatus>,
+}
+
+#[derive(Deserialize)]
+struct LspServerStatus {
+    #[serde(default)]
+    running: bool,
+}
+
+impl LspDiagnosticsCell {
+    pub(crate) fn from_message(message: &str) -> Option<Self> {
+        let payload = message.trim().strip_prefix("lsp_diagnostics\n")?;
+        let payload: LspDiagnosticsPayload = serde_json::from_str(payload.trim()).ok()?;
+        Some(Self {
+            file: payload.file,
+            diagnostics: payload.diagnostics,
+            error: payload.error,
+            status: payload.status,
+        })
+    }
+}
+
+impl HistoryCell for LspDiagnosticsCell {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
+        let mut lines = vec![Line::from(vec![Span::styled(
+            "LSP Diagnostics",
+            Style::default()
+                .fg(TEXT_SECONDARY)
+                .add_modifier(Modifier::ITALIC),
+        )])];
+
+        let status_label = if let Some(error) = self.error.as_deref() {
+            format!("error: {error}")
+        } else if self.diagnostics.is_empty() {
+            "no diagnostics".to_string()
+        } else {
+            format!("{} diagnostic(s)", self.diagnostics.len())
+        };
+        lines.push(Line::from(vec![
+            Span::styled(shorten(&self.file, width), Style::default().fg(TEXT_MUTED)),
+            Span::raw(" · "),
+            Span::styled(status_label, Style::default().fg(self.summary_color())),
+        ]));
+
+        for diagnostic in self.diagnostics.iter().take(MAX_VISIBLE_DIAGNOSTICS) {
+            lines.push(diagnostic_line(diagnostic, width));
+        }
+
+        let hidden = self
+            .diagnostics
+            .len()
+            .saturating_sub(MAX_VISIBLE_DIAGNOSTICS);
+        if hidden > 0 {
+            lines.push(Line::from(Span::styled(
+                format!("... {hidden} more diagnostic(s)"),
+                Style::default().fg(TEXT_MUTED),
+            )));
+        }
+
+        if let Some(status) = self.status.as_ref() {
+            lines.push(Line::from(Span::styled(
+                status_summary(status),
+                Style::default().fg(TEXT_MUTED),
+            )));
+        }
+
+        lines
+    }
+}
+
+impl LspDiagnosticsCell {
+    fn summary_color(&self) -> ratatui::style::Color {
+        if self.error.is_some() {
+            STATUS_ERROR
+        } else if self.diagnostics.is_empty() {
+            STATUS_SUCCESS
+        } else {
+            STATUS_WARNING
+        }
+    }
+}
+
+fn diagnostic_line(diagnostic: &LspDiagnostic, width: u16) -> Line<'static> {
+    let severity = diagnostic.severity.to_ascii_lowercase();
+    let code = diagnostic
+        .code
+        .as_deref()
+        .filter(|code| !code.trim().is_empty())
+        .map(|code| format!(" [{code}]"))
+        .unwrap_or_default();
+    let location = format!(
+        "{}:{}:{}",
+        diagnostic.file,
+        diagnostic.line + 1,
+        diagnostic.column + 1
+    );
+    let prefix = format!("{} {location}{code} ", severity_label(&severity));
+    let remaining = usize::from(width)
+        .saturating_sub(prefix.chars().count())
+        .min(usize::from(width));
+    Line::from(vec![
+        Span::styled(prefix, Style::default().fg(severity_color(&severity))),
+        Span::raw(shorten(&diagnostic.message, remaining as u16)),
+    ])
+}
+
+fn severity_label(severity: &str) -> &'static str {
+    match severity {
+        "error" => "[error]",
+        "warning" => "[warn]",
+        "information" | "info" => "[info]",
+        "hint" => "[hint]",
+        _ => "[diag]",
+    }
+}
+
+fn severity_color(severity: &str) -> ratatui::style::Color {
+    match severity {
+        "error" => STATUS_ERROR,
+        "warning" => STATUS_WARNING,
+        "information" | "info" | "hint" => STATUS_INFO,
+        _ => TEXT_SECONDARY,
+    }
+}
+
+fn status_summary(status: &LspStatus) -> String {
+    let running = status
+        .servers
+        .iter()
+        .filter(|server| server.running)
+        .count();
+    format!(
+        "status: {running} running · {} cached diagnostic(s)",
+        status.diagnostic_count
+    )
+}
+
+fn shorten(value: &str, width: u16) -> String {
+    let width = usize::from(width);
+    let char_count = value.chars().count();
+    if char_count <= width {
+        return value.to_string();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    if width <= 3 {
+        return value.chars().take(width).collect();
+    }
+    let mut collected = value.chars().take(width - 3).collect::<String>();
+    collected.push_str("...");
+    collected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line_text(line: &Line<'static>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>()
+    }
+
+    #[test]
+    fn renders_lsp_diagnostics_payload() {
+        let message = r#"lsp_diagnostics
+{
+  "file": "src/main.rs",
+  "diagnostics": [{
+    "file": "src/main.rs",
+    "line": 4,
+    "column": 8,
+    "severity": "Error",
+    "message": "cannot find value `x` in this scope",
+    "code": "E0425"
+  }],
+  "status": {
+    "diagnostic_count": 1,
+    "servers": [{ "running": true }]
+  }
+}"#;
+
+        let cell = LspDiagnosticsCell::from_message(message).unwrap();
+        let rendered = cell
+            .display_lines(120)
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("LSP Diagnostics"));
+        assert!(rendered.contains("src/main.rs · 1 diagnostic(s)"));
+        assert!(rendered.contains("[error] src/main.rs:5:9 [E0425]"));
+        assert!(rendered.contains("cannot find value `x`"));
+        assert!(rendered.contains("status: 1 running · 1 cached diagnostic(s)"));
+    }
+
+    #[test]
+    fn renders_lsp_error_payload() {
+        let message = r#"lsp_diagnostics
+{
+  "file": "src/main.rs",
+  "diagnostics": [],
+  "error": "no LSP server for src/main.rs"
+}"#;
+
+        let cell = LspDiagnosticsCell::from_message(message).unwrap();
+        let rendered = cell
+            .display_lines(120)
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("src/main.rs · error: no LSP server for src/main.rs"));
+    }
+
+    #[test]
+    fn shorten_respects_width_when_truncated() {
+        assert_eq!(shorten("abcdef", 0), "");
+        assert_eq!(shorten("abcdef", 2), "ab");
+        assert_eq!(shorten("abcdef", 3), "abc");
+        assert_eq!(shorten("abcdef", 4), "a...");
+        assert_eq!(shorten("abcdef", 6), "abcdef");
+    }
+}

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -7,6 +7,7 @@ mod active_turn;
 #[path = "committed_turn.rs"]
 mod committed_turn;
 mod interaction_cells;
+mod lsp_diagnostics;
 mod message_cell;
 mod plan_cells;
 mod responding_cell;
@@ -20,6 +21,7 @@ pub(crate) use self::committed_turn::CommittedTurnCell;
 pub(crate) use self::interaction_cells::{
     CommittedInteractionCell, PendingInteractionCell, QueuedFollowUpCell, TerminalCell,
 };
+pub(crate) use self::lsp_diagnostics::LspDiagnosticsCell;
 pub(crate) use self::message_cell::MessageCell;
 pub(crate) use self::plan_cells::{
     PlanModeCell, PlanSummaryCell, PlanningSuggestionCell, planning_suggestion_text,

--- a/src/tui/render/cells/responding_cell.rs
+++ b/src/tui/render/cells/responding_cell.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use super::tool_progress::tool_progress_lines;
-use super::{HistoryCell, InteractionCompletionKind};
+use super::{HistoryCell, InteractionCompletionKind, LspDiagnosticsCell};
 use crate::tui::interaction_text::{
     pending_interaction_card_title, status_planning_suggestion_text,
 };
@@ -152,7 +152,13 @@ impl HistoryCell for RespondingCell<'_> {
                 role,
                 message,
                 max_lines,
-            } => prefixed_message_lines(role, message, *max_lines),
+            } => {
+                if let Some(cell) = LspDiagnosticsCell::from_message(message) {
+                    cell.display_lines(width)
+                } else {
+                    prefixed_message_lines(role, message, *max_lines)
+                }
+            }
             RespondingCellContent::Working(detail) => compact_message_lines(detail, 1),
         }
     }

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -444,6 +444,9 @@ fn apply_patch_targets(patch: &str) -> Vec<String> {
 }
 
 pub(super) fn format_tool_result(name: &str, content: &str) -> String {
+    if name == "lsp_diagnostics" {
+        return format!("lsp_diagnostics\n{}", content.trim());
+    }
     if matches!(name, "explore_agent" | "plan_agent" | "spawn_agent") {
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(content) {
             let summary = value

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -699,6 +699,33 @@ fn formats_subagent_tool_result_with_returned_ids() {
 }
 
 #[test]
+fn formats_lsp_diagnostics_tool_result_as_parseable_payload() {
+    let rendered = format_tool_result(
+        "lsp_diagnostics",
+        &serde_json::to_string_pretty(&json!({
+            "file": "src/main.rs",
+            "diagnostics": [{
+                "file": "src/main.rs",
+                "line": 4,
+                "column": 8,
+                "severity": "Error",
+                "message": "cannot find value `x` in this scope",
+                "code": "E0425"
+            }],
+            "status": {
+                "diagnostic_count": 1,
+                "servers": [{ "running": true }]
+            }
+        }))
+        .unwrap(),
+    );
+
+    assert!(rendered.starts_with("lsp_diagnostics\n{"));
+    assert!(rendered.contains("\"diagnostics\""));
+    assert!(rendered.contains("\"E0425\""));
+}
+
+#[test]
 fn formats_replace_lines_tool_result_as_edit_summary() {
     let rendered = format_tool_result(
         "replace_lines",


### PR DESCRIPTION
## Summary

- Keep `lsp_diagnostics` compact tool results as parseable JSON.
- Render `lsp_diagnostics` tool results with a dedicated TUI diagnostics cell.
- Show file, diagnostic count, severity, location, optional code, message preview, runtime cache count, and tool error state.
- Cover the formatter and cell renderer with focused tests.
- Update the LSP feature spec and journal note.

## Motivation

The LSP tool returns structured diagnostic JSON, but the transcript previously treated it as a generic tool result preview. That made the TUI harder to scan and also discarded useful structure. This change keeps the JSON parseable and renders it as a first-class diagnostics surface.

## Implementation Notes

- `ToolResultStore` now preserves `lsp_diagnostics` results as pretty JSON.
- `format_tool_result` prefixes the payload with `lsp_diagnostics` so renderers can identify it without guessing from generic text.
- `LspDiagnosticsCell` parses the payload and is used for both committed tool results and the active latest tool result.

## Related Issues

- Stacked on #456.

## Testing

- `cargo fmt`
- `cargo test lsp_diagnostics -- --nocapture`
- `cargo test formats_lsp_diagnostics_tool_result_as_parseable_payload -- --nocapture`
- `cargo check -p rara`
