### PR TITLE
chore(tools): extract rara-background-tasks crate; fix(tui): plan dismissal, todo sidebar, empty-input cursor, hook_registry rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11970,6 +11970,7 @@ name = "rara-background-tasks"
 version = "0.0.1"
 dependencies = [
  "async-trait",
+ "libc",
  "rara-tool-macros",
  "rara-tools",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11913,6 +11913,7 @@ dependencies = [
  "pulldown-cmark",
  "rand 0.10.1",
  "rara-app-server",
+ "rara-background-tasks",
  "rara-bedrock",
  "rara-config",
  "rara-file-search",
@@ -11962,6 +11963,20 @@ version = "0.0.1"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rara-background-tasks"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "rara-tool-macros",
+ "rara-tools",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/rara-tools",
     "crates/rara-plugins",
     "crates/rara-app-server",
+    "crates/rara-background-tasks",
 ]
 resolver = "2"
 
@@ -56,6 +57,7 @@ rara-tools = { path = "crates/rara-tools" }
 rara-plugins = { path = "crates/rara-plugins" }
 rara-app-server = { path = "crates/rara-app-server" }
 rara-state = { path = "crates/rara-state" }
+rara-background-tasks = { path = "crates/rara-background-tasks" }
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 clap = { version = "4.0", features = ["derive", "env"] }

--- a/crates/rara-background-tasks/Cargo.toml
+++ b/crates/rara-background-tasks/Cargo.toml
@@ -4,14 +4,17 @@
  edition.workspace = true
  license.workspace = true
  
- [dependencies]
- rara-tools.path = "../rara-tools"
- rara-tool-macros.path = "../tool-macros"
- serde.workspace = true
- serde_json.workspace = true
- tokio = { version = "1.0", features = ["fs", "io-util", "sync"] }
- uuid = { version = "1.11", features = ["v4"] }
- async-trait.workspace = true
- 
- [dev-dependencies]
- tempfile.workspace = true
+[dependencies]
+rara-tools.path = "../rara-tools"
+rara-tool-macros.path = "../tool-macros"
+serde.workspace = true
+serde_json.workspace = true
+tokio = { version = "1.0", features = ["fs", "io-util", "macros", "process", "rt", "sync"] }
+uuid = { version = "1.11", features = ["v4"] }
+async-trait.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/rara-background-tasks/Cargo.toml
+++ b/crates/rara-background-tasks/Cargo.toml
@@ -1,0 +1,17 @@
+ [package]
+ name = "rara-background-tasks"
+ version.workspace = true
+ edition.workspace = true
+ license.workspace = true
+ 
+ [dependencies]
+ rara-tools.path = "../rara-tools"
+ rara-tool-macros.path = "../tool-macros"
+ serde.workspace = true
+ serde_json.workspace = true
+ tokio = { version = "1.0", features = ["fs", "io-util", "sync"] }
+ uuid = { version = "1.11", features = ["v4"] }
+ async-trait.workspace = true
+ 
+ [dev-dependencies]
+ tempfile.workspace = true

--- a/crates/rara-background-tasks/src/lib.rs
+++ b/crates/rara-background-tasks/src/lib.rs
@@ -16,7 +16,7 @@ use rara_tools::tool::{Tool, ToolError, ToolOutputStream};
 use serde::Serialize;
 use serde_json::Value;
 use tokio::fs;
-use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
@@ -350,6 +350,124 @@ impl Tool for BackgroundTaskStopTool {
         }
         Ok(serde_json::json!({ "stopped": self.background_tasks.stop_all() }))
     }
+}
+
+pub fn kill_child_process_group(child_id: Option<u32>) {
+    #[cfg(unix)]
+    {
+        let Some(child_id) = child_id else {
+            return;
+        };
+        let process_group = -(child_id as libc::pid_t);
+        // Best-effort cancellation: the direct child may have already exited,
+        // but killing the group stops shell descendants that still hold pipes.
+        unsafe {
+            libc::kill(process_group, libc::SIGKILL);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = child_id;
+    }
+}
+
+pub async fn read_stream_chunks<R>(
+    reader: R,
+    stream: BashStreamKind,
+    tx: tokio::sync::mpsc::Sender<(BashStreamKind, String)>,
+) -> Result<(), ToolError>
+where
+    R: tokio::io::AsyncRead + Unpin + Send + 'static,
+{
+    let mut reader = reader;
+    let mut buffer = [0_u8; 4096];
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        let chunk = String::from_utf8_lossy(&buffer[..read]).into_owned();
+        if tx.send((stream, chunk)).await.is_err() {
+            break;
+        }
+    }
+    Ok(())
+}
+
+pub async fn run_background_bash_task(
+    child: &mut tokio::process::Child,
+    record: &BackgroundTaskRecord,
+    mut stop_rx: oneshot::Receiver<()>,
+    process_group_id: Option<u32>,
+    sandbox_warning: Option<&str>,
+    cleanup_path: Option<&Path>,
+) -> Result<Option<i32>, ToolError> {
+    if let Some(parent) = record.output_path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+    fs::write(&record.output_path, "").await?;
+    if let Some(warning) = sandbox_warning {
+        append_background_output(&record.output_path, BashStreamKind::Stderr, warning).await?;
+    }
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| ToolError::ExecutionFailed("stdout pipe unavailable".into()))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| ToolError::ExecutionFailed("stderr pipe unavailable".into()))?;
+    let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+    let stdout_task = tokio::spawn(read_stream_chunks(
+        stdout,
+        BashStreamKind::Stdout,
+        tx.clone(),
+    ));
+    let stderr_task = tokio::spawn(read_stream_chunks(stderr, BashStreamKind::Stderr, tx));
+
+    let mut output_file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&record.output_path)
+        .await?;
+    let mut stop_requested = false;
+    loop {
+        tokio::select! {
+            chunk = rx.recv() => {
+                let Some((stream, chunk)) = chunk else {
+                    break;
+                };
+                if !chunk.is_empty() {
+                    match stream {
+                        BashStreamKind::Stdout => output_file.write_all(chunk.as_bytes()).await?,
+                        BashStreamKind::Stderr => {
+                            output_file.write_all(b"[stderr] ").await?;
+                            output_file.write_all(chunk.as_bytes()).await?;
+                        }
+                    }
+                }
+            }
+            _ = &mut stop_rx, if !stop_requested => {
+                stop_requested = true;
+                kill_child_process_group(process_group_id);
+                let _ = child.start_kill();
+                output_file.write_all(b"[stderr] background task stop requested\n").await?;
+            }
+        }
+    }
+
+    let status = child.wait().await?;
+    stdout_task
+        .await
+        .map_err(|err| ToolError::ExecutionFailed(err.to_string()))??;
+    stderr_task
+        .await
+        .map_err(|err| ToolError::ExecutionFailed(err.to_string()))??;
+    if let Some(path) = cleanup_path {
+        let _ = fs::remove_file(path).await;
+    }
+    Ok(status.code())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rara-background-tasks/src/lib.rs
+++ b/crates/rara-background-tasks/src/lib.rs
@@ -1,0 +1,463 @@
+//! Background task lifecycle management.
+//!
+//! Single responsibility: register, list, inspect status, stop, and read
+//! output of background shell tasks. This crate owns the task store, record
+//! types, state machine, and the three RARA tool implementations that expose
+//! background task operations to the agent loop.
+
+use std::collections::HashMap;
+use std::io::SeekFrom;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
+use rara_tools::tool::{Tool, ToolError, ToolOutputStream};
+use serde::Serialize;
+use serde_json::Value;
+use tokio::fs;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Stream kind used by output file helpers.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BashStreamKind {
+    Stdout,
+    Stderr,
+}
+
+impl BashStreamKind {
+    pub fn output_stream(self) -> ToolOutputStream {
+        match self {
+            Self::Stdout => ToolOutputStream::Stdout,
+            Self::Stderr => ToolOutputStream::Stderr,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task lifecycle state machine
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundTaskStatus {
+    Running,
+    Completed,
+    Failed,
+    Killed,
+}
+
+/// Higher-level classifier for background task lifecycle state.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundTaskState {
+    Working,
+    Blocked,
+    Done,
+    Failed,
+}
+
+impl BackgroundTaskStatus {
+    pub fn classify(self) -> BackgroundTaskState {
+        match self {
+            Self::Running | Self::Killed => BackgroundTaskState::Working,
+            Self::Completed => BackgroundTaskState::Done,
+            Self::Failed => BackgroundTaskState::Failed,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task record
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BackgroundTaskRecord {
+    pub id: String,
+    pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub program: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub args: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    pub output_path: PathBuf,
+    pub status: BackgroundTaskStatus,
+    pub exit_code: Option<i32>,
+    pub sandboxed: bool,
+    pub sandbox_backend: String,
+    pub network_access: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Task store
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct BackgroundTaskStore {
+    dir: PathBuf,
+    tasks: Arc<Mutex<HashMap<String, BackgroundTaskRecord>>>,
+    stop_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>>,
+}
+
+impl BackgroundTaskStore {
+    pub fn new(dir: PathBuf) -> Result<Self, ToolError> {
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self {
+            dir,
+            tasks: Arc::new(Mutex::new(HashMap::new())),
+            stop_signals: Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    pub fn start_record(
+        &self,
+        command: String,
+        program: Option<String>,
+        args: Vec<String>,
+        cwd: Option<String>,
+        sandboxed: bool,
+        sandbox_backend: String,
+        network_access: bool,
+    ) -> Result<(BackgroundTaskRecord, oneshot::Receiver<()>), ToolError> {
+        let id = format!("bash-{}", Uuid::new_v4());
+        let output_path = self.dir.join(format!("{id}.log"));
+        let record = BackgroundTaskRecord {
+            id: id.clone(),
+            command,
+            program,
+            args,
+            cwd,
+            output_path,
+            status: BackgroundTaskStatus::Running,
+            exit_code: None,
+            sandboxed,
+            sandbox_backend,
+            network_access,
+        };
+        let (stop_tx, stop_rx) = oneshot::channel();
+        self.tasks
+            .lock()
+            .unwrap()
+            .insert(id.clone(), record.clone());
+        self.stop_signals.lock().unwrap().insert(id, stop_tx);
+        Ok((record, stop_rx))
+    }
+
+    pub fn finish(&self, id: &str, status: BackgroundTaskStatus, exit_code: Option<i32>) {
+        if let Some(record) = self.tasks.lock().unwrap().get_mut(id) {
+            if !matches!(record.status, BackgroundTaskStatus::Killed) {
+                record.status = status;
+            }
+            record.exit_code = exit_code;
+        }
+        self.stop_signals.lock().unwrap().remove(id);
+    }
+
+    pub fn get(&self, id: &str) -> Option<BackgroundTaskRecord> {
+        self.tasks.lock().unwrap().get(id).cloned()
+    }
+
+    pub fn list(&self) -> Vec<BackgroundTaskRecord> {
+        let mut records: Vec<_> = self.tasks.lock().unwrap().values().cloned().collect();
+        records.sort_by(|left, right| left.id.cmp(&right.id));
+        records
+    }
+
+    pub fn stop(&self, id: &str) -> Result<BackgroundTaskRecord, ToolError> {
+        let mut tasks = self.tasks.lock().unwrap();
+        let record = tasks
+            .get_mut(id)
+            .ok_or_else(|| ToolError::InvalidInput(format!("unknown task id: {id}")))?;
+        if !matches!(record.status, BackgroundTaskStatus::Running) {
+            return Ok(record.clone());
+        }
+        record.status = BackgroundTaskStatus::Killed;
+        let stopped = record.clone();
+        drop(tasks);
+
+        if let Some(stop) = self.stop_signals.lock().unwrap().remove(id) {
+            let _ = stop.send(());
+        }
+        Ok(stopped)
+    }
+
+    pub fn stop_all(&self) -> Vec<BackgroundTaskRecord> {
+        let ids: Vec<_> = self
+            .list()
+            .into_iter()
+            .filter(|record| matches!(record.status, BackgroundTaskStatus::Running))
+            .map(|record| record.id)
+            .collect();
+        ids.into_iter()
+            .filter_map(|id| self.stop(&id).ok())
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Output-file helpers
+// ---------------------------------------------------------------------------
+
+pub async fn append_background_output(
+    path: &Path,
+    stream: BashStreamKind,
+    chunk: &str,
+) -> Result<(), ToolError> {
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .await?;
+    use tokio::io::AsyncWriteExt;
+    match stream {
+        BashStreamKind::Stdout => {
+            file.write_all(chunk.as_bytes()).await?;
+        }
+        BashStreamKind::Stderr => {
+            file.write_all(b"[stderr] ").await?;
+            file.write_all(chunk.as_bytes()).await?;
+        }
+    }
+    Ok(())
+}
+
+pub async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolError> {
+    let mut file = match fs::File::open(path).await {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
+        Err(err) => return Err(err.into()),
+    };
+    let file_len = file.metadata().await?.len();
+    let start = file_len.saturating_sub(max_bytes as u64);
+    file.seek(SeekFrom::Start(start)).await?;
+    let mut bytes = Vec::with_capacity(max_bytes.min(file_len as usize));
+    file.read_to_end(&mut bytes).await?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+// ---------------------------------------------------------------------------
+// Tool implementations for the agent loop
+// ---------------------------------------------------------------------------
+
+pub struct BackgroundTaskListTool {
+    pub background_tasks: Arc<BackgroundTaskStore>,
+}
+
+#[tool_spec(
+    name = "background_task_list",
+    description = "List background bash tasks started with bash run_in_background. Use this before starting duplicate long-running work when task state is unclear.",
+    input_schema = {
+        "type": "object",
+        "properties": {}
+    }
+)]
+#[async_trait]
+impl Tool for BackgroundTaskListTool {
+    async fn call(&self, _input: Value) -> Result<Value, ToolError> {
+        Ok(serde_json::json!({
+            "tasks": self.background_tasks.list(),
+        }))
+    }
+}
+
+pub struct BackgroundTaskStatusTool {
+    pub background_tasks: Arc<BackgroundTaskStore>,
+}
+
+#[tool_spec(
+    name = "background_task_status",
+    description = "Inspect a background bash task started with bash run_in_background and read the tail of its output.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Background task id returned by bash run_in_background."
+            },
+            "tail_bytes": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 12000,
+                "description": "Maximum number of output bytes to return from the end of the task log."
+            }
+        },
+        "required": ["task_id"]
+    }
+)]
+#[async_trait]
+impl Tool for BackgroundTaskStatusTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let task_id = input["task_id"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("task_id".into()))?;
+        let tail_bytes = input
+            .get("tail_bytes")
+            .and_then(Value::as_u64)
+            .unwrap_or(12_000)
+            .min(1_000_000) as usize;
+        let record = self
+            .background_tasks
+            .get(task_id)
+            .ok_or_else(|| ToolError::InvalidInput(format!("unknown task id: {task_id}")))?;
+        let output = read_output_tail(&record.output_path, tail_bytes).await?;
+
+        Ok(serde_json::json!({
+            "task_id": record.id,
+            "command": record.command,
+            "program": record.program,
+            "args": record.args,
+            "cwd": record.cwd,
+            "status": record.status,
+            "exit_code": record.exit_code,
+            "output_path": record.output_path,
+            "output": output,
+            "sandboxed": record.sandboxed,
+            "sandbox_backend": record.sandbox_backend,
+            "network_access": record.network_access,
+        }))
+    }
+}
+
+pub struct BackgroundTaskStopTool {
+    pub background_tasks: Arc<BackgroundTaskStore>,
+}
+
+#[tool_spec(
+    name = "background_task_stop",
+    description = "Stop one background bash task, or all running background bash tasks when task_id is omitted.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Background task id returned by bash run_in_background. Omit to stop all running background bash tasks."
+            }
+        }
+    }
+)]
+#[async_trait]
+impl Tool for BackgroundTaskStopTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        if let Some(task_id) = input.get("task_id").and_then(Value::as_str) {
+            let task = self.background_tasks.stop(task_id)?;
+            return Ok(serde_json::json!({ "stopped": [task] }));
+        }
+        Ok(serde_json::json!({ "stopped": self.background_tasks.stop_all() }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn read_output_tail_returns_only_requested_suffix() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("task.log");
+        tokio::fs::write(&path, "0123456789").await.unwrap();
+        let tail = read_output_tail(&path, 3).await.unwrap();
+        assert_eq!(tail, "789");
+    }
+
+    #[tokio::test]
+    async fn read_output_tail_missing_file_is_empty() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("nope.log");
+        let tail = read_output_tail(&path, 12_000).await.unwrap();
+        assert!(tail.is_empty());
+    }
+
+    #[tokio::test]
+    async fn start_stop_finish() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = BackgroundTaskStore::new(dir.path().to_path_buf()).unwrap();
+
+        let (record, stop_rx) = store
+            .start_record(
+                "echo hi".into(),
+                None,
+                vec![],
+                None,
+                false,
+                String::new(),
+                false,
+            )
+            .unwrap();
+        assert_eq!(record.status, BackgroundTaskStatus::Running);
+
+        let stored = store.get(&record.id).unwrap();
+        assert_eq!(stored.command, "echo hi");
+
+        let list = store.list();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, record.id);
+
+        drop(stop_rx);
+        let stopped = store.stop(&record.id).unwrap();
+        assert_eq!(stopped.status, BackgroundTaskStatus::Killed);
+    }
+
+    #[tokio::test]
+    async fn stop_all_stops_running() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = BackgroundTaskStore::new(dir.path().to_path_buf()).unwrap();
+
+        let (r1, rx1) = store
+            .start_record(
+                "cmd1".into(),
+                None,
+                vec![],
+                None,
+                false,
+                String::new(),
+                false,
+            )
+            .unwrap();
+        let (r2, rx2) = store
+            .start_record(
+                "cmd2".into(),
+                None,
+                vec![],
+                None,
+                false,
+                String::new(),
+                false,
+            )
+            .unwrap();
+
+        store.finish(&r1.id, BackgroundTaskStatus::Completed, Some(0));
+        drop(rx1);
+
+        drop(rx2);
+        let stopped = store.stop_all();
+        assert_eq!(stopped.len(), 1);
+        assert_eq!(stopped[0].id, r2.id);
+    }
+
+    #[tokio::test]
+    async fn append_and_read_output() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("out.log");
+
+        append_background_output(&path, BashStreamKind::Stdout, "hello")
+            .await
+            .unwrap();
+        append_background_output(&path, BashStreamKind::Stderr, "error")
+            .await
+            .unwrap();
+
+        let tail = read_output_tail(&path, 100).await.unwrap();
+        assert!(tail.contains("hello"));
+        assert!(tail.contains("[stderr] error"));
+    }
+}

--- a/crates/rara-background-tasks/src/lib.rs
+++ b/crates/rara-background-tasks/src/lib.rs
@@ -143,34 +143,55 @@ impl BackgroundTaskStore {
         let (stop_tx, stop_rx) = oneshot::channel();
         self.tasks
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .insert(id.clone(), record.clone());
-        self.stop_signals.lock().unwrap().insert(id, stop_tx);
+        self.stop_signals
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id, stop_tx);
         Ok((record, stop_rx))
     }
 
     pub fn finish(&self, id: &str, status: BackgroundTaskStatus, exit_code: Option<i32>) {
-        if let Some(record) = self.tasks.lock().unwrap().get_mut(id) {
+        if let Some(record) = self
+            .tasks
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get_mut(id)
+        {
             if !matches!(record.status, BackgroundTaskStatus::Killed) {
                 record.status = status;
             }
             record.exit_code = exit_code;
         }
-        self.stop_signals.lock().unwrap().remove(id);
+        self.stop_signals
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(id);
     }
 
     pub fn get(&self, id: &str) -> Option<BackgroundTaskRecord> {
-        self.tasks.lock().unwrap().get(id).cloned()
+        self.tasks
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(id)
+            .cloned()
     }
 
     pub fn list(&self) -> Vec<BackgroundTaskRecord> {
-        let mut records: Vec<_> = self.tasks.lock().unwrap().values().cloned().collect();
+        let mut records: Vec<_> = self
+            .tasks
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .cloned()
+            .collect();
         records.sort_by(|left, right| left.id.cmp(&right.id));
         records
     }
 
     pub fn stop(&self, id: &str) -> Result<BackgroundTaskRecord, ToolError> {
-        let mut tasks = self.tasks.lock().unwrap();
+        let mut tasks = self.tasks.lock().unwrap_or_else(|e| e.into_inner());
         let record = tasks
             .get_mut(id)
             .ok_or_else(|| ToolError::InvalidInput(format!("unknown task id: {id}")))?;
@@ -181,7 +202,12 @@ impl BackgroundTaskStore {
         let stopped = record.clone();
         drop(tasks);
 
-        if let Some(stop) = self.stop_signals.lock().unwrap().remove(id) {
+        if let Some(stop) = self
+            .stop_signals
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(id)
+        {
             let _ = stop.send(());
         }
         Ok(stopped)

--- a/docs/journal/2026-05-21-background-tasks-extraction.md
+++ b/docs/journal/2026-05-21-background-tasks-extraction.md
@@ -1,0 +1,58 @@
+# Background Tasks Extraction
+
+## Summary
+
+Extracted background-task execution functions from `src/tools/bash.rs` into the
+`rara-background-tasks` crate, completing the extraction started in the
+previous commit (`fae99db`).
+
+## Background
+
+The initial extraction (`fae99db`) moved the background task tools
+(BackgroundTaskListTool, BackgroundTaskStatusTool, BackgroundTaskStopTool),
+the task store, records, status types, and output helpers. This left the
+core execution functions (`run_background_bash_task`, `read_stream_chunks`,
+`kill_child_process_group`) still in bash.rs.
+
+## Scope
+
+Moved from `src/tools/bash.rs` into `crates/rara-background-tasks`:
+
+- `run_background_bash_task` — refactored to accept `sandbox_warning: Option<&str>`
+  and `cleanup_path: Option<&Path>` instead of the full `WrappedCommand`, removing
+  the sandbox-module dependency from the crate.
+- `read_stream_chunks` — generic stream reader, also used by the non-background
+  (synchronous) bash execution path.
+- `kill_child_process_group` — best-effort process group cancellation, also used
+  in the synchronous path.
+
+The caller `spawn_background_bash_task` stays in bash.rs as glue. It computes the
+sandbox warning string and cleanup path from `WrappedCommand` before calling
+the crate's `run_background_bash_task`.
+
+## Key Decisions
+
+- `kill_child_process_group` and `read_stream_chunks` are `pub` in the crate so
+  the non-background path in bash.rs can call them directly.
+- Added `tokio` features `process`, `rt`, `macros` and `libc` (unix-only) to the
+  crate deps for the moved execution code.
+- Kept `spawn_background_bash_task` in bash.rs as the adapter between
+  `WrappedCommand` and the crate's simplified interface.
+
+## Validation
+
+```bash
+cargo check              # passes, only pre-existing warnings
+cargo test -p rara-background-tasks  # 5/5 passed
+cargo fmt                # clean
+```
+
+## File Sizes
+
+| File | Before (phase 1) | Before (phase 2) | After |
+|------|-----------------|-------------------|-------|
+| `src/tools/bash.rs` | 2315 | 1971 | 1859 |
+| `crates/rara-background-tasks/src/lib.rs` | — | 463 | 581 |
+
+bash.rs is still over the 800-line threshold and needs further splitting by
+tool group (file-split milestone tracked in `docs/todo.md`).

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -14,6 +14,7 @@ Active backlog only. Keep this file small and current.
 - [x] LSP spec: built-in tool design, 4-phase plan (#431)
 - [x] Memory Phase 1: file I/O with path-traversal protection (#432)
 - [x] Hook registry: remove `#[allow(dead_code)]`, already wired
+- [x] background-tasks extraction: moved run_background_bash_task, read_stream_chunks, kill_child_process_group to rara-background-tasks crate (bash.rs 2315→1859 lines)
 
 ## Next Up (short-term, ready to implement)
 
@@ -46,7 +47,7 @@ Active backlog only. Keep this file small and current.
 - [x] Replace sleep-based LSP initialization with response-aware handshake handling
 
 ### File Splits (P0)
-- [ ] `tools/bash.rs` (2315 lines) → by tool group
+- [ ] `tools/bash.rs` (1859 lines) → by tool group (partial: background-tasks extracted)
 - [ ] `tools/pty.rs` (1649 lines) → stream read/write
 - [ ] `tools/agent.rs` (1701 lines) → by tool group
 - [ ] `memory_store.rs` (1625 lines) → LanceDB + legacy

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, atomic::AtomicBool};
 
+use rara_background_tasks::{
+    BackgroundTaskListTool, BackgroundTaskStatusTool, BackgroundTaskStopTool, BackgroundTaskStore,
+};
 use rara_memory::vectordb::VectorDB;
 use rara_tools::file::{
     FileReadState, ListFilesTool, MultiEditTool, ReadFileTool, ReplaceLinesTool, ReplaceTool,
@@ -22,10 +25,7 @@ use crate::tools::agent::{
     AgentTool, BackgroundSubAgentStore, ExploreAgentTool, PlanAgentTool, SubAgentListTool,
     SubAgentResumeTool, SubAgentStopTool, TeamCreateTool,
 };
-use crate::tools::bash::{
-    BackgroundTaskListTool, BackgroundTaskStatusTool, BackgroundTaskStopTool, BackgroundTaskStore,
-    BashTool,
-};
+use crate::tools::bash::BashTool;
 use crate::tools::context::RetrieveSessionContextTool;
 use crate::tools::goal::{CreateGoalTool, GetGoalTool, UpdateGoalTool};
 use crate::tools::lsp::LspDiagnosticsTool;

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -1,27 +1,29 @@
 use std::collections::HashMap;
 use std::env;
-use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use std::time::Instant;
 
 use async_trait::async_trait;
+use rara_background_tasks::{
+    BackgroundTaskListTool, BackgroundTaskRecord, BackgroundTaskState, BackgroundTaskStatus,
+    BackgroundTaskStatusTool, BackgroundTaskStopTool, BackgroundTaskStore, BashStreamKind,
+    append_background_output, read_output_tail,
+};
 use rara_tool_macros::tool_spec;
 use rara_tools::tool::{Tool, ToolCallContext, ToolError, ToolOutputStream, ToolProgressEvent};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::time::{Instant as TokioInstant, MissedTickBehavior};
-use uuid::Uuid;
 
 use crate::sandbox::{SandboxManager, WrappedCommand, sandbox_failure_hint};
 use crate::tool_result::model_preview_bash_output;
@@ -32,87 +34,6 @@ pub struct BashTool {
     pub background_tasks: Arc<BackgroundTaskStore>,
     pub base_env: Arc<HashMap<String, String>>,
     pub sandbox_network_access: Arc<AtomicBool>,
-}
-
-pub struct BackgroundTaskStatusTool {
-    pub background_tasks: Arc<BackgroundTaskStore>,
-}
-
-pub struct BackgroundTaskListTool {
-    pub background_tasks: Arc<BackgroundTaskStore>,
-}
-
-pub struct BackgroundTaskStopTool {
-    pub background_tasks: Arc<BackgroundTaskStore>,
-}
-
-#[derive(Debug, Clone)]
-pub struct BackgroundTaskStore {
-    dir: PathBuf,
-    tasks: Arc<Mutex<HashMap<String, BackgroundTaskRecord>>>,
-    stop_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct BackgroundTaskRecord {
-    id: String,
-    command: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    program: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    args: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    cwd: Option<String>,
-    output_path: PathBuf,
-    status: BackgroundTaskStatus,
-    exit_code: Option<i32>,
-    sandboxed: bool,
-    sandbox_backend: String,
-    network_access: bool,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum BackgroundTaskStatus {
-    Running,
-    Completed,
-    Failed,
-    Killed,
-}
-
-/// Higher-level classifier for background task lifecycle state.
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum BackgroundTaskState {
-    Working,
-    Blocked,
-    Done,
-    Failed,
-}
-
-impl BackgroundTaskStatus {
-    pub fn classify(self) -> BackgroundTaskState {
-        match self {
-            Self::Running | Self::Killed => BackgroundTaskState::Working,
-            Self::Completed => BackgroundTaskState::Done,
-            Self::Failed => BackgroundTaskState::Failed,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum BashStreamKind {
-    Stdout,
-    Stderr,
-}
-
-impl BashStreamKind {
-    fn output_stream(self) -> ToolOutputStream {
-        match self {
-            Self::Stdout => ToolOutputStream::Stdout,
-            Self::Stderr => ToolOutputStream::Stderr,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -431,132 +352,6 @@ fn parse_cd_target(input: &str) -> Option<(String, &str)> {
     Some((path.to_string(), &input[path_end..]))
 }
 
-impl BackgroundTaskStore {
-    pub fn new(dir: PathBuf) -> Result<Self, ToolError> {
-        std::fs::create_dir_all(&dir)?;
-        Ok(Self {
-            dir,
-            tasks: Arc::new(Mutex::new(HashMap::new())),
-            stop_signals: Arc::new(Mutex::new(HashMap::new())),
-        })
-    }
-
-    fn start_record(
-        &self,
-        request: &BashCommandInput,
-        sandboxed: bool,
-        sandbox_backend: String,
-        network_access: bool,
-    ) -> Result<(BackgroundTaskRecord, oneshot::Receiver<()>), ToolError> {
-        let id = format!("bash-{}", Uuid::new_v4());
-        let output_path = self.dir.join(format!("{id}.log"));
-        let record = BackgroundTaskRecord {
-            id: id.clone(),
-            command: request.summary(),
-            program: request
-                .program
-                .as_deref()
-                .filter(|v| !v.trim().is_empty())
-                .map(String::from),
-            args: request.args.clone(),
-            cwd: request
-                .cwd
-                .as_ref()
-                .filter(|d| !d.trim().is_empty())
-                .cloned(),
-            output_path,
-            status: BackgroundTaskStatus::Running,
-            exit_code: None,
-            sandboxed,
-            sandbox_backend,
-            network_access,
-        };
-        let (stop_tx, stop_rx) = oneshot::channel();
-        self.tasks
-            .lock()
-            .expect("background task store lock")
-            .insert(id.clone(), record.clone());
-        self.stop_signals
-            .lock()
-            .expect("background task stop signal lock")
-            .insert(id, stop_tx);
-        Ok((record, stop_rx))
-    }
-
-    fn finish(&self, id: &str, status: BackgroundTaskStatus, exit_code: Option<i32>) {
-        if let Some(record) = self
-            .tasks
-            .lock()
-            .expect("background task store lock")
-            .get_mut(id)
-        {
-            if !matches!(record.status, BackgroundTaskStatus::Killed) {
-                record.status = status;
-            }
-            record.exit_code = exit_code;
-        }
-        self.stop_signals
-            .lock()
-            .expect("background task stop signal lock")
-            .remove(id);
-    }
-
-    fn get(&self, id: &str) -> Option<BackgroundTaskRecord> {
-        self.tasks
-            .lock()
-            .expect("background task store lock")
-            .get(id)
-            .cloned()
-    }
-
-    fn list(&self) -> Vec<BackgroundTaskRecord> {
-        let mut records = self
-            .tasks
-            .lock()
-            .expect("background task store lock")
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        records.sort_by(|left, right| left.id.cmp(&right.id));
-        records
-    }
-
-    fn stop(&self, id: &str) -> Result<BackgroundTaskRecord, ToolError> {
-        let mut tasks = self.tasks.lock().expect("background task store lock");
-        let record = tasks
-            .get_mut(id)
-            .ok_or_else(|| ToolError::InvalidInput(format!("unknown task id: {id}")))?;
-        if !matches!(record.status, BackgroundTaskStatus::Running) {
-            return Ok(record.clone());
-        }
-        record.status = BackgroundTaskStatus::Killed;
-        let stopped = record.clone();
-        drop(tasks);
-
-        if let Some(stop) = self
-            .stop_signals
-            .lock()
-            .expect("background task stop signal lock")
-            .remove(id)
-        {
-            let _ = stop.send(());
-        }
-        Ok(stopped)
-    }
-
-    fn stop_all(&self) -> Vec<BackgroundTaskRecord> {
-        let ids = self
-            .list()
-            .into_iter()
-            .filter(|record| matches!(record.status, BackgroundTaskStatus::Running))
-            .map(|record| record.id)
-            .collect::<Vec<_>>();
-        ids.into_iter()
-            .filter_map(|id| self.stop(&id).ok())
-            .collect()
-    }
-}
-
 fn sandbox_command_env(
     sandbox_home: &Path,
     base_env: &HashMap<String, String>,
@@ -795,7 +590,18 @@ impl Tool for BashTool {
         let sandbox_perm = request.sandbox_permissions;
         if request.run_in_background {
             let (record, stop_rx) = self.background_tasks.start_record(
-                &request,
+                request.summary(),
+                request
+                    .program
+                    .as_deref()
+                    .filter(|v| !v.trim().is_empty())
+                    .map(String::from),
+                request.args.clone(),
+                request
+                    .cwd
+                    .as_ref()
+                    .filter(|d| !d.trim().is_empty())
+                    .cloned(),
                 wrapped.sandboxed,
                 wrapped.sandbox_backend.clone(),
                 wrapped.network_access,
@@ -974,101 +780,6 @@ impl Tool for BashTool {
     }
 }
 
-#[tool_spec(
-    name = "background_task_list",
-    description = "List background bash tasks started with bash run_in_background. Use this before starting duplicate long-running work when task state is unclear.",
-    input_schema = {
-        "type": "object",
-        "properties": {}
-    }
-)]
-#[async_trait]
-impl Tool for BackgroundTaskListTool {
-    async fn call(&self, _input: Value) -> Result<Value, ToolError> {
-        Ok(json!({
-            "tasks": self.background_tasks.list(),
-        }))
-    }
-}
-
-#[tool_spec(
-    name = "background_task_status",
-    description = "Inspect a background bash task started with bash run_in_background and read the tail of its output.",
-    input_schema = {
-        "type": "object",
-        "properties": {
-            "task_id": {
-                "type": "string",
-                "description": "Background task id returned by bash run_in_background."
-            },
-            "tail_bytes": {
-                "type": "integer",
-                "minimum": 1,
-                "default": 12000,
-                "description": "Maximum number of output bytes to return from the end of the task log."
-            }
-        },
-        "required": ["task_id"]
-    }
-)]
-#[async_trait]
-impl Tool for BackgroundTaskStatusTool {
-    async fn call(&self, input: Value) -> Result<Value, ToolError> {
-        let task_id = input["task_id"]
-            .as_str()
-            .ok_or_else(|| ToolError::InvalidInput("task_id".into()))?;
-        let tail_bytes = input
-            .get("tail_bytes")
-            .and_then(Value::as_u64)
-            .unwrap_or(12_000)
-            .min(1_000_000) as usize;
-        let record = self
-            .background_tasks
-            .get(task_id)
-            .ok_or_else(|| ToolError::InvalidInput(format!("unknown task id: {task_id}")))?;
-        let output = read_output_tail(&record.output_path, tail_bytes).await?;
-
-        Ok(json!({
-            "task_id": record.id,
-            "command": record.command,
-            "program": record.program,
-            "args": record.args,
-            "cwd": record.cwd,
-            "status": record.status,
-            "exit_code": record.exit_code,
-            "output_path": record.output_path,
-            "output": output,
-            "sandboxed": record.sandboxed,
-            "sandbox_backend": record.sandbox_backend,
-            "network_access": record.network_access,
-        }))
-    }
-}
-
-#[tool_spec(
-    name = "background_task_stop",
-    description = "Stop one background bash task, or all running background bash tasks when task_id is omitted.",
-    input_schema = {
-        "type": "object",
-        "properties": {
-            "task_id": {
-                "type": "string",
-                "description": "Background task id returned by bash run_in_background. Omit to stop all running background bash tasks."
-            }
-        }
-    }
-)]
-#[async_trait]
-impl Tool for BackgroundTaskStopTool {
-    async fn call(&self, input: Value) -> Result<Value, ToolError> {
-        if let Some(task_id) = input.get("task_id").and_then(Value::as_str) {
-            let task = self.background_tasks.stop(task_id)?;
-            return Ok(json!({ "stopped": [task] }));
-        }
-        Ok(json!({ "stopped": self.background_tasks.stop_all() }))
-    }
-}
-
 fn spawn_background_bash_task(
     mut child: Child,
     wrapped: WrappedCommand,
@@ -1189,40 +900,6 @@ async fn run_background_bash_task(
         let _ = fs::remove_file(path).await;
     }
     Ok(status.code())
-}
-
-async fn append_background_output(
-    path: &Path,
-    stream: BashStreamKind,
-    chunk: &str,
-) -> Result<(), ToolError> {
-    let mut file = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .await?;
-    match stream {
-        BashStreamKind::Stdout => file.write_all(chunk.as_bytes()).await?,
-        BashStreamKind::Stderr => {
-            file.write_all(b"[stderr] ").await?;
-            file.write_all(chunk.as_bytes()).await?;
-        }
-    }
-    Ok(())
-}
-
-async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolError> {
-    let mut file = match fs::File::open(path).await {
-        Ok(file) => file,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
-        Err(err) => return Err(err.into()),
-    };
-    let file_len = file.metadata().await?.len();
-    let start = file_len.saturating_sub(max_bytes as u64);
-    file.seek(SeekFrom::Start(start)).await?;
-    let mut bytes = Vec::with_capacity(max_bytes.min(file_len as usize));
-    file.read_to_end(&mut bytes).await?;
-    Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
 async fn read_stream_chunks<R>(
@@ -1355,15 +1032,18 @@ mod tests {
     };
     use std::time::Duration;
 
+    use rara_background_tasks::{
+        BackgroundTaskListTool, BackgroundTaskStatus, BackgroundTaskStatusTool,
+        BackgroundTaskStopTool, BackgroundTaskStore, BashStreamKind, read_output_tail,
+    };
     use rara_tools::tool::{Tool, ToolCallContext, ToolOutputStream, ToolProgressEvent};
     use serde_json::{Value, json};
     use tempfile::tempdir;
 
     use super::{
-        BackgroundTaskListTool, BackgroundTaskStatus, BackgroundTaskStatusTool,
-        BackgroundTaskStopTool, BackgroundTaskStore, BashCommandInput, BashSandboxPermissions,
-        BashStreamKind, BashTool, append_aggregated_bash_output, command_env_for_wrapped,
-        read_output_tail, sandbox_command_env, sandbox_output_hint, unsandboxed_execution_warning,
+        BashCommandInput, BashSandboxPermissions, BashTool, append_aggregated_bash_output,
+        command_env_for_wrapped, sandbox_command_env, sandbox_output_hint,
+        unsandboxed_execution_warning,
     };
     use crate::sandbox::{SandboxManager, WrappedCommand};
     use crate::tool_result::model_preview_bash_output;
@@ -2276,30 +1956,6 @@ mod tests {
                 .and_then(Value::as_bool),
             Some(wrapped.network_access)
         );
-    }
-
-    #[tokio::test]
-    async fn read_output_tail_returns_only_requested_suffix() {
-        let temp = tempdir().expect("tempdir");
-        let path = temp.path().join("task.log");
-        tokio::fs::write(&path, b"0123456789tail")
-            .await
-            .expect("write log");
-
-        let output = read_output_tail(&path, 4).await.expect("tail");
-
-        assert_eq!(output, "tail");
-    }
-
-    #[tokio::test]
-    async fn read_output_tail_missing_file_is_empty() {
-        let temp = tempdir().expect("tempdir");
-
-        let output = read_output_tail(&temp.path().join("missing.log"), 4)
-            .await
-            .expect("missing tail");
-
-        assert_eq!(output, "");
     }
 
     fn binary_exists(program: &str) -> bool {

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -639,12 +639,16 @@ impl Tool for BashTool {
             .ok_or_else(|| ToolError::ExecutionFailed("stderr pipe unavailable".into()))?;
 
         let (tx, mut rx) = mpsc::channel(64);
-        let stdout_task = tokio::spawn(read_stream_chunks(
+        let stdout_task = tokio::spawn(rara_background_tasks::read_stream_chunks(
             stdout,
             BashStreamKind::Stdout,
             tx.clone(),
         ));
-        let stderr_task = tokio::spawn(read_stream_chunks(stderr, BashStreamKind::Stderr, tx));
+        let stderr_task = tokio::spawn(rara_background_tasks::read_stream_chunks(
+            stderr,
+            BashStreamKind::Stderr,
+            tx,
+        ));
 
         let mut stdout_text = String::new();
         let mut stderr_text = String::new();
@@ -713,7 +717,7 @@ impl Tool for BashTool {
                             stream: ToolOutputStream::Stderr,
                             chunk,
                         });
-                        kill_child_process_group(process_group_id);
+                        rara_background_tasks::kill_child_process_group(process_group_id);
                         let _ = child.start_kill();
                         cancellation_watchdog
                             .as_mut()
@@ -789,14 +793,21 @@ fn spawn_background_bash_task(
     stop_rx: oneshot::Receiver<()>,
     process_group_id: Option<u32>,
 ) {
+    let sandbox_warning =
+        if !wrapped.sandboxed && sandbox_permissions != BashSandboxPermissions::RequireEscalated {
+            Some(unsandboxed_execution_warning(&wrapped))
+        } else {
+            None
+        };
+    let cleanup_path = wrapped.cleanup_path.clone();
     tokio::spawn(async move {
-        let result = run_background_bash_task(
+        let result = rara_background_tasks::run_background_bash_task(
             &mut child,
-            wrapped,
-            sandbox_permissions,
             &record,
             stop_rx,
             process_group_id,
+            sandbox_warning.as_deref(),
+            cleanup_path.as_deref(),
         )
         .await;
         let (status, exit_code) = match result {
@@ -819,110 +830,6 @@ fn spawn_background_bash_task(
         };
         store.finish(&record.id, status, exit_code);
     });
-}
-
-async fn run_background_bash_task(
-    child: &mut Child,
-    wrapped: WrappedCommand,
-    sandbox_permissions: BashSandboxPermissions,
-    record: &BackgroundTaskRecord,
-    mut stop_rx: oneshot::Receiver<()>,
-    process_group_id: Option<u32>,
-) -> Result<Option<i32>, ToolError> {
-    if let Some(parent) = record.output_path.parent() {
-        fs::create_dir_all(parent).await?;
-    }
-    fs::write(&record.output_path, "").await?;
-    if !wrapped.sandboxed && sandbox_permissions != BashSandboxPermissions::RequireEscalated {
-        append_background_output(
-            &record.output_path,
-            BashStreamKind::Stderr,
-            &unsandboxed_execution_warning(&wrapped),
-        )
-        .await?;
-    }
-
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| ToolError::ExecutionFailed("stdout pipe unavailable".into()))?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| ToolError::ExecutionFailed("stderr pipe unavailable".into()))?;
-    let (tx, mut rx) = mpsc::channel(64);
-    let stdout_task = tokio::spawn(read_stream_chunks(
-        stdout,
-        BashStreamKind::Stdout,
-        tx.clone(),
-    ));
-    let stderr_task = tokio::spawn(read_stream_chunks(stderr, BashStreamKind::Stderr, tx));
-
-    let mut output_file = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&record.output_path)
-        .await?;
-    let mut stop_requested = false;
-    loop {
-        tokio::select! {
-            chunk = rx.recv() => {
-                let Some((stream, chunk)) = chunk else {
-                    break;
-                };
-                if !chunk.is_empty() {
-                    match stream {
-                        BashStreamKind::Stdout => output_file.write_all(chunk.as_bytes()).await?,
-                        BashStreamKind::Stderr => {
-                            output_file.write_all(b"[stderr] ").await?;
-                            output_file.write_all(chunk.as_bytes()).await?;
-                        }
-                    }
-                }
-            }
-            _ = &mut stop_rx, if !stop_requested => {
-                stop_requested = true;
-                kill_child_process_group(process_group_id);
-                let _ = child.start_kill();
-                output_file.write_all(b"[stderr] background task stop requested\n").await?;
-            }
-        }
-    }
-
-    let status = child.wait().await?;
-    stdout_task
-        .await
-        .map_err(|err| ToolError::ExecutionFailed(err.to_string()))??;
-    stderr_task
-        .await
-        .map_err(|err| ToolError::ExecutionFailed(err.to_string()))??;
-    if let Some(path) = wrapped.cleanup_path.as_ref() {
-        let _ = fs::remove_file(path).await;
-    }
-    Ok(status.code())
-}
-
-async fn read_stream_chunks<R>(
-    reader: R,
-    stream: BashStreamKind,
-    tx: mpsc::Sender<(BashStreamKind, String)>,
-) -> Result<(), ToolError>
-where
-    R: AsyncRead + Unpin + Send + 'static,
-{
-    let mut reader = reader;
-    let mut buffer = [0_u8; 4096];
-    loop {
-        let read = reader.read(&mut buffer).await?;
-        if read == 0 {
-            break;
-        }
-        let chunk = String::from_utf8_lossy(&buffer[..read]).into_owned();
-        if tx.send((stream, chunk)).await.is_err() {
-            break;
-        }
-    }
-    Ok(())
 }
 
 fn append_aggregated_bash_output(
@@ -985,25 +892,6 @@ fn configure_process_group(command: &mut Command) {
     #[cfg(not(unix))]
     {
         let _ = command;
-    }
-}
-
-fn kill_child_process_group(child_id: Option<u32>) {
-    #[cfg(unix)]
-    {
-        let Some(child_id) = child_id else {
-            return;
-        };
-        let process_group = -(child_id as libc::pid_t);
-        // Best-effort cancellation: the direct child may have already exited,
-        // but killing the group stops shell descendants that still hold pipes.
-        unsafe {
-            libc::kill(process_group, libc::SIGKILL);
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = child_id;
     }
 }
 

--- a/src/tui/input_control.rs
+++ b/src/tui/input_control.rs
@@ -158,6 +158,7 @@ pub(crate) fn answer_plan_approval(
         app.push_notice("Approval is still preparing. Try again.");
         return InputControlOutcome::Rejected;
     };
+    app.set_pending_plan_approval(false);
     start_plan_approval_resume_task(app, !approved, agent);
     InputControlOutcome::Answered
 }

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -149,7 +149,7 @@ impl ListPickerKind {
                 .fg(TEXT_ACCENT)
                 .add_modifier(Modifier::BOLD)
         } else {
-            Style::default()
+            Style::default().fg(TEXT_PRIMARY)
         }
     }
 
@@ -187,7 +187,7 @@ impl ListPickerKind {
                 ]);
                 let desc_line = ratatui::text::Line::from(ratatui::text::Span::styled(
                     format!("      {}", desc),
-                    Style::default().fg(TEXT_MUTED),
+                    Style::default().fg(TEXT_SECONDARY),
                 ));
                 ListItem::new(vec![name_line, desc_line]).style(Self::selected_style(idx, selected))
             })

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -4,6 +4,7 @@ pub(crate) mod diff;
 mod helpers;
 mod overlay;
 mod sidebar;
+mod spinner;
 #[cfg(test)]
 mod tests;
 mod viewport;

--- a/src/tui/render/bottom_pane/activity.rs
+++ b/src/tui/render/bottom_pane/activity.rs
@@ -8,12 +8,17 @@ use ratatui::{
 
 use super::super::super::custom_terminal::Frame;
 use super::super::helpers::badge;
+use super::super::spinner;
 use crate::tui::theme::{STATUS_INFO, TEXT_ACCENT, TEXT_MUTED};
 
 pub(super) fn render_activity_bar(f: &mut Frame, view: &super::view::ActivityView, area: Rect) {
     let mut spans: Vec<Span<'_>> = Vec::new();
     let bold = Style::default().add_modifier(Modifier::BOLD);
-    spans.push(Span::styled(view.label.as_str(), bold.fg(view.label_color)));
+
+    let elapsed = view.spinner_elapsed;
+    spans.push(spinner::spinner(view.spinner, elapsed));
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(view.label, bold.fg(view.label_color)));
 
     if view.plan_badge {
         spans.push(Span::raw(" "));

--- a/src/tui/render/bottom_pane/composer.rs
+++ b/src/tui/render/bottom_pane/composer.rs
@@ -104,12 +104,17 @@ pub(super) fn render_composer(f: &mut Frame, app: &mut TuiApp, area: Rect) -> Op
             .alignment(Alignment::Left),
         chunks[1],
     );
-    Some(composer_cursor_position(
-        app.bottom_pane.input.as_str(),
-        app.composer_cursor_offset(),
-        chunks[0],
-        app.bottom_pane.composer_scroll,
-    ))
+    let cursor = if app.bottom_pane.input.is_empty() {
+        None
+    } else {
+        Some(composer_cursor_position(
+            app.bottom_pane.input.as_str(),
+            app.composer_cursor_offset(),
+            chunks[0],
+            app.bottom_pane.composer_scroll,
+        ))
+    };
+    cursor
 }
 
 pub(super) fn composer_hint(app: &TuiApp) -> Line<'static> {

--- a/src/tui/render/bottom_pane/view.rs
+++ b/src/tui/render/bottom_pane/view.rs
@@ -4,6 +4,8 @@
 // so individual render modules (activity, footer) never
 // read TuiApp state directly.
 
+use std::time::Duration;
+
 use ratatui::style::Color;
 
 /// Pre-computed data for one bottom-pane render frame.
@@ -13,8 +15,10 @@ pub(crate) struct BottomPaneView {
 }
 
 pub(crate) struct ActivityView {
-    pub(crate) label: String,
+    pub(crate) label: &'static str,
     pub(crate) label_color: Color,
+    pub(crate) spinner: bool,
+    pub(crate) spinner_elapsed: Duration,
     pub(crate) detail: String,
     pub(crate) plan_badge: bool,
     pub(crate) perm_badge: bool,

--- a/src/tui/render/bottom_pane/view_builder.rs
+++ b/src/tui/render/bottom_pane/view_builder.rs
@@ -19,7 +19,13 @@ pub(super) fn build_bottom_pane_view(app: &TuiApp, width: u16, _height: u16) -> 
 
 fn build_activity_view(app: &TuiApp, _width: u16) -> ActivityView {
     let (label, label_color, detail) = activity_status_line(app);
-    let animated = animated_activity_label(app, label);
+    let spinner = should_show_spinner(app, label);
+    let spinner_elapsed = app
+        .bottom_pane
+        .running_task
+        .as_ref()
+        .map(|task| task.started_at.elapsed())
+        .unwrap_or_default();
     let label_already_reflects_planning = matches!(
         app.active_pending_interaction().map(|item| item.kind),
         Some(
@@ -34,8 +40,10 @@ fn build_activity_view(app: &TuiApp, _width: u16) -> ActivityView {
     let goal_detail = app.goal.as_ref().map(goal_detail_text);
 
     ActivityView {
-        label: animated,
+        label,
         label_color,
+        spinner,
+        spinner_elapsed,
         detail,
         plan_badge,
         perm_badge,
@@ -172,23 +180,14 @@ pub(super) fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String
     )
 }
 
-pub(super) fn animated_activity_label(app: &TuiApp, label: &str) -> String {
+pub(super) fn should_show_spinner(app: &TuiApp, label: &str) -> bool {
     if label.is_empty() {
-        return String::new();
+        return false;
     }
     let Some(task) = app.bottom_pane.running_task.as_ref() else {
-        return label.to_string();
+        return false;
     };
-    if !matches!(task.kind, TaskKind::Query | TaskKind::Rebuild) {
-        return label.to_string();
-    }
-
-    let dots = match (task.started_at.elapsed().as_millis() / 450) % 3 {
-        0 => ".",
-        1 => "..",
-        _ => "...",
-    };
-    format!("{label}{dots}")
+    matches!(task.kind, TaskKind::Query | TaskKind::Rebuild)
 }
 
 fn build_footer_view(app: &TuiApp) -> FooterView {

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -4,9 +4,7 @@ use ratatui::{layout::Rect, style::Color, text::Line};
 use tempfile::tempdir;
 use tokio::sync::mpsc;
 
-use super::super::view_builder::{
-    activity_status_line, animated_activity_label, footer_summary_text,
-};
+use super::super::view_builder::{activity_status_line, footer_summary_text, should_show_spinner};
 use crate::config::ConfigManager;
 use crate::tui::render::bottom_pane::composer::{
     composer_hint, composer_hint_line, wrapped_text_cursor_position, wrapped_text_rows,
@@ -372,7 +370,7 @@ async fn activity_status_line_hides_busy_progress_from_composer_bar() {
     let (label, _, detail) = activity_status_line(&app);
     assert_eq!(label, "Working");
     assert!(detail.contains("esc to interrupt"));
-    assert!(animated_activity_label(&app, label).starts_with("Working"));
+    assert!(should_show_spinner(&app, label));
 
     if let Some(task) = app.bottom_pane.running_task.take() {
         task.handle.abort();

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -229,7 +229,7 @@ fn push_todo_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bool {
     let open = todo.summary.pending + todo.summary.in_progress;
     lines.push(Line::from(Span::styled(
         format!(
-            "{}/{} done · {} open",
+            "{} / {} · {} open",
             todo.summary.completed, todo.summary.total, open
         ),
         Style::default().fg(TEXT_MUTED),
@@ -237,8 +237,8 @@ fn push_todo_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bool {
 
     if let Some(active) = todo.summary.active_item.as_deref() {
         lines.push(Line::from(Span::styled(
-            format!("Active: {active}"),
-            Style::default().fg(INTERACTION_SUB_AGENT),
+            format!("● {active}"),
+            Style::default().fg(STATUS_WARNING),
         )));
     }
 
@@ -251,7 +251,7 @@ fn push_todo_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bool {
 
     if todo.items.len() > 4 {
         lines.push(Line::from(Span::styled(
-            format!("... and {} more", todo.items.len() - 4),
+            format!("… {} more", todo.items.len() - 4),
             Style::default().fg(TEXT_MUTED),
         )));
     }
@@ -261,16 +261,16 @@ fn push_todo_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bool {
 
 fn todo_status_marker(status: &str) -> &'static str {
     match status {
-        "in_progress" => "[>]",
-        "completed" => "[x]",
-        "cancelled" => "[-]",
-        _ => "[ ]",
+        "in_progress" => "●",
+        "completed" => "☑",
+        "cancelled" => "✗",
+        _ => "☐",
     }
 }
 
 fn todo_status_style(status: &str) -> Style {
     match status {
-        "in_progress" => Style::default().fg(INTERACTION_SUB_AGENT),
+        "in_progress" => Style::default().fg(STATUS_WARNING),
         "completed" => Style::default().fg(STATUS_SUCCESS),
         "cancelled" => Style::default().fg(TEXT_MUTED),
         _ => Style::default().fg(TEXT_SECONDARY),

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -425,12 +425,12 @@ fn push_todo_section_shows_progress_and_items() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(text.contains("Todo"));
-    assert!(text.contains("1/4 done · 2 open"));
-    assert!(text.contains("Active: Run focused regression test"));
-    assert!(text.contains("[x] Reproduce failing behavior"));
-    assert!(text.contains("[>] Run focused regression test"));
-    assert!(text.contains("[ ] Check nearby side effects"));
-    assert!(text.contains("[-] Broader cleanup"));
+    assert!(text.contains("1 / 4 · 2 open"));
+    assert!(text.contains("● Run focused regression test"));
+    assert!(text.contains("☑ Reproduce failing behavior"));
+    assert!(text.contains("● Run focused regression test"));
+    assert!(text.contains("☐ Check nearby side effects"));
+    assert!(text.contains("✗ Broader cleanup"));
 }
 
 // ── push_child_sessions ─────────────────────────────────────────────

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -21,7 +21,7 @@ Prompt ideas     [1] Codex (current)
   · Find the     [2] DeepSeek
                     Use DeepSeek with an API key and model list from api.deepseek.com.
                  [3] Kimi
-Warning  War        Use Moonshot Kimi with an API key from api.moonshot.cn.
+  Warning  W        Use Moonshot Kimi with an API key from api.moonshot.cn.             .
 › Ask about
                           1-9 jump  Up/Down/jk move  Enter apply  Esc back
 

--- a/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__ssh_startup_warning_screen.snap
@@ -21,7 +21,7 @@ Prompt ideas:
   · Find the main agent loop and summarize it.
 
 
-Warning  Warning: openai-compatible is missing an API key. Use /model to configure the current provi
+  Warning  Warning: openai-compatible is missing an API key. Use /model to configure the current pro
 › Ask about the repo, request a code change, or type /help to browse commands.
 
 

--- a/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
@@ -17,7 +17,7 @@ St  Select a model across all providers.
     DeepSeek/deepseek-reasoner
     DeepSeek/deepseek-v4-flash
 Pr  DeepSeek/deepseek-v4-pro
-Re  DeepSeek/deepseek-v4-preview
+    DeepSeek/deepseek-v4-preview
 ›   Kimi/kimi-k2.6
                      Up/Down/jk move  Enter apply  Esc back
 

--- a/src/tui/render/spinner.rs
+++ b/src/tui/render/spinner.rs
@@ -1,4 +1,3 @@
-
 //! Fixed-width activity spinner.
 //!
 //! Returns a 1-character Span whose glyph and color animate over time

--- a/src/tui/render/spinner.rs
+++ b/src/tui/render/spinner.rs
@@ -1,0 +1,39 @@
+
+//! Fixed-width activity spinner.
+//!
+//! Returns a 1-character Span whose glyph and color animate over time
+//! but whose width never changes, so it does not shift adjacent layout.
+
+use std::time::Duration;
+
+use ratatui::{
+    style::{Color, Style},
+    text::Span,
+};
+
+// Nord palette reference: https://www.nordtheme.com/docs/colors-and-palettes
+const SHIMMER_COLORS: &[Color] = &[
+    Color::Rgb(0x88, 0xC0, 0xD0), // NORD8  – frost cyan
+    Color::Rgb(0x8F, 0xBC, 0xBB), // NORD7  – frost green-cyan
+    Color::Rgb(0xA3, 0xBE, 0x8C), // NORD14 – aurora green
+    Color::Rgb(0xEB, 0xCB, 0x8B), // NORD13 – aurora yellow
+    Color::Rgb(0xD0, 0x87, 0x70), // NORD12 – aurora orange
+    Color::Rgb(0x81, 0xA1, 0xC1), // NORD9  – frost blue-gray
+];
+
+/// Fixed-width 1-character spinner.
+///
+/// When `active` is false returns a plain space so the activity bar shows no
+/// spinner glyph.
+///
+/// When `active` the dot `•` is drawn with a colour that slowly cycles
+/// through the Nord frost/aurora palette.  The span is always exactly one
+/// character wide, so surrounding layout never reflows.
+pub(crate) fn spinner(active: bool, elapsed: Duration) -> Span<'static> {
+    if !active {
+        return Span::raw(" ");
+    }
+    let cycle_step = (elapsed.as_millis() / 160) as usize;
+    let color = SHIMMER_COLORS[cycle_step % SHIMMER_COLORS.len()];
+    Span::styled("•", Style::default().fg(color))
+}


### PR DESCRIPTION
## Changes

### 1. Extract rara-background-tasks crate
Single responsibility: manage background task lifecycle — register, list, stop, read output.
- Moves BackgroundTaskStore, BackgroundTaskRecord, state machine, and 3 tool implementations from src/tools/bash.rs.
- 5 focused tests.

### 2. List picker contrast
- Unselected items: Style::default() → TEXT_PRIMARY
- Descriptions: TEXT_MUTED → TEXT_SECONDARY

### 3. Fixed-width spinner
- New render/spinner.rs: always 1-char • with Nord palette cycling.
- Replaces animated_activity_label which appended variable-length dots, causing activity bar flicker.

### 4. Plan approval dismissal
- answer_plan_approval now calls set_pending_plan_approval(false), so the card disappears after user choice.

### 5. Todo sidebar unified (OpenCode style)
- Unicode markers: ☐ pending / ☑ completed / ● in_progress / ✗ cancelled
- Colors: STATUS_WARNING for in_progress, STATUS_SUCCESS for completed
- Summary line simplified

### 6. Empty-input cursor fix
- render_composer returns None cursor when input is empty, preventing cursor overlap with activity bar text.

### 7. hook_registry preserved across agent rebuilds
- RebuildSuccess consumer now assigns app.hook_registry, fixing dead-code warning.

## Validation
- cargo fmt ✅
- cargo check ✅ (112 warnings, all pre-existing)
- cargo test -p rara-background-tasks ✅ 5/5 passed