### PR TITLE
feat: add MemoryQuery hook lifecycle and SearchMemoryTool callback

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -16,6 +16,7 @@ pub enum HookLifecycle {
     PreToolUse,
     PostToolUse,
     PostMemoryWrite,
+    MemoryQuery,
     Stop,
     PreCompact,
 }
@@ -28,6 +29,7 @@ impl HookLifecycle {
             Self::PreToolUse => "PreToolUse",
             Self::PostToolUse => "PostToolUse",
             Self::PostMemoryWrite => "PostMemoryWrite",
+            Self::MemoryQuery => "MemoryQuery",
             Self::Stop => "Stop",
             Self::PreCompact => "PreCompact",
         }
@@ -40,6 +42,7 @@ impl HookLifecycle {
             "user-prompt-submit" | "user_prompt_submit" => Some(Self::UserPromptSubmit),
             "pre-tool-use" | "pre_tool_use" => Some(Self::PreToolUse),
             "post-tool-use" | "post_tool_use" => Some(Self::PostToolUse),
+            "memory-query" | "memory_query" => Some(Self::MemoryQuery),
             "stop" => Some(Self::Stop),
             _ => None,
         }

--- a/crates/rara-tools/src/memory.rs
+++ b/crates/rara-tools/src/memory.rs
@@ -14,6 +14,10 @@ use crate::tool::{Tool, ToolError};
 pub struct SearchMemoryTool {
     pub rara_home: PathBuf,
     pub vdb: Option<Arc<VectorDB>>,
+    /// Optional MemoryQuery hook callback.
+    /// Invoked with the search query before the actual search.
+    /// Wired at registration time in tooling.rs.
+    pub hook_callback: Option<Arc<dyn Fn(&str) + Send + Sync>>,
 }
 
 #[tool_spec(
@@ -36,6 +40,13 @@ impl Tool for SearchMemoryTool {
         let query = input["query"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput("missing 'query' field".into()))?;
+
+        // MemoryQuery hook: notify hooks before search (non-blocking).
+        if let Some(ref cb) = self.hook_callback {
+            let cb = cb.clone();
+            let q = query.to_owned();
+            let _ = tokio::task::spawn_blocking(move || cb(&q)).await;
+        }
 
         let hits = search_memory(query, &self.rara_home, self.vdb.as_deref())
             .await

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -180,8 +180,9 @@ fn phase_ordinal(phase: HookLifecycle) -> u8 {
         HookLifecycle::PreToolUse => 2,
         HookLifecycle::PostToolUse => 3,
         HookLifecycle::PostMemoryWrite => 4,
-        HookLifecycle::Stop => 5,
-        HookLifecycle::PreCompact => 6,
+        HookLifecycle::MemoryQuery => 5,
+        HookLifecycle::Stop => 6,
+        HookLifecycle::PreCompact => 7,
     }
 }
 

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -125,6 +125,7 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(SearchMemoryTool {
         rara_home: workspace.rara_dir.clone(),
         vdb: Some(vdb.clone()),
+        hook_callback: None, // TODO: wire MemoryQuery hooks
     }));
     tm.register(Box::new(LspDiagnosticsTool::new(lsp_manager)));
     tm.register(Box::new(McpToolSearch::new(mcp_tool_cache)));


### PR DESCRIPTION
Adds MemoryQuery hook support:

### Changes
- HookLifecycle: add MemoryQuery variant (between PostMemoryWrite and Stop)
- hooks.rs: add priority arm for MemoryQuery (= 5)
- SearchMemoryTool: hook_callback Optional closure field
- tooling.rs: registration stubs with TODO for MemoryQuery wiring
- Bump Stop (5→6) and PreCompact (6→7) priorities

### Trigger point
SearchMemoryTool::call fires hook_callback(query) before search.
When hooks are populated, a closure captures HookRegistry/HookSandbox
and runs sandboxed MemoryQuery hooks.