### PR TITLE
chore: remove unused warning scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11229,6 +11229,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ reqwest = { version = "0.13", features = ["blocking", "json", "stream"] }
 async-trait = "0.1"
 anyhow = "1.0"
 thiserror = "2.0"
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting", "macros"] }
 owo-colors = "4.0"
 indicatif = "0.18"
 tiktoken-rs = "0.12"

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -9,11 +9,12 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 
 use crate::defaults::{
-    DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, DEFAULT_DEEPSEEK_BASE_URL, DEFAULT_DEEPSEEK_MODEL,
-    DEFAULT_GEMINI_BASE_URL, DEFAULT_KIMI_BASE_URL, DEFAULT_KIMI_MODEL,
-    DEFAULT_OPENAI_COMPATIBLE_BASE_URL, DEFAULT_OPENAI_COMPATIBLE_MODEL,
-    DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OPENROUTER_MODEL, DEFAULT_REASONING_SUMMARY,
-    should_apply_codex_base_url, should_reset_codex_model,
+    DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, DEFAULT_CONSOLIDATION_MIN_HOURS,
+    DEFAULT_CONSOLIDATION_MIN_SESSIONS, DEFAULT_CONSOLIDATION_SCAN_INTERVAL_MINUTES,
+    DEFAULT_DEEPSEEK_BASE_URL, DEFAULT_DEEPSEEK_MODEL, DEFAULT_GEMINI_BASE_URL,
+    DEFAULT_KIMI_BASE_URL, DEFAULT_KIMI_MODEL, DEFAULT_OPENAI_COMPATIBLE_BASE_URL,
+    DEFAULT_OPENAI_COMPATIBLE_MODEL, DEFAULT_OPENROUTER_BASE_URL, DEFAULT_OPENROUTER_MODEL,
+    DEFAULT_REASONING_SUMMARY, should_apply_codex_base_url, should_reset_codex_model,
 };
 use crate::mcp::{McpRegistry, load_mcp_registry};
 use crate::migration::migrate_reasoning_summary;
@@ -25,7 +26,7 @@ use crate::serde_helpers::{normalize_optional_string, normalize_reasoning_summar
 ///
 /// Consolidation runs as a background sub-agent that reads session logs,
 /// extracts durable facts, and merges them into the project memory index.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct MemoryConsolidationConfig {
     /// Model name.  `"inherit"` (default) uses the main model.
@@ -40,6 +41,24 @@ pub struct MemoryConsolidationConfig {
     pub min_new_sessions: u64,
     /// Minimum scan interval in minutes.
     pub scan_interval_minutes: u64,
+}
+
+impl Default for MemoryConsolidationConfig {
+    fn default() -> Self {
+        Self {
+            model: default_consolidation_model(),
+            reasoning_effort: default_consolidation_reasoning_effort(),
+            min_hours_since_last: DEFAULT_CONSOLIDATION_MIN_HOURS,
+            min_new_sessions: DEFAULT_CONSOLIDATION_MIN_SESSIONS,
+            scan_interval_minutes: DEFAULT_CONSOLIDATION_SCAN_INTERVAL_MINUTES,
+        }
+    }
+}
+
+impl MemoryConsolidationConfig {
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
 }
 
 fn default_consolidation_model() -> String {
@@ -209,6 +228,8 @@ pub struct RaraConfig {
         skip_serializing_if = "SandboxWorkspaceWriteConfig::is_default"
     )]
     pub sandbox_workspace_write: SandboxWorkspaceWriteConfig,
+    #[serde(default, skip_serializing_if = "MemoryConsolidationConfig::is_default")]
+    pub memory_consolidation: MemoryConsolidationConfig,
 }
 
 impl RaraConfig {

--- a/crates/rara-plugins/src/loader.rs
+++ b/crates/rara-plugins/src/loader.rs
@@ -260,7 +260,7 @@ mod tests {
 
         let plugin = load_plugin(dir.path()).unwrap();
         assert_eq!(plugin.name, "test-plugin");
-        assert_eq!(plugin.version.unwrap(), "1.0.0");
+        assert_eq!(plugin.version.as_deref(), Some("1.0.0"));
         assert_eq!(plugin.hooks.len(), 1);
 
         let registered = registered_hooks_for_plugin(&plugin);

--- a/crates/rara-state/src/state_db/tests.rs
+++ b/crates/rara-state/src/state_db/tests.rs
@@ -529,6 +529,7 @@ fn indexes_spawn_agent_edges_for_listing_queries() -> Result<()> {
                 child_session_id: "child-1".to_string(),
                 status: "done".to_string(),
                 summary: Some("Finished.".to_string()),
+                token_budget: None,
             },
         ],
     )?;
@@ -562,6 +563,7 @@ fn indexes_spawn_agent_edges_for_listing_queries() -> Result<()> {
             child_session_id: "child-1".to_string(),
             status: "done".to_string(),
             summary: Some("Finished.".to_string()),
+            token_budget: None,
         }],
     )?;
     let id_after_noop_sync: i64 = {

--- a/crates/rara-tools/Cargo.toml
+++ b/crates/rara-tools/Cargo.toml
@@ -17,3 +17,6 @@ serde_json.workspace = true
 thiserror = "2"
 walkdir = "2.5"
 tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/rara-tools/src/patch.rs
+++ b/crates/rara-tools/src/patch.rs
@@ -621,10 +621,6 @@ fn is_opening_context(chars: &[char], pos: usize) -> bool {
     )
 }
 
-fn find_subsequence(haystack: &[String], needle: &[String]) -> Option<usize> {
-    seek_sequence(haystack, needle, 0, false)
-}
-
 fn write_text_file(path: &str, content: &str) -> Result<(), ToolError> {
     if let Some(parent) = Path::new(path).parent() {
         fs::create_dir_all(parent)?;
@@ -644,8 +640,8 @@ mod tests {
     use serde_json::json;
 
     use super::ApplyPatchTool;
+    use crate::file::{FileReadState, ReadFileTool};
     use crate::tool::Tool;
-    use crate::tools::file::{FileReadState, ReadFileTool};
 
     #[test]
     fn apply_patch_description_encodes_safe_edit_contract() {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1417,26 +1417,6 @@ Rules:
         Ok(crate::classifier::parse_auto_permission_response(&raw)?)
     }
 
-    /// Classify a background task's current state using the auxiliary model.
-    async fn classify_background_task(
-        &self,
-        request: &crate::classifier::BackgroundTaskClassifyRequest,
-    ) -> Result<crate::classifier::BackgroundTaskClassifyResponse> {
-        let instructions = "\
-You are a process observer. Given a command and its recent output tail,
-classify its state. Output exactly one JSON object with fields:
-- \"state\": \"working\", \"blocked\", \"done\", or \"failed\"
-- \"tempo\": \"active\", \"idle\", or \"blocked\"
-- \"detail\": one-line status description
-- \"needs\": what the user should do to unblock (only when state is \"blocked\", omit otherwise)
-        ";
-
-        let message = crate::classifier::build_background_task_message(request);
-
-        let raw = self.llm_backend.classify(instructions, &[message]).await?;
-        Ok(crate::classifier::parse_background_task_response(&raw)?)
-    }
-
     fn tool_call_context(&self) -> ToolCallContext {
         let context = ToolCallContext::default().with_session_id(self.session_id.clone());
         match self.cancellation_token.as_ref() {

--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -49,73 +49,6 @@ pub struct AutoPermissionResponse {
     pub matched_rule: Option<String>,
 }
 
-// ── Background Task Status Classifier ──────────────────────────────────────────
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BackgroundTaskClassifyRequest {
-    /// The command that was run
-    pub command: String,
-    /// The task status: running, completed, killed
-    pub status: String,
-    /// Tail of the task's output (last ~2KB)
-    pub output_tail: String,
-    /// How long the task has been running
-    pub elapsed: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum BackgroundTaskState {
-    /// Task is actively producing output
-    Working,
-    /// Task appears stuck waiting for something
-    Blocked,
-    /// Task completed successfully
-    Done,
-    /// Task failed with an error
-    Failed,
-}
-
-impl std::fmt::Display for BackgroundTaskState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Working => write!(f, "working"),
-            Self::Blocked => write!(f, "blocked"),
-            Self::Done => write!(f, "done"),
-            Self::Failed => write!(f, "failed"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum BackgroundTaskTempo {
-    Active,
-    Idle,
-    Blocked,
-}
-
-impl std::fmt::Display for BackgroundTaskTempo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Active => write!(f, "active"),
-            Self::Idle => write!(f, "idle"),
-            Self::Blocked => write!(f, "blocked"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BackgroundTaskClassifyResponse {
-    pub state: BackgroundTaskState,
-    pub tempo: BackgroundTaskTempo,
-    /// One-line status description
-    pub detail: String,
-    /// What the user needs to do to unblock (only filled when Blocked)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub needs: Option<String>,
-}
-
 // ── Transcript Projection Helpers ──────────────────────────────────────────────
 
 /// Build a classifier prompt from the conversation messages, excluding assistant
@@ -185,29 +118,6 @@ pub fn build_classifier_messages(
     result
 }
 
-/// Build a classifier message for background task status evaluation.
-pub fn build_background_task_message(
-    request: &BackgroundTaskClassifyRequest,
-) -> crate::agent::Message {
-    let mut parts = vec![
-        format!("Command: {}", request.command),
-        format!("Status: {}", request.status),
-    ];
-
-    if let Some(ref elapsed) = request.elapsed {
-        parts.push(format!("Elapsed: {}", elapsed));
-    }
-
-    if !request.output_tail.is_empty() {
-        parts.push(format!("Recent output:\n{}", request.output_tail));
-    }
-
-    crate::agent::Message {
-        role: "user".into(),
-        content: Value::String(parts.join("\n")),
-    }
-}
-
 fn extract_text_content(content: &Value) -> Option<String> {
     if let Some(text) = content.as_str() {
         return Some(text.to_string());
@@ -235,16 +145,6 @@ pub fn parse_auto_permission_response(
     raw: &str,
 ) -> Result<AutoPermissionResponse, serde_json::Error> {
     if let Ok(resp) = serde_json::from_str::<AutoPermissionResponse>(raw) {
-        return Ok(resp);
-    }
-    serde_json::from_str(clean_json_response(raw))
-}
-
-/// Parse BackgroundTaskClassifyResponse from classifier LLM output.
-pub fn parse_background_task_response(
-    raw: &str,
-) -> Result<BackgroundTaskClassifyResponse, serde_json::Error> {
-    if let Ok(resp) = serde_json::from_str::<BackgroundTaskClassifyResponse>(raw) {
         return Ok(resp);
     }
     serde_json::from_str(clean_json_response(raw))
@@ -328,39 +228,5 @@ mod tests {
         let raw = "```json\n{\"decision\": \"ask\", \"reason\": \"network request\"}\n```";
         let resp = parse_auto_permission_response(raw).unwrap();
         assert_eq!(resp.decision, AutoPermissionDecision::Ask);
-    }
-
-    #[test]
-    fn test_parse_background_task_working() {
-        let raw = r#"{"state": "working", "tempo": "active", "detail": "Building in progress"}"#;
-        let resp = parse_background_task_response(raw).unwrap();
-        assert_eq!(resp.state, BackgroundTaskState::Working);
-        assert_eq!(resp.tempo, BackgroundTaskTempo::Active);
-    }
-
-    #[test]
-    fn test_parse_background_task_blocked() {
-        let raw = r#"{"state": "blocked", "tempo": "blocked", "detail": "Waiting for input", "needs": "Provide SSH passphrase"}"#;
-        let resp = parse_background_task_response(raw).unwrap();
-        assert_eq!(resp.state, BackgroundTaskState::Blocked);
-        assert_eq!(resp.tempo, BackgroundTaskTempo::Blocked);
-        assert_eq!(resp.needs, Some("Provide SSH passphrase".to_string()));
-    }
-
-    #[test]
-    fn test_build_background_task_message() {
-        let request = BackgroundTaskClassifyRequest {
-            command: "cargo build --release".to_string(),
-            status: "running".to_string(),
-            output_tail: "   Compiling rara v0.0.1\n   Compiling ...".to_string(),
-            elapsed: Some("30s".to_string()),
-        };
-
-        let msg = build_background_task_message(&request);
-        let prompt = msg.content.as_str().unwrap();
-        assert!(prompt.contains("cargo build --release"));
-        assert!(prompt.contains("running"));
-        assert!(prompt.contains("30s"));
-        assert!(prompt.contains("Compiling rara"));
     }
 }

--- a/src/hook_registry.rs
+++ b/src/hook_registry.rs
@@ -19,9 +19,7 @@ use crate::runtime_event_bus::RuntimeEventBus;
 /// A stored hook declaration.
 #[derive(Clone, Debug)]
 pub struct HookEntry {
-    pub id: String,
     pub lifecycle: HookLifecycle,
-    pub description: String,
 }
 
 /// Registry of control-plane-declared hooks.
@@ -47,12 +45,10 @@ impl HookRegistry {
             HookControlRequest::Declare {
                 hook_id,
                 lifecycle,
-                description,
+                description: _,
             } => {
                 let entry = HookEntry {
-                    id: hook_id.clone(),
                     lifecycle: lifecycle.clone(),
-                    description: description.clone(),
                 };
                 self.hooks.write().await.insert(hook_id.clone(), entry);
                 let _ = self
@@ -74,24 +70,5 @@ impl HookRegistry {
                 }
             }
         }
-    }
-
-    /// Return a snapshot of all registered hooks.
-    pub async fn all_hooks(&self) -> Vec<HookEntry> {
-        self.hooks.read().await.values().cloned().collect()
-    }
-
-    /// Return hooks registered for a given lifecycle phase (non-async).
-    pub fn hooks_for_phase(&self, phase: HookLifecycle) -> Vec<HookEntry> {
-        self.hooks
-            .try_read()
-            .map(|guard| {
-                guard
-                    .values()
-                    .filter(|h| h.lifecycle == phase)
-                    .cloned()
-                    .collect()
-            })
-            .unwrap_or_default()
     }
 }

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -21,21 +21,16 @@ type HookCallback = Box<dyn Fn(&AgentEvent) + Send + Sync>;
 
 struct HookEntry {
     lifecycle: HookLifecycle,
-    description: String,
     callback: HookCallback,
 }
 
 /// In-process hook dispatch runtime.
 ///
-pub type ToolModifier = Box<dyn Fn(&str, &Value) -> Option<Value> + Send + Sync>;
-
 /// Hooks are stored behind an `Arc<RwLock<HashMap<...>>>` so that the
-/// control-plane can register / unregister hooks while the dispatch
-/// loop is already running.
+/// control-plane can register hooks while the dispatch loop is already running.
 pub struct HookRuntime {
     bus: Arc<RuntimeEventBus>,
     hooks: Arc<RwLock<HashMap<String, HookEntry>>>,
-    tool_modifiers: Arc<std::sync::RwLock<Vec<(String, ToolModifier)>>>,
     /// Collected stdout from command hooks. Drained before each model turn
     /// and injected as system messages into the model context.
     outputs: Arc<std::sync::Mutex<Vec<String>>>,
@@ -47,7 +42,6 @@ impl HookRuntime {
         Self {
             bus,
             hooks: Arc::new(RwLock::new(HashMap::new())),
-            tool_modifiers: Arc::new(std::sync::RwLock::new(Vec::new())),
             outputs: Arc::new(std::sync::Mutex::new(Vec::new())),
             started: AtomicBool::new(false),
         }
@@ -60,15 +54,6 @@ impl HookRuntime {
         }
     }
 
-    /// Drain and return all collected hook outputs, clearing the buffer.
-    pub fn drain_outputs(&self) -> Vec<String> {
-        if let Ok(mut guard) = self.outputs.lock() {
-            std::mem::take(&mut *guard)
-        } else {
-            Vec::new()
-        }
-    }
-
     /// Drain outputs synchronously (for use in non-async contexts).
     pub fn blocking_drain_outputs(&self) -> Vec<String> {
         if let Ok(mut guard) = self.outputs.lock() {
@@ -78,34 +63,16 @@ impl HookRuntime {
         }
     }
 
-    /// Register a PreToolUse modifier that can transform tool input.
-    pub fn register_tool_modifier(&self, name: String, modifier: ToolModifier) {
-        if let Ok(mut guard) = self.tool_modifiers.write() {
-            guard.push((name, modifier));
-        }
-    }
-
-    /// Run all registered tool modifiers against the given tool name and input.
-    /// Returns the final (possibly modified) input value.
-    pub fn modify_tool_input(&self, tool_name: &str, input: Value) -> Value {
-        let modifiers = self.tool_modifiers.read().unwrap();
-        let mut current = input;
-        for (_name, modifier) in modifiers.iter() {
-            if let Some(modified) = modifier(tool_name, &current) {
-                current = modified;
-            }
-        }
-        current
+    pub fn modify_tool_input(
+        &self,
+        _tool_name: &str,
+        input: serde_json::Value,
+    ) -> serde_json::Value {
+        input
     }
 
     /// Register an in-process hook.  Safe to call while `start` is running.
-    pub fn register(
-        &self,
-        hook_id: String,
-        lifecycle: HookLifecycle,
-        description: String,
-        callback: HookCallback,
-    ) {
+    pub fn register(&self, hook_id: String, lifecycle: HookLifecycle, callback: HookCallback) {
         self.hooks
             .write()
             .expect("hook runtime registry lock poisoned")
@@ -113,19 +80,9 @@ impl HookRuntime {
                 hook_id,
                 HookEntry {
                     lifecycle,
-                    description,
                     callback,
                 },
             );
-    }
-
-    /// Unregister a previously declared hook by id.
-    pub fn unregister(&self, hook_id: &str) -> bool {
-        self.hooks
-            .write()
-            .expect("hook runtime registry lock poisoned")
-            .remove(hook_id)
-            .is_some()
     }
 
     /// Return the number of registered hooks.
@@ -196,159 +153,6 @@ fn lifecycle_for_event(event: &AgentEvent) -> Option<HookLifecycle> {
 
 fn lifecycle_matches(lifecycle: &HookLifecycle, event: &AgentEvent) -> bool {
     lifecycle_for_event(event).as_ref() == Some(lifecycle)
-}
-
-/// Result of executing a command-type hook.
-#[derive(Debug, Clone)]
-pub struct HookRunResult {
-    pub exit_code: Option<i32>,
-    pub stdout: String,
-    pub stderr: String,
-    pub error: Option<String>,
-    pub duration_ms: u64,
-}
-
-/// Spawn a background thread that executes `script_path` as a hook,
-/// writing `input_json` to stdin.  Uses a separate stdin-writer thread
-/// to avoid pipe-buffer deadlock.  Kills the child on timeout.
-fn spawn_command_hook(
-    script_path: std::path::PathBuf,
-    input_json: String,
-    cwd: std::path::PathBuf,
-    timeout_secs: u64,
-) {
-    std::thread::spawn(move || {
-        let result = run_command_hook(&script_path, &input_json, &cwd, timeout_secs);
-        match result {
-            Some(ref r) if r.error.is_some() => {
-                eprintln!(
-                    "command hook failed {}: {} ({}ms)",
-                    script_path.display(),
-                    r.error.as_ref().unwrap(),
-                    r.duration_ms
-                );
-            }
-            Some(ref r) => {
-                eprintln!(
-                    "command hook {} exit={:?} {}ms ({}b stdout)",
-                    script_path.display(),
-                    r.exit_code,
-                    r.duration_ms,
-                    r.stdout.len()
-                );
-            }
-            None => {}
-        }
-    });
-}
-
-/// Execute a shell script as a hook, feeding `input_json` to stdin.
-///
-/// The script runs with `cwd` set to the workspace root and a timeout of
-/// `timeout_secs`.  If the script doesn't exist, returns `None`.
-/// On timeout the child process is killed and the wait thread is joined.
-pub fn run_command_hook(
-    script_path: &std::path::Path,
-    input_json: &str,
-    cwd: &std::path::Path,
-    timeout_secs: u64,
-) -> Option<HookRunResult> {
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-
-    if !script_path.exists() {
-        return None;
-    }
-    let started = std::time::Instant::now();
-
-    let mut child = match Command::new(script_path)
-        .current_dir(cwd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            return Some(HookRunResult {
-                exit_code: None,
-                stdout: String::new(),
-                stderr: String::new(),
-                error: Some(e.to_string()),
-                duration_ms: started.elapsed().as_millis() as u64,
-            });
-        }
-    };
-
-    // Write stdin in a separate thread to avoid deadlock when input exceeds
-    // the pipe buffer and the child is also writing to stdout/stderr.
-    if let Some(mut stdin) = child.stdin.take() {
-        let stdin_bytes: Vec<u8> = input_json.as_bytes().to_vec();
-        std::thread::spawn(move || {
-            let _ = stdin.write_all(&stdin_bytes);
-            // stdin is dropped here, closing the pipe
-        });
-    }
-
-    // Remember the child PID so we can kill it on timeout.
-    let child_id = child.id();
-
-    let (tx, rx) = std::sync::mpsc::channel();
-    let wait_thread = std::thread::spawn(move || {
-        let output = child.wait_with_output();
-        let _ = tx.send(output);
-    });
-
-    match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
-        Ok(Ok(output)) => {
-            let _ = wait_thread.join();
-            Some(HookRunResult {
-                exit_code: output.status.code(),
-                stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-                error: None,
-                duration_ms: started.elapsed().as_millis() as u64,
-            })
-        }
-        Ok(Err(e)) => {
-            let _ = wait_thread.join();
-            Some(HookRunResult {
-                exit_code: None,
-                stdout: String::new(),
-                stderr: String::new(),
-                error: Some(e.to_string()),
-                duration_ms: started.elapsed().as_millis() as u64,
-            })
-        }
-        Err(_timeout) => {
-            // Kill the child process so the wait thread can join
-            let _ = std::process::Command::new("kill")
-                .arg(child_id.to_string())
-                .output();
-            let _ = wait_thread.join();
-            Some(HookRunResult {
-                exit_code: None,
-                stdout: String::new(),
-                stderr: String::new(),
-                error: Some(format!("hook timed out after {timeout_secs}s")),
-                duration_ms: started.elapsed().as_millis() as u64,
-            })
-        }
-    }
-}
-
-/// Build a `HookCallback` that spawns `script_path` as a fire-and-forget
-/// command-type hook in a background thread.  The dispatch loop is never
-/// blocked.
-pub fn make_command_hook(
-    script_path: std::path::PathBuf,
-    cwd: std::path::PathBuf,
-    timeout_secs: u64,
-) -> HookCallback {
-    Box::new(move |_event: &AgentEvent| {
-        let input_json = "{}".to_string();
-        spawn_command_hook(script_path.clone(), input_json, cwd.clone(), timeout_secs);
-    })
 }
 
 // ---------------------------------------------------------------------------
@@ -428,7 +232,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_register_and_unregister() {
+    async fn test_registers_hooks() {
         let bus = Arc::new(RuntimeEventBus::new(4));
         let runtime = HookRuntime::new(bus);
 
@@ -437,14 +241,8 @@ mod tests {
         runtime.register(
             "hook-1".into(),
             HookLifecycle::SessionStart,
-            "test hook".into(),
             Box::new(|_| {}),
         );
         assert_eq!(runtime.hook_count(), 1);
-
-        assert!(runtime.unregister("hook-1"));
-        assert_eq!(runtime.hook_count(), 0);
-
-        assert!(!runtime.unregister("hook-1"));
     }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -153,24 +153,6 @@ impl HookRegistry {
             .filter(|h| h.parse_status == HookParseStatus::Ok && h.phase == phase)
             .collect()
     }
-
-    /// For /context and /status: list each hook with phase, path, and parse status.
-    pub fn status_lines(&self) -> Vec<String> {
-        let mut lines = Vec::new();
-        for hook in self.hooks.values() {
-            let status = match hook.parse_status {
-                HookParseStatus::Ok => "ok",
-                HookParseStatus::ParseError => "parse_error",
-            };
-            lines.push(format!(
-                "  {}  {}  {}  (disabled)",
-                hook.phase.as_str(),
-                hook.source_path,
-                status
-            ));
-        }
-        lines
-    }
 }
 
 fn phase_ordinal(phase: HookLifecycle) -> u8 {
@@ -273,7 +255,6 @@ impl Default for HookSandbox {
 
 /// Outcome of a hook execution.
 pub struct HookOutcome {
-    pub stdout: String,
     pub stderr: String,
     pub exit_code: Option<i32>,
     pub timed_out: bool,
@@ -338,7 +319,6 @@ pub fn run_sandboxed_hook(
                     let _ = child.kill();
                     let _ = child.wait();
                     return Ok(HookOutcome {
-                        stdout: String::new(),
                         stderr: format!("hook {} timed out after {:?}", hook.id, sandbox.timeout),
                         exit_code: None,
                         timed_out: true,
@@ -350,7 +330,6 @@ pub fn run_sandboxed_hook(
     }
 
     Ok(HookOutcome {
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         exit_code: output.status.code(),
         timed_out: false,

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -318,7 +318,7 @@ pub fn run_sandboxed_hook(
     // stdin is dropped here — closes the pipe so the hook sees EOF.
 
     let start = Instant::now();
-    let mut output: Option<std::process::Output> = None;
+    let output: std::process::Output;
 
     // Busy-wait with timeout — single-threaded, acceptable for <1s hooks.
     loop {
@@ -326,11 +326,11 @@ pub fn run_sandboxed_hook(
             Some(status) => {
                 // Child exited — collect remaining output.
                 let o = child.wait_with_output()?;
-                output = Some(std::process::Output {
+                output = std::process::Output {
                     status,
                     stdout: o.stdout,
                     stderr: o.stderr,
-                });
+                };
                 break;
             }
             None => {
@@ -348,14 +348,6 @@ pub fn run_sandboxed_hook(
             }
         }
     }
-
-    if output.is_none() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "hook process did not produce output after wait",
-        ));
-    }
-    let output = output.unwrap();
 
     Ok(HookOutcome {
         stdout: String::from_utf8_lossy(&output.stdout).into_owned(),

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -45,7 +45,6 @@ impl BrowserLoginSession {
 
 #[derive(Clone)]
 pub struct OAuthManager {
-    pub config_dir: PathBuf,
     codex_home: PathBuf,
     legacy_codex_home: PathBuf,
     saved_auth_available: Arc<Mutex<Option<bool>>>,
@@ -64,19 +63,10 @@ impl OAuthManager {
         std::fs::create_dir_all(&codex_home)?;
         std::fs::create_dir_all(&legacy_codex_home)?;
         Ok(Self {
-            config_dir,
             codex_home,
             legacy_codex_home,
             saved_auth_available: Arc::new(Mutex::new(None)),
         })
-    }
-
-    pub fn codex_issuer(&self) -> &'static str {
-        ISSUER
-    }
-
-    pub fn client_id(&self) -> &'static str {
-        CLIENT_ID
     }
 
     pub fn start_browser_login(&self, open_browser: bool) -> Result<BrowserLoginSession> {

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -106,7 +106,6 @@ fn register_plugin_hooks_blocking(
             runtime.register(
                 format!("{}-{}", plugin_name, rh.event.as_str()),
                 lifecycle,
-                format!("plugin hook: {}", plugin_name),
                 callback,
             );
 

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -73,8 +73,7 @@ pub(super) fn agent_tool_to_config_name(name: &str) -> &str {
     }
 }
 
-/// Agent definition matching Claude Code .claude/agents/*.md format.
-
+// Agent definition matching Claude Code .claude/agents/*.md format.
 include!("agent_def.rs");
 
 /// Progress tracking for a subagent (Claude Code AgentProgress compatible).

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -112,7 +112,7 @@ impl PtySessionStore {
         let idle_cutoff = Duration::from_secs(PTY_IDLE_PRUNE_SECS);
 
         // Collect (id, last_read, has_exited) for all sessions
-        let mut meta: Vec<(String, Instant, bool)> = sessions
+        let meta: Vec<(String, Instant, bool)> = sessions
             .iter()
             .map(|(id, s)| {
                 let exited = !matches!(

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -398,8 +398,10 @@ fn render_todo_context(app: &TuiApp) -> String {
 }
 
 fn format_unix_timestamp_utc(timestamp: i64) -> String {
-    let format = format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second] UTC")
-        .expect("static timestamp format should be valid");
+    let format = format_description::parse_borrowed::<2>(
+        "[year]-[month]-[day] [hour]:[minute]:[second] UTC",
+    )
+    .expect("static timestamp format should be valid");
 
     OffsetDateTime::from_unix_timestamp(timestamp)
         .ok()

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -1,7 +1,7 @@
 // Status items reserved for inline TUI command surfaces.
 
 use rara_observability::{LatencyPercentiles, memory_latency_snapshot};
-use time::{OffsetDateTime, format_description};
+use time::OffsetDateTime;
 
 use crate::config::RaraConfig;
 use crate::context::{CacheStatus, RetrievalCandidateContextEntry, RetrievalProviderStatus};
@@ -398,10 +398,8 @@ fn render_todo_context(app: &TuiApp) -> String {
 }
 
 fn format_unix_timestamp_utc(timestamp: i64) -> String {
-    let format = format_description::parse_borrowed::<2>(
-        "[year]-[month]-[day] [hour]:[minute]:[second] UTC",
-    )
-    .expect("static timestamp format should be valid");
+    let format =
+        time::macros::format_description!("[year]-[month]-[day] [hour]:[minute]:[second] UTC");
 
     OffsetDateTime::from_unix_timestamp(timestamp)
         .ok()

--- a/src/tui/custom_terminal.rs
+++ b/src/tui/custom_terminal.rs
@@ -175,8 +175,6 @@ where
     /// Last known position of the cursor. Used to find the new area when the viewport is inlined
     /// and the terminal resized.
     pub last_known_cursor_pos: Position,
-    /// Count of visible history rows rendered above the viewport in inline mode.
-    visible_history_rows: u16,
 }
 
 impl<B> Drop for Terminal<B>
@@ -214,7 +212,6 @@ where
             viewport_area: Rect::new(0, cursor_pos.y, 0, 0),
             last_known_screen_size: screen_size,
             last_known_cursor_pos: cursor_pos,
-            visible_history_rows: 0,
         })
     }
 
@@ -247,11 +244,6 @@ where
         &mut self.buffers[1 - self.current]
     }
 
-    /// Gets the backend
-    pub const fn backend(&self) -> &B {
-        &self.backend
-    }
-
     /// Gets the backend as a mutable reference
     pub fn backend_mut(&mut self) -> &mut B {
         &mut self.backend
@@ -282,7 +274,6 @@ where
         self.current_buffer_mut().resize(area);
         self.previous_buffer_mut().resize(area);
         self.viewport_area = area;
-        self.visible_history_rows = self.visible_history_rows.min(area.top());
     }
 
     /// Queries the backend for size and resizes if it doesn't match the previous size.
@@ -428,44 +419,7 @@ where
         Ok(())
     }
 
-    /// Clear the terminal and force a full redraw on the next draw call.
-    pub fn clear(&mut self) -> io::Result<()> {
-        if self.viewport_area.is_empty() {
-            return Ok(());
-        }
-        self.backend
-            .set_cursor_position(self.viewport_area.as_position())?;
-        self.backend.clear_region(ClearType::AfterCursor)?;
-        // Reset the back buffer to make sure the next update will redraw everything.
-        self.previous_buffer_mut().reset();
-        Ok(())
-    }
-
-    /// Force the next draw pass to repaint the entire viewport by resetting the
-    /// diff buffer. Call this after operations that move screen content outside of
-    /// ratatui's knowledge (e.g., Zellij-mode scrolling via raw newlines), since
-    /// the diff buffer's assumptions about what is currently displayed are invalid.
-    pub fn invalidate_viewport(&mut self) {
-        self.previous_buffer_mut().reset();
-    }
-
     // ---- helpers (pub(super)) ------------------------------------------------
-
-    /// Clear terminal scrollback (if supported) and force a full redraw.
-    pub fn clear_scrollback(&mut self) -> io::Result<()> {
-        if self.viewport_area.is_empty() {
-            return Ok(());
-        }
-        let home = Position { x: 0, y: 0 };
-        // Use an explicit cursor-home around scrollback purge for terminals that
-        // are sensitive to inline viewport cursor placement (e.g. Terminal.app).
-        self.set_cursor_position(home)?;
-        queue!(self.backend, Clear(crossterm::terminal::ClearType::Purge))?;
-        self.set_cursor_position(home)?;
-        std::io::Write::flush(&mut self.backend)?;
-        self.previous_buffer_mut().reset();
-        Ok(())
-    }
 
     /// Clear the entire visible screen (not just the viewport) and force a full redraw.
     pub fn clear_visible_screen(&mut self) -> io::Result<()> {
@@ -477,39 +431,8 @@ where
         self.backend.clear_region(ClearType::All)?;
         self.set_cursor_position(home)?;
         std::io::Write::flush(&mut self.backend)?;
-        self.visible_history_rows = 0;
         self.previous_buffer_mut().reset();
         Ok(())
-    }
-
-    /// Hard-reset scrollback + visible screen using an explicit ANSI sequence.
-    ///
-    /// Some terminals behave more reliably when purge + clear are emitted as a
-    /// single ANSI sequence instead of separate backend commands.
-    pub fn clear_scrollback_and_visible_screen_ansi(&mut self) -> io::Result<()> {
-        if self.viewport_area.is_empty() {
-            return Ok(());
-        }
-
-        // Reset scroll region + style state, home cursor, clear screen, purge scrollback.
-        // The order matches the common shell `clear && printf '\\e[3J'` behavior.
-        write!(self.backend, "\x1b[r\x1b[0m\x1b[H\x1b[2J\x1b[3J\x1b[H")?;
-        std::io::Write::flush(&mut self.backend)?;
-        self.last_known_cursor_pos = Position { x: 0, y: 0 };
-        self.visible_history_rows = 0;
-        self.previous_buffer_mut().reset();
-        Ok(())
-    }
-
-    pub fn visible_history_rows(&self) -> u16 {
-        self.visible_history_rows
-    }
-
-    pub(crate) fn note_history_rows_inserted(&mut self, inserted_rows: u16) {
-        self.visible_history_rows = self
-            .visible_history_rows
-            .saturating_add(inserted_rows)
-            .min(self.viewport_area.top());
     }
 
     /// Clears the inactive buffer and swaps it with the current buffer
@@ -759,101 +682,7 @@ impl ModifierDiff {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, Write};
-
-    use ratatui::{
-        backend::{Backend, ClearType, WindowSize},
-        layout::{Position, Rect, Size},
-        style::Style,
-    };
-
-    use super::{Terminal, display_width};
-
-    /// Minimal backend for testing Terminal state transitions.
-    /// Captures written bytes, reports a fixed size and cursor position.
-    struct StateTestBackend {
-        inner: Vec<u8>,
-        screen_size: Size,
-        cursor_pos: Position,
-    }
-
-    impl StateTestBackend {
-        fn new(width: u16, height: u16) -> Self {
-            Self {
-                inner: Vec::new(),
-                screen_size: Size::new(width, height),
-                cursor_pos: Position { x: 0, y: 0 },
-            }
-        }
-    }
-
-    impl Write for StateTestBackend {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.inner.write(buf)
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            self.inner.flush()
-        }
-    }
-
-    impl Backend for StateTestBackend {
-        type Error = io::Error;
-
-        fn size(&self) -> io::Result<Size> {
-            Ok(self.screen_size)
-        }
-
-        fn get_cursor_position(&mut self) -> io::Result<Position> {
-            Ok(self.cursor_pos)
-        }
-
-        fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
-            self.cursor_pos = position.into();
-            Ok(())
-        }
-
-        fn hide_cursor(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-
-        fn show_cursor(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-
-        fn clear_region(&mut self, _clear_type: ClearType) -> io::Result<()> {
-            Ok(())
-        }
-
-        fn clear(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-
-        fn window_size(&mut self) -> io::Result<WindowSize> {
-            Ok(WindowSize {
-                columns_rows: self.screen_size,
-                pixels: Size::new(0, 0),
-            })
-        }
-
-        fn draw<'a, I>(&mut self, _content: I) -> io::Result<()>
-        where
-            I: Iterator<Item = (u16, u16, &'a ratatui::buffer::Cell)>,
-        {
-            Ok(())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    fn make_test_terminal(width: u16, height: u16) -> Terminal<StateTestBackend> {
-        let backend = StateTestBackend::new(width, height);
-        let mut terminal = Terminal::new(backend).expect("create test terminal");
-        terminal.set_viewport_area(Rect::new(0, height.saturating_sub(5), width, 5));
-        terminal
-    }
+    use super::display_width;
 
     #[test]
     fn display_width_ignores_osc_sequences() {
@@ -871,72 +700,5 @@ mod tests {
     fn display_width_ignores_csi_sequences() {
         let text = "\x1b[31mred\x1b[0m";
         assert_eq!(display_width(text), 3);
-    }
-
-    #[test]
-    fn invalidate_viewport_resets_previous_buffer() {
-        let mut terminal = make_test_terminal(80, 24);
-        // viewport area: x=0, y=19, w=80, h=5
-        let top = terminal.viewport_area.y;
-
-        // Write into the current buffer at viewport-relative (0,0) = absolute (0, top).
-        terminal
-            .current_buffer_mut()
-            .set_string(0, top, "old-content", Style::default());
-
-        // Swap to simulate a completed draw pass.
-        terminal.swap_buffers();
-
-        // Now the "previous" buffer has "old-content". Write fresh content.
-        terminal
-            .current_buffer_mut()
-            .set_string(0, top, "new-content", Style::default());
-
-        // Before invalidation, diff would see both buffers have content.
-        let cell_before = terminal
-            .previous_buffer()
-            .cell(Position { x: 0, y: top })
-            .unwrap();
-        assert_eq!(cell_before.symbol(), "o");
-
-        terminal.invalidate_viewport();
-
-        // After invalidation, previous buffer is reset — diff will treat it as empty.
-        let cell_after = terminal
-            .previous_buffer()
-            .cell(Position { x: 0, y: top })
-            .unwrap();
-        assert_eq!(cell_after.symbol(), " ");
-    }
-
-    #[test]
-    fn note_history_rows_inserted_tracks_and_clamps() {
-        let mut terminal = make_test_terminal(80, 24);
-        // viewport_area: y=19, height=5 → top is 19
-
-        assert_eq!(terminal.visible_history_rows(), 0);
-
-        terminal.note_history_rows_inserted(5);
-        assert_eq!(terminal.visible_history_rows(), 5);
-
-        // Insert more — should clamp to viewport top (19)
-        terminal.note_history_rows_inserted(20);
-        assert_eq!(terminal.visible_history_rows(), 19);
-    }
-
-    #[test]
-    fn set_viewport_area_clamps_visible_history_rows() {
-        let mut terminal = make_test_terminal(80, 24);
-        // viewport_area: y=19 → top=19. Insert some history.
-        terminal.note_history_rows_inserted(5);
-        assert_eq!(terminal.visible_history_rows(), 5);
-
-        // Shrink viewport (raise the top) — visible_history_rows clamps to the new top.
-        terminal.set_viewport_area(Rect::new(0, 22, 80, 2));
-        assert_eq!(terminal.visible_history_rows(), 5);
-
-        // Grow viewport (lower the top) — visible_history_rows stays at 5.
-        terminal.note_history_rows_inserted(20);
-        assert_eq!(terminal.visible_history_rows(), 22); // clamped to top=22
     }
 }

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -837,7 +837,7 @@ impl ScopedEnvGuard {
 
     fn set(vars: &[(&str, &str)]) -> Self {
         let keys: Vec<&str> = vars.iter().map(|(k, _)| *k).collect();
-        let mut guard = Self::remove(&keys);
+        let guard = Self::remove(&keys);
         for (k, v) in vars {
             unsafe { std::env::set_var(k, v) };
         }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -205,12 +205,12 @@ pub(super) async fn execute_local_command(
             app.open_overlay(Overlay::Status(StatusTab::Overview));
         }
         LocalCommandKind::Dream => {
-            let summary = agent_slot
-                .as_mut()
-                .unwrap()
-                .consolidation_scheduler
-                .status();
-            app.set_runtime_phase(RuntimePhase::LocalCommand, Some(summary));
+            if let Some(agent) = agent_slot.as_mut() {
+                let summary = agent.consolidation_scheduler.status();
+                app.set_runtime_phase(RuntimePhase::LocalCommand, Some(summary));
+            } else {
+                app.push_notice("Memory consolidation is not available until an agent is ready.");
+            }
         }
 
         LocalCommandKind::Goal => {
@@ -923,6 +923,36 @@ command = "docs-server"
         assert_eq!(
             app.bottom_pane.notice.as_deref(),
             Some("A goal already exists. Use /goal clear before setting a new goal.")
+        );
+    }
+
+    #[tokio::test]
+    async fn dream_command_without_agent_reports_unavailable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager = Arc::new(
+            OAuthManager::new_for_config_dir(dir.path().join("oauth")).expect("oauth manager"),
+        );
+        let mut agent_slot = None;
+
+        execute_local_command(
+            LocalCommand {
+                kind: LocalCommandKind::Dream,
+                arg: None,
+            },
+            &mut app,
+            &mut agent_slot,
+            &oauth_manager,
+        )
+        .await
+        .expect("dream command should be handled");
+
+        assert_eq!(
+            app.bottom_pane.notice.as_deref(),
+            Some("Memory consolidation is not available until an agent is ready.")
         );
     }
 

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -43,10 +43,6 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Dream => "dream",
     });
     match command.kind {
-        LocalCommandKind::Dream => {
-            // handled in the full async dispatch below
-            return Ok(false);
-        }
         LocalCommandKind::Approval => {
             if app.is_busy() {
                 app.push_notice("A task is already running. Wait for it to finish.");
@@ -214,7 +210,7 @@ pub(super) async fn execute_local_command(
                 .unwrap()
                 .consolidation_scheduler
                 .status();
-            app.set_runtime_phase(RuntimePhase::LocalCommand, Some("dream".into()));
+            app.set_runtime_phase(RuntimePhase::LocalCommand, Some(summary));
         }
 
         LocalCommandKind::Goal => {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -242,7 +242,6 @@ async fn sync_snapshot_reports_registered_runtime_hooks() {
     runtime.register(
         "plugin-pre-tool".into(),
         crate::runtime_control::HookLifecycle::PreToolUse,
-        "plugin hook".into(),
         Box::new(|_| {}),
     );
     app.hook_runtime = Some(runtime);

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2332,8 +2332,6 @@ async fn deepseek_provider_family_prompts_for_api_key_before_model_list() {
         crate::protocol_sources::MemoryControlHandler::new(bus.clone()),
     ));
 
-    let oauth_manager = crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
-        .expect("oauth manager");
     app.provider_picker_idx = provider_family_idx(ProviderFamily::DeepSeek);
 
     open_provider_family_overlay(&mut app);
@@ -3045,8 +3043,6 @@ async fn codex_provider_family_routes_to_auth_picker_without_saved_login() {
         crate::protocol_sources::MemoryControlHandler::new(bus.clone()),
     ));
 
-    let oauth_manager = crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
-        .expect("oauth manager");
     app.provider_picker_idx = 0;
 
     assert_eq!(app.selected_provider_family(), ProviderFamily::Codex);
@@ -3539,7 +3535,7 @@ async fn deepseek_model_picker_shows_dynamic_models_after_list_load() {
 #[test]
 fn mouse_wheel_with_no_overlay_routes_to_scroll_transcript() {
     let temp = tempdir().expect("tempdir");
-    let mut app = TuiApp::new(ConfigManager {
+    let app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
     })
     .expect("build tui app");


### PR DESCRIPTION
## Summary

- wire the memory consolidation config into `RaraConfig` and fix non-dead compiler warnings
- remove unused hook, classifier, OAuth, and custom terminal scaffolding that only produced dead-code warnings
- keep currently used hook and OAuth behavior intact while deleting unreferenced APIs and tests

## Purpose

This reduces the compile warning surface without adding broad `allow(dead_code)` suppressions. The cleanup removes code paths that were not wired into production behavior, including background task classifier scaffolding, unused hook runtime helpers, and stale custom terminal helpers.

## Related Issues

None.

## Testing

- `cargo fmt`
- `cargo check --workspace --all-targets`
- `git diff --check`
