### PR TITLE
fix(vectordb): validate embedding dimension on read path, prevent crash

### DIFF
--- a/crates/rara-memory/src/vectordb.rs
+++ b/crates/rara-memory/src/vectordb.rs
@@ -148,6 +148,14 @@ impl VectorDB {
         let Some(table) = self.open_table_if_exists(table_name).await? else {
             return Ok(Vec::new());
         };
+        if let Err(e) = validate_table_vector_dim(&table, query_vector.len()).await {
+            log::warn!(
+                "LanceDB table {table_name} vector dimension mismatch; \
+                 skipping search, table will be rebuilt on next write. \
+                 Error: {e}"
+            );
+            return Ok(Vec::new());
+        }
         let batches = table
             .query()
             .nearest_to(query_vector)?

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -72,7 +72,7 @@ Active backlog only. Keep this file small and current.
 
 ### Features
 - [ ] `rara resume --last`: restore last session after exit
-- [ ] Embedding dimension consistency: detect + rebuild on mismatch
+- [x] Embedding dimension consistency: detect + rebuild on mismatch
 - [ ] Sidebar status update: `app.local_model_server` after bootstrap
 
 ### Specs to Write


### PR DESCRIPTION
## What

`vector_search_hits` now validates LanceDB table vector dimension before executing `nearest_to`, preventing a crash when the embedding model changes and produces vectors of a different dimension.

## Why

- **Write path** (`upsert_turn`) already handles dimension mismatch via `open_or_create_table` → `validate_table_vector_dim` → drop + rebuild.
- **Read path** (`vector_search_hits`) was calling `open_table_if_exists` without validation, causing LanceDB to error when the query vector dimension differed from the table schema.
- This fix makes the read path gracefully return empty results with a warning, letting the next write auto-rebuild the table.

## Changes

- `crates/rara-memory/src/vectordb.rs`: add `validate_table_vector_dim` check in `vector_search_hits`
- `docs/todo.md`: mark "Embedding dimension consistency" as done

## Verification

`cargo check -p rara-memory` passes.