### PR TITLE
fix(tui): preserve hook_registry across agent rebuilds

### DIFF
--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -986,6 +986,7 @@ pub(crate) async fn finish_running_task_if_ready(
                 app.prompt_source_registry = Some(rebuilt.prompt_source_registry);
                 app.skill_source_registry = Some(rebuilt.skill_source_registry);
                 app.memory_handler = Some(rebuilt.memory_handler);
+                app.hook_registry = Some(rebuilt.hook_registry);
                 app.local_model_server = rebuilt.local_model_server;
                 app.config_manager.save(&app.config)?;
                 let is_bootstrap = app.setup_status.is_none();


### PR DESCRIPTION
## Summary

RebuildSuccess.hook_registry was constructed during rebuild but never restored to app.hook_registry in the consumption path.

## Fix

Added the missing line in the rebuild completion handler:
```rust
app.hook_registry = Some(rebuilt.hook_registry);
```

This also silences the pre-existing dead-code warning on the field.

## Validation

- cargo fmt ✅
- cargo check ✅ (warnings down from 113 to 112)