### PR TITLE
refactor: convert assembler.rs to assembler/mod.rs directory

### DIFF
--- a/src/context/assembler/mod.rs
+++ b/src/context/assembler/mod.rs
@@ -311,7 +311,7 @@ impl<'a> ContextAssembler<'a> {
 
 // Keep budget helpers in the assembler module so private context assembly
 // helpers remain shared without registering budget_assembly as a Rust module.
-include!("budget_assembly.rs");
+include!("../budget_assembly.rs");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Enables future types/logic split by converting the single-file module to a directory module.  No line-count change — this is the prerequisite for extracting data types to types.rs.

- Move assembler.rs → assembler/mod.rs
- Update include!("budget_assembly.rs") → include!("../budget_assembly.rs")