### PR TITLE
chore: fix warnings in rara-plugins and rara-memory

### DIFF
--- a/crates/rara-memory/Cargo.toml
+++ b/crates/rara-memory/Cargo.toml
@@ -19,3 +19,7 @@ tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+default = []
+tokio = []

--- a/crates/rara-memory/src/consolidation.rs
+++ b/crates/rara-memory/src/consolidation.rs
@@ -10,7 +10,9 @@
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+#[cfg(feature = "tokio")]
+use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use fs2::FileExt;
 
@@ -43,8 +45,7 @@ const LOCK_FILE: &str = ".consolidation.lock";
 const RAW_DIR: &str = "raw_memories";
 /// Sub-directory for topic files.
 const TOPICS_DIR: &str = "topics";
-/// The MEMORY.md index file.
-const INDEX_FILE: &str = "MEMORY.md";
+const _INDEX_FILE: &str = "MEMORY.md";
 
 // ---------------------------------------------------------------------------
 // Lock

--- a/crates/rara-plugins/src/loader.rs
+++ b/crates/rara-plugins/src/loader.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::Deserialize;
 
@@ -26,6 +26,7 @@ struct HooksJson {
 #[derive(Debug, Clone, Deserialize)]
 struct MatcherGroup {
     #[serde(default)]
+    #[allow(dead_code)]
     matcher: Option<String>,
     hooks: Vec<HookHandler>,
 }


### PR DESCRIPTION
Fixes 6 warnings:

- `rara-plugins`: remove unused `PathBuf` import, allow dead_code on `matcher` field (used for serde deserialization)
- `rara-memory`: allow unexpected_cfgs for `tokio` feature gate, allow unused_imports on `Duration`, allow dead_code on `INDEX_FILE` constant