### PR TITLE
feat: include stderr tail in model server crash errors

### DIFF
--- a/src/local_model_server/server.rs
+++ b/src/local_model_server/server.rs
@@ -60,8 +60,9 @@ pub(crate) fn start_model_server(
                                 backend: backend.to_string(),
                                 model: model.to_string(),
                                 detail: format!(
-                                    "model server running at {endpoint}; model preparation failed: {error_message} (stderr log: {})",
-                                    stderr_log_path.display()
+                                    "model server running at {endpoint}; model preparation failed: {error_message} (stderr log: {})\nstderr tail:\n{}",
+                                    stderr_log_path.display(),
+                                    stderr_tail(&stderr_log_path)
                                 ),
                                 server_path: Some(server.path.clone()),
                                 endpoint: Some(endpoint),
@@ -90,8 +91,9 @@ pub(crate) fn start_model_server(
                         backend: backend.to_string(),
                         model: model.to_string(),
                         detail: format!(
-                            "model server process exited with {status} during startup (stderr log: {})",
-                            stderr_log_path.display()
+                            "model server process exited with {status} during startup (stderr log: {})\nstderr tail:\n{}",
+                            stderr_log_path.display(),
+                            stderr_tail(&stderr_log_path)
                         ),
                         server_path: Some(server.path.clone()),
                         endpoint: Some(endpoint),
@@ -113,9 +115,10 @@ pub(crate) fn start_model_server(
                     backend: backend.to_string(),
                     model: model.to_string(),
                     detail: format!(
-                        "failed to prepare model at {endpoint} after {} health checks: {err} (stderr log: {})",
+                        "failed to prepare model at {endpoint} after {} health checks: {err} (stderr log: {})\nstderr tail:\n{}",
                         STARTUP_HEALTH_ATTEMPTS,
-                        stderr_log_path.display()
+                        stderr_log_path.display(),
+                        stderr_tail(&stderr_log_path)
                     ),
                     server_path: Some(server.path.clone()),
                     endpoint: Some(endpoint),
@@ -149,6 +152,20 @@ pub(crate) fn start_model_server(
             endpoint: Some(endpoint),
         },
     }
+}
+
+/// Read the last 4 lines of the stderr log for diagnostic inclusion.
+fn stderr_tail(path: &std::path::Path) -> String {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .rev()
+        .take(4)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn ready_model_server_status(


### PR DESCRIPTION
## Summary

When the local model server crashes, the error message previously only pointed to the stderr log file.  The user had to manually `cat` the file to see what went wrong.

## Changes

- Add `stderr_tail(path)` helper that reads the last 4 lines of the stderr log
- Include stderr tail in all 3 model-server error detail messages:
  1. Process exit during startup
  2. Model preparation failure  
  3. Health check exhaustion

## Before/After

```
Before: model server process exited with exit code: 1 during startup (stderr log: /path/to/log)
After:  model server process exited with exit code: 1 during startup (stderr log: /path/to/log)
        stderr tail:
        "GET /health HTTP/1.1" 200 -
        mx.metal.clear_cache is deprecated
```