### PR TITLE
chore: reduce unused warning surface

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -70,6 +70,12 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Explicit embedding controls: enable/disable, provider override (low priority)
 - [ ] `/status` context fields for model/provider/thread/retrieval/memory/workspace
+- [ ] Decide the Gemini AI Studio runtime path: either wire `provider=gemini`
+      to the native `GeminiBackend::new` API-key backend or remove that native
+      API-key path in favor of the current OpenAI-compatible endpoint.
+- [ ] Wire Codex model catalog refresh into the active TUI provider/model
+      selection flow, or remove the catalog loader and stored
+      `codex_model_options` state if Codex presets stay static.
 
 ## Long-term
 

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -30,9 +30,6 @@ use crate::runtime_control::{
 };
 use crate::runtime_event_bus::RuntimeEventBus;
 
-/// Maximum agentic turns per ACP prompt to prevent infinite loops.
-const MAX_ACP_TURNS: usize = 15;
-
 /// ACP agent state shared across request handlers.
 pub struct RaraAcpAgent {
     pub llm_backend: Arc<dyn LlmBackend>,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -29,9 +29,10 @@ use crate::hooks::HookDefinition;
 use crate::hooks::HookParseStatus;
 use crate::hooks::HookRegistry;
 use crate::hooks::{HookSandbox, run_sandboxed_hook};
+#[cfg(test)]
+use crate::llm::LlmEmbeddingBackend;
 use crate::llm::{
-    ContentBlock, EmbeddingBackend, EmbeddingInputKind, LlmBackend, LlmEmbeddingBackend,
-    LlmStreamEvent, LlmTurnMetadata,
+    ContentBlock, EmbeddingBackend, EmbeddingInputKind, LlmBackend, LlmStreamEvent, LlmTurnMetadata,
 };
 use crate::lsp_manager::LspManager;
 use crate::mcp_status::McpStatusSnapshot;
@@ -236,6 +237,7 @@ impl Agent {
         self.aux_total_cache_miss_tokens += miss;
     }
 
+    #[cfg(test)]
     pub fn new(
         tool_manager: ToolManager,
         llm_backend: Arc<dyn LlmBackend>,

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -10,6 +10,9 @@ use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 use crate::tool_result::ToolResultProjectionPolicy;
 
 impl Agent {
+    /// Reserved for the prompt-runtime compatibility API documented in
+    /// docs/features/prompt-runtime.md.
+    #[allow(dead_code)]
     pub fn assemble_context(&self) -> AssembledContext {
         self.context_assembler().assemble({
             match self.execution_mode {
@@ -103,10 +106,17 @@ impl Agent {
         policy
     }
 
+    /// Reserved for prompt-runtime callers that need only the assembled system
+    /// prompt; docs/features/prompt-runtime.md keeps this as the compatibility
+    /// boundary.
+    #[allow(dead_code)]
     pub fn build_system_prompt(&self) -> String {
         self.assemble_context().effective_prompt.text
     }
 
+    /// Reserved for prompt-runtime callers that need source/provenance details
+    /// from the effective prompt; see docs/features/prompt-runtime.md.
+    #[allow(dead_code)]
     pub fn effective_prompt(&self) -> prompt::EffectivePrompt {
         self.assemble_context().effective_prompt
     }

--- a/src/codex_model_catalog.rs
+++ b/src/codex_model_catalog.rs
@@ -24,6 +24,9 @@ pub struct CodexModelOption {
     pub is_default: bool,
 }
 
+/// Reserved for the Codex model picker refresh path; docs/todo.md tracks
+/// whether the active provider/model flow should wire this loader.
+#[allow(dead_code)]
 pub async fn load_codex_model_catalog(
     codex_home: &Path,
     refresh_strategy: RefreshStrategy,

--- a/src/context/assembler/mod.rs
+++ b/src/context/assembler/mod.rs
@@ -68,6 +68,7 @@ pub struct RuntimeInteractionInput {
 }
 
 impl AssembledContext {
+    #[cfg(test)]
     pub fn system_prompt(&self) -> &str {
         &self.effective_prompt.text
     }
@@ -89,7 +90,9 @@ impl<'a> ContextAssembler<'a> {
         }
     }
 
-    /// Set the hook lifecycle phase so only matching hooks are injected.
+    /// Reserved for per-phase file-hook injection; docs/features/file-hooks.md
+    /// tracks the follow-up beyond the current all-hooks-every-turn behavior.
+    #[allow(dead_code)]
     pub fn with_hook_phase(mut self, phase: HookLifecycle) -> Self {
         self.hook_phase = Some(phase);
         self
@@ -131,10 +134,6 @@ impl<'a> ContextAssembler<'a> {
 
     pub fn effective_prompt(&self, mode: PromptMode) -> EffectivePrompt {
         self.assemble(mode).effective_prompt
-    }
-
-    pub fn system_prompt(&self, mode: PromptMode) -> String {
-        self.assemble(mode).effective_prompt.text
     }
 
     pub fn compact_instruction(&self) -> String {

--- a/src/context/retrieval_provider.rs
+++ b/src/context/retrieval_provider.rs
@@ -103,6 +103,9 @@ impl RetrievalSourceProvider for PrecomputedSourceProvider<'_> {
     }
 }
 
+/// Reserved MCP resource adapter for protocol/MCP references; resource body
+/// loading is tracked in docs/features/mcp-runtime.md.
+#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct McpResourceReference {
     pub server_name: String,
@@ -114,6 +117,9 @@ pub(crate) struct McpResourceReference {
     pub source_path: Option<String>,
 }
 
+/// Reserved for MCP resource candidates supplied by protocol/MCP adapters; see
+/// docs/journal/2026-05-09-mcp-resource-context.md.
+#[allow(dead_code)]
 pub(crate) fn mcp_resource_candidate(
     reference: McpResourceReference,
     rank: usize,

--- a/src/context/retriever.rs
+++ b/src/context/retriever.rs
@@ -5,7 +5,9 @@ use crate::context::assembler::latest_user_request;
 use crate::context::{
     RETRIEVED_THREAD_CONTEXT_KIND, RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievedMemoryCandidate,
 };
-use crate::llm::{EmbeddingBackend, EmbeddingInputKind, LlmBackend, LlmEmbeddingBackend};
+use crate::llm::{EmbeddingBackend, EmbeddingInputKind};
+#[cfg(test)]
+use crate::llm::{LlmBackend, LlmEmbeddingBackend};
 use crate::memory_store::{MemoryRecordSearchHit, MemoryStore};
 use crate::session::SessionManager;
 use crate::session_context::SessionContextSearchHit;
@@ -21,6 +23,7 @@ pub(crate) struct MemoryRetrievalOrchestrator {
 }
 
 impl MemoryRetrievalOrchestrator {
+    #[cfg(test)]
     pub(crate) fn new(
         backend: Arc<dyn LlmBackend>,
         session_manager: Arc<SessionManager>,

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -6,10 +6,19 @@ use crate::tool_result::{ToolResultProjectionPolicy, ToolResultProjectionReport}
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheStatus {
     /// Content was served from the in-memory cache (mtime unchanged).
+    /// Reserved until WorkspaceMemory cache signals are wired into /context;
+    /// tracked in docs/journal/2026-05-01-cache-status-context.md.
+    #[allow(dead_code)]
     Hit,
     /// Content was re-read from disk (mtime changed or first read).
+    /// Reserved until WorkspaceMemory cache signals are wired into /context;
+    /// tracked in docs/journal/2026-05-01-cache-status-context.md.
+    #[allow(dead_code)]
     Miss,
     /// Cache does not apply (non-file source, e.g. append-system-prompt).
+    /// Reserved for non-file /context entries once cache status is fully wired;
+    /// tracked in docs/journal/2026-05-01-cache-status-context.md.
+    #[allow(dead_code)]
     NoCache,
 }
 

--- a/src/llm/gemini.rs
+++ b/src/llm/gemini.rs
@@ -27,6 +27,9 @@ const AI_STUDIO_ENDPOINT: &str = "https://generativelanguage.googleapis.com/v1be
 #[derive(Debug, Clone)]
 pub enum GeminiAuthMode {
     /// Google AI Studio — API key in query param or Bearer.
+    /// Reserved until docs/todo.md decides whether `provider=gemini` uses this
+    /// native API-key backend or the current OpenAI-compatible endpoint.
+    #[allow(dead_code)]
     ApiKey(String),
     /// Google Code Assist — OAuth access token.
     OAuth { oauth: GoogleOAuthManager },
@@ -42,6 +45,9 @@ pub struct GeminiBackend {
 }
 
 impl GeminiBackend {
+    /// Reserved for the native Gemini AI Studio API-key backend; docs/todo.md
+    /// tracks whether `provider=gemini` should wire this path.
+    #[allow(dead_code)]
     pub fn new(api_key: String, model: String) -> Result<Self> {
         Ok(Self {
             auth: GeminiAuthMode::ApiKey(api_key),

--- a/src/llm/gemini_schema.rs
+++ b/src/llm/gemini_schema.rs
@@ -97,6 +97,7 @@ pub fn sanitize_gemini_schema(schema: &Value) -> Value {
 ///
 /// If the input is empty or invalid, returns a minimal `{type: "object",
 /// properties: {}}` schema.
+#[cfg(test)]
 pub fn sanitize_gemini_tool_parameters(parameters: &Value) -> Value {
     let cleaned = sanitize_gemini_schema(parameters);
     if cleaned.is_null() || cleaned.as_object().is_none_or(|o| o.is_empty()) {

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -993,6 +993,7 @@ fn normalize_deepseek_reasoning_effort(
     }
 }
 
+#[cfg(test)]
 pub(super) fn to_openai_messages(messages: &[Message]) -> Vec<Value> {
     to_openai_messages_for_endpoint(messages, OpenAiEndpointKind::Custom)
 }

--- a/src/local_backend.rs
+++ b/src/local_backend.rs
@@ -47,10 +47,6 @@ struct GenerationResult {
 }
 
 impl LocalLlmBackend {
-    pub fn from_config(config: &RaraConfig) -> Result<Self> {
-        Self::from_config_with_progress(config, None)
-    }
-
     pub fn from_config_with_progress(
         config: &RaraConfig,
         progress: Option<LocalProgressReporter>,

--- a/src/local_model_server/backend.rs
+++ b/src/local_model_server/backend.rs
@@ -1,10 +1,5 @@
 
 impl LocalModelServerEmbeddingBackend {
-    pub(crate) fn new(rara_home: PathBuf) -> Result<Self> {
-        let status = prepare_local_model_server_status(&rara_home);
-        Self::from_initial_status(rara_home, status)
-    }
-
     pub(crate) fn from_initial_status(
         rara_home: PathBuf,
         status: LocalModelServerStatus,
@@ -174,10 +169,6 @@ pub(crate) fn ensure_bundled_model_server(rara_home: &Path) -> Result<BundledMod
     })
 }
 
-pub(crate) fn prepare_local_model_server_status(rara_home: &Path) -> LocalModelServerStatus {
-    prepare_local_model_server_status_with_progress(rara_home, None)
-}
-
 pub(crate) fn prepare_local_model_server_status_with_progress(
     rara_home: &Path,
     progress: Option<LocalProgressReporter>,
@@ -218,4 +209,3 @@ pub(crate) enum BootstrapMode {
     Automatic,
     InspectOnly,
 }
-

--- a/src/local_model_server/types.rs
+++ b/src/local_model_server/types.rs
@@ -50,7 +50,13 @@ pub(crate) enum LocalModelServerState {
     Ready,
     Starting,
     WaitingForServer,
+    /// Reserved for finer-grained local embedding setup progress in
+    /// docs/features/local-embedding-runtimes.md.
+    #[allow(dead_code)]
     CreatingVenv,
+    /// Reserved for finer-grained local embedding setup progress in
+    /// docs/features/local-embedding-runtimes.md.
+    #[allow(dead_code)]
     InstallingDependencies,
     PreparingModel,
     PreparedButStopped,

--- a/src/memory_records.rs
+++ b/src/memory_records.rs
@@ -17,6 +17,9 @@ impl MemoryRecord {
         }
     }
 
+    /// Reserved for automatic memory cleanup once retention enforcement is
+    /// wired; see docs/journal/2026-05-05-memory-retention.md.
+    #[allow(dead_code)]
     pub fn is_protected_from_automatic_cleanup(&self) -> bool {
         self.pinned
             || self.source == MemorySource::UserCreated
@@ -129,6 +132,9 @@ impl MemoryRecordFileStore {
             .context("join memory record get task")?
     }
 
+    /// Reserved for the durable memory pinning API; see
+    /// docs/features/memory-records.md.
+    #[allow(dead_code)]
     async fn set_pinned(&self, id: &str, pinned: bool) -> Result<MemoryRecord> {
         let path = self.path.clone();
         let lock_path = self.lock_path.clone();

--- a/src/memory_store_impl.rs
+++ b/src/memory_store_impl.rs
@@ -1,4 +1,5 @@
 impl MemoryStore {
+    #[cfg(test)]
     pub fn new(backend: Arc<dyn LlmBackend>, vdb: Arc<VectorDB>) -> Self {
         let embedding_backend: Arc<dyn EmbeddingBackend> =
             Arc::new(LlmEmbeddingBackend::new(backend.clone()));
@@ -20,7 +21,8 @@ impl MemoryStore {
         }
     }
 
-    pub fn new_with_record_path(
+    #[cfg(test)]
+    pub(crate) fn new_with_record_path(
         backend: Arc<dyn LlmBackend>,
         vdb: Arc<VectorDB>,
         record_path: PathBuf,
@@ -35,7 +37,8 @@ impl MemoryStore {
         )
     }
 
-    pub fn new_with_embedding_backend_and_record_path(
+    #[cfg(test)]
+    pub(crate) fn new_with_embedding_backend_and_record_path(
         llm_backend: Arc<dyn LlmBackend>,
         embedding_backend: Arc<dyn EmbeddingBackend>,
         vdb: Arc<VectorDB>,
@@ -174,6 +177,9 @@ impl MemoryStore {
         self.records.get(id).await
     }
 
+    /// Reserved for the memory-record pinning API documented in
+    /// docs/features/memory-records.md.
+    #[allow(dead_code)]
     pub async fn set_pinned(&self, id: &str, pinned: bool) -> Result<MemoryRecord> {
         let _timer = self.observability.start_timer(MemoryOperation::Write);
         self.records.set_pinned(id, pinned).await
@@ -234,6 +240,9 @@ impl MemoryStore {
     }
 
     /// Returns the most recent records for a scope. No embedding required.
+    /// Reserved for the memory-record listing API documented in
+    /// docs/features/memory-records.md.
+    #[allow(dead_code)]
     pub async fn list_recent(
         &self,
         scope: Option<MemoryScope>,
@@ -262,4 +271,3 @@ impl MemoryStore {
         Ok(self.records.load_map().await?.len())
     }
 }
-

--- a/src/memory_types.rs
+++ b/src/memory_types.rs
@@ -11,10 +11,15 @@ use rara_observability::{MemoryObservability, MemoryOperation, global_memory_obs
 use rara_persistence::atomic_file;
 use rara_persistence::file_lock::AdvisoryFileLock;
 
-use crate::llm::{EmbeddingBackend, EmbeddingInputKind, LlmBackend, LlmEmbeddingBackend};
+use crate::llm::{EmbeddingBackend, EmbeddingInputKind, LlmBackend};
+#[cfg(test)]
+use crate::llm::LlmEmbeddingBackend;
 
 const EXPERIENCES_TABLE: &str = "experiences";
 const DEFAULT_IMPORTANCE: f32 = 0.5;
+/// Reserved for automatic memory cleanup protection; see
+/// docs/journal/2026-05-05-memory-retention.md.
+#[allow(dead_code)]
 const HIGH_IMPORTANCE_RETENTION_THRESHOLD: f32 = 0.8;
 const MEMORY_RECORD_INDEX_PLACEHOLDER: u32 = 0;
 const MEMORY_RECORDS_FILE_VERSION: u32 = 1;
@@ -103,6 +108,9 @@ pub enum MemoryPromotionTarget {
         thread_id: String,
         source_span: Option<MemorySourceSpan>,
     },
+    /// Reserved for session-context promotion; the promotion path is tracked in
+    /// docs/journal/2026-05-09-memory-scope-promotion-rules.md.
+    #[allow(dead_code)]
     Session {
         session_id: String,
         source_span: Option<MemorySourceSpan>,


### PR DESCRIPTION
## Summary

- remove genuinely dead warning leftovers and mark test-only constructors as `#[cfg(test)]`
- add item-level reserved warnings for documented prompt/context, MCP, memory, local embedding, and provider surfaces
- record unresolved Gemini AI Studio and Codex model catalog wiring decisions in `docs/todo.md`

## Purpose

Continue reducing the unused-code warning surface without deleting unfinished capability contracts that are still documented or user-facing.

## Related Issue

None.

## Testing

- `cargo fmt`
- `git diff --check`
- `cargo check --workspace --all-targets`
- `cargo test memory_store`
- `cargo test local_model_server`
- `cargo test context::retriever`
- `cargo test llm::`
