### PR TITLE
chore: fix three compiler warnings

### DIFF
--- a/src/tui/custom_terminal.rs
+++ b/src/tui/custom_terminal.rs
@@ -579,6 +579,7 @@ fn diff_buffers(a: &Buffer, b: &Buffer) -> Vec<DrawCommand> {
     // Cells from the current buffer to skip due to preceding multi-width characters taking
     // their place (the skipped cells should be blank anyway), or due to per-cell-skipping:
     let mut to_skip: usize = 0;
+    #[allow(deprecated)] // Cell::skip deprecated in ratatui 0.30; CellDiffOption not available yet
     for (i, (current, previous)) in next_buffer.iter().zip(previous_buffer.iter()).enumerate() {
         if !current.skip && (current != previous || invalidated > 0) && to_skip == 0 {
             let (x, y) = a.pos_of(i);

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -48,7 +48,7 @@ fn wrapped_text_height(text: &str, area_width: u16) -> u16 {
 
 pub(super) fn render_provider_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect) {
     let block = super::popup_block();
-    let inner = block.inner(area);
+    let _inner = block.inner(area);
     f.render_widget(block, area);
     let items = PROVIDER_FAMILIES
         .iter()
@@ -245,7 +245,7 @@ pub(super) fn render_model_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect)
         )
     };
     let block = super::popup_block();
-    let inner = block.inner(area);
+    let _inner = block.inner(area);
     f.render_widget(block, area);
     let help_height = wrapped_text_height(help, area.width.saturating_sub(2));
     let chunks = Layout::default()

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -742,7 +742,7 @@ pub(crate) async fn finish_running_task_if_ready(
                     // or the budget is exhausted.  Single no-tool turns (analysis/planning)
                     // are allowed; the budget gate prevents infinite loops.
                     let prior_total_input_tokens = app.snapshot.total_input_tokens;
-                    let agent_had_tools = agent.last_turn_had_tool_calls();
+                    let _agent_had_tools = agent.last_turn_had_tool_calls();
                     let should_auto_continue_goal = !finished_plan_turn
                         && app
                             .goal_handle
@@ -753,7 +753,7 @@ pub(crate) async fn finish_running_task_if_ready(
                         && !app.has_pending_plan_approval();
                     // Always account goal turn usage, even when we suppress
                     // continuation (no-tool-call turns still consume budget).
-                    let goal_is_pursuing = !finished_plan_turn
+                    let _goal_is_pursuing = !finished_plan_turn
                         && app
                             .goal_handle
                             .read()

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -742,18 +742,7 @@ pub(crate) async fn finish_running_task_if_ready(
                     // or the budget is exhausted.  Single no-tool turns (analysis/planning)
                     // are allowed; the budget gate prevents infinite loops.
                     let prior_total_input_tokens = app.snapshot.total_input_tokens;
-                    let _agent_had_tools = agent.last_turn_had_tool_calls();
                     let should_auto_continue_goal = !finished_plan_turn
-                        && app
-                            .goal_handle
-                            .read()
-                            .unwrap()
-                            .as_ref()
-                            .is_some_and(|g| g.status == GoalStatus::Pursuing)
-                        && !app.has_pending_plan_approval();
-                    // Always account goal turn usage, even when we suppress
-                    // continuation (no-tool-call turns still consume budget).
-                    let _goal_is_pursuing = !finished_plan_turn
                         && app
                             .goal_handle
                             .read()


### PR DESCRIPTION
Fixes three compiler warnings using handle-unused-code skill:

- `custom_terminal.rs`: `#[allow(deprecated)]` for `Cell::skip` — replaced API `CellDiffOption` not available in ratatui 0.30
- `tasks.rs`: **delete** `agent_had_tools` (Bucket B — removed from Ralph loop condition in #486) and `goal_is_pursuing` (Bucket B — duplicate of should_auto_continue_goal, budget accounting never implemented)
- `overlay_setup.rs`: prefix unused `inner` variables with underscore