### PR TITLE
feat: realtime transcript persistence per entry

### DIFF
--- a/crates/rara-persistence/src/thread_turn_log.rs
+++ b/crates/rara-persistence/src/thread_turn_log.rs
@@ -99,3 +99,48 @@ fn sync_parent_dir_best_effort(parent: &Path) {
 
 #[cfg(not(unix))]
 fn sync_parent_dir_best_effort(_parent: &Path) {}
+
+const LIVE_LOG_FILE: &str = "live.jsonl";
+
+/// Append one entry to the per-session live log (realtime persistence).
+pub fn append_rollout_fragment(
+    root_dir: &Path,
+    session_id: &str,
+    entry: &PersistedTurnEntry,
+) -> Result<()> {
+    let dir = root_dir.join(session_id);
+    fs::create_dir_all(&dir)?;
+    let path = dir.join(LIVE_LOG_FILE);
+    let _lock = AdvisoryFileLock::acquire(path.with_extension("lock"))?;
+    let mut line = serde_json::to_vec(entry)?;
+    line.push(b'\n');
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .with_context(|| format!("open live log {}", path.display()))?;
+    file.write_all(&line)?;
+    file.sync_data()?;
+    #[cfg(unix)]
+    sync_parent_dir_best_effort(&dir);
+    Ok(())
+}
+
+/// Remove the live log so resume doesn't load a stale partial turn.
+pub fn clear_live_log(root_dir: &Path, session_id: &str) {
+    let path = root_dir.join(session_id).join(LIVE_LOG_FILE);
+    let _ = fs::remove_file(path);
+}
+
+/// Read all entries from the live log, oldest first.
+pub fn load_live_entries(root_dir: &Path, session_id: &str) -> Vec<PersistedTurnEntry> {
+    let path = root_dir.join(session_id).join(LIVE_LOG_FILE);
+    let Ok(content) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    content
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<PersistedTurnEntry>(l).ok())
+        .collect()
+}

--- a/crates/rara-persistence/src/thread_turn_log.rs
+++ b/crates/rara-persistence/src/thread_turn_log.rs
@@ -103,6 +103,9 @@ fn sync_parent_dir_best_effort(_parent: &Path) {}
 const LIVE_LOG_FILE: &str = "live.jsonl";
 
 /// Append one entry to the per-session live log (realtime persistence).
+///
+/// Uses buffered I/O without fsync (best-effort) — on crash the last few
+/// entries may not survive, but the committed turn log covers full turns.
 pub fn append_rollout_fragment(
     root_dir: &Path,
     session_id: &str,
@@ -111,7 +114,6 @@ pub fn append_rollout_fragment(
     let dir = root_dir.join(session_id);
     fs::create_dir_all(&dir)?;
     let path = dir.join(LIVE_LOG_FILE);
-    let _lock = AdvisoryFileLock::acquire(path.with_extension("lock"))?;
     let mut line = serde_json::to_vec(entry)?;
     line.push(b'\n');
     let mut file = OpenOptions::new()
@@ -120,27 +122,48 @@ pub fn append_rollout_fragment(
         .open(&path)
         .with_context(|| format!("open live log {}", path.display()))?;
     file.write_all(&line)?;
-    file.sync_data()?;
-    #[cfg(unix)]
-    sync_parent_dir_best_effort(&dir);
     Ok(())
 }
 
 /// Remove the live log so resume doesn't load a stale partial turn.
 pub fn clear_live_log(root_dir: &Path, session_id: &str) {
     let path = root_dir.join(session_id).join(LIVE_LOG_FILE);
-    let _ = fs::remove_file(path);
+    if let Err(e) = fs::remove_file(&path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            eprintln!(
+                "failed to clear live log for session {session_id}: {e} (path: {})",
+                path.display()
+            );
+        }
+    }
 }
 
 /// Read all entries from the live log, oldest first.
 pub fn load_live_entries(root_dir: &Path, session_id: &str) -> Vec<PersistedTurnEntry> {
     let path = root_dir.join(session_id).join(LIVE_LOG_FILE);
-    let Ok(content) = fs::read_to_string(&path) else {
-        return Vec::new();
+    let file = match fs::File::open(&path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(e) => {
+            eprintln!("failed to open live log for {session_id}: {e}");
+            return Vec::new();
+        }
     };
-    content
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .filter_map(|l| serde_json::from_str::<PersistedTurnEntry>(l).ok())
-        .collect()
+    let reader = BufReader::new(file);
+    let mut entries = Vec::new();
+    for (i, line_result) in reader.lines().enumerate() {
+        match line_result {
+            Ok(line) if line.trim().is_empty() => continue,
+            Ok(line) => match serde_json::from_str::<PersistedTurnEntry>(&line) {
+                Ok(entry) => entries.push(entry),
+                Err(e) => {
+                    eprintln!("parse error at live log line {i} for {session_id}: {e}");
+                }
+            },
+            Err(e) => {
+                eprintln!("i/o error at live log line {i} for {session_id}: {e}");
+            }
+        }
+    }
+    entries
 }

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -279,6 +279,39 @@ impl TuiApp {
                 Some(state_db_status_error("turn write failed", err.to_string()));
         }
     }
+
+    /// Realtime per-entry write to the live log (Claude Code style).
+    /// Called from push_entry so resume can recover partial turns.
+    pub(crate) fn record_entry_realtime(&self, entry: &PersistedTurnEntry) {
+        let Some(state_db) = self.state_db.as_ref() else {
+            return;
+        };
+        if self.snapshot.session_id.is_empty() {
+            return;
+        }
+        let root_dir = state_db.rollout_root();
+        if let Err(e) = rara_persistence::thread_turn_log::append_rollout_fragment(
+            &root_dir,
+            &self.snapshot.session_id,
+            entry,
+        ) {
+            eprintln!("live write failed: {e}");
+        }
+    }
+
+    /// Clear the live log after a turn is committed.
+    pub(crate) fn clear_live_log(&self) {
+        let Some(state_db) = self.state_db.as_ref() else {
+            return;
+        };
+        if self.snapshot.session_id.is_empty() {
+            return;
+        }
+        rara_persistence::thread_turn_log::clear_live_log(
+            &state_db.rollout_root(),
+            &self.snapshot.session_id,
+        );
+    }
 }
 
 fn resume_thread_matches_query(thread: &crate::thread_store::ThreadSummary, query: &str) -> bool {

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use rara_state::state_db::{
@@ -283,16 +284,12 @@ impl TuiApp {
     /// Realtime per-entry write to the live log (Claude Code style).
     /// Called from push_entry so resume can recover partial turns.
     pub(crate) fn record_entry_realtime(&self, entry: &PersistedTurnEntry) {
-        let Some(state_db) = self.state_db.as_ref() else {
+        let Some((root_dir, session_id)) = self.live_log_context() else {
             return;
         };
-        if self.snapshot.session_id.is_empty() {
-            return;
-        }
-        let root_dir = state_db.rollout_root();
         if let Err(e) = rara_persistence::thread_turn_log::append_rollout_fragment(
             &root_dir,
-            &self.snapshot.session_id,
+            &session_id,
             entry,
         ) {
             eprintln!("live write failed: {e}");
@@ -301,16 +298,19 @@ impl TuiApp {
 
     /// Clear the live log after a turn is committed.
     pub(crate) fn clear_live_log(&self) {
-        let Some(state_db) = self.state_db.as_ref() else {
+        let Some((root_dir, session_id)) = self.live_log_context() else {
             return;
         };
-        if self.snapshot.session_id.is_empty() {
-            return;
+        rara_persistence::thread_turn_log::clear_live_log(&root_dir, &session_id);
+    }
+
+    fn live_log_context(&self) -> Option<(PathBuf, String)> {
+        let state_db = self.state_db.as_ref()?;
+        let session_id = self.snapshot.session_id.clone();
+        if session_id.is_empty() {
+            return None;
         }
-        rara_persistence::thread_turn_log::clear_live_log(
-            &state_db.rollout_root(),
-            &self.snapshot.session_id,
-        );
+        Some((state_db.rollout_root(), session_id))
     }
 }
 


### PR DESCRIPTION
## Summary

Add per-entry realtime transcript persistence, modeled after Claude Code's `recordTranscript` + `enqueueWrite` pattern. Previously, the transcript was only saved at turn boundaries (`commit_active_turn`). Now each entry is immediately written to a live log, so resume can recover partial turns even if the process is killed mid-turn.

## Changes

- `append_rollout_fragment` / `clear_live_log` / `load_live_entries` in `rara_persistence::thread_turn_log` — per-entry JSONL append
- `record_entry_realtime` + `clear_live_log` on `TuiApp` — called from `push_entry` and `commit_active_turn`
- Live log cleared on turn commit; resume loads from live log if entries exist

## Flow

```
user types → push_entry → record_entry_realtime (live.jsonl)
agent tokens → push_entry → record_entry_realtime (live.jsonl)
turn commit → persist_turn (SQLite + turns.jsonl) + clear_live_log
```