### PR TITLE
fix: dismiss all stacked overlays on /quit

### DIFF
--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -89,9 +89,9 @@ pub(crate) async fn handle_submit(
 
 /// Persist the active turn and runtime state before quitting.
 fn save_before_quit(app: &mut TuiApp) {
-    // Dismiss any open overlay (e.g. Command Palette) before quitting,
-    // so the quit phase transition is the last thing the user sees.
-    if app.overlay.is_some() {
+    // Dismiss all stacked overlays before quitting, so the quit phase
+    // transition is the last thing the user sees.
+    while app.overlay.is_some() {
         app.dismiss_overlay();
     }
     app.finalize_active_turn();


### PR DESCRIPTION
## Summary

Use a `while` loop in `save_before_quit` instead of a single `if` check, so multiple stacked overlays are all dismissed cleanly before the app exits.

## Review feedback from #490

> Should loop through all overlays to dismiss them, not just one

## Changes

- `src/tui/submit.rs`: `if app.overlay.is_some()` → `while app.overlay.is_some()`

The auto-hide logic in `open_overlay` already covers all non-palette overlays — no change needed there.