### PR TITLE
chore(tui): trim transcript warning helpers

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,6 +21,9 @@ Active backlog only. Keep this file small and current.
 ## TUI / UX
 
 - [ ] Refactor ~7 large methods out of `impl TuiApp` to enable file split.
+- [ ] Restore Claude Code-style realtime transcript live-log writes from
+      `push_entry` and clear the live log after turn commit so resume can
+      recover partial turns after restart.
 - [ ] Introduce an opencode-style configurable TUI theme token schema instead
       of static unused palette constants. Wire markdown, diff, syntax
       highlighting, picker, and overlay renderers through semantic theme tokens;

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -367,10 +367,6 @@ fn report_local_embedding_progress(
     }
 }
 
-pub(crate) async fn build_backend(config: &RaraConfig) -> Result<Box<dyn LlmBackend>> {
-    build_backend_with_progress(config, None).await
-}
-
 pub(crate) async fn build_backend_with_progress(
     config: &RaraConfig,
     progress: Option<LocalProgressReporter>,

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -282,7 +282,9 @@ impl TuiApp {
     }
 
     /// Realtime per-entry write to the live log (Claude Code style).
-    /// Called from push_entry so resume can recover partial turns.
+    /// Will be called from push_entry so resume can recover partial turns.
+    /// Reserved for restoring partial-turn resume recovery (docs/todo.md).
+    #[allow(dead_code)]
     pub(crate) fn record_entry_realtime(&self, entry: &PersistedTurnEntry) {
         let Some((root_dir, session_id)) = self.live_log_context() else {
             return;
@@ -297,6 +299,8 @@ impl TuiApp {
     }
 
     /// Clear the live log after a turn is committed.
+    /// Reserved for restoring partial-turn resume recovery (docs/todo.md).
+    #[allow(dead_code)]
     pub(crate) fn clear_live_log(&self) {
         let Some((root_dir, session_id)) = self.live_log_context() else {
             return;

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -112,17 +112,6 @@ impl TuiApp {
         self.reset_transcript_scroll_if_following_tail();
     }
 
-    pub fn append_to_latest_entry(&mut self, role: &'static str, delta: &str) {
-        if let Some(last) = self.active_turn.entries.last_mut()
-            && last.role == role
-        {
-            last.message.push_str(delta);
-            self.reset_transcript_scroll_if_following_tail();
-            return;
-        }
-        self.push_entry(role, delta.to_string());
-    }
-
     pub fn append_agent_delta(&mut self, delta: &str) {
         let cwd = if !self.snapshot.cwd.is_empty() {
             PathBuf::from(self.snapshot.cwd.as_str())
@@ -310,13 +299,6 @@ impl TuiApp {
             + self.active_turn.entries.len()
     }
 
-    pub fn committed_entry_count(&self) -> usize {
-        self.committed_turns
-            .iter()
-            .map(|turn| turn.entries.len())
-            .sum()
-    }
-
     fn materialize_active_live_entries(&mut self) {
         if !self.active_live.events.is_empty() {
             for event in &self.active_live.events {
@@ -474,6 +456,7 @@ impl TuiApp {
         self.bottom_pane.pending_follow_up_messages.len()
     }
 
+    #[cfg(test)]
     pub fn queued_follow_up_preview(&self) -> Option<&str> {
         self.bottom_pane
             .pending_follow_up_messages
@@ -525,6 +508,7 @@ impl TuiApp {
         self.queued_follow_up_count()
     }
 
+    #[cfg(test)]
     pub fn pop_queued_follow_up_message(&mut self) -> Option<String> {
         if self.bottom_pane.queued_follow_up_messages.is_empty() {
             None
@@ -573,6 +557,7 @@ impl TuiApp {
         self.bottom_pane.queued_follow_up_messages.extend(released);
     }
 
+    #[cfg(test)]
     pub fn queue_planning_suggestion(&mut self, prompt: impl Into<String>) {
         self.bottom_pane.pending_planning_suggestion = Some(prompt.into());
         self.bottom_pane.notice = Some(
@@ -580,10 +565,6 @@ impl TuiApp {
                 .into(),
         );
         self.transcript_scroll = 0;
-    }
-
-    pub fn take_pending_planning_suggestion(&mut self) -> Option<String> {
-        self.bottom_pane.pending_planning_suggestion.take()
     }
 
     pub fn clear_pending_planning_suggestion(&mut self) {


### PR DESCRIPTION
## Summary

- remove unused backend/transcript helper methods that no longer have callers
- narrow queued follow-up and planning-suggestion helpers to test-only code
- keep the Claude Code-style realtime transcript live-log hooks as reserved TODO-backed code instead of deleting them

## Purpose

This continues warning cleanup after #620 while preserving incomplete resume recovery work that was originally borrowed from Claude Code-style realtime transcript persistence.

## Reference Check

- Claude Code keeps realtime/partial transcript recovery concepts around resume flows; RARA has the storage hooks but no active `push_entry` wiring yet, so this PR records the follow-up in `docs/todo.md` and keeps the hooks with item-level `#[allow(dead_code)]`.
- Codex keeps queued follow-up as an active runtime path; RARA's active path uses `drain_queued_follow_up_messages`, while preview/pop helpers are only test conveniences, so they are now `#[cfg(test)]`.
- The removed `build_backend` wrapper duplicated `build_backend_with_progress(config, None)` and had no active caller or TODO.

## Related Issues

- N/A

## Testing

- `cargo fmt`
- `cargo check --workspace --all-targets`
- `cargo test tui::state::tests::queued_follow_up -- --nocapture`
- `cargo test tui::runtime::tasks::tests::queued_follow -- --nocapture`
- `cargo test queued_follow_up -- --nocapture`
- `git diff --check`

## Warning Baseline

- Before: `rara` bin generated 33 warnings; bin test generated 16 warnings.
- After: `rara` bin generated 30 warnings; bin test generated 13 warnings.
