### PR TITLE
fix(tui): eagerly check LSP server availability in sidebar status

### DIFF
--- a/src/lsp_manager.rs
+++ b/src/lsp_manager.rs
@@ -697,4 +697,13 @@ mod tests {
         assert!(rx.try_recv().is_err());
         assert!(diagnostics.lock().unwrap().is_empty());
     }
+
+    #[test]
+    fn server_available_caches_result_via_once_lock() {
+        // First call runs --version (or finds cached result)
+        let a = server_available(ServerKind::RustAnalyzer);
+        // Second call hits OnceLock, returns same bool
+        let b = server_available(ServerKind::RustAnalyzer);
+        assert_eq!(a, b);
+    }
 }

--- a/src/lsp_manager.rs
+++ b/src/lsp_manager.rs
@@ -239,12 +239,12 @@ impl LspManager {
             .iter()
             .map(|kind| {
                 let detected = self.workspace_root.join(kind.detect_file()).exists();
-                let availability = server_available_cached(*kind);
+                let availability = server_available(*kind);
                 LspServerStatus {
                     name: kind.label().to_string(),
                     detected,
-                    checked: availability.is_some(),
-                    available: detected && availability.unwrap_or(false),
+                    checked: true,
+                    available: detected && availability,
                     running: servers.get(kind).is_some_and(Option::is_some),
                 }
             })
@@ -457,10 +457,6 @@ fn server_available(kind: ServerKind) -> bool {
         let cmd = kind.command()[0];
         Command::new(cmd).arg("--version").output().is_ok()
     })
-}
-
-fn server_available_cached(kind: ServerKind) -> Option<bool> {
-    server_availability_lock(kind).get().copied()
 }
 
 fn server_availability_lock(kind: ServerKind) -> &'static std::sync::OnceLock<bool> {


### PR DESCRIPTION
## Summary

Sidebar LSP status was stuck at `detected · not started` forever because
`status_snapshot()` called `server_available_cached()` which only reads
the `OnceLock` cache — populated exclusively when the agent calls
`lsp_diagnostics`.

## Fix

- Replace `server_available_cached()` with `server_available()` in
  `status_snapshot()`. The latter calls `OnceLock::get_or_init` which
  runs `--version` on first access and caches.
- Remove dead `server_available_cached` function.
- After first render, sidebar shows `idle` or `1 available` instead of
  `detected · not started`.

## Before / After

| Before | After |
|---|---|
| `rust-analyzer detected · not started [?]` | `rust-analyzer idle · 1 available [ ]` |

## Validation

- `cargo check` ✅ (109 pre-existing warnings)