### PR TITLE
feat: add consolidation inline message

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -451,7 +451,16 @@ impl Agent {
                             )
                             .await;
                             match result {
-                                Ok(r) => eprintln!("consolidation complete: status={}", r.status),
+                                Ok(r) => {
+                                    if r.summary.is_empty() {
+                                        eprintln!(
+                                            "📝 consolidation complete — status={}",
+                                            r.status
+                                        );
+                                    } else {
+                                        eprintln!("📝 consolidation: {}", r.summary);
+                                    }
+                                }
                                 Err(e) => eprintln!("consolidation subagent failed: {e}"),
                             }
                         });

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1271,7 +1271,7 @@ pub(crate) struct SubAgentResult {
     agent_id: String,
     session_id: String,
     pub(crate) status: &'static str,
-    summary: String,
+    pub(crate) summary: String,
     persistence_error: Option<String>,
     plan: Option<Vec<PlanStep>>,
     plan_explanation: Option<String>,


### PR DESCRIPTION
Shows the consolidation subagent's summary as an inline message
in the conversation, matching CC's "Improved N files" pattern.

- `SubAgentResult::summary` made `pub(crate)` for access
- Consolidation completion handler now prints 📝 consolidation:
  with the subagent's own summary text
- Fallback to status-only message when summary is empty