### PR TITLE
chore(control): trim protocol warning surface

### DIFF
--- a/docs/journal/2026-07-01-protocol-control-warning-cleanup.md
+++ b/docs/journal/2026-07-01-protocol-control-warning-cleanup.md
@@ -1,0 +1,36 @@
+# Protocol Control Warning Cleanup
+
+## Summary
+
+The protocol prompt-source registry no longer exposes older static listing and
+manual turn-advance helpers. Query-time snapshots now use
+`list_prompt_sources_for_query`, which is the single path that converts active
+protocol sources into prompt-runtime sources, advances turn-limited lifetimes,
+and emits lifecycle events.
+
+The TUI runtime now builds `MemoryControlHandler` with the active agent
+`MemoryStore`, so local control-plane memory requests use the durable
+store-backed path instead of the scaffold-only event path.
+
+## Key Decisions
+
+- Remove unused prompt-source helper APIs rather than suppressing them, because
+  they were superseded by the query-time snapshot API.
+- Keep protocol skill precedence hints as a reserved field because the runtime
+  control-plane spec still requires advisory ordering for external skill roots.
+- Keep the structured event subscription API reserved for ACP, Wire, and
+  appserver consumers.
+
+## Validation
+
+```bash
+cargo fmt
+cargo check --locked --workspace --all-targets
+cargo test --locked prompt_source_registry
+cargo test --locked protocol_prompt_registry_feeds_prompt_runtime_for_query
+```
+
+## Follow-Ups
+
+- Continue warning cleanup in the session promotion, thread materialization,
+  and TUI command/event palettes.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -78,6 +78,9 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Explicit embedding controls: enable/disable, provider override (low priority)
 - [ ] `/status` context fields for model/provider/thread/retrieval/memory/workspace
+- [ ] Continue warning cleanup for session promotion, thread materialization,
+      and TUI command/event palettes (see
+      docs/journal/2026-07-01-protocol-control-warning-cleanup.md).
 - [ ] Decide the Gemini AI Studio runtime path: either wire `provider=gemini`
       to the native `GeminiBackend::new` API-key backend or remove that native
       API-key path in favor of the current OpenAI-compatible endpoint.

--- a/src/agent/tests/context_view.rs
+++ b/src/agent/tests/context_view.rs
@@ -11,8 +11,8 @@ use crate::memory_store::{MemoryLabel, MemoryScope, MemorySource, MemoryStore, N
 use crate::prompt::PromptRuntimeConfig;
 use crate::protocol_sources::PromptSourceRegistry;
 use crate::runtime_control::{
-    PromptSourceControlRequest, PromptSourceLifetime, PromptSourceRegistration, SourceLayer,
-    SourceScope,
+    PromptSourceControlRequest, PromptSourceLifetime, PromptSourceRegistration, RuntimeProvenance,
+    SourceLayer, SourceScope,
 };
 use crate::runtime_event_bus::RuntimeEventBus;
 
@@ -432,16 +432,17 @@ async fn protocol_prompt_registry_feeds_prompt_runtime_for_query() {
     );
     let registry = Arc::new(PromptSourceRegistry::new(Arc::new(RuntimeEventBus::new(8))));
     registry
-        .handle_control(&PromptSourceControlRequest::Register(
-            PromptSourceRegistration {
+        .handle_control_with_provenance(
+            &PromptSourceControlRequest::Register(PromptSourceRegistration {
                 source_id: "editor-selection".to_string(),
                 scope: SourceScope::Protocol,
                 layer: SourceLayer::User,
                 budget_hint_tokens: Some(64),
                 lifetime: PromptSourceLifetime::Turns(1),
                 content: "The active editor selection is src/main.rs.".to_string(),
-            },
-        ))
+            }),
+            RuntimeProvenance::runtime(None),
+        )
         .await;
     agent.set_prompt_source_registry(registry.clone());
 
@@ -472,7 +473,7 @@ async fn protocol_prompt_registry_feeds_prompt_runtime_for_query() {
             })
     );
     assert!(
-        registry.list_prompt_sources().await.is_empty(),
+        registry.list_prompt_sources_for_query().await.is_empty(),
         "turn-limited source should be consumed after one user query"
     );
     assert!(

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -105,11 +105,6 @@ impl PromptSourceRegistry {
         }
     }
 
-    pub async fn handle_control(&self, request: &PromptSourceControlRequest) {
-        self.handle_control_with_provenance(request, RuntimeProvenance::runtime(None))
-            .await;
-    }
-
     /// Handle a prompt source control request while explicitly recording the
     /// provenance of the runtime-control envelope that carried it.
     pub async fn handle_control_with_provenance(
@@ -160,60 +155,6 @@ impl PromptSourceRegistry {
         }
     }
 
-    /// Decrement remaining turns for turn-limited sources.
-    /// Sources whose remaining turns reach 0 are removed.
-    pub async fn advance_turn(&self) {
-        let mut sources = self.sources.write().await;
-        let mut expired = Vec::new();
-        for (id, entry) in sources.iter_mut() {
-            if let Some(ref mut remaining) = entry.remaining_turns {
-                if *remaining <= 1 {
-                    expired.push(id.clone());
-                } else {
-                    *remaining -= 1;
-                }
-            }
-        }
-        for id in &expired {
-            sources.remove(id);
-            let _ = self.event_bus.publish_control(RuntimeEvent::PromptSource(
-                PromptSourceEvent::Dropped {
-                    source_id: id.clone(),
-                    reason: "turn limit expired".into(),
-                },
-            ));
-        }
-    }
-
-    /// Return all registered sources (for prompt assembly).
-    pub async fn list_sources(&self) -> Vec<PromptSourceRegistration> {
-        self.sources
-            .read()
-            .await
-            .values()
-            .map(|e| e.registration.clone())
-            .collect()
-    }
-
-    /// Return all registered sources with provenance and remaining lifetime.
-    pub async fn list_source_snapshots(&self) -> Vec<ProtocolPromptSourceSnapshot> {
-        self.sources
-            .read()
-            .await
-            .values()
-            .map(ProtocolPromptSourceSnapshot::from)
-            .collect()
-    }
-
-    /// Return active protocol sources in the prompt-runtime source format.
-    pub async fn list_prompt_sources(&self) -> Vec<PromptSource> {
-        self.list_source_snapshots()
-            .await
-            .iter()
-            .map(ProtocolPromptSourceSnapshot::to_prompt_source)
-            .collect()
-    }
-
     /// Atomically snapshot active prompt sources for one query and advance
     /// turn-limited lifetimes under the same registry lock.
     pub async fn list_prompt_sources_for_query(&self) -> Vec<PromptSource> {
@@ -259,6 +200,9 @@ impl PromptSourceRegistry {
 #[derive(Clone, Debug)]
 pub struct SkillSourceEntry {
     pub source_id: String,
+    /// Reserved for protocol skill ordering. Will be activated when external
+    /// skill roots are merged into local skill discovery (docs/features/runtime-control-plane.md).
+    #[allow(dead_code)]
     pub precedence_hint: Option<i32>,
 }
 
@@ -707,13 +651,7 @@ mod tests {
             )
             .await;
 
-        let snapshots = registry.list_source_snapshots().await;
-        assert_eq!(snapshots.len(), 1);
-        assert_eq!(snapshots[0].registration.source_id, "protocol-source-1");
-        assert_eq!(snapshots[0].provenance, provenance);
-        assert_eq!(snapshots[0].remaining_turns, Some(2));
-
-        let prompt_sources = registry.list_prompt_sources().await;
+        let prompt_sources = registry.list_prompt_sources_for_query().await;
         assert_eq!(prompt_sources.len(), 1);
         assert_eq!(
             prompt_sources[0].kind,
@@ -731,6 +669,17 @@ mod tests {
             prompt_sources[0].content,
             "Protocol context should keep provenance."
         );
+
+        let second_query_sources = registry.list_prompt_sources_for_query().await;
+        assert_eq!(
+            second_query_sources.len(),
+            1,
+            "Turns(2) sources should remain available for a second query"
+        );
+        assert_eq!(
+            second_query_sources[0].display_path,
+            "protocol:acp:acp:protocol-source-1"
+        );
     }
 
     #[tokio::test]
@@ -740,16 +689,17 @@ mod tests {
         let registry = PromptSourceRegistry::new(bus);
 
         registry
-            .handle_control(&PromptSourceControlRequest::Register(
-                PromptSourceRegistration {
+            .handle_control_with_provenance(
+                &PromptSourceControlRequest::Register(PromptSourceRegistration {
                     source_id: "protocol-source-1".to_string(),
                     scope: crate::runtime_control::SourceScope::Protocol,
                     layer: crate::runtime_control::SourceLayer::User,
                     budget_hint_tokens: Some(128),
                     lifetime: PromptSourceLifetime::Turns(1),
                     content: "Protocol context should emit lifecycle events.".to_string(),
-                },
-            ))
+                }),
+                RuntimeProvenance::runtime(None),
+            )
             .await;
         let registered = events.recv().await.expect("registered event");
         assert!(matches!(

--- a/src/runtime_event_bus.rs
+++ b/src/runtime_event_bus.rs
@@ -80,6 +80,9 @@ impl RuntimeEventBus {
     ///
     /// Past events are not replayed. Use the embedded sequence and event id to
     /// preserve stream order and adapter acknowledgements.
+    /// Reserved for external structured event subscribers as specified in
+    /// docs/features/runtime-control-plane.md.
+    #[allow(dead_code)]
     pub fn subscribe_control(&self) -> broadcast::Receiver<RuntimeControlEvent> {
         self.control_sender.subscribe()
     }

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -66,7 +66,10 @@ pub async fn run_tui(
     app.hook_registry = Some(hook_registry);
     app.lsp_manager = Some(lsp_manager);
     app.memory_handler = Some(Arc::new(
-        crate::protocol_sources::MemoryControlHandler::new(event_bus.clone()),
+        crate::protocol_sources::MemoryControlHandler::with_store(
+            event_bus,
+            agent.memory_store.clone(),
+        ),
     ));
     app.sandbox_network_access
         .store(false, std::sync::atomic::Ordering::Relaxed);

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -34,8 +34,9 @@ pub(super) async fn rebuild_agent_with_progress(
         hook_registry,
         lsp_manager,
     ) = bootstrap.into_parts();
-    let memory_handler = Arc::new(crate::protocol_sources::MemoryControlHandler::new(
+    let memory_handler = Arc::new(crate::protocol_sources::MemoryControlHandler::with_store(
         event_bus,
+        agent.memory_store.clone(),
     ));
     Ok(RebuildSuccess {
         agent,


### PR DESCRIPTION
## Summary

- Remove obsolete prompt-source registry helper APIs that were superseded by query-time snapshots.
- Build TUI memory control handlers with the active agent MemoryStore so local control-plane memory requests use the store-backed path.
- Document the checkpoint and track remaining warning groups in docs/todo.md.

## Purpose

Reduce current dead-code warnings without hiding unfinished protocol-control contracts behind broad allowances.

## Related Issues

None.

## Tests

- cargo fmt
- cargo check --locked --workspace --all-targets
- cargo test --locked prompt_source_registry
- cargo test --locked protocol_prompt_registry_feeds_prompt_runtime_for_query