### PR TITLE
fix(model-server): detect process exit and report error instead of showing stale status

### DIFF
--- a/src/local_model_server/status.rs
+++ b/src/local_model_server/status.rs
@@ -192,11 +192,48 @@ pub(crate) fn reusable_server_status(
         return None;
     }
     let endpoint = endpoint_url(&metadata.host, metadata.port);
-    let health = probe_health(&metadata.host, metadata.port).ok()?;
+    let health = match probe_health(&metadata.host, metadata.port) {
+        Ok(h) => h,
+        Err(_) => {
+            if process_exited(metadata.pid) {
+                return Some(LocalModelServerStatus {
+                    state: LocalModelServerState::Error,
+                    backend: backend.to_string(),
+                    model: model.to_string(),
+                    detail: format!(
+                        "model server process (pid {}) exited unexpectedly; \
+                         check stderr log at {}",
+                        metadata.pid,
+                        server.runtime_dir.join("model-server-stderr.log").display(),
+                    ),
+                    server_path: Some(server.path.clone()),
+                    endpoint: Some(endpoint),
+                });
+            }
+            return None;
+        }
+    };
     if !health_identity_matches(&health, backend, model) {
         return None;
     }
     if !health_model_ready(&health, backend) {
+        // Check if the process exited while we were polling — if so,
+        // report the crash instead of pretending it's still loading.
+        if process_exited(metadata.pid) {
+            return Some(LocalModelServerStatus {
+                state: LocalModelServerState::Error,
+                backend: backend.to_string(),
+                model: model.to_string(),
+                detail: format!(
+                    "model server process (pid {}) exited unexpectedly while loading model; \
+                     check stderr log at {}",
+                    metadata.pid,
+                    server.runtime_dir.join("model-server-stderr.log").display(),
+                ),
+                server_path: Some(server.path.clone()),
+                endpoint: Some(endpoint),
+            });
+        }
         if let Some(error_message) = health_preparation_error(&health, backend) {
             return Some(LocalModelServerStatus {
                 state: LocalModelServerState::Error,

--- a/src/local_model_server/util.rs
+++ b/src/local_model_server/util.rs
@@ -311,3 +311,18 @@ pub(crate) fn set_private_file_permissions(path: &Path) -> Result<()> {
 pub(crate) fn set_private_file_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
+
+/// Check whether a process identified by `pid` has exited.
+/// Returns `true` if the pid is no longer running (or never existed).
+pub(crate) fn process_exited(pid: u32) -> bool {
+    use std::process::Command;
+    let pid_str = pid.to_string();
+    Command::new("kill")
+        .arg("-0")
+        .arg(&pid_str)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| !status.success())
+        .unwrap_or(true)
+}

--- a/src/local_model_server/util.rs
+++ b/src/local_model_server/util.rs
@@ -315,14 +315,9 @@ pub(crate) fn set_private_file_permissions(_path: &Path) -> Result<()> {
 /// Check whether a process identified by `pid` has exited.
 /// Returns `true` if the pid is no longer running (or never existed).
 pub(crate) fn process_exited(pid: u32) -> bool {
-    use std::process::Command;
-    let pid_str = pid.to_string();
-    Command::new("kill")
-        .arg("-0")
-        .arg(&pid_str)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|status| !status.success())
-        .unwrap_or(true)
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    // Signal 0 (null signal) — does not actually send a signal, only
+    // checks whether the process exists and we have permission.
+    kill(Pid::from_raw(pid as i32), None).is_err()
 }


### PR DESCRIPTION
## Summary

When the model server Python process crashes, RARA previously showed stale status (`○ stopped` or `○ preparing`) because nobody checked whether the process was still alive after the startup health loop finished.

### Fix

- Add `process_exited(pid)` helper — uses `kill -0` to check if process is alive
- In `reusable_server_status`: check `process_exited` when health probe fails (endpoint unreachable) and when model is still loading (health probe returns but model not ready)
- If process exited: return `✗ error` with pid and stderr log path

### Before / After

| Before | After |
|---|---|
| Silently shows old status | Sidebar shows `✗ error: process exited, check stderr` |

### Validation

- `cargo check` ✅ (111 pre-existing warnings)