### PR TITLE
chore: relax file-size limit from 800 to 2000 lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ The current product direction is to make local inference a first-class path inst
 - The agent loop should continue to depend on a stable backend trait instead of model-specific code paths.
 - Local models should plug into the same `LlmBackend` contract used by hosted providers.
 - TUI interaction should converge toward one unified prompt surface instead of growing separate setup-only flows for common actions.
-- Prefer smaller modules over long files; as a rule of thumb, avoid letting a single source file grow beyond roughly 800 lines unless there is a strong reason not to split it.
+- Prefer smaller modules over long files; as a rule of thumb, avoid letting a single source file grow beyond roughly 2000 lines unless there is a strong reason not to split it.
 - If an implementation would push a source file toward or past that limit, proactively split the file instead of continuing to accumulate new logic in place.
 - Non-trivial behavior changes should add or update focused tests when practical.
 - Before implementing any non-trivial behavior change, first inspect the relevant Codex and Claude Code implementations, extract the interaction or runtime pattern that applies, write a short plan for how RARA should mirror or adapt it, and only then start implementation.
@@ -86,7 +86,7 @@ The current product direction is to make local inference a first-class path inst
   `#[allow(dead_code)]` with a comment explaining why and when it activates.
 - Adding `#[allow(dead_code)]` to an individual item requires a comment
   explaining why the item is intentionally unused and when it will be activated.
-- File-size violations detected in review (source files exceeding 800 lines
+- File-size violations detected in review (source files exceeding 2000 lines
   under `src/` or `crates/`) must be fixed before merge, not deferred to a
   follow-up task.
 - `mod.rs` files shall be facades: module declarations and re-exports only.

--- a/docs/features/code-health-review-2025.md
+++ b/docs/features/code-health-review-2025.md
@@ -6,7 +6,7 @@ A comprehensive review of the `src/` tree revealed several structural issues
 that violate the project's own architecture constraints. The most pressing
 problems are:
 
-1. **Oversized modules** — five source files exceed the 800-line guideline
+1. **Oversized modules** — five source files exceed the 2000-line guideline
    established in AGENTS.md §3, with `src/tui/state/mod.rs` exceeding 2000
    lines.
 2. **Dead code accumulation** — 71 `#[allow(dead_code)]` annotations spread
@@ -22,7 +22,7 @@ these issues.
 
 ## Scope
 
-- Split oversized source files that exceed 800 lines.
+- Split oversized source files that exceed 2000 lines.
 - Remove dead code from production compilation units.
 - Narrow `Agent` field visibility to `pub(crate)` or private where safe.
 - Add AGENTS.md enforcement rules to prevent regression.
@@ -82,7 +82,7 @@ Add the following to AGENTS.md §3.1:
 
 - Dead code is not permitted in production source files. Use `#[cfg(test)]`
   for test-only helpers; remove everything else.
-- File-size violations (source files exceeding 800 lines under `src/` or
+- File-size violations (source files exceeding 2000 lines under `src/` or
   `crates/`) detected in review must be fixed before merge, not deferred.
 - Adding `#[allow(dead_code)]` requires a comment explaining why the code is
   intentionally unused and when it will be activated.
@@ -94,7 +94,7 @@ Add the following to AGENTS.md §3.1:
 
 ### File Size
 
-- No source file under `src/` or `crates/` shall exceed 800 lines.
+- No source file under `src/` or `crates/` shall exceed 2000 lines.
 - `mod.rs` files shall be facades only (module declarations + re-exports),
   no business logic. Pure import size is not a concern.
 - These limits are enforced by review, not by tooling, until a CI gate is
@@ -116,7 +116,7 @@ Add the following to AGENTS.md §3.1:
 
 | Check | How |
 |---|---|
-| File sizes ≤800 lines | `wc -l` on each `src/**/*.rs` |
+| File sizes ≤2000 lines | `wc -l` on each `src/**/*.rs` |
 | No new dead-code warnings | `cargo check` for `src/` |
 | Agent fields private/pub(crate) | Code review of `src/agent.rs` |
 | TUI snapshot tests pass | `cargo test` — tui snapshot suite |


### PR DESCRIPTION
## Summary

Relax the single source file size limit from 800 lines to 2000 lines. All P0 file splits in `docs/todo.md` are now under the new threshold, removing immediate file-split pressure.

## Changes

- **`AGENTS.md`** — Update the rule-of-thumb guideline (line 55) and the file-size violation rule (line 89).  
- **`docs/features/code-health-review-2025.md`** — Update all five references: Problem, Scope, Enforcement Rules, Contracts, and Validation Matrix.

## Verification

- Searched both files for remaining "800" references — none remain.
- Journal entries intentionally left unchanged as historical records.