### PR TITLE
chore(tui): trim unused theme tokens

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,6 +21,11 @@ Active backlog only. Keep this file small and current.
 ## TUI / UX
 
 - [ ] Refactor ~7 large methods out of `impl TuiApp` to enable file split.
+- [ ] Introduce an opencode-style configurable TUI theme token schema instead
+      of static unused palette constants. Wire markdown, diff, syntax
+      highlighting, picker, and overlay renderers through semantic theme tokens;
+      for syntax highlighting, define how the app theme maps to or selects the
+      active `syntect` theme.
 - [x] Sidebar Plan replaces Todo (PR #597)
 - [x] Approval dock above composer (PR #591, #594, #599)
 - [x] Mouse text selection — drag-select + clipboard copy

--- a/src/tui/markdown_render.rs
+++ b/src/tui/markdown_render.rs
@@ -15,6 +15,10 @@ use self::local_links::{
     is_local_path_like_link, render_local_link_target, should_render_link_destination,
 };
 use crate::tui::highlight::highlight_code_to_lines;
+use crate::tui::theme::{
+    MD_BLOCK_QUOTE, MD_BOLD, MD_CODE, MD_HEADING, MD_ITALIC, MD_LINK, MD_LIST_BULLET, TEXT_MUTED,
+    TEXT_SECONDARY,
+};
 
 #[derive(Default)]
 struct MarkdownStyles {
@@ -40,23 +44,23 @@ struct MarkdownStyles {
 impl MarkdownStyles {
     fn new() -> Self {
         Self {
-            h1: Style::new().bold().underlined(),
-            h2: Style::new().bold(),
-            h3: Style::new().bold().italic(),
-            h4: Style::new().italic(),
-            h5: Style::new().italic(),
-            h6: Style::new().italic(),
-            code: Style::new().cyan(),
-            emphasis: Style::new().italic(),
-            strong: Style::new().bold(),
+            h1: Style::new().fg(MD_HEADING).bold().underlined(),
+            h2: Style::new().fg(MD_HEADING).bold(),
+            h3: Style::new().fg(MD_HEADING).bold().italic(),
+            h4: Style::new().fg(MD_HEADING).italic(),
+            h5: Style::new().fg(MD_HEADING).italic(),
+            h6: Style::new().fg(MD_HEADING).italic(),
+            code: Style::new().fg(MD_CODE),
+            emphasis: Style::new().fg(MD_ITALIC).italic(),
+            strong: Style::new().fg(MD_BOLD).bold(),
             strikethrough: Style::new().crossed_out(),
-            ordered_list_marker: Style::new().light_blue(),
-            unordered_list_marker: Style::new(),
-            link: Style::new().cyan().underlined(),
-            blockquote: Style::new().green(),
-            code_block_lang_tag: Style::new().dark_gray(),
+            ordered_list_marker: Style::new().fg(MD_LIST_BULLET),
+            unordered_list_marker: Style::new().fg(MD_LIST_BULLET),
+            link: Style::new().fg(MD_LINK).underlined(),
+            blockquote: Style::new().fg(MD_BLOCK_QUOTE),
+            code_block_lang_tag: Style::new().fg(TEXT_SECONDARY),
             task_list_marker: Style::new().bold(),
-            footnote: Style::new(),
+            footnote: Style::new().fg(TEXT_MUTED),
         }
     }
 }

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -256,6 +256,60 @@ fn active_turn_cell_renders_terminal_result_as_terminal_cell() {
 }
 
 #[test]
+fn active_turn_cell_renders_latest_tool_result_diff_preview() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.active_turn = TranscriptTurn {
+        thinking_duration: None,
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Edit the file".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool".into(),
+                message: "replace src/main.rs".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool Result".into(),
+                message: [
+                    "replace src/main.rs",
+                    "replacements=1 line_delta=0",
+                    "diff:",
+                    "*** Begin Patch",
+                    "*** Update File: src/main.rs",
+                    "@@",
+                    "-old",
+                    "+new",
+                    "*** End Patch",
+                ]
+                .join("\n"),
+                payload: None,
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Tool Result"));
+    assert!(rendered.contains("replace src/main.rs"));
+    assert!(rendered.contains("Edited src/main.rs"));
+    assert!(rendered.contains("- old"));
+    assert!(rendered.contains("+ new"));
+}
+
+#[test]
 fn active_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells/cells_tests/committed.rs
+++ b/src/tui/render/cells/cells_tests/committed.rs
@@ -529,6 +529,47 @@ fn committed_turn_cell_shows_tail_for_long_tool_messages() {
 }
 
 #[test]
+fn committed_turn_cell_renders_tool_result_diff_preview() {
+    let entries = vec![
+        TranscriptEntry {
+            role: "You".into(),
+            message: "Edit the file".into(),
+            payload: None,
+        },
+        TranscriptEntry {
+            role: "Tool Result".into(),
+            message: [
+                "replace src/main.rs",
+                "replacements=1 line_delta=0",
+                "diff:",
+                "*** Begin Patch",
+                "*** Update File: src/main.rs",
+                "@@",
+                "-old",
+                "+new",
+                "*** End Patch",
+            ]
+            .join("\n"),
+            payload: None,
+        },
+    ];
+
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Tool Result"));
+    assert!(rendered.contains("replace src/main.rs"));
+    assert!(rendered.contains("Edited src/main.rs"));
+    assert!(rendered.contains("- old"));
+    assert!(rendered.contains("+ new"));
+    assert!(!rendered.contains("earlier line(s)"));
+}
+
+#[test]
 fn committed_turn_cell_renders_typed_terminal_event_as_terminal_cell() {
     let entries = vec![
         TranscriptEntry {

--- a/src/tui/render/cells/message_cell.rs
+++ b/src/tui/render/cells/message_cell.rs
@@ -16,7 +16,7 @@ use crate::tui::plan_display::updated_plan_lines;
 use crate::tui::queued_input::{
     QueuedFollowUpSection, pending_follow_up_heading, queued_follow_up_heading,
 };
-use crate::tui::render::diff::render_patch_preview;
+use crate::tui::render::diff::render_message_diff_preview;
 use crate::tui::render::{
     formatted_message_lines, prefixed_message_lines, prefixed_tail_message_lines,
     rendered_markdown_lines, section_label,
@@ -73,17 +73,7 @@ impl<'a> MessageCell<'a> {
 
 impl HistoryCell for MessageCell<'_> {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
-        if self.message.contains("*** Begin Patch") {
-            let mut lines = Vec::new();
-            if !self.role.is_empty() {
-                lines.push(Line::from(vec![Span::styled(
-                    self.role.to_string(),
-                    Style::default()
-                        .fg(TEXT_SECONDARY)
-                        .add_modifier(Modifier::ITALIC),
-                )]));
-            }
-            lines.extend(render_patch_preview(self.message, width));
+        if let Some(lines) = render_message_diff_preview(Some(self.role), self.message, width) {
             return lines;
         }
         if matches!(self.window, MessageWindow::Tail) {

--- a/src/tui/render/cells/responding_cell.rs
+++ b/src/tui/render/cells/responding_cell.rs
@@ -16,7 +16,7 @@ use crate::tui::plan_display::updated_plan_lines;
 use crate::tui::queued_input::{
     QueuedFollowUpSection, pending_follow_up_heading, queued_follow_up_heading,
 };
-use crate::tui::render::diff::render_patch_preview;
+use crate::tui::render::diff::render_message_diff_preview;
 use crate::tui::render::{
     formatted_message_lines, prefixed_message_lines, rendered_markdown_lines,
     startup_card_inner_width, truncate_for_startup_card, truncate_path_middle,
@@ -154,6 +154,9 @@ impl HistoryCell for RespondingCell<'_> {
             } => {
                 if let Some(cell) = LspDiagnosticsCell::from_message(message) {
                     cell.display_lines(width)
+                } else if let Some(lines) = render_message_diff_preview(Some(role), message, width)
+                {
+                    lines
                 } else {
                     prefixed_message_lines(role, message, *max_lines)
                 }

--- a/src/tui/render/diff.rs
+++ b/src/tui/render/diff.rs
@@ -96,6 +96,92 @@ pub(crate) fn render_patch_preview(patch: &str, width: u16) -> Vec<Line<'static>
     lines
 }
 
+pub(crate) fn render_message_diff_preview(
+    role: Option<&str>,
+    message: &str,
+    width: u16,
+) -> Option<Vec<Line<'static>>> {
+    let split = split_message_diff(message)?;
+    let mut lines = Vec::new();
+
+    if let Some(role) = role.filter(|role| !role.is_empty()) {
+        lines.push(Line::from(vec![Span::styled(
+            role.to_string(),
+            Style::default()
+                .fg(TEXT_SECONDARY)
+                .add_modifier(Modifier::ITALIC),
+        )]));
+    }
+
+    for line in split.prefix_lines {
+        if line.trim().is_empty() {
+            continue;
+        }
+        lines.push(Line::from(format!("  {line}")));
+    }
+
+    if split.had_diff_label {
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                "diff:",
+                Style::default()
+                    .fg(PHASE_PLANNING)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
+
+    lines.extend(render_patch_preview(&split.patch, width));
+    Some(lines)
+}
+
+struct MessageDiff {
+    prefix_lines: Vec<String>,
+    patch: String,
+    had_diff_label: bool,
+}
+
+fn split_message_diff(message: &str) -> Option<MessageDiff> {
+    let mut prefix_lines = Vec::new();
+    let mut patch_lines = Vec::new();
+    let mut found_diff_label = false;
+
+    for line in message.lines() {
+        if !found_diff_label && line.trim_start() == "diff:" {
+            found_diff_label = true;
+            continue;
+        }
+        if found_diff_label {
+            patch_lines.push(line.trim_start().to_string());
+        } else {
+            prefix_lines.push(line.to_string());
+        }
+    }
+
+    if found_diff_label {
+        let patch = patch_lines.join("\n");
+        if patch.trim().is_empty() {
+            return None;
+        }
+        return Some(MessageDiff {
+            prefix_lines,
+            patch,
+            had_diff_label: true,
+        });
+    }
+
+    if message.contains("*** Begin Patch") {
+        return Some(MessageDiff {
+            prefix_lines: Vec::new(),
+            patch: message.to_string(),
+            had_diff_label: false,
+        });
+    }
+
+    None
+}
+
 fn render_raw_patch_preview(patch: &str, width: u16) -> Vec<Line<'static>> {
     let content_width = usize::from(width).saturating_sub(2).max(20);
     let mut lines = Vec::new();
@@ -309,9 +395,9 @@ fn push_wrapped_diff_line(
         ),
         DiffLineType::Context => (
             " ",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(DIFF_CONTEXT_FG),
             None,
-            Style::default().fg(TEXT_MUTED),
+            Style::default().fg(DIFF_CONTEXT_FG),
         ),
     };
 

--- a/src/tui/render/spinner.rs
+++ b/src/tui/render/spinner.rs
@@ -5,20 +5,12 @@
 
 use std::time::Duration;
 
-use ratatui::{
-    style::{Color, Style},
-    text::Span,
-};
+use ratatui::{style::Style, text::Span};
+
+use crate::tui::theme::{NORD7, NORD8, NORD9, NORD12, NORD13, NORD14};
 
 // Nord palette reference: https://www.nordtheme.com/docs/colors-and-palettes
-const SHIMMER_COLORS: &[Color] = &[
-    Color::Rgb(0x88, 0xC0, 0xD0), // NORD8  – frost cyan
-    Color::Rgb(0x8F, 0xBC, 0xBB), // NORD7  – frost green-cyan
-    Color::Rgb(0xA3, 0xBE, 0x8C), // NORD14 – aurora green
-    Color::Rgb(0xEB, 0xCB, 0x8B), // NORD13 – aurora yellow
-    Color::Rgb(0xD0, 0x87, 0x70), // NORD12 – aurora orange
-    Color::Rgb(0x81, 0xA1, 0xC1), // NORD9  – frost blue-gray
-];
+const SHIMMER_COLORS: &[ratatui::style::Color] = &[NORD8, NORD7, NORD14, NORD13, NORD12, NORD9];
 
 /// Fixed-width 1-character spinner.
 ///

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -4,13 +4,9 @@
 // ratatui::style::Color values so that the color palette can be
 // changed in one place and the visual hierarchy stays consistent.
 //
-// The palette is based on the Nord color scheme (matching OpenCode's
-// default dark theme) extended with semantic tokens for UI, Markdown,
-// and syntax highlighting.
-//
-// Many constants are reserved for planned rendering features (Markdown
-// syntax highlighting, diff views, phase badges, etc.). The full palette
-// is kept here as a single source of truth.
+// The palette is based on the Nord color scheme. Keep this module limited to
+// tokens that the current renderer consumes; a future configurable theme system
+// should introduce a real token schema instead of unused static constants.
 use ratatui::style::Color;
 
 // See https://www.nordtheme.com/docs/colors-and-palettes
@@ -40,15 +36,11 @@ pub(crate) const NORD14: Color = Color::Rgb(0xA3, 0xBE, 0x8C); // Aurora (green)
 pub(crate) const NORD15: Color = Color::Rgb(0xB4, 0x8E, 0xAD); // Aurora (purple)
 
 // ── UI surface colors ───────────────────────────────────────────
-pub(crate) const UI_BG: Color = NORD0;
-pub(crate) const UI_PANEL_BG: Color = NORD1;
 pub(crate) const UI_ELEMENT_BG: Color = NORD2;
-pub(crate) const UI_BORDER: Color = NORD3;
-pub(crate) const UI_BORDER_ACTIVE: Color = NORD8;
 
 // ── Popup / overlay surfaces ────────────────────────────────────
 pub(crate) const POPUP_BG: Color = NORD1;
-/// Full-screen dimmer behind centered popups (matches UI_BG).
+/// Full-screen dimmer behind centered popups.
 pub(crate) const POPUP_DIMMER_BG: Color = NORD0;
 
 // ── Text ────────────────────────────────────────────────────────
@@ -66,7 +58,6 @@ pub(crate) const ROLE_PREFIX: Color = NORD8;
 // ── Progress phases ─────────────────────────────────────────────
 pub(crate) const PHASE_EXPLORING: Color = NORD13;
 pub(crate) const PHASE_EXPLORED: Color = NORD13;
-pub(crate) const PHASE_THINKING: Color = NORD9;
 pub(crate) const PHASE_PLANNING: Color = NORD8;
 pub(crate) const PHASE_RUNNING: Color = NORD13;
 pub(crate) const PHASE_RAN: Color = NORD7;
@@ -83,7 +74,6 @@ pub(crate) const SURFACE_BOTTOM_PANE_BG: Color = Color::Reset;
 
 // ── Badge / section label ───────────────────────────────────────
 pub(crate) const BADGE_FG_DARK: Color = NORD6;
-pub(crate) const BADGE_FG_LIGHT: Color = NORD0;
 
 // ── Interaction ─────────────────────────────────────────────────
 pub(crate) const INTERACTION_SUB_AGENT: Color = NORD13;
@@ -101,28 +91,16 @@ pub(crate) const DIFF_DEL_BG: Color = Color::Rgb(58, 26, 26);
 pub(crate) const DIFF_DEL_FG: Color = NORD11;
 pub(crate) const DIFF_HUNK_BG: Color = NORD1;
 pub(crate) const DIFF_HUNK_FG: Color = NORD3;
-pub(crate) const DIFF_CONTEXT_BG: Color = NORD0;
 pub(crate) const DIFF_CONTEXT_FG: Color = NORD4;
-pub(crate) const DIFF_HIGHLIGHT_BG: Color = NORD2;
 
 // ── Markdown ────────────────────────────────────────────────────
 pub(crate) const MD_HEADING: Color = NORD8;
 pub(crate) const MD_LINK: Color = NORD9;
 pub(crate) const MD_CODE: Color = NORD14;
-pub(crate) const MD_CODE_BLOCK: Color = NORD5;
 pub(crate) const MD_BLOCK_QUOTE: Color = NORD3;
 pub(crate) const MD_LIST_BULLET: Color = NORD8;
 pub(crate) const MD_BOLD: Color = NORD6;
 pub(crate) const MD_ITALIC: Color = NORD4;
-
-// ── Syntax ──────────────────────────────────────────────────────
-pub(crate) const SYNTAX_COMMENT: Color = NORD3;
-pub(crate) const SYNTAX_KEYWORD: Color = NORD9;
-pub(crate) const SYNTAX_FUNCTION: Color = NORD8;
-pub(crate) const SYNTAX_VARIABLE: Color = NORD4;
-pub(crate) const SYNTAX_STRING: Color = NORD14;
-pub(crate) const SYNTAX_NUMBER: Color = NORD15;
-pub(crate) const SYNTAX_TYPE: Color = NORD7;
 
 // ── Budget bar segments ─────────────────────────────────────────
 pub(crate) const BUDGET_SYSTEM: Color = NORD9;


### PR DESCRIPTION
## Summary

- route Markdown renderer styles through existing TUI theme tokens
- route diff context lines and spinner shimmer colors through the shared palette
- remove theme constants that still have no runtime consumer
- render edit tool result `diff:` blocks as patch previews in active and committed turns
- add a TODO for an opencode-style configurable theme token schema and syntax theme mapping

## Purpose

This keeps the current static palette warning-clean while preserving the useful theme wiring that was missing from existing renderers. The remaining configurable theme work is tracked explicitly instead of keeping unused Rust constants.

## Related Issues

- N/A

## Testing

- `cargo fmt`
- `cargo test tui::markdown_render -- --nocapture`
- `cargo test tui::render::diff -- --nocapture`
- `cargo test committed_turn_cell_renders_tool_result_diff_preview -- --nocapture`
- `cargo test active_turn_cell_renders_latest_tool_result_diff_preview -- --nocapture`
- `cargo check --workspace --all-targets`
- `git diff --check`
