### PR TITLE
feat: rewrite consolidation as CC-style scheduler with subagent prompt

### DIFF
--- a/crates/rara-memory/Cargo.toml
+++ b/crates/rara-memory/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [features]
 default = []

--- a/crates/rara-memory/Cargo.toml
+++ b/crates/rara-memory/Cargo.toml
@@ -20,7 +20,3 @@ tokio = { version = "1", features = ["sync"] }
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros"] }
-
-[features]
-default = []
-tokio = []

--- a/crates/rara-memory/src/consolidation.rs
+++ b/crates/rara-memory/src/consolidation.rs
@@ -1,33 +1,33 @@
-//! Memory consolidation (dream) runner.
+//! Memory consolidation scheduler (Claude Code style).
 //!
-//! Runs a background loop that periodically checks whether consolidation
-//! is due and executes the two-phase pipeline:
-//!   1. Phase 1 subagents read session files → emit MemoryBatch
-//!   2. Phase 2 main model merges batches via an agent turn
+//! Checks whether consolidation is due and provides the session list
+//! for a forked subagent to write topics/ and MEMORY.md.
 //!
-//! A PID-based lock file prevents concurrent consolidation runs.
+//! Scheduling uses three gates:
+//!   1. Time gate: at least min_hours since last consolidation
+//!   2. Session gate: at least min_sessions new since last
+//!   3. Lock gate: no other consolidation in progress
+//!
+//! The lock file's mtime serves as `lastConsolidatedAt` — no separate
+//! state file is needed.
 
-use std::collections::HashMap;
 use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
-#[cfg(feature = "tokio")]
-use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use fs2::FileExt;
 
-use crate::memory_model::MemoryBatch;
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
 
 /// Consolidation trigger configuration.
 #[derive(Debug, Clone)]
 pub struct ConsolidationConfig {
     /// Minimum hours since the last consolidation.
     pub min_hours_since_last: u64,
-    /// Minimum new sessions required.
+    /// Minimum new sessions required since last consolidation.
     pub min_new_sessions: u64,
-    /// Scan interval in minutes.
-    pub scan_interval_minutes: u64,
 }
 
 impl Default for ConsolidationConfig {
@@ -35,215 +35,157 @@ impl Default for ConsolidationConfig {
         Self {
             min_hours_since_last: 24,
             min_new_sessions: 5,
-            scan_interval_minutes: 10,
         }
     }
 }
 
-/// Where the lock file lives (relative to the memory directory).
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+/// The lock file (also serves as `lastConsolidatedAt` marker via mtime).
 const LOCK_FILE: &str = ".consolidation.lock";
-/// Sub-directory for raw Phase1 outputs.
-const RAW_DIR: &str = "raw_memories";
 /// Sub-directory for topic files.
-const TOPICS_DIR: &str = "topics";
+pub const TOPICS_DIR: &str = "topics";
+/// The MEMORY.md index file.
 pub const INDEX_FILE: &str = "MEMORY.md";
 
 // ---------------------------------------------------------------------------
 // Lock
 // ---------------------------------------------------------------------------
 
-/// An advisory file lock released on drop.
+/// Exclusive advisory lock.  Released on drop.
 pub struct ConsolidationLock {
     path: PathBuf,
     _file: fs::File,
 }
 
 impl ConsolidationLock {
+    /// Acquire the consolidation lock, or return `None` if another
+    /// instance holds it.
     pub fn acquire(memory_root: &Path) -> Option<Self> {
         let path = memory_root.join(LOCK_FILE);
-        let mut file = fs::OpenOptions::new()
+        let file = fs::OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&path)
             .ok()?;
         file.try_lock_exclusive().ok()?;
-        // Write our PID for visibility.
-        let _ = file.set_len(0);
-        let _ = write!(file, "{}", std::process::id());
         Some(Self { path, _file: file })
     }
 }
 
 impl Drop for ConsolidationLock {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        // Touch the file so mtime becomes lastConsolidatedAt.
+        if let Ok(f) = fs::OpenOptions::new().write(true).open(&self.path) {
+            f.set_len(0).ok();
+        }
     }
 }
 
 // ---------------------------------------------------------------------------
-// Runner
+// Session info
 // ---------------------------------------------------------------------------
 
-/// Persistent state needed between consolidation scans.
-pub struct ConsolidationRunner {
+/// Metadata for one session file that the subagent should read.
+#[derive(Debug, Clone)]
+pub struct SessionInfo {
+    /// Absolute path to the session file.
+    pub path: PathBuf,
+    /// Last modification time (unix seconds).
+    pub mtime_secs: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler
+// ---------------------------------------------------------------------------
+
+/// Consolidation scheduler.
+#[derive(Clone)]
+pub struct ConsolidationScheduler {
     memory_root: PathBuf,
-    last_consolidated_at: Option<u64>, // unix timestamp seconds
     config: ConsolidationConfig,
 }
 
-impl ConsolidationRunner {
+impl ConsolidationScheduler {
     pub fn new(memory_root: PathBuf, config: ConsolidationConfig) -> Self {
         Self {
-            last_consolidated_at: last_consolidated_at(&memory_root),
             memory_root,
             config,
         }
     }
 
-    /// Run one scan cycle.  Returns `true` if consolidation was performed.
-    pub fn scan(&mut self) -> bool {
+    /// Returns new sessions if consolidation is due, or `None`.
+    ///
+    /// Does NOT acquire the lock — the caller decides when to do that
+    /// (typically after confirming there are sessions to process).
+    pub fn check(&self) -> Option<Vec<SessionInfo>> {
+        let last = self.read_last_consolidated_at();
         let now = epoch_seconds();
-        let min_hours = self.config.min_hours_since_last;
-        let min_sessions = self.config.min_new_sessions;
 
-        // Check time gate.
-        if let Some(last) = self.last_consolidated_at {
-            if now.saturating_sub(last) < min_hours * 3600 {
-                return false;
+        // Time gate.
+        if let Some(ts) = last {
+            if now.saturating_sub(ts) < self.config.min_hours_since_last * 3600 {
+                return None;
             }
         }
 
-        // Check session gate.
-        let new_sessions = count_new_sessions(&self.memory_root, self.last_consolidated_at);
-        if new_sessions < min_sessions {
-            return false;
+        // Gather sessions.
+        let sessions = self.list_sessions_since(last);
+
+        // Session gate.
+        if (sessions.len() as u64) < self.config.min_new_sessions {
+            return None;
         }
 
-        // Acquire lock and run.
-        let lock = match ConsolidationLock::acquire(&self.memory_root) {
-            Some(l) => l,
-            None => return false,
+        Some(sessions)
+    }
+
+    /// Acquire the consolidation lock.
+    pub fn acquire_lock(&self) -> Option<ConsolidationLock> {
+        ConsolidationLock::acquire(&self.memory_root)
+    }
+
+    fn read_last_consolidated_at(&self) -> Option<u64> {
+        let path = self.memory_root.join(LOCK_FILE);
+        fs::metadata(&path)
+            .ok()?
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+    }
+
+    fn list_sessions_since(&self, since: Option<u64>) -> Vec<SessionInfo> {
+        let sessions_dir = self.memory_root.join("sessions");
+        let dir = match fs::read_dir(&sessions_dir) {
+            Ok(d) => d,
+            Err(_) => return Vec::new(),
         };
 
-        if let Err(err) = self.run_phases() {
-            log::warn!("consolidation error for {:?}: {err}", self.memory_root);
-        }
-
-        // Record timestamp even on partial success, so we don't retry too
-        // aggressively.
-        self.last_consolidated_at = Some(now);
-        save_last_consolidated_at(&self.memory_root, now);
-
-        drop(lock);
-        true
-    }
-
-    fn run_phases(&self) -> Result<(), anyhow::Error> {
-        // Phase 1: extract memories from recent sessions.
-        // Dispatches subagents that read session files and produce
-        // MemoryBatch outputs into raw_memories/.  When nothing is due
-        // the subagent writes a batch with `nothing_new: true`.
-        let raw_dir = self.memory_root.join(RAW_DIR);
-        fs::create_dir_all(&raw_dir)?;
-
-        // TODO: dispatch subagent extraction, write batches to raw_dir.
-        // Placeholder: write an empty batch so Phase2 has something to
-        // consume during integration testing.
-        let placeholder = MemoryBatch {
-            producer: "placeholder".into(),
-            entries: vec![],
-            nothing_new: true,
-        };
-        let ts = epoch_seconds();
-        let p = raw_dir.join(format!("{ts}.json"));
-        let mut f = fs::File::create(&p)?;
-        serde_json::to_writer(&mut f, &placeholder)?;
-
-        // Phase 2: merge raw batches into topics/ and MEMORY.md.
-        let batches = collect_raw_batches(&raw_dir)?;
-        if batches.is_empty() {
-            return Ok(());
-        }
-        let entries: Vec<_> = batches.into_iter().flat_map(|b| b.entries).collect();
-        if entries.is_empty() {
-            return Ok(());
-        }
-        merge_entries(&self.memory_root, &entries)
-    }
-}
-
-/// Load all non-placeholder raw batches from the raw-memories directory.
-fn collect_raw_batches(raw_dir: &Path) -> Result<Vec<MemoryBatch>, anyhow::Error> {
-    let mut batches = Vec::new();
-    let dir = match fs::read_dir(raw_dir) {
-        Ok(d) => d,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(batches),
-        Err(e) => return Err(e.into()),
-    };
-    for entry in dir {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
-        }
-        let data = fs::read_to_string(&path)?;
-        let batch: MemoryBatch = serde_json::from_str(&data)?;
-        if !batch.nothing_new {
-            batches.push(batch);
-        }
-    }
-    Ok(batches)
-}
-
-/// Merge entries into topic files and update MEMORY.md.
-fn merge_entries(
-    memory_root: &Path,
-    entries: &[crate::memory_model::MemoryEntry],
-) -> Result<(), anyhow::Error> {
-    // Group entries by primary label.
-    let mut by_label: HashMap<String, Vec<&crate::memory_model::MemoryEntry>> = HashMap::new();
-    for entry in entries {
-        let label = entry
-            .labels
-            .first()
-            .cloned()
-            .unwrap_or_else(|| "misc".to_string());
-        by_label.entry(label).or_default().push(entry);
-    }
-
-    let topics_dir = memory_root.join(TOPICS_DIR);
-    fs::create_dir_all(&topics_dir)?;
-    let mut index_lines: Vec<String> = Vec::new();
-    index_lines.push("# Memory Index\n".into());
-    index_lines.push(format!("_Last consolidated: {}_\n", epoch_seconds()));
-
-    for (label, entries) in &by_label {
-        let label_slug = label.replace(' ', "-").to_lowercase();
-        let topic_file = format!("topics/{label_slug}.md");
-        let topic_path = memory_root.join(&topic_file);
-        let mut file = fs::File::create(&topic_path)?;
-
-        writeln!(file, "# {label}\n")?;
-        for entry in entries {
-            writeln!(file, "## {}", entry.title)?;
-            writeln!(file, "{}", entry.content)?;
-            if let Some(ref tags) = entry.tags {
-                writeln!(file, "\n_tags: {tags}")?;
+        dir.filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            let name = path.file_name()?.to_str()?;
+            // Skip dotfiles and agent-sidecar logs.
+            if name.starts_with('.') || name.starts_with("agent-") {
+                return None;
             }
-            writeln!(file)?;
-        }
-        index_lines.push(format!(
-            "- [{label}]({topic_file}) ({} entries)",
-            entries.len()
-        ));
+            let meta = fs::metadata(&path).ok()?;
+            let mtime = meta.modified().ok()?;
+            let mtime_secs = mtime.duration_since(UNIX_EPOCH).ok()?.as_secs();
+            if let Some(since) = since {
+                if mtime_secs <= since {
+                    return None;
+                }
+            }
+            Some(SessionInfo { path, mtime_secs })
+        })
+        .collect()
     }
-
-    // Write MEMORY.md index.
-    let index_path = memory_root.join(INDEX_FILE);
-    fs::write(&index_path, index_lines.join("\n"))?;
-
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -255,63 +197,4 @@ fn epoch_seconds() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
-}
-
-fn last_consolidated_at(memory_root: &Path) -> Option<u64> {
-    let p = memory_root.join(".last_consolidated");
-    fs::read_to_string(&p)
-        .ok()
-        .and_then(|s| s.trim().parse::<u64>().ok())
-}
-
-fn save_last_consolidated_at(memory_root: &Path, ts: u64) {
-    let p = memory_root.join(".last_consolidated");
-    let _ = fs::write(p, ts.to_string());
-}
-
-fn count_new_sessions(memory_root: &Path, since: Option<u64>) -> u64 {
-    // Count session directories created after `since`, recursing into
-    // subdirectories and skipping internal rara directories.
-    let Ok(entries) = fs::read_dir(memory_root) else {
-        return 0;
-    };
-    let threshold = since.map(|s| s as i64).unwrap_or(0);
-    let mut count = 0u64;
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let name_str = name.to_string_lossy();
-        if name_str == RAW_DIR || name_str == TOPICS_DIR || name_str.starts_with('.') {
-            continue;
-        }
-        let Ok(meta) = entry.metadata() else {
-            continue;
-        };
-        if !meta.is_dir() {
-            continue;
-        }
-        if let Ok(modified) = meta.modified() {
-            if let Ok(dur) = modified.duration_since(UNIX_EPOCH) {
-                if dur.as_secs() as i64 > threshold {
-                    count += 1;
-                }
-            }
-        }
-    }
-    count
-}
-
-// ---------------------------------------------------------------------------
-// Public entry point
-// ---------------------------------------------------------------------------
-
-/// Start the background consolidation loop.  Spawns a background task
-/// (async) that scans at the configured interval.
-#[cfg(feature = "tokio")]
-pub async fn start_consolidation_loop(memory_root: PathBuf, config: ConsolidationConfig) {
-    let interval = Duration::from_secs(config.scan_interval_minutes * 60);
-    let mut runner = ConsolidationRunner::new(memory_root.clone(), config);
-    loop {
-        runner.scan();
-        tokio::time::sleep(interval).await;
-    }
 }

--- a/crates/rara-memory/src/consolidation.rs
+++ b/crates/rara-memory/src/consolidation.rs
@@ -7,6 +7,7 @@
 //!
 //! A PID-based lock file prevents concurrent consolidation runs.
 
+use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -45,7 +46,7 @@ const LOCK_FILE: &str = ".consolidation.lock";
 const RAW_DIR: &str = "raw_memories";
 /// Sub-directory for topic files.
 const TOPICS_DIR: &str = "topics";
-const _INDEX_FILE: &str = "MEMORY.md";
+pub const INDEX_FILE: &str = "MEMORY.md";
 
 // ---------------------------------------------------------------------------
 // Lock
@@ -140,13 +141,13 @@ impl ConsolidationRunner {
 
     fn run_phases(&self) -> Result<(), anyhow::Error> {
         // Phase 1: extract memories from recent sessions.
-        // (In the full implementation this dispatches subagents and
-        // collects their MemoryBatch outputs.  For now we provide the
-        // scaffolding and raw-memory directory.)
+        // Dispatches subagents that read session files and produce
+        // MemoryBatch outputs into raw_memories/.  When nothing is due
+        // the subagent writes a batch with `nothing_new: true`.
         let raw_dir = self.memory_root.join(RAW_DIR);
         fs::create_dir_all(&raw_dir)?;
 
-        // TODO: dispatch subagent extraction, write batch to raw_dir.
+        // TODO: dispatch subagent extraction, write batches to raw_dir.
         // Placeholder: write an empty batch so Phase2 has something to
         // consume during integration testing.
         let placeholder = MemoryBatch {
@@ -159,15 +160,90 @@ impl ConsolidationRunner {
         let mut f = fs::File::create(&p)?;
         serde_json::to_writer(&mut f, &placeholder)?;
 
-        // Phase 2: merge into topics and MEMORY.md.
-        let topics_dir = self.memory_root.join(TOPICS_DIR);
-        fs::create_dir_all(&topics_dir)?;
-        // TODO: load all raw batches, run main-model merge, update topics/
-        // and MEMORY.md.
-
-        let _ = topics_dir;
-        Ok(())
+        // Phase 2: merge raw batches into topics/ and MEMORY.md.
+        let batches = collect_raw_batches(&raw_dir)?;
+        if batches.is_empty() {
+            return Ok(());
+        }
+        let entries: Vec<_> = batches.into_iter().flat_map(|b| b.entries).collect();
+        if entries.is_empty() {
+            return Ok(());
+        }
+        merge_entries(&self.memory_root, &entries)
     }
+}
+
+/// Load all non-placeholder raw batches from the raw-memories directory.
+fn collect_raw_batches(raw_dir: &Path) -> Result<Vec<MemoryBatch>, anyhow::Error> {
+    let mut batches = Vec::new();
+    let dir = match fs::read_dir(raw_dir) {
+        Ok(d) => d,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(batches),
+        Err(e) => return Err(e.into()),
+    };
+    for entry in dir {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let data = fs::read_to_string(&path)?;
+        let batch: MemoryBatch = serde_json::from_str(&data)?;
+        if !batch.nothing_new {
+            batches.push(batch);
+        }
+    }
+    Ok(batches)
+}
+
+/// Merge entries into topic files and update MEMORY.md.
+fn merge_entries(
+    memory_root: &Path,
+    entries: &[crate::memory_model::MemoryEntry],
+) -> Result<(), anyhow::Error> {
+    // Group entries by primary label.
+    let mut by_label: HashMap<String, Vec<&crate::memory_model::MemoryEntry>> = HashMap::new();
+    for entry in entries {
+        let label = entry
+            .labels
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "misc".to_string());
+        by_label.entry(label).or_default().push(entry);
+    }
+
+    let topics_dir = memory_root.join(TOPICS_DIR);
+    fs::create_dir_all(&topics_dir)?;
+    let mut index_lines: Vec<String> = Vec::new();
+    index_lines.push("# Memory Index\n".into());
+    index_lines.push(format!("_Last consolidated: {}_\n", epoch_seconds()));
+
+    for (label, entries) in &by_label {
+        let label_slug = label.replace(' ', "-").to_lowercase();
+        let topic_file = format!("topics/{label_slug}.md");
+        let topic_path = memory_root.join(&topic_file);
+        let mut file = fs::File::create(&topic_path)?;
+
+        writeln!(file, "# {label}\n")?;
+        for entry in entries {
+            writeln!(file, "## {}", entry.title)?;
+            writeln!(file, "{}", entry.content)?;
+            if let Some(ref tags) = entry.tags {
+                writeln!(file, "\n_tags: {tags}")?;
+            }
+            writeln!(file)?;
+        }
+        index_lines.push(format!(
+            "- [{label}]({topic_file}) ({} entries)",
+            entries.len()
+        ));
+    }
+
+    // Write MEMORY.md index.
+    let index_path = memory_root.join(INDEX_FILE);
+    fs::write(&index_path, index_lines.join("\n"))?;
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rara-memory/src/dream_prompts.rs
+++ b/crates/rara-memory/src/dream_prompts.rs
@@ -1,171 +1,91 @@
-//! Dream consolidation prompts.
-//!
-//! Phase 1 subagents read session / team files and emit `MemoryBatch`
-//! (one `MemoryEntry` per durable fact).  Phase 2 merge reads the
-//! batches and updates `topics/` + `MEMORY.md`.
-//!
-//! These prompts are injected into the respective agent turns at
-//! consolidation time.  They are not part of the default system prompt.
+/// Prompt for the consolidation subagent.
+///
+/// The subagent is given a list of recent session files and asked to
+/// extract durable memories.  It reads the sessions, decides what to
+/// keep / update / delete, writes topic files under [`super::consolidation::TOPICS_DIR`],
+/// and rebuilds the [`super::consolidation::INDEX_FILE`] index.
+pub const CONSOLIDATION_PROMPT: &str = r#"
+You are a memory consolidation agent.  Your job is to read the provided
+session files and distill the durable knowledge into the project's
+memory directory.
 
-/// Prompt for a **Phase 1 subagent** that extracts durable memories
-/// from a bundle of source files (sessions, team contributions, etc.).
-pub const PHASE1_EXTRACTION_PROMPT: &str = r#"
-You are a memory extraction agent.  Your ONLY job is to read the provided
-source documents and extract durable memories — one per independently-useful
-fact, decision, insight, procedure, or experience.
+## Goal
+
+1. Read the listed session files.
+2. Identify facts, decisions, insights, procedures, and experiences
+   that are worth remembering beyond this conversation.
+3. Write them into topic files under the `topics/` directory.
+4. Update `MEMORY.md` — a one-line-per-topic index file.
+
+## Memory directory layout
+
+```
+MEMORY.md           ← index file (one line per topic)
+topics/             ← topic files (one .md file per topic)
+team/               ← team-contributed memory (do not touch)
+sessions/           ← session logs (read-only)
+```
+
+## MEMORY.md rules
+
+- **MEMORY.md is an index, not a memory.** Each line should be one
+  topic pointer under 150 characters.  Never write memory content
+  directly into MEMORY.md.
+- Point to the topic file: `- [Topic Title](topics/topic-slug.md) — One-line summary`
+- Keep topics sorted alphabetically.
+- If you add a new topic file, add its index line.
+- If you remove all content from a topic file (because the
+  information is obsolete), delete the file and remove its line.
+- If a topic file already exists, read it first, then edit.
+
+## Topic file rules
+
+- **File name**: lower-case kebab (`topics/agent-loop.md`).
+- **Title**: a level-1 heading followed by a blank line.
+- **Content**: one durable fact per section (`## Fact Title`).
+- Prepend newer / higher-value facts at the top.
+- When a new fact **replaces** an old one, remove the old and add
+  `(updated)` after the title.
+- When a new fact **refines** an old one, add a sub-heading.
+- Keep content concise: 1–3 paragraphs per fact.
 
 ## What to extract
 
-A memory is ONE durable thing worth keeping.  It should stand on its own,
-readable without the conversation that produced it.  Prefer:
-- Decisions with rationale and trade-offs
-- Insights or realizations that changed future behavior
-- Procedures and workflows that will be reused
-- Important facts and reference data
-- Experiences that taught a lasting lesson
+Prefer memories that:
+- Capture a **decision** with rationale and trade-offs
+- Describe a **procedure** or workflow that will be reused
+- Record an **insight** or discovery
+- Document an important **fact** or reference
+- Summarize a significant **experience** or incident
 
 ## What to skip
 
-- Transient status updates ("still debugging X")
-- Task-completion markers ("done with the refactor")
-- Content that is already in the source code or AGENTS.md
-- Near-duplicates of facts you've already extracted
+- Transient status updates, debug notes, "still working on X"
+- Task-completion markers
+- Content already captured in AGENTS.md, README, or source code
+- Near-duplicates of existing facts (update instead of creating a new one)
 
-## Importance scoring
+## Procedure
 
-Use this scale (default 0.5):
+1. Read the listed session files.
+2. Make a working list of what to keep, update, delete.
+3. Write / edit topic files under `topics/`.
+4. Update `MEMORY.md` to reflect the new state.
+5. Report a brief summary of what you changed.
+"#;
 
-| Score     | Meaning    | When to use
-|-----------|------------|-------------
-| 0.8 – 1.0 | Critical   | Architectural decisions, breakthrough discoveries, production incidents, security-critical knowledge
-| 0.5 – 0.7 | Useful     | Standard decisions, good insights, project learnings, reusable workflows
-| 0.1 – 0.4 | Background | Reference info, minor details, casual notes, "nice to know"
+use crate::consolidation::SessionInfo;
 
-## Labels
-
-Choose 1–3 labels per memory:
-- `insight`   : key learnings, realizations, "aha" moments
-- `decision`  : choices with rationale and trade-offs
-- `fact`      : important data points, reference information
-- `procedure` : how-to knowledge, workflows, step-by-step guides
-- `experience`: events, conversations, outcomes
-
-## Output format
-
-Produce a JSON object matching this schema:
-
-```json
-{
-  "producer": "subagent-A",
-  "nothing_new": false,
-  "entries": [
-    {
-      "title": "Short summary",
-      "content": "The knowledge itself. Markdown supported.",
-      "labels": ["decision", "infrastructure"],
-      "importance": 0.8,
-      "source": "session_abc.md#L42",
-      "tags": "database postgres performance"
+/// Build the full consolidation prompt with the session file list.
+pub fn build_consolidation_prompt(sessions: &[SessionInfo]) -> String {
+    let mut prompt = String::from(CONSOLIDATION_PROMPT);
+    prompt.push_str("\n## Sessions to process\n\n");
+    for s in sessions {
+        prompt.push_str(&format!(
+            "- `{}` (modified {})\n",
+            s.path.display(),
+            s.mtime_secs
+        ));
     }
-  ]
+    prompt
 }
-```
-
-Keep the `content` concise but complete — 1 to 3 paragraphs usually.  If you
-found NO new durable information, set `nothing_new: true` and return an empty
-entries array.
-"#;
-
-/// Prompt for the **Phase 2 merge** agent.  It reads all Phase 1
-/// subagent batches and updates the project memory.
-pub const PHASE2_MERGE_PROMPT: &str = r#"
-You are a memory merge agent.  You are given a set of extracted memory
-entries from multiple subagents that read recent session logs and team
-contributions.  Your job is to merge these into the project memory.
-
-## Input
-
-1. `raw_memories/<ts>.jsonl` — Phase 1 extraction batches
-2. `topics/` — existing topic files
-3. `MEMORY.md` — the current index file
-4. `team/` — team-contributed memory files (if any)
-
-## Merge rules
-
-### Clustering
-
-Group related entries by topic.  Use existing topic files where the new
-entries naturally extend an existing subject.  Create new topic files
-only when entries clearly form a new subject.
-
-### Merging into existing topics
-
-When merging new facts into an existing topic:
-- Prepend newer/higher-importance content at the top
-- If a new entry **replaces** an old one, remove the old content and
-  add a `(updated)` note inline
-- If a new entry **refines** an old one, add a sub-heading
-- Never silently overwrite — the reader should see evolution
-
-### Conflict resolution
-
-When two entries conflict:
-- Prefer the one with higher **importance** score
-- If equal importance, prefer **more recent** (by created date)
-- Mark the lowered entry as `(deprecated)` — do NOT delete it
-
-### MEMORY.md index update
-
-Each topic file gets ONE index line in MEMORY.md:
-
-```
-- ★ [Title](topics/name.md) — One sentence summary tags:tag1 tag2
-- · [Another](topics/foo.md) — Summary tags:tag1
--   [Minor](topics/bar.md) — Summary
-```
-
-- ★ for importance ≥ 0.8
-- · for importance ≥ 0.5
-- ` ` for lower
-
-### Team memory
-
-Team-contributed files under `team/` are treated as pre-extracted
-memories.  Don't re-extract them — merge their content directly into
-the appropriate topic files.
-
-## Down-weighting and pruning
-
-- If an entry ≤ 0.4 importance and no one has referenced it for 90 days,
-  move it to a `(legacy)` section at the bottom of the topic file.
-- If an entry ≤ 0.2 importance, you may remove it entirely from the
-  topic file (but keep it in LanceDB for archival search).
-- When removing from topic, remove its index line from MEMORY.md.
-
-## Output
-
-Update the following files (use the file-writing tools):
-1. `topics/*.md` — updated topic files
-2. `MEMORY.md` — updated index
-3. Optionally, `topics/_deleted.md` — list of removed entries for audit
-"#;
-
-/// Brief prompt appended to the consolidation agent's system message
-/// that explains the MEMORY.md format the agent must maintain.
-pub const MEMORY_INDEX_FORMAT_PROMPT: &str = r#"
-## MEMORY.md index format
-
-MEMORY.md is a **pure index** — never add paragraphs or free-form text.
-Every line is a pointer:
-
-```
-- ★ [Title](topics/name.md) — One sentence summary tags:keyword1 keyword2
-```
-
-- `★` prefix = critical (importance ≥ 0.8)
-- `·` prefix = useful (importance ≥ 0.5)
-- ` ` prefix = background (importance < 0.5)
-
-No other formatting.  The file is parsed by tooling that expects this exact
-schema.
-"#;

--- a/crates/rara-memory/src/files.rs
+++ b/crates/rara-memory/src/files.rs
@@ -470,8 +470,8 @@ mod tests {
             .unwrap_or(false)
     }
 
-    #[test]
-    fn search_memory_returns_rg_hits() {
+    #[tokio::test]
+    async fn search_memory_returns_rg_hits() {
         if !rg_available() {
             return; // skip when rg is not installed
         }
@@ -481,7 +481,7 @@ mod tests {
         let session_path = rara_home.join("memory").join("sessions").join("test.md");
         fs::write(&session_path, "remember: use cargo fmt before commit").unwrap();
 
-        let hits = search_memory("cargo fmt", &rara_home).unwrap();
+        let hits = search_memory("cargo fmt", &rara_home, None).await.unwrap();
         assert!(hits.iter().any(|h| h.snippet.contains("cargo fmt")));
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -165,6 +165,7 @@ pub struct Agent {
     pub vdb: Arc<VectorDB>,
     pub memory_store: Arc<MemoryStore>,
     pub session_manager: Arc<SessionManager>,
+    pub consolidation_scheduler: rara_memory::consolidation::ConsolidationScheduler,
     state_db: Option<Arc<StateDb>>,
     pub workspace: Arc<WorkspaceMemory>,
     pub history: Vec<Message>,
@@ -255,6 +256,16 @@ impl Agent {
                     }
                 },
             );
+        let memory_root = if let Some(rara_dir) = session_manager.storage_dir.parent() {
+            rara_dir.join("memory")
+        } else {
+            workspace.root.join(".rara").join("memory")
+        };
+        let consolidation_config = rara_memory::consolidation::ConsolidationConfig::default();
+        let consolidation_scheduler = rara_memory::consolidation::ConsolidationScheduler::new(
+            memory_root,
+            consolidation_config,
+        );
         Self {
             tool_manager,
             llm_backend,
@@ -262,6 +273,7 @@ impl Agent {
             vdb,
             memory_store,
             session_manager,
+            consolidation_scheduler,
             state_db,
             workspace,
             history: Vec::new(),
@@ -382,7 +394,58 @@ impl Agent {
             .run_agent_loop_with_limit(output_mode, &mut report, &mut agentic_turns)
             .await
         {
-            Ok(()) => {}
+            Ok(()) => {
+                // Post-turn consolidation check (fire-and-forget).
+                let sessions = self.consolidation_scheduler.check();
+                if sessions.is_some() {
+                    let prompt_config = self.prompt_config.clone();
+                    let llm_backend = self.llm_backend.clone();
+                    let embedding_backend = self.embedding_backend.clone();
+                    let vdb = self.vdb.clone();
+                    let session_manager = self.session_manager.clone();
+                    let workspace = self.workspace.clone();
+                    let scheduler = self.consolidation_scheduler.clone();
+                    std::thread::spawn(move || {
+                        let rt = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .expect("consolidation runtime");
+                        rt.block_on(async move {
+                            let Some(sessions) = sessions else { return };
+                            let Some(_lock) = scheduler.acquire_lock() else {
+                                return;
+                            };
+                            let prompt =
+                                rara_memory::dream_prompts::build_consolidation_prompt(&sessions);
+                            eprintln!(
+                                "consolidation: {} sessions ready, dispatching subagent",
+                                sessions.len()
+                            );
+                            let result = crate::tools::agent::run_sub_agent(
+                                crate::tools::agent::SubAgentKind::Consolidate,
+                                &uuid::Uuid::new_v4().to_string(),
+                                None,
+                                Some("consolidation"),
+                                None,
+                                &prompt,
+                                None,
+                                None,
+                                llm_backend,
+                                embedding_backend,
+                                vdb,
+                                session_manager,
+                                workspace,
+                                prompt_config,
+                            )
+                            .await;
+                            match result {
+                                Ok(r) => eprintln!("consolidation complete: status={}", r.status),
+                                Err(e) => eprintln!("consolidation subagent failed: {e}"),
+                            }
+                        });
+                    });
+                }
+            }
             Err(err) => {
                 if self
                     .try_continue_after_recoverable_runtime_error(
@@ -689,6 +752,10 @@ impl Agent {
             .await
     }
 
+    /// Post-turn consolidation check (Claude Code style).
+    ///
+    /// Checks whether memory consolidation is due.  When sessions are
+    /// ready, acquires the lock and dispatches a Consolidate subagent
     async fn run_agent_loop_with_limit<F>(
         &mut self,
         output_mode: AgentOutputMode,

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -33,10 +33,11 @@ use crate::thread_store::{ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeSta
 use crate::workspace::WorkspaceMemory;
 
 #[derive(Clone, Copy, Debug)]
-enum SubAgentKind {
+pub(crate) enum SubAgentKind {
     General,
     Explore,
     Plan,
+    Consolidate,
 }
 
 /// Maps Claude Code agent config tool names to RARA internal tool names.
@@ -344,6 +345,7 @@ impl SubAgentKind {
             SubAgentKind::General => "done",
             SubAgentKind::Explore => "explored",
             SubAgentKind::Plan => "planned",
+            SubAgentKind::Consolidate => "completed consolidation",
         }
     }
 
@@ -401,13 +403,30 @@ impl SubAgentKind {
                     "- End with exactly one of: <proposed_plan>, <request_user_input>, or <continue_inspection/>."
                 )
             }
+            SubAgentKind::Consolidate => {
+                concat!(
+                    "## Sub-Agent Role\n",
+                    "- You are a memory consolidation agent.\n",
+                    "- Read the listed session files and distill durable knowledge.\n",
+                    "- Write topic files under `topics/` and update the `MEMORY.md` index.\n",
+                    "- MEMORY.md is an index — one line per topic under 150 characters.\n",
+                    "- Do not write memory content directly into MEMORY.md.\n",
+                    "- Group facts by topic, write concise topic files with level-2 headings.\n",
+                    "- Prefer updating existing files over creating duplicates.\n",
+                    "- Do not delegate to another agent or spawn sub-agents.\n",
+                    "- Do not modify files outside the memory directory.\n",
+                    "- Report a brief summary of what you changed."
+                )
+            }
         }
     }
 
     fn execution_mode(self) -> AgentExecutionMode {
         match self {
             SubAgentKind::Plan => AgentExecutionMode::Plan,
-            SubAgentKind::General | SubAgentKind::Explore => AgentExecutionMode::Execute,
+            SubAgentKind::General | SubAgentKind::Explore | SubAgentKind::Consolidate => {
+                AgentExecutionMode::Execute
+            }
         }
     }
 
@@ -416,11 +435,12 @@ impl SubAgentKind {
             SubAgentKind::Plan => 200,
             SubAgentKind::General => 100,
             SubAgentKind::Explore => 100,
+            SubAgentKind::Consolidate => 200,
         }
     }
 
     fn read_only(self) -> bool {
-        !matches!(self, SubAgentKind::General)
+        matches!(self, SubAgentKind::Explore | SubAgentKind::Plan)
     }
 
     fn label(self) -> &'static str {
@@ -428,6 +448,7 @@ impl SubAgentKind {
             SubAgentKind::General => "general",
             SubAgentKind::Explore => "explore",
             SubAgentKind::Plan => "plan",
+            SubAgentKind::Consolidate => "consolidate",
         }
     }
 }
@@ -1231,20 +1252,20 @@ struct TeamTask {
     kind: SubAgentKind,
 }
 
-struct SubAgentResult {
+pub(crate) struct SubAgentResult {
     agent_id: String,
     session_id: String,
-    status: &'static str,
+    pub(crate) status: &'static str,
     summary: String,
     persistence_error: Option<String>,
     plan: Option<Vec<PlanStep>>,
     plan_explanation: Option<String>,
     request_user_input: Option<PendingUserInput>,
-    total_input_tokens: u32,
-    total_output_tokens: u32,
+    pub(crate) total_input_tokens: u32,
+    pub(crate) total_output_tokens: u32,
 }
 
-async fn run_sub_agent(
+pub(crate) async fn run_sub_agent(
     kind: SubAgentKind,
     agent_id: &str,
     definition: Option<&AgentDefinition>,
@@ -1437,7 +1458,7 @@ fn build_read_only_tool_manager() -> ToolManager {
     tool_manager
 }
 
-fn build_subagent_tool_manager(kind: SubAgentKind) -> ToolManager {
+pub(crate) fn build_subagent_tool_manager(kind: SubAgentKind) -> ToolManager {
     if kind.read_only() {
         build_read_only_tool_manager()
     } else {
@@ -1541,7 +1562,7 @@ fn validate_agent_id_label(value: &str) -> Option<String> {
     (!label.is_empty()).then_some(label)
 }
 
-fn append_subagent_prompt(
+pub(crate) fn append_subagent_prompt(
     mut prompt_config: PromptRuntimeConfig,
     appended_instructions: &str,
 ) -> PromptRuntimeConfig {


### PR DESCRIPTION
## Summary

Rewrites RARA's memory consolidation to follow Claude Code's pattern, including subagent dispatch support.

### What changed

**Consolidation scheduler** (CC-style)
- `ConsolidationScheduler` with three gates: time (24h), session count (5), lock
- `ConsolidationLock` uses file mtime as `lastConsolidatedAt`
- Sub-millisecond gate checks (stat-only)

**Dream prompt** (CC-style)
- Single prompt instructing subagent to read sessions → write topics → update MEMORY.md
- `build_consolidation_prompt(sessions)` formats the session list

**SubAgentKind::Consolidate** (new)
- Added to SubAgentKind enum with read+write tools (not read_only)
- 200-turn limit, Execute mode
- Consolidation-specific prompt appended to system prompt

**Agent hook**
- `check_consolidation_after_turn()` fires after each conversation session
- Acquires lock when due, ready for subagent dispatch

**Removed**
- `raw_memories/` directory concept, `MemoryBatch`
- Mechanical `merge_entries()` / `collect_raw_batches()`
- Background timer loop / tokio feature gate

### Architecture

```
conversation ends → scheduler.check() → acquire lock
  → build_consolidation_prompt(sessions)
  → run_sub_agent(kind=Consolidate, instruction=prompt)
```

### Files

| File | Changes |
|------|---------|
| `crates/rara-memory/src/consolidation.rs` | Scheduler + lock (rewrite) |
| `crates/rara-memory/src/dream_prompts.rs` | CC-style prompt (rewrite) |
| `crates/rara-memory/Cargo.toml` | Clean up tokio feature gate |
| `crates/rara-memory/src/files.rs` | Fix broken search_memory test |
| `src/agent.rs` | Consolidation hook + scheduler init |
| `src/tools/agent.rs` | SubAgentKind::Consolidate |