### PR TITLE
feat: track auxiliary model cache stats separately

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -174,6 +174,8 @@ pub struct Agent {
     pub total_output_tokens: u32,
     pub total_cache_hit_tokens: u32,
     pub total_cache_miss_tokens: u32,
+    pub aux_total_cache_hit_tokens: u32,
+    pub aux_total_cache_miss_tokens: u32,
     pub tool_result_store: ToolResultStore,
     pub max_turns: Option<usize>,
     pub execution_mode: AgentExecutionMode,
@@ -210,6 +212,14 @@ pub struct Agent {
 }
 
 impl Agent {
+    /// Accumulate subagent (auxiliary model) cache statistics.
+    /// Called by consolidation and other subagent completion
+    /// handlers to split cache reporting between main and aux models.
+    pub fn accumulate_aux_cache(&mut self, hit: u32, miss: u32) {
+        self.aux_total_cache_hit_tokens += hit;
+        self.aux_total_cache_miss_tokens += miss;
+    }
+
     pub fn new(
         tool_manager: ToolManager,
         llm_backend: Arc<dyn LlmBackend>,
@@ -282,6 +292,8 @@ impl Agent {
             total_output_tokens: 0,
             total_cache_hit_tokens: 0,
             total_cache_miss_tokens: 0,
+            aux_total_cache_hit_tokens: 0,
+            aux_total_cache_miss_tokens: 0,
             tool_result_store: ToolResultStore::new(
                 default_tool_result_store_dir().unwrap_or_else(|_| {
                     std::env::temp_dir().join(format!("rara-tool-results-{}", Uuid::new_v4()))

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1266,6 +1266,8 @@ pub(crate) struct SubAgentResult {
     request_user_input: Option<PendingUserInput>,
     pub(crate) total_input_tokens: u32,
     pub(crate) total_output_tokens: u32,
+    pub(crate) total_cache_hit_tokens: u32,
+    pub(crate) total_cache_miss_tokens: u32,
 }
 
 pub(crate) async fn run_sub_agent(
@@ -1359,6 +1361,8 @@ pub(crate) async fn run_sub_agent(
         session_id: sub.session_id.clone(),
         total_input_tokens: sub.total_input_tokens,
         total_output_tokens: sub.total_output_tokens,
+        total_cache_hit_tokens: sub.total_cache_hit_tokens,
+        total_cache_miss_tokens: sub.total_cache_miss_tokens,
         status,
         summary,
         persistence_error,


### PR DESCRIPTION
Adds separate cache hit/miss counters for auxiliary subagents (consolidation, explore, plan).

### Changes
- `Agent`: add `aux_total_cache_hit_tokens` and `aux_total_cache_miss_tokens`
- `SubAgentResult`: add `total_cache_hit_tokens` and `total_cache_miss_tokens`
- `run_sub_agent`: extract cache stats from subagent session

### How it works
```
main model turn → total_cache_hit_tokens/miss
subagent turn → SubAgentResult.cache_hit/miss → aux_total_cache_hit_tokens/miss
```

### Follow-up
- Wire aux stats through RuntimeContext → TuiSnapshot for TUI display
- When #537 (consolidation hook) merges, one-line accumulation in hook