### PR TITLE
feat(hooks): inject command hook outputs as system messages into model context

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -712,6 +712,16 @@ impl Agent {
                 }
             }
             self.ensure_active_plan_step();
+            // Inject hook outputs as system messages before the model turn
+            if let Some(hr) = crate::hook_runtime::get_global_hook_runtime() {
+                let outputs = hr.blocking_drain_outputs();
+                for text in outputs {
+                    self.history.push(Message {
+                        role: "system".to_string(),
+                        content: Value::String(text),
+                    });
+                }
+            }
             let mut turn_output = self.run_model_turn(output_mode, report).await?;
             self.record_agent_turn_trace(&turn_output, *agentic_turns, None, None, false);
             self.last_query_plan_updated = turn_output.plan_updated;

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use serde_json::Value;
+
 use crate::agent::AgentEvent;
 use crate::runtime_control::HookLifecycle;
 use crate::runtime_event_bus::RuntimeEventBus;
@@ -25,15 +27,18 @@ struct HookEntry {
 
 /// In-process hook dispatch runtime.
 ///
+pub type ToolModifier = Box<dyn Fn(&str, &Value) -> Option<Value> + Send + Sync>;
+
 /// Hooks are stored behind an `Arc<RwLock<HashMap<...>>>` so that the
 /// control-plane can register / unregister hooks while the dispatch
 /// loop is already running.
 pub struct HookRuntime {
     bus: Arc<RuntimeEventBus>,
     hooks: Arc<tokio::sync::RwLock<HashMap<String, HookEntry>>>,
+    tool_modifiers: Arc<std::sync::RwLock<Vec<(String, ToolModifier)>>>,
     /// Collected stdout from command hooks. Drained before each model turn
     /// and injected as system messages into the model context.
-    outputs: Arc<tokio::sync::Mutex<Vec<String>>>,
+    outputs: Arc<std::sync::Mutex<Vec<String>>>,
     started: AtomicBool,
 }
 
@@ -42,24 +47,55 @@ impl HookRuntime {
         Self {
             bus,
             hooks: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
-            outputs: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            tool_modifiers: Arc::new(std::sync::RwLock::new(Vec::new())),
+            outputs: Arc::new(std::sync::Mutex::new(Vec::new())),
             started: AtomicBool::new(false),
         }
     }
 
     /// Push a hook output (typically command stdout) into the collection buffer.
-    pub async fn push_output(&self, text: String) {
-        self.outputs.lock().await.push(text);
+    pub fn push_output(&self, text: String) {
+        if let Ok(mut guard) = self.outputs.lock() {
+            guard.push(text);
+        }
     }
 
     /// Drain and return all collected hook outputs, clearing the buffer.
-    pub async fn drain_outputs(&self) -> Vec<String> {
-        std::mem::take(&mut *self.outputs.lock().await)
+    pub fn drain_outputs(&self) -> Vec<String> {
+        if let Ok(mut guard) = self.outputs.lock() {
+            std::mem::take(&mut *guard)
+        } else {
+            Vec::new()
+        }
     }
 
     /// Drain outputs synchronously (for use in non-async contexts).
     pub fn blocking_drain_outputs(&self) -> Vec<String> {
-        std::mem::take(&mut *self.outputs.blocking_lock())
+        if let Ok(mut guard) = self.outputs.lock() {
+            std::mem::take(&mut *guard)
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Register a PreToolUse modifier that can transform tool input.
+    pub fn register_tool_modifier(&self, name: String, modifier: ToolModifier) {
+        if let Ok(mut guard) = self.tool_modifiers.write() {
+            guard.push((name, modifier));
+        }
+    }
+
+    /// Run all registered tool modifiers against the given tool name and input.
+    /// Returns the final (possibly modified) input value.
+    pub fn modify_tool_input(&self, tool_name: &str, input: Value) -> Value {
+        let modifiers = self.tool_modifiers.read().unwrap();
+        let mut current = input;
+        for (_name, modifier) in modifiers.iter() {
+            if let Some(modified) = modifier(tool_name, &current) {
+                current = modified;
+            }
+        }
+        current
     }
 
     /// Register an in-process hook.  Safe to call while `start` is running.
@@ -318,6 +354,13 @@ pub(crate) fn set_global_hook_runtime(hr: Arc<HookRuntime>) {
 
 pub(crate) fn get_global_hook_runtime() -> Option<&'static Arc<HookRuntime>> {
     GLOBAL_HOOK_RUNTIME.get()
+}
+
+pub(crate) fn global_modify_tool_input(tool_name: &str, input: Value) -> Value {
+    match GLOBAL_HOOK_RUNTIME.get() {
+        Some(hr) => hr.modify_tool_input(tool_name, input),
+        None => input,
+    }
 }
 
 #[cfg(test)]

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -10,18 +10,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use serde_json::Value;
-
 use crate::agent::AgentEvent;
 use crate::runtime_control::HookLifecycle;
 use crate::runtime_event_bus::RuntimeEventBus;
 
 /// A registered in-process hook combining a lifecycle trigger and a callback.
 type HookCallback = Box<dyn Fn(&AgentEvent) + Send + Sync>;
-
-/// A PreToolUse modifier that can return modified tool input.
-/// Returns `None` if no modification is needed, or `Some(modified_input)`.
-pub type ToolModifier = Box<dyn Fn(&str, &Value) -> Option<Value> + Send + Sync>;
 
 struct HookEntry {
     lifecycle: HookLifecycle,
@@ -37,7 +31,9 @@ struct HookEntry {
 pub struct HookRuntime {
     bus: Arc<RuntimeEventBus>,
     hooks: Arc<tokio::sync::RwLock<HashMap<String, HookEntry>>>,
-    tool_modifiers: Arc<std::sync::RwLock<Vec<(String, ToolModifier)>>>,
+    /// Collected stdout from command hooks. Drained before each model turn
+    /// and injected as system messages into the model context.
+    outputs: Arc<tokio::sync::Mutex<Vec<String>>>,
     started: AtomicBool,
 }
 
@@ -46,32 +42,24 @@ impl HookRuntime {
         Self {
             bus,
             hooks: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
-            tool_modifiers: Arc::new(std::sync::RwLock::new(Vec::new())),
+            outputs: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             started: AtomicBool::new(false),
         }
     }
 
-    /// Register a PreToolUse modifier that can transform tool input.
-    /// Called synchronously, safe to invoke while `start` is running.
-    pub fn register_tool_modifier(&self, name: String, modifier: ToolModifier) {
-        if let Ok(mut guard) = self.tool_modifiers.write() {
-            guard.push((name, modifier));
-        }
+    /// Push a hook output (typically command stdout) into the collection buffer.
+    pub async fn push_output(&self, text: String) {
+        self.outputs.lock().await.push(text);
     }
 
-    /// Run all registered tool modifiers against the given tool name and input.
-    /// Returns the final (possibly modified) input value.
-    /// Each modifier receives the tool name and the current input value.
-    /// If a modifier returns `Some(v)`, `v` becomes the input for the next modifier.
-    pub fn modify_tool_input(&self, tool_name: &str, input: Value) -> Value {
-        let modifiers = self.tool_modifiers.read().unwrap();
-        let mut current = input;
-        for (_name, modifier) in modifiers.iter() {
-            if let Some(modified) = modifier(tool_name, &current) {
-                current = modified;
-            }
-        }
-        current
+    /// Drain and return all collected hook outputs, clearing the buffer.
+    pub async fn drain_outputs(&self) -> Vec<String> {
+        std::mem::take(&mut *self.outputs.lock().await)
+    }
+
+    /// Drain outputs synchronously (for use in non-async contexts).
+    pub fn blocking_drain_outputs(&self) -> Vec<String> {
+        std::mem::take(&mut *self.outputs.blocking_lock())
     }
 
     /// Register an in-process hook.  Safe to call while `start` is running.
@@ -164,22 +152,7 @@ fn lifecycle_matches(lifecycle: &HookLifecycle, event: &AgentEvent) -> bool {
     lifecycle_for_event(event).as_ref() == Some(lifecycle)
 }
 
-/// Global hook runtime — avoids threading Arc<HookRuntime> through every
-/// Agent constructor. Set once by the builder, read by the agent loop.
-// ---------------------------------------------------------------------------
-
-static GLOBAL_HOOK_RUNTIME: std::sync::OnceLock<Arc<HookRuntime>> = std::sync::OnceLock::new();
-
-pub(crate) fn set_global_hook_runtime(hr: Arc<HookRuntime>) {
-    let _ = GLOBAL_HOOK_RUNTIME.set(hr);
-}
-
-pub(crate) fn global_modify_tool_input(tool_name: &str, input: Value) -> Value {
-    match GLOBAL_HOOK_RUNTIME.get() {
-        Some(hr) => hr.modify_tool_input(tool_name, input),
-        None => input,
-    }
-}
+/// Result of executing a command-type hook.
 #[derive(Debug, Clone)]
 pub struct HookRunResult {
     pub exit_code: Option<i32>,
@@ -330,6 +303,21 @@ pub fn make_command_hook(
         let input_json = "{}".to_string();
         spawn_command_hook(script_path.clone(), input_json, cwd.clone(), timeout_secs);
     })
+}
+
+// ---------------------------------------------------------------------------
+// Global hook runtime — avoids threading Arc<HookRuntime> through every
+// Agent constructor. Set once by the builder, read by the agent loop.
+// ---------------------------------------------------------------------------
+
+static GLOBAL_HOOK_RUNTIME: std::sync::OnceLock<Arc<HookRuntime>> = std::sync::OnceLock::new();
+
+pub(crate) fn set_global_hook_runtime(hr: Arc<HookRuntime>) {
+    let _ = GLOBAL_HOOK_RUNTIME.set(hr);
+}
+
+pub(crate) fn get_global_hook_runtime() -> Option<&'static Arc<HookRuntime>> {
+    GLOBAL_HOOK_RUNTIME.get()
 }
 
 #[cfg(test)]

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -47,6 +47,7 @@ pub async fn register_plugin_hooks(
             let lifecycle = hook_event_to_lifecycle(rh.event);
 
             let plugin_name_for_callback = plugin_name.clone();
+            let runtime_for_output = runtime.clone();
             let callback = Box::new(move |event: &AgentEvent| {
                 let hook_event_name = match agent_event_to_hook_event(event) {
                     Some(e) => e.as_str().to_string(),
@@ -65,6 +66,7 @@ pub async fn register_plugin_hooks(
                 let h = hook.clone();
                 let pr = plugin_root.clone();
                 let pn = plugin_name_for_callback.clone();
+                let r = runtime_for_output.clone();
                 tokio::task::spawn(async move {
                     let result = execute_command_hook(&h, &pr, input).await;
                     if !result.ok {
@@ -73,6 +75,9 @@ pub async fn register_plugin_hooks(
                             result.exit_code.unwrap_or(-1),
                             result.stderr
                         );
+                    }
+                    if !result.stdout.trim().is_empty() {
+                        r.push_output(result.stdout).await;
                     }
                 });
             });

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -77,7 +77,7 @@ pub async fn register_plugin_hooks(
                         );
                     }
                     if !result.stdout.trim().is_empty() {
-                        r.push_output(result.stdout).await;
+                        r.push_output(result.stdout);
                     }
                 });
             });


### PR DESCRIPTION
## Summary

Completes the hook output pipeline: after a command hook fires, its stdout is collected and injected as a system message before the next model turn.

### How it works

1. **HookRuntime** gains an `outputs: Mutex<Vec<String>>` buffer
2. **plugin_middleware** pushes command hook stdout into the buffer after each hook execution
3. **agent.rs** drains outputs before each model turn and pushes them into the agent's message history as `role: "system"` messages

### Changes

- `hook_runtime.rs`: add `outputs` buffer + `push_output` / `drain_outputs` / `blocking_drain_outputs` + `get_global_hook_runtime` accessor
- `plugin_middleware.rs`: push hook stdout to runtime outputs
- `agent.rs`: drain outputs before `run_model_turn` and inject as system messages

### Validation

- `cargo check` ✅ (110 pre-existing warnings)