### PR TITLE
feat(tui): Alt+T to toggle thinking collapse with duration summary

### DIFF
--- a/src/auto_memory.rs
+++ b/src/auto_memory.rs
@@ -508,6 +508,7 @@ mod tests {
 
     fn transcript_turn(user: &str, assistant: &str) -> TranscriptTurn {
         TranscriptTurn {
+            thinking_duration: None,
             entries: vec![
                 TranscriptEntry::new("You", user),
                 TranscriptEntry::new("Agent", assistant),

--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -50,4 +50,5 @@ pub enum AppEvent {
     CancelRunningTask,
     ClearComposer,
     ToggleSidebar,
+    ToggleThinking,
 }

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -57,6 +57,9 @@ pub(crate) async fn dispatch_event(
         AppEvent::ToggleSidebar => {
             app.sidebar_visible = !app.sidebar_visible;
         }
+        AppEvent::ToggleThinking => {
+            app.thinking_collapsed = !app.thinking_collapsed;
+        }
         AppEvent::SubmitComposer => {
             app.bottom_pane.expand_large_paste();
             if resume_pending_shell_approval_after_full_access(app, agent_slot) {

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -215,6 +215,7 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
                     AppEvent::DeleteForward
                 }
                 (KeyCode::Char('b'), KeyModifiers::CONTROL) => AppEvent::ToggleSidebar,
+                (KeyCode::Char('t'), KeyModifiers::ALT) => AppEvent::ToggleThinking,
                 (KeyCode::Char(c), _) => AppEvent::InputChar(c),
                 _ => AppEvent::Noop,
             }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -197,7 +197,13 @@ fn committed_transcript_lines(app: &TuiApp, width: u16) -> Vec<Line<'static>> {
     let cwd = (!app.snapshot.cwd.is_empty()).then(|| Path::new(app.snapshot.cwd.as_str()));
     let mut lines = Vec::new();
     for turn in &app.committed_turns {
-        let mut turn_lines = committed_turn_lines(turn.entries.as_slice(), cwd, width);
+        let mut turn_lines = committed_turn_lines(
+            turn.entries.as_slice(),
+            cwd,
+            width,
+            app.thinking_collapsed,
+            turn.thinking_duration,
+        );
         if turn_lines.is_empty() {
             continue;
         }
@@ -239,16 +245,20 @@ fn turn_divider_line(width: u16) -> Line<'static> {
 pub fn committed_turn_cell<'a>(
     entries: &'a [TranscriptEntry],
     cwd: Option<&'a Path>,
+    thinking_collapsed: bool,
+    thinking_duration: Option<std::time::Duration>,
 ) -> CommittedTurnCell<'a> {
-    CommittedTurnCell::new(entries, cwd)
+    CommittedTurnCell::new(entries, cwd, thinking_collapsed, thinking_duration)
 }
 
 pub(crate) fn committed_turn_lines(
     entries: &[TranscriptEntry],
     cwd: Option<&Path>,
     width: u16,
+    thinking_collapsed: bool,
+    thinking_duration: Option<std::time::Duration>,
 ) -> Vec<Line<'static>> {
-    committed_turn_cell(entries, cwd).display_lines(width)
+    committed_turn_cell(entries, cwd, thinking_collapsed, thinking_duration).display_lines(width)
 }
 
 pub fn active_turn_cell<'a>(app: &'a TuiApp) -> ActiveTurnCell<'a> {

--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -175,7 +175,14 @@ impl ActiveCell for ActiveTurnCell<'_> {
                         cells.push(Box::new(ExploringCell::new(summary, turn_live)));
                     }
                     OrderedActiveSegment::Progress(role, messages) => {
-                        push_progress_group(&mut cells, *role, messages.clone(), turn_live);
+                        push_progress_group(
+                            &mut cells,
+                            *role,
+                            messages.clone(),
+                            turn_live,
+                            self.app.thinking_collapsed,
+                            None,
+                        );
                     }
                     OrderedActiveSegment::Agent(message) => {
                         cells.push(Box::new(MessageCell::new(
@@ -202,11 +209,20 @@ impl ActiveCell for ActiveTurnCell<'_> {
                     ProgressRole::Thinking => {}
                 }
             }
+            let thinking_dur = self
+                .app
+                .active_live
+                .thinking_started_at
+                .map(|start| start.elapsed());
+            // Live streaming thinking is always expanded (tail mode).
+            // The toggle only affects committed (finalized) thinking blocks.
             push_live_events(
                 &mut cells,
                 live_events,
                 streaming_thinking_lines.filter(|_| has_live_thinking),
                 true,
+                false,
+                thinking_dur,
             );
         }
 
@@ -217,7 +233,14 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
         if let Some(groups) = explicit_progress_groups.as_ref() {
             for (role, messages) in groups {
-                push_progress_group(&mut cells, *role, messages.clone(), turn_live);
+                push_progress_group(
+                    &mut cells,
+                    *role,
+                    messages.clone(),
+                    turn_live,
+                    self.app.thinking_collapsed,
+                    None,
+                );
             }
         }
         let has_explicit_progress_groups = explicit_progress_groups

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -11,6 +11,7 @@ fn active_turn_cell_keeps_sections_in_stable_order() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("waiting for tool output".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -111,6 +112,7 @@ fn active_turn_cell_renders_progress_sections_as_compact_stack() {
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect the codebase".into(),
@@ -158,6 +160,7 @@ fn active_turn_cell_hides_background_stdout_label_and_pins_stderr() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -218,6 +221,7 @@ fn active_turn_cell_renders_terminal_result_as_terminal_cell() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -260,6 +264,7 @@ fn active_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -344,6 +349,7 @@ fn active_turn_cell_keeps_exploration_notes_inside_exploring_block() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("waiting for model response · 12s elapsed".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "You".into(), message: "Review this repository".into(), payload: None },
             TranscriptEntry { role: "Tool".into(), message: "read_file src/main.rs".into(), payload: None },
@@ -385,6 +391,7 @@ fn active_turn_cell_uses_stateful_live_exploration_sections() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("waiting for model response · 20s elapsed".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect the repository".into(),
@@ -420,6 +427,7 @@ fn active_turn_cell_compacts_live_response_when_process_sections_exist() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("waiting for model response".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "You".into(), message: "Inspect the repository".into(), payload: None },
             TranscriptEntry { role: "Agent".into(), message: "I have inspected the repository structure.\nI checked the runtime boundary.\nI checked the prompt assembly path.\nNext I will inspect the persistence layer.\nThen I will verify the restore contract."
@@ -452,6 +460,7 @@ fn active_turn_cell_appends_long_live_exploration_events() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect the repository".into(),
@@ -491,6 +500,7 @@ fn active_turn_cell_appends_long_live_planning_events() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Refine the plan".into(),
@@ -530,6 +540,7 @@ fn active_turn_cell_appends_long_live_running_events() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run the checks".into(),
@@ -568,6 +579,7 @@ fn active_turn_cell_updated_plan_snapshot() {
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("waiting for model response · 3s elapsed".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Read the local codebase and propose the next refactor".into(),
@@ -614,6 +626,7 @@ fn active_turn_cell_hides_structured_plan_response_once_plan_card_exists() {
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "You".into(), message: "Plan the next refactor".into(), payload: None },
             TranscriptEntry { role: "Agent".into(), message: "<proposed_plan>\n- [completed] Inspect the auth flow\n- [in_progress] Reuse codex_login\n- [pending] Add auth picker snapshots\n</proposed_plan>\nPrefer direct auth reuse before expanding more TUI flows.".into(), payload: None },
@@ -649,6 +662,7 @@ fn active_turn_cell_prefers_inline_plan_artifact_over_preamble_before_snapshot_s
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "You".into(), message: "Review the codebase and propose changes".into(), payload: None },
             TranscriptEntry { role: "Agent".into(), message: "I reviewed the current implementation.\nHere is the concise plan.\n<proposed_plan>\n- [completed] Inspect the runtime entrypoint\n- [pending] Tighten the render path\n</proposed_plan>\nKeep the diff narrow and reviewable.".into(), payload: None },
@@ -680,6 +694,7 @@ fn active_turn_cell_suppresses_planning_chatter_when_exploring() {
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -720,6 +735,7 @@ fn active_turn_cell_uses_planning_sidecar_for_non_structured_plan_output() {
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -755,6 +771,7 @@ fn active_turn_cell_uses_explicit_sidecar_entries_when_live_state_is_empty() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -803,6 +820,7 @@ fn active_turn_cell_preserves_exploration_agent_exploration_order() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -859,6 +877,7 @@ fn active_turn_cell_preserves_duplicate_restored_exploration_segments() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -914,6 +933,7 @@ fn active_turn_cell_preserves_agent_then_exploration_order() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -958,6 +978,7 @@ fn active_turn_cell_preserves_interleaved_agent_and_progress_output() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1028,6 +1049,7 @@ fn active_turn_cell_uses_lightweight_busy_response_when_not_streaming() {
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("waiting for model response · 2s elapsed".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1067,6 +1089,7 @@ fn active_turn_cell_shows_live_thinking_stream() {
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("thinking".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review this repository".into(),
@@ -1094,6 +1117,7 @@ fn active_turn_cell_flattens_thinking_and_running_events_in_order() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run a long task".into(),
@@ -1137,6 +1161,7 @@ fn active_turn_cell_places_streaming_thinking_after_latest_progress_event() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run a long task".into(),
@@ -1176,6 +1201,7 @@ fn active_turn_cell_places_streaming_thinking_after_latest_exploration_event() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect before reasoning again".into(),
@@ -1215,6 +1241,7 @@ fn active_turn_cell_groups_consecutive_thinking_events_with_stream() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Reason about a task".into(),
@@ -1249,6 +1276,7 @@ fn active_turn_cell_preserves_flushed_thinking_leading_indentation() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect thinking formatting".into(),
@@ -1278,6 +1306,7 @@ fn active_turn_cell_preserves_repeated_progress_events_when_interleaved() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run checks".into(),
@@ -1315,6 +1344,7 @@ fn active_turn_cell_groups_consecutive_exploration_events_only() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect and run checks".into(),
@@ -1363,6 +1393,7 @@ fn active_turn_cell_preserves_consecutive_duplicate_progress_events() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run checks".into(),
@@ -1397,6 +1428,7 @@ fn active_turn_cell_shows_live_thinking_tail_without_cloning_full_body() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review this repository".into(),
@@ -1428,6 +1460,7 @@ fn active_turn_cell_renders_live_response_as_lightweight_message() {
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("waiting for model response".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1466,6 +1499,7 @@ fn active_turn_cell_prefers_responding_over_tool_result_while_processing_respons
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("waiting for model output".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1502,6 +1536,7 @@ fn active_turn_cell_prefers_responding_over_system_notice_while_sending_prompt()
     app.runtime_phase = RuntimePhase::SendingPrompt;
     app.runtime_phase_detail = Some("sending prompt to provider".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1537,6 +1572,7 @@ fn active_turn_cell_shows_planning_section_for_plan_agent() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("plan_agent {\"instruction\":\"refine the plan\"}".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Plan the refactor".into(),
@@ -1568,6 +1604,7 @@ fn active_turn_cell_renders_device_code_prompt_system_message() {
     app.runtime_phase = RuntimePhase::OAuthPollingDeviceCode;
     app.runtime_phase_detail = Some("Waiting for device-code confirmation.".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "Runtime".into(), message: "Starting Codex device-code login flow.".into(), payload: None },
             TranscriptEntry { role: "System".into(), message: "Open this URL in a browser and enter the one-time code:\nhttps://example.test\n\nCode: ABCD".into(), payload: Some(crate::tui::state::TranscriptEntryPayload::System(crate::tui::state::SystemMessageKind::OAuthPrompt)) },

--- a/src/tui/render/cells/cells_tests/active_plan.rs
+++ b/src/tui/render/cells/cells_tests/active_plan.rs
@@ -9,6 +9,7 @@ fn active_turn_cell_renders_plan_approval_as_interaction_card() {
     .expect("build tui app");
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
@@ -50,6 +51,7 @@ fn active_turn_cell_renders_updated_plan_checklist() {
     .expect("build tui app");
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Improve the plan rendering".into(),
@@ -92,6 +94,7 @@ fn active_turn_cell_hides_stale_updated_plan_after_plan_turn_finishes() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Implement the approved fix".into(),
@@ -121,6 +124,7 @@ fn active_turn_cell_hides_stale_exploring_after_live_phase_finishes() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::Idle;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -154,6 +158,7 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -224,6 +229,7 @@ fn active_turn_cell_renders_queued_follow_up_without_hiding_shell_approval() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run a shell command".into(),
@@ -271,6 +277,7 @@ fn active_turn_cell_does_not_render_completed_plan_decision() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
@@ -303,6 +310,7 @@ fn active_turn_cell_does_not_render_completed_shell_approval_while_live() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -348,6 +356,7 @@ fn active_turn_cell_falls_back_to_previous_completion_when_shell_approval_is_liv
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -397,6 +406,7 @@ fn active_turn_cell_keeps_streaming_response_without_responding_card() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -438,6 +448,7 @@ fn active_turn_cell_does_not_repeat_stale_plan_decision_from_snapshot() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Approve the plan".into(),
@@ -452,6 +463,7 @@ fn active_turn_cell_does_not_repeat_stale_plan_decision_from_snapshot() {
     );
     app.finalize_active_turn();
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Continue with the next task".into(),
@@ -477,6 +489,7 @@ fn active_turn_cell_labels_delegated_plan_questions() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
@@ -517,6 +530,7 @@ fn active_turn_cell_labels_delegated_completed_questions() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),

--- a/src/tui/render/cells/cells_tests/committed.rs
+++ b/src/tui/render/cells/cells_tests/committed.rs
@@ -46,7 +46,7 @@ fn committed_turn_cell_keeps_user_summary_and_agent_sections_in_order() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -83,7 +83,7 @@ fn committed_turn_cell_ignores_routine_system_notices() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -117,7 +117,7 @@ fn committed_turn_cell_renders_memory_action_notices() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -148,7 +148,7 @@ fn committed_turn_cell_renders_materialized_sidecar_sections() {
         TranscriptEntry { role: "Agent".into(), message: "Here is the final recommendation.".into(), payload: None },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -204,7 +204,7 @@ fn committed_turn_cell_keeps_progress_segments_and_terminal_output() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -254,7 +254,7 @@ fn committed_turn_cell_preserves_interleaved_agent_and_progress_output() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -325,7 +325,7 @@ fn committed_turn_cell_appends_adjacent_progress_entries() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -365,7 +365,7 @@ fn committed_turn_cell_places_completion_records_before_final_agent_message() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -412,7 +412,7 @@ fn committed_turn_cell_preserves_completion_record_order() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -441,7 +441,7 @@ fn committed_turn_cell_renders_terminal_result_as_terminal_cell() {
         TranscriptEntry { role: "Agent".into(), message: "The background test task completed.".into(), payload: None },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -473,7 +473,7 @@ fn committed_turn_cell_renders_terminal_result_with_inline_output_path() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -508,7 +508,7 @@ fn committed_turn_cell_shows_tail_for_long_tool_messages() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -553,7 +553,7 @@ fn committed_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -593,7 +593,7 @@ fn committed_turn_cell_keeps_final_agent_response_when_system_notice_arrives_aft
         },
     ];
 
-    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")))
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())

--- a/src/tui/render/cells/committed_turn.rs
+++ b/src/tui/render/cells/committed_turn.rs
@@ -18,18 +18,36 @@ const TOOL_MESSAGE_MAX_LINES: usize = 5;
 pub(crate) struct CommittedTurnCell<'a> {
     entries: &'a [TranscriptEntry],
     cwd: Option<&'a Path>,
+    thinking_collapsed: bool,
+    thinking_duration: Option<std::time::Duration>,
 }
 
 impl<'a> CommittedTurnCell<'a> {
-    pub(crate) fn new(entries: &'a [TranscriptEntry], cwd: Option<&'a Path>) -> Self {
-        Self { entries, cwd }
+    pub(crate) fn new(
+        entries: &'a [TranscriptEntry],
+        cwd: Option<&'a Path>,
+        thinking_collapsed: bool,
+        thinking_duration: Option<std::time::Duration>,
+    ) -> Self {
+        Self {
+            entries,
+            cwd,
+            thinking_collapsed,
+            thinking_duration,
+        }
     }
 }
 
 impl HistoryCell for CommittedTurnCell<'_> {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
         let mut cells: Vec<Box<dyn HistoryCell + '_>> = Vec::new();
-        push_ordered_committed_activity(&mut cells, self.entries, self.cwd);
+        push_ordered_committed_activity(
+            &mut cells,
+            self.entries,
+            self.cwd,
+            self.thinking_collapsed,
+            self.thinking_duration,
+        );
 
         let mut lines = Vec::new();
         let mut previous_was_progress_stack_title = false;
@@ -54,20 +72,29 @@ fn push_ordered_committed_activity<'a>(
     cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
     entries: &'a [TranscriptEntry],
     cwd: Option<&'a Path>,
+    thinking_collapsed: bool,
+    thinking_duration: Option<std::time::Duration>,
 ) {
     let mut pending_progress: Option<(ProgressRole, Vec<String>)> = None;
 
-    let flush_progress =
-        |cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-         pending_progress: &mut Option<(ProgressRole, Vec<String>)>| {
-            if let Some((role, messages)) = pending_progress.take() {
-                push_progress_group(cells, role, messages, false);
-            }
-        };
+    let flush_progress = |cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
+                          pending_progress: &mut Option<(ProgressRole, Vec<String>)>,
+                          thinking_duration: Option<std::time::Duration>| {
+        if let Some((role, messages)) = pending_progress.take() {
+            push_progress_group(
+                cells,
+                role,
+                messages,
+                false,
+                thinking_collapsed,
+                thinking_duration,
+            );
+        }
+    };
 
     for entry in entries {
         if entry.role == "You" {
-            flush_progress(cells, &mut pending_progress);
+            flush_progress(cells, &mut pending_progress, thinking_duration);
             cells.push(Box::new(UserCell::new(entry.message.clone())));
             continue;
         }
@@ -82,13 +109,13 @@ fn push_ordered_committed_activity<'a>(
             {
                 last_messages.extend(messages);
             } else {
-                flush_progress(cells, &mut pending_progress);
+                flush_progress(cells, &mut pending_progress, thinking_duration);
                 pending_progress = Some((role, messages));
             }
             continue;
         }
 
-        flush_progress(cells, &mut pending_progress);
+        flush_progress(cells, &mut pending_progress, thinking_duration);
 
         if let Some(cell) = terminal_cell_from_entries(std::iter::once(entry)) {
             cells.push(Box::new(cell));
@@ -144,5 +171,5 @@ fn push_ordered_committed_activity<'a>(
         }
     }
 
-    flush_progress(cells, &mut pending_progress);
+    flush_progress(cells, &mut pending_progress, thinking_duration);
 }

--- a/src/tui/render/cells/progress.rs
+++ b/src/tui/render/cells/progress.rs
@@ -89,11 +89,16 @@ pub(super) fn push_progress_group<'a>(
     role: ProgressRole,
     messages: Vec<String>,
     active: bool,
+    collapsed: bool,
+    duration: Option<std::time::Duration>,
 ) {
     match role {
-        ProgressRole::Thinking => {
-            cells.push(Box::new(ThinkingBlockCell::new(&messages.join("\n"), 4)))
-        }
+        ProgressRole::Thinking => cells.push(Box::new(ThinkingBlockCell::new(
+            &messages.join("\n"),
+            4,
+            collapsed,
+            duration,
+        ))),
         ProgressRole::Exploring => cells.push(Box::new(ExploringCell::new(
             compact_summary_lines(messages.as_slice(), 4, "more exploration step(s)"),
             active,
@@ -114,6 +119,8 @@ pub(super) fn push_live_events<'a>(
     events: &[crate::tui::state::ActiveLiveEvent],
     streaming_thinking_lines: Option<&'a [Line<'static>]>,
     active: bool,
+    collapsed: bool,
+    thinking_duration: Option<std::time::Duration>,
 ) {
     let mut thinking_messages = Vec::new();
     let mut exploration_actions = Vec::new();
@@ -136,7 +143,13 @@ pub(super) fn push_live_events<'a>(
                 thinking_messages.push(event.message().to_string());
             }
             ProgressRole::Exploring => {
-                push_live_thinking_group(cells, &mut thinking_messages, None);
+                push_live_thinking_group(
+                    cells,
+                    &mut thinking_messages,
+                    None,
+                    collapsed,
+                    thinking_duration,
+                );
                 push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
                 push_live_running_group(cells, &mut running_actions, active);
                 if event.is_note() {
@@ -146,7 +159,13 @@ pub(super) fn push_live_events<'a>(
                 }
             }
             ProgressRole::Planning => {
-                push_live_thinking_group(cells, &mut thinking_messages, None);
+                push_live_thinking_group(
+                    cells,
+                    &mut thinking_messages,
+                    None,
+                    collapsed,
+                    thinking_duration,
+                );
                 push_live_exploration_group(
                     cells,
                     &mut exploration_actions,
@@ -161,7 +180,13 @@ pub(super) fn push_live_events<'a>(
                 }
             }
             ProgressRole::Running => {
-                push_live_thinking_group(cells, &mut thinking_messages, None);
+                push_live_thinking_group(
+                    cells,
+                    &mut thinking_messages,
+                    None,
+                    collapsed,
+                    thinking_duration,
+                );
                 push_live_exploration_group(
                     cells,
                     &mut exploration_actions,
@@ -182,13 +207,21 @@ pub(super) fn push_live_events<'a>(
     );
     push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
     push_live_running_group(cells, &mut running_actions, active);
-    push_live_thinking_group(cells, &mut thinking_messages, streaming_thinking_lines);
+    push_live_thinking_group(
+        cells,
+        &mut thinking_messages,
+        streaming_thinking_lines,
+        collapsed,
+        thinking_duration,
+    );
 }
 
 pub(super) fn push_live_thinking_group<'a>(
     cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
     messages: &mut Vec<String>,
     stream_lines: Option<&'a [Line<'static>]>,
+    collapsed: bool,
+    duration: Option<std::time::Duration>,
 ) {
     if messages.is_empty() && stream_lines.is_none_or(|lines| lines.is_empty()) {
         return;
@@ -197,6 +230,8 @@ pub(super) fn push_live_thinking_group<'a>(
         std::mem::take(messages).join("\n"),
         stream_lines,
         4,
+        collapsed,
+        duration,
     )));
 }
 

--- a/src/tui/render/cells/thinking_cells.rs
+++ b/src/tui/render/cells/thinking_cells.rs
@@ -9,21 +9,30 @@ use crate::tui::theme::TEXT_MUTED;
 
 /// Renders thinking content as dimmed lines with a ┊ accent prefix.
 ///
-/// Design follows OpenCode: no header label, no toggle, no token count.
-/// Every line is prefixed with ┊ and colored TEXT_MUTED for a subdued
-/// "inner monologue" visual layer between # You and # Agent sections.
+/// When collapsed (default): shows first 2 lines plus duration summary.
+/// When expanded (Alt+T): shows last max_lines lines (stale-tail for stream).
+/// The `duration` field is Some for committed turns with a known duration.
 pub(crate) struct ThinkingBlockCell<'a> {
     message: String,
     stream_lines: Option<&'a [Line<'static>]>,
     max_lines: usize,
+    collapsed: bool,
+    duration: Option<std::time::Duration>,
 }
 
 impl<'a> ThinkingBlockCell<'a> {
-    pub(crate) fn new(message: &str, max_lines: usize) -> Self {
+    pub(crate) fn new(
+        message: &str,
+        max_lines: usize,
+        collapsed: bool,
+        duration: Option<std::time::Duration>,
+    ) -> Self {
         Self {
             message: message.to_string(),
             stream_lines: None,
             max_lines,
+            collapsed,
+            duration,
         }
     }
 
@@ -31,11 +40,28 @@ impl<'a> ThinkingBlockCell<'a> {
         message: String,
         stream_lines: Option<&'a [Line<'static>]>,
         max_lines: usize,
+        collapsed: bool,
+        duration: Option<std::time::Duration>,
     ) -> Self {
         Self {
             message,
             stream_lines,
             max_lines,
+            collapsed,
+            duration,
+        }
+    }
+
+    fn duration_label(&self) -> Option<String> {
+        self.duration.map(|d| format!(" ({:.1}s)", d.as_secs_f64()))
+    }
+
+    fn collapse_hint(&self) -> Option<String> {
+        if self.duration.is_some() {
+            let action = if self.collapsed { "expand" } else { "collapse" };
+            Some(format!(" — Alt+T to {action}"))
+        } else {
+            None
         }
     }
 }
@@ -53,25 +79,73 @@ impl HistoryCell for ThinkingBlockCell<'_> {
             rendered_lines.extend(lines.iter().cloned());
         }
 
-        let start = rendered_lines.len().saturating_sub(self.max_lines);
-        let tail = &rendered_lines[start..];
-
-        let mut lines = Vec::with_capacity(tail.len());
-        if start > 0 {
-            lines.push(Line::from(Span::styled(
-                format!("┊  ... {start} more lines"),
-                Style::default().fg(TEXT_MUTED),
-            )));
+        if rendered_lines.is_empty() {
+            return vec![];
         }
-        for line in tail {
-            let mut accented = Line::from(Span::styled("┊ ", Style::default().fg(TEXT_MUTED)));
-            for span in &line.spans {
-                accented.push_span(Span::styled(
-                    span.content.to_string(),
-                    span.style.patch(Style::default().fg(TEXT_MUTED)),
-                ));
+
+        // Compute how many content lines to show.
+        let effective_max = if self.collapsed {
+            2usize.min(self.max_lines)
+        } else {
+            self.max_lines
+        };
+
+        // Build heading line with duration + collapse hint.
+        let mut heading_parts: Vec<String> = vec!["Thinking".to_string()];
+        if let Some(dur) = self.duration_label() {
+            heading_parts.push(dur);
+        }
+        if let Some(hint) = self.collapse_hint() {
+            heading_parts.push(hint);
+        }
+
+        let total = rendered_lines.len();
+        let mut lines = Vec::with_capacity(effective_max + 2);
+
+        lines.push(Line::from(Span::styled(
+            format!("┊ {}", heading_parts.join("")),
+            Style::default().fg(TEXT_MUTED),
+        )));
+
+        if self.collapsed {
+            // Show first N lines (preview mode).
+            let head = &rendered_lines[..effective_max.min(total)];
+            for line in head {
+                let mut accented = Line::from(Span::styled("┊ ", Style::default().fg(TEXT_MUTED)));
+                for span in &line.spans {
+                    accented.push_span(Span::styled(
+                        span.content.to_string(),
+                        span.style.patch(Style::default().fg(TEXT_MUTED)),
+                    ));
+                }
+                lines.push(accented);
             }
-            lines.push(accented);
+            if total > effective_max {
+                lines.push(Line::from(Span::styled(
+                    format!("┊  ... {} more lines", total - effective_max),
+                    Style::default().fg(TEXT_MUTED),
+                )));
+            }
+        } else {
+            // Show tail lines (stale-tail for stream, or full for expanded).
+            let start = total.saturating_sub(effective_max);
+            if start > 0 {
+                lines.push(Line::from(Span::styled(
+                    format!("┊  ... {start} more lines"),
+                    Style::default().fg(TEXT_MUTED),
+                )));
+            }
+            let tail = &rendered_lines[start..];
+            for line in tail {
+                let mut accented = Line::from(Span::styled("┊ ", Style::default().fg(TEXT_MUTED)));
+                for span in &line.spans {
+                    accented.push_span(Span::styled(
+                        span.content.to_string(),
+                        span.style.patch(Style::default().fg(TEXT_MUTED)),
+                    ));
+                }
+                lines.push(accented);
+            }
         }
         lines
     }

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -11,6 +11,7 @@ fn active_turn_cell_keeps_sections_in_stable_order() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("waiting for tool output".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -71,6 +72,7 @@ fn active_turn_cell_renders_progress_sections_as_compact_stack() {
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect the codebase".into(),
@@ -118,6 +120,7 @@ fn active_turn_cell_renders_terminal_result_as_terminal_cell() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -160,6 +163,7 @@ fn active_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -224,6 +228,7 @@ fn active_turn_cell_keeps_exploration_notes_inside_exploring_block() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("waiting for model response · 12s elapsed".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "You".into(), message: "Review this repository".into(), payload: None },
             TranscriptEntry { role: "Tool".into(), message: "read_file src/main.rs".into(), payload: None },
@@ -265,6 +270,7 @@ fn active_turn_cell_uses_stateful_live_exploration_sections() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("waiting for model response · 20s elapsed".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect the repository".into(),
@@ -300,6 +306,7 @@ fn active_turn_cell_compacts_live_response_when_process_sections_exist() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("waiting for model response".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "You".into(), message: "Inspect the repository".into(), payload: None },
             TranscriptEntry { role: "Agent".into(), message: "I have inspected the repository structure.\nI checked the runtime boundary.\nI checked the prompt assembly path.\nNext I will inspect the persistence layer.\nThen I will verify the restore contract."
@@ -332,6 +339,7 @@ fn active_turn_cell_appends_long_live_exploration_events() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect the repository".into(),
@@ -371,6 +379,7 @@ fn active_turn_cell_appends_long_live_planning_events() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Refine the plan".into(),
@@ -410,6 +419,7 @@ fn active_turn_cell_appends_long_live_running_events() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run the checks".into(),
@@ -448,6 +458,7 @@ fn active_turn_cell_updated_plan_snapshot() {
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("waiting for model response · 3s elapsed".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Read the local codebase and propose the next refactor".into(),
@@ -494,6 +505,7 @@ fn active_turn_cell_hides_structured_plan_response_once_plan_card_exists() {
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "You".into(), message: "Plan the next refactor".into(), payload: None },
             TranscriptEntry { role: "Agent".into(), message: "<proposed_plan>\n- [completed] Inspect the auth flow\n- [in_progress] Reuse codex_login\n- [pending] Add auth picker snapshots\n</proposed_plan>\nPrefer direct auth reuse before expanding more TUI flows.".into(), payload: None },
@@ -529,6 +541,7 @@ fn active_turn_cell_prefers_inline_plan_artifact_over_preamble_before_snapshot_s
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "You".into(), message: "Review the codebase and propose changes".into(), payload: None },
             TranscriptEntry { role: "Agent".into(), message: "I reviewed the current implementation.\nHere is the concise plan.\n<proposed_plan>\n- [completed] Inspect the runtime entrypoint\n- [pending] Tighten the render path\n</proposed_plan>\nKeep the diff narrow and reviewable.".into(), payload: None },
@@ -560,6 +573,7 @@ fn active_turn_cell_suppresses_planning_chatter_when_exploring() {
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -600,6 +614,7 @@ fn active_turn_cell_uses_planning_sidecar_for_non_structured_plan_output() {
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -635,6 +650,7 @@ fn active_turn_cell_uses_explicit_sidecar_entries_when_live_state_is_empty() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -683,6 +699,7 @@ fn active_turn_cell_preserves_exploration_agent_exploration_order() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -739,6 +756,7 @@ fn active_turn_cell_preserves_duplicate_restored_exploration_segments() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -794,6 +812,7 @@ fn active_turn_cell_preserves_agent_then_exploration_order() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -839,6 +858,7 @@ fn active_turn_cell_uses_lightweight_busy_response_when_not_streaming() {
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("waiting for model response · 2s elapsed".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -878,6 +898,7 @@ fn active_turn_cell_shows_live_thinking_stream() {
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("thinking".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review this repository".into(),
@@ -906,6 +927,7 @@ fn active_turn_cell_flattens_thinking_and_running_events_in_order() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run a long task".into(),
@@ -948,6 +970,7 @@ fn active_turn_cell_places_streaming_thinking_after_latest_progress_event() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run a long task".into(),
@@ -986,6 +1009,7 @@ fn active_turn_cell_places_streaming_thinking_after_latest_exploration_event() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect before reasoning again".into(),
@@ -1024,6 +1048,7 @@ fn active_turn_cell_groups_consecutive_thinking_events_with_stream() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Reason about a task".into(),
@@ -1058,6 +1083,7 @@ fn active_turn_cell_preserves_flushed_thinking_leading_indentation() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect thinking formatting".into(),
@@ -1087,6 +1113,7 @@ fn active_turn_cell_preserves_repeated_progress_events_when_interleaved() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run checks".into(),
@@ -1124,6 +1151,7 @@ fn active_turn_cell_groups_consecutive_exploration_events_only() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Inspect and run checks".into(),
@@ -1172,6 +1200,7 @@ fn active_turn_cell_preserves_consecutive_duplicate_progress_events() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::RunningTool;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run checks".into(),
@@ -1206,6 +1235,7 @@ fn active_turn_cell_shows_live_thinking_tail_without_cloning_full_body() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review this repository".into(),
@@ -1238,6 +1268,7 @@ fn active_turn_cell_renders_live_response_as_lightweight_message() {
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("waiting for model response".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1276,6 +1307,7 @@ fn active_turn_cell_prefers_responding_over_tool_result_while_processing_respons
     app.runtime_phase = RuntimePhase::ProcessingResponse;
     app.runtime_phase_detail = Some("waiting for model output".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1312,6 +1344,7 @@ fn active_turn_cell_prefers_responding_over_system_notice_while_sending_prompt()
     app.runtime_phase = RuntimePhase::SendingPrompt;
     app.runtime_phase_detail = Some("sending prompt to provider".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1347,6 +1380,7 @@ fn active_turn_cell_shows_planning_section_for_plan_agent() {
     app.runtime_phase = RuntimePhase::RunningTool;
     app.runtime_phase_detail = Some("plan_agent {\"instruction\":\"refine the plan\"}".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Plan the refactor".into(),
@@ -1378,6 +1412,7 @@ fn active_turn_cell_renders_device_code_prompt_system_message() {
     app.runtime_phase = RuntimePhase::OAuthPollingDeviceCode;
     app.runtime_phase_detail = Some("Waiting for device-code confirmation.".into());
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry { role: "Runtime".into(), message: "Starting Codex device-code login flow.".into(), payload: None },
             TranscriptEntry { role: "System".into(), message: "Open this URL in a browser and enter the one-time code:\nhttps://example.test\n\nCode: ABCD".into(), payload: None },

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -9,6 +9,7 @@ fn active_turn_cell_renders_plan_approval_as_interaction_card() {
     .expect("build tui app");
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
@@ -50,6 +51,7 @@ fn active_turn_cell_renders_updated_plan_checklist() {
     .expect("build tui app");
     app.agent_execution_mode = crate::agent::AgentExecutionMode::Plan;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Improve the plan rendering".into(),
@@ -92,6 +94,7 @@ fn active_turn_cell_hides_stale_updated_plan_after_plan_turn_finishes() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Implement the approved fix".into(),
@@ -121,6 +124,7 @@ fn active_turn_cell_hides_stale_exploring_after_live_phase_finishes() {
     .expect("build tui app");
     app.runtime_phase = RuntimePhase::Idle;
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -154,6 +158,7 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -218,6 +223,7 @@ fn active_turn_cell_renders_queued_follow_up_without_hiding_shell_approval() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Run a shell command".into(),
@@ -265,6 +271,7 @@ fn active_turn_cell_does_not_render_completed_plan_decision() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
@@ -297,6 +304,7 @@ fn active_turn_cell_does_not_render_completed_shell_approval_while_live() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -342,6 +350,7 @@ fn active_turn_cell_falls_back_to_previous_completion_when_shell_approval_is_liv
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -391,6 +400,7 @@ fn active_turn_cell_keeps_streaming_response_without_responding_card() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -432,6 +442,7 @@ fn active_turn_cell_does_not_repeat_stale_plan_decision_from_snapshot() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Approve the plan".into(),
@@ -446,6 +457,7 @@ fn active_turn_cell_does_not_repeat_stale_plan_decision_from_snapshot() {
     );
     app.finalize_active_turn();
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Continue with the next task".into(),
@@ -471,6 +483,7 @@ fn active_turn_cell_labels_delegated_plan_questions() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),
@@ -511,6 +524,7 @@ fn active_turn_cell_labels_delegated_completed_questions() {
     })
     .expect("build tui app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Review the codebase and propose changes".into(),

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -48,7 +48,7 @@ fn committed_turn_does_not_truncate_agent_response() {
         },
     ];
 
-    let rendered = committed_turn_cell(entries.as_slice(), Some(Path::new(".")))
+    let rendered = committed_turn_cell(entries.as_slice(), Some(Path::new(".")), false, None)
         .display_lines(100)
         .into_iter()
         .map(|line| line.to_string())
@@ -67,6 +67,7 @@ fn keeps_history_reserve_once_transcript_exists() {
     })
     .expect("build tui app");
     app.committed_turns.push(TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "You".into(),
             message: "Earlier prompt".into(),
@@ -111,6 +112,7 @@ fn transcript_render_stays_above_bottom_pane() {
     })
     .expect("build tui app");
     app.committed_turns.push(TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -247,6 +249,7 @@ fn renderable_transcript_lines_include_committed_and_active_turns() {
     })
     .expect("build tui app");
     app.committed_turns.push(TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -287,6 +290,7 @@ fn renderable_transcript_lines_insert_turn_dividers_between_rounds() {
     .expect("build tui app");
     app.committed_turns = vec![
         TranscriptTurn {
+            thinking_duration: None,
             entries: vec![TranscriptEntry {
                 role: "You".into(),
                 message: "First prompt".into(),
@@ -294,6 +298,7 @@ fn renderable_transcript_lines_insert_turn_dividers_between_rounds() {
             }],
         },
         TranscriptTurn {
+            thinking_duration: None,
             entries: vec![TranscriptEntry {
                 role: "Agent".into(),
                 message: "Second reply".into(),
@@ -393,7 +398,10 @@ fn effective_height_includes_final_row_at_bottom_sticky() {
             payload: None,
         })
         .collect();
-    app.restore_committed_turns(vec![TranscriptTurn { entries }]);
+    app.restore_committed_turns(vec![TranscriptTurn {
+        thinking_duration: None,
+        entries,
+    }]);
 
     let viewport = transcript_viewport(&app, 80, 5);
     let (visible_lines, _inner) = viewport.visible_window(80, 5);
@@ -420,6 +428,7 @@ fn renderable_transcript_lines_cache_is_invalidated_when_committed_turns_change(
     })
     .expect("build tui app");
     app.restore_committed_turns(vec![TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "Agent".into(),
             message: "First answer".into(),
@@ -435,6 +444,7 @@ fn renderable_transcript_lines_cache_is_invalidated_when_committed_turns_change(
     assert!(first.contains("First answer"));
 
     app.restore_committed_turns(vec![TranscriptTurn {
+        thinking_duration: None,
         entries: vec![TranscriptEntry {
             role: "Agent".into(),
             message: "Second answer".into(),
@@ -459,6 +469,7 @@ fn transcript_viewport_is_independent_from_overlay_state() {
     })
     .expect("build tui app");
     app.committed_turns.push(TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -505,6 +516,7 @@ fn transcript_viewport_keeps_manual_scroll_when_overlay_opens() {
     })
     .expect("build tui app");
     app.committed_turns.push(TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -185,7 +185,10 @@ pub(super) fn restore_thread_by_id(
                     .into_iter()
                     .map(|entry| TranscriptEntry::new(entry.role, entry.message))
                     .collect::<Vec<_>>();
-                turns.push(TranscriptTurn { entries });
+                turns.push(TranscriptTurn {
+                    thinking_duration: None,
+                    entries,
+                });
             }
             RolloutItem::Turn(_)
             | RolloutItem::Compaction(_)

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -298,6 +298,7 @@ impl TuiApp {
             overlay,
             overlay_stack: Vec::new(),
             sidebar_visible: true,
+            thinking_collapsed: false,
             config: cfg,
             config_manager: cm,
             setup_status: None,

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -982,6 +982,7 @@ fn finalize_agent_stream_updates_latest_committed_turn_when_final_text_arrives_l
     };
     let mut app = TuiApp::new(cm).expect("app");
     app.committed_turns.push(TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1175,6 +1176,7 @@ fn finalize_agent_stream_replaces_earlier_agent_entries_in_active_turn() {
     };
     let mut app = TuiApp::new(cm).expect("app");
     app.active_turn = TranscriptTurn {
+        thinking_duration: None,
         entries: vec![
             TranscriptEntry {
                 role: "You".into(),
@@ -1222,12 +1224,15 @@ fn restore_committed_turns_sets_inserted_counter_to_match() {
     // Simulate session resume: restore N turns that were already on screen.
     let turns = vec![
         TranscriptTurn {
+            thinking_duration: None,
             entries: vec![TranscriptEntry::new("You", "hello")],
         },
         TranscriptTurn {
+            thinking_duration: None,
             entries: vec![TranscriptEntry::new("Agent", "hi there")],
         },
         TranscriptTurn {
+            thinking_duration: None,
             entries: vec![TranscriptEntry::new("You", "bye")],
         },
     ];

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -142,10 +142,14 @@ impl TuiApp {
         } else {
             std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
         };
+        let is_first_delta = self.agent_thinking_stream.is_none();
         let stream = self
             .agent_thinking_stream
             .get_or_insert_with(|| super::AgentMarkdownStreamState::new(cwd));
         stream.push_delta(delta);
+        if is_first_delta {
+            self.active_live.thinking_started_at = Some(std::time::Instant::now());
+        }
         self.reset_transcript_scroll_if_following_tail();
     }
 
@@ -340,7 +344,8 @@ impl TuiApp {
             self.clear_active_live_sections();
             return;
         }
-        let turn = std::mem::take(&mut self.active_turn);
+        let mut turn = std::mem::take(&mut self.active_turn);
+        turn.thinking_duration = self.active_live.thinking_started_at.map(|s| s.elapsed());
         let ordinal = self.committed_turns.len();
         self.persist_turn(ordinal, &turn);
         self.committed_turns.push(turn);

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -527,6 +527,7 @@ impl TranscriptEntry {
 #[derive(Clone, Default)]
 pub struct TranscriptTurn {
     pub entries: Vec<TranscriptEntry>,
+    pub thinking_duration: Option<std::time::Duration>,
 }
 
 #[derive(Default)]
@@ -644,6 +645,9 @@ impl ActiveLiveEvent {
 #[derive(Default)]
 pub struct ActiveLiveSections {
     pub events: Vec<ActiveLiveEvent>,
+    /// Timestamp of the first Thinking event in the current agent turn,
+    /// used to display how long the model spent thinking.
+    pub thinking_started_at: Option<std::time::Instant>,
     pub exploration_actions: Vec<String>,
     pub exploration_notes: Vec<String>,
     pub planning_actions: Vec<String>,
@@ -665,6 +669,9 @@ pub struct TuiApp {
     /// Whether the sidebar is visible in wide-screen mode.
     /// Toggled with Ctrl+B.
     pub sidebar_visible: bool,
+    /// Whether thinking blocks globally appear collapsed (first lines + duration)
+    /// or fully expanded. Toggled with Alt+T. Default: expanded.
+    pub thinking_collapsed: bool,
     pub config: RaraConfig,
     pub config_manager: ConfigManager,
     pub setup_status: Option<String>,


### PR DESCRIPTION
## Summary

Add global thinking collapse toggle (Alt+T). When collapsed, thinking blocks show only the first 2 lines with a duration label. Live streaming thinking always stays in tail mode.

## Changes

- **`src/tui/state/types.rs`** — Add `thinking_collapsed` to TuiApp, `thinking_started_at` to ActiveLiveSections
- **`src/tui/state/transcript.rs`** — Record first-delta timestamp in `append_agent_thinking_delta`
- **`src/tui/render/cells/thinking_cells.rs`** — Rewrite with collapsed/expanded modes, duration label
- **`src/tui/render/cells/progress.rs`** — Thread `collapsed` + `duration` through call chain
- **`src/tui/event_dispatch.rs`** — Handle `AppEvent::ToggleThinking`
- **`src/tui/app_event.rs`** — Add `ToggleThinking` variant
- **`src/tui/keymap.rs`** — Map Alt+T to `ToggleThinking`

## Behavior

| State | Display |
|-------|---------|
| Live streaming | Tail mode (last N lines), always expanded |
| Committed, expanded | Full content with duration label |
| Committed, collapsed (Alt+T) | First 2 lines + duration + '... N more lines' |

## Verification

- `cargo build` — no new warnings
- `cargo test` — 1097 passed, 0 failed