### PR TITLE
fix: close command palette when input has arguments

### DIFF
--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -45,7 +45,7 @@ pub(crate) async fn dispatch_event(
             ) {
                 app.clear_resume_search();
             }
-            app.close_overlay();
+            app.dismiss_overlay();
         }
         AppEvent::CancelRunningTask => {
             input_control::handle_session_control(app, SessionControlRequest::CancelCurrentTurn);
@@ -258,7 +258,7 @@ pub(crate) async fn dispatch_event(
                     app.config.base_url.as_deref().unwrap_or("unset")
                 ));
                 if app.openai_setup_steps.is_empty() {
-                    app.close_overlay();
+                    app.dismiss_overlay();
                 } else {
                     app.advance_openai_profile_setup();
                 }
@@ -287,7 +287,7 @@ pub(crate) async fn dispatch_event(
                 app.config_manager.save(&app.config)?;
                 app.bottom_pane.notice = Some("Cleared API key for the current provider.".into());
                 if app.openai_setup_steps.is_empty() {
-                    app.close_overlay();
+                    app.dismiss_overlay();
                 } else {
                     app.advance_openai_profile_setup();
                 }
@@ -304,20 +304,20 @@ pub(crate) async fn dispatch_event(
                 if app.config.provider == "codex" {
                     app.bottom_pane.notice =
                         Some("Saved Codex API key. Rebuilding backend.".into());
-                    app.close_overlay();
+                    app.dismiss_overlay();
                     start_rebuild_task(app);
                 } else if was_deepseek {
                     app.bottom_pane.notice = Some("Saved DeepSeek API key. Loading models.".into());
-                    app.close_overlay();
+                    app.dismiss_overlay();
                     start_deepseek_model_list_task(app);
                 } else if was_kimi {
                     app.bottom_pane.notice = Some("Saved Kimi API key. Loading models.".into());
-                    app.close_overlay();
+                    app.dismiss_overlay();
                     start_kimi_model_list_task(app);
                 } else {
                     app.bottom_pane.notice = Some("Saved API key for the current provider.".into());
                     if app.openai_setup_steps.is_empty() {
-                        app.close_overlay();
+                        app.dismiss_overlay();
                     } else {
                         app.advance_openai_profile_setup();
                     }
@@ -337,7 +337,7 @@ pub(crate) async fn dispatch_event(
                     app.config.model.as_deref().unwrap_or("unset")
                 ));
                 if app.openai_setup_steps.is_empty() {
-                    app.close_overlay();
+                    app.dismiss_overlay();
                 } else {
                     app.advance_openai_profile_setup();
                 }
@@ -411,7 +411,7 @@ pub(crate) async fn dispatch_event(
             {
                 app.clear_resume_search();
             } else {
-                app.close_overlay();
+                app.dismiss_overlay();
             }
         }
 
@@ -436,7 +436,7 @@ pub(crate) async fn dispatch_event(
                         .iter()
                         .position(|p| p.model_id == preset.model_id && p.family == preset.family)
                     {
-                        app.close_overlay();
+                        app.dismiss_overlay();
                         app.model_search_query.clear();
                         app.select_unified_model(global_idx);
                     }
@@ -449,7 +449,7 @@ pub(crate) async fn dispatch_event(
                     // the composer input for CommandPalette to prevent immediate
                     // re-open via sync_command_palette_with_input.
                     let usage = spec.usage.to_string();
-                    app.close_overlay();
+                    app.dismiss_overlay();
                     app.bottom_pane.input = usage;
                     app.bottom_pane.input_cursor_offset = None;
                     if handle_submit(app, agent_slot, oauth_manager).await? {
@@ -469,7 +469,7 @@ pub(crate) async fn dispatch_event(
                         "Saved base URL: {}",
                         app.config.base_url.as_deref().unwrap_or("unset")
                     ));
-                    app.close_overlay();
+                    app.dismiss_overlay();
                 }
             }
             Some(Overlay::ListPicker(kind)) => {
@@ -580,7 +580,7 @@ pub(crate) async fn dispatch_event(
                                 }
                                 ProviderFamily::CandleLocal => {
                                     app.push_notice("Local models (alpha) are for preview only.");
-                                    app.close_overlay();
+                                    app.dismiss_overlay();
                                 }
                                 _ => {
                                     if preset.family == ProviderFamily::DeepSeek {
@@ -592,7 +592,7 @@ pub(crate) async fn dispatch_event(
                         }
                         ListPickerKind::AuthMode => match app.auth_mode_idx {
                             0 if !is_ssh_session() => {
-                                app.close_overlay();
+                                app.dismiss_overlay();
                                 start_oauth_task(
                                     app,
                                     Arc::clone(oauth_manager),
@@ -601,7 +601,7 @@ pub(crate) async fn dispatch_event(
                             }
                             0 => app.push_notice("Browser login unavailable in SSH/headless."),
                             1 => {
-                                app.close_overlay();
+                                app.dismiss_overlay();
                                 start_oauth_task(
                                     app,
                                     Arc::clone(oauth_manager),
@@ -640,7 +640,7 @@ pub(crate) async fn dispatch_event(
                                 .map(|session| session.metadata.session_id.clone())
                             {
                                 restore_thread_by_id(thread_id.as_str(), app, agent_slot)?;
-                                app.close_overlay();
+                                app.dismiss_overlay();
                             }
                         }
                         ListPickerKind::OpenAiEndpointKind => {
@@ -692,7 +692,7 @@ pub(crate) async fn dispatch_event(
                     apply_permission_mode(app, agent_slot, mode);
                     app.permission_mode = mode;
                     let label = mode.label();
-                    app.close_overlay();
+                    app.dismiss_overlay();
                     if !resume_pending_shell_approval_after_full_access(app, agent_slot) {
                         app.push_notice(format!("Permission mode: {label}."));
                     }

--- a/src/tui/provider_flow.rs
+++ b/src/tui/provider_flow.rs
@@ -152,7 +152,7 @@ pub(super) fn open_provider_connection(app: &mut TuiApp) {
         app.bottom_pane.notice = Some(format!(
             "{label} is connected ✓  Run /model to change models, /connect again to reconfigure."
         ));
-        app.close_overlay();
+        app.dismiss_overlay();
         return;
     }
 

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -1000,7 +1000,7 @@ pub(crate) async fn finish_running_task_if_ready(
                 if let Some(agent) = agent_slot.as_ref() {
                     app.sync_snapshot(agent);
                 }
-                app.close_overlay();
+                app.dismiss_overlay();
                 app.set_runtime_phase(RuntimePhase::BackendReady, Some("backend ready".into()));
                 app.push_system(
                     app.setup_status.clone().unwrap_or_default(),
@@ -1062,7 +1062,7 @@ pub(crate) async fn finish_running_task_if_ready(
                 app.setup_status = Some(saved_message.into());
                 app.bottom_pane.notice = app.setup_status.clone();
                 app.set_runtime_phase(RuntimePhase::OAuthSaved, Some("oauth token saved".into()));
-                app.close_overlay();
+                app.dismiss_overlay();
                 app.push_entry("Runtime", saved_message);
                 start_rebuild_task(app);
             }
@@ -1100,7 +1100,7 @@ pub(crate) async fn finish_running_task_if_ready(
                     RuntimePhase::OAuthSaved,
                     Some("google oauth token saved".into()),
                 );
-                app.close_overlay();
+                app.dismiss_overlay();
                 app.push_entry("Runtime", msg);
                 start_rebuild_task(app);
             }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -146,7 +146,11 @@ fn completed_interaction_role(kind: InteractionKind, source: Option<&str>) -> &'
 }
 
 pub fn input_requests_command_palette(input: &str) -> bool {
-    input.trim_start().starts_with('/')
+    let trimmed = input.trim_start();
+    // Open the palette when the user types a bare '/' or the start of a
+    // command name.  Once a space (argument) appears, close it so Enter
+    // goes to Submit instead of ApplyOverlaySelection.
+    trimmed.starts_with('/') && !trimmed.contains(|c: char| c.is_whitespace())
 }
 
 pub(crate) fn contains_structured_planning_output(message: &str) -> bool {

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1803,13 +1803,26 @@ impl TuiApp {
         self.overlay = Some(overlay);
     }
 
+    /// Pop the top overlay from the stack without user-visible side
+    /// effects (preserves input, does not cancel setups).  Used when
+    /// the overlay becomes irrelevant due to an input change rather
+    /// than an explicit user action.
+    fn hide_overlay(&mut self) {
+        self.overlay_stack.pop();
+        self.overlay = self.overlay_stack.last().copied();
+        self.command_palette_idx = 0;
+    }
+
+    /// Keep the command-palette overlay in sync with the current
+    /// input.  Opens the palette when the user starts typing `/`,
+    /// and auto-hides it when the input contains a space (i.e. the
+    /// command has arguments and the user intends to submit).
     pub fn sync_command_palette_with_input(&mut self) {
-        if input_requests_command_palette(self.bottom_pane.input.as_str()) {
-            if self.overlay.is_none() {
-                self.open_overlay(Overlay::CommandPalette);
-            }
-        } else if matches!(self.overlay, Some(Overlay::CommandPalette)) {
-            self.close_overlay();
+        let should_show = input_requests_command_palette(self.bottom_pane.input.as_str());
+        match (should_show, &self.overlay) {
+            (true, None) => self.open_overlay(Overlay::CommandPalette),
+            (false, Some(Overlay::CommandPalette)) => self.hide_overlay(),
+            _ => {}
         }
     }
 
@@ -2007,7 +2020,7 @@ impl TuiApp {
         self.persist_runtime_state();
     }
 
-    pub fn close_overlay(&mut self) {
+    pub fn dismiss_overlay(&mut self) {
         if matches!(
             self.overlay,
             Some(Overlay::BaseUrlEditor | Overlay::ApiKeyEditor | Overlay::ModelNameEditor)
@@ -2015,7 +2028,7 @@ impl TuiApp {
             self.cancel_openai_profile_setup();
         }
 
-        // When closing the command palette, clear the `/` input so
+        // When dismissing the command palette, clear the `/` input so
         // sync_command_palette_with_input won't immediately re-open it.
         if matches!(
             self.overlay,
@@ -2025,8 +2038,7 @@ impl TuiApp {
             self.command_palette_idx = 0;
         }
 
-        // Pop the current overlay from the stack and restore the previous one.
-        self.overlay_stack.pop();
+        self.hide_overlay();
         self.overlay = self.overlay_stack.last().copied();
     }
 }

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -800,7 +800,7 @@ fn closing_auth_mode_picker_with_empty_stack_returns_to_none() {
     let mut app = TuiApp::new(cm).expect("app");
 
     app.open_overlay(Overlay::ListPicker(ListPickerKind::AuthMode));
-    app.close_overlay();
+    app.dismiss_overlay();
 
     // Stack-based back-navigation: closing the only overlay returns to None.
     assert!(app.overlay.is_none());
@@ -1265,7 +1265,7 @@ fn close_command_palette_clears_input_and_resets_idx() {
     app.command_palette_idx = 2;
 
     // Close the palette
-    app.close_overlay();
+    app.dismiss_overlay();
 
     // After close: input should be cleared, idx reset
     assert!(app.bottom_pane.input.is_empty(), "input should be cleared");

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3347,7 +3347,7 @@ async fn deepseek_model_picker_shows_dynamic_models_after_list_load() {
         "after loading models, picker should show 2 models + 1 action"
     );
 
-    app.close_overlay();
+    app.dismiss_overlay();
     app.open_overlay(Overlay::ListPicker(ListPickerKind::Model));
     assert_eq!(
         ListPickerKind::Model.item_count(&app),


### PR DESCRIPTION
## Summary

Fix `/goal` (and other commands with arguments) being impossible to send via Enter because the command palette overlay intercepted the key.

## Root cause

`input_requests_command_palette` returned true for ANY `/`-prefixed input, so the palette stayed open for `/goal fix the build`, consuming Enter as `ApplyOverlaySelection` instead of `Submit`.

## Fix

Palette now closes when the input contains whitespace. Bare command names still open the palette. Typing a space closes it, restoring Enter → Submit.