### PR TITLE
fix: handle stale model server metadata and auto-recover on preparation failure

### DIFF
--- a/src/local_model_server/server.rs
+++ b/src/local_model_server/server.rs
@@ -47,6 +47,7 @@ pub(crate) fn start_model_server(
             let mut health_ever_passed = false;
             let mut last_prepare_error: Option<anyhow::Error> = None;
             let mut saw_model_loading = false;
+            let marker_path = model_snapshot_marker_path(&server.runtime_dir);
             for _ in 0..STARTUP_HEALTH_ATTEMPTS {
                 if let Ok(health) = probe_health(host, port) {
                     health_ever_passed = true;
@@ -55,6 +56,9 @@ pub(crate) fn start_model_server(
                             return ready_model_server_status(server, backend, model, &endpoint);
                         }
                         if let Some(error_message) = health_preparation_error(&health, backend) {
+                            if let Err(e) = std::fs::remove_file(&marker_path) {
+                                eprintln!("warn: failed to remove model snapshot marker: {e}");
+                            }
                             return LocalModelServerStatus {
                                 state: LocalModelServerState::Error,
                                 backend: backend.to_string(),
@@ -110,6 +114,9 @@ pub(crate) fn start_model_server(
                 );
             }
             if let Some(err) = last_prepare_error {
+                if let Err(e) = std::fs::remove_file(&marker_path) {
+                    eprintln!("warn: failed to remove model snapshot marker: {e}");
+                }
                 return LocalModelServerStatus {
                     state: LocalModelServerState::Error,
                     backend: backend.to_string(),

--- a/src/local_model_server/status.rs
+++ b/src/local_model_server/status.rs
@@ -195,9 +195,6 @@ pub(crate) fn reusable_server_status(
     let health = match probe_health(&metadata.host, metadata.port) {
         Ok(h) => h,
         Err(_) => {
-            if process_exited(metadata.pid) {
-                return None;
-            }
             return None;
         }
     };
@@ -205,8 +202,8 @@ pub(crate) fn reusable_server_status(
         return None;
     }
     if !health_model_ready(&health, backend) {
-        // Check if the process exited while we were polling — if so,
-        // report the crash instead of pretending it's still loading.
+        // If the process exited while we were polling, treat metadata
+        // as stale so the caller can recover.
         if process_exited(metadata.pid) {
             return None;
         }

--- a/src/local_model_server/status.rs
+++ b/src/local_model_server/status.rs
@@ -196,19 +196,7 @@ pub(crate) fn reusable_server_status(
         Ok(h) => h,
         Err(_) => {
             if process_exited(metadata.pid) {
-                return Some(LocalModelServerStatus {
-                    state: LocalModelServerState::Error,
-                    backend: backend.to_string(),
-                    model: model.to_string(),
-                    detail: format!(
-                        "model server process (pid {}) exited unexpectedly; \
-                         check stderr log at {}",
-                        metadata.pid,
-                        server.runtime_dir.join("model-server-stderr.log").display(),
-                    ),
-                    server_path: Some(server.path.clone()),
-                    endpoint: Some(endpoint),
-                });
+                return None;
             }
             return None;
         }
@@ -220,19 +208,7 @@ pub(crate) fn reusable_server_status(
         // Check if the process exited while we were polling — if so,
         // report the crash instead of pretending it's still loading.
         if process_exited(metadata.pid) {
-            return Some(LocalModelServerStatus {
-                state: LocalModelServerState::Error,
-                backend: backend.to_string(),
-                model: model.to_string(),
-                detail: format!(
-                    "model server process (pid {}) exited unexpectedly while loading model; \
-                     check stderr log at {}",
-                    metadata.pid,
-                    server.runtime_dir.join("model-server-stderr.log").display(),
-                ),
-                server_path: Some(server.path.clone()),
-                endpoint: Some(endpoint),
-            });
+            return None;
         }
         if let Some(error_message) = health_preparation_error(&health, backend) {
             return Some(LocalModelServerStatus {

--- a/src/local_model_server/tests.rs
+++ b/src/local_model_server/tests.rs
@@ -315,6 +315,33 @@ fn stale_metadata_with_wrong_hash_is_not_reused() {
 }
 
 #[test]
+fn stale_metadata_with_exited_pid_is_not_reused() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let server = ensure_bundled_model_server(temp.path()).expect("install model server");
+    let (backend, model) = super::default_embedding_backend();
+
+    // Create a known-dead PID by spawning a short-lived process.
+    let mut child = std::process::Command::new("true").spawn().expect("spawn");
+    let dead_pid = child.id();
+    child.wait().expect("wait");
+
+    let metadata = ModelServerMetadata {
+        pid: dead_pid,
+        host: "127.0.0.1".to_string(),
+        port: 9,
+        component_sha256: server.sha256.clone(),
+        profile: super::embedding_profile_id().to_string(),
+        started_at: unix_timestamp_secs(),
+    };
+    write_server_metadata(&metadata_path(&server.runtime_dir), &metadata).expect("write metadata");
+
+    assert!(
+        reusable_server_status(&server, backend, model).is_none(),
+        "metadata with exited PID should not be reused"
+    );
+}
+
+#[test]
 fn startup_lock_allows_only_one_owner() {
     let temp = tempfile::tempdir().expect("tempdir");
     let lock_path = startup_lock_path(temp.path());


### PR DESCRIPTION
## Summary

Two related fixes for model server lifecycle:

### 1. Stale metadata handling (status.rs)
`reusable_server_status` returned `Some(Error)` when the model server process had exited. This blocked both `InspectOnly` from falling back to `PreparedButStopped` and `Automatic` from starting a new server. Now returns `None` so the caller can decide the next action.

### 2. Auto-invalidate model snapshot on preparation failure (server.rs)
When the model server reports a preparation error (e.g. corrupted model files, incomplete download), the model-snapshot.json marker is now deleted. On next startup, RARA will re-download the model automatically instead of repeating the same error.

## Verification

- `cargo check` passes with no new warnings
- 24 local_model_server tests pass