### PR TITLE
chore: clean up unused warning leftovers

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -37,6 +37,29 @@ Active backlog only. Keep this file small and current.
 - [x] Subagent token_budget field (PR #601)
 - [ ] Subagent restart/reconnect — built-in capability, not a separate tool
 - [x] Subagent context budget design — token_budget on AgentDefinition
+- [ ] Unify `.claude/agents` parsing for execution and `/status` discovery so
+      `AgentDefinition` and `ImportedAgentProfile` cannot drift.
+- [ ] Cache Claude-style agent definitions at runtime construction time and
+      expose an explicit reload path instead of scanning on each `spawn_agent`.
+- [ ] Implement remaining Claude-compatible `AgentDefinition` metadata:
+      `token_budget`, `permission_mode`, `hidden`, and description/listing
+      behavior.
+- [ ] Add an end-to-end `spawn_agent` regression test proving custom
+      `.claude/agents` definitions affect prompt body, tool filtering,
+      `maxTurns`, and `planModeRequired`.
+
+## Planning Control Plane
+
+- [ ] Replace boolean plan approval handling with an explicit decision enum:
+      approve, continue planning with feedback, and reject/cancel.
+- [ ] Persist planning lifecycle state in the structured rollout log:
+      `plan_ready`, `plan_revising`, `plan_approved`, and `plan_rejected`.
+- [ ] Restore pending plan approval after restart and avoid reinjecting an
+      approved-plan tool result more than once.
+- [ ] Expose planning lifecycle fields in `/status` and `/context`: plan path,
+      approval status, pending age, last decision, and approved plan revision.
+- [ ] Support continue-planning feedback so rejecting a plan can carry user
+      instructions back into planning mode instead of only a generic retry.
 
 ## Hooks
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -207,7 +207,6 @@ pub struct Agent {
     file_search_provider: FileSearchCandidateProvider,
     inspection_progress: InspectionProgress,
     last_query_plan_updated: bool,
-    last_turn_had_tool_calls: bool,
     recent_tool_calls: Vec<(String, String)>,
     pending_plan_exit_tool_id: Option<String>,
     prompt_config: PromptRuntimeConfig,
@@ -351,7 +350,6 @@ impl Agent {
             file_search_provider: FileSearchCandidateProvider::new(root, true),
             inspection_progress: InspectionProgress::default(),
             last_query_plan_updated: false,
-            last_turn_had_tool_calls: false,
             recent_tool_calls: Vec::new(),
             pending_plan_exit_tool_id: None,
             prompt_config: PromptRuntimeConfig::default(),
@@ -835,7 +833,6 @@ impl Agent {
             let mut turn_output = self.run_model_turn(output_mode, report).await?;
             self.record_agent_turn_trace(&turn_output, *agentic_turns, None, None, false);
             self.last_query_plan_updated = turn_output.plan_updated;
-            self.last_turn_had_tool_calls = !turn_output.tool_calls.is_empty();
             if !turn_output.tool_calls.is_empty() {
                 // Detect repeated tool calls — both within a single turn
                 // and across consecutive turns.

--- a/src/agent/compact/main.rs
+++ b/src/agent/compact/main.rs
@@ -7,10 +7,6 @@ use crate::llm::{ContextBudget, is_context_window_error};
 use crate::session::PersistedCompactionEvent;
 
 impl Agent {
-    pub async fn compact_if_needed(&mut self) -> Result<()> {
-        self.compact_if_needed_with_reporter(|_| {}).await
-    }
-
     pub async fn compact_if_needed_with_reporter<F>(&mut self, mut report: F) -> Result<()>
     where
         F: FnMut(AgentEvent) + Send,

--- a/src/agent/control_handler.rs
+++ b/src/agent/control_handler.rs
@@ -2,8 +2,8 @@ use std::sync::atomic::Ordering;
 
 use anyhow::{Result, anyhow};
 
-use crate::agent::{Agent, AgentEvent, AgentExecutionMode, AgentOutputMode, BashApprovalDecision};
-use crate::runtime_control::{InputControlRequest, SessionControlRequest, ShellApprovalDecision};
+use crate::agent::{Agent, AgentEvent, AgentOutputMode, BashApprovalDecision};
+use crate::runtime_control::{InputControlRequest, SessionControlRequest};
 
 impl Agent {
     /// Handle a session control request.
@@ -49,23 +49,12 @@ impl Agent {
                     .await?;
             }
             InputControlRequest::AnswerPlanApproval { approved } => {
-                if *approved {
-                    self.set_execution_mode(AgentExecutionMode::Execute);
-                    self.query_with_mode_and_events(
-                        "Plan approved. Proceed with implementation.".to_string(),
-                        AgentOutputMode::Silent,
-                        report,
-                    )
-                    .await?;
-                } else {
-                    self.query_with_mode_and_events(
-                        "Plan rejected. Please revise the plan or suggest an alternative."
-                            .to_string(),
-                        AgentOutputMode::Silent,
-                        report,
-                    )
-                    .await?;
-                }
+                self.resume_after_plan_approval_with_events(
+                    !*approved,
+                    AgentOutputMode::Silent,
+                    report,
+                )
+                .await?;
             }
             InputControlRequest::AnswerShellApproval { decision } => {
                 let decision = BashApprovalDecision::from(*decision);

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -142,10 +142,6 @@ impl Agent {
         self.last_query_plan_updated
     }
 
-    pub fn last_turn_had_tool_calls(&self) -> bool {
-        self.last_turn_had_tool_calls
-    }
-
     pub fn has_pending_plan_exit_approval(&self) -> bool {
         self.pending_plan_exit_tool_id.is_some()
     }

--- a/src/agent/tests/support.rs
+++ b/src/agent/tests/support.rs
@@ -2,9 +2,8 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use async_trait::async_trait;
-use rara_memory::vectordb::VectorDB;
 use rara_tool_macros::tool_spec;
-use rara_tools::tool::{Tool, ToolError, ToolManager};
+use rara_tools::tool::{Tool, ToolError};
 use serde_json::{Value, json};
 use tempfile::tempdir;
 
@@ -38,34 +37,6 @@ impl Tool for StubTool {
 impl Tool for StubBashTool {
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
         Ok(json!({ "stdout": "ok\n", "stderr": "", "exit_code": 0 }))
-    }
-}
-
-pub(super) struct ListFilesStub;
-
-#[tool_spec(
-    name = "list_files",
-    description = "Return a simple list result",
-    input_schema = { "type": "object" }
-)]
-#[async_trait]
-impl Tool for ListFilesStub {
-    async fn call(&self, _input: Value) -> Result<Value, ToolError> {
-        Ok(json!({ "path": ".", "entries": [] }))
-    }
-}
-
-pub(super) struct PlanAgentStub;
-
-#[tool_spec(
-    name = "plan_agent",
-    description = "Return a delegated planning result",
-    input_schema = { "type": "object" }
-)]
-#[async_trait]
-impl Tool for PlanAgentStub {
-    async fn call(&self, _input: Value) -> Result<Value, ToolError> {
-        Ok(json!({ "status": "ok", "summary": "delegated inspection complete" }))
     }
 }
 
@@ -141,14 +112,4 @@ impl LlmBackend for SequencedBackend {
     async fn summarize(&self, _messages: &[Message], _instruction: &str) -> Result<String> {
         Ok("summary".to_string())
     }
-}
-
-pub(super) fn empty_agent(backend: Arc<dyn LlmBackend>) -> crate::agent::Agent {
-    crate::agent::Agent::new(
-        ToolManager::new(),
-        backend,
-        Arc::new(VectorDB::new("data/lancedb")),
-        Arc::new(SessionManager::new().expect("session manager")),
-        Arc::new(WorkspaceMemory::new().expect("workspace memory")),
-    )
 }

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -168,6 +168,7 @@ impl AgentRegistry {
         if lines.is_empty() {
             lines.push("  (none)".to_string());
         }
+        lines.sort();
         lines
     }
 }

--- a/src/mcp_connection_manager.rs
+++ b/src/mcp_connection_manager.rs
@@ -18,7 +18,6 @@ use tokio::sync::RwLock;
 
 use crate::config::{McpRegistry, SourcedMcpServerConfig};
 use crate::mcp_status::McpConnectionState;
-use crate::mcp_tool_cache::McpToolCache;
 use crate::runtime_control::{McpControlRequest, McpEvent, RuntimeEvent};
 use crate::runtime_event_bus::RuntimeEventBus;
 
@@ -52,21 +51,15 @@ pub struct McpConnectionManager {
     registry: Arc<McpRegistry>,
     event_bus: Arc<RuntimeEventBus>,
     entries: RwLock<Vec<(String, McpServerEntry)>>,
-    tool_cache: McpToolCache,
 }
 
 impl McpConnectionManager {
     /// Create a new manager from the current MCP registry and event bus.
-    pub fn new(
-        registry: Arc<McpRegistry>,
-        event_bus: Arc<RuntimeEventBus>,
-        tool_cache: McpToolCache,
-    ) -> Self {
+    pub fn new(registry: Arc<McpRegistry>, event_bus: Arc<RuntimeEventBus>) -> Self {
         Self {
             registry,
             event_bus,
             entries: RwLock::new(Vec::new()),
-            tool_cache,
         }
     }
 

--- a/src/mcp_tool_cache.rs
+++ b/src/mcp_tool_cache.rs
@@ -10,7 +10,6 @@ use std::sync::{Arc, Mutex};
 
 use rara_mcp_client::McpToolRecord;
 
-use crate::config::McpRegistry;
 use crate::config::McpServerTransport;
 
 /// In-memory cache of MCP tool records, keyed by server name.
@@ -70,43 +69,10 @@ impl McpToolCache {
         map.clear();
     }
 
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         let map = self.tools.lock().unwrap();
         map.is_empty()
-    }
-
-    /// Connect to all configured MCP stdio servers and populate the cache.
-    /// Call once at startup; the registry tells us which servers to connect to.
-    pub async fn populate_from_registry(&self, registry: &McpRegistry) {
-        for (name, entry) in &registry.servers {
-            // Only handle stdio transport for now.
-            let (command, args, env, cwd) = match &entry.config.transport {
-                McpServerTransport::Stdio {
-                    command,
-                    args,
-                    env,
-                    cwd,
-                } => {
-                    let cmd = std::ffi::OsString::from(command);
-                    let argv: Vec<std::ffi::OsString> = args.iter().map(|a| a.into()).collect();
-                    let env_map: HashMap<String, String> = env
-                        .clone()
-                        .map(|m| m.into_iter().collect())
-                        .unwrap_or_default();
-                    (cmd, argv, env_map, cwd.clone())
-                }
-                _ => continue, // skip HTTP MCP servers for now
-            };
-
-            match rara_mcp_client::list_stdio_tools(command, args, env, cwd).await {
-                Ok(tools) => {
-                    self.insert_server_tools(name.clone(), tools);
-                }
-                Err(e) => {
-                    eprintln!("[mcp-tool-cache] Failed to list tools from {name}: {e}");
-                }
-            }
-        }
     }
 
     /// For testing: shared Arc clone.

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -197,7 +197,6 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     let mcp_manager = Arc::new(McpConnectionManager::new(
         mcp_registry.clone(),
         event_bus.clone(),
-        mcp_tool_cache.clone(),
     ));
 
     // Discover file-based hooks and inject into prompt config

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -57,22 +57,6 @@ pub(super) fn agent_tool_to_internal_name(name: &str) -> &str {
     }
 }
 
-/// Reverse mapping from RARA internal tool name to Claude Code config name.
-pub(super) fn agent_tool_to_config_name(name: &str) -> &str {
-    match name {
-        "bash" => "Bash",
-        "read_file" => "Read",
-        "write_file" => "Write",
-        "apply_patch" => "Edit",
-        "glob" => "Glob",
-        "grep" => "Grep",
-        "web_search" => "WebSearch",
-        "web_fetch" => "WebFetch",
-        "spawn_agent" => "Task",
-        n => n,
-    }
-}
-
 // Agent definition matching Claude Code .claude/agents/*.md format.
 include!("agent_def.rs");
 
@@ -86,7 +70,15 @@ pub struct SubagentProgress {
     pub total_cache_hit_tokens: usize,
     pub total_cache_miss_tokens: usize,
     pub activity: Vec<String>,
+    /// Reserved for background subagent UI state.
+    /// Will be activated with queued background subagent messages
+    /// (docs/features/subagent-and-aux-compression.md).
+    #[allow(dead_code)]
     pub is_backgrounded: bool,
+    /// Reserved for background subagent progress labels.
+    /// Will be activated with queued background subagent messages
+    /// (docs/features/subagent-and-aux-compression.md).
+    #[allow(dead_code)]
     pub subagent_name: String,
 }
 
@@ -105,6 +97,10 @@ impl SubagentProgress {
         }
     }
 
+    /// Reserved for per-tool subagent activity summaries.
+    /// Will be activated with subagent progress tracking
+    /// (docs/features/subagent-and-aux-compression.md).
+    #[allow(dead_code)]
     pub fn record_activity(&mut self, desc: impl Into<String>) {
         let s = desc.into();
         self.activity.push(s);
@@ -327,15 +323,16 @@ impl AgentTool {
         let name = i["name"]
             .as_str()
             .ok_or(ToolError::InvalidInput("name".into()))?;
-        if validate_agent_id_label(name).is_none() {
+        let Some(agent_label) = validate_agent_id_label(name) else {
             return Err(ToolError::InvalidInput(
                 "name must normalize to a non-empty agent id label".into(),
             ));
-        }
+        };
         let instruction = i["instruction"]
             .as_str()
             .ok_or(ToolError::InvalidInput("instruction".into()))?;
         let agent_id = next_subagent_id(SubAgentKind::General, Some(name));
+        let definition = resolve_spawn_agent_definition(&self.workspace.root, &agent_label);
         if i.get("run_in_background")
             .and_then(Value::as_bool)
             .unwrap_or(false)
@@ -344,7 +341,7 @@ impl AgentTool {
                 kind: SubAgentKind::General,
                 agent_id,
                 name: Some(name.to_string()),
-                definition: resolve_spawn_agent_definition(name),
+                definition,
                 parent_session_id: parent_session_id.map(str::to_string),
                 instruction: instruction.to_string(),
                 backend: self.backend.clone(),
@@ -359,7 +356,7 @@ impl AgentTool {
         let result = run_sub_agent(
             SubAgentKind::General,
             &agent_id,
-            None,
+            Some(&definition),
             Some(name),
             parent_session_id,
             instruction,
@@ -1134,7 +1131,14 @@ pub(crate) async fn run_sub_agent(
     } else {
         kind.execution_mode()
     });
-    sub.set_prompt_config(append_subagent_prompt(prompt_config, kind.append_prompt()));
+    let appended_prompt = match definition
+        .map(|d| d.system_prompt.trim())
+        .filter(|prompt| !prompt.is_empty())
+    {
+        Some(system_prompt) => format!("{}\n\n{}", kind.append_prompt(), system_prompt),
+        None => kind.append_prompt().to_string(),
+    };
+    sub.set_prompt_config(append_subagent_prompt(prompt_config, &appended_prompt));
 
     let def_max_turns = definition
         .and_then(|d| {
@@ -1515,8 +1519,14 @@ fn resolve_kind_definition(kind: SubAgentKind) -> AgentDefinition {
     })
 }
 
-fn resolve_spawn_agent_definition(name: &str) -> AgentDefinition {
-    builtin_agent_definition(name).unwrap_or(AgentDefinition {
+fn resolve_spawn_agent_definition(workspace_root: &Path, normalized_name: &str) -> AgentDefinition {
+    let registry = load_agent_definitions(workspace_root);
+    resolve_agent(normalized_name, &registry)
+        .unwrap_or_else(|| fallback_spawn_agent_definition(normalized_name))
+}
+
+fn fallback_spawn_agent_definition(name: &str) -> AgentDefinition {
+    AgentDefinition {
         token_budget: None,
         name: name.to_string(),
         description: name.to_string(),
@@ -1528,7 +1538,7 @@ fn resolve_spawn_agent_definition(name: &str) -> AgentDefinition {
         permission_mode: None,
         hidden: false,
         system_prompt: String::new(),
-    })
+    }
 }
 
 fn build_filtered_tool_manager(kind: SubAgentKind, definition: &AgentDefinition) -> ToolManager {

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -4,6 +4,9 @@ pub struct AgentDefinition {
     /// Canonical name (also the file stem).
     pub name: String,
     /// Short description for /agents listing.
+    /// Reserved for the future /agents listing surface
+    /// (docs/features/subagent-claude-compat.md).
+    #[allow(dead_code)]
     pub description: String,
     /// Allowed tools (Claude Code display names). Empty = all tools.
     #[serde(default)]
@@ -18,15 +21,26 @@ pub struct AgentDefinition {
     /// Max tool-calling turns. 0 = system default.
     #[serde(default)]
     pub max_turns: usize,
+    /// Reserved for per-agent context budgets.
+    /// Will be activated with subagent budget enforcement
+    /// (docs/features/subagent-claude-compat.md).
+    #[allow(dead_code)]
     pub token_budget: Option<i64>,
     /// Permission mode (e.g. "acceptEdits", "default").
+    /// Reserved for per-agent permission overrides.
+    /// Will be activated with subagent permission-mode resolution
+    /// (docs/features/subagent-claude-compat.md).
     #[serde(default)]
+    #[allow(dead_code)]
     pub permission_mode: Option<String>,
     /// Whether plan approval is required before action.
     #[serde(default)]
     pub plan_mode_required: bool,
     /// Hidden from /agents listing (Claude Code compat).
+    /// Reserved for the future /agents listing surface
+    /// (docs/features/subagent-claude-compat.md).
     #[serde(default)]
+    #[allow(dead_code)]
     pub hidden: bool,
     /// System prompt — body after frontmatter `---`.
     #[serde(default, skip_deserializing)]
@@ -189,4 +203,3 @@ fn builtin_agent_definition(name: &str) -> Option<AgentDefinition> {
         _ => None,
     }
 }
-

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -18,7 +18,7 @@ use super::{
     BackgroundSubAgentStore, SubAgentKind, SubagentProgress, TEAM_CREATE_CONCURRENCY_LIMIT,
     append_subagent_prompt, build_filtered_tool_manager, build_read_only_tool_manager,
     build_subagent_tool_manager, latest_assistant_text_from_history, parse_team_task_kind,
-    resolve_kind_definition, resolve_spawn_agent_definition,
+    resolve_kind_definition, resolve_spawn_agent_definition, validate_agent_id_label,
 };
 use crate::agent::Message;
 use crate::llm::{ContentBlock, EmbeddingBackend, LlmBackend, LlmResponse, MockLlm};
@@ -1229,15 +1229,75 @@ fn resolve_kind_definition_explore_no_plan_mode() {
 
 #[test]
 fn resolve_spawn_agent_definition_resolves_builtin() {
-    let def = resolve_spawn_agent_definition("Explore");
-    assert_eq!(def.name, "Explore");
+    let temp = tempdir().expect("tempdir");
+    let def = resolve_spawn_agent_definition(temp.path(), "explore");
+    assert_eq!(def.name, "explore");
 }
 
 #[test]
 fn resolve_spawn_agent_definition_falls_back_for_unknown() {
-    let def = resolve_spawn_agent_definition("unknown-agent");
+    let temp = tempdir().expect("tempdir");
+    let def = resolve_spawn_agent_definition(temp.path(), "unknown-agent");
     assert_eq!(def.name, "unknown-agent");
     assert!(!def.plan_mode_required);
+}
+
+#[test]
+fn resolve_spawn_agent_definition_loads_workspace_agent() {
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("agents dir");
+    std::fs::write(
+        agents_dir.join("code-reviewer.md"),
+        r#"---
+name: code-reviewer
+description: Reviews code changes
+tools: [Read, Grep]
+disallowedTools: [Bash]
+maxTurns: 7
+planModeRequired: true
+---
+
+Review the assigned change and report concrete findings.
+"#,
+    )
+    .expect("agent definition");
+
+    let def = resolve_spawn_agent_definition(temp.path(), "code-reviewer");
+
+    assert_eq!(def.name, "code-reviewer");
+    assert_eq!(def.description, "Reviews code changes");
+    assert_eq!(def.tools, vec!["Read", "Grep"]);
+    assert_eq!(def.disallowed_tools, vec!["Bash"]);
+    assert_eq!(def.max_turns, 7);
+    assert!(def.plan_mode_required);
+    assert!(def.system_prompt.contains("Review the assigned change"));
+}
+
+#[test]
+fn spawn_agent_definition_lookup_uses_normalized_label() {
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("agents dir");
+    std::fs::write(
+        agents_dir.join("code-reviewer.md"),
+        r#"---
+name: code-reviewer
+description: Reviews code changes
+tools: [Read]
+---
+
+Review the assigned change.
+"#,
+    )
+    .expect("agent definition");
+
+    let label = validate_agent_id_label("Code Reviewer").expect("label");
+    let def = resolve_spawn_agent_definition(temp.path(), &label);
+
+    assert_eq!(label, "code-reviewer");
+    assert_eq!(def.name, "code-reviewer");
+    assert_eq!(def.tools, vec!["Read"]);
 }
 
 #[test]

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -925,24 +925,6 @@ async fn read_output_tail(path: &Path, max_bytes: usize) -> Result<String, ToolE
     Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
-fn parse_pty_dimension(value: Option<&Value>, default: u16, name: &str) -> Result<u16, ToolError> {
-    let Some(value) = value else {
-        return Ok(default);
-    };
-    let Some(value) = value.as_u64() else {
-        return Err(ToolError::InvalidInput(format!(
-            "{name} must be an integer"
-        )));
-    };
-    if value == 0 || value > u16::MAX as u64 {
-        return Err(ToolError::InvalidInput(format!(
-            "{name} must be between 1 and {}",
-            u16::MAX
-        )));
-    }
-    Ok(value as u16)
-}
-
 #[cfg(test)]
 mod tests {
     use tempfile::tempdir;
@@ -961,15 +943,6 @@ mod tests {
         let output = read_output_tail(&path, 4).await.expect("tail");
 
         assert_eq!(output, "tail");
-    }
-
-    #[test]
-    fn parse_pty_dimension_rejects_overflowing_values() {
-        let value = json!(u16::MAX as u64 + 1);
-
-        let err = parse_pty_dimension(Some(&value), 24, "rows").expect_err("overflow rejected");
-
-        assert!(matches!(err, ToolError::InvalidInput(_)));
     }
 
     #[test]

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -117,6 +117,7 @@ impl Tool for SkillTool {
     }
 }
 
+#[tokio::test]
 async fn list_returns_scopes_and_skills() {
     let mut manager = SkillManager::new();
     manager.load_warnings = vec!["test warning".into()];

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -255,7 +255,6 @@ fn rebuild_success(
         mcp_manager: Arc::new(crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         )),
         prompt_source_registry: Arc::new(crate::protocol_sources::PromptSourceRegistry::new(
             bus.clone(),
@@ -397,7 +396,6 @@ fn browser_oauth_is_rejected_before_task_start_in_ssh() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -564,7 +562,6 @@ async fn queued_follow_ups_start_as_one_multiline_turn() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -630,7 +627,6 @@ async fn queued_follow_up_starts_after_query_failure() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -676,7 +672,6 @@ async fn queued_follow_up_starts_after_query_cancellation() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -728,7 +723,6 @@ async fn plan_turn_completion_keeps_plan_mode_after_plain_answer() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -807,7 +801,6 @@ async fn agent_driven_plan_mode_auto_approves_and_resumes_execution() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -892,7 +885,6 @@ async fn exit_plan_mode_stops_for_plan_approval() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -963,7 +955,6 @@ async fn query_heartbeat_preserves_running_tool_phase() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1019,7 +1010,6 @@ async fn query_cancellation_sets_running_task_token() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1672,7 +1672,6 @@ impl TuiApp {
             context_observability: runtime_context.observability,
             assembly_entries: runtime_context.assembly.entries,
             // ── Extensions ──────────────────────────────────────
-            // ── Extensions ──────────────────────────────────────
             extension_skill_count: agent.prompt_config().available_skills.len(),
             extension_skill_scopes: {
                 let mut scopes: Vec<String> = agent
@@ -1688,6 +1687,7 @@ impl TuiApp {
             },
             extension_hook_count: ext_counts.0.max(runtime_hook_count),
             extension_agent_count: ext_counts.1,
+            extension_agent_status_lines: ext_counts.2,
         };
         self.agent_execution_mode = agent.execution_mode;
         self.bash_approval_mode = agent.bash_approval_mode;
@@ -2070,13 +2070,19 @@ impl TuiApp {
     }
 }
 
-fn discover_extension_counts(cwd: &str) -> (usize, usize) {
+fn discover_extension_counts(cwd: &str) -> (usize, usize, Vec<String>) {
     let root = std::path::Path::new(cwd);
     let mut hr = crate::hooks::HookRegistry::new();
     let mut ar = crate::agents_ext::AgentRegistry::new();
     hr.discover_repo_hooks(root);
     ar.discover_repo_agents(root);
-    (hr.hooks.len(), ar.agents.len())
+    let agent_count = ar.agents.len();
+    let agent_status_lines = if agent_count == 0 {
+        Vec::new()
+    } else {
+        ar.status_lines()
+    };
+    (hr.hooks.len(), agent_count, agent_status_lines)
 }
 
 mod helpers;

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -281,6 +281,7 @@ pub struct RuntimeSnapshot {
     pub extension_skill_scopes: Vec<String>,
     pub extension_hook_count: usize,
     pub extension_agent_count: usize,
+    pub extension_agent_status_lines: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -114,6 +114,12 @@ fn render_overview_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
         &snap.extension_agent_count.to_string(),
         Color::DarkGray,
     );
+    for line in &snap.extension_agent_status_lines {
+        lines.push(Line::from(Span::styled(
+            line.clone(),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
 }
 
 fn render_config_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
@@ -415,7 +421,7 @@ mod tests {
 
     use super::render_status_lines;
     use crate::config::ConfigManager;
-    use crate::tui::state::{StatusTab, TuiApp};
+    use crate::tui::state::{RuntimeSnapshot, StatusTab, TuiApp};
 
     #[test]
     fn overview_status_reports_local_embedding_component() {
@@ -434,5 +440,31 @@ mod tests {
         assert!(rendered.contains("Local Embeddings"));
         assert!(rendered.contains("setup_required"));
         assert!(rendered.contains("embedding"));
+    }
+
+    #[test]
+    fn overview_status_reports_agent_extension_details() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.snapshot = RuntimeSnapshot {
+            extension_agent_count: 1,
+            extension_agent_status_lines: vec![
+                "  code-reviewer  .claude/agents/code-reviewer.md  ok  (disabled)".to_string(),
+            ],
+            ..RuntimeSnapshot::default()
+        };
+
+        let rendered = render_status_lines(&app, StatusTab::Overview)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("agents"));
+        assert!(rendered.contains("code-reviewer"));
+        assert!(rendered.contains(".claude/agents/code-reviewer.md"));
     }
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -74,7 +74,6 @@ async fn busy_submit_queues_follow_up_message() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -149,7 +148,6 @@ fn status_overlay_shortcuts_switch_tabs() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -200,7 +198,6 @@ fn context_overlay_scroll_keybindings() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -260,7 +257,6 @@ fn context_scroll_direction_is_top_down() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -321,7 +317,6 @@ async fn pending_plan_approval_blocks_plain_submit() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -373,7 +368,6 @@ async fn submit_numeric_input_handles_pending_shell_approval() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -425,7 +419,6 @@ async fn empty_submit_keeps_shell_approval_on_card_surface() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -476,7 +469,6 @@ async fn plain_submit_queues_while_shell_approval_is_pending() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -528,7 +520,6 @@ async fn esc_cancels_busy_query_without_overlay() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -581,7 +572,6 @@ async fn busy_submit_allows_quit_command() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -645,7 +635,6 @@ async fn slash_palette_model_selection_opens_provider_picker_in_local_and_ssh() 
             crate::mcp_connection_manager::McpConnectionManager::new(
                 Arc::new(crate::config::McpRegistry::empty()),
                 bus.clone(),
-                crate::mcp_tool_cache::McpToolCache::new(),
             ),
         ));
         app.memory_handler = Some(Arc::new(
@@ -705,7 +694,6 @@ fn provider_picker_number_keys_cover_current_provider_families() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -745,7 +733,6 @@ fn auth_mode_picker_prefers_selection_navigation() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -878,7 +865,6 @@ fn pending_shell_approval_number_shortcuts_work_in_local_and_ssh() {
             crate::mcp_connection_manager::McpConnectionManager::new(
                 Arc::new(crate::config::McpRegistry::empty()),
                 bus.clone(),
-                crate::mcp_tool_cache::McpToolCache::new(),
             ),
         ));
         app.memory_handler = Some(Arc::new(
@@ -940,7 +926,6 @@ fn pending_shell_approval_preserves_modifier_shortcuts() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -984,7 +969,6 @@ async fn pending_shell_approval_card_selection_clamps_with_navigation() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1046,7 +1030,6 @@ fn pending_shell_approval_does_not_render_as_request_input() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1086,7 +1069,6 @@ async fn full_access_permission_picker_resumes_pending_shell_approval_in_local_a
             crate::mcp_connection_manager::McpConnectionManager::new(
                 Arc::new(crate::config::McpRegistry::empty()),
                 bus.clone(),
-                crate::mcp_tool_cache::McpToolCache::new(),
             ),
         ));
         app.memory_handler = Some(Arc::new(
@@ -1149,7 +1131,6 @@ async fn always_shell_approval_promotes_full_access_for_follow_up_commands() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1208,7 +1189,6 @@ async fn full_access_mode_resumes_stale_pending_shell_approval_from_shortcuts() 
             crate::mcp_connection_manager::McpConnectionManager::new(
                 Arc::new(crate::config::McpRegistry::empty()),
                 bus.clone(),
-                crate::mcp_tool_cache::McpToolCache::new(),
             ),
         ));
         app.memory_handler = Some(Arc::new(
@@ -1257,7 +1237,6 @@ async fn full_access_mode_does_not_resume_shell_approval_behind_active_plan_appr
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1314,7 +1293,6 @@ fn request_input_shortcuts_match_advertised_three_options() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1356,7 +1334,6 @@ fn plain_input_does_not_treat_s_as_setup_shortcut() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1393,7 +1370,6 @@ fn shift_enter_inserts_newline_in_main_composer() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1432,7 +1408,6 @@ fn arrow_keys_and_home_end_map_to_composer_cursor_events() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1489,7 +1464,6 @@ fn empty_composer_uses_up_down_for_input_history_when_available() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1530,7 +1504,6 @@ fn empty_composer_keeps_vim_keys_for_transcript_scroll() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1571,7 +1544,6 @@ fn input_history_navigation_recalls_previous_submissions_and_restores_draft() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1622,7 +1594,6 @@ fn input_history_navigation_starts_from_non_empty_draft_at_start() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1666,7 +1637,6 @@ fn input_history_keeps_recent_entries_bounded() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1710,7 +1680,6 @@ fn input_history_navigation_keeps_multiline_cursor_movement_for_unrecalled_text(
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1753,7 +1722,6 @@ fn mouse_wheel_scrolls_transcript() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1797,7 +1765,6 @@ fn mouse_wheel_with_command_palette_routes_to_move_command_selection() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1843,7 +1810,6 @@ async fn composer_supports_mid_input_insertion_and_backspace() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1911,7 +1877,6 @@ async fn paste_inserts_at_current_cursor_offset() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -1949,7 +1914,6 @@ async fn paste_normalizes_crlf_and_cr_newlines() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2070,7 +2034,6 @@ fn crossterm_paste_event_uses_paste_channel() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2105,7 +2068,6 @@ async fn composer_supports_vertical_cursor_navigation_across_lines() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2186,7 +2148,6 @@ async fn openai_model_picker_delete_row_removes_active_profile() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2261,7 +2222,6 @@ async fn openai_model_picker_space_activates_selected_profile_and_starts_setup_w
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2325,7 +2285,6 @@ async fn deepseek_provider_family_prompts_for_api_key_before_model_list() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2361,7 +2320,6 @@ async fn deepseek_api_key_save_starts_model_catalog_task() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2421,7 +2379,6 @@ async fn deepseek_model_picker_enter_without_api_key_opens_api_key_editor() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2475,7 +2432,6 @@ async fn deepseek_model_picker_api_key_action_opens_editor_even_when_key_exists(
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2531,7 +2487,6 @@ async fn openai_model_picker_edit_shortcut_starts_wizard_for_selected_profile() 
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2600,7 +2555,6 @@ async fn openai_profile_edit_wizard_keeps_existing_api_key_when_blank() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2678,7 +2632,6 @@ async fn openai_model_picker_create_shortcut_opens_endpoint_kind_picker() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2729,7 +2682,6 @@ async fn selecting_custom_endpoint_kind_prompts_for_profile_label() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2787,7 +2739,6 @@ async fn selecting_openai_profile_from_picker_switches_active_profile() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2856,7 +2807,6 @@ async fn saving_openai_profile_label_creates_new_openrouter_profile() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2937,7 +2887,6 @@ async fn save_api_key_input_allows_clearing_openai_compatible_credentials() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -2996,7 +2945,6 @@ fn codex_auth_detection_uses_saved_auth_storage() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3036,7 +2984,6 @@ async fn codex_provider_family_routes_to_auth_picker_without_saved_login() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3076,7 +3023,6 @@ async fn codex_provider_family_routes_to_model_picker_with_saved_login() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3119,7 +3065,6 @@ async fn codex_provider_family_uses_saved_codex_provider_state() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3166,7 +3111,6 @@ async fn codex_model_picker_opens_reasoning_level_overlay_before_rebuild() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3244,7 +3188,6 @@ async fn codex_model_picker_applies_single_reasoning_level_without_overlay() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3320,7 +3263,6 @@ fn codex_auth_store_is_synced_into_config_before_model_flow() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3381,7 +3323,6 @@ fn codex_chatgpt_auth_store_sets_chatgpt_base_url_before_model_flow() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3456,7 +3397,6 @@ async fn save_api_key_input_sets_codex_defaults_before_rebuild() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3609,7 +3549,6 @@ fn mouse_wheel_with_status_overlay_routes_to_noop() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(
@@ -3646,7 +3585,6 @@ fn mouse_wheel_with_context_overlay_routes_to_scroll_context() {
         crate::mcp_connection_manager::McpConnectionManager::new(
             Arc::new(crate::config::McpRegistry::empty()),
             bus.clone(),
-            crate::mcp_tool_cache::McpToolCache::new(),
         ),
     ));
     app.memory_handler = Some(Arc::new(


### PR DESCRIPTION
## Summary

- remove stale unused test helpers, MCP manager state, PTY parsing leftovers, and agent loop status fields
- wire previously unused plan-approval control handling into the structured approval resume path
- wire Claude-style `.claude/agents` definitions into `spawn_agent` execution and surface discovered agent details in `/status`
- keep intentionally reserved subagent definition metadata with item-level explanations

## Purpose

Continue reducing compiler warnings while checking whether unused code represented unfinished borrowed functionality from Claude Code, OpenCode, or Codex. Where the code was a real unfinished path, this PR wires it up instead of deleting it.

## Related issues

None.

## Testing

- `cargo fmt`
- `cargo test overview_status_reports_agent_extension_details --quiet`
- `cargo test exit_plan_mode_stops_for_plan_approval --quiet`
- `cargo test agent_driven_plan_mode_auto_approves_and_resumes_execution --quiet`
- `cargo test resolve_spawn_agent_definition_loads_workspace_agent --quiet`
- `cargo test resolve_spawn_agent_definition_resolves_builtin --quiet`
- `cargo check --workspace --all-targets`
- `git diff --check`
