### PR TITLE
feat: register SearchMemoryTool with rg + LanceDB search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10837,6 +10837,7 @@ dependencies = [
  "async-trait",
  "glob",
  "rara-file-search",
+ "rara-memory",
  "rara-tool-macros",
  "regex",
  "serde",

--- a/crates/rara-memory/src/files.rs
+++ b/crates/rara-memory/src/files.rs
@@ -292,7 +292,7 @@ pub fn condense_old_entries(content: &str) -> String {
 }
 
 /// A single search hit from memory files.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct MemorySearchHit {
     pub path: String,
     pub snippet: String,

--- a/crates/rara-tools/Cargo.toml
+++ b/crates/rara-tools/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 rara-tool-macros = { path = "../tool-macros" }
 rara-file-search = { path = "../file-search" }
+rara-memory = { path = "../rara-memory" }
 anyhow.workspace = true
 async-trait.workspace = true
 glob = "0.3"

--- a/crates/rara-tools/src/lib.rs
+++ b/crates/rara-tools/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(unused_imports)]
 
 pub mod file;
+pub mod memory;
 pub mod patch;
 pub mod planning;
 pub mod search;

--- a/crates/rara-tools/src/memory.rs
+++ b/crates/rara-tools/src/memory.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rara_memory::files::search_memory;
+use rara_memory::vectordb::VectorDB;
+use rara_tool_macros::tool_spec;
+use serde_json::{Value, json};
+
+use crate::tool::{Tool, ToolError};
+
+/// Search project memory using ripgrep text search and LanceDB vector search.
+#[derive(Clone)]
+pub struct SearchMemoryTool {
+    pub rara_home: PathBuf,
+    pub vdb: Option<Arc<VectorDB>>,
+}
+
+#[tool_spec(
+    name = "search_memory",
+    description = "Search project memory using ripgrep (text) and LanceDB (vector) search. Returns memory entries matching the query from session files, topics, and MEMORY.md.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query for text and vector search"
+            }
+        },
+        "required": ["query"]
+    }
+)]
+#[async_trait]
+impl Tool for SearchMemoryTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let query = input["query"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput("missing 'query' field".into()))?;
+
+        let hits = search_memory(query, &self.rara_home, self.vdb.as_deref())
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+        serde_json::to_value(hits)
+            .map_err(|e| ToolError::ExecutionFailed(format!("serialization: {e}")))
+    }
+}

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -9,6 +9,7 @@ use rara_tools::file::{
     FileReadState, ListFilesTool, MultiEditTool, ReadFileTool, ReplaceLinesTool, ReplaceTool,
     WriteFileTool,
 };
+use rara_tools::memory::SearchMemoryTool;
 use rara_tools::patch::ApplyPatchTool;
 use rara_tools::planning::{EnterPlanModeTool, ExitPlanModeTool};
 use rara_tools::search::{GlobTool, GrepTool};
@@ -121,6 +122,10 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(WebSearchTool::from_env()));
     tm.register(Box::new(GlobTool));
     tm.register(Box::new(GrepTool));
+    tm.register(Box::new(SearchMemoryTool {
+        rara_home: workspace.rara_dir.clone(),
+        vdb: Some(vdb.clone()),
+    }));
     tm.register(Box::new(LspDiagnosticsTool::new(lsp_manager)));
     tm.register(Box::new(McpToolSearch::new(mcp_tool_cache)));
     tm.register(Box::new(EnterPlanModeTool));


### PR DESCRIPTION
Registers the `search_memory` tool so the agent can search project memory.

### Changes
- Add `rara-memory` dependency to `rara-tools`
- Create `SearchMemoryTool` struct with `#[tool_spec]` macro
- Register in `tooling.rs` alongside existing search tools
- Add `Serialize` derive to `MemorySearchHit` for JSON output

### How it works
agent calls search_memory(query="...")
  -> SearchMemoryTool::call()
  -> rara_memory::files::search_memory()
  -> rg text search + LanceDB vector search
  -> returns Vec of MemorySearchHit as JSON

The function layer was already complete (rg + LanceDB dual search).
This PR adds the Tool wrapper and registry entry.
