### PR TITLE
feat(tui,memory): sidebar local model status + auto-rebuild LanceDB on dimension mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10650,6 +10650,7 @@ dependencies = [
  "fs2",
  "futures",
  "lancedb",
+ "log",
  "rara-persistence",
  "serde",
  "tempfile",

--- a/crates/rara-memory/Cargo.toml
+++ b/crates/rara-memory/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 rara-persistence = { path = "../rara-persistence" }
 anyhow.workspace = true
+log = "0.4"
 fs2 = "0.4"
 serde = { version = "1", features = ["derive"] }
 arrow-array = "58"

--- a/crates/rara-memory/src/vectordb.rs
+++ b/crates/rara-memory/src/vectordb.rs
@@ -206,8 +206,17 @@ impl VectorDB {
     async fn open_or_create_table(&self, table_name: &str, vector_dim: usize) -> Result<Table> {
         let db = self.db().await?;
         if let Some(table) = self.open_table_if_exists(table_name).await? {
-            validate_table_vector_dim(&table, vector_dim).await?;
-            return Ok(table);
+            if let Err(e) = validate_table_vector_dim(&table, vector_dim).await {
+                log::warn!(
+                    "LanceDB vector dimension mismatch for table {table_name}; \
+                     dropping and recreating. {e}"
+                );
+                db.drop_table(table_name, &[])
+                    .await
+                    .with_context(|| format!("drop mismatched LanceDB table {table_name}"))?;
+            } else {
+                return Ok(table);
+            }
         }
         db.create_empty_table(table_name, memory_schema(vector_dim))
             .execute()

--- a/crates/rara-memory/src/vectordb.rs
+++ b/crates/rara-memory/src/vectordb.rs
@@ -205,18 +205,21 @@ impl VectorDB {
 
     async fn open_or_create_table(&self, table_name: &str, vector_dim: usize) -> Result<Table> {
         let db = self.db().await?;
-        if let Some(table) = self.open_table_if_exists(table_name).await? {
-            if let Err(e) = validate_table_vector_dim(&table, vector_dim).await {
-                log::warn!(
-                    "LanceDB vector dimension mismatch for table {table_name}; \
-                     dropping and recreating. {e}"
-                );
-                db.drop_table(table_name, &[])
-                    .await
-                    .with_context(|| format!("drop mismatched LanceDB table {table_name}"))?;
-            } else {
-                return Ok(table);
-            }
+        match self.open_table_if_exists(table_name).await? {
+            Some(table) => match validate_table_vector_dim(&table, vector_dim).await {
+                Ok(()) => return Ok(table),
+                Err(e) => {
+                    log::warn!(
+                        "LanceDB vector dimension mismatch for table {table_name}; \
+                         dropping and recreating. {e}"
+                    );
+                    db.drop_table(table_name, &[])
+                        .await
+                        .with_context(|| format!("drop mismatched LanceDB table {table_name}"))?;
+                    self.fts_indexed_tables.lock().await.remove(table_name);
+                }
+            },
+            None => {}
         }
         db.create_empty_table(table_name, memory_schema(vector_dim))
             .execute()

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -8,11 +8,11 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
+use crate::local_model_server::LocalModelServerState;
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::TuiApp;
 use crate::tui::status_display::context_sidebar_summary;
 use crate::tui::theme::*;
-use crate::local_model_server::LocalModelServerState;
 
 /// Width allocated to the sidebar when the terminal is wide enough.
 pub(crate) const SIDEBAR_WIDTH: u16 = 38;
@@ -240,7 +240,9 @@ fn push_local_model_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
         LocalModelServerState::PreparedButStopped => {
             ("○ stopped", Style::default().fg(TEXT_SECONDARY))
         }
-        LocalModelServerState::SetupRequired => ("○ setup required", Style::default().fg(TEXT_MUTED)),
+        LocalModelServerState::SetupRequired => {
+            ("○ setup required", Style::default().fg(TEXT_MUTED))
+        }
         LocalModelServerState::Error => ("✗ error", Style::default().fg(STATUS_ERROR)),
     };
     lines.push(Line::from(Span::styled(marker, style)));

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -12,6 +12,7 @@ use crate::tui::custom_terminal::Frame;
 use crate::tui::state::TuiApp;
 use crate::tui::status_display::context_sidebar_summary;
 use crate::tui::theme::*;
+use crate::local_model_server::LocalModelServerState;
 
 /// Width allocated to the sidebar when the terminal is wide enough.
 pub(crate) const SIDEBAR_WIDTH: u16 = 38;
@@ -41,6 +42,8 @@ pub(crate) fn render_sidebar(f: &mut Frame, app: &TuiApp, area: Rect) {
     push_context_summary(&mut lines, app);
     lines.push(Line::from(""));
     push_lsp_status(&mut lines, app);
+    lines.push(Line::from(""));
+    push_local_model_section(&mut lines, app);
     lines.push(Line::from(""));
     if push_todo_section(&mut lines, app) {
         lines.push(Line::from(""));
@@ -215,6 +218,36 @@ fn push_lsp_status(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
         lines.push(Line::from(Span::styled(
             format!("last error: {error}"),
             Style::default().fg(STATUS_WARNING),
+        )));
+    }
+}
+
+fn push_local_model_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
+    let status = &app.local_model_server;
+    lines.push(Line::from(super::section_label(
+        "Local Model",
+        TEXT_SECONDARY,
+    )));
+    let (marker, style) = match status.state {
+        LocalModelServerState::Ready => ("● ready", Style::default().fg(STATUS_SUCCESS)),
+        LocalModelServerState::Starting
+        | LocalModelServerState::WaitingForServer
+        | LocalModelServerState::CreatingVenv
+        | LocalModelServerState::InstallingDependencies
+        | LocalModelServerState::PreparingModel => {
+            ("○ preparing …", Style::default().fg(STATUS_WARNING))
+        }
+        LocalModelServerState::PreparedButStopped => {
+            ("○ stopped", Style::default().fg(TEXT_SECONDARY))
+        }
+        LocalModelServerState::SetupRequired => ("○ setup required", Style::default().fg(TEXT_MUTED)),
+        LocalModelServerState::Error => ("✗ error", Style::default().fg(STATUS_ERROR)),
+    };
+    lines.push(Line::from(Span::styled(marker, style)));
+    if !status.model.is_empty() {
+        lines.push(Line::from(Span::styled(
+            format!("  {}", status.model),
+            Style::default().fg(TEXT_MUTED),
         )));
     }
 }


### PR DESCRIPTION
## Summary

Two complementary improvements:

### 1. Sidebar — local model server status
New `Local Model` section in the sidebar showing:
- `● ready` — model server is running
- `○ preparing …` — starting / waiting / installing / creating venv
- `○ stopped` — prepared but not started
- `○ setup required` — not configured
- `✗ error` — startup failed

Also shows the model name (e.g. `all-MiniLM-L6-v2`).

### 2. Memory — auto-rebuild LanceDB on dimension mismatch
When the embedding model changes and produces vectors of a different dimension than the existing LanceDB index, the table is now automatically dropped and recreated instead of panicking with an error.

## Validation

- `cargo check` ✅ (109 pre-existing warnings)