### PR TITLE
fix: approval Enter works with text in composer

### DIFF
--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -130,22 +130,31 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             {
                 return AppEvent::SelectPendingOption(index);
             }
-            if app.bottom_pane.input.is_empty()
-                && app.active_pending_interaction().is_some_and(|interaction| {
-                    interaction.kind == super::state::ActivePendingInteractionKind::ShellApproval
-                })
-            {
-                match (code, modifiers) {
-                    (KeyCode::Up | KeyCode::Char('k'), KeyModifiers::NONE) => {
-                        return AppEvent::MoveApprovalSelection(-1);
+            // Shell approval: Enter always selects, even with text in composer.
+            // j/k navigation requires empty composer so regular typing works.
+            if app.active_pending_interaction().is_some_and(|interaction| {
+                interaction.kind == super::state::ActivePendingInteractionKind::ShellApproval
+            }) {
+                if code == KeyCode::Enter && modifiers.is_empty() {
+                    return AppEvent::SelectPendingOption(app.approval_picker_idx);
+                }
+                if app.bottom_pane.input.is_empty() {
+                    match (code, modifiers) {
+                        (KeyCode::Up | KeyCode::Char('k'), KeyModifiers::NONE) => {
+                            return AppEvent::MoveApprovalSelection(-1);
+                        }
+                        (KeyCode::Down | KeyCode::Char('j'), KeyModifiers::NONE) => {
+                            return AppEvent::MoveApprovalSelection(1);
+                        }
+                        _ => {}
                     }
-                    (KeyCode::Down | KeyCode::Char('j'), KeyModifiers::NONE) => {
-                        return AppEvent::MoveApprovalSelection(1);
+                    for (i, digit) in ['1', '2', '3', '4'].into_iter().enumerate() {
+                        if code == KeyCode::Char(digit) && modifiers.is_empty()
+                            || matches!(code, KeyCode::F(1..=4))
+                        {
+                            return AppEvent::SelectPendingOption(i);
+                        }
                     }
-                    (KeyCode::Enter, KeyModifiers::NONE) => {
-                        return AppEvent::SelectPendingOption(app.approval_picker_idx);
-                    }
-                    _ => {}
                 }
             }
 

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -148,12 +148,8 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
                         }
                         _ => {}
                     }
-                    for (i, digit) in ['1', '2', '3', '4'].into_iter().enumerate() {
-                        if code == KeyCode::Char(digit) && modifiers.is_empty()
-                            || matches!(code, KeyCode::F(1..=4))
-                        {
-                            return AppEvent::SelectPendingOption(i);
-                        }
+                    if let KeyCode::F(num @ 1..=4) = code {
+                        return AppEvent::SelectPendingOption((num - 1) as usize);
                     }
                 }
             }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -896,6 +896,14 @@ fn pending_shell_approval_number_shortcuts_work_in_local_and_ssh() {
             AppEvent::SelectPendingOption(3)
         ));
         assert!(matches!(
+            map_key_to_event(key(KeyCode::F(2)), &app),
+            AppEvent::SelectPendingOption(1)
+        ));
+        assert!(matches!(
+            map_key_to_event(key(KeyCode::F(4)), &app),
+            AppEvent::SelectPendingOption(3)
+        ));
+        assert!(matches!(
             map_key_to_event(key(KeyCode::Down), &app),
             AppEvent::MoveApprovalSelection(1)
         ));


### PR DESCRIPTION
Move ShellApproval Enter handling before is_empty() guard so pressing Enter with non-empty composer text selects the approval option.