### PR TITLE
feat: add handle-unused-code skill and fix module-level allow(dead_code)

### DIFF
--- a/.agents/skills/handle-unused-code/SKILL.md
+++ b/.agents/skills/handle-unused-code/SKILL.md
@@ -105,7 +105,7 @@ all items.  Each item must stand on its own.
 // If the item is reserved for future use:
 /// Reserved hook level — will be activated with plugin system (docs/todo.md).
 #[allow(dead_code)]
-pub const PostToolUse: HookLevel = HookLevel::new("post_tool_use");
+pub const POST_TOOL_USE: HookLevel = HookLevel::new("post_tool_use");
 
 // If the item is genuinely dead (no plans, no references):
 // Just delete it.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -67,9 +67,10 @@ Active backlog only. Keep this file small and current.
 - [ ] `context/assembler.rs` (916 lines) → budget + assembly
 
 ### Dead Code Cleanup
-- [ ] `runtime_control.rs`: consolidate 40+ individual `#[allow(dead_code)]` to module-level
-- [ ] `hook_registry.rs`: remove `#[allow(dead_code)]` from `all_hooks`
-- [ ] `acp_consumer.rs`: add scaffolding comment per AGENTS.md
+- [ ] `runtime_control.rs`: audit 40+ `#[allow(dead_code)]` — classify each using handle-unused-code skill
+- [x] `hook_registry.rs`: remove `#[allow(dead_code)]` from `all_hooks` (#532)
+- [ ] `google_oauth.rs`: audit 20+ items hidden by `#![allow(dead_code)]`, classify individually
+- [x] `theme.rs`: remove module-level `#![allow]`, add per-item `// Nord palette` comments
 - [ ] `mcp_status.rs`: add scaffolding comment per AGENTS.md
 - [ ] `tui/custom_terminal.rs`: add scaffolding comment per AGENTS.md
 

--- a/src/google_oauth.rs
+++ b/src/google_oauth.rs
@@ -1,6 +1,6 @@
 //! Google OAuth PKCE flow for Gemini Code Assist.
 // Some items reserved for future OAuth flows.
-#![allow(dead_code)]
+#![allow(dead_code)] // FIXME(#546): audit 20+ items individually per handle-unused-code skill
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -11,42 +11,32 @@
 // Many constants are reserved for planned rendering features (Markdown
 // syntax highlighting, diff views, phase badges, etc.). The full palette
 // is kept here as a single source of truth.
-#![allow(dead_code)]
 use ratatui::style::Color;
 
-// ── Nord palette (reference) ────────────────────────────────────
 // See https://www.nordtheme.com/docs/colors-and-palettes
-#[allow(dead_code)]
+#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD0: Color = Color::Rgb(0x2E, 0x34, 0x40); // Polar Night (darkest bg)
-#[allow(dead_code)]
 pub(crate) const NORD1: Color = Color::Rgb(0x3B, 0x42, 0x52); // Polar Night
-#[allow(dead_code)]
+#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD2: Color = Color::Rgb(0x43, 0x4C, 0x5E); // Polar Night
-#[allow(dead_code)]
+#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD3: Color = Color::Rgb(0x4C, 0x56, 0x6A); // Polar Night (lightest bg)
-#[allow(dead_code)]
+#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD4: Color = Color::Rgb(0xD8, 0xDE, 0xE9); // Snow Storm (darkest fg)
-#[allow(dead_code)]
+#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD5: Color = Color::Rgb(0xE5, 0xE9, 0xF0); // Snow Storm
-#[allow(dead_code)]
+#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD6: Color = Color::Rgb(0xEC, 0xEF, 0xF4); // Snow Storm (brightest fg)
-#[allow(dead_code)]
 pub(crate) const NORD7: Color = Color::Rgb(0x8F, 0xBC, 0xBB); // Frost (green-cyan)
-#[allow(dead_code)]
 pub(crate) const NORD8: Color = Color::Rgb(0x88, 0xC0, 0xD0); // Frost (cyan)
-#[allow(dead_code)]
 pub(crate) const NORD9: Color = Color::Rgb(0x81, 0xA1, 0xC1); // Frost (blue-gray)
-#[allow(dead_code)]
+#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD10: Color = Color::Rgb(0x5E, 0x81, 0xAC); // Frost (dark blue)
-#[allow(dead_code)]
 pub(crate) const NORD11: Color = Color::Rgb(0xBF, 0x61, 0x6A); // Aurora (red)
-#[allow(dead_code)]
 pub(crate) const NORD12: Color = Color::Rgb(0xD0, 0x87, 0x70); // Aurora (orange)
-#[allow(dead_code)]
 pub(crate) const NORD13: Color = Color::Rgb(0xEB, 0xCB, 0x8B); // Aurora (yellow)
-#[allow(dead_code)]
 pub(crate) const NORD14: Color = Color::Rgb(0xA3, 0xBE, 0x8C); // Aurora (green)
-#[allow(dead_code)]
+#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD15: Color = Color::Rgb(0xB4, 0x8E, 0xAD); // Aurora (purple)
 
 // ── UI surface colors ───────────────────────────────────────────


### PR DESCRIPTION
Adds a reusable skill and updates policy for unused code.

### Skill: `handle-unused-code`
Three-bucket workflow:
- **A — unimplemented capability**: suppress with item-level `#[allow]` + journal/todo link
- **B — genuinely dead**: delete
- **C — reserved palette**: treat each item individually (never module-level blanket)

### AGENTS.md update
`#![allow(dead_code)]` at module level is now **explicitly prohibited** — it silently hides real dead code.

### Code fixes
- `theme.rs`: removed `#![allow(dead_code)]`, added per-color `// Nord palette` comments
- `google_oauth.rs`: flagged with `// TODO: classify each item individually` for follow-up

### Docs
- `docs/todo.md`: updated Dead Code Cleanup section to match new policy