### PR TITLE
chore(deps): bump codex from rust-v0.131.0 to rust-v0.132.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,8 +1820,8 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1839,8 +1839,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1868,8 +1868,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "clap",
@@ -1892,8 +1892,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1902,8 +1902,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1928,13 +1928,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 
 [[package]]
 name = "codex-config"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1977,8 +1977,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "clap",
@@ -1993,8 +1993,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2003,8 +2003,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2016,8 +2016,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "codex-protocol",
@@ -2027,8 +2027,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2051,8 +2051,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "keyring",
  "tracing",
@@ -2060,8 +2060,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2094,8 +2094,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -2107,8 +2107,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2127,8 +2127,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2157,8 +2157,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2189,8 +2189,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2226,8 +2226,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -2245,16 +2245,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "dirs",
  "dunce",
@@ -2265,8 +2265,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "lru",
  "sha1",
@@ -2275,8 +2275,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2284,8 +2284,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2297,8 +2297,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2306,8 +2306,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2316,16 +2316,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "rustls 0.23.40",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 dependencies = [
  "regex-lite",
  "serde",
@@ -2334,8 +2334,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.131.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.131.0#05eb8678451435cbc8d79c6d8254276289f2bdf1"
+version = "0.132.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.132.0#13595c36e218fcbd13df118eeadf00d4eb0e6d31"
 
 [[package]]
 name = "color_quant"
@@ -6381,7 +6381,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -9964,7 +9964,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10002,7 +10002,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -14147,7 +14147,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ tempfile = "3.17"
 ignore = "0.4.23"
 nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
 rmcp = { version = "1.7", features = ["client", "transport-child-process"] }
-codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.131.0" }
+codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.132.0" }
 rara-instructions = { path = "crates/instructions" }
 
 [package]


### PR DESCRIPTION
## Summary

Bump all codex dependencies from `rust-v0.131.0` to `rust-v0.132.0`.

- `codex-execpolicy`
- `codex-login`  
- `codex-models-manager`

30 transitive codex crates updated from v0.131.0 → v0.132.0.

## Validation

- `cargo update -p codex-*` ✅
- `cargo check` ✅ (109 pre-existing warnings)