### PR TITLE
chore: surface plugin hook status

### DIFF
--- a/docs/journal/2026-06-14-plugin-hook-status.md
+++ b/docs/journal/2026-06-14-plugin-hook-status.md
@@ -1,0 +1,24 @@
+# 2026-06-14 — Plugin Hook Runtime Status
+
+RARA now reflects plugin hook registration in the TUI `/status` Extensions
+panel. Runtime rebuild completes plugin hook registration before refreshing the
+runtime snapshot, and the snapshot reads the in-process `HookRuntime` hook count
+instead of relying only on repository file discovery.
+
+This keeps the status panel aligned with the hooks that will actually dispatch
+for the current session. File discovery remains as a fallback so existing
+repo-local hook counts still render before runtime registration is available.
+Plugin discovery and registration now run on a blocking worker during runtime
+rebuild so synchronous filesystem work does not block the async runtime, and the
+hook registry uses a synchronous lock because registry reads are not held across
+await points.
+
+Verification:
+
+- `sync_snapshot_reports_registered_runtime_hooks`
+- existing rebuild and status tests continue to cover local model/sidebar state
+
+Remaining follow-up:
+
+- Hook output injection into model context is still blocked on the sandbox
+  policy decision tracked in `docs/todo.md`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -9,6 +9,15 @@
 
 Active backlog only. Keep this file small and current.
 
+## Execution Plan (2026-06-14)
+
+1. Finish plugin/runtime status correctness before adding more plugin surface.
+2. Add `rara plugin install/list/remove` once runtime registration is observable.
+3. Improve TUI live feedback: thinking collapse/summary, then live bash transcript.
+4. Close context/embedding correctness: canonical vector schema, rebuild on mismatch,
+   model-aware budgeting, project `AGENTS.md` memory injection.
+5. Split P0 large files only after the behavior surfaces above have tests.
+
 ## Recently Completed (2025-07-15..16)
 
 - [x] uv venv: replace manual Python discovery with `uv venv --python 3.14 --seed` (#423)
@@ -50,7 +59,7 @@ Active backlog only. Keep this file small and current.
 - [x] Per-phase conditional hook injection (#556)
 - [x] PreToolUse hook (#556)
 - [ ] Hook output injection into model context (blocked on sandbox policy)
-- [ ] Wire plugin hook registration into runtime startup
+- [x] Wire plugin hook registration into runtime startup/status panel
 
 ### LSP (Phase 1)
 - [x] LSP runtime wiring: shared manager, lazy server startup, diagnostics parsing, sidebar status
@@ -75,7 +84,7 @@ Active backlog only. Keep this file small and current.
 - [x] `tui/custom_terminal.rs`: add `#[allow(deprecated)]` for Cell::skip (#549)
 ### Features
 - [x] Embedding dimension consistency: detect + rebuild on mismatch
-- [ ] Sidebar status update: `app.local_model_server` after bootstrap
+- [x] Sidebar status update: `app.local_model_server` after bootstrap
 
 ### Specs to Write
 - [x] Hooks/plugin lifecycle spec — `docs/features/file-hooks.md`
@@ -115,7 +124,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Thinking expand/collapse with duration summary.
 - [ ] Live bash transcript: streaming output frames.
 - [ ] After local embedding sidecar lands: `/status` context fields for backend/model/state.
-- [ ] Plugin hook registration feed into TUI runtime status panel.
+- [x] Plugin hook registration feed into TUI runtime status panel.
 
 ## Context / Embeddings
 

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -7,8 +7,8 @@
 //! against the current set of registered hooks.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
 
 use serde_json::Value;
 
@@ -34,7 +34,7 @@ pub type ToolModifier = Box<dyn Fn(&str, &Value) -> Option<Value> + Send + Sync>
 /// loop is already running.
 pub struct HookRuntime {
     bus: Arc<RuntimeEventBus>,
-    hooks: Arc<tokio::sync::RwLock<HashMap<String, HookEntry>>>,
+    hooks: Arc<RwLock<HashMap<String, HookEntry>>>,
     tool_modifiers: Arc<std::sync::RwLock<Vec<(String, ToolModifier)>>>,
     /// Collected stdout from command hooks. Drained before each model turn
     /// and injected as system messages into the model context.
@@ -46,7 +46,7 @@ impl HookRuntime {
     pub fn new(bus: Arc<RuntimeEventBus>) -> Self {
         Self {
             bus,
-            hooks: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            hooks: Arc::new(RwLock::new(HashMap::new())),
             tool_modifiers: Arc::new(std::sync::RwLock::new(Vec::new())),
             outputs: Arc::new(std::sync::Mutex::new(Vec::new())),
             started: AtomicBool::new(false),
@@ -99,31 +99,41 @@ impl HookRuntime {
     }
 
     /// Register an in-process hook.  Safe to call while `start` is running.
-    pub async fn register(
+    pub fn register(
         &self,
         hook_id: String,
         lifecycle: HookLifecycle,
         description: String,
         callback: HookCallback,
     ) {
-        self.hooks.write().await.insert(
-            hook_id,
-            HookEntry {
-                lifecycle,
-                description,
-                callback,
-            },
-        );
+        self.hooks
+            .write()
+            .expect("hook runtime registry lock poisoned")
+            .insert(
+                hook_id,
+                HookEntry {
+                    lifecycle,
+                    description,
+                    callback,
+                },
+            );
     }
 
     /// Unregister a previously declared hook by id.
-    pub async fn unregister(&self, hook_id: &str) -> bool {
-        self.hooks.write().await.remove(hook_id).is_some()
+    pub fn unregister(&self, hook_id: &str) -> bool {
+        self.hooks
+            .write()
+            .expect("hook runtime registry lock poisoned")
+            .remove(hook_id)
+            .is_some()
     }
 
     /// Return the number of registered hooks.
-    pub async fn hook_count(&self) -> usize {
-        self.hooks.read().await.len()
+    pub fn hook_count(&self) -> usize {
+        self.hooks
+            .read()
+            .expect("hook runtime registry lock poisoned")
+            .len()
     }
 
     /// Start the hook dispatch loop on a dedicated Tokio task.
@@ -143,7 +153,7 @@ impl HookRuntime {
             loop {
                 match rx.recv().await {
                     Ok(event) => {
-                        let guard = hooks.read().await;
+                        let guard = hooks.read().expect("hook runtime registry lock poisoned");
                         for entry in guard.values() {
                             if lifecycle_matches(&entry.lifecycle, &event) {
                                 (entry.callback)(&event);
@@ -422,21 +432,19 @@ mod tests {
         let bus = Arc::new(RuntimeEventBus::new(4));
         let runtime = HookRuntime::new(bus);
 
-        assert_eq!(runtime.hook_count().await, 0);
+        assert_eq!(runtime.hook_count(), 0);
 
-        runtime
-            .register(
-                "hook-1".into(),
-                HookLifecycle::SessionStart,
-                "test hook".into(),
-                Box::new(|_| {}),
-            )
-            .await;
-        assert_eq!(runtime.hook_count().await, 1);
+        runtime.register(
+            "hook-1".into(),
+            HookLifecycle::SessionStart,
+            "test hook".into(),
+            Box::new(|_| {}),
+        );
+        assert_eq!(runtime.hook_count(), 1);
 
-        assert!(runtime.unregister("hook-1").await);
-        assert_eq!(runtime.hook_count().await, 0);
+        assert!(runtime.unregister("hook-1"));
+        assert_eq!(runtime.hook_count(), 0);
 
-        assert!(!runtime.unregister("hook-1").await);
+        assert!(!runtime.unregister("hook-1"));
     }
 }

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -34,6 +34,27 @@ pub async fn register_plugin_hooks(
     user_plugins_dir: &PathBuf,
     session_id: &str,
 ) -> usize {
+    let runtime = runtime.clone();
+    let user_plugins_dir = user_plugins_dir.clone();
+    let session_id = session_id.to_string();
+    match tokio::task::spawn_blocking(move || {
+        register_plugin_hooks_blocking(&runtime, &user_plugins_dir, &session_id)
+    })
+    .await
+    {
+        Ok(count) => count,
+        Err(err) => {
+            eprintln!("plugin hook registration task failed: {err}");
+            0
+        }
+    }
+}
+
+fn register_plugin_hooks_blocking(
+    runtime: &Arc<HookRuntime>,
+    user_plugins_dir: &PathBuf,
+    session_id: &str,
+) -> usize {
     let plugins = discover_plugins(user_plugins_dir);
     let mut registered = 0usize;
 
@@ -82,14 +103,12 @@ pub async fn register_plugin_hooks(
                 });
             });
 
-            runtime
-                .register(
-                    format!("{}-{}", plugin_name, rh.event.as_str()),
-                    lifecycle,
-                    format!("plugin hook: {}", plugin_name),
-                    callback,
-                )
-                .await;
+            runtime.register(
+                format!("{}-{}", plugin_name, rh.event.as_str()),
+                lifecycle,
+                format!("plugin hook: {}", plugin_name),
+                callback,
+            );
 
             registered += 1;
         }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -971,16 +971,12 @@ pub(crate) async fn finish_running_task_if_ready(
                 {
                     let plugins_dir = workspace_root.join(".rara").join("plugins");
                     if plugins_dir.is_dir() {
-                        let hr = hr.clone();
-                        let plugins_dir = plugins_dir.clone();
-                        tokio::spawn(async move {
-                            let _ = crate::plugin_middleware::register_plugin_hooks(
-                                &hr,
-                                &plugins_dir,
-                                "",
-                            )
-                            .await;
-                        });
+                        crate::plugin_middleware::register_plugin_hooks(
+                            hr,
+                            &plugins_dir,
+                            &agent.session_id,
+                        )
+                        .await;
                     }
                 }
                 app.local_model_server = rebuilt.local_model_server;

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1603,6 +1603,11 @@ impl TuiApp {
             );
         }
         let ext_counts = discover_extension_counts(&runtime_context.cwd);
+        let runtime_hook_count = self
+            .hook_runtime
+            .as_ref()
+            .map(|runtime| runtime.hook_count())
+            .unwrap_or(0);
         self.snapshot = RuntimeSnapshot {
             cwd: runtime_context.cwd,
             branch: runtime_context.branch,
@@ -1678,7 +1683,7 @@ impl TuiApp {
                 scopes.sort();
                 scopes
             },
-            extension_hook_count: ext_counts.0,
+            extension_hook_count: ext_counts.0.max(runtime_hook_count),
             extension_agent_count: ext_counts.1,
         };
         self.agent_execution_mode = agent.execution_mode;

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -216,6 +216,42 @@ fn sync_snapshot_reports_effective_network_access_for_pending_approval() {
     assert!(approval.allow_net);
 }
 
+#[tokio::test]
+async fn sync_snapshot_reports_registered_runtime_hooks() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let rara_dir = root.join(".rara");
+    std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+    std::fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+    let mut app = TuiApp::new(ConfigManager {
+        path: root.join("config.json"),
+    })
+    .expect("app");
+    let agent = Agent::new(
+        ToolManager::new(),
+        std::sync::Arc::new(MockLlm),
+        std::sync::Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        std::sync::Arc::new(SessionManager {
+            storage_dir: rara_dir.join("rollouts"),
+            legacy_storage_dir: rara_dir.join("sessions"),
+        }),
+        std::sync::Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+    );
+    let bus = std::sync::Arc::new(crate::runtime_event_bus::RuntimeEventBus::new(4));
+    let runtime = std::sync::Arc::new(crate::hook_runtime::HookRuntime::new(bus));
+    runtime.register(
+        "plugin-pre-tool".into(),
+        crate::runtime_control::HookLifecycle::PreToolUse,
+        "plugin hook".into(),
+        Box::new(|_| {}),
+    );
+    app.hook_runtime = Some(runtime);
+
+    app.sync_snapshot(&agent);
+
+    assert_eq!(app.snapshot.extension_hook_count, 1);
+}
+
 #[test]
 fn parse_repo_slug_supports_common_github_remote_forms() {
     assert_eq!(


### PR DESCRIPTION
## Summary
- add the short-term TODO execution plan
- register plugin hooks during rebuild before refreshing the runtime snapshot
- report registered HookRuntime hooks in the /status Extensions panel
- mark completed plugin-hook/sidebar status TODO items and add a journal checkpoint

## Verification
- cargo fmt
- cargo test sync_snapshot_reports_registered_runtime_hooks -- --nocapture
- cargo test rebuild_success_refreshes_local_model_server_status -- --nocapture
- cargo test overview_status_reports_local_embedding_component -- --nocapture
- git diff --check

Note: targeted tests pass; the workspace still emits existing unrelated warnings.