### PR TITLE
chore(tui): remove stale render helpers

### DIFF
--- a/src/tui/layout_utils.rs
+++ b/src/tui/layout_utils.rs
@@ -13,8 +13,3 @@ pub(crate) fn total_visual_rows(lines: &[Line<'_>], width: u16) -> usize {
         .map(|line| line.width().max(1).div_ceil(wrap_width))
         .sum()
 }
-
-/// Sum of visual rows, clamped to at least 1.
-pub(crate) fn wrapped_line_count(lines: &[Line<'_>], width: u16) -> u16 {
-    total_visual_rows(lines, width).max(1) as u16
-}

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -277,18 +277,6 @@ pub(crate) fn startup_card_lines(app: &TuiApp, width: u16) -> Vec<Line<'static>>
     startup_card_cell(app).display_lines(width)
 }
 
-fn current_turn_exploration_summary(
-    app: &TuiApp,
-    current_turn: &[&TranscriptEntry],
-    prefer_live_label: bool,
-) -> Option<String> {
-    current_turn_exploration_summary_from_entries(
-        current_turn,
-        app.is_busy() && prefer_live_label,
-        app.runtime_phase_detail.as_deref(),
-    )
-}
-
 pub(crate) fn current_turn_exploration_summary_from_entries(
     current_turn: &[&TranscriptEntry],
     _show_live_detail: bool,
@@ -782,39 +770,6 @@ fn bulleted_markdown_message_lines(
         Span::styled("• ", Style::default().add_modifier(Modifier::DIM)),
         Span::raw("  "),
     );
-    if hidden_count > 0 {
-        lines.push(Line::from(Span::styled(
-            format!("  ... {} more line(s)", hidden_count),
-            Style::default().fg(Color::DarkGray),
-        )));
-    }
-    lines.extend(prefix_lines(
-        tail.to_vec(),
-        Span::raw("  "),
-        Span::raw("  "),
-    ));
-    lines
-}
-
-fn markdown_message_lines(
-    role: &str,
-    message: &str,
-    max_lines: usize,
-    cwd: Option<&Path>,
-) -> Vec<Line<'static>> {
-    let mut rendered = Vec::new();
-    super::markdown::append_markdown(message, None, cwd, &mut rendered);
-    let rendered_len = rendered.len();
-
-    if rendered.is_empty() {
-        return vec![Line::from(role.to_string())];
-    }
-
-    let mut lines = vec![Line::from(role.to_string())];
-    let hidden_count = truncated_line_count(rendered_len, max_lines);
-    let (head, tail) = head_tail_line_window(rendered.as_slice(), max_lines);
-    let prefixed = prefix_lines(head.to_vec(), Span::raw("  "), Span::raw("  "));
-    lines.extend(prefixed);
     if hidden_count > 0 {
         lines.push(Line::from(Span::styled(
             format!("  ... {} more line(s)", hidden_count),

--- a/src/tui/render/bottom_pane/view_builder.rs
+++ b/src/tui/render/bottom_pane/view_builder.rs
@@ -310,7 +310,3 @@ fn compact_shell_approval_detail(app: &TuiApp) -> String {
         })
         .unwrap_or_default()
 }
-
-fn pending_interaction_detail_text(app: &TuiApp, kind: ActivePendingInteractionKind) -> String {
-    super::super::super::interaction_text::pending_interaction_detail_text(app, kind)
-}

--- a/src/tui/render/cells/interaction_cells.rs
+++ b/src/tui/render/cells/interaction_cells.rs
@@ -8,9 +8,7 @@ use ratatui::{
 
 use super::tool_progress::tool_progress_lines;
 use super::{HistoryCell, InteractionCompletionKind};
-use crate::tui::interaction_text::{
-    pending_interaction_card_title, status_planning_suggestion_text,
-};
+use crate::tui::interaction_text::pending_interaction_card_title;
 use crate::tui::markdown_render::render_markdown_text_with_width;
 use crate::tui::plan_display::updated_plan_lines;
 use crate::tui::queued_input::{
@@ -18,9 +16,7 @@ use crate::tui::queued_input::{
 };
 use crate::tui::render::diff::render_patch_preview;
 use crate::tui::render::{
-    display_width, formatted_message_lines, prefixed_message_lines, rendered_markdown_lines,
-    section_label, startup_card_inner_width, truncate_for_startup_card, truncate_path_middle,
-    with_border,
+    formatted_message_lines, prefixed_message_lines, rendered_markdown_lines, section_label,
 };
 use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
 use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;
@@ -306,31 +302,6 @@ impl PendingInteractionCell {
 impl HistoryCell for PendingInteractionCell {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
         self.inner.display_lines(width)
-    }
-}
-
-pub(crate) struct PlanningSuggestionCell {
-    text: String,
-}
-
-impl PlanningSuggestionCell {
-    pub(crate) fn new(text: impl Into<String>) -> Self {
-        Self { text: text.into() }
-    }
-}
-
-impl HistoryCell for PlanningSuggestionCell {
-    fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
-        let mut lines = vec![Line::from(section_label(
-            "Planning Suggested",
-            PHASE_PLANNING,
-        ))];
-        lines.extend(
-            self.text
-                .lines()
-                .map(|line| Line::from(format!("  {line}"))),
-        );
-        lines
     }
 }
 

--- a/src/tui/render/cells/message_cell.rs
+++ b/src/tui/render/cells/message_cell.rs
@@ -18,9 +18,8 @@ use crate::tui::queued_input::{
 };
 use crate::tui::render::diff::render_patch_preview;
 use crate::tui::render::{
-    display_width, formatted_message_lines, prefixed_message_lines, prefixed_tail_message_lines,
-    rendered_markdown_lines, section_label, startup_card_inner_width, truncate_for_startup_card,
-    truncate_path_middle, with_border,
+    formatted_message_lines, prefixed_message_lines, prefixed_tail_message_lines,
+    rendered_markdown_lines, section_label,
 };
 use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
 use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;
@@ -91,65 +90,5 @@ impl HistoryCell for MessageCell<'_> {
             return prefixed_tail_message_lines(self.role, self.message, self.max_lines);
         }
         formatted_message_lines(self.role, self.message, self.max_lines, self.cwd)
-    }
-}
-
-pub(crate) struct StartupCardCell {
-    model_label: String,
-    directory: String,
-}
-
-impl StartupCardCell {
-    pub(crate) fn new(model_label: String, directory: String) -> Self {
-        Self {
-            model_label,
-            directory,
-        }
-    }
-}
-
-impl HistoryCell for StartupCardCell {
-    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
-        let Some(inner_width) = startup_card_inner_width(width) else {
-            return Vec::new();
-        };
-
-        let model_label = "model:";
-        let directory_label = "directory:";
-        let label_width = directory_label.len();
-        let model_prefix = format!("{model_label:<label_width$} ");
-        let hint = "/model to change";
-        let hint_width = display_width(hint);
-        let model_prefix_width = display_width(&model_prefix);
-        let model_available_width = inner_width
-            .saturating_sub(model_prefix_width)
-            .saturating_sub(1)
-            .saturating_sub(hint_width);
-        let model_value = truncate_for_startup_card(&self.model_label, model_available_width);
-        let model_value_width = display_width(&model_value);
-        let gap_width = inner_width
-            .saturating_sub(model_prefix_width)
-            .saturating_sub(model_value_width)
-            .saturating_sub(hint_width)
-            .max(1);
-        let directory_prefix = format!("{directory_label:<label_width$} ");
-        let directory_max_width = inner_width.saturating_sub(display_width(&directory_prefix));
-
-        let lines = vec![
-            Line::from(vec![Span::from(">_ "), Span::from("RARA")]),
-            Line::from(""),
-            Line::from(vec![
-                Span::from(model_prefix),
-                Span::from(model_value),
-                Span::from(" ".repeat(gap_width)),
-                Span::from(hint),
-            ]),
-            Line::from(vec![
-                Span::from(directory_prefix),
-                Span::from(truncate_path_middle(&self.directory, directory_max_width)),
-            ]),
-        ];
-
-        with_border(lines, inner_width)
     }
 }

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -30,14 +30,9 @@ pub(crate) use self::responding_cell::RespondingCell;
 pub(crate) use self::summary_cells::{ExploringCell, PlanningCell, RunningCell};
 pub(crate) use self::thinking_cells::ThinkingBlockCell;
 pub(crate) use self::user_startup::{StartupCardCell, UserCell};
-use super::wrapped_history_line_count;
 
 pub(crate) trait HistoryCell {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>>;
-
-    fn desired_height(&self, width: u16) -> u16 {
-        wrapped_history_line_count(self.display_lines(width).as_slice(), width)
-    }
 }
 
 pub(crate) trait ActiveCell {

--- a/src/tui/render/cells/plan_cells.rs
+++ b/src/tui/render/cells/plan_cells.rs
@@ -20,7 +20,6 @@ use crate::tui::render::diff::render_patch_preview;
 use crate::tui::render::{
     display_width, formatted_message_lines, prefixed_message_lines, rendered_markdown_lines,
     section_label, startup_card_inner_width, truncate_for_startup_card, truncate_path_middle,
-    with_border,
 };
 use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
 use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;

--- a/src/tui/render/cells/responding_cell.rs
+++ b/src/tui/render/cells/responding_cell.rs
@@ -18,9 +18,8 @@ use crate::tui::queued_input::{
 };
 use crate::tui::render::diff::render_patch_preview;
 use crate::tui::render::{
-    display_width, formatted_message_lines, prefixed_message_lines, rendered_markdown_lines,
-    section_label, startup_card_inner_width, truncate_for_startup_card, truncate_path_middle,
-    with_border,
+    formatted_message_lines, prefixed_message_lines, rendered_markdown_lines,
+    startup_card_inner_width, truncate_for_startup_card, truncate_path_middle,
 };
 use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
 use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;
@@ -264,31 +263,5 @@ fn compact_markdown_message_lines(
         )));
     }
 
-    lines
-}
-
-fn responding_card_lines(
-    title: &'static str,
-    mut body_lines: Vec<Line<'static>>,
-    width: u16,
-) -> Vec<Line<'static>> {
-    if body_lines.is_empty() {
-        body_lines.push(Line::from(String::new()));
-    }
-
-    let available_inner_width = usize::from(width.saturating_sub(4).max(1));
-    let inner_width = body_lines
-        .iter()
-        .map(|line| {
-            line.iter()
-                .map(|span| display_width(span.content.as_ref()))
-                .sum::<usize>()
-        })
-        .max()
-        .unwrap_or(1)
-        .clamp(1, available_inner_width.max(1));
-
-    let mut lines = vec![Line::from(section_label(title, PHASE_PLANNING))];
-    lines.extend(with_border(body_lines, inner_width));
     lines
 }

--- a/src/tui/render/cells/summary_cells.rs
+++ b/src/tui/render/cells/summary_cells.rs
@@ -20,7 +20,6 @@ use crate::tui::render::diff::render_patch_preview;
 use crate::tui::render::{
     display_width, formatted_message_lines, prefixed_message_lines, rendered_markdown_lines,
     section_label, startup_card_inner_width, truncate_for_startup_card, truncate_path_middle,
-    with_border,
 };
 use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
 use crate::tui::sub_agent_display::SUB_AGENT_QUESTION_COLOR;

--- a/src/tui/render/helpers.rs
+++ b/src/tui/render/helpers.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     style::{Color, Modifier, Style},
-    text::{Line, Span},
+    text::Span,
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -72,31 +72,6 @@ pub(crate) fn startup_card_inner_width(width: u16) -> Option<usize> {
     Some(std::cmp::min(width.saturating_sub(4) as usize, 56))
 }
 
-/// Lightweight container — adds a thin top rule above content instead of a heavy border box.
-pub(crate) fn with_border(lines: Vec<Line<'static>>, inner_width: usize) -> Vec<Line<'static>> {
-    let mut out = Vec::with_capacity(lines.len() + 2);
-    let top_rule = format!("──{}", "─".repeat(inner_width.saturating_sub(2)));
-    out.push(Line::from(Span::styled(
-        top_rule,
-        Style::default().fg(TEXT_MUTED),
-    )));
-
-    for line in lines {
-        let used_width = line
-            .iter()
-            .map(|span| display_width(span.content.as_ref()))
-            .sum::<usize>();
-        let mut spans = Vec::with_capacity(line.spans.len() + 3);
-        spans.push(Span::from("  "));
-        spans.extend(line);
-        if used_width < inner_width {
-            spans.push(Span::from(" ".repeat(inner_width - used_width)));
-        }
-        out.push(Line::from(spans));
-    }
-    out
-}
-
 pub(crate) fn badge<'a>(label: &'a str, value: &'a str, color: Color) -> Span<'a> {
     let fg = match color {
         Color::Black
@@ -119,8 +94,4 @@ pub(crate) fn badge<'a>(label: &'a str, value: &'a str, color: Color) -> Span<'a
 /// Lightweight section label — colored foreground, no heavy background badge.
 pub(crate) fn section_label(title: &str, color: Color) -> Span<'static> {
     Span::styled(format!("# {title}"), Style::default().fg(color))
-}
-
-pub(crate) fn wrapped_history_line_count(lines: &[Line<'static>], width: u16) -> u16 {
-    crate::tui::layout_utils::wrapped_line_count(lines, width)
 }

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -339,6 +339,7 @@ fn command_palette_item(spec: &CommandSpec) -> ListItem<'static> {
     ]))
 }
 
+#[cfg(test)]
 fn command_palette_line(spec: &CommandSpec) -> Line<'static> {
     let name_span = Span::styled(
         format!("{:<11}", spec.usage),

--- a/src/tui/render/viewport.rs
+++ b/src/tui/render/viewport.rs
@@ -77,11 +77,6 @@ impl TranscriptViewport {
         }
     }
 
-    pub(crate) fn update_lines(&mut self, lines: Vec<Line<'static>>, width: u16) {
-        self.layout = LineLayout::compute(&lines, usize::from(width));
-        self.lines = lines;
-    }
-
     /// O(log n) scroll window using pre-computed row boundaries.
     pub(crate) fn visible_window(&self, _width: u16, height: u16) -> (Vec<Line<'static>>, u16) {
         if self.lines.is_empty() || height == 0 {


### PR DESCRIPTION
## Summary

- Remove stale TUI render helper functions left behind by the cell split.
- Delete duplicate unused `StartupCardCell` and `PlanningSuggestionCell` definitions.
- Scope the command palette line helper to tests only.

## Motivation

This continues the warning cleanup after #617 by trimming render-only dead code that has no active call sites or documented activation plan.

## Related Issues

None.

## Testing

- `cargo fmt`
- `cargo test tui::render::tests -- --nocapture`
- `cargo check --workspace --all-targets`
- `git diff --check`
