### PR TITLE
fix(local_model_server): build reqwest blocking client on dedicated OS thread

### DIFF
--- a/src/local_model_server/util.rs
+++ b/src/local_model_server/util.rs
@@ -151,11 +151,16 @@ pub(crate) fn post_json(
 }
 
 pub(crate) fn model_server_http_client(timeout: Duration) -> Result<reqwest::blocking::Client> {
-    reqwest::blocking::Client::builder()
-        .timeout(timeout)
-        .no_proxy()
-        .build()
-        .context("build model server HTTP client")
+    // Build on a dedicated OS thread to avoid tokio runtime shutdown conflicts.
+    std::thread::spawn(move || {
+        reqwest::blocking::Client::builder()
+            .timeout(timeout)
+            .no_proxy()
+            .build()
+            .context("build model server HTTP client")
+    })
+    .join()
+    .unwrap_or_else(|e| Err(anyhow::anyhow!("thread panicked building HTTP client: {e:?}")))
 }
 
 pub(crate) fn model_server_url(host: &str, port: u16, path: &str) -> Result<reqwest::Url> {


### PR DESCRIPTION

Avoids 'Cannot drop a runtime in a context where blocking is not allowed' panic when rara starts with a local model server configured.

The reqwest::blocking::Client is now built inside std::thread::spawn so its Drop does not interfere with tokio runtime shutdown.

Root cause: reqwest::blocking::Client::build() creates an internal tokio runtime for connection pooling. When the builder is called inside an async context (rara's #[tokio::main]), the internal runtime's Drop panics because tokio forbids dropping a runtime from within an async context.