### PR TITLE
chore(tui): trim unused warning surface

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -81,6 +81,9 @@ Active backlog only. Keep this file small and current.
 - [ ] Wire Codex model catalog refresh into the active TUI provider/model
       selection flow, or remove the catalog loader and stored
       `codex_model_options` state if Codex presets stay static.
+- [ ] Wire Gemini Code Assist OAuth login into the TUI provider connection
+      flow, or remove the Google OAuth task surface if Gemini remains API-key
+      only in the terminal UI.
 
 ## Long-term
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -238,6 +238,8 @@ impl OAuthManager {
         self.clear_saved_auth_cache();
     }
 
+    /// Reserved for Codex model catalog refresh wiring (docs/todo.md).
+    #[allow(dead_code)]
     pub fn codex_home(&self) -> &Path {
         self.codex_home.as_path()
     }

--- a/src/tui/markdown_stream.rs
+++ b/src/tui/markdown_stream.rs
@@ -21,11 +21,6 @@ impl MarkdownStreamCollector {
         }
     }
 
-    pub fn clear(&mut self) {
-        self.buffer.clear();
-        self.committed_line_count = 0;
-    }
-
     pub fn push_delta(&mut self, delta: &str) {
         self.buffer.push_str(delta);
     }
@@ -73,10 +68,15 @@ impl MarkdownStreamCollector {
     }
 
     pub fn finalize_and_drain(&mut self) -> Vec<Line<'static>> {
+        if self.buffer.is_empty() {
+            return Vec::new();
+        }
+
         let mut source = self.buffer.clone();
         if !source.ends_with('\n') {
             source.push('\n');
         }
+
         let mut rendered = Vec::new();
         markdown::append_markdown(&source, self.width, Some(self.cwd.as_path()), &mut rendered);
         let out = if self.committed_line_count >= rendered.len() {
@@ -84,7 +84,9 @@ impl MarkdownStreamCollector {
         } else {
             rendered[self.committed_line_count..].to_vec()
         };
-        self.clear();
+
+        self.buffer.clear();
+        self.committed_line_count = 0;
         out
     }
 }
@@ -107,13 +109,6 @@ mod tests {
     }
 
     #[test]
-    fn finalize_commits_partial_line() {
-        let mut collector = MarkdownStreamCollector::new(None, &test_cwd());
-        collector.push_delta("Partial");
-        assert_eq!(collector.finalize_and_drain().len(), 1);
-    }
-
-    #[test]
     fn preview_only_returns_uncommitted_tail() {
         let mut collector = MarkdownStreamCollector::new(None, &test_cwd());
         collector.push_delta("Hello\nWorld");
@@ -121,5 +116,14 @@ mod tests {
         assert_eq!(committed.len(), 1);
         let preview = collector.preview_lines();
         assert_eq!(preview.len(), 1);
+    }
+
+    #[test]
+    fn finalize_commits_partial_line() {
+        let mut collector = MarkdownStreamCollector::new(None, &test_cwd());
+        collector.push_delta("Line without newline");
+        let out = collector.finalize_and_drain();
+        assert_eq!(out.len(), 1);
+        assert!(collector.preview_lines().is_empty());
     }
 }

--- a/src/tui/provider_flow.rs
+++ b/src/tui/provider_flow.rs
@@ -121,6 +121,8 @@ pub(super) fn codex_auth_is_available(app: &TuiApp, oauth_manager: &OAuthManager
     oauth_manager.has_saved_auth().is_ok_and(|saved| saved)
 }
 
+/// Reserved for wiring Codex model catalog refresh into active picker flow (docs/todo.md).
+#[allow(dead_code)]
 pub(super) async fn refresh_codex_model_picker(
     app: &mut TuiApp,
     oauth_manager: &OAuthManager,

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use super::state::{LocalCommand, OAuthLoginMode, TuiApp};
 use crate::agent::{Agent, BashApprovalDecision};
-use crate::google_oauth::GoogleOAuthManager;
 use crate::oauth::OAuthManager;
 
 pub async fn execute_local_command(
@@ -58,25 +57,10 @@ pub fn start_oauth_task(app: &mut TuiApp, oauth_manager: Arc<OAuthManager>, mode
     tasks::start_oauth_task(app, oauth_manager, mode);
 }
 
-pub fn start_google_oauth_task(
-    app: &mut TuiApp,
-    oauth_manager: Arc<GoogleOAuthManager>,
-    mode: OAuthLoginMode,
-) {
-    tasks::start_google_oauth_task(app, oauth_manager, mode);
-}
-
 pub fn start_deepseek_model_list_task(app: &mut TuiApp) {
     tasks::start_deepseek_model_list_task(app);
 }
 
 pub fn start_kimi_model_list_task(app: &mut TuiApp) {
     tasks::start_kimi_model_list_task(app);
-}
-
-pub async fn finish_running_task_if_ready(
-    app: &mut TuiApp,
-    agent_slot: &mut Option<Agent>,
-) -> anyhow::Result<()> {
-    tasks::finish_running_task_if_ready(app, agent_slot).await
 }

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -541,6 +541,8 @@ pub(super) fn start_oauth_task(
     oauth::start_oauth_task(app, oauth_manager, mode);
 }
 
+/// Reserved for Gemini Code Assist OAuth connection from the TUI (docs/todo.md).
+#[allow(dead_code)]
 pub(super) fn start_google_oauth_task(
     app: &mut TuiApp,
     oauth_manager: Arc<crate::google_oauth::GoogleOAuthManager>,

--- a/src/tui/runtime/tasks/google_oauth.rs
+++ b/src/tui/runtime/tasks/google_oauth.rs
@@ -8,6 +8,8 @@ use crate::tui::state::{
     OAuthLoginMode, RunningTask, RuntimePhase, TaskCompletion, TaskKind, TuiApp, TuiEvent,
 };
 
+/// Reserved for Gemini Code Assist OAuth connection from the TUI (docs/todo.md).
+#[allow(dead_code)]
 pub(crate) fn start_google_oauth_task(
     app: &mut TuiApp,
     oauth_manager: Arc<GoogleOAuthManager>,
@@ -56,6 +58,8 @@ pub(crate) fn start_google_oauth_task(
     });
 }
 
+/// Reserved for Gemini Code Assist OAuth connection from the TUI (docs/todo.md).
+#[allow(dead_code)]
 pub(super) async fn run_google_oauth_login(
     oauth_manager: Arc<GoogleOAuthManager>,
     mode: OAuthLoginMode,

--- a/src/tui/state/bottom_pane_model.rs
+++ b/src/tui/state/bottom_pane_model.rs
@@ -62,12 +62,6 @@ impl BottomPaneModel {
 
     // ── Paste-burst ──────────────────────────────────────────────────
 
-    /// Whether the composer is currently in a paste burst — i.e. chars are
-    /// being accumulated rather than applied one at a time.
-    pub fn is_in_paste_burst(&self) -> bool {
-        self.paste_burst_buffer.is_some()
-    }
-
     /// Absorb a full paste chunk into the burst buffer rather than inserting
     /// char-by-char through the normal input path.
     pub fn handle_paste_burst_chunk(&mut self, chunk: &str) {
@@ -144,14 +138,6 @@ impl BottomPaneModel {
         }
         // Also handle legacy single-entry format for safety
         self.large_paste_counter = 0;
-    }
-
-    pub fn has_queued_follow_up_messages(&self) -> bool {
-        !self.queued_follow_up_messages.is_empty()
-    }
-
-    pub fn has_pending_follow_up_messages(&self) -> bool {
-        !self.pending_follow_up_messages.is_empty()
     }
 }
 

--- a/src/tui/state/composer.rs
+++ b/src/tui/state/composer.rs
@@ -81,6 +81,8 @@ impl TuiApp {
         )
     }
 
+    /// Test helper for seeding composer input without simulating key events.
+    #[allow(dead_code)]
     pub fn set_input(&mut self, input: String) {
         self.bottom_pane.input = input;
         self.bottom_pane.input_cursor_offset = None;

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -1000,6 +1000,8 @@ impl TuiApp {
             .unwrap_or(0);
     }
 
+    /// Reserved for wiring Codex model catalog refresh into active picker flow (docs/todo.md).
+    #[allow(dead_code)]
     pub fn set_codex_model_options(&mut self, options: Vec<CodexModelOption>) {
         self.codex_model_options = options;
         self.model_picker_idx = self.selected_preset_idx();
@@ -1100,10 +1102,6 @@ impl TuiApp {
             .as_deref()
             .is_none_or(|value| value.trim().is_empty());
         missing_api || missing_base_url || missing_model
-    }
-
-    pub fn openai_endpoint_kind_count(&self) -> usize {
-        openai_profile_setup_kinds().len()
     }
 
     pub fn selected_openai_setup_kind(&self) -> OpenAiEndpointKind {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -69,6 +69,23 @@ fn agent_markdown_stream_sanitizes_terminal_controls() {
 }
 
 #[test]
+fn agent_markdown_stream_finalize_commits_partial_line() {
+    let mut stream = AgentMarkdownStreamState::new(std::path::PathBuf::from("."));
+
+    stream.push_delta("Partial answer without newline");
+    stream.finalize_display_lines();
+
+    let rendered = stream
+        .display_lines
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("Partial answer without newline"));
+    assert_eq!(stream.display_lines.len(), 1);
+}
+
+#[test]
 fn prioritizes_active_pending_interaction_in_ui_order() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -193,7 +193,10 @@ impl TuiApp {
         let fallback = self
             .agent_markdown_stream
             .take()
-            .map(|stream| stream.sanitized_raw_text())
+            .map(|mut stream| {
+                stream.finalize_display_lines();
+                stream.sanitized_raw_text()
+            })
             .filter(|text| !text.is_empty());
         let Some(message) = final_message.or(fallback) else {
             return;

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -128,16 +128,6 @@ pub struct UnifiedModelPreset {
 }
 
 impl PermissionMode {
-    pub fn cycle(self) -> Self {
-        match self {
-            Self::Auto => Self::AcceptEdits,
-            Self::AcceptEdits => Self::ReadOnly,
-            Self::ReadOnly => Self::FullAccess,
-            Self::Custom => Self::Auto,
-            Self::FullAccess => Self::Auto,
-        }
-    }
-
     pub fn label(self) -> &'static str {
         match self {
             Self::Auto => "auto",
@@ -224,9 +214,15 @@ pub enum RuntimePhase {
     OAuthExchangingToken,
     OAuthDeviceCodePrompt,
     OAuthPollingDeviceCode,
+    /// Reserved for granular OAuth status rendering (docs/todo.md).
+    #[allow(dead_code)]
     OAuthVerifying,
+    /// Reserved for granular OAuth status rendering (docs/todo.md).
+    #[allow(dead_code)]
     OAuthSuccess,
     OAuthSaved,
+    /// Reserved for granular OAuth status rendering (docs/todo.md).
+    #[allow(dead_code)]
     OAuthError,
     Failed,
 }
@@ -339,6 +335,8 @@ pub enum TaskKind {
     Compact,
     Rebuild,
     OAuth,
+    /// Reserved for Gemini Code Assist OAuth connection from the TUI (docs/todo.md).
+    #[allow(dead_code)]
     GoogleOAuth,
     DeepSeekModels,
     KimiModels,
@@ -366,6 +364,8 @@ pub enum TaskCompletion {
         mode: OAuthLoginMode,
         result: anyhow::Result<secrecy::SecretString>,
     },
+    /// Reserved for Gemini Code Assist OAuth connection from the TUI (docs/todo.md).
+    #[allow(dead_code)]
     GoogleOAuth {
         mode: OAuthLoginMode,
         result: anyhow::Result<crate::google_oauth::GoogleCredential>,
@@ -604,6 +604,12 @@ impl AgentMarkdownStreamState {
             .extend(self.collector.commit_complete_lines());
         self.display_lines = self.committed_lines.clone();
         self.display_lines.extend(self.collector.preview_lines());
+    }
+
+    pub(crate) fn finalize_display_lines(&mut self) {
+        self.committed_lines
+            .extend(self.collector.finalize_and_drain());
+        self.display_lines = self.committed_lines.clone();
     }
 }
 


### PR DESCRIPTION
## Summary

- restore and wire the TUI markdown stream final drain path to match the Codex stream collector pattern
- remove obsolete runtime facade methods that duplicate the active task path
- remove unused bottom-pane and permission-mode helpers that no longer have callers
- mark unfinished Codex catalog refresh and Gemini Code Assist OAuth TUI wiring as reserved with item-level dead-code allows
- track the Gemini OAuth TUI connection follow-up in `docs/todo.md`

## Purpose

This continues warning cleanup after #619 while keeping unfinished provider/auth capabilities explicit instead of deleting planned surfaces.

## Reference Check

- Codex keeps a `MarkdownStreamCollector::finalize_and_drain*` path and calls it when streaming completes, so this PR keeps RARA's final drain behavior wired instead of deleting it as dead code.
- Codex keeps paste-burst/bottom-pane accessors only where view routing actually calls them; the removed RARA bottom-pane methods were duplicate `BottomPaneModel` accessors with no caller.
- Claude Code updates permission mode through explicit state transitions and mappings, not an enum `cycle()` helper; the removed RARA `PermissionMode::cycle` had no equivalent active flow.
- Claude Code has a full OAuth status surface, while RARA's Gemini Code Assist OAuth TUI connection is still incomplete; this PR keeps that surface as reserved TODO-backed code instead of deleting it.

## Related Issues

- N/A

## Testing

- `cargo fmt`
- `cargo test tui::markdown_stream -- --nocapture`
- `cargo test tui::state::tests::agent_markdown_stream -- --nocapture`
- `cargo check --workspace --all-targets`
- `git diff --check`

## Warning Baseline

- Before: `rara` bin generated 48 warnings; bin test generated 29 warnings.
- After: `rara` bin generated 33 warnings; bin test generated 16 warnings.
