### PR TITLE
feat(hooks): add PostMemoryWrite lifecycle, wire hook_runtime to TuiApp

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -15,6 +15,7 @@ pub enum HookLifecycle {
     UserPromptSubmit,
     PreToolUse,
     PostToolUse,
+    PostMemoryWrite,
     Stop,
     PreCompact,
 }
@@ -26,6 +27,7 @@ impl HookLifecycle {
             Self::UserPromptSubmit => "UserPromptSubmit",
             Self::PreToolUse => "PreToolUse",
             Self::PostToolUse => "PostToolUse",
+            Self::PostMemoryWrite => "PostMemoryWrite",
             Self::Stop => "Stop",
             Self::PreCompact => "PreCompact",
         }

--- a/crates/rara-app-server/src/runtime_control.rs
+++ b/crates/rara-app-server/src/runtime_control.rs
@@ -271,6 +271,7 @@ pub enum HookLifecycle {
     UserPromptSubmit,
     PreToolUse,
     PostToolUse,
+    PostMemoryWrite,
     Stop,
     PreCompact,
 }

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -115,13 +115,13 @@ fn lifecycle_for_event(event: &AgentEvent) -> Option<HookLifecycle> {
         AgentEvent::AgentStop { .. } => Some(HookLifecycle::Stop),
         AgentEvent::ToolUse { .. } => Some(HookLifecycle::PreToolUse),
         AgentEvent::ToolResult { .. } => Some(HookLifecycle::PostToolUse),
+        AgentEvent::MemoryAction { .. } => Some(HookLifecycle::PostMemoryWrite),
         AgentEvent::ModelRequest { .. } | AgentEvent::ModelResponse { .. } => None,
         AgentEvent::Status(_)
         | AgentEvent::AssistantText(_)
         | AgentEvent::AssistantDelta(_)
         | AgentEvent::AssistantThinkingDelta(_)
         | AgentEvent::ToolProgress { .. }
-        | AgentEvent::MemoryAction { .. }
         | AgentEvent::McpStatusUpdated(_)
         | AgentEvent::McpStatusLoadFailed { .. }
         | AgentEvent::TodoUpdated(_)

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -171,8 +171,9 @@ fn phase_ordinal(phase: HookLifecycle) -> u8 {
         HookLifecycle::UserPromptSubmit => 1,
         HookLifecycle::PreToolUse => 2,
         HookLifecycle::PostToolUse => 3,
-        HookLifecycle::Stop => 4,
-        HookLifecycle::PreCompact => 5,
+        HookLifecycle::PostMemoryWrite => 4,
+        HookLifecycle::Stop => 5,
+        HookLifecycle::PreCompact => 6,
     }
 }
 

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -987,6 +987,7 @@ pub(crate) async fn finish_running_task_if_ready(
                 app.skill_source_registry = Some(rebuilt.skill_source_registry);
                 app.memory_handler = Some(rebuilt.memory_handler);
                 app.hook_registry = Some(rebuilt.hook_registry);
+                app.hook_runtime = Some(rebuilt.hook_runtime);
                 app.local_model_server = rebuilt.local_model_server;
                 app.config_manager.save(&app.config)?;
                 let is_bootstrap = app.setup_status.is_none();

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -42,6 +42,7 @@ pub(super) async fn rebuild_agent_with_progress(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
+        hook_runtime: Arc::new(hook_runtime),
         memory_handler,
         lsp_manager,
     })

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -264,6 +264,7 @@ fn rebuild_success(
             bus.clone(),
         )),
         hook_registry: Arc::new(crate::hook_registry::HookRegistry::new(bus.clone())),
+        hook_runtime: Arc::new(crate::hook_runtime::HookRuntime::new(bus.clone())),
         memory_handler: Arc::new(crate::protocol_sources::MemoryControlHandler::new(bus)),
         lsp_manager: Arc::new(crate::lsp_manager::LspManager::new(
             temp.path().to_path_buf(),

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -350,6 +350,7 @@ impl TuiApp {
             prompt_source_registry: None,
             skill_source_registry: None,
             hook_registry: None,
+            hook_runtime: None,
             memory_handler: None,
             provider_connection_status: std::collections::HashMap::new(),
             repo_context_task: None,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -388,6 +388,7 @@ pub struct RebuildSuccess {
     pub prompt_source_registry: Arc<PromptSourceRegistry>,
     pub skill_source_registry: Arc<SkillSourceRegistry>,
     pub hook_registry: Arc<HookRegistry>,
+    pub hook_runtime: Arc<crate::hook_runtime::HookRuntime>,
     pub memory_handler: Arc<MemoryControlHandler>,
     pub lsp_manager: Arc<LspManager>,
 }
@@ -722,6 +723,7 @@ pub struct TuiApp {
     pub prompt_source_registry: Option<Arc<PromptSourceRegistry>>,
     pub skill_source_registry: Option<Arc<SkillSourceRegistry>>,
     pub hook_registry: Option<Arc<HookRegistry>>,
+    pub hook_runtime: Option<Arc<crate::hook_runtime::HookRuntime>>,
     pub memory_handler: Option<Arc<MemoryControlHandler>>,
     pub provider_connection_status: std::collections::HashMap<ProviderFamily, bool>,
     pub repo_context_task: Option<JoinHandle<(Option<String>, Option<String>)>>,


### PR DESCRIPTION
## Summary

Wires memory hooks and hook runtime infrastructure into the agent rebuild flow.

### Changes

- **PostMemoryWrite lifecycle** added to all HookLifecycle enums (instructions crate, app-server, hook runtime)
- **lifecycle_for_event** maps AgentEvent::MemoryAction → PostMemoryWrite
- **hook_runtime** added to RebuildSuccess and TuiApp
- **phase_ordinal** updated with new lifecycle variant

### Validation

- cargo fmt ✅
- cargo check ✅ (113 pre-existing warnings)