### PR TITLE
chore: remove dead code in rara-tools

### DIFF
--- a/crates/rara-tools/src/file.rs
+++ b/crates/rara-tools/src/file.rs
@@ -36,27 +36,6 @@ pub(crate) fn read_file_content(path: &str) -> Result<String, ToolError> {
     }
 }
 
-/// Return a path suggestion when a file is not found: look for a sibling
-/// with a different extension but the same stem, or the same file under
-/// the current working directory.
-fn find_similar_file(path: &str) -> Option<String> {
-    let p = Path::new(path);
-    let parent = p.parent()?;
-    let stem = p.file_stem()?.to_str()?;
-    // Check siblings: same stem, different extension.
-    if let Ok(entries) = fs::read_dir(parent) {
-        for entry in entries.flatten() {
-            let candidate = entry.path();
-            if candidate.file_stem().and_then(|s| s.to_str()) == Some(stem)
-                && candidate.extension() != p.extension()
-            {
-                return Some(candidate.display().to_string());
-            }
-        }
-    }
-    None
-}
-
 #[derive(Debug, Default)]
 pub struct FileReadState {
     files: Mutex<HashMap<PathBuf, FileReadEntry>>,

--- a/crates/rara-tools/src/patch.rs
+++ b/crates/rara-tools/src/patch.rs
@@ -621,10 +621,6 @@ fn is_opening_context(chars: &[char], pos: usize) -> bool {
     )
 }
 
-fn find_subsequence(haystack: &[String], needle: &[String]) -> Option<usize> {
-    seek_sequence(haystack, needle, 0, false)
-}
-
 fn write_text_file(path: &str, content: &str) -> Result<(), ToolError> {
     if let Some(parent) = Path::new(path).parent() {
         fs::create_dir_all(parent)?;


### PR DESCRIPTION
Remove two dead functions in `crates/rara-tools` that were orphaned during the #313 crate extraction:

- `find_similar_file` in `file.rs`
- `find_subsequence` in `patch.rs` (wraps `seek_sequence` which stays)

Both are never called. Compiles warning-clean for rara-tools.