### PR TITLE
feat: wire aux cache tracking into subagent tools

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1268,6 +1268,34 @@ impl Agent {
                             self.todo_state = Some(state.clone());
                             report(AgentEvent::TodoUpdated(state));
                         }
+                        // Accumulate subagent (auxiliary model) cache statistics.
+                        if matches!(
+                            tool_name.as_str(),
+                            "spawn_agent" | "explore_agent" | "plan_agent" | "team_create"
+                        ) {
+                            let (hit, miss) = if tool_name == "team_create" {
+                                // team_create nests results under "team_results[*]".
+                                result["team_results"]
+                                    .as_array()
+                                    .map(|results| {
+                                        results.iter().fold((0, 0), |(h, m), res| {
+                                            (
+                                                h + res["cache_hit_tokens"].as_u64().unwrap_or(0)
+                                                    as u32,
+                                                m + res["cache_miss_tokens"].as_u64().unwrap_or(0)
+                                                    as u32,
+                                            )
+                                        })
+                                    })
+                                    .unwrap_or((0, 0))
+                            } else {
+                                (
+                                    result["cache_hit_tokens"].as_u64().unwrap_or(0) as u32,
+                                    result["cache_miss_tokens"].as_u64().unwrap_or(0) as u32,
+                                )
+                            };
+                            self.accumulate_aux_cache(hit, miss);
+                        }
                         let result_text = self.tool_result_store.compact_result(
                             &tool_name,
                             &tool_id,

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -269,6 +269,8 @@ pub struct SubagentProgress {
     pub tool_use_total: Option<usize>,
     pub total_input_tokens: usize,
     pub total_output_tokens: usize,
+    pub total_cache_hit_tokens: usize,
+    pub total_cache_miss_tokens: usize,
     pub activity: Vec<String>,
     pub is_backgrounded: bool,
     pub subagent_name: String,
@@ -281,6 +283,8 @@ impl SubagentProgress {
             tool_use_total: None,
             total_input_tokens: 0,
             total_output_tokens: 0,
+            total_cache_hit_tokens: 0,
+            total_cache_miss_tokens: 0,
             activity: Vec::new(),
             is_backgrounded: false,
             subagent_name: name.into(),
@@ -561,6 +565,8 @@ impl AgentTool {
             "name": name,
             "status": result.status,
             "summary": result.summary,
+            "cache_hit_tokens": result.total_cache_hit_tokens,
+            "cache_miss_tokens": result.total_cache_miss_tokens,
             "persistence_error": result.persistence_error,
             "request_user_input": result
                 .request_user_input
@@ -665,6 +671,8 @@ impl ExploreAgentTool {
             "session_id": result.session_id,
             "status": result.status,
             "summary": result.summary,
+            "cache_hit_tokens": result.total_cache_hit_tokens,
+            "cache_miss_tokens": result.total_cache_miss_tokens,
             "persistence_error": result.persistence_error,
             "request_user_input": result
                 .request_user_input
@@ -769,6 +777,8 @@ impl PlanAgentTool {
             "session_id": result.session_id,
             "status": result.status,
             "summary": result.summary,
+            "cache_hit_tokens": result.total_cache_hit_tokens,
+            "cache_miss_tokens": result.total_cache_miss_tokens,
             "persistence_error": result.persistence_error,
             "plan": result
                 .plan
@@ -971,6 +981,8 @@ impl BackgroundSubAgentStore {
             Ok(result) => {
                 record.progress.total_input_tokens = result.total_input_tokens as usize;
                 record.progress.total_output_tokens = result.total_output_tokens as usize;
+                record.progress.total_cache_hit_tokens = result.total_cache_hit_tokens as usize;
+                record.progress.total_cache_miss_tokens = result.total_cache_miss_tokens as usize;
                 record.status = result.status;
                 record.summary = Some(result.summary);
                 record.persistence_error = result.persistence_error;
@@ -1536,6 +1548,8 @@ fn serialize_team_result(name: &str, result: SubAgentResult) -> Value {
         "name": name,
         "status": result.status,
         "summary": result.summary,
+        "cache_hit_tokens": result.total_cache_hit_tokens,
+        "cache_miss_tokens": result.total_cache_miss_tokens,
         "persistence_error": result.persistence_error,
         "plan": result.plan.as_ref().map(|steps| serialize_plan_steps(steps)),
         "plan_explanation": result.plan_explanation,


### PR DESCRIPTION
Follow-up to #540 — wires the aux cache accumulation so it actually works.

### Changes
- Add `cache_hit_tokens` / `cache_miss_tokens` to JSON output of
  `AgentTool`, `ExploreAgentTool`, `PlanAgentTool`, and
  `TeamCreateTool` (`serialize_team_result`)
- In `execute_tool_calls`, extract cache stats from subagent tool
  results and call `self.accumulate_aux_cache()`

### How it works
```
subagent tool returns → JSON has cache_hit_tokens/miss
execute_tool_calls → parse from result ↴
  → self.accumulate_aux_cache(hit, miss)
  → aux_total_cache_hit_tokens / aux_total_cache_miss_tokens
```

Follow-up: wire aux stats through RuntimeContext → TuiSnapshot → TUI display