### PR TITLE
feat(hooks): PreToolUse tool input modifiers

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -616,14 +616,16 @@ impl Agent {
                         name: name.clone(),
                         input: input.clone(),
                     });
+                    let modified_input =
+                        crate::hook_runtime::global_modify_tool_input(name.as_str(), input.clone());
                     report(AgentEvent::ToolUse {
                         name: name.clone(),
-                        input: input.clone(),
+                        input: modified_input.clone(),
                     });
                     tool_calls.push(ToolCall {
                         id: id.clone(),
                         name: name.clone(),
-                        input: input.clone(),
+                        input: modified_input,
                     });
                 }
                 ContentBlock::ProviderMetadata {

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -10,12 +10,18 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use serde_json::Value;
+
 use crate::agent::AgentEvent;
 use crate::runtime_control::HookLifecycle;
 use crate::runtime_event_bus::RuntimeEventBus;
 
 /// A registered in-process hook combining a lifecycle trigger and a callback.
 type HookCallback = Box<dyn Fn(&AgentEvent) + Send + Sync>;
+
+/// A PreToolUse modifier that can return modified tool input.
+/// Returns `None` if no modification is needed, or `Some(modified_input)`.
+pub type ToolModifier = Box<dyn Fn(&str, &Value) -> Option<Value> + Send + Sync>;
 
 struct HookEntry {
     lifecycle: HookLifecycle,
@@ -31,6 +37,7 @@ struct HookEntry {
 pub struct HookRuntime {
     bus: Arc<RuntimeEventBus>,
     hooks: Arc<tokio::sync::RwLock<HashMap<String, HookEntry>>>,
+    tool_modifiers: Arc<tokio::sync::RwLock<Vec<(String, ToolModifier)>>>,
     started: AtomicBool,
 }
 
@@ -39,8 +46,30 @@ impl HookRuntime {
         Self {
             bus,
             hooks: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            tool_modifiers: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             started: AtomicBool::new(false),
         }
+    }
+
+    /// Register a PreToolUse modifier that can transform tool input.
+    /// Called synchronously, safe to invoke while `start` is running.
+    pub async fn register_tool_modifier(&self, name: String, modifier: ToolModifier) {
+        self.tool_modifiers.write().await.push((name, modifier));
+    }
+
+    /// Run all registered tool modifiers against the given tool name and input.
+    /// Returns the final (possibly modified) input value.
+    /// Each modifier receives the tool name and the current input value.
+    /// If a modifier returns `Some(v)`, `v` becomes the input for the next modifier.
+    pub fn modify_tool_input(&self, tool_name: &str, input: Value) -> Value {
+        let modifiers = self.tool_modifiers.blocking_read();
+        let mut current = input;
+        for (_name, modifier) in modifiers.iter() {
+            if let Some(modified) = modifier(tool_name, &current) {
+                current = modified;
+            }
+        }
+        current
     }
 
     /// Register an in-process hook.  Safe to call while `start` is running.
@@ -133,7 +162,22 @@ fn lifecycle_matches(lifecycle: &HookLifecycle, event: &AgentEvent) -> bool {
     lifecycle_for_event(event).as_ref() == Some(lifecycle)
 }
 
-/// Result of executing a command-type hook.
+/// Global hook runtime — avoids threading Arc<HookRuntime> through every
+/// Agent constructor. Set once by the builder, read by the agent loop.
+// ---------------------------------------------------------------------------
+
+static GLOBAL_HOOK_RUNTIME: std::sync::OnceLock<Arc<HookRuntime>> = std::sync::OnceLock::new();
+
+pub(crate) fn set_global_hook_runtime(hr: Arc<HookRuntime>) {
+    let _ = GLOBAL_HOOK_RUNTIME.set(hr);
+}
+
+pub(crate) fn global_modify_tool_input(tool_name: &str, input: Value) -> Value {
+    match GLOBAL_HOOK_RUNTIME.get() {
+        Some(hr) => hr.modify_tool_input(tool_name, input),
+        None => input,
+    }
+}
 #[derive(Debug, Clone)]
 pub struct HookRunResult {
     pub exit_code: Option<i32>,

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -37,7 +37,7 @@ struct HookEntry {
 pub struct HookRuntime {
     bus: Arc<RuntimeEventBus>,
     hooks: Arc<tokio::sync::RwLock<HashMap<String, HookEntry>>>,
-    tool_modifiers: Arc<tokio::sync::RwLock<Vec<(String, ToolModifier)>>>,
+    tool_modifiers: Arc<std::sync::RwLock<Vec<(String, ToolModifier)>>>,
     started: AtomicBool,
 }
 
@@ -46,15 +46,17 @@ impl HookRuntime {
         Self {
             bus,
             hooks: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
-            tool_modifiers: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            tool_modifiers: Arc::new(std::sync::RwLock::new(Vec::new())),
             started: AtomicBool::new(false),
         }
     }
 
     /// Register a PreToolUse modifier that can transform tool input.
     /// Called synchronously, safe to invoke while `start` is running.
-    pub async fn register_tool_modifier(&self, name: String, modifier: ToolModifier) {
-        self.tool_modifiers.write().await.push((name, modifier));
+    pub fn register_tool_modifier(&self, name: String, modifier: ToolModifier) {
+        if let Ok(mut guard) = self.tool_modifiers.write() {
+            guard.push((name, modifier));
+        }
     }
 
     /// Run all registered tool modifiers against the given tool name and input.
@@ -62,7 +64,7 @@ impl HookRuntime {
     /// Each modifier receives the tool name and the current input value.
     /// If a modifier returns `Some(v)`, `v` becomes the input for the next modifier.
     pub fn modify_tool_input(&self, tool_name: &str, input: Value) -> Value {
-        let modifiers = self.tool_modifiers.blocking_read();
+        let modifiers = self.tool_modifiers.read().unwrap();
         let mut current = input;
         for (_name, modifier) in modifiers.iter() {
             if let Some(modified) = modifier(tool_name, &current) {

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -13,7 +13,8 @@ pub(super) async fn rebuild_agent_with_progress(
     let event_bus = bootstrap.event_bus.clone();
 
     // Start the hook runtime — registers command-type hooks found in `.claude/hooks/`
-    let hook_runtime = crate::hook_runtime::HookRuntime::new(event_bus.clone());
+    let hook_runtime = Arc::new(crate::hook_runtime::HookRuntime::new(event_bus.clone()));
+    crate::hook_runtime::set_global_hook_runtime(hook_runtime.clone());
     hook_runtime.start();
 
     let (
@@ -42,7 +43,7 @@ pub(super) async fn rebuild_agent_with_progress(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
-        hook_runtime: Arc::new(hook_runtime),
+        hook_runtime,
         memory_handler,
         lsp_manager,
     })


### PR DESCRIPTION
## Summary

Makes PreToolUse hooks actually functional: hooks can now modify tool input before execution.

### How it works

1. **HookRuntime** gains `register_tool_modifier` and `modify_tool_input` — synchronous modifier pipeline
2. **Builder** registers HookRuntime globally via `set_global_hook_runtime`
3. **agent.rs**: before emitting `ToolUse` and pushing to `tool_calls`, calls `global_modify_tool_input` to get possibly modified input
4. Each modifier receives `(tool_name, &input)` → returns `Option<Value>`. If `Some`, it becomes the input for the next modifier (pipeline)

### Validation

- `cargo check` ✅ (109 pre-existing warnings)