### PR TITLE
feat(memory): consolidation config, memory model, and dream prompts

### DIFF
--- a/crates/config/src/defaults.rs
+++ b/crates/config/src/defaults.rs
@@ -19,6 +19,13 @@ pub const LEGACY_CODEX_MODEL: &str = "codex";
 pub const LEGACY_CODEX_MODEL_V1: &str = "gpt-5-codex";
 pub const LEGACY_CODEX_MODEL_V1_MINI: &str = "gpt-5-codex-mini";
 
+// ── Memory consolidation (dream) defaults ────────────────────────
+pub const DEFAULT_CONSOLIDATION_MODEL: &str = "inherit";
+pub const DEFAULT_CONSOLIDATION_REASONING_EFFORT: &str = "low";
+pub const DEFAULT_CONSOLIDATION_MIN_HOURS: u64 = 24;
+pub const DEFAULT_CONSOLIDATION_MIN_SESSIONS: u64 = 5;
+pub const DEFAULT_CONSOLIDATION_SCAN_INTERVAL_MINUTES: u64 = 10;
+
 pub fn should_reset_codex_base_url(url: Option<&str>) -> bool {
     url.map(str::trim)
         .is_none_or(|value| value.is_empty() || value == LEGACY_CODEX_BASE_URL)

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -21,7 +21,35 @@ use crate::provider_surface::{ConfigValueSource, EffectiveProviderSurface, Resol
 use crate::secrets::{deserialize_secret_option, serialize_secret_option};
 use crate::serde_helpers::{normalize_optional_string, normalize_reasoning_summary};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+/// Background memory consolidation (dream) settings.
+///
+/// Consolidation runs as a background sub-agent that reads session logs,
+/// extracts durable facts, and merges them into the project memory index.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct MemoryConsolidationConfig {
+    /// Model name.  `"inherit"` (default) uses the main model.
+    #[serde(default = "default_consolidation_model")]
+    pub model: String,
+    /// Reasoning effort (low / medium / high).
+    #[serde(default = "default_consolidation_reasoning_effort")]
+    pub reasoning_effort: String,
+    /// Minimum hours since last consolidation before next is eligible.
+    pub min_hours_since_last: u64,
+    /// Minimum new touching sessions before triggering.
+    pub min_new_sessions: u64,
+    /// Minimum scan interval in minutes.
+    pub scan_interval_minutes: u64,
+}
+
+fn default_consolidation_model() -> String {
+    super::defaults::DEFAULT_CONSOLIDATION_MODEL.into()
+}
+
+fn default_consolidation_reasoning_effort() -> String {
+    super::defaults::DEFAULT_CONSOLIDATION_REASONING_EFFORT.into()
+}
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProviderConfigState {
     #[serde(
         default,

--- a/crates/rara-memory/src/dream_prompts.rs
+++ b/crates/rara-memory/src/dream_prompts.rs
@@ -1,0 +1,167 @@
+//! Dream consolidation prompts.
+//!
+//! Phase 1 subagents read session / team files and emit `MemoryBatch`
+//! (one `MemoryEntry` per durable fact).  Phase 2 merge reads the
+//! batches and updates `topics/` + `MEMORY.md`.
+//!
+//! These prompts are injected into the respective agent turns at
+//! consolidation time.  They are not part of the default system prompt.
+
+/// Prompt for a **Phase 1 subagent** that extracts durable memories
+/// from a bundle of source files (sessions, team contributions, etc.).
+pub const PHASE1_EXTRACTION_PROMPT: &str = r#"
+You are a memory extraction agent.  Your ONLY job is to read the provided
+source documents and extract durable memories — one per independently-useful
+fact, decision, insight, procedure, or experience.
+
+## What to extract
+
+A memory is ONE durable thing worth keeping.  It should stand on its own,
+readable without the conversation that produced it.  Prefer:
+- Decisions with rationale and trade-offs
+- Insights or realizations that changed future behavior
+- Procedures and workflows that will be reused
+- Important facts and reference data
+- Experiences that taught a lasting lesson
+
+## What to skip
+
+- Transient status updates ("still debugging X")
+- Task-completion markers ("done with the refactor")
+- Content that is already in the source code or AGENTS.md
+- Near-duplicates of facts you've already extracted
+
+## Importance scoring
+
+Use this scale (default 0.5):
+
+| Score     | Meaning    | When to use
+|-----------|------------|-------------
+| 0.8 – 1.0 | Critical   | Architectural decisions, breakthrough discoveries, production incidents, security-critical knowledge
+| 0.5 – 0.7 | Useful     | Standard decisions, good insights, project learnings, reusable workflows
+| 0.1 – 0.4 | Background | Reference info, minor details, casual notes, "nice to know"
+
+## Labels
+
+Choose 1–3 labels per memory:
+- `insight`   : key learnings, realizations, "aha" moments
+- `decision`  : choices with rationale and trade-offs
+- `fact`      : important data points, reference information
+- `procedure` : how-to knowledge, workflows, step-by-step guides
+- `experience`: events, conversations, outcomes
+
+## Output format
+
+Produce a JSON array — one object per memory:
+
+```json
+[
+  {
+    "title": "Short summary",
+    "content": "The knowledge itself. Markdown supported.",
+    "labels": ["decision", "infrastructure"],
+    "importance": 0.8,
+    "source": "session_abc.md#L42",
+    "tags": "database postgres performance"
+  }
+]
+```
+
+Keep the `content` concise but complete — 1 to 3 paragraphs usually.  If you
+found NO new durable information, set `nothing_new: true` and return an empty
+entries array.
+"#;
+
+/// Prompt for the **Phase 2 merge** agent.  It reads all Phase 1
+/// subagent batches and updates the project memory.
+pub const PHASE2_MERGE_PROMPT: &str = r#"
+You are a memory merge agent.  You are given a set of extracted memory
+entries from multiple subagents that read recent session logs and team
+contributions.  Your job is to merge these into the project memory.
+
+## Input
+
+1. `raw_memories/<ts>.jsonl` — Phase 1 extraction batches
+2. `topics/` — existing topic files
+3. `MEMORY.md` — the current index file
+4. `team/` — team-contributed memory files (if any)
+
+## Merge rules
+
+### Clustering
+
+Group related entries by topic.  Use existing topic files where the new
+entries naturally extend an existing subject.  Create new topic files
+only when entries clearly form a new subject.
+
+### Merging into existing topics
+
+When merging new facts into an existing topic:
+- Prepend newer/higher-importance content at the top
+- If a new entry **replaces** an old one, remove the old content and
+  add a `(updated)` note inline
+- If a new entry **refines** an old one, add a sub-heading
+- Never silently overwrite — the reader should see evolution
+
+### Conflict resolution
+
+When two entries conflict:
+- Prefer the one with higher **importance** score
+- If equal importance, prefer **more recent** (by created date)
+- Mark the lowered entry as `(deprecated)` — do NOT delete it
+
+### MEMORY.md index update
+
+Each topic file gets ONE index line in MEMORY.md:
+
+```
+★ [Title](topics/name.md) — One sentence summary tags:tag1 tag2
+· [Another](topics/foo.md) — Summary tags:tag1
+  [Minor](topics/bar.md) — Summary
+```
+
+- ★ for importance ≥ 0.8
+- · for importance ≥ 0.5
+- ` ` for lower
+
+### Team memory
+
+Team-contributed files under `team/` are treated as pre-extracted
+memories.  Don't re-extract them — merge their content directly into
+the appropriate topic files.
+
+## Down-weighting and pruning
+
+- If an entry ≤ 0.4 importance and no one has referenced it for 90 days,
+  move it to a `(legacy)` section at the bottom of the topic file.
+- If an entry ≤ 0.2 importance, you may remove it entirely from the
+  topic file (but keep it in LanceDB for archival search).
+- When removing from topic, remove its index line from MEMORY.md.
+
+## Output
+
+Update the following files (use the file-writing tools):
+1. `topics/*.md` — updated topic files
+2. `MEMORY.md` — updated index
+3. Optionally, `topics/_deleted.md` — list of removed entries for audit
+"#;
+
+/// Brief prompt appended to the consolidation agent's system message
+/// that explains the MEMORY.md format the agent must maintain.
+pub const MEMORY_INDEX_FORMAT_PROMPT: &str = r#"
+## MEMORY.md index format
+
+MEMORY.md is a **pure index** — never add paragraphs or free-form text.
+Every line is a pointer:
+
+```
+- [Title](topics/name.md) — One sentence summary tags:keyword1 keyword2
+```
+
+- `★` prefix = critical (importance ≥ 0.8)
+- `·` prefix = useful (importance ≥ 0.5)
+- ` ` prefix = background (importance < 0.5)
+
+No other formatting.  The file is parsed by tooling that expects this exact
+schema.
+"#;

--- a/crates/rara-memory/src/dream_prompts.rs
+++ b/crates/rara-memory/src/dream_prompts.rs
@@ -52,19 +52,23 @@ Choose 1–3 labels per memory:
 
 ## Output format
 
-Produce a JSON array — one object per memory:
+Produce a JSON object matching this schema:
 
 ```json
-[
-  {
-    "title": "Short summary",
-    "content": "The knowledge itself. Markdown supported.",
-    "labels": ["decision", "infrastructure"],
-    "importance": 0.8,
-    "source": "session_abc.md#L42",
-    "tags": "database postgres performance"
-  }
-]
+{
+  "producer": "subagent-A",
+  "nothing_new": false,
+  "entries": [
+    {
+      "title": "Short summary",
+      "content": "The knowledge itself. Markdown supported.",
+      "labels": ["decision", "infrastructure"],
+      "importance": 0.8,
+      "source": "session_abc.md#L42",
+      "tags": "database postgres performance"
+    }
+  ]
+}
 ```
 
 Keep the `content` concise but complete — 1 to 3 paragraphs usually.  If you
@@ -115,9 +119,9 @@ When two entries conflict:
 Each topic file gets ONE index line in MEMORY.md:
 
 ```
-★ [Title](topics/name.md) — One sentence summary tags:tag1 tag2
-· [Another](topics/foo.md) — Summary tags:tag1
-  [Minor](topics/bar.md) — Summary
+- ★ [Title](topics/name.md) — One sentence summary tags:tag1 tag2
+- · [Another](topics/foo.md) — Summary tags:tag1
+-   [Minor](topics/bar.md) — Summary
 ```
 
 - ★ for importance ≥ 0.8
@@ -155,7 +159,7 @@ MEMORY.md is a **pure index** — never add paragraphs or free-form text.
 Every line is a pointer:
 
 ```
-- [Title](topics/name.md) — One sentence summary tags:keyword1 keyword2
+- ★ [Title](topics/name.md) — One sentence summary tags:keyword1 keyword2
 ```
 
 - `★` prefix = critical (importance ≥ 0.8)

--- a/crates/rara-memory/src/lib.rs
+++ b/crates/rara-memory/src/lib.rs
@@ -1,2 +1,4 @@
+pub mod dream_prompts;
 pub mod files;
+pub mod memory_model;
 pub mod vectordb;

--- a/crates/rara-memory/src/memory_model.rs
+++ b/crates/rara-memory/src/memory_model.rs
@@ -59,9 +59,9 @@ impl MemoryEntry {
     /// A one-line pointer suitable for the `MEMORY.md` index.
     pub fn index_line(&self, topic_file: &str) -> String {
         let importance = match self.importance {
-            i if i >= 0.8 => "★",
-            i if i >= 0.5 => "·",
-            _ => " ",
+            i if i >= 0.8 => "- ★",
+            i if i >= 0.5 => "- ·",
+            _ => "-  ",
         };
         let tags = self
             .tags
@@ -82,12 +82,19 @@ impl MemoryEntry {
 /// Truncate content to at most `max_chars` characters, breaking at a word
 /// boundary.
 fn content_summary(content: &str, max_chars: usize) -> String {
-    if content.len() <= max_chars {
+    if content.chars().count() <= max_chars {
         return content.to_string();
     }
-    let end = content[..max_chars]
+    // Safe: use char_indices so we never split inside a multi-byte char.
+    let byte_end = content
+        .char_indices()
+        .take(max_chars)
+        .last()
+        .map(|(i, _c)| i)
+        .unwrap_or(0);
+    let end = content[..byte_end]
         .rfind(|c: char| c.is_whitespace())
-        .unwrap_or(max_chars);
+        .unwrap_or(byte_end);
     format!("{}…", &content[..end])
 }
 

--- a/crates/rara-memory/src/memory_model.rs
+++ b/crates/rara-memory/src/memory_model.rs
@@ -1,0 +1,103 @@
+//! Durable memory entry model with importance scoring and labels.
+//!
+//! Follows the Memory spec from Nowledge Mem:
+//!   Importance: 0.1–1.0 (default 0.5)
+//!   Labels: insight, decision, fact, procedure, experience
+//!
+//! Each `MemoryEntry` is the unit emitted by dream Phase 1 subagents
+//! and consumed by the Phase 2 merge agent.
+
+use serde::{Deserialize, Serialize};
+
+/// Importance scale for a durable memory.
+///
+/// | Range     | Meaning    | Examples
+/// |-----------|------------|----------
+/// | 0.8 – 1.0 | Critical   | Architectural decisions, breakthrough discoveries, production incidents
+/// | 0.5 – 0.7 | Useful     | Standard decisions, good insights, project learnings
+/// | 0.1 – 0.4 | Background | Reference info, minor details, casual notes
+pub type Importance = f32;
+
+/// Standard memory labels (lowercase, hyphenated).
+pub mod label {
+    pub const INSIGHT: &str = "insight";
+    pub const DECISION: &str = "decision";
+    pub const FACT: &str = "fact";
+    pub const PROCEDURE: &str = "procedure";
+    pub const EXPERIENCE: &str = "experience";
+}
+
+/// A single durable memory extracted from sessions or contributed sources.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryEntry {
+    /// Short summary (auto-generated or set manually).
+    pub title: String,
+    /// The knowledge itself.  Markdown.
+    pub content: String,
+    /// Categories for filtering / organisation.
+    #[serde(default)]
+    pub labels: Vec<String>,
+    /// 0.1 – 1.0.  Affects search ranking and briefing priority.
+    #[serde(default = "default_importance")]
+    pub importance: Importance,
+    /// Where this memory was extracted from (session id, team file, etc.).
+    #[serde(default)]
+    pub source: Option<String>,
+    /// When the memory was created / extracted.
+    #[serde(default)]
+    pub created: Option<String>,
+    /// Optional tags for LanceDB keyword search (space-separated).
+    #[serde(default)]
+    pub tags: Option<String>,
+}
+
+fn default_importance() -> Importance {
+    0.5
+}
+
+impl MemoryEntry {
+    /// A one-line pointer suitable for the `MEMORY.md` index.
+    pub fn index_line(&self, topic_file: &str) -> String {
+        let importance = match self.importance {
+            i if i >= 0.8 => "★",
+            i if i >= 0.5 => "·",
+            _ => " ",
+        };
+        let tags = self
+            .tags
+            .as_deref()
+            .map(|t| format!(" tags:{}", t))
+            .unwrap_or_default();
+        format!(
+            "{importance} [{title}]({file}) — {summary}{tags}",
+            importance = importance,
+            title = self.title,
+            file = topic_file,
+            summary = content_summary(&self.content, 120),
+            tags = tags,
+        )
+    }
+}
+
+/// Truncate content to at most `max_chars` characters, breaking at a word
+/// boundary.
+fn content_summary(content: &str, max_chars: usize) -> String {
+    if content.len() <= max_chars {
+        return content.to_string();
+    }
+    let end = content[..max_chars]
+        .rfind(|c: char| c.is_whitespace())
+        .unwrap_or(max_chars);
+    format!("{}…", &content[..end])
+}
+
+/// Collection of memory entries produced by one subagent batch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryBatch {
+    /// Which subagent (or source) produced this batch.
+    pub producer: String,
+    /// The extracted entries.
+    pub entries: Vec<MemoryEntry>,
+    /// Whether the subagent found no new durable information.
+    pub nothing_new: bool,
+}

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,12 @@
 # TODO
 
+## Recently Completed (2026-05-20)
+
+- [x] TUI popup color-block redesign: replace wireframe Borders with panel bg (#455)
+- [x] TUI popup adaptive sizing: popup_rect with overflow clamp (#455)
+- [x] Approval/stderr readability: remove special backgrounds (#459)
+- [x] wrapped_text_height fix: account for block padding (#459)
+
 Active backlog only. Keep this file small and current.
 
 ## Recently Completed (2025-07-15..16)


### PR DESCRIPTION
## Summary

Add the configuration and data model for background memory consolidation (dream). Does not yet wire the trigger logic — this is the foundation layer.

## Changes

### Consolidation config (`rara-config`)
- `MemoryConsolidationConfig`: model (default "inherit"), reasoning_effort, min_hours_since_last, min_new_sessions, scan_interval_minutes
- Default: 24h gap, 5 new sessions, 10min scan interval
- Fix `ProviderConfigState` missing Debug/Clone/Default/Serialize/Deserialize derives

### Memory model (`rara-memory`)
- `MemoryEntry`: title, content, labels, importance (0.1–1.0, default 0.5), source, tags
- Importance scale aligned with Nowledge Mem: 0.8+ critical, 0.5+ useful, <0.5 background
- Standard labels: insight, decision, fact, procedure, experience
- `MemoryBatch`: subagent output container
- `MemoryEntry::index_line()`: generates MEMORY.md index line with ★/· prefix

### Dream prompts
- `PHASE1_EXTRACTION_PROMPT`: subagent batch extraction from sessions
- `PHASE2_MERGE_PROMPT`: main model merges into topics + MEMORY.md
- `MEMORY_INDEX_FORMAT_PROMPT`: index line schema for the agent