### PR TITLE
chore: bump Codex dependencies to 0.142.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 **/*.rs.bk
 .rara/
+.idea/
 data/lancedb
 .DS_Store
 .tmp-pr-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,8 +1949,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1968,8 +1968,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -1997,8 +1997,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "anyhow",
  "clap",
@@ -2022,8 +2022,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -2031,8 +2031,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -2059,13 +2059,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 
 [[package]]
 name = "codex-config"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2109,8 +2109,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "anyhow",
  "clap",
@@ -2125,8 +2125,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2135,8 +2135,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2148,8 +2148,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2161,8 +2161,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2186,8 +2186,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "keyring",
  "tracing",
@@ -2195,8 +2195,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2229,8 +2229,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -2242,8 +2242,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -2261,8 +2261,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2295,8 +2295,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2327,8 +2327,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2365,8 +2365,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "age",
  "anyhow",
@@ -2384,8 +2384,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -2404,16 +2404,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "dirs",
  "dunce",
@@ -2424,8 +2424,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "lru 0.16.4",
  "sha1",
@@ -2434,8 +2434,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2443,8 +2443,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2456,8 +2456,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2465,8 +2465,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2475,8 +2475,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -2490,16 +2490,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "rustls 0.23.41",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 dependencies = [
  "regex-lite",
  "serde",
@@ -2508,8 +2508,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.142.4"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.4#d0fd96663e19a6cd5d6f315e3420c4d154562013"
+version = "0.142.5"
+source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
 
 [[package]]
 name = "color_quant"
@@ -6716,7 +6716,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -10246,7 +10246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -10265,7 +10265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10416,7 +10416,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10454,7 +10454,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -14734,7 +14734,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ tempfile = "3.17"
 ignore = "0.4.26"
 nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
 rmcp = { version = "2.0", features = ["client", "transport-child-process"] }
-codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.142.4" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.142.4" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.142.4" }
+codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.142.5" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.142.5" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.142.5" }
 rara-instructions = { path = "crates/instructions" }
 
 [package]


### PR DESCRIPTION
## Summary

- Bump Codex git dependencies from `rust-v0.142.4` to `rust-v0.142.5`.
- Refresh `Cargo.lock` for the Codex dependency graph.
- Add `.idea/` to `.gitignore` to avoid committing local JetBrains project metadata.

## Purpose

Keep RARA aligned with the requested Codex release while preventing local IDE metadata from showing up as untracked project changes.

## Related Issue

None.

## Testing

- `cargo fmt`
- `git diff --check`
- `cargo check --workspace --all-targets`
