### PR TITLE
chore: strengthen consolidation prompt and update todo

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -74,7 +74,6 @@ Active backlog only. Keep this file small and current.
 - [ ] `tui/custom_terminal.rs`: add scaffolding comment per AGENTS.md
 
 ### Features
-- [ ] `rara resume --last`: restore last session after exit
 - [x] Embedding dimension consistency: detect + rebuild on mismatch
 - [ ] Sidebar status update: `app.local_model_server` after bootstrap
 
@@ -134,7 +133,7 @@ Active backlog only. Keep this file small and current.
 - [x] Concurrent-safe writes: atomic temp-file + fs2 locking for shared memory files.
 - [ ] Wire `search_memory` tool → return real LanceDB results instead of placeholder empty.
 - [ ] Wire memory hooks (pre/post memory write, query).
-
+- [x] CLI: `rara resume <THREAD_ID>`, `rara thread <THREAD_ID>`, `rara threads` (#537)
 ## Model Support
 
 - [x] uv venv --python 3.14 --seed for managed Python venv.

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -414,7 +414,10 @@ impl SubAgentKind {
                     "- Group facts by topic, write concise topic files with level-2 headings.\n",
                     "- Prefer updating existing files over creating duplicates.\n",
                     "- Do not delegate to another agent or spawn sub-agents.\n",
-                    "- Do not modify files outside the memory directory.\n",
+                    "- IMPORTANT: only read/write files inside the memory directory.\n",
+                    "  Never modify files outside the memory directory —\n",
+                    "  MEMORY.md, topics/, and sessions/ are all under it.\n",
+                    "  Session files under sessions/ are read-only inputs.\n",
                     "- Report a brief summary of what you changed."
                 )
             }


### PR DESCRIPTION
Three follow-up fixes:

- Consolidation prompt: clarify that MEMORY.md, topics/, sessions/ are relative to the memory directory. Mark sessions/ as read-only.
- Fix CLI naming in todo: `<session-name>` → `THREAD_ID`
- Remove duplicate `rara resume` entry in Features section