### PR TITLE
chore: mark BottomPaneModel migration as done

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -111,7 +111,7 @@ Active backlog only. Keep this file small and current.
 ## TUI / Composer / Status
 
 - [x] BottomPaneModel struct with structured notice/prompt/input.
-- [ ] Finish BottomPaneModel migration: composer/sizing read structured data.
+- [x] Finish BottomPaneModel migration: composer/sizing already reads from model
 - [ ] Thinking expand/collapse with duration summary.
 - [ ] Live bash transcript: streaming output frames.
 - [ ] After local embedding sidecar lands: `/status` context fields for backend/model/state.


### PR DESCRIPTION
BottomPaneModel already exists and composer/sizing reads from app.bottom_pane (the model). The migration was completed in an earlier PR — marking it done in the todo.