### PR TITLE
fix: cap composer at 40% of terminal height

### DIFF
--- a/src/tui/render/bottom_pane/composer.rs
+++ b/src/tui/render/bottom_pane/composer.rs
@@ -197,7 +197,10 @@ pub(super) fn composer_cursor_position(
 pub(super) fn desired_composer_height(app: &TuiApp, width: u16, rows: u16) -> u16 {
     let available_width = width.max(1);
     let content_rows = composer_content_line_count(app, available_width);
-    let max_height = rows.saturating_sub(4).max(3);
+    // Cap at 40% of terminal height (Codex style) so the transcript
+    // stays visible above a growing input.
+    // `.max(3)` keeps `clamp` safe even when rows < 7.
+    let max_height = ((rows as f64 * 0.4).ceil() as u16).clamp(3, rows.saturating_sub(4).max(3));
     content_rows.clamp(3, max_height)
 }
 


### PR DESCRIPTION
## Summary

The composer previously maxed at `rows - 4`, allowing it to grow to cover nearly the entire terminal.  Multi-line input would hide the transcript behind it.

## Fix

Cap the composer at 40% of terminal height (Codex style), clamped to `[3, rows-4]`.  On a 24-row terminal the composer maxes at 10 lines (down from 20); on an 80-row terminal it maxes at 32 (down from 76).