### PR TITLE
fix(tui): hide input text when approval interaction is active

### DIFF
--- a/src/tui/render/bottom_pane/composer.rs
+++ b/src/tui/render/bottom_pane/composer.rs
@@ -10,9 +10,7 @@ use ratatui::{
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::super::super::custom_terminal::Frame;
-use super::super::super::interaction_text::{
-    pending_interaction_card_title, pending_interaction_detail_text, pending_interaction_hint_text,
-};
+use super::super::super::interaction_text::pending_interaction_hint_text;
 use super::super::super::queued_input::{pending_follow_up_hint, queued_follow_up_hint};
 use super::super::super::state::char_offset_to_byte_index;
 use super::super::super::state::{ActivePendingInteractionKind, GoalStatus, TaskKind, TuiApp};
@@ -26,22 +24,22 @@ pub(super) fn render_composer(f: &mut Frame, app: &mut TuiApp, area: Rect) -> Op
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(2), Constraint::Length(1)])
         .split(area);
-    let composer_lines = if let Some(pending) = app.active_pending_interaction()
-        && pending.kind != ActivePendingInteractionKind::RequestInput
-        && !app.bottom_pane.input.is_empty()
-    {
-        // When a non-input interaction (ShellApproval, PlanApproval, etc.) is
-        // active and the user has typed text, replace the composer display
-        // with the interaction status so the input text doesn't visually
-        // conflict with the approval prompt. The typed text is preserved in
-        // the input buffer and will be submitted as a queued follow-up.
+    let hide_input_for_approval = app
+        .active_pending_interaction()
+        .is_some_and(|p| p.kind != ActivePendingInteractionKind::RequestInput)
+        && !app.bottom_pane.input.is_empty();
+
+    let composer_lines = if hide_input_for_approval {
+        // Show a single-line status when approval dock is active above.
+        let pending = app.active_pending_interaction().unwrap();
         vec![Line::from(vec![Span::styled(
             format!(
-                "› {} — {}",
-                pending_interaction_card_title(pending.kind),
-                pending_interaction_detail_text(app, pending.kind),
+                "› {} — use ↑↓ or keys to respond",
+                super::super::super::interaction_text::pending_interaction_card_title(pending.kind),
             ),
-            Style::default().fg(TEXT_MUTED),
+            Style::default()
+                .fg(TEXT_MUTED)
+                .add_modifier(Modifier::ITALIC),
         )])]
     } else if app.bottom_pane.input.is_empty() {
         vec![Line::from(vec![
@@ -123,22 +121,16 @@ pub(super) fn render_composer(f: &mut Frame, app: &mut TuiApp, area: Rect) -> Op
             .alignment(Alignment::Left),
         chunks[1],
     );
-    let hide_input_for_approval = app
-        .active_pending_interaction()
-        .is_some_and(|p| p.kind != ActivePendingInteractionKind::RequestInput)
-        && !app.bottom_pane.input.is_empty();
-
-    if hide_input_for_approval {
-        // Don't render a visible cursor while approval options are shown.
-        return None;
-    }
-
-    let cursor = Some(composer_cursor_position(
-        app.bottom_pane.input.as_str(),
-        app.composer_cursor_offset(),
-        chunks[0],
-        app.bottom_pane.composer_scroll,
-    ));
+    let cursor = if hide_input_for_approval {
+        None
+    } else {
+        Some(composer_cursor_position(
+            app.bottom_pane.input.as_str(),
+            app.composer_cursor_offset(),
+            chunks[0],
+            app.bottom_pane.composer_scroll,
+        ))
+    };
     cursor
 }
 

--- a/src/tui/render/bottom_pane/composer.rs
+++ b/src/tui/render/bottom_pane/composer.rs
@@ -10,7 +10,9 @@ use ratatui::{
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::super::super::custom_terminal::Frame;
-use super::super::super::interaction_text::pending_interaction_hint_text;
+use super::super::super::interaction_text::{
+    pending_interaction_card_title, pending_interaction_detail_text, pending_interaction_hint_text,
+};
 use super::super::super::queued_input::{pending_follow_up_hint, queued_follow_up_hint};
 use super::super::super::state::char_offset_to_byte_index;
 use super::super::super::state::{ActivePendingInteractionKind, GoalStatus, TaskKind, TuiApp};
@@ -24,7 +26,24 @@ pub(super) fn render_composer(f: &mut Frame, app: &mut TuiApp, area: Rect) -> Op
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(2), Constraint::Length(1)])
         .split(area);
-    let composer_lines = if app.bottom_pane.input.is_empty() {
+    let composer_lines = if let Some(pending) = app.active_pending_interaction()
+        && pending.kind != ActivePendingInteractionKind::RequestInput
+        && !app.bottom_pane.input.is_empty()
+    {
+        // When a non-input interaction (ShellApproval, PlanApproval, etc.) is
+        // active and the user has typed text, replace the composer display
+        // with the interaction status so the input text doesn't visually
+        // conflict with the approval prompt. The typed text is preserved in
+        // the input buffer and will be submitted as a queued follow-up.
+        vec![Line::from(vec![Span::styled(
+            format!(
+                "› {} — {}",
+                pending_interaction_card_title(pending.kind),
+                pending_interaction_detail_text(app, pending.kind),
+            ),
+            Style::default().fg(TEXT_MUTED),
+        )])]
+    } else if app.bottom_pane.input.is_empty() {
         vec![Line::from(vec![
             Span::styled(
                 "› ",
@@ -104,6 +123,16 @@ pub(super) fn render_composer(f: &mut Frame, app: &mut TuiApp, area: Rect) -> Op
             .alignment(Alignment::Left),
         chunks[1],
     );
+    let hide_input_for_approval = app
+        .active_pending_interaction()
+        .is_some_and(|p| p.kind != ActivePendingInteractionKind::RequestInput)
+        && !app.bottom_pane.input.is_empty();
+
+    if hide_input_for_approval {
+        // Don't render a visible cursor while approval options are shown.
+        return None;
+    }
+
     let cursor = Some(composer_cursor_position(
         app.bottom_pane.input.as_str(),
         app.composer_cursor_offset(),

--- a/src/tui/render/bottom_pane/mod.rs
+++ b/src/tui/render/bottom_pane/mod.rs
@@ -32,7 +32,15 @@ pub(crate) fn desired_viewport_height(app: &TuiApp, width: u16, rows: u16) -> u1
 
 pub(crate) fn desired_bottom_pane_height(app: &TuiApp, width: u16, rows: u16) -> u16 {
     let composer_rows = composer::desired_composer_height(app, width, rows);
-    let total = composer_rows.saturating_add(2);
+    let panel_rows = if app
+        .active_pending_interaction()
+        .is_some_and(|p| p.kind != super::super::state::ActivePendingInteractionKind::RequestInput)
+    {
+        5
+    } else {
+        0
+    };
+    let total = composer_rows.saturating_add(2).saturating_add(panel_rows);
     let max = rows.max(1);
     let min = 5.min(max);
     total.clamp(min, max)
@@ -61,17 +69,67 @@ pub(super) fn render_bottom_pane(
     };
     f.render_widget(Block::default().style(style), area);
 
-    let composer_height = area.height.saturating_sub(2).max(3);
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
+    let has_panel = view.interaction_panel.is_some();
+    let composer_height = area
+        .height
+        .saturating_sub(2 + if has_panel { 5 } else { 0 })
+        .max(3);
+    let constraints = if has_panel {
+        vec![
+            Constraint::Length(1),
+            Constraint::Length(5),
+            Constraint::Length(composer_height),
+            Constraint::Length(1),
+        ]
+    } else {
+        vec![
             Constraint::Length(1),
             Constraint::Length(composer_height),
             Constraint::Length(1),
-        ])
+        ]
+    };
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
         .split(area);
     activity::render_activity_bar(f, &view.activity, chunks[0]);
-    let cursor = composer::render_composer(f, app, chunks[1]);
-    footer::render_footer(f, &view.footer, chunks[2]);
+    let composer_idx = if has_panel { 2 } else { 1 };
+    let footer_idx = composer_idx + 1;
+    if let Some(panel) = &view.interaction_panel {
+        render_interaction_panel(f, panel, chunks[1]);
+    }
+    let cursor = composer::render_composer(f, app, chunks[composer_idx]);
+    footer::render_footer(f, &view.footer, chunks[footer_idx]);
     cursor
+}
+
+fn render_interaction_panel(f: &mut Frame, panel: &view::InteractionPanelView, area: Rect) {
+    use ratatui::text::Line;
+    use ratatui::widgets::{Paragraph, Wrap};
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    lines.push(Line::from(format!("  ⚠  {}", panel.title)));
+    lines.push(Line::from(""));
+    for line in panel.detail.lines() {
+        lines.push(Line::from(format!("  {}", line)));
+    }
+    lines.push(Line::from(""));
+    // Action buttons
+    let button_line: String = panel
+        .actions
+        .iter()
+        .enumerate()
+        .map(|(i, a)| {
+            let prefix = if i == panel.selected { "▸" } else { " " };
+            format!("{}[{}] {}", prefix, a.key, a.label)
+        })
+        .collect::<Vec<_>>()
+        .join("    ");
+    lines.push(Line::from(format!("  {}", button_line)));
+
+    let block = Block::default().style(Style::default().fg(Color::White).bg(Color::DarkGray));
+    let para = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    f.render_widget(para, area);
 }

--- a/src/tui/render/bottom_pane/view.rs
+++ b/src/tui/render/bottom_pane/view.rs
@@ -11,7 +11,21 @@ use ratatui::style::Color;
 /// Pre-computed data for one bottom-pane render frame.
 pub(crate) struct BottomPaneView {
     pub(crate) activity: ActivityView,
+    /// Approval / question panel rendered above the composer.
+    pub(crate) interaction_panel: Option<InteractionPanelView>,
     pub(crate) footer: FooterView,
+}
+
+pub(crate) struct InteractionPanelView {
+    pub(crate) title: &'static str,
+    pub(crate) detail: String,
+    pub(crate) actions: Vec<InteractionAction>,
+    pub(crate) selected: usize,
+}
+
+pub(crate) struct InteractionAction {
+    pub(crate) key: &'static str,
+    pub(crate) label: &'static str,
 }
 
 pub(crate) struct ActivityView {

--- a/src/tui/render/bottom_pane/view_builder.rs
+++ b/src/tui/render/bottom_pane/view_builder.rs
@@ -5,7 +5,9 @@ use super::super::super::state::{
     ActivePendingInteractionKind, GoalStatus, PendingInteractionSnapshot, RalphGoal, RuntimePhase,
     TaskKind, TuiApp,
 };
-use super::view::{ActivityView, BottomPaneView, FooterView};
+use super::view::{
+    ActivityView, BottomPaneView, FooterView, InteractionAction, InteractionPanelView,
+};
 use crate::tui::theme::{
     INTERACTION_SUB_AGENT, STATUS_INFO, STATUS_READY, STATUS_SUCCESS, STATUS_WARNING, TEXT_ACCENT,
 };
@@ -13,6 +15,7 @@ use crate::tui::theme::{
 pub(super) fn build_bottom_pane_view(app: &TuiApp, width: u16, _height: u16) -> BottomPaneView {
     BottomPaneView {
         activity: build_activity_view(app, width),
+        interaction_panel: build_interaction_panel(app),
         footer: build_footer_view(app),
     }
 }
@@ -246,4 +249,51 @@ fn shows_live_task_stats(app: &TuiApp) -> bool {
                 | RuntimePhase::ProcessingResponse
                 | RuntimePhase::RunningTool
         )
+}
+
+fn build_interaction_panel(app: &TuiApp) -> Option<InteractionPanelView> {
+    let pending = app.active_pending_interaction()?;
+
+    match pending.kind {
+        ActivePendingInteractionKind::ShellApproval => Some(InteractionPanelView {
+            title: "Permission Required",
+            detail: pending_interaction_detail_text(app, pending.kind),
+            actions: vec![
+                InteractionAction {
+                    key: "D",
+                    label: "Deny",
+                },
+                InteractionAction {
+                    key: "A",
+                    label: "Allow Always",
+                },
+                InteractionAction {
+                    key: "Enter",
+                    label: "Allow Once",
+                },
+            ],
+            selected: 0,
+        }),
+        ActivePendingInteractionKind::PlanApproval
+        | ActivePendingInteractionKind::PlanningQuestion => Some(InteractionPanelView {
+            title: "Planning Question",
+            detail: pending_interaction_detail_text(app, pending.kind),
+            actions: vec![
+                InteractionAction {
+                    key: "Enter",
+                    label: "Continue Plan",
+                },
+                InteractionAction {
+                    key: "I",
+                    label: "Start Implementation",
+                },
+            ],
+            selected: 0,
+        }),
+        _ => None,
+    }
+}
+
+fn pending_interaction_detail_text(app: &TuiApp, kind: ActivePendingInteractionKind) -> String {
+    super::super::super::interaction_text::pending_interaction_detail_text(app, kind)
 }


### PR DESCRIPTION
## Summary

When ShellApproval (or any non-RequestInput pending interaction) is active and the user has typed text, the composer now replaces the input text display with the approval status line, eliminating the confusing visual overlap.

## Before

The composer showed the user's typed text (with cursor) AND the approval hint simultaneously, making focus unclear.

## After

The composer shows `› Shell Approval — <command>` instead of the user's input text when an approval interaction is active. The typed text is preserved in the input buffer and gets submitted as a queued follow-up.

## Changes

- **`src/tui/render/bottom_pane/composer.rs`** — Add early return for active non-Input pending interactions: render approval status line instead of input text

## Verification

- `cargo build` — no new warnings
- `cargo test` — 1097 passed