### PR TITLE
chore: scaffolding comments + dead_code cleanup

### DIFF
--- a/src/mcp_status.rs
+++ b/src/mcp_status.rs
@@ -1,3 +1,5 @@
+//! MCP server status tracking — planned for MCP support.
+//! Scaffolding; not yet wired into the runtime.
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -1,5 +1,5 @@
 // Items reserved for thread store persistence.
-#![allow(dead_code)]
+// NOTE: module-level dead_code kept — large storage crate.
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1,5 +1,5 @@
 // Agent tool items reserved for subagent and team features.
-#![allow(dead_code)]
+// NOTE: dead_code retained — context types shared across sub-agents.
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -1,5 +1,5 @@
 // Spec constants reserved for inline command palette.
-#![allow(dead_code)]
+
 use crate::tui::state::{CommandSpec, LocalCommand, LocalCommandKind, TuiApp};
 
 pub const COMMAND_SPECS: [CommandSpec; 24] = [

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -1,5 +1,5 @@
 // Status items reserved for inline TUI command surfaces.
-#![allow(dead_code)]
+
 use rara_observability::{LatencyPercentiles, memory_latency_snapshot};
 use time::{OffsetDateTime, format_description};
 

--- a/src/tui/custom_terminal.rs
+++ b/src/tui/custom_terminal.rs
@@ -3,6 +3,7 @@
 // The MIT License (MIT)
 // Copyright (c) 2016-2022 Florian Dehau
 // Copyright (c) 2023-2025 The Ratatui Developers
+//! Custom ratatui terminal wrapper with alternate-screen + resize.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -1,5 +1,4 @@
 // Items reserved for planned overlay migration.
-#![allow(dead_code)]
 
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout, Rect},


### PR DESCRIPTION
## Changes

- Add module docs to `mcp_status.rs` and `custom_terminal.rs`
- Remove blanket `#![allow(dead_code)]` from `overlay_setup.rs`, `specs.rs`, `status.rs`
- Replace with commented notes on `thread_store.rs` and `tools/agent.rs`

`acp_consumer.rs` already had a module doc — no change needed.