### PR TITLE
fix(tui): approval & stderr readability — remove special backgrounds

### DIFF
--- a/docs/journal/2026-05-20-tui-popup-color-block.md
+++ b/docs/journal/2026-05-20-tui-popup-color-block.md
@@ -66,3 +66,37 @@ that design language in RARA.
 - Command palette and model search still use `command_palette_rect` instead of
   the centered `popup_rect` — evaluate whether these should also become
   centered overlays
+
+## Follow-up: approval card readability (2026-05-20)
+
+### Problem
+`ApprovalCell` in `interaction_cells.rs` rendered command output lines with
+`PENDING_CARD_BG` (NORD1, #3B4252) background. On the main `UI_BG` (NORD0,
+#2E3440) this created only ~6% lightness difference — the card blended into
+the terminal background, making sandbox/permission command output hard to
+read.
+
+### Fix
+Removed `.bg(PENDING_CARD_BG)` from `card_style` in `ApprovalCell::display_lines()`.
+The approval card content now renders on the default terminal background with
+only foreground color styling. Removed now-unused `PENDING_CARD_BG` constant
+from `theme.rs`.
+
+## OpenCode color scheme observations
+
+OpenCode derives its palette from the terminal's ANSI color slots (not fixed
+hex values), constructing a 12-step grayscale ramp:
+
+| token | role | example (dark) |
+|-------|------|----------------|
+| background | main surface | #0a0a0a |
+| backgroundPanel | popup/dialog | #141414 |
+| backgroundElement | input fields | #1e1e1e |
+| backgroundMenu | dropdowns | #262626 |
+| text | primary content | #eeeeee |
+| textMuted | secondary | #808080 |
+
+Key insight: each surface level is 4–8 lightness units apart, forming a clear
+visual hierarchy. RARA's NORD palette has similar spacing but is blue-tinted
+(NORD0=#2E3440, NORD1=#3B4252, NORD2=#434C5E). Future work could explore a
+pure-grayscale ramp for deeper visual depth.

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -477,14 +477,7 @@ fn resume_compaction_detail(summary: &ThreadSummary) -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
-// Popup color-block helper (mirrors `popup_block()` in overlay.rs)
-// ---------------------------------------------------------------------------
-
-fn popup_block() -> Block<'static> {
-    Block::default()
-        .style(Style::default().bg(POPUP_BG))
-        .padding(Padding::horizontal(1))
-}
+use crate::tui::render::popup_block;
 
 // ---------------------------------------------------------------------------
 // Unified render — one function for all ListPicker variants
@@ -519,7 +512,10 @@ pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, are
         ),
         chunks[0],
     );
-    f.render_widget(List::new(items), chunks[1]);
+    f.render_widget(
+        List::new(items).block(Block::default().padding(Padding::horizontal(1))),
+        chunks[1],
+    );
     f.render_widget(
         Paragraph::new(kind.help_text()).alignment(Alignment::Center),
         chunks[2],
@@ -579,6 +575,7 @@ fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
     }
     f.render_stateful_widget(
         List::new(items)
+            .block(Block::default().padding(Padding::horizontal(1)))
             .highlight_style(Style::default().fg(TEXT_ACCENT))
             .highlight_symbol("› "),
         chunks[1],

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -22,6 +22,7 @@ pub(crate) use self::bottom_pane::desired_viewport_height;
 use self::bottom_pane::{desired_bottom_pane_height, render_bottom_pane};
 pub(crate) use self::cells::{ActiveCell, HistoryCell};
 use self::cells::{ActiveTurnCell, CommittedTurnCell, StartupCardCell};
+pub(crate) use self::overlay::popup_block;
 use self::overlay::render_overlay;
 use self::viewport::TranscriptViewport;
 use super::custom_terminal::Frame;

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -201,10 +201,12 @@ fn active_turn_cell_hides_background_stdout_label_and_pins_stderr() {
         .iter()
         .find(|line| line.to_string().contains("warning: retrying download"))
         .expect("stderr line should render");
-    assert!(stderr_line.spans.iter().any(|span| {
-        span.style.fg == Some(crate::tui::theme::TOOL_STDERR_FG)
-            && span.style.bg == Some(crate::tui::theme::TOOL_STDERR_BG)
-    }));
+    assert!(
+        stderr_line
+            .spans
+            .iter()
+            .any(|span| { span.style.fg == Some(crate::tui::theme::TOOL_STDERR_FG) })
+    );
 }
 
 #[test]

--- a/src/tui/render/cells/interaction_cells.rs
+++ b/src/tui/render/cells/interaction_cells.rs
@@ -180,11 +180,8 @@ impl HistoryCell for TerminalCell {
                 for (i, line) in stderr.iter().take(edge).enumerate() {
                     let prefix = if i == 0 { "  └ " } else { "    " };
                     lines.push(Line::from(vec![
-                        Span::styled(prefix, Style::default().fg(TOOL_STDERR_FG)),
-                        Span::styled(
-                            line.clone(),
-                            Style::default().bg(TOOL_STDERR_BG).fg(TOOL_STDERR_FG),
-                        ),
+                        Span::styled(prefix, Style::default().fg(TEXT_PRIMARY)),
+                        Span::styled(line.clone(), Style::default().fg(TOOL_STDERR_FG)),
                     ]));
                 }
                 let omitted = stderr_count - edge * 2;
@@ -192,28 +189,20 @@ impl HistoryCell for TerminalCell {
                     format!(
                         "      ... {omitted} more stderr line(s)  (showing {edge} + {edge} of {stderr_count})"
                     ),
-                    Style::default()
-                        .fg(TOOL_STDERR_FG)
-                        .bg(TOOL_STDERR_BG),
+                    Style::default().fg(TOOL_STDERR_FG),
                 )));
                 for line in stderr.iter().skip(stderr_count - edge) {
                     lines.push(Line::from(vec![
-                        Span::styled("    ", Style::default().fg(TOOL_STDERR_FG)),
-                        Span::styled(
-                            line.clone(),
-                            Style::default().bg(TOOL_STDERR_BG).fg(TOOL_STDERR_FG),
-                        ),
+                        Span::styled("    ", Style::default().fg(TEXT_PRIMARY)),
+                        Span::styled(line.clone(), Style::default().fg(TOOL_STDERR_FG)),
                     ]));
                 }
             } else {
                 for (i, line) in stderr.iter().enumerate() {
                     let prefix = if i == 0 { "  └ " } else { "    " };
                     lines.push(Line::from(vec![
-                        Span::styled(prefix, Style::default().fg(TOOL_STDERR_FG)),
-                        Span::styled(
-                            line.clone(),
-                            Style::default().bg(TOOL_STDERR_BG).fg(TOOL_STDERR_FG),
-                        ),
+                        Span::styled(prefix, Style::default().fg(TEXT_PRIMARY)),
+                        Span::styled(line.clone(), Style::default().fg(TOOL_STDERR_FG)),
                     ]));
                 }
             }

--- a/src/tui/render/cells/tool_progress.rs
+++ b/src/tui/render/cells/tool_progress.rs
@@ -4,7 +4,7 @@ use ratatui::{
 };
 
 use crate::tui::render::display_width;
-use crate::tui::theme::{STATUS_WARNING, TEXT_SECONDARY, TOOL_STDERR_BG, TOOL_STDERR_FG};
+use crate::tui::theme::{STATUS_WARNING, TEXT_SECONDARY, TOOL_STDERR_FG};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ToolProgressStream {
@@ -237,7 +237,7 @@ fn styled_stderr_progress_line(text: &str, width: u16) -> Line<'static> {
     let padding = target_width.saturating_sub(display_width(&text));
     Line::from(Span::styled(
         format!("{text}{}", " ".repeat(padding)),
-        Style::default().fg(TOOL_STDERR_FG).bg(TOOL_STDERR_BG),
+        Style::default().fg(TOOL_STDERR_FG),
     ))
 }
 
@@ -300,9 +300,9 @@ mod tests {
         assert!(rendered_text.contains("err 3"));
         assert!(rendered_text.contains("err 4"));
         assert!(rendered.iter().all(|line| {
-            line.spans.iter().any(|span| {
-                span.style.fg == Some(TOOL_STDERR_FG) && span.style.bg == Some(TOOL_STDERR_BG)
-            })
+            line.spans
+                .iter()
+                .any(|span| span.style.fg == Some(TOOL_STDERR_FG))
         }));
     }
 

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -83,31 +83,41 @@ pub(super) fn render_overlay(f: &mut Frame, app: &TuiApp, overlay: Overlay) -> O
             let popup = setup_flow_rect(f.area());
             render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
-            render_base_url_editor_modal(f, app, popup)
+            let inner = popup_block().inner(popup);
+            f.render_widget(popup_block(), popup);
+            render_base_url_editor_modal(f, app, inner)
         }
         Overlay::ApiKeyEditor => {
             let popup = setup_flow_rect(f.area());
             render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
-            render_api_key_editor_modal(f, app, popup)
+            let inner = popup_block().inner(popup);
+            f.render_widget(popup_block(), popup);
+            render_api_key_editor_modal(f, app, inner)
         }
         Overlay::ModelNameEditor => {
             let popup = setup_flow_rect(f.area());
             render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
-            render_model_name_editor_modal(f, app, popup)
+            let inner = popup_block().inner(popup);
+            f.render_widget(popup_block(), popup);
+            render_model_name_editor_modal(f, app, inner)
         }
         Overlay::OpenAiProfileLabelEditor => {
             let popup = setup_flow_rect(f.area());
             render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
-            render_openai_profile_label_editor_modal(f, app, popup)
+            let inner = popup_block().inner(popup);
+            f.render_widget(popup_block(), popup);
+            render_openai_profile_label_editor_modal(f, app, inner)
         }
         Overlay::SkillsPicker => {
             let popup = setup_flow_rect(f.area());
             render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
-            render_skills_picker_modal(f, app, popup);
+            let inner = popup_block().inner(popup);
+            f.render_widget(popup_block(), popup);
+            render_skills_picker_modal(f, app, inner);
             None
         }
     }
@@ -470,7 +480,7 @@ fn render_dimmer(f: &mut Frame, area: Rect) {
 
 /// Styled block for popup content areas: solid panel background, no borders,
 /// 1-char horizontal padding (opencode color-block style).
-fn popup_block() -> Block<'static> {
+pub(crate) fn popup_block() -> Block<'static> {
     Block::default()
         .style(Style::default().bg(POPUP_BG))
         .padding(Padding::horizontal(1))

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -48,6 +48,9 @@ fn wrapped_text_height(text: &str, area_width: u16) -> u16 {
 }
 
 pub(super) fn render_provider_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
+    let block = super::popup_block();
+    let inner = block.inner(area);
+    f.render_widget(block, area);
     let items = PROVIDER_FAMILIES
         .iter()
         .enumerate()
@@ -242,6 +245,9 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
                 .unwrap_or("http://localhost:11434"),
         )
     };
+    let block = super::popup_block();
+    let inner = block.inner(area);
+    f.render_widget(block, area);
     let help_height = wrapped_text_height(help, area.width);
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -70,7 +70,7 @@ pub(super) fn render_provider_picker_modal(f: &mut Frame, app: &TuiApp, area: Re
         })
         .collect::<Vec<_>>();
     let intro = "Choose a provider family first, then continue into model selection or setup.";
-    let intro_height = wrapped_text_height(intro, area.width);
+    let intro_height = wrapped_text_height(intro, area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -248,7 +248,7 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
     let block = super::popup_block();
     let inner = block.inner(area);
     f.render_widget(block, area);
-    let help_height = wrapped_text_height(help, area.width);
+    let help_height = wrapped_text_height(help, area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -292,7 +292,7 @@ fn render_openai_profile_manager_modal(f: &mut Frame, app: &TuiApp, area: Rect) 
         app.current_model_label(),
         api_key_status(&app.config),
     );
-    let help_height = wrapped_text_height(help.as_str(), area.width);
+    let help_height = wrapped_text_height(help.as_str(), area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -514,7 +514,7 @@ pub(super) fn render_openai_endpoint_kind_picker_modal(f: &mut Frame, app: &TuiA
         })
         .collect::<Vec<_>>();
     let intro = "Choose which OpenAI-compatible endpoint family to configure first.\nThe next steps will walk through the connection fields for that endpoint.";
-    let intro_height = wrapped_text_height(intro, area.width);
+    let intro_height = wrapped_text_height(intro, area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -679,7 +679,7 @@ pub(super) fn render_base_url_editor_modal(
     } else {
         "Edit the Ollama base URL for this provider.\nLeave it empty to clear the override. Default: http://localhost:11434"
     };
-    let intro_height = wrapped_text_height(intro_text, area.width);
+    let intro_height = wrapped_text_height(intro_text, area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -717,7 +717,7 @@ pub(super) fn render_base_url_editor_modal(
 pub(super) fn render_skills_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     let title = format!(" Skills ({} loaded) ", app.skill_picker_entries.len());
     let intro = "Space toggle enable/disable  Esc close";
-    let intro_height = wrapped_text_height(intro, area.width);
+    let intro_height = wrapped_text_height(intro, area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -783,7 +783,7 @@ pub(super) fn render_skills_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect
 
 pub(super) fn render_auth_mode_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     let view = build_auth_mode_picker_view(app, is_ssh_session());
-    let intro_height = wrapped_text_height(view.intro.as_str(), area.width);
+    let intro_height = wrapped_text_height(view.intro.as_str(), area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -842,7 +842,7 @@ pub(super) fn render_api_key_editor_modal(
             "Enter save and rebuild  Esc back to login guide",
         ),
     };
-    let intro_height = wrapped_text_height(intro_text, area.width);
+    let intro_height = wrapped_text_height(intro_text, area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -882,7 +882,7 @@ pub(super) fn render_model_name_editor_modal(
     area: Rect,
 ) -> Option<(u16, u16)> {
     let intro_text = "Set the model name for the selected OpenAI-compatible endpoint profile.\nExample: gpt-4o-mini, kimi-k2.6, deepseek-chat, or any server-specific model id.";
-    let intro_height = wrapped_text_height(intro_text, area.width);
+    let intro_height = wrapped_text_height(intro_text, area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -929,7 +929,7 @@ pub(super) fn render_openai_profile_label_editor_modal(
         "Create a new {} endpoint profile.\nThis label is only used locally in the picker and status surfaces.",
         kind.label()
     );
-    let intro_height = wrapped_text_height(intro_text.as_str(), area.width);
+    let intro_height = wrapped_text_height(intro_text.as_str(), area.width.saturating_sub(2));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/src/tui/render/snapshots/rara__tui__render__tests__api_key_editor_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__api_key_editor_standard_terminal.snap
@@ -2,10 +2,10 @@
 source: src/tui/render/tests.rs
 expression: rendered
 ---
- API Key
- Paste the API key for the selected OpenAI-compatible endpoint profile.
+  API Key
+  Paste the API key for the selected OpenAI-compatible endpoint profile.
 
- Value
+  Value
 
 
                                 Enter save  Esc back to model picker

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -16,12 +16,12 @@ Start with:
   /status  i  Provider
   /quit    l  Select a provider family.
 
-Prompt ideas    [1] Codex (current)
-  · Explain        Use Codex with browser login, device-code login, or a Codex API key.
-  · Find the    [2] DeepSeek
-                   Use DeepSeek with an API key and model list from api.deepseek.com.
-                [3] Kimi
-Warning  War       Use Moonshot Kimi with an API key from api.moonshot.cn.
+Prompt ideas     [1] Codex (current)
+  · Explain         Use Codex with browser login, device-code login, or a Codex API ke
+  · Find the     [2] DeepSeek
+                    Use DeepSeek with an API key and model list from api.deepseek.com.
+                 [3] Kimi
+Warning  War        Use Moonshot Kimi with an API key from api.moonshot.cn.
 › Ask about
                           1-9 jump  Up/Down/jk move  Enter apply  Esc back
 

--- a/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
@@ -12,13 +12,13 @@ Type a message to start a task or run a local command.
     All Models
 St  Select a model across all providers.
 
-   Codex/gpt-4o
-   DeepSeek/deepseek-chat
-   DeepSeek/deepseek-reasoner
-   DeepSeek/deepseek-v4-flash
-Pr DeepSeek/deepseek-v4-pro
-Re DeepSeek/deepseek-v4-preview
-›  Kimi/kimi-k2.6
+    Codex/gpt-4o
+    DeepSeek/deepseek-chat
+    DeepSeek/deepseek-reasoner
+    DeepSeek/deepseek-v4-flash
+Pr  DeepSeek/deepseek-v4-pro
+Re  DeepSeek/deepseek-v4-preview
+›   Kimi/kimi-k2.6
                      Up/Down/jk move  Enter apply  Esc back
 
                                                    perm=auto approval=suggestion

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -102,7 +102,6 @@ pub(crate) const INTERACTION_SUB_AGENT: Color = NORD13;
 pub(crate) const PENDING_CARD_FG: Color = NORD5;
 
 // ── Tool output ─────────────────────────────────────────────────
-pub(crate) const TOOL_STDERR_BG: Color = NORD11;
 pub(crate) const TOOL_STDERR_FG: Color = NORD6;
 
 // ── Diff view ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #455. Removes special background colors from approval cards and stderr command output that caused readability issues (background and text too close, per user feedback).

## Changes

### Approval cards
- Remove `PENDING_CARD_BG` (NORD1, #3B4252) background from `ApprovalCell`
- Text now renders on terminal default background — fixes the "too similar" contrast issue
- Removed unused `PENDING_CARD_BG` theme constant

### Stderr command output
- Remove `TOOL_STDERR_BG` (NORD11 red, #BF616A) background from `TerminalCell` and `tool_progress`
- Stderr keeps bright white `TOOL_STDERR_FG` for visibility without jarring red background
- Removed unused `TOOL_STDERR_BG` theme constant

### Journal
- OpenCode color scheme observations (grayscale ramp, contrast hierarchy)