### PR TITLE
feat(context): scale budget by model window

### DIFF
--- a/docs/journal/2026-06-14-model-aware-context-budget.md
+++ b/docs/journal/2026-06-14-model-aware-context-budget.md
@@ -1,0 +1,31 @@
+# Model-aware context budget
+
+## Summary
+
+RARA now derives output reserve and compaction slack from the resolved model
+context window instead of applying one fixed reserve pattern to every model.
+Small, medium, and long-context windows keep different margins so compacting
+does not start too early on long-context providers or too late on small local
+windows.
+
+## Background
+
+The context budget already flowed through provider/model resolution, but
+`context_budget_from_window` used one ratio plus one fixed 2048-token slack for
+all models.  That made the final threshold less intentional for both 8K local
+windows and million-token provider windows.
+
+## Key Decisions
+
+- Small windows reserve a larger fraction for output and keep a small slack.
+- Medium windows preserve the previous broad behavior.
+- Long windows cap output reserve and use a larger absolute compaction slack.
+- The policy remains window-driven and provider-neutral; provider-specific
+  overrides still belong in backend model-window resolution.
+
+## Validation
+
+- `cargo fmt`
+- `cargo test llm::tests::context_budget_scales_reserved_output_by_window_size -- --nocapture`
+- `cargo test llm::tests::derives_context_budget_for_codex_like_models -- --nocapture`
+- `cargo test llm::tests::derives_context_budget_for_deepseek_v4_models -- --nocapture`

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -462,15 +462,36 @@ pub(super) fn should_bypass_proxy(base_url: &str) -> bool {
 }
 
 pub(super) fn context_budget_from_window(context_window_tokens: usize) -> ContextBudget {
-    let reserved_output_tokens = (context_window_tokens / 8).clamp(1024, 16384);
+    let reserved_output_tokens = reserved_output_tokens_for_window(context_window_tokens);
+    let compaction_slack_tokens = compaction_slack_tokens_for_window(context_window_tokens);
     let compact_threshold_tokens = context_window_tokens
         .saturating_sub(reserved_output_tokens)
-        .saturating_sub(2048);
+        .saturating_sub(compaction_slack_tokens);
     ContextBudget {
         context_window_tokens,
         reserved_output_tokens,
         compact_threshold_tokens,
     }
+}
+
+fn reserved_output_tokens_for_window(context_window_tokens: usize) -> usize {
+    if context_window_tokens <= 32_768 {
+        return (context_window_tokens / 6).clamp(1024, 4096);
+    }
+    if context_window_tokens <= 128_000 {
+        return (context_window_tokens / 8).clamp(4096, 16_384);
+    }
+    (context_window_tokens / 10).clamp(16_384, 32_768)
+}
+
+fn compaction_slack_tokens_for_window(context_window_tokens: usize) -> usize {
+    if context_window_tokens <= 32_768 {
+        return (context_window_tokens / 16).clamp(512, 2048);
+    }
+    if context_window_tokens <= 128_000 {
+        return (context_window_tokens / 24).clamp(2048, 4096);
+    }
+    (context_window_tokens / 32).clamp(4096, 8192)
 }
 
 const OPENAI_LONG_CONTEXT_WINDOW_TOKENS: usize = 200_000;

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -475,23 +475,25 @@ pub(super) fn context_budget_from_window(context_window_tokens: usize) -> Contex
 }
 
 fn reserved_output_tokens_for_window(context_window_tokens: usize) -> usize {
-    if context_window_tokens <= 32_768 {
-        return (context_window_tokens / 6).clamp(1024, 4096);
-    }
-    if context_window_tokens <= 128_000 {
-        return (context_window_tokens / 8).clamp(4096, 16_384);
-    }
-    (context_window_tokens / 10).clamp(16_384, 32_768)
+    let reserved = if context_window_tokens <= 32_768 {
+        (context_window_tokens / 6).clamp(1024, 4096)
+    } else if context_window_tokens <= 128_000 {
+        (context_window_tokens / 8).clamp(4096, 16_384)
+    } else {
+        (context_window_tokens / 10).clamp(16_384, 32_768)
+    };
+    reserved.min(context_window_tokens / 2)
 }
 
 fn compaction_slack_tokens_for_window(context_window_tokens: usize) -> usize {
-    if context_window_tokens <= 32_768 {
-        return (context_window_tokens / 16).clamp(512, 2048);
-    }
-    if context_window_tokens <= 128_000 {
-        return (context_window_tokens / 24).clamp(2048, 4096);
-    }
-    (context_window_tokens / 32).clamp(4096, 8192)
+    let slack = if context_window_tokens <= 32_768 {
+        (context_window_tokens / 16).clamp(512, 2048)
+    } else if context_window_tokens <= 128_000 {
+        (context_window_tokens / 24).clamp(2048, 4096)
+    } else {
+        (context_window_tokens / 32).clamp(4096, 8192)
+    };
+    slack.min(context_window_tokens / 4)
 }
 
 const OPENAI_LONG_CONTEXT_WINDOW_TOKENS: usize = 200_000;

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -2433,10 +2433,13 @@ fn does_not_infer_deepseek_long_context_from_unlisted_versions() {
 
 #[test]
 fn context_budget_scales_reserved_output_by_window_size() {
+    let micro = context_budget_from_window(1_024);
     let small = context_budget_from_window(8_192);
     let medium = context_budget_from_window(128_000);
     let large = context_budget_from_window(1_048_576);
 
+    assert_eq!(micro.reserved_output_tokens, 512);
+    assert_eq!(micro.compact_threshold_tokens, 256);
     assert_eq!(small.reserved_output_tokens, 1365);
     assert_eq!(small.compact_threshold_tokens, 6315);
     assert_eq!(medium.reserved_output_tokens, 16_000);

--- a/src/llm/tests.rs
+++ b/src/llm/tests.rs
@@ -17,7 +17,8 @@ use super::openai_compatible::{
     to_openai_messages_for_endpoint,
 };
 use super::shared::{
-    extract_message_text, model_context_budget, parse_tool_arguments, should_bypass_proxy,
+    context_budget_from_window, extract_message_text, model_context_budget, parse_tool_arguments,
+    should_bypass_proxy,
 };
 use crate::agent::Message;
 use crate::config::OpenAiEndpointKind;
@@ -2413,6 +2414,7 @@ fn prefers_explicit_num_ctx_override_for_ollama_options() {
 fn derives_context_budget_for_codex_like_models() {
     let budget = model_context_budget("gpt-5.1-codex").expect("budget");
     assert_eq!(budget.context_window_tokens, 200_000);
+    assert_eq!(budget.reserved_output_tokens, 20_000);
     assert!(budget.compact_threshold_tokens < budget.context_window_tokens);
 }
 
@@ -2420,12 +2422,27 @@ fn derives_context_budget_for_codex_like_models() {
 fn derives_context_budget_for_deepseek_v4_models() {
     let budget = model_context_budget("deepseek-v4-preview").expect("budget");
     assert_eq!(budget.context_window_tokens, 1_048_576);
+    assert_eq!(budget.reserved_output_tokens, 32_768);
     assert!(budget.compact_threshold_tokens > 900_000);
 }
 
 #[test]
 fn does_not_infer_deepseek_long_context_from_unlisted_versions() {
     assert!(model_context_budget("deepseek-v3").is_none());
+}
+
+#[test]
+fn context_budget_scales_reserved_output_by_window_size() {
+    let small = context_budget_from_window(8_192);
+    let medium = context_budget_from_window(128_000);
+    let large = context_budget_from_window(1_048_576);
+
+    assert_eq!(small.reserved_output_tokens, 1365);
+    assert_eq!(small.compact_threshold_tokens, 6315);
+    assert_eq!(medium.reserved_output_tokens, 16_000);
+    assert_eq!(medium.compact_threshold_tokens, 107_904);
+    assert_eq!(large.reserved_output_tokens, 32_768);
+    assert_eq!(large.compact_threshold_tokens, 1_007_616);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- derive reserved output and compaction slack from resolved context window tiers
- cover small, medium, and long context windows in LLM budget tests
- document the model-aware context budgeting policy in a journal note

## Motivation
Addresses the context-budget TODO without overlapping the existing vector schema metadata PR or the subagent context spec PR.

## Validation
- `cargo fmt`
- `cargo test llm::tests::context_budget_scales_reserved_output_by_window_size -- --nocapture`
- `cargo test llm::tests::derives_context_budget_for_codex_like_models -- --nocapture`
- `cargo test llm::tests::derives_context_budget_for_deepseek_v4_models -- --nocapture`
- `git diff --check`
