### PR TITLE
fix(memory): prepare local embeddings from Rust

### DIFF
--- a/components/model_server/rara_model_server.py
+++ b/components/model_server/rara_model_server.py
@@ -228,8 +228,6 @@ class FastEmbedBgeM3Backend(EmbeddingBackend):
     def load(self, model_path: str | None = None) -> None:
         if self.model is not None:
             return
-        if model_path is not None:
-            raise RuntimeError("FastEmbed local model paths are not supported")
         requested = os.environ.get("RARA_FASTEMBED_EMBEDDING_MODEL", FASTEMBED_MODEL_ID)
         if requested != FASTEMBED_MODEL_ID:
             raise RuntimeError(f"unsupported FastEmbed model: {requested}")
@@ -242,6 +240,10 @@ class FastEmbedBgeM3Backend(EmbeddingBackend):
         cache_dir = os.environ.get("RARA_MODEL_CACHE_DIR")
         if cache_dir:
             kwargs["cache_dir"] = cache_dir
+        local_model_path = _validated_local_model_path(model_path)
+        if local_model_path:
+            kwargs["specific_model_path"] = local_model_path
+            kwargs["local_files_only"] = True
         self.model = TextEmbedding(**kwargs)
         self.loaded_at = time.monotonic()
 
@@ -324,21 +326,6 @@ class ModelRegistry:
             "model": backend.model_id,
             "state": "ready",
         }
-
-    def start_background_preparation(self) -> None:
-        backend_name = self._platform_default_backend()
-
-        def _run() -> None:
-            try:
-                self.prepare_model(backend_name, None)
-            except Exception as exc:
-                print(
-                    f"[model-server] background model preparation failed: {exc}",
-                    file=sys.stderr,
-                )
-
-        t = threading.Thread(target=_run, daemon=True)
-        t.start()
 
     def status(self) -> dict[str, Any]:
         default_backend = self._platform_default_backend()
@@ -463,7 +450,6 @@ def main() -> int:
         raise RuntimeError("RARA model server only binds to loopback hosts")
     server = ThreadingHTTPServer((host, port), RequestHandler)
     print(f"RARA model server listening on {host}:{port}", flush=True)
-    REGISTRY.start_background_preparation()
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/docs/features/local-embedding-runtimes.md
+++ b/docs/features/local-embedding-runtimes.md
@@ -57,7 +57,7 @@ Runtime artifacts are platform-specific:
 | Platform | Runtime | Artifact | Status |
 |---|---|---|---|
 | macOS Apple Silicon | `mlx_qwen3` | `mlx-community/Qwen3-Embedding-0.6B-4bit-DWQ` | First slice |
-| Linux / Windows / macOS Intel | `fastembed_bge_m3` | `BAAI/bge-m3` | First slice scaffold |
+| Linux / Windows / macOS Intel | `fastembed_bge_m3` | `BAAI/bge-m3` | First slice |
 
 The canonical model id, dimension, and embedding schema version should drive
 future LanceDB table identity. Runtime artifact names must not become the only
@@ -109,11 +109,13 @@ under the managed model-server runtime directory, not under the workspace:
 ~/.rara/runtime/model-server/venv/bin/python
 ```
 
-Dependency installation and model preparation are startup-managed background
+Dependency installation and model preparation are startup-managed initialization
 work, not separate user-facing commands. Startup should not block the TUI until
 the full model is ready, but it should begin preparation automatically when local
 embeddings are enabled and the required venv, packages, server process, or model
-artifact are missing.
+artifact are missing. The Python sidecar must not eagerly load a model at
+process start; Rust owns the prepare call so Rust-managed profiles can pass the
+validated local snapshot path.
 
 ### Embedding Backend Boundary
 
@@ -306,12 +308,11 @@ The canonical Rust consumer is `LocalModelServerEmbeddingBackend`.
 
 ### Model Preparation And Progress
 
-Model download ownership is split by runtime profile. Each profile declares
-whether Rust or Python owns model artifact preparation. The macOS MLX Qwen3
-profile is Rust-managed so startup can report byte progress and skip repeated
-network work after local cache state proves the snapshot is present. Portable
-FastEmbed/BGE-M3 is Python-managed for this slice and lets the Python backend
-stack resolve its package-level model cache.
+Model download ownership is Rust-managed for the default local embedding
+profiles. The macOS MLX Qwen3 profile prepares the full allowlisted Hugging
+Face snapshot. Portable FastEmbed/BGE-M3 prepares only the ONNX/tokenizer files
+needed by FastEmbed, avoiding unrelated PyTorch or Safetensors weights while
+still giving Rust ownership of download progress and cache reuse.
 
 - Rust creates or reuses the managed venv.
 - Rust-managed profiles prepare their Hugging Face snapshot in the RARA model
@@ -323,8 +324,6 @@ stack resolve its package-level model cache.
 - Rust asks the server to prepare a backend/model through a dedicated prepare
   API, passing a prepared local snapshot path only for Rust-managed profiles.
 - Python loads from the validated local snapshot path when one is provided.
-  Python-managed profiles such as portable FastEmbed perform their own model
-  resolution through the configured model cache.
 - Python exposes structured preparation progress.
 - Rust polls or subscribes to that progress and surfaces it in `/status` and
   startup status text.
@@ -373,6 +372,7 @@ Valid preparation states:
 | `prepared_stopped` | The managed Python runtime is prepared, but no reusable server is currently running |
 | `reusing_server` | Rust found and reused an existing healthy server |
 | `downloading` | Rust or Python is downloading model artifacts, depending on the runtime profile |
+| `loading` | The server process is alive and the selected model is being loaded into memory |
 | `ready` | Server and selected embedding model are ready |
 | `error` | Bootstrap, server startup, dependency install, or model preparation failed |
 
@@ -436,8 +436,10 @@ Valid preparation states:
   is asked to prepare the selected backend/model. A completed snapshot marker or
   complete local Hugging Face `refs/<revision>` snapshot lets later startups
   skip the Hugging Face metadata request and download path.
-- Portable FastEmbed model artifact resolution remains inside the Python
-  backend stack for this slice.
+- The Python sidecar must not start model preparation on its own at process
+  startup. Rust must initiate `/models/prepare` after snapshot preparation so a
+  Rust-managed profile cannot race with an eager Python load that lacks the
+  local snapshot path.
 - Local loopback embedding requests must bypass system proxy configuration.
 
 ## Validation Matrix
@@ -472,8 +474,8 @@ Valid preparation states:
   only execute that Python server command and should not reinstall dependencies.
 - If dependency installation fails, startup should delete the managed venv
   directory and report the install error instead of leaving a partial runtime.
-- Startup should prepare the server automatically; `/status` should report that
-  background preparation state rather than initiating it.
+- Startup should prepare the server automatically; `/status` should report the
+  current initialization state rather than initiating it.
 - TUI startup should not block first paint on local embedding bootstrap. A
   completed sidecar should be reused silently; an incomplete sidecar should show
   initialization progress and close that status surface when the rebuild task
@@ -508,3 +510,4 @@ Valid preparation states:
 ## Source Journals
 
 - `docs/journal/2026-05-12-local-embedding-sidecar.md`
+- `docs/journal/2026-05-19-local-embedding-prepare-race.md`

--- a/docs/journal/2026-05-19-local-embedding-prepare-race.md
+++ b/docs/journal/2026-05-19-local-embedding-prepare-race.md
@@ -1,0 +1,41 @@
+# 2026-05-19 Local Embedding Prepare Race
+
+## Summary
+
+Local embedding startup now avoids the race between Rust-managed model snapshot
+preparation and Python-side eager model loading.
+
+The bundled model server no longer starts a background model preparation job at
+process startup. Rust owns the prepare boundary because it may need to pass a
+validated local snapshot path to `POST /models/prepare` after ensuring the
+allowlisted Hugging Face files are already present in RARA's cache.
+
+Rust startup also keeps polling when `/models/prepare` reports `loading`
+instead of immediately returning `PreparingModel`. `PreparingModel` is now used
+only after the startup wait window is exhausted while the sidecar still reports
+an in-flight load.
+
+Portable FastEmbed/BGE-M3 now uses the same Rust-managed model preparation
+boundary as macOS MLX. Rust downloads only the FastEmbed-required
+`BAAI/bge-m3` ONNX and tokenizer files into the RARA model cache, records the
+snapshot marker, and passes the validated snapshot path to Python. Python then
+loads FastEmbed with that local path and `local_files_only`, so Linux startup
+does not delegate the initial model download to FastEmbed.
+
+## Background
+
+The previous flow could report `Model · ready` or `Model · already available`
+after the Hugging Face snapshot was present, then remain in
+`PreparingModel`. That status did not mean the files were still downloading; it
+meant the Python sidecar had not yet loaded the embedding backend into memory.
+
+The sidecar made this confusing by starting a background load with no
+Rust-provided snapshot path. A subsequent Rust `/models/prepare` call could
+therefore see `loading`, return `PreparingModel`, and leave the UI with a
+coarse status even though file preparation had already completed.
+
+## Validation
+
+- `cargo test local_model_server::tests::bundled_model_server_does_not_start_background_model_prepare -- --nocapture`
+- `python3 -m py_compile components/model_server/rara_model_server.py`
+- `cargo check -p rara`

--- a/src/local_model_server/model.rs
+++ b/src/local_model_server/model.rs
@@ -81,8 +81,8 @@ pub(crate) fn prepare_local_embedding_model_snapshot(
         .filter(|name| !name.ends_with('/'))
         .collect();
     let files = selected_snapshot_files(required_files, available_files);
-    if files.is_empty() {
-        bail!("model repository has no downloadable files");
+    if !snapshot_has_minimum_model_files(required_files, &files) {
+        bail!("model repository is missing required files for profile");
     }
 
     let snapshot_path = cache_repo.pointer_path(&info.sha);

--- a/src/local_model_server/model.rs
+++ b/src/local_model_server/model.rs
@@ -3,9 +3,7 @@ pub(crate) fn prepare_local_embedding_model_snapshot(
     profile: &LocalEmbeddingModelProfile,
     progress: &Option<LocalProgressReporter>,
 ) -> Result<Option<PathBuf>> {
-    let SnapshotPreparation::RustManaged { required_files } = profile.snapshot_preparation else {
-        return Ok(None);
-    };
+    let required_files = profile.required_files;
     let model = profile.model;
 
     let cache_dir = default_local_model_cache_dir();
@@ -76,12 +74,13 @@ pub(crate) fn prepare_local_embedding_model_snapshot(
     let info = api_repo
         .info()
         .context("resolve model repository metadata")?;
-    let files: Vec<String> = info
+    let available_files: Vec<String> = info
         .siblings
         .into_iter()
         .map(|sibling| sibling.rfilename)
         .filter(|name| !name.ends_with('/'))
         .collect();
+    let files = selected_snapshot_files(required_files, available_files);
     if files.is_empty() {
         bail!("model repository has no downloadable files");
     }
@@ -142,6 +141,30 @@ pub(crate) fn snapshot_has_all_files(snapshot_path: &Path, files: &[String]) -> 
     files
         .iter()
         .all(|filename| snapshot_path.join(filename).exists())
+}
+
+pub(crate) fn selected_snapshot_files(
+    required_files: SnapshotRequiredFiles,
+    available_files: Vec<String>,
+) -> Vec<String> {
+    match required_files {
+        SnapshotRequiredFiles::MlxQwen3 => available_files,
+        SnapshotRequiredFiles::FastEmbedBgeM3 => available_files
+            .into_iter()
+            .filter(|file| {
+                matches!(
+                    file.as_str(),
+                    "config.json"
+                        | "tokenizer.json"
+                        | "tokenizer_config.json"
+                        | "special_tokens_map.json"
+                        | "preprocessor_config.json"
+                        | "onnx/model.onnx"
+                        | "onnx/model.onnx_data"
+                )
+            })
+            .collect(),
+    }
 }
 
 pub(crate) fn local_cached_model_snapshot(
@@ -229,6 +252,13 @@ pub(crate) fn snapshot_has_minimum_model_files(
             let has_weights = files.iter().any(|file| file.ends_with(".safetensors"));
             has_config && has_tokenizer && has_weights
         }
+        SnapshotRequiredFiles::FastEmbedBgeM3 => {
+            let has_config = files.iter().any(|file| file == "config.json");
+            let has_tokenizer = files.iter().any(|file| file == "tokenizer.json");
+            let has_model = files.iter().any(|file| file == "onnx/model.onnx");
+            let has_external_data = files.iter().any(|file| file == "onnx/model.onnx_data");
+            has_config && has_tokenizer && has_model && has_external_data
+        }
     }
 }
 
@@ -288,4 +318,3 @@ pub(crate) fn cached_snapshot_under_cache(snapshot_path: &Path, cache_dir: &Path
     };
     Ok(snapshot == cache || snapshot.starts_with(cache))
 }
-

--- a/src/local_model_server/prepare.rs
+++ b/src/local_model_server/prepare.rs
@@ -1,19 +1,19 @@
 pub(crate) fn default_embedding_profile() -> LocalEmbeddingModelProfile {
     if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
         LocalEmbeddingModelProfile {
+            id: "qwen3-embedding-0.6b",
             backend: "mlx_qwen3",
             model: MLX_QWEN3_MODEL_ID,
             revision: MODEL_REVISION,
-            snapshot_preparation: SnapshotPreparation::RustManaged {
-                required_files: SnapshotRequiredFiles::MlxQwen3,
-            },
+            required_files: SnapshotRequiredFiles::MlxQwen3,
         }
     } else {
         LocalEmbeddingModelProfile {
+            id: "bge-m3-fastembed",
             backend: "fastembed_bge_m3",
             model: FASTEMBED_BGE_M3_MODEL_ID,
             revision: MODEL_REVISION,
-            snapshot_preparation: SnapshotPreparation::PythonManaged,
+            required_files: SnapshotRequiredFiles::FastEmbedBgeM3,
         }
     }
 }
@@ -24,7 +24,7 @@ pub(crate) fn default_embedding_backend() -> (&'static str, &'static str) {
 }
 
 pub(crate) fn embedding_profile_id() -> &'static str {
-    "qwen3-embedding-0.6b"
+    default_embedding_profile().id
 }
 
 pub(crate) fn venv_python_path(venv_dir: &Path) -> PathBuf {
@@ -150,4 +150,3 @@ pub(crate) fn requirements_marker_matches(path: &Path, expected_hash: &str) -> R
         .and_then(Value::as_str)
         .is_some_and(|hash| hash == expected_hash))
 }
-

--- a/src/local_model_server/server.rs
+++ b/src/local_model_server/server.rs
@@ -46,35 +46,36 @@ pub(crate) fn start_model_server(
 
             let mut health_ever_passed = false;
             let mut last_prepare_error: Option<anyhow::Error> = None;
+            let mut saw_model_loading = false;
             for _ in 0..STARTUP_HEALTH_ATTEMPTS {
                 if let Ok(health) = probe_health(host, port) {
                     health_ever_passed = true;
                     if health_identity_matches(&health, backend, model) {
+                        if health_model_ready(&health, backend) {
+                            return ready_model_server_status(server, backend, model, &endpoint);
+                        }
+                        if let Some(error_message) = health_preparation_error(&health, backend) {
+                            return LocalModelServerStatus {
+                                state: LocalModelServerState::Error,
+                                backend: backend.to_string(),
+                                model: model.to_string(),
+                                detail: format!(
+                                    "model server running at {endpoint}; model preparation failed: {error_message} (stderr log: {})",
+                                    stderr_log_path.display()
+                                ),
+                                server_path: Some(server.path.clone()),
+                                endpoint: Some(endpoint),
+                            };
+                        }
                         match prepare_model(host, port, backend, model_path) {
                             Ok(state) => {
-                                let (state_tag, detail) = if state == "ready" {
-                                    (
-                                        LocalModelServerState::Ready,
-                                        format!(
-                                            "started model server and prepared model at {endpoint}"
-                                        ),
-                                    )
+                                if state == "ready" {
+                                    return ready_model_server_status(
+                                        server, backend, model, &endpoint,
+                                    );
                                 } else {
-                                    (
-                                        LocalModelServerState::PreparingModel,
-                                        format!(
-                                            "started model server at {endpoint}; model is still loading"
-                                        ),
-                                    )
-                                };
-                                return LocalModelServerStatus {
-                                    state: state_tag,
-                                    backend: backend.to_string(),
-                                    model: model.to_string(),
-                                    detail,
-                                    server_path: Some(server.path.clone()),
-                                    endpoint: Some(endpoint),
-                                };
+                                    saw_model_loading = true;
+                                }
                             }
                             Err(err) => {
                                 last_prepare_error = Some(err);
@@ -97,6 +98,15 @@ pub(crate) fn start_model_server(
                     };
                 }
             }
+            if saw_model_loading {
+                return preparing_model_server_status(
+                    server,
+                    backend,
+                    model,
+                    &endpoint,
+                    &stderr_log_path,
+                );
+            }
             if let Some(err) = last_prepare_error {
                 return LocalModelServerStatus {
                     state: LocalModelServerState::Error,
@@ -113,41 +123,6 @@ pub(crate) fn start_model_server(
             }
 
             let stderr_hint = format!(" (stderr log: {})", stderr_log_path.display());
-            match prepare_model(host, port, backend, model_path) {
-                Ok(state) => {
-                    health_ever_passed = true;
-                    if state == "ready" {
-                        return LocalModelServerStatus {
-                            state: LocalModelServerState::Ready,
-                            backend: backend.to_string(),
-                            model: model.to_string(),
-                            detail: format!(
-                                "started model server and prepared model at {endpoint}"
-                            ),
-                            server_path: Some(server.path.clone()),
-                            endpoint: Some(endpoint),
-                        };
-                    }
-                    if let Ok(health) = probe_health(host, port) {
-                        if health_identity_matches(&health, backend, model) {
-                            return LocalModelServerStatus {
-                                state: LocalModelServerState::PreparingModel,
-                                backend: backend.to_string(),
-                                model: model.to_string(),
-                                detail: format!(
-                                    "started model server at {endpoint}; model is still loading"
-                                ),
-                                server_path: Some(server.path.clone()),
-                                endpoint: Some(endpoint),
-                            };
-                        }
-                    }
-                }
-                Err(err) => {
-                    last_prepare_error = Some(err);
-                }
-            }
-
             LocalModelServerStatus {
                 state: LocalModelServerState::Starting,
                 backend: backend.to_string(),
@@ -176,3 +151,38 @@ pub(crate) fn start_model_server(
     }
 }
 
+fn ready_model_server_status(
+    server: &BundledModelServer,
+    backend: &str,
+    model: &str,
+    endpoint: &str,
+) -> LocalModelServerStatus {
+    LocalModelServerStatus {
+        state: LocalModelServerState::Ready,
+        backend: backend.to_string(),
+        model: model.to_string(),
+        detail: format!("started model server and prepared model at {endpoint}"),
+        server_path: Some(server.path.clone()),
+        endpoint: Some(endpoint.to_string()),
+    }
+}
+
+fn preparing_model_server_status(
+    server: &BundledModelServer,
+    backend: &str,
+    model: &str,
+    endpoint: &str,
+    stderr_log_path: &Path,
+) -> LocalModelServerStatus {
+    LocalModelServerStatus {
+        state: LocalModelServerState::PreparingModel,
+        backend: backend.to_string(),
+        model: model.to_string(),
+        detail: format!(
+            "model files are available; waiting for model server at {endpoint} to load model (stderr log: {})",
+            stderr_log_path.display()
+        ),
+        server_path: Some(server.path.clone()),
+        endpoint: Some(endpoint.to_string()),
+    }
+}

--- a/src/local_model_server/tests.rs
+++ b/src/local_model_server/tests.rs
@@ -535,6 +535,24 @@ fn fastembed_snapshot_selection_avoids_non_onnx_weights() {
 }
 
 #[test]
+fn fastembed_snapshot_selection_still_requires_external_data() {
+    let selected = selected_snapshot_files(
+        super::SnapshotRequiredFiles::FastEmbedBgeM3,
+        vec![
+            "config.json".to_string(),
+            "tokenizer.json".to_string(),
+            "onnx/model.onnx".to_string(),
+            "pytorch_model.bin".to_string(),
+        ],
+    );
+
+    assert!(!snapshot_has_minimum_model_files(
+        super::SnapshotRequiredFiles::FastEmbedBgeM3,
+        &selected
+    ));
+}
+
+#[test]
 fn ensure_managed_venv_creates_and_reuses_venv_with_pip() {
     let temp = tempfile::tempdir().expect("tempdir");
     let server = ensure_bundled_model_server(temp.path()).expect("install model server");

--- a/src/local_model_server/tests.rs
+++ b/src/local_model_server/tests.rs
@@ -13,9 +13,10 @@ use super::{
     health_identity_matches, health_model_ready, local_cached_model_snapshot, metadata_path,
     model_snapshot_marker_path, prepare_local_model_server_status_inner,
     read_matching_model_snapshot_marker, requirements_marker_matches, requirements_marker_path,
-    reusable_server_status, selected_requirements_file, sha256_hex, snapshot_has_all_files,
-    snapshot_has_minimum_model_files, startup_lock_path, unix_timestamp_secs, venv_python_path,
-    write_file_atomically, write_model_snapshot_marker, write_server_metadata,
+    reusable_server_status, selected_requirements_file, selected_snapshot_files, sha256_hex,
+    snapshot_has_all_files, snapshot_has_minimum_model_files, startup_lock_path,
+    unix_timestamp_secs, venv_python_path, write_file_atomically, write_model_snapshot_marker,
+    write_server_metadata,
 };
 use crate::llm::{EmbeddingBackend, EmbeddingInputKind};
 
@@ -64,6 +65,20 @@ fn repairs_modified_model_server() {
     assert_eq!(
         fs::read(&repaired.path).expect("read repaired model server"),
         super::MODEL_SERVER
+    );
+}
+
+#[test]
+fn bundled_model_server_does_not_start_background_model_prepare() {
+    let source = std::str::from_utf8(super::MODEL_SERVER).expect("model server utf8");
+    let main_body = source
+        .split("def main()")
+        .nth(1)
+        .expect("model server main function");
+
+    assert!(
+        !main_body.contains("start_background_preparation"),
+        "Rust startup must provide the local snapshot path before the Python server loads a model"
     );
 }
 
@@ -473,6 +488,50 @@ fn snapshot_required_files_are_profile_driven() {
             "model.safetensors".to_string(),
         ]
     ));
+    assert!(!snapshot_has_minimum_model_files(
+        super::SnapshotRequiredFiles::FastEmbedBgeM3,
+        &[
+            "config.json".to_string(),
+            "tokenizer.json".to_string(),
+            "onnx/model.onnx".to_string(),
+        ]
+    ));
+    assert!(snapshot_has_minimum_model_files(
+        super::SnapshotRequiredFiles::FastEmbedBgeM3,
+        &[
+            "config.json".to_string(),
+            "tokenizer.json".to_string(),
+            "onnx/model.onnx".to_string(),
+            "onnx/model.onnx_data".to_string(),
+        ]
+    ));
+}
+
+#[test]
+fn fastembed_snapshot_selection_avoids_non_onnx_weights() {
+    let selected = selected_snapshot_files(
+        super::SnapshotRequiredFiles::FastEmbedBgeM3,
+        vec![
+            "config.json".to_string(),
+            "tokenizer.json".to_string(),
+            "tokenizer_config.json".to_string(),
+            "onnx/model.onnx".to_string(),
+            "onnx/model.onnx_data".to_string(),
+            "pytorch_model.bin".to_string(),
+            "model.safetensors".to_string(),
+        ],
+    );
+
+    assert_eq!(
+        selected,
+        vec![
+            "config.json".to_string(),
+            "tokenizer.json".to_string(),
+            "tokenizer_config.json".to_string(),
+            "onnx/model.onnx".to_string(),
+            "onnx/model.onnx_data".to_string(),
+        ]
+    );
 }
 
 #[test]

--- a/src/local_model_server/types.rs
+++ b/src/local_model_server/types.rs
@@ -31,24 +31,18 @@ pub(crate) const MODEL_REVISION: &str = "main";
 pub(crate) static ATOMIC_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SnapshotPreparation {
-    RustManaged {
-        required_files: SnapshotRequiredFiles,
-    },
-    PythonManaged,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SnapshotRequiredFiles {
     MlxQwen3,
+    FastEmbedBgeM3,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct LocalEmbeddingModelProfile {
+    id: &'static str,
     backend: &'static str,
     model: &'static str,
     revision: &'static str,
-    snapshot_preparation: SnapshotPreparation,
+    required_files: SnapshotRequiredFiles,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- remove eager Python-side model preparation so Rust owns the local snapshot boundary before `/models/prepare`
- make portable FastEmbed/BGE-M3 Rust-managed by downloading only the ONNX/tokenizer files needed by FastEmbed
- keep startup polling while the sidecar reports `loading`, and document the prepare/load distinction

## Motivation

A completed model file download does not mean the Python sidecar has loaded the embedding model. The previous startup path could also race with Python background preparation, causing Rust to see `loading` and leave the UI in `PreparingModel` even after the local files were ready.

For Linux and other portable platforms, Rust should own the default model artifact preparation too. This PR moves BGE-M3 onto the same Rust-managed path without downloading unrelated PyTorch or Safetensors files from the repository.

## Related Issue

None.

## Testing

- `cargo fmt`
- `python3 -m py_compile components/model_server/rara_model_server.py`
- `cargo test local_model_server::tests -- --nocapture`
- `cargo check -p rara`

Note: `cargo check` passes with existing repository warnings.
