### PR TITLE
fix(local_model_server): use OnceLock for cached blocking HTTP client

### DIFF
--- a/src/local_model_server/util.rs
+++ b/src/local_model_server/util.rs
@@ -150,12 +150,21 @@ pub(crate) fn post_json(
     response.json().context("parse model server POST response")
 }
 
-pub(crate) fn model_server_http_client(timeout: Duration) -> Result<reqwest::blocking::Client> {
-    reqwest::blocking::Client::builder()
-        .timeout(timeout)
-        .no_proxy()
-        .build()
-        .context("build model server HTTP client")
+use std::sync::OnceLock;
+
+/// Returns a cached blocking HTTP client, built lazily on first access.
+/// The client is built on the calling thread but held for the lifetime of
+/// the process, so its internal tokio runtime is torn down only at exit
+/// (outside any async context).
+pub(crate) fn model_server_http_client(timeout: Duration) -> Result<&'static reqwest::blocking::Client> {
+    static CLIENT: OnceLock<reqwest::blocking::Client> = OnceLock::new();
+    CLIENT.get_or_try_init(|| {
+        reqwest::blocking::Client::builder()
+            .timeout(timeout)
+            .no_proxy()
+            .build()
+            .context("build model server HTTP client")
+    })
 }
 
 pub(crate) fn model_server_url(host: &str, port: u16, path: &str) -> Result<reqwest::Url> {


### PR DESCRIPTION
## Problem
rara panics on startup with 'Cannot drop a runtime in a context where blocking is not allowed' when a local model server is configured.

## Root Cause
`model_server_http_client` creates a `reqwest::blocking::Client` whose internal tokio runtime panics when dropped inside rara's `#[tokio::main]` async context.

## Fix
Use `std::sync::OnceLock` to cache a single `reqwest::blocking::Client` for the process lifetime. The client is built lazily on the first HTTP request. Its internal runtime only shuts down at process exit, outside any async context, avoiding the panic entirely.

This is more correct than the std::thread::spawn approach (#583/#584), which still allows the client to be dropped on the calling tokio thread (as noted by Gemini code review).

Supersedes #583 and #584.

## Testing
`cargo build` + `./target/debug/rara` should start without panic when a local model server is configured.