### PR TITLE
chore: add TODO comments to remaining allow(dead_code)

### DIFF
--- a/src/acp_consumer.rs
+++ b/src/acp_consumer.rs
@@ -15,13 +15,13 @@ use crate::runtime_event_bus::RuntimeEventBus;
 
 /// Subscribes to RuntimeEventBus and yields ACP SessionNotification
 /// for each AgentEvent. The caller sends notifications to the ACP client.
-#[allow(dead_code)]
+#[allow(dead_code)] // TODO: ACP peer lifecycle — activate when ACP integration is wired in.
 pub struct AcpConsumer {
     rx: tokio::sync::broadcast::Receiver<AgentEvent>,
     session_id: SessionId,
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // TODO: ACP peer channel — activate when ACP integration is wired in.
 impl AcpConsumer {
     pub fn new(event_bus: Arc<RuntimeEventBus>, session_id: SessionId) -> Self {
         Self {

--- a/src/context/file_search_provider.rs
+++ b/src/context/file_search_provider.rs
@@ -79,7 +79,7 @@ impl FileSearchCandidateProvider {
     ///
     /// Each candidate carries provenance, budget, and a stable order
     /// (score descending, path ascending).
-    #[allow(dead_code)]
+    #[allow(dead_code)] // TODO: file search provider — activate when file search context is wired in.
     pub fn context_candidates(
         &self,
         query: &str,

--- a/src/tui/custom_terminal.rs
+++ b/src/tui/custom_terminal.rs
@@ -414,7 +414,7 @@ where
     /// Gets the current cursor position.
     ///
     /// This is the position of the cursor after the last draw call.
-    #[allow(dead_code)]
+    #[allow(dead_code)] // TODO: terminal restart — activate when custom terminal features are wired in.
     pub fn get_cursor_position(&mut self) -> io::Result<Position> {
         self.backend.get_cursor_position()
     }


### PR DESCRIPTION
Add TODO activation comments to remaining `#[allow(dead_code)]` items per AGENTS.md:

- `acp_consumer.rs` — ACP peer lifecycle + channel
- `custom_terminal.rs` — terminal restart
- `file_search_provider.rs` — file search provider