### PR TITLE
fix(startup): avoid dropping reqwest blocking runtime in async context

### DIFF
--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -296,7 +296,8 @@ async fn run_tui_command(
     oauth_manager: OAuthManager,
     startup_resume: StartupResumeTarget,
 ) -> Result<()> {
-    let initialize_local_embeddings = should_initialize_local_embeddings_on_tui_startup(config)?;
+    let initialize_local_embeddings =
+        should_initialize_local_embeddings_on_tui_startup(config).await?;
     let bootstrap = if initialize_local_embeddings {
         runtime_context::initialize_rara_context_with_local_embedding_bootstrap(
             config,
@@ -343,12 +344,18 @@ async fn run_tui_command(
     Ok(())
 }
 
-fn should_initialize_local_embeddings_on_tui_startup(config: &RaraConfig) -> Result<bool> {
+async fn should_initialize_local_embeddings_on_tui_startup(config: &RaraConfig) -> Result<bool> {
     if !runtime_context::config_requires_local_embedding_sidecar(config) {
         return Ok(false);
     }
     let rara_home = ensure_rara_home_dir()?;
-    let status = crate::local_model_server::inspect_local_model_server_status(&rara_home);
+    // `inspect_local_model_server_status` uses a `reqwest::blocking` client, which spins up and
+    // drops its own Tokio runtime. Dropping a runtime inside the async context would panic, so run
+    // the blocking probe on a dedicated blocking thread where that is allowed.
+    let status = tokio::task::spawn_blocking(move || {
+        crate::local_model_server::inspect_local_model_server_status(&rara_home)
+    })
+    .await?;
     Ok(!matches!(
         status.state,
         crate::local_model_server::LocalModelServerState::Ready

--- a/src/local_model_server/backend.rs
+++ b/src/local_model_server/backend.rs
@@ -189,6 +189,30 @@ pub(crate) fn inspect_local_model_server_status(rara_home: &Path) -> LocalModelS
     prepare_local_model_server_status_inner(rara_home, BootstrapMode::InspectOnly, None)
 }
 
+/// Inspect the local model server status from a synchronous context that may itself be running
+/// inside a Tokio runtime.
+///
+/// `inspect_local_model_server_status` uses a `reqwest::blocking` client, which spins up and drops
+/// its own Tokio runtime. Dropping a runtime while inside the async context of a multi-threaded
+/// runtime panics ("Cannot drop a runtime in a context where blocking is not allowed"). When called
+/// from inside a runtime we therefore hop onto a dedicated OS thread that has no runtime entered;
+/// outside a runtime we probe directly.
+pub(crate) fn inspect_local_model_server_status_off_runtime(
+    rara_home: &Path,
+) -> LocalModelServerStatus {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        let rara_home = rara_home.to_path_buf();
+        std::thread::scope(|scope| {
+            scope
+                .spawn(|| inspect_local_model_server_status(&rara_home))
+                .join()
+                .expect("local model server status probe thread panicked")
+        })
+    } else {
+        inspect_local_model_server_status(rara_home)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BootstrapMode {
     Automatic,

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -141,7 +141,8 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
         local_embedding_bootstrap,
         embedding_progress,
         &mut embedding_warnings,
-    )?;
+    )
+    .await?;
 
     let workspace = Arc::new(WorkspaceMemory::new()?);
     let vdb = Arc::new(VectorDB::new(&vector_db_uri_for_workspace(&workspace)));
@@ -289,7 +290,7 @@ pub(crate) fn config_requires_local_embedding_sidecar(config: &RaraConfig) -> bo
     )
 }
 
-fn build_embedding_backends(
+async fn build_embedding_backends(
     config: &RaraConfig,
     chat_backend: Arc<dyn LlmBackend>,
     bootstrap: LocalEmbeddingBootstrap,
@@ -304,7 +305,17 @@ fn build_embedding_backends(
         }
         EmbeddingRoute::LocalModelServer => {
             let rara_home = ensure_rara_home_dir()?;
-            let status = local_model_server_status_for_bootstrap(&rara_home, bootstrap, &progress);
+            // `local_model_server_status_for_bootstrap` uses a `reqwest::blocking` client, which
+            // spins up and drops its own Tokio runtime. Dropping a runtime inside the async context
+            // would panic, so run the probe on a blocking thread where that is allowed.
+            let status = {
+                let rara_home = rara_home.clone();
+                tokio::task::spawn_blocking(move || {
+                    local_model_server_status_for_bootstrap(&rara_home, bootstrap, &progress)
+                })
+                .await
+                .context("join local model server bootstrap status")?
+            };
             if status.state == crate::local_model_server::LocalModelServerState::Error {
                 warnings.push(format!(
                     "local embedding backend bootstrap reported: {}",

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -7,9 +7,14 @@ pub(super) async fn rebuild_agent_with_progress(
     progress: Option<crate::local_backend::LocalProgressReporter>,
 ) -> anyhow::Result<RebuildSuccess> {
     let bootstrap = crate::runtime_context::initialize_rara_context(config, progress).await?;
-    let local_model_server = crate::local_model_server::inspect_local_model_server_status(
-        &crate::config::ensure_rara_home_dir()?,
-    );
+    // `inspect_local_model_server_status` uses a `reqwest::blocking` client, which spins up and
+    // drops its own Tokio runtime; dropping a runtime inside the async context would panic, so run
+    // it on a blocking thread where that is allowed.
+    let rara_home = crate::config::ensure_rara_home_dir()?;
+    let local_model_server = tokio::task::spawn_blocking(move || {
+        crate::local_model_server::inspect_local_model_server_status(&rara_home)
+    })
+    .await?;
     let event_bus = bootstrap.event_bus.clone();
 
     // Start the hook runtime — registers command-type hooks found in `.claude/hooks/`

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -280,7 +280,9 @@ impl TuiApp {
             .map(std::path::Path::to_path_buf)
             .unwrap_or_else(|| std::path::PathBuf::from("."));
         let local_model_server =
-            crate::local_model_server::inspect_local_model_server_status(&local_model_server_home);
+            crate::local_model_server::inspect_local_model_server_status_off_runtime(
+                &local_model_server_home,
+            );
         let mut app = Self {
             bottom_pane: BottomPaneModel {
                 input: String::new(),


### PR DESCRIPTION
## Problem

`./target/debug/rara` panicked on startup:

```
Cannot drop a runtime in a context where blocking is not allowed.
This happens when a runtime is dropped from within an asynchronous context.
```

## Root cause

The chain `inspect_local_model_server_status` → `probe_health` → `model_server_http_client` builds a `reqwest::blocking::Client`, which internally spins up *its own* Tokio runtime and drops it. Under `#[tokio::main]` (a multi-threaded runtime), dropping a runtime on a worker thread is forbidden → panic.

This blocking probe was called **synchronously from three async startup paths**. Tests never caught it because `#[tokio::test]` defaults to a single-threaded runtime, where dropping a runtime *is* allowed.

## Fix

Run the probe off the async runtime, matching the existing `spawn_blocking` pattern already used in `refresh_endpoint`:

- `should_initialize_local_embeddings_on_tui_startup` / `build_embedding_backends` become `async` and wrap the probe in `tokio::task::spawn_blocking`.
- the agent-rebuild path (`rebuild_agent_with_progress`) wraps its probe in `spawn_blocking` (would have panicked on every model rebuild).
- the sync `AppState::new` constructor (can't `.await`) uses a new `inspect_local_model_server_status_off_runtime` helper that detects an active runtime via `Handle::try_current()` and hops onto a dedicated OS thread when needed.

## Verification

- `cargo build` clean.
- TUI now starts cleanly under a real PTY (renders, stays alive, no panic).
- `cargo test --bin rara local_model_server` passes (25 tests, incl. `rebuild_success_refreshes_local_model_server_status`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)