### PR TITLE
fix: spawn reqwest blocking client in dedicated OS thread to avoid tokio runtime panic

### DIFF
--- a/src/local_model_server/util.rs
+++ b/src/local_model_server/util.rs
@@ -151,10 +151,13 @@ pub(crate) fn post_json(
 }
 
 pub(crate) fn model_server_http_client(timeout: Duration) -> Result<reqwest::blocking::Client> {
-    reqwest::blocking::Client::builder()
-        .timeout(timeout)
-        .no_proxy()
-        .build()
+    let handle = std::thread::spawn(move || {
+        reqwest::blocking::Client::builder()
+            .timeout(timeout)
+            .no_proxy()
+            .build()
+    });
+    handle.join().map_err(|_| anyhow::anyhow!("failed to spawn client thread"))?
         .context("build model server HTTP client")
 }
 


### PR DESCRIPTION
## Problem
`rara` panics on startup with:
```
Cannot drop a runtime in a context where blocking is not allowed
```

## Root Cause
`model_server_http_client` in `src/local_model_server/util.rs` creates a `reqwest::blocking::Client` which internally spawns a tokio runtime. When called from an async context (`tokio::main`), tokio 1.52+ panics.

## Fix
Wrap the `reqwest::blocking::Client::builder().build()` call in `std::thread::spawn`, using a dedicated OS thread to isolate it from the tokio async runtime.

## Testing
`cargo build` + `./target/debug/rara` should start without panic.