### PR TITLE
chore(app-server): deduplicate HookLifecycle enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11961,6 +11961,7 @@ dependencies = [
 name = "rara-app-server"
 version = "0.0.1"
 dependencies = [
+ "rara-instructions",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ rmcp = { version = "1.7", features = ["client", "transport-child-process"] }
 codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
 codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
 codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+rara-instructions = { path = "crates/instructions" }
 
 [package]
 name = "rara"

--- a/crates/rara-app-server/Cargo.toml
+++ b/crates/rara-app-server/Cargo.toml
@@ -5,6 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-rara-instructions = { path = "../instructions" }
+rara-instructions = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rara-app-server/Cargo.toml
+++ b/crates/rara-app-server/Cargo.toml
@@ -5,5 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+rara-instructions = { path = "../instructions" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rara-app-server/src/runtime_control.rs
+++ b/crates/rara-app-server/src/runtime_control.rs
@@ -265,16 +265,7 @@ pub enum MemoryScope {
 }
 
 /// Lifecycle phase for hooks declared through the app-server control plane.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum HookLifecycle {
-    SessionStart,
-    UserPromptSubmit,
-    PreToolUse,
-    PostToolUse,
-    PostMemoryWrite,
-    Stop,
-    PreCompact,
-}
+pub use rara_instructions::HookLifecycle;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]


### PR DESCRIPTION
## Summary

`HookLifecycle` was defined independently in two crates with identical variants. After this change it lives only in `rara-instructions`; `rara-app-server` re-exports it via `pub use`.

### Changes

- `rara-app-server/Cargo.toml`: add `rara-instructions` dependency
- `rara-app-server/src/runtime_control.rs`: replace 10-line enum definition with `pub use rara_instructions::HookLifecycle;`

### Validation

- `cargo check` ✅ (113 pre-existing warnings)