### PR TITLE
fix(tui): suppress duplicate interaction card in transcript when dock panel is active

### DIFF
--- a/src/tui/render/bottom_pane/composer.rs
+++ b/src/tui/render/bottom_pane/composer.rs
@@ -10,9 +10,7 @@ use ratatui::{
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::super::super::custom_terminal::Frame;
-use super::super::super::interaction_text::{
-    pending_interaction_card_title, pending_interaction_detail_text, pending_interaction_hint_text,
-};
+use super::super::super::interaction_text::pending_interaction_hint_text;
 use super::super::super::queued_input::{pending_follow_up_hint, queued_follow_up_hint};
 use super::super::super::state::char_offset_to_byte_index;
 use super::super::super::state::{ActivePendingInteractionKind, GoalStatus, TaskKind, TuiApp};
@@ -26,22 +24,22 @@ pub(super) fn render_composer(f: &mut Frame, app: &mut TuiApp, area: Rect) -> Op
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(2), Constraint::Length(1)])
         .split(area);
-    let composer_lines = if let Some(pending) = app.active_pending_interaction()
-        && pending.kind != ActivePendingInteractionKind::RequestInput
-        && !app.bottom_pane.input.is_empty()
-    {
-        // When a non-input interaction (ShellApproval, PlanApproval, etc.) is
-        // active and the user has typed text, replace the composer display
-        // with the interaction status so the input text doesn't visually
-        // conflict with the approval prompt. The typed text is preserved in
-        // the input buffer and will be submitted as a queued follow-up.
+    let hide_input_for_approval = app
+        .active_pending_interaction()
+        .is_some_and(|p| p.kind != ActivePendingInteractionKind::RequestInput)
+        && !app.bottom_pane.input.is_empty();
+
+    let composer_lines = if hide_input_for_approval {
+        // Show a single-line status when approval dock is active above.
+        let pending = app.active_pending_interaction().unwrap();
         vec![Line::from(vec![Span::styled(
             format!(
-                "› {} — {}",
-                pending_interaction_card_title(pending.kind),
-                pending_interaction_detail_text(app, pending.kind),
+                "› {} — use ↑↓ or keys to respond",
+                super::super::super::interaction_text::pending_interaction_card_title(pending.kind),
             ),
-            Style::default().fg(TEXT_MUTED),
+            Style::default()
+                .fg(TEXT_MUTED)
+                .add_modifier(Modifier::ITALIC),
         )])]
     } else if app.bottom_pane.input.is_empty() {
         vec![Line::from(vec![
@@ -123,22 +121,16 @@ pub(super) fn render_composer(f: &mut Frame, app: &mut TuiApp, area: Rect) -> Op
             .alignment(Alignment::Left),
         chunks[1],
     );
-    let hide_input_for_approval = app
-        .active_pending_interaction()
-        .is_some_and(|p| p.kind != ActivePendingInteractionKind::RequestInput)
-        && !app.bottom_pane.input.is_empty();
-
-    if hide_input_for_approval {
-        // Don't render a visible cursor while approval options are shown.
-        return None;
-    }
-
-    let cursor = Some(composer_cursor_position(
-        app.bottom_pane.input.as_str(),
-        app.composer_cursor_offset(),
-        chunks[0],
-        app.bottom_pane.composer_scroll,
-    ));
+    let cursor = if hide_input_for_approval {
+        None
+    } else {
+        Some(composer_cursor_position(
+            app.bottom_pane.input.as_str(),
+            app.composer_cursor_offset(),
+            chunks[0],
+            app.bottom_pane.composer_scroll,
+        ))
+    };
     cursor
 }
 

--- a/src/tui/render/bottom_pane/composer.rs
+++ b/src/tui/render/bottom_pane/composer.rs
@@ -10,7 +10,9 @@ use ratatui::{
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use super::super::super::custom_terminal::Frame;
-use super::super::super::interaction_text::pending_interaction_hint_text;
+use super::super::super::interaction_text::{
+    pending_interaction_card_title, pending_interaction_detail_text, pending_interaction_hint_text,
+};
 use super::super::super::queued_input::{pending_follow_up_hint, queued_follow_up_hint};
 use super::super::super::state::char_offset_to_byte_index;
 use super::super::super::state::{ActivePendingInteractionKind, GoalStatus, TaskKind, TuiApp};
@@ -24,7 +26,24 @@ pub(super) fn render_composer(f: &mut Frame, app: &mut TuiApp, area: Rect) -> Op
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(2), Constraint::Length(1)])
         .split(area);
-    let composer_lines = if app.bottom_pane.input.is_empty() {
+    let composer_lines = if let Some(pending) = app.active_pending_interaction()
+        && pending.kind != ActivePendingInteractionKind::RequestInput
+        && !app.bottom_pane.input.is_empty()
+    {
+        // When a non-input interaction (ShellApproval, PlanApproval, etc.) is
+        // active and the user has typed text, replace the composer display
+        // with the interaction status so the input text doesn't visually
+        // conflict with the approval prompt. The typed text is preserved in
+        // the input buffer and will be submitted as a queued follow-up.
+        vec![Line::from(vec![Span::styled(
+            format!(
+                "› {} — {}",
+                pending_interaction_card_title(pending.kind),
+                pending_interaction_detail_text(app, pending.kind),
+            ),
+            Style::default().fg(TEXT_MUTED),
+        )])]
+    } else if app.bottom_pane.input.is_empty() {
         vec![Line::from(vec![
             Span::styled(
                 "› ",
@@ -104,6 +123,16 @@ pub(super) fn render_composer(f: &mut Frame, app: &mut TuiApp, area: Rect) -> Op
             .alignment(Alignment::Left),
         chunks[1],
     );
+    let hide_input_for_approval = app
+        .active_pending_interaction()
+        .is_some_and(|p| p.kind != ActivePendingInteractionKind::RequestInput)
+        && !app.bottom_pane.input.is_empty();
+
+    if hide_input_for_approval {
+        // Don't render a visible cursor while approval options are shown.
+        return None;
+    }
+
     let cursor = Some(composer_cursor_position(
         app.bottom_pane.input.as_str(),
         app.composer_cursor_offset(),

--- a/src/tui/render/bottom_pane/mod.rs
+++ b/src/tui/render/bottom_pane/mod.rs
@@ -127,7 +127,7 @@ fn render_interaction_panel(f: &mut Frame, panel: &view::InteractionPanelView, a
         .join("    ");
     lines.push(Line::from(format!("  {}", button_line)));
 
-    let block = Block::default().style(Style::default().fg(Color::White).bg(Color::DarkGray));
+    let block = Block::default();
     let para = Paragraph::new(lines)
         .block(block)
         .wrap(Wrap { trim: false });

--- a/src/tui/render/bottom_pane/mod.rs
+++ b/src/tui/render/bottom_pane/mod.rs
@@ -32,7 +32,15 @@ pub(crate) fn desired_viewport_height(app: &TuiApp, width: u16, rows: u16) -> u1
 
 pub(crate) fn desired_bottom_pane_height(app: &TuiApp, width: u16, rows: u16) -> u16 {
     let composer_rows = composer::desired_composer_height(app, width, rows);
-    let total = composer_rows.saturating_add(2);
+    let panel_rows = if app
+        .active_pending_interaction()
+        .is_some_and(|p| p.kind != super::super::state::ActivePendingInteractionKind::RequestInput)
+    {
+        5
+    } else {
+        0
+    };
+    let total = composer_rows.saturating_add(2).saturating_add(panel_rows);
     let max = rows.max(1);
     let min = 5.min(max);
     total.clamp(min, max)
@@ -61,17 +69,67 @@ pub(super) fn render_bottom_pane(
     };
     f.render_widget(Block::default().style(style), area);
 
-    let composer_height = area.height.saturating_sub(2).max(3);
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
+    let has_panel = view.interaction_panel.is_some();
+    let composer_height = area
+        .height
+        .saturating_sub(2 + if has_panel { 5 } else { 0 })
+        .max(3);
+    let constraints = if has_panel {
+        vec![
+            Constraint::Length(1),
+            Constraint::Length(5),
+            Constraint::Length(composer_height),
+            Constraint::Length(1),
+        ]
+    } else {
+        vec![
             Constraint::Length(1),
             Constraint::Length(composer_height),
             Constraint::Length(1),
-        ])
+        ]
+    };
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
         .split(area);
     activity::render_activity_bar(f, &view.activity, chunks[0]);
-    let cursor = composer::render_composer(f, app, chunks[1]);
-    footer::render_footer(f, &view.footer, chunks[2]);
+    let composer_idx = if has_panel { 2 } else { 1 };
+    let footer_idx = composer_idx + 1;
+    if let Some(panel) = &view.interaction_panel {
+        render_interaction_panel(f, panel, chunks[1]);
+    }
+    let cursor = composer::render_composer(f, app, chunks[composer_idx]);
+    footer::render_footer(f, &view.footer, chunks[footer_idx]);
     cursor
+}
+
+fn render_interaction_panel(f: &mut Frame, panel: &view::InteractionPanelView, area: Rect) {
+    use ratatui::text::Line;
+    use ratatui::widgets::{Paragraph, Wrap};
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    lines.push(Line::from(format!("  ⚠  {}", panel.title)));
+    lines.push(Line::from(""));
+    for line in panel.detail.lines() {
+        lines.push(Line::from(format!("  {}", line)));
+    }
+    lines.push(Line::from(""));
+    // Action buttons
+    let button_line: String = panel
+        .actions
+        .iter()
+        .enumerate()
+        .map(|(i, a)| {
+            let prefix = if i == panel.selected { "▸" } else { " " };
+            format!("{}[{}] {}", prefix, a.key, a.label)
+        })
+        .collect::<Vec<_>>()
+        .join("    ");
+    lines.push(Line::from(format!("  {}", button_line)));
+
+    let block = Block::default().style(Style::default().fg(Color::White).bg(Color::DarkGray));
+    let para = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    f.render_widget(para, area);
 }

--- a/src/tui/render/bottom_pane/view.rs
+++ b/src/tui/render/bottom_pane/view.rs
@@ -11,7 +11,21 @@ use ratatui::style::Color;
 /// Pre-computed data for one bottom-pane render frame.
 pub(crate) struct BottomPaneView {
     pub(crate) activity: ActivityView,
+    /// Approval / question panel rendered above the composer.
+    pub(crate) interaction_panel: Option<InteractionPanelView>,
     pub(crate) footer: FooterView,
+}
+
+pub(crate) struct InteractionPanelView {
+    pub(crate) title: &'static str,
+    pub(crate) detail: String,
+    pub(crate) actions: Vec<InteractionAction>,
+    pub(crate) selected: usize,
+}
+
+pub(crate) struct InteractionAction {
+    pub(crate) key: &'static str,
+    pub(crate) label: &'static str,
 }
 
 pub(crate) struct ActivityView {

--- a/src/tui/render/bottom_pane/view_builder.rs
+++ b/src/tui/render/bottom_pane/view_builder.rs
@@ -5,7 +5,9 @@ use super::super::super::state::{
     ActivePendingInteractionKind, GoalStatus, PendingInteractionSnapshot, RalphGoal, RuntimePhase,
     TaskKind, TuiApp,
 };
-use super::view::{ActivityView, BottomPaneView, FooterView};
+use super::view::{
+    ActivityView, BottomPaneView, FooterView, InteractionAction, InteractionPanelView,
+};
 use crate::tui::theme::{
     INTERACTION_SUB_AGENT, STATUS_INFO, STATUS_READY, STATUS_SUCCESS, STATUS_WARNING, TEXT_ACCENT,
 };
@@ -13,6 +15,7 @@ use crate::tui::theme::{
 pub(super) fn build_bottom_pane_view(app: &TuiApp, width: u16, _height: u16) -> BottomPaneView {
     BottomPaneView {
         activity: build_activity_view(app, width),
+        interaction_panel: build_interaction_panel(app),
         footer: build_footer_view(app),
     }
 }
@@ -246,4 +249,51 @@ fn shows_live_task_stats(app: &TuiApp) -> bool {
                 | RuntimePhase::ProcessingResponse
                 | RuntimePhase::RunningTool
         )
+}
+
+fn build_interaction_panel(app: &TuiApp) -> Option<InteractionPanelView> {
+    let pending = app.active_pending_interaction()?;
+
+    match pending.kind {
+        ActivePendingInteractionKind::ShellApproval => Some(InteractionPanelView {
+            title: "Permission Required",
+            detail: pending_interaction_detail_text(app, pending.kind),
+            actions: vec![
+                InteractionAction {
+                    key: "D",
+                    label: "Deny",
+                },
+                InteractionAction {
+                    key: "A",
+                    label: "Allow Always",
+                },
+                InteractionAction {
+                    key: "Enter",
+                    label: "Allow Once",
+                },
+            ],
+            selected: 0,
+        }),
+        ActivePendingInteractionKind::PlanApproval
+        | ActivePendingInteractionKind::PlanningQuestion => Some(InteractionPanelView {
+            title: "Planning Question",
+            detail: pending_interaction_detail_text(app, pending.kind),
+            actions: vec![
+                InteractionAction {
+                    key: "Enter",
+                    label: "Continue Plan",
+                },
+                InteractionAction {
+                    key: "I",
+                    label: "Start Implementation",
+                },
+            ],
+            selected: 0,
+        }),
+        _ => None,
+    }
+}
+
+fn pending_interaction_detail_text(app: &TuiApp, kind: ActivePendingInteractionKind) -> String {
+    super::super::super::interaction_text::pending_interaction_detail_text(app, kind)
 }

--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -381,10 +381,31 @@ impl ActiveCell for ActiveTurnCell<'_> {
             if let Some(shortcut_text) = pending_interaction_shortcut_text(pending.kind) {
                 request_lines.push(shortcut_text.to_string());
             }
-            cells.push(Box::new(PendingInteractionCell::new(
+            // Skip transcript rendering for interaction kinds that have a dock
+            // panel rendered above the composer.  ShellApproval and plan
+            // interactions now show action buttons in the dock instead of
+            // numbered options in the transcript.
+            let shows_dock = matches!(
                 pending.kind,
-                request_lines,
-            )));
+                ActivePendingInteractionKind::ShellApproval
+                    | ActivePendingInteractionKind::PlanApproval
+                    | ActivePendingInteractionKind::PlanningQuestion
+            );
+            if !shows_dock {
+                cells.push(Box::new(PendingInteractionCell::new(
+                    pending.kind,
+                    request_lines,
+                )));
+            } else {
+                // Still render a compact status line so the transcript has
+                // a record of the interaction being pending.
+                cells.push(Box::new(PendingInteractionCell::new(
+                    pending.kind,
+                    vec![format!(
+                        "Responding via dock — use keys shown above the input."
+                    )],
+                )));
+            }
         }
 
         let queued_sections = queued_follow_up_sections(

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -98,7 +98,7 @@ fn active_turn_cell_renders_pending_approval_without_transcript_entries() {
         .join("\n");
 
     assert!(rendered.contains("# Shell Approval"));
-    assert!(rendered.contains("git diff origin/main -- src/context/assembler.rs"));
+    assert!(rendered.contains("Responding via dock"));
     assert!(!rendered.contains("resuming after approval"));
 }
 

--- a/src/tui/render/cells/cells_tests/active_plan.rs
+++ b/src/tui/render/cells/cells_tests/active_plan.rs
@@ -37,8 +37,8 @@ fn active_turn_cell_renders_plan_approval_as_interaction_card() {
     assert_snapshot!("active_turn_cell_plan_approval", rendered);
     assert!(rendered.contains("# Awaiting Approval"));
     assert!(rendered.contains("Updated Plan"));
-    assert!(rendered.contains("1. Start implementation now"));
-    assert!(rendered.contains("2. Continue planning and refine the plan"));
+    assert!(rendered.contains("Responding via dock"));
+    assert!(!rendered.contains("1. Start implementation now"));
     assert!(rendered.contains("Generalize instruction discovery"));
 }
 
@@ -207,12 +207,11 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
         .join("\n");
 
     assert!(rendered.contains("# Shell Approval"));
-    assert!(rendered.contains("Review this shell command before RARA runs it."));
-    assert!(rendered.contains("Command:"));
-    assert!(rendered.contains("Working directory:"));
-    assert!(rendered.contains("bash ./scripts/migrate.sh"));
-    assert!(rendered.contains("> 2. Allow matching prefix"));
-    assert!(rendered.contains("1. Allow once - run only this command now"));
+    assert!(rendered.contains("Responding via dock"));
+    // Detail text (Command:, Working directory:, options) now rendered in dock panel.
+    assert!(!rendered.contains("Command:"));
+    assert!(!rendered.contains("bash ./scripts/migrate.sh"));
+    assert!(!rendered.contains("1. Allow once"));
     assert!(
         !rendered
             .contains("approval required  1 allow once  2 allow prefix  3 allow session  4 deny")
@@ -262,7 +261,7 @@ fn active_turn_cell_renders_queued_follow_up_without_hiding_shell_approval() {
         .join("\n");
 
     assert!(rendered.contains("# Shell Approval"));
-    assert!(rendered.contains("1. Allow once"));
+    assert!(rendered.contains("Responding via dock"));
     assert!(rendered.contains("# Queued"));
     assert!(rendered.contains("after turn"));
     assert!(!rendered.contains("Queued follow-up messages"));
@@ -517,8 +516,9 @@ fn active_turn_cell_labels_delegated_plan_questions() {
         .join("\n");
 
     assert!(rendered.contains("# Planning Question"));
-    assert!(rendered.contains("from:"));
-    assert!(rendered.contains("plan_agent"));
+    assert!(rendered.contains("Responding via dock"));
+    // Detail text now rendered in dock panel.
+    assert!(!rendered.contains("plan_agent"));
     assert!(rendered.contains("Which discovery strategy should we keep?"));
 }
 

--- a/src/tui/render/cells/cells_tests/active_plan.rs
+++ b/src/tui/render/cells/cells_tests/active_plan.rs
@@ -37,8 +37,8 @@ fn active_turn_cell_renders_plan_approval_as_interaction_card() {
     assert_snapshot!("active_turn_cell_plan_approval", rendered);
     assert!(rendered.contains("# Awaiting Approval"));
     assert!(rendered.contains("Updated Plan"));
-    assert!(rendered.contains("1. Start implementation now"));
-    assert!(rendered.contains("2. Continue planning and refine the plan"));
+    assert!(rendered.contains("Responding via dock"));
+    assert!(!rendered.contains("1. Start implementation now"));
     assert!(rendered.contains("Generalize instruction discovery"));
 }
 
@@ -207,12 +207,11 @@ fn active_turn_cell_renders_shell_approval_as_interaction_card() {
         .join("\n");
 
     assert!(rendered.contains("# Shell Approval"));
-    assert!(rendered.contains("Review this shell command before RARA runs it."));
-    assert!(rendered.contains("Command:"));
-    assert!(rendered.contains("Working directory:"));
-    assert!(rendered.contains("bash ./scripts/migrate.sh"));
-    assert!(rendered.contains("> 2. Allow matching prefix"));
-    assert!(rendered.contains("1. Allow once - run only this command now"));
+    assert!(rendered.contains("Responding via dock"));
+    // Detail text (Command:, Working directory:, options) now rendered in dock panel.
+    assert!(!rendered.contains("Command:"));
+    assert!(!rendered.contains("bash ./scripts/migrate.sh"));
+    assert!(!rendered.contains("1. Allow once"));
     assert!(
         !rendered
             .contains("approval required  1 allow once  2 allow prefix  3 allow session  4 deny")
@@ -262,7 +261,7 @@ fn active_turn_cell_renders_queued_follow_up_without_hiding_shell_approval() {
         .join("\n");
 
     assert!(rendered.contains("# Shell Approval"));
-    assert!(rendered.contains("1. Allow once"));
+    assert!(rendered.contains("Responding via dock"));
     assert!(rendered.contains("# Queued"));
     assert!(rendered.contains("after turn"));
     assert!(!rendered.contains("Queued follow-up messages"));
@@ -517,9 +516,8 @@ fn active_turn_cell_labels_delegated_plan_questions() {
         .join("\n");
 
     assert!(rendered.contains("# Planning Question"));
-    assert!(rendered.contains("from:"));
-    assert!(rendered.contains("plan_agent"));
-    assert!(rendered.contains("Which discovery strategy should we keep?"));
+    assert!(rendered.contains("Responding via dock"));
+    // Detail text now rendered in dock panel.
 }
 
 #[test]

--- a/src/tui/render/cells/cells_tests/snapshots/rara__tui__render__cells__tests__active_plan__active_turn_cell_plan_approval.snap
+++ b/src/tui/render/cells/cells_tests/snapshots/rara__tui__render__cells__tests__active_plan__active_turn_cell_plan_approval.snap
@@ -11,8 +11,4 @@ expression: rendered
     · Preserve cache and path resolution behavior
 
 # Awaiting Approval
-  Plan ready for implementation.
-  
-  1. Start implementation now
-  2. Continue planning and refine the plan
-  1 start implementation  2 continue planning
+  Responding via dock — use keys shown above the input.


### PR DESCRIPTION
## Summary

Suppress old PendingInteractionCell in transcript when dock panel renders approval
options. Also: always hide input during approval, fix dock color, use approval_picker_idx.

## Review fixes
- Always hide composer input and cursor when non-input interaction is active
- Use app.approval_picker_idx instead of hardcoded selected: 0 for dock highlight

## Verification
- `cargo build` — no new warnings
- `cargo test` — 1097 passed