### PR TITLE
fix: persist session state before /quit

### DIFF
--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -94,7 +94,7 @@ impl TuiApp {
         self.state_db_status = Some(state_db_status_error("unavailable", error));
     }
 
-    pub(super) fn persist_runtime_state(&mut self) {
+    pub(crate) fn persist_runtime_state(&mut self) {
         let Some(state_db) = self.state_db.as_ref() else {
             return;
         };

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -52,6 +52,7 @@ pub(crate) async fn handle_submit(
             if let Some(command) = parse_local_command(&trimmed)
                 && matches!(command.kind, LocalCommandKind::Quit)
             {
+                save_before_quit(app);
                 return execute_local_command(command, app, agent_slot, oauth_manager).await;
             }
             app.push_notice(
@@ -71,7 +72,9 @@ pub(crate) async fn handle_submit(
         return Ok(false);
     }
     if let Some(command) = parse_local_command(&trimmed) {
-        if execute_local_command(command, app, agent_slot, oauth_manager).await? {
+        let should_quit = execute_local_command(command, app, agent_slot, oauth_manager).await?;
+        if should_quit {
+            save_before_quit(app);
             return Ok(true);
         }
     } else if trimmed.starts_with('/') {
@@ -82,6 +85,12 @@ pub(crate) async fn handle_submit(
         input_control::submit_user_prompt(app, agent_slot, trimmed);
     }
     Ok(false)
+}
+
+/// Persist the active turn and runtime state before quitting.
+fn save_before_quit(app: &mut TuiApp) {
+    app.finalize_active_turn();
+    app.persist_runtime_state();
 }
 
 pub(crate) fn apply_openai_model_picker_action(


### PR DESCRIPTION
## Summary

Fix session resume losing the latest turn: call `finalize_active_turn()` + `persist_runtime_state()` in both `/quit` code paths before the event loop exits.

## Root cause

When the user typed `/quit`, the `handle_submit` function called `execute_local_command` which set the quit phase and returned `Ok(true)`. But the TRANSCRIPT's `finalize_active_turn()` was never called — the current active turn (and any uncommitted runtime state) was silently dropped. When resuming the session, the latest turn(s) were missing.

## Fix

- In the busy+quit path: call `finalize_active_turn()` + `persist_runtime_state()` before executing the quit command  
- In the non-busy+quit path: same before returning `Ok(true)`
- Made `persist_runtime_state` `pub(crate)` so `submit.rs` can call it

## Files

- `src/tui/submit.rs` — add save-before-quit calls
- `src/tui/state/persistence.rs` — `pub(super)` → `pub(crate)`