### PR TITLE
chore(thread): trim thread store warning surface

### DIFF
--- a/docs/journal/2026-07-01-thread-store-warning-cleanup.md
+++ b/docs/journal/2026-07-01-thread-store-warning-cleanup.md
@@ -1,0 +1,40 @@
+# Thread Store Warning Cleanup
+
+## Summary
+
+The thread-store warning cleanup keeps the documented thread inspection and
+memory-distillation contracts while making the active CLI inspection path use
+more of the materialized thread data:
+
+- `rara thread <THREAD_ID>` now prints materialization provenance, lineage,
+  rollout event counts, rollout interaction statuses, spawn-agent summaries,
+  and compaction replacement metadata.
+- `ThreadStore::latest_thread_id` was removed because callers already use
+  `latest_thread_summary` and no spec depends on the thin id-only alias.
+- `ThreadStore::export_thread_markdown`, `ThreadStore::distill_thread_summary`,
+  `ThreadRecorder::flush`, and the summary-record formatter remain as reserved
+  contract boundaries with item-level dead-code rationale.
+
+## Background
+
+`ThreadStore` is the canonical materialization boundary for thread metadata,
+transcript history, non-turn rollout events, compaction records, and legacy
+fallbacks. Several inspection fields were populated but not displayed by the
+CLI, so the compiler correctly reported them as unused in the binary even
+though they are part of the thread contract.
+
+The summary-style distillation path is intentionally retained as a compatibility
+path. The active product path remains `ThreadStore::distill_thread_memories`,
+which extracts multiple durable memory records from loaded thread markdown.
+
+## Validation
+
+```bash
+cargo fmt
+cargo check --locked --workspace --all-targets
+cargo test --locked thread_cli::tests::
+```
+
+## Follow-Ups
+
+- Continue warning cleanup in `AgentEvent` and the TUI command/event palettes.

--- a/docs/journal/2026-07-01-thread-store-warning-cleanup.md
+++ b/docs/journal/2026-07-01-thread-store-warning-cleanup.md
@@ -14,6 +14,9 @@ more of the materialized thread data:
 - `ThreadStore::export_thread_markdown`, `ThreadStore::distill_thread_summary`,
   `ThreadRecorder::flush`, and the summary-record formatter remain as reserved
   contract boundaries with item-level dead-code rationale.
+- `src/thread_store.rs` was split into focused `types`, `format`, and
+  `recorder` submodules so the main materialization file stays under the
+  project source-file size limit.
 
 ## Background
 
@@ -33,6 +36,7 @@ which extracts multiple durable memory records from loaded thread markdown.
 cargo fmt
 cargo check --locked --workspace --all-targets
 cargo test --locked thread_cli::tests::
+cargo test --locked thread_store::tests::
 ```
 
 ## Follow-Ups

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -78,8 +78,8 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Explicit embedding controls: enable/disable, provider override (low priority)
 - [ ] `/status` context fields for model/provider/thread/retrieval/memory/workspace
-- [ ] Continue warning cleanup for thread materialization and TUI command/event
-      palettes (see docs/journal/2026-07-01-session-warning-cleanup.md).
+- [ ] Continue warning cleanup for `AgentEvent` and the TUI command/event
+      palettes (see docs/journal/2026-07-01-thread-store-warning-cleanup.md).
 - [ ] Decide the Gemini AI Studio runtime path: either wire `provider=gemini`
       to the native `GeminiBackend::new` API-key backend or remove that native
       API-key path in favor of the current OpenAI-compatible endpoint.

--- a/src/thread_cli.rs
+++ b/src/thread_cli.rs
@@ -284,7 +284,7 @@ fn rollout_summary(thread: &ThreadSnapshot) -> RolloutSummary {
             } => {
                 summary.spawn_agent_count += 1;
                 summary.last_spawn_agent = format!(
-                    "event={} agent={} child={} name={} status={} summary={}",
+                    "event={} agent={} child={} name=\"{}\" status={} summary=\"{}\"",
                     event_id,
                     agent_id,
                     child_session_id,
@@ -314,8 +314,8 @@ fn rollout_summary(thread: &ThreadSnapshot) -> RolloutSummary {
 fn compaction_replaced_range(compaction: &crate::thread_store::CompactionRecord) -> String {
     match (compaction.replaced_start, compaction.replaced_end) {
         (Some(start), Some(end)) => format!("{start}..{end}"),
-        (Some(start), None) => format!("{start}..-"),
-        (None, Some(end)) => format!("-..{end}"),
+        (Some(start), None) => format!("{start}.."),
+        (None, Some(end)) => format!("..{end}"),
         (None, None) => "-".to_string(),
     }
 }
@@ -333,7 +333,10 @@ mod tests {
     use rara_persistence::thread_data::{PersistedTurnEntry, PersistedTurnSummary};
     use rara_state::state_db::PersistedInteraction;
 
-    use super::{format_distilled_memories, format_recent_threads, format_thread_snapshot};
+    use super::{
+        compaction_replaced_range, format_distilled_memories, format_recent_threads,
+        format_thread_snapshot,
+    };
     use crate::memory_store::{MemoryLabel, MemoryRecord, MemoryScope, MemorySource};
     use crate::thread_store::{
         CompactionRecord, RolloutItem, RolloutTurnItem, ThreadHistorySource,
@@ -436,6 +439,14 @@ mod tests {
                     },
                     entries: Vec::<PersistedTurnEntry>::new(),
                 }),
+                RolloutItem::SpawnAgent {
+                    event_id: "evt-1".to_string(),
+                    agent_id: "agent-1".to_string(),
+                    name: Some("plan reviewer".to_string()),
+                    child_session_id: "child-1".to_string(),
+                    status: "completed".to_string(),
+                    summary: Some("checked warning cleanup".to_string()),
+                },
             ],
         });
 
@@ -452,10 +463,32 @@ mod tests {
         assert!(output.contains("rollout_compaction_indexes=4"));
         assert!(output.contains("rollout_interactions=1"));
         assert!(output.contains("rollout_interaction_statuses=approval:completed"));
+        assert!(output.contains("rollout_spawn_agents=1"));
+        assert!(output.contains(
+            "rollout_last_spawn=event=evt-1 agent=agent-1 child=child-1 name=\"plan reviewer\" status=completed summary=\"checked warning cleanup\""
+        ));
         assert!(output.contains("compactions=3"));
         assert!(output.contains("compaction_replaced_range=2..5"));
         assert!(output.contains("compaction_metadata_owner=thread-recorder"));
         assert!(output.contains("compaction_recent_files=src/main.rs, src/thread_store.rs"));
+    }
+
+    #[test]
+    fn compaction_replaced_range_uses_standard_rust_range_notation() {
+        assert_eq!(
+            compaction_replaced_range(&CompactionRecord {
+                replaced_start: Some(2),
+                ..Default::default()
+            }),
+            "2.."
+        );
+        assert_eq!(
+            compaction_replaced_range(&CompactionRecord {
+                replaced_end: Some(5),
+                ..Default::default()
+            }),
+            "..5"
+        );
     }
 
     #[test]

--- a/src/thread_cli.rs
+++ b/src/thread_cli.rs
@@ -121,11 +121,7 @@ fn format_thread_summary_lines(thread: &ThreadSummary) -> Vec<String> {
 
 fn format_thread_snapshot(thread: &ThreadSnapshot) -> String {
     let workspace = workspace_label(&thread.metadata.cwd);
-    let turn_count = thread
-        .rollout_items
-        .iter()
-        .filter(|item| matches!(item, crate::thread_store::RolloutItem::Turn(_)))
-        .count();
+    let rollout = rollout_summary(thread);
     let interaction_count = thread.interactions.len();
     let plan_step_count = thread.plan_steps.len();
     let recent_files = if thread.compaction.recent_files.is_empty() {
@@ -145,17 +141,33 @@ fn format_thread_snapshot(thread: &ThreadSnapshot) -> String {
             "mode={}\n",
             "approval={}\n",
             "origin={}\n",
+            "is_fork={}\n",
             "forked_from={}\n",
+            "lineage_kind={}\n",
+            "lineage_source={}\n",
+            "provenance={}\n",
             "created_at={}\n",
             "updated_at={}\n",
             "history_messages={}\n",
             "transcript_entries={}\n",
             "turns={}\n",
+            "turn_ordinals={}\n",
             "plan_steps={}\n",
             "interactions={}\n",
+            "rollout_compactions={}\n",
+            "rollout_compaction_indexes={}\n",
+            "rollout_plan_snapshots={}\n",
+            "rollout_plan_snapshot_steps={}\n",
+            "rollout_plan_snapshot_explanations={}\n",
+            "rollout_interactions={}\n",
+            "rollout_interaction_statuses={}\n",
+            "rollout_spawn_agents={}\n",
+            "rollout_last_spawn={}\n",
             "compactions={}\n",
             "compaction_before_tokens={}\n",
             "compaction_after_tokens={}\n",
+            "compaction_replaced_range={}\n",
+            "compaction_metadata_owner={}\n",
             "compaction_boundary_version={}\n",
             "compaction_recent_files={}\n"
         ),
@@ -168,18 +180,32 @@ fn format_thread_snapshot(thread: &ThreadSnapshot) -> String {
         thread.metadata.agent_mode,
         thread.metadata.bash_approval,
         thread.metadata.origin_kind,
+        thread.is_fork(),
         thread
             .metadata
             .forked_from_thread_id
             .as_deref()
             .unwrap_or("-"),
+        thread.lineage().0,
+        thread.lineage().1.unwrap_or("-"),
+        thread.provenance_description(),
         thread.metadata.created_at,
         thread.metadata.updated_at,
         thread.history.len(),
         thread.metadata.transcript_len,
-        turn_count,
+        rollout.turn_count,
+        rollout.turn_ordinals,
         plan_step_count,
         interaction_count,
+        rollout.compaction_count,
+        rollout.compaction_indexes,
+        rollout.plan_state_count,
+        rollout.plan_state_step_count,
+        rollout.plan_state_explanation_count,
+        rollout.interaction_count,
+        rollout.interaction_statuses,
+        rollout.spawn_agent_count,
+        rollout.last_spawn_agent,
         thread.compaction.compaction_count,
         thread
             .compaction
@@ -191,6 +217,8 @@ fn format_thread_snapshot(thread: &ThreadSnapshot) -> String {
             .after_tokens
             .map(|value| value.to_string())
             .unwrap_or_else(|| "-".to_string()),
+        compaction_replaced_range(&thread.compaction),
+        thread.compaction.metadata_owner.as_deref().unwrap_or("-"),
         thread
             .compaction
             .boundary_version
@@ -198,6 +226,98 @@ fn format_thread_snapshot(thread: &ThreadSnapshot) -> String {
             .unwrap_or_else(|| "-".to_string()),
         recent_files,
     )
+}
+
+#[derive(Default)]
+struct RolloutSummary {
+    turn_count: usize,
+    turn_ordinals: String,
+    compaction_count: usize,
+    compaction_indexes: String,
+    plan_state_count: usize,
+    plan_state_step_count: usize,
+    plan_state_explanation_count: usize,
+    interaction_count: usize,
+    interaction_statuses: String,
+    spawn_agent_count: usize,
+    last_spawn_agent: String,
+}
+
+fn rollout_summary(thread: &ThreadSnapshot) -> RolloutSummary {
+    let mut summary = RolloutSummary {
+        turn_ordinals: "-".to_string(),
+        compaction_indexes: "-".to_string(),
+        interaction_statuses: "-".to_string(),
+        last_spawn_agent: "-".to_string(),
+        ..RolloutSummary::default()
+    };
+    let mut turn_ordinals = Vec::new();
+    let mut compaction_indexes = Vec::new();
+    let mut interaction_statuses = Vec::new();
+    for item in &thread.rollout_items {
+        match item {
+            crate::thread_store::RolloutItem::Compaction(record) => {
+                summary.compaction_count += 1;
+                compaction_indexes.push(record.compaction_count.to_string());
+            }
+            crate::thread_store::RolloutItem::PlanState { explanation, steps } => {
+                summary.plan_state_count += 1;
+                summary.plan_state_step_count += steps.len();
+                if explanation
+                    .as_deref()
+                    .is_some_and(|value| !value.trim().is_empty())
+                {
+                    summary.plan_state_explanation_count += 1;
+                }
+            }
+            crate::thread_store::RolloutItem::Interaction(interaction) => {
+                summary.interaction_count += 1;
+                interaction_statuses.push(format!("{}:{}", interaction.kind, interaction.status));
+            }
+            crate::thread_store::RolloutItem::SpawnAgent {
+                event_id,
+                agent_id,
+                name,
+                child_session_id,
+                status,
+                summary: spawn_summary,
+            } => {
+                summary.spawn_agent_count += 1;
+                summary.last_spawn_agent = format!(
+                    "event={} agent={} child={} name={} status={} summary={}",
+                    event_id,
+                    agent_id,
+                    child_session_id,
+                    name.as_deref().unwrap_or("-"),
+                    status,
+                    spawn_summary.as_deref().unwrap_or("-")
+                );
+            }
+            crate::thread_store::RolloutItem::Turn(turn) => {
+                summary.turn_count += 1;
+                turn_ordinals.push(turn.summary.ordinal.to_string());
+            }
+        }
+    }
+    if !turn_ordinals.is_empty() {
+        summary.turn_ordinals = turn_ordinals.join(",");
+    }
+    if !compaction_indexes.is_empty() {
+        summary.compaction_indexes = compaction_indexes.join(",");
+    }
+    if !interaction_statuses.is_empty() {
+        summary.interaction_statuses = interaction_statuses.join(",");
+    }
+    summary
+}
+
+fn compaction_replaced_range(compaction: &crate::thread_store::CompactionRecord) -> String {
+    match (compaction.replaced_start, compaction.replaced_end) {
+        (Some(start), Some(end)) => format!("{start}..{end}"),
+        (Some(start), None) => format!("{start}..-"),
+        (None, Some(end)) => format!("-..{end}"),
+        (None, None) => "-".to_string(),
+    }
 }
 
 fn workspace_label(cwd: &str) -> &str {
@@ -210,14 +330,15 @@ fn workspace_label(cwd: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
+    use rara_persistence::thread_data::{PersistedTurnEntry, PersistedTurnSummary};
     use rara_state::state_db::PersistedInteraction;
 
     use super::{format_distilled_memories, format_recent_threads, format_thread_snapshot};
     use crate::memory_store::{MemoryLabel, MemoryRecord, MemoryScope, MemorySource};
     use crate::thread_store::{
-        CompactionRecord, RolloutItem, ThreadHistorySource, ThreadMaterializationProvenance,
-        ThreadMetadata, ThreadMetadataSource, ThreadNonTurnRolloutSource, ThreadSnapshot,
-        ThreadSummary,
+        CompactionRecord, RolloutItem, RolloutTurnItem, ThreadHistorySource,
+        ThreadMaterializationProvenance, ThreadMetadata, ThreadMetadataSource,
+        ThreadNonTurnRolloutSource, ThreadSnapshot, ThreadSummary,
     };
 
     fn metadata() -> ThreadMetadata {
@@ -276,6 +397,9 @@ mod tests {
                 compaction_count: 3,
                 before_tokens: Some(1200),
                 after_tokens: Some(400),
+                replaced_start: Some(2),
+                replaced_end: Some(5),
+                metadata_owner: Some("thread-recorder".to_string()),
                 recent_files: vec!["src/main.rs".to_string(), "src/thread_store.rs".to_string()],
                 boundary_version: Some(2),
                 summary: Some("kept the runtime checkpoint".to_string()),
@@ -290,22 +414,47 @@ mod tests {
                 summary: "approved".to_string(),
                 payload: None,
             }],
-            rollout_items: vec![RolloutItem::Interaction(PersistedInteraction {
-                kind: "approval".to_string(),
-                status: "completed".to_string(),
-                title: "Approval".to_string(),
-                summary: "approved".to_string(),
-                payload: None,
-            })],
+            rollout_items: vec![
+                RolloutItem::Interaction(PersistedInteraction {
+                    kind: "approval".to_string(),
+                    status: "completed".to_string(),
+                    title: "Approval".to_string(),
+                    summary: "approved".to_string(),
+                    payload: None,
+                }),
+                RolloutItem::Compaction(CompactionRecord {
+                    compaction_count: 4,
+                    ..Default::default()
+                }),
+                RolloutItem::Turn(RolloutTurnItem {
+                    summary: PersistedTurnSummary {
+                        ordinal: 7,
+                        event_count: 2,
+                        artifact_path: "thread-123/turns.jsonl".to_string(),
+                        preview: "ran a command".to_string(),
+                        updated_at: 1_713_955_200,
+                    },
+                    entries: Vec::<PersistedTurnEntry>::new(),
+                }),
+            ],
         });
 
         assert!(output.contains("Thread thread-123"));
         assert!(output.contains("provider=codex"));
         assert!(output.contains("origin=fresh"));
+        assert!(output.contains("is_fork=false"));
         assert!(output.contains("forked_from=-"));
+        assert!(output.contains("lineage_kind=fresh"));
+        assert!(output.contains("provenance=metadata=StateDb fallback"));
         assert!(output.contains("workspace=rara"));
         assert!(output.contains("interactions=1"));
+        assert!(output.contains("turn_ordinals=7"));
+        assert!(output.contains("rollout_compaction_indexes=4"));
+        assert!(output.contains("rollout_interactions=1"));
+        assert!(output.contains("rollout_interaction_statuses=approval:completed"));
         assert!(output.contains("compactions=3"));
+        assert!(output.contains("compaction_replaced_range=2..5"));
+        assert!(output.contains("compaction_metadata_owner=thread-recorder"));
         assert!(output.contains("compaction_recent_files=src/main.rs, src/thread_store.rs"));
     }
 

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -1,5 +1,3 @@
-// Items reserved for thread store persistence.
-// NOTE: module-level dead_code kept — large storage crate.
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
@@ -345,12 +343,6 @@ impl<'a> ThreadStore<'a> {
         }
     }
 
-    pub fn latest_thread_id(&self) -> Result<Option<String>> {
-        Ok(self
-            .latest_thread_summary()?
-            .map(|thread| thread.metadata.session_id))
-    }
-
     pub fn latest_thread_summary(&self) -> Result<Option<ThreadSummary>> {
         Ok(self.list_recent_threads(1)?.into_iter().next())
     }
@@ -373,10 +365,17 @@ impl<'a> ThreadStore<'a> {
         })
     }
 
+    /// Reserved portable export boundary for external thread inspection.
+    /// This is part of the thread contract documented in docs/features/threads.md.
+    #[allow(dead_code)]
     pub fn export_thread_markdown(&self, session_id: &str) -> Result<String> {
         Ok(format_thread_markdown(&self.load_thread(session_id)?))
     }
 
+    /// Reserved compatibility path for one-record thread distillation.
+    /// The active product path is `distill_thread_memories`; this remains part
+    /// of the thread contract documented in docs/features/memory-records.md.
+    #[allow(dead_code)]
     pub async fn distill_thread_summary(
         &self,
         memory_store: &MemoryStore,
@@ -1205,6 +1204,10 @@ impl<'a> ThreadRecorder<'a> {
         self.rollout_recorder(session_id).append_event(item)
     }
 
+    /// Reserved explicit durability barrier for transcript/event persistence.
+    /// The session transcript contract documents both flush and shutdown
+    /// boundaries in docs/features/session-transcript.md.
+    #[allow(dead_code)]
     pub fn flush(&self, session_id: &str) -> Result<()> {
         self.rollout_recorder(session_id).flush()
     }
@@ -1380,6 +1383,10 @@ fn format_thread_markdown(thread: &ThreadSnapshot) -> String {
     lines.join("\n")
 }
 
+/// Reserved compatibility formatter for summary-style thread distillation.
+/// Activated through `distill_thread_summary` when callers need the legacy
+/// one-record path documented in docs/features/memory-records.md.
+#[allow(dead_code)]
 fn thread_summary_memory_record(thread: &ThreadSnapshot) -> Option<NewMemoryRecord> {
     let summary = thread
         .compaction

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -7,12 +7,11 @@ use anyhow::{Context, Result, anyhow};
 use rara_persistence::atomic_file;
 use rara_persistence::thread_data::{
     PersistedCompactState, PersistedInteraction, PersistedLegacyRolloutMigration,
-    PersistedLegacyRolloutSource, PersistedPlanStep, PersistedPromptRuntimeState,
-    PersistedRecentThreadRecord, PersistedRuntimeRolloutItem, PersistedStructuredRolloutEvent,
-    PersistedThreadLineage, PersistedThreadRecord, PersistedTurnEntry, PersistedTurnSummary,
+    PersistedLegacyRolloutSource, PersistedPlanStep, PersistedRuntimeRolloutItem,
+    PersistedStructuredRolloutEvent, PersistedThreadLineage, PersistedThreadRecord,
 };
 use rara_persistence::thread_metadata;
-use rara_persistence::thread_rollout_log::{self, RolloutEventRecorder};
+use rara_persistence::thread_rollout_log;
 use rara_persistence::thread_turn_log;
 use rara_state::state_db::StateDb;
 use uuid::Uuid;
@@ -21,270 +20,26 @@ use crate::agent::Message;
 use crate::memory_distiller::{
     MemoryDistiller, dedupe_memory_drafts, new_memory_record_from_draft,
 };
-use crate::memory_store::{
-    MemoryPromotionTarget, MemoryRecord, MemorySource, MemorySourceSpan, MemoryStore,
-    NewMemoryRecord,
-};
+use crate::memory_store::{MemoryRecord, MemoryStore};
 use crate::session::{
     PersistedCompactionEvent, PersistedCompactionEventsMigration, PersistedCompactionEventsSource,
     PersistedThreadHistoryMigration, PersistedThreadHistorySource, SessionManager,
 };
-use crate::session_transcript::{self, ThreadTranscriptRecorder};
+use crate::session_transcript;
+
+mod format;
+mod recorder;
+mod types;
 
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, Clone, Default)]
-pub struct CompactionRecord {
-    pub compaction_count: usize,
-    pub before_tokens: Option<usize>,
-    pub after_tokens: Option<usize>,
-    pub recent_file_count: Option<usize>,
-    pub boundary_version: Option<u32>,
-    pub replaced_start: Option<usize>,
-    pub replaced_end: Option<usize>,
-    pub metadata_owner: Option<String>,
-    pub recent_files: Vec<String>,
-    pub summary: Option<String>,
-}
-
-impl From<PersistedCompactState> for CompactionRecord {
-    fn from(value: PersistedCompactState) -> Self {
-        Self {
-            compaction_count: value.compaction_count,
-            before_tokens: value.last_compaction_before_tokens,
-            after_tokens: value.last_compaction_after_tokens,
-            recent_file_count: value.last_compaction_recent_file_count,
-            boundary_version: value.last_compaction_boundary_version,
-            replaced_start: None,
-            replaced_end: None,
-            metadata_owner: None,
-            recent_files: Vec::new(),
-            summary: None,
-        }
-    }
-}
-
-impl From<PersistedCompactionEvent> for CompactionRecord {
-    fn from(value: PersistedCompactionEvent) -> Self {
-        Self {
-            compaction_count: value.event_index,
-            before_tokens: Some(value.before_tokens),
-            after_tokens: Some(value.after_tokens),
-            recent_file_count: Some(value.recent_files.len()),
-            boundary_version: Some(value.boundary_version),
-            replaced_start: value.replaced_start,
-            replaced_end: value.replaced_end,
-            metadata_owner: value.metadata_owner,
-            recent_files: value.recent_files,
-            summary: Some(value.summary),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ThreadMetadata {
-    pub session_id: String,
-    pub cwd: String,
-    pub branch: String,
-    pub provider: String,
-    pub model: String,
-    pub base_url: Option<String>,
-    pub agent_mode: String,
-    pub bash_approval: String,
-    pub created_at: i64,
-    pub origin_kind: String,
-    pub forked_from_thread_id: Option<String>,
-    pub history_len: usize,
-    pub transcript_len: usize,
-    pub updated_at: i64,
-}
-
-#[derive(Debug, Clone)]
-pub struct ThreadSummary {
-    pub metadata: ThreadMetadata,
-    pub preview: String,
-    pub compaction: CompactionRecord,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ThreadMetadataSource {
-    StructuredMetadata,
-    StateDb,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ThreadHistorySource {
-    CanonicalHistory,
-    HistorySnapshotBackfilled,
-    LegacyHistoryBackfilled,
-    Missing,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ThreadNonTurnRolloutSource {
-    StructuredEventsLog,
-    LegacyBackfilled,
-    StateDbFallback,
-    Empty,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ThreadMaterializationProvenance {
-    pub metadata_source: ThreadMetadataSource,
-    pub history_source: ThreadHistorySource,
-    pub non_turn_rollout_source: ThreadNonTurnRolloutSource,
-}
-
-impl ThreadMaterializationProvenance {
-    /// Human-readable description of where each piece of the thread snapshot
-    /// was sourced from, making the legacy-fallback hierarchy explicit.
-    pub fn describe(&self) -> String {
-        let metadata = match self.metadata_source {
-            ThreadMetadataSource::StructuredMetadata => "structured thread metadata",
-            ThreadMetadataSource::StateDb => "StateDb fallback",
-        };
-        let history = match self.history_source {
-            ThreadHistorySource::CanonicalHistory => "canonical transcript.jsonl",
-            ThreadHistorySource::HistorySnapshotBackfilled => "history.json snapshot (backfilled)",
-            ThreadHistorySource::LegacyHistoryBackfilled => "legacy session JSON (backfilled)",
-            ThreadHistorySource::Missing => "missing",
-        };
-        let rollout = match self.non_turn_rollout_source {
-            ThreadNonTurnRolloutSource::StructuredEventsLog => "structured events log (canonical)",
-            ThreadNonTurnRolloutSource::LegacyBackfilled => "legacy rollout (backfilled)",
-            ThreadNonTurnRolloutSource::StateDbFallback => "StateDb fallback",
-            ThreadNonTurnRolloutSource::Empty => "empty",
-        };
-        format!("metadata={metadata} history={history} non-turn-rollout={rollout}")
-    }
-}
-
-impl From<PersistedThreadRecord> for ThreadMetadata {
-    fn from(value: PersistedThreadRecord) -> Self {
-        Self {
-            session_id: value.session_id,
-            cwd: value.cwd,
-            branch: value.branch,
-            provider: value.provider,
-            model: value.model,
-            base_url: value.base_url,
-            agent_mode: value.agent_mode,
-            bash_approval: value.bash_approval,
-            created_at: value.created_at,
-            origin_kind: value.lineage.origin_kind,
-            forked_from_thread_id: value.lineage.forked_from_thread_id,
-            history_len: value.history_len,
-            transcript_len: value.transcript_len,
-            updated_at: value.updated_at,
-        }
-    }
-}
-
-impl ThreadMetadata {
-    /// Returns true when this thread was forked from another thread.
-    pub fn is_fork(&self) -> bool {
-        self.origin_kind == "fork" && self.forked_from_thread_id.is_some()
-    }
-
-    /// Returns the origin kind and optional source thread id, making the
-    /// lineage explicit for callers that need to trace thread ancestry.
-    pub fn lineage(&self) -> (&str, Option<&str>) {
-        (
-            self.origin_kind.as_str(),
-            self.forked_from_thread_id.as_deref(),
-        )
-    }
-}
-
-impl From<PersistedRecentThreadRecord> for ThreadSummary {
-    fn from(value: PersistedRecentThreadRecord) -> Self {
-        Self {
-            metadata: ThreadMetadata {
-                session_id: value.session_id,
-                cwd: value.cwd,
-                branch: value.branch,
-                provider: value.provider,
-                model: value.model,
-                base_url: value.base_url,
-                agent_mode: value.agent_mode,
-                bash_approval: value.bash_approval,
-                created_at: value.created_at,
-                origin_kind: value.lineage.origin_kind,
-                forked_from_thread_id: value.lineage.forked_from_thread_id,
-                history_len: value.history_len,
-                transcript_len: value.transcript_len,
-                updated_at: value.updated_at,
-            },
-            preview: value.preview,
-            compaction: CompactionRecord {
-                compaction_count: value.compaction_count,
-                before_tokens: value.last_compaction_before_tokens,
-                after_tokens: value.last_compaction_after_tokens,
-                recent_file_count: value.last_compaction_recent_file_count,
-                boundary_version: value.last_compaction_boundary_version,
-                replaced_start: None,
-                replaced_end: None,
-                metadata_owner: None,
-                recent_files: Vec::new(),
-                summary: None,
-            },
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct RolloutTurnItem {
-    pub summary: PersistedTurnSummary,
-    pub entries: Vec<PersistedTurnEntry>,
-}
-
-#[derive(Debug, Clone)]
-pub enum RolloutItem {
-    Compaction(CompactionRecord),
-    PlanState {
-        explanation: Option<String>,
-        steps: Vec<PersistedPlanStep>,
-    },
-    Interaction(PersistedInteraction),
-    SpawnAgent {
-        event_id: String,
-        agent_id: String,
-        name: Option<String>,
-        child_session_id: String,
-        status: String,
-        summary: Option<String>,
-    },
-    Turn(RolloutTurnItem),
-}
-
-#[derive(Debug, Clone)]
-pub struct ThreadSnapshot {
-    pub metadata: ThreadMetadata,
-    pub provenance: ThreadMaterializationProvenance,
-    pub history: Vec<Message>,
-    pub compaction: CompactionRecord,
-    pub plan_explanation: Option<String>,
-    pub plan_steps: Vec<PersistedPlanStep>,
-    pub interactions: Vec<PersistedInteraction>,
-    pub rollout_items: Vec<RolloutItem>,
-}
-
-impl ThreadSnapshot {
-    /// Human-readable provenance description showing the source hierarchy.
-    pub fn provenance_description(&self) -> String {
-        self.provenance.describe()
-    }
-
-    /// Returns true when this snapshot was forked from another thread.
-    pub fn is_fork(&self) -> bool {
-        self.metadata.is_fork()
-    }
-
-    pub fn lineage(&self) -> (&str, Option<&str>) {
-        self.metadata.lineage()
-    }
-}
+pub use recorder::{ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeState};
+pub use types::{
+    CompactionRecord, RolloutItem, RolloutTurnItem, ThreadHistorySource,
+    ThreadMaterializationProvenance, ThreadMetadata, ThreadMetadataSource,
+    ThreadNonTurnRolloutSource, ThreadSnapshot, ThreadSummary,
+};
 
 #[derive(Debug, Clone)]
 struct ThreadMaterializedState {
@@ -369,7 +124,9 @@ impl<'a> ThreadStore<'a> {
     /// This is part of the thread contract documented in docs/features/threads.md.
     #[allow(dead_code)]
     pub fn export_thread_markdown(&self, session_id: &str) -> Result<String> {
-        Ok(format_thread_markdown(&self.load_thread(session_id)?))
+        Ok(format::format_thread_markdown(
+            &self.load_thread(session_id)?,
+        ))
     }
 
     /// Reserved compatibility path for one-record thread distillation.
@@ -382,7 +139,7 @@ impl<'a> ThreadStore<'a> {
         session_id: &str,
     ) -> Result<Option<MemoryRecord>> {
         let snapshot = self.load_thread(session_id)?;
-        let Some(input) = thread_summary_memory_record(&snapshot) else {
+        let Some(input) = format::thread_summary_memory_record(&snapshot) else {
             return Ok(None);
         };
         Ok(Some(memory_store.insert(input).await?))
@@ -394,7 +151,7 @@ impl<'a> ThreadStore<'a> {
         session_id: &str,
     ) -> Result<Vec<MemoryRecord>> {
         let snapshot = self.load_thread(session_id)?;
-        let markdown = format_thread_markdown(&snapshot);
+        let markdown = format::format_thread_markdown(&snapshot);
         let distiller = MemoryDistiller::new(memory_store.backend());
         let drafts = distiller.distill_thread_markdown(&markdown).await?;
         if drafts.is_empty() {
@@ -406,7 +163,7 @@ impl<'a> ThreadStore<'a> {
             existing_hits.push(memory_store.search(&draft.content, 5).await?);
         }
 
-        let base = thread_distilled_memory_base(&snapshot)?;
+        let base = format::thread_distilled_memory_base(&snapshot)?;
         let mut records = Vec::new();
         for draft in dedupe_memory_drafts(drafts, &existing_hits) {
             records.push(
@@ -424,7 +181,7 @@ impl<'a> ThreadStore<'a> {
             .state_db
             .load_session_runtime_state(source_thread_id)?
             .unwrap_or_default();
-        let compact_state = compact_state_from_record(&materialized.compaction);
+        let compact_state = recorder::compact_state_from_record(&materialized.compaction);
         let forked_thread_id = Uuid::new_v4().to_string();
         let lineage = PersistedThreadLineage {
             origin_kind: "fork".to_string(),
@@ -1132,406 +889,6 @@ impl<'a> ThreadStore<'a> {
             self.state_db.load_thread_record(session_id)?,
             ThreadMetadataSource::StateDb,
         ))
-    }
-}
-
-pub struct ThreadRuntimeState<'a> {
-    pub session_id: &'a str,
-    pub cwd: &'a str,
-    pub branch: &'a str,
-    pub provider: &'a str,
-    pub model: &'a str,
-    pub base_url: Option<&'a str>,
-    pub agent_mode: &'a str,
-    pub bash_approval: &'a str,
-    pub plan_explanation: Option<&'a str>,
-    pub prompt_runtime: PersistedPromptRuntimeState,
-    pub history_len: usize,
-    pub transcript_len: usize,
-    pub compact_state: PersistedCompactState,
-}
-
-pub struct ThreadRuntimeLineage {
-    pub origin_kind: String,
-    pub forked_from_thread_id: Option<String>,
-}
-
-pub struct ThreadRecorder<'a> {
-    state_db: &'a StateDb,
-}
-
-impl<'a> ThreadRecorder<'a> {
-    pub fn new(state_db: &'a StateDb) -> Self {
-        Self { state_db }
-    }
-
-    pub fn persist_history_checkpoint(&self, session_id: &str, history: &[Message]) -> Result<()> {
-        let rollout_root = self.state_db.rollout_root();
-        let recorder = ThreadTranscriptRecorder::main(&rollout_root, session_id);
-        recorder.sync_history_checkpoint(history)?;
-        recorder.shutdown()?;
-        write_history_snapshot(&rollout_root, session_id, history)
-    }
-
-    pub fn persist_compaction_event(
-        &self,
-        session_id: &str,
-        event: &PersistedCompactionEvent,
-    ) -> Result<()> {
-        self.append_rollout_item(
-            session_id,
-            &PersistedStructuredRolloutEvent::Compaction {
-                recorded_at: Some(crate::utils::epoch_seconds()),
-                event_index: event.event_index,
-                before_tokens: event.before_tokens,
-                after_tokens: event.after_tokens,
-                boundary_version: event.boundary_version,
-                replaced_start: event.replaced_start,
-                replaced_end: event.replaced_end,
-                metadata_owner: event.metadata_owner.clone(),
-                recent_files: event.recent_files.clone(),
-                summary: event.summary.clone(),
-            },
-        )?;
-        self.shutdown(session_id)
-    }
-
-    pub fn append_rollout_item(
-        &self,
-        session_id: &str,
-        item: &PersistedStructuredRolloutEvent,
-    ) -> Result<()> {
-        self.rollout_recorder(session_id).append_event(item)
-    }
-
-    /// Reserved explicit durability barrier for transcript/event persistence.
-    /// The session transcript contract documents both flush and shutdown
-    /// boundaries in docs/features/session-transcript.md.
-    #[allow(dead_code)]
-    pub fn flush(&self, session_id: &str) -> Result<()> {
-        self.rollout_recorder(session_id).flush()
-    }
-
-    pub fn shutdown(&self, session_id: &str) -> Result<()> {
-        self.rollout_recorder(session_id).shutdown()
-    }
-
-    fn rollout_recorder(&self, session_id: &str) -> RolloutEventRecorder {
-        RolloutEventRecorder::new(&self.state_db.rollout_root(), session_id)
-    }
-
-    pub fn persist_runtime_state(&self, state: &ThreadRuntimeState<'_>) -> Result<()> {
-        let lineage = self.current_lineage(state.session_id)?;
-        self.persist_runtime_state_with_lineage(state, &lineage)
-    }
-
-    pub fn persist_runtime_state_with_lineage(
-        &self,
-        state: &ThreadRuntimeState<'_>,
-        lineage: &ThreadRuntimeLineage,
-    ) -> Result<()> {
-        let now = crate::utils::epoch_seconds();
-        let existing_metadata = match thread_metadata::load_thread_record(
-            &self.state_db.rollout_root(),
-            state.session_id,
-        )? {
-            Some(record) => Some(record),
-            None => self.state_db.load_thread_record(state.session_id)?,
-        };
-        let created_at = existing_metadata
-            .as_ref()
-            .map(|record| record.created_at)
-            .unwrap_or(now);
-        let record = PersistedThreadRecord {
-            session_id: state.session_id.to_string(),
-            cwd: state.cwd.to_string(),
-            branch: state.branch.to_string(),
-            provider: state.provider.to_string(),
-            model: state.model.to_string(),
-            base_url: state.base_url.map(str::to_string),
-            agent_mode: state.agent_mode.to_string(),
-            bash_approval: state.bash_approval.to_string(),
-            created_at,
-            lineage: PersistedThreadLineage {
-                origin_kind: lineage.origin_kind.clone(),
-                forked_from_thread_id: lineage.forked_from_thread_id.clone(),
-            },
-            plan_explanation: state.plan_explanation.map(str::to_string),
-            history_len: state.history_len,
-            transcript_len: state.transcript_len,
-            updated_at: now,
-        };
-        thread_metadata::write_thread_record(&self.state_db.rollout_root(), &record)?;
-        self.state_db.upsert_session_with_lineage(
-            state.session_id,
-            state.cwd,
-            state.branch,
-            state.provider,
-            state.model,
-            state.base_url,
-            state.agent_mode,
-            state.bash_approval,
-            &PersistedThreadLineage {
-                origin_kind: lineage.origin_kind.clone(),
-                forked_from_thread_id: lineage.forked_from_thread_id.clone(),
-            },
-            state.plan_explanation,
-            &state.prompt_runtime,
-            state.history_len,
-            state.transcript_len,
-            &state.compact_state,
-        )
-    }
-
-    fn current_lineage(&self, session_id: &str) -> Result<ThreadRuntimeLineage> {
-        let lineage = self
-            .state_db
-            .load_thread_record(session_id)?
-            .map(|record| ThreadRuntimeLineage {
-                origin_kind: record.lineage.origin_kind,
-                forked_from_thread_id: record.lineage.forked_from_thread_id,
-            })
-            .unwrap_or(ThreadRuntimeLineage {
-                origin_kind: "fresh".to_string(),
-                forked_from_thread_id: None,
-            });
-        Ok(lineage)
-    }
-
-    pub fn replace_plan_steps(&self, session_id: &str, steps: &[PersistedPlanStep]) -> Result<()> {
-        self.state_db.replace_plan_steps(session_id, steps)
-    }
-
-    pub fn replace_interactions(
-        &self,
-        session_id: &str,
-        interactions: &[PersistedInteraction],
-    ) -> Result<()> {
-        self.state_db.replace_interactions(session_id, interactions)
-    }
-
-    pub fn replace_runtime_rollout_events(
-        &self,
-        session_id: &str,
-        items: &[PersistedStructuredRolloutEvent],
-    ) -> Result<()> {
-        self.append_rollout_item(
-            session_id,
-            &PersistedStructuredRolloutEvent::runtime_state_from_items(
-                items,
-                Some(crate::utils::epoch_seconds()),
-            ),
-        )?;
-        self.shutdown(session_id)
-    }
-
-    pub fn persist_turn(
-        &self,
-        session_id: &str,
-        ordinal: usize,
-        entries: &[PersistedTurnEntry],
-    ) -> Result<PersistedTurnSummary> {
-        let summary = thread_turn_log::append_turn_record(
-            &self.state_db.rollout_root(),
-            session_id,
-            ordinal,
-            entries,
-        )?;
-        if let Err(err) = self.state_db.persist_turn(session_id, ordinal, entries) {
-            eprintln!(
-                "Warning: canonical turn log advanced for {session_id}, but StateDb turn index update failed: {err}"
-            );
-        }
-        Ok(summary)
-    }
-}
-
-fn format_thread_markdown(thread: &ThreadSnapshot) -> String {
-    let title = thread_title(thread);
-    let mut lines = vec![
-        "---".to_string(),
-        format!("title: {}", yaml_scalar(&title)),
-        "source: rara".to_string(),
-        format!("session_id: {}", yaml_scalar(&thread.metadata.session_id)),
-        format!("workspace: {}", yaml_scalar(&thread.metadata.cwd)),
-        format!("model: {}", yaml_scalar(&thread.metadata.model)),
-        format!("created_at: {}", thread.metadata.created_at),
-        format!("updated_at: {}", thread.metadata.updated_at),
-        "---".to_string(),
-        String::new(),
-        format!("# {title}"),
-        String::new(),
-    ];
-
-    if let Some(summary) = thread
-        .compaction
-        .summary
-        .as_deref()
-        .filter(|value| !value.trim().is_empty())
-    {
-        lines.push("## Summary".to_string());
-        lines.push(summary.trim().to_string());
-        lines.push(String::new());
-    }
-
-    for message in &thread.history {
-        lines.push(format!("## {}", role_heading(&message.role)));
-        lines.push(render_message_content(&message.content));
-        lines.push(String::new());
-    }
-
-    lines.join("\n")
-}
-
-/// Reserved compatibility formatter for summary-style thread distillation.
-/// Activated through `distill_thread_summary` when callers need the legacy
-/// one-record path documented in docs/features/memory-records.md.
-#[allow(dead_code)]
-fn thread_summary_memory_record(thread: &ThreadSnapshot) -> Option<NewMemoryRecord> {
-    let summary = thread
-        .compaction
-        .summary
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(str::to_string)
-        .or_else(|| first_user_message(thread));
-    let summary = summary?;
-    let title = thread_title(thread);
-    let mut record = thread_distilled_memory_base(thread).ok()?;
-    record.title = Some(title);
-    record.content = format!(
-        concat!(
-            "## Summary\n",
-            "{summary}\n\n",
-            "## Provenance\n",
-            "- session_id: {session_id}\n",
-            "- thread_id: {thread_id}\n",
-            "- workspace: {workspace}\n",
-            "- provider: {provider}\n",
-            "- model: {model}\n"
-        ),
-        summary = summary.as_str(),
-        session_id = thread.metadata.session_id.as_str(),
-        thread_id = thread.metadata.session_id.as_str(),
-        workspace = thread.metadata.cwd.as_str(),
-        provider = thread.metadata.provider.as_str(),
-        model = thread.metadata.model.as_str(),
-    );
-    Some(record)
-}
-
-fn thread_distilled_memory_base(thread: &ThreadSnapshot) -> Result<NewMemoryRecord> {
-    let end_turn_index = thread.history.len().saturating_sub(1) as u32;
-    NewMemoryRecord::promotion_base(
-        MemorySource::ThreadDistill,
-        MemoryPromotionTarget::Thread {
-            session_id: Some(thread.metadata.session_id.clone()),
-            thread_id: thread.metadata.session_id.clone(),
-            source_span: Some(MemorySourceSpan {
-                start_turn_index: 0,
-                end_turn_index,
-            }),
-        },
-    )
-}
-
-fn thread_title(thread: &ThreadSnapshot) -> String {
-    first_user_message(thread)
-        .map(|value| truncate_chars(&collapse_whitespace(&value), 80))
-        .unwrap_or_else(|| format!("Thread {}", thread.metadata.session_id))
-}
-
-fn first_user_message(thread: &ThreadSnapshot) -> Option<String> {
-    thread
-        .history
-        .iter()
-        .find(|message| message.role == "user")
-        .map(|message| render_message_content(&message.content))
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-
-fn role_heading(role: &str) -> &str {
-    match role {
-        "assistant" => "Assistant",
-        "system" => "System",
-        "tool" => "Tool",
-        "user" => "User",
-        _ => "Message",
-    }
-}
-
-fn render_message_content(content: &serde_json::Value) -> String {
-    if let Some(text) = content.as_str() {
-        return text.to_string();
-    }
-    if let Some(items) = content.as_array() {
-        let rendered = items
-            .iter()
-            .filter_map(render_content_item)
-            .collect::<Vec<_>>();
-        if !rendered.is_empty() {
-            return rendered.join("\n\n");
-        }
-    }
-    serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string())
-}
-
-fn render_content_item(item: &serde_json::Value) -> Option<String> {
-    match item.get("type").and_then(serde_json::Value::as_str) {
-        Some("text") => item
-            .get("text")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string),
-        Some("tool_use") => {
-            let name = item
-                .get("name")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("tool");
-            let input = item
-                .get("input")
-                .map(|value| {
-                    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
-                })
-                .unwrap_or_else(|| "{}".to_string());
-            Some(format!("Tool use: {name}\n\n```json\n{input}\n```"))
-        }
-        Some("tool_result") => item
-            .get("content")
-            .and_then(serde_json::Value::as_str)
-            .map(str::to_string),
-        _ => Some(serde_json::to_string_pretty(item).unwrap_or_else(|_| item.to_string())),
-    }
-}
-
-fn yaml_scalar(value: &str) -> String {
-    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
-}
-
-fn collapse_whitespace(value: &str) -> String {
-    value.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-fn truncate_chars(value: &str, max_chars: usize) -> String {
-    let mut chars = value.chars();
-    let truncated = chars.by_ref().take(max_chars).collect::<String>();
-    if chars.next().is_some() {
-        format!("{truncated}...")
-    } else {
-        truncated
-    }
-}
-
-fn compact_state_from_record(record: &CompactionRecord) -> PersistedCompactState {
-    PersistedCompactState {
-        compaction_count: record.compaction_count,
-        last_compaction_before_tokens: record.before_tokens,
-        last_compaction_after_tokens: record.after_tokens,
-        last_compaction_recent_file_count: record
-            .recent_file_count
-            .or(Some(record.recent_files.len()).filter(|value| *value > 0)),
-        last_compaction_boundary_version: record.boundary_version,
     }
 }
 

--- a/src/thread_store/format.rs
+++ b/src/thread_store/format.rs
@@ -1,0 +1,181 @@
+use anyhow::Result;
+
+use super::ThreadSnapshot;
+use crate::memory_store::{MemoryPromotionTarget, MemorySource, MemorySourceSpan, NewMemoryRecord};
+
+pub(super) fn format_thread_markdown(thread: &ThreadSnapshot) -> String {
+    let title = thread_title(thread);
+    let mut lines = vec![
+        "---".to_string(),
+        format!("title: {}", yaml_scalar(&title)),
+        "source: rara".to_string(),
+        format!("session_id: {}", yaml_scalar(&thread.metadata.session_id)),
+        format!("workspace: {}", yaml_scalar(&thread.metadata.cwd)),
+        format!("model: {}", yaml_scalar(&thread.metadata.model)),
+        format!("created_at: {}", thread.metadata.created_at),
+        format!("updated_at: {}", thread.metadata.updated_at),
+        "---".to_string(),
+        String::new(),
+        format!("# {title}"),
+        String::new(),
+    ];
+
+    if let Some(summary) = thread
+        .compaction
+        .summary
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        lines.push("## Summary".to_string());
+        lines.push(summary.trim().to_string());
+        lines.push(String::new());
+    }
+
+    for message in &thread.history {
+        lines.push(format!("## {}", role_heading(&message.role)));
+        lines.push(render_message_content(&message.content));
+        lines.push(String::new());
+    }
+
+    lines.join("\n")
+}
+
+/// Reserved compatibility formatter for summary-style thread distillation.
+/// Activated through `distill_thread_summary` when callers need the legacy
+/// one-record path documented in docs/features/memory-records.md.
+#[allow(dead_code)]
+pub(super) fn thread_summary_memory_record(thread: &ThreadSnapshot) -> Option<NewMemoryRecord> {
+    let summary = thread
+        .compaction
+        .summary
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .or_else(|| first_user_message(thread));
+    let summary = summary?;
+    let title = thread_title(thread);
+    let mut record = thread_distilled_memory_base(thread).ok()?;
+    record.title = Some(title);
+    record.content = format!(
+        concat!(
+            "## Summary\n",
+            "{summary}\n\n",
+            "## Provenance\n",
+            "- session_id: {session_id}\n",
+            "- thread_id: {thread_id}\n",
+            "- workspace: {workspace}\n",
+            "- provider: {provider}\n",
+            "- model: {model}\n"
+        ),
+        summary = summary.as_str(),
+        session_id = thread.metadata.session_id.as_str(),
+        thread_id = thread.metadata.session_id.as_str(),
+        workspace = thread.metadata.cwd.as_str(),
+        provider = thread.metadata.provider.as_str(),
+        model = thread.metadata.model.as_str(),
+    );
+    Some(record)
+}
+
+pub(super) fn thread_distilled_memory_base(thread: &ThreadSnapshot) -> Result<NewMemoryRecord> {
+    let end_turn_index = thread.history.len().saturating_sub(1) as u32;
+    NewMemoryRecord::promotion_base(
+        MemorySource::ThreadDistill,
+        MemoryPromotionTarget::Thread {
+            session_id: Some(thread.metadata.session_id.clone()),
+            thread_id: thread.metadata.session_id.clone(),
+            source_span: Some(MemorySourceSpan {
+                start_turn_index: 0,
+                end_turn_index,
+            }),
+        },
+    )
+}
+
+fn thread_title(thread: &ThreadSnapshot) -> String {
+    first_user_message(thread)
+        .map(|value| truncate_chars(&collapse_whitespace(&value), 80))
+        .unwrap_or_else(|| format!("Thread {}", thread.metadata.session_id))
+}
+
+fn first_user_message(thread: &ThreadSnapshot) -> Option<String> {
+    thread
+        .history
+        .iter()
+        .find(|message| message.role == "user")
+        .map(|message| render_message_content(&message.content))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn role_heading(role: &str) -> &str {
+    match role {
+        "assistant" => "Assistant",
+        "system" => "System",
+        "tool" => "Tool",
+        "user" => "User",
+        _ => "Message",
+    }
+}
+
+fn render_message_content(content: &serde_json::Value) -> String {
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    if let Some(items) = content.as_array() {
+        let rendered = items
+            .iter()
+            .filter_map(render_content_item)
+            .collect::<Vec<_>>();
+        if !rendered.is_empty() {
+            return rendered.join("\n\n");
+        }
+    }
+    serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string())
+}
+
+fn render_content_item(item: &serde_json::Value) -> Option<String> {
+    match item.get("type").and_then(serde_json::Value::as_str) {
+        Some("text") => item
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        Some("tool_use") => {
+            let name = item
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("tool");
+            let input = item
+                .get("input")
+                .map(|value| {
+                    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+                })
+                .unwrap_or_else(|| "{}".to_string());
+            Some(format!("Tool use: {name}\n\n```json\n{input}\n```"))
+        }
+        Some("tool_result") => item
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        _ => Some(serde_json::to_string_pretty(item).unwrap_or_else(|_| item.to_string())),
+    }
+}
+
+fn yaml_scalar(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
+fn collapse_whitespace(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}

--- a/src/thread_store/recorder.rs
+++ b/src/thread_store/recorder.rs
@@ -1,0 +1,238 @@
+use anyhow::Result;
+use rara_persistence::thread_data::{
+    PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
+    PersistedStructuredRolloutEvent, PersistedThreadLineage, PersistedThreadRecord,
+    PersistedTurnEntry, PersistedTurnSummary,
+};
+use rara_persistence::thread_metadata;
+use rara_persistence::thread_rollout_log::RolloutEventRecorder;
+use rara_persistence::thread_turn_log;
+use rara_state::state_db::StateDb;
+
+use super::{CompactionRecord, write_history_snapshot};
+use crate::agent::Message;
+use crate::session::PersistedCompactionEvent;
+use crate::session_transcript::ThreadTranscriptRecorder;
+
+pub struct ThreadRuntimeState<'a> {
+    pub session_id: &'a str,
+    pub cwd: &'a str,
+    pub branch: &'a str,
+    pub provider: &'a str,
+    pub model: &'a str,
+    pub base_url: Option<&'a str>,
+    pub agent_mode: &'a str,
+    pub bash_approval: &'a str,
+    pub plan_explanation: Option<&'a str>,
+    pub prompt_runtime: PersistedPromptRuntimeState,
+    pub history_len: usize,
+    pub transcript_len: usize,
+    pub compact_state: PersistedCompactState,
+}
+
+pub struct ThreadRuntimeLineage {
+    pub origin_kind: String,
+    pub forked_from_thread_id: Option<String>,
+}
+
+pub struct ThreadRecorder<'a> {
+    state_db: &'a StateDb,
+}
+
+impl<'a> ThreadRecorder<'a> {
+    pub fn new(state_db: &'a StateDb) -> Self {
+        Self { state_db }
+    }
+
+    pub fn persist_history_checkpoint(&self, session_id: &str, history: &[Message]) -> Result<()> {
+        let rollout_root = self.state_db.rollout_root();
+        let recorder = ThreadTranscriptRecorder::main(&rollout_root, session_id);
+        recorder.sync_history_checkpoint(history)?;
+        recorder.shutdown()?;
+        write_history_snapshot(&rollout_root, session_id, history)
+    }
+
+    pub fn persist_compaction_event(
+        &self,
+        session_id: &str,
+        event: &PersistedCompactionEvent,
+    ) -> Result<()> {
+        self.append_rollout_item(
+            session_id,
+            &PersistedStructuredRolloutEvent::Compaction {
+                recorded_at: Some(crate::utils::epoch_seconds()),
+                event_index: event.event_index,
+                before_tokens: event.before_tokens,
+                after_tokens: event.after_tokens,
+                boundary_version: event.boundary_version,
+                replaced_start: event.replaced_start,
+                replaced_end: event.replaced_end,
+                metadata_owner: event.metadata_owner.clone(),
+                recent_files: event.recent_files.clone(),
+                summary: event.summary.clone(),
+            },
+        )?;
+        self.shutdown(session_id)
+    }
+
+    pub fn append_rollout_item(
+        &self,
+        session_id: &str,
+        item: &PersistedStructuredRolloutEvent,
+    ) -> Result<()> {
+        self.rollout_recorder(session_id).append_event(item)
+    }
+
+    /// Reserved explicit durability barrier for transcript/event persistence.
+    /// The session transcript contract documents both flush and shutdown
+    /// boundaries in docs/features/session-transcript.md.
+    #[allow(dead_code)]
+    pub fn flush(&self, session_id: &str) -> Result<()> {
+        self.rollout_recorder(session_id).flush()
+    }
+
+    pub fn shutdown(&self, session_id: &str) -> Result<()> {
+        self.rollout_recorder(session_id).shutdown()
+    }
+
+    fn rollout_recorder(&self, session_id: &str) -> RolloutEventRecorder {
+        RolloutEventRecorder::new(&self.state_db.rollout_root(), session_id)
+    }
+
+    pub fn persist_runtime_state(&self, state: &ThreadRuntimeState<'_>) -> Result<()> {
+        let lineage = self.current_lineage(state.session_id)?;
+        self.persist_runtime_state_with_lineage(state, &lineage)
+    }
+
+    pub fn persist_runtime_state_with_lineage(
+        &self,
+        state: &ThreadRuntimeState<'_>,
+        lineage: &ThreadRuntimeLineage,
+    ) -> Result<()> {
+        let now = crate::utils::epoch_seconds();
+        let existing_metadata = match thread_metadata::load_thread_record(
+            &self.state_db.rollout_root(),
+            state.session_id,
+        )? {
+            Some(record) => Some(record),
+            None => self.state_db.load_thread_record(state.session_id)?,
+        };
+        let created_at = existing_metadata
+            .as_ref()
+            .map(|record| record.created_at)
+            .unwrap_or(now);
+        let record = PersistedThreadRecord {
+            session_id: state.session_id.to_string(),
+            cwd: state.cwd.to_string(),
+            branch: state.branch.to_string(),
+            provider: state.provider.to_string(),
+            model: state.model.to_string(),
+            base_url: state.base_url.map(str::to_string),
+            agent_mode: state.agent_mode.to_string(),
+            bash_approval: state.bash_approval.to_string(),
+            created_at,
+            lineage: PersistedThreadLineage {
+                origin_kind: lineage.origin_kind.clone(),
+                forked_from_thread_id: lineage.forked_from_thread_id.clone(),
+            },
+            plan_explanation: state.plan_explanation.map(str::to_string),
+            history_len: state.history_len,
+            transcript_len: state.transcript_len,
+            updated_at: now,
+        };
+        thread_metadata::write_thread_record(&self.state_db.rollout_root(), &record)?;
+        self.state_db.upsert_session_with_lineage(
+            state.session_id,
+            state.cwd,
+            state.branch,
+            state.provider,
+            state.model,
+            state.base_url,
+            state.agent_mode,
+            state.bash_approval,
+            &PersistedThreadLineage {
+                origin_kind: lineage.origin_kind.clone(),
+                forked_from_thread_id: lineage.forked_from_thread_id.clone(),
+            },
+            state.plan_explanation,
+            &state.prompt_runtime,
+            state.history_len,
+            state.transcript_len,
+            &state.compact_state,
+        )
+    }
+
+    fn current_lineage(&self, session_id: &str) -> Result<ThreadRuntimeLineage> {
+        let lineage = self
+            .state_db
+            .load_thread_record(session_id)?
+            .map(|record| ThreadRuntimeLineage {
+                origin_kind: record.lineage.origin_kind,
+                forked_from_thread_id: record.lineage.forked_from_thread_id,
+            })
+            .unwrap_or(ThreadRuntimeLineage {
+                origin_kind: "fresh".to_string(),
+                forked_from_thread_id: None,
+            });
+        Ok(lineage)
+    }
+
+    pub fn replace_plan_steps(&self, session_id: &str, steps: &[PersistedPlanStep]) -> Result<()> {
+        self.state_db.replace_plan_steps(session_id, steps)
+    }
+
+    pub fn replace_interactions(
+        &self,
+        session_id: &str,
+        interactions: &[PersistedInteraction],
+    ) -> Result<()> {
+        self.state_db.replace_interactions(session_id, interactions)
+    }
+
+    pub fn replace_runtime_rollout_events(
+        &self,
+        session_id: &str,
+        items: &[PersistedStructuredRolloutEvent],
+    ) -> Result<()> {
+        self.append_rollout_item(
+            session_id,
+            &PersistedStructuredRolloutEvent::runtime_state_from_items(
+                items,
+                Some(crate::utils::epoch_seconds()),
+            ),
+        )?;
+        self.shutdown(session_id)
+    }
+
+    pub fn persist_turn(
+        &self,
+        session_id: &str,
+        ordinal: usize,
+        entries: &[PersistedTurnEntry],
+    ) -> Result<PersistedTurnSummary> {
+        let summary = thread_turn_log::append_turn_record(
+            &self.state_db.rollout_root(),
+            session_id,
+            ordinal,
+            entries,
+        )?;
+        if let Err(err) = self.state_db.persist_turn(session_id, ordinal, entries) {
+            eprintln!(
+                "Warning: canonical turn log advanced for {session_id}, but StateDb turn index update failed: {err}"
+            );
+        }
+        Ok(summary)
+    }
+}
+
+pub(super) fn compact_state_from_record(record: &CompactionRecord) -> PersistedCompactState {
+    PersistedCompactState {
+        compaction_count: record.compaction_count,
+        last_compaction_before_tokens: record.before_tokens,
+        last_compaction_after_tokens: record.after_tokens,
+        last_compaction_recent_file_count: record
+            .recent_file_count
+            .or(Some(record.recent_files.len()).filter(|value| *value > 0)),
+        last_compaction_boundary_version: record.boundary_version,
+    }
+}

--- a/src/thread_store/types.rs
+++ b/src/thread_store/types.rs
@@ -1,0 +1,259 @@
+use rara_persistence::thread_data::{
+    PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedRecentThreadRecord,
+    PersistedThreadRecord, PersistedTurnEntry, PersistedTurnSummary,
+};
+
+use crate::agent::Message;
+use crate::session::PersistedCompactionEvent;
+
+#[derive(Debug, Clone, Default)]
+pub struct CompactionRecord {
+    pub compaction_count: usize,
+    pub before_tokens: Option<usize>,
+    pub after_tokens: Option<usize>,
+    pub recent_file_count: Option<usize>,
+    pub boundary_version: Option<u32>,
+    pub replaced_start: Option<usize>,
+    pub replaced_end: Option<usize>,
+    pub metadata_owner: Option<String>,
+    pub recent_files: Vec<String>,
+    pub summary: Option<String>,
+}
+
+impl From<PersistedCompactState> for CompactionRecord {
+    fn from(value: PersistedCompactState) -> Self {
+        Self {
+            compaction_count: value.compaction_count,
+            before_tokens: value.last_compaction_before_tokens,
+            after_tokens: value.last_compaction_after_tokens,
+            recent_file_count: value.last_compaction_recent_file_count,
+            boundary_version: value.last_compaction_boundary_version,
+            replaced_start: None,
+            replaced_end: None,
+            metadata_owner: None,
+            recent_files: Vec::new(),
+            summary: None,
+        }
+    }
+}
+
+impl From<PersistedCompactionEvent> for CompactionRecord {
+    fn from(value: PersistedCompactionEvent) -> Self {
+        Self {
+            compaction_count: value.event_index,
+            before_tokens: Some(value.before_tokens),
+            after_tokens: Some(value.after_tokens),
+            recent_file_count: Some(value.recent_files.len()),
+            boundary_version: Some(value.boundary_version),
+            replaced_start: value.replaced_start,
+            replaced_end: value.replaced_end,
+            metadata_owner: value.metadata_owner,
+            recent_files: value.recent_files,
+            summary: Some(value.summary),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadMetadata {
+    pub session_id: String,
+    pub cwd: String,
+    pub branch: String,
+    pub provider: String,
+    pub model: String,
+    pub base_url: Option<String>,
+    pub agent_mode: String,
+    pub bash_approval: String,
+    pub created_at: i64,
+    pub origin_kind: String,
+    pub forked_from_thread_id: Option<String>,
+    pub history_len: usize,
+    pub transcript_len: usize,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadSummary {
+    pub metadata: ThreadMetadata,
+    pub preview: String,
+    pub compaction: CompactionRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadMetadataSource {
+    StructuredMetadata,
+    StateDb,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadHistorySource {
+    CanonicalHistory,
+    HistorySnapshotBackfilled,
+    LegacyHistoryBackfilled,
+    Missing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ThreadNonTurnRolloutSource {
+    StructuredEventsLog,
+    LegacyBackfilled,
+    StateDbFallback,
+    Empty,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadMaterializationProvenance {
+    pub metadata_source: ThreadMetadataSource,
+    pub history_source: ThreadHistorySource,
+    pub non_turn_rollout_source: ThreadNonTurnRolloutSource,
+}
+
+impl ThreadMaterializationProvenance {
+    /// Human-readable description of where each piece of the thread snapshot
+    /// was sourced from, making the legacy-fallback hierarchy explicit.
+    pub fn describe(&self) -> String {
+        let metadata = match self.metadata_source {
+            ThreadMetadataSource::StructuredMetadata => "structured thread metadata",
+            ThreadMetadataSource::StateDb => "StateDb fallback",
+        };
+        let history = match self.history_source {
+            ThreadHistorySource::CanonicalHistory => "canonical transcript.jsonl",
+            ThreadHistorySource::HistorySnapshotBackfilled => "history.json snapshot (backfilled)",
+            ThreadHistorySource::LegacyHistoryBackfilled => "legacy session JSON (backfilled)",
+            ThreadHistorySource::Missing => "missing",
+        };
+        let rollout = match self.non_turn_rollout_source {
+            ThreadNonTurnRolloutSource::StructuredEventsLog => "structured events log (canonical)",
+            ThreadNonTurnRolloutSource::LegacyBackfilled => "legacy rollout (backfilled)",
+            ThreadNonTurnRolloutSource::StateDbFallback => "StateDb fallback",
+            ThreadNonTurnRolloutSource::Empty => "empty",
+        };
+        format!("metadata={metadata} history={history} non-turn-rollout={rollout}")
+    }
+}
+
+impl From<PersistedThreadRecord> for ThreadMetadata {
+    fn from(value: PersistedThreadRecord) -> Self {
+        Self {
+            session_id: value.session_id,
+            cwd: value.cwd,
+            branch: value.branch,
+            provider: value.provider,
+            model: value.model,
+            base_url: value.base_url,
+            agent_mode: value.agent_mode,
+            bash_approval: value.bash_approval,
+            created_at: value.created_at,
+            origin_kind: value.lineage.origin_kind,
+            forked_from_thread_id: value.lineage.forked_from_thread_id,
+            history_len: value.history_len,
+            transcript_len: value.transcript_len,
+            updated_at: value.updated_at,
+        }
+    }
+}
+
+impl ThreadMetadata {
+    /// Returns true when this thread was forked from another thread.
+    pub fn is_fork(&self) -> bool {
+        self.origin_kind == "fork" && self.forked_from_thread_id.is_some()
+    }
+
+    /// Returns the origin kind and optional source thread id, making the
+    /// lineage explicit for callers that need to trace thread ancestry.
+    pub fn lineage(&self) -> (&str, Option<&str>) {
+        (
+            self.origin_kind.as_str(),
+            self.forked_from_thread_id.as_deref(),
+        )
+    }
+}
+
+impl From<PersistedRecentThreadRecord> for ThreadSummary {
+    fn from(value: PersistedRecentThreadRecord) -> Self {
+        Self {
+            metadata: ThreadMetadata {
+                session_id: value.session_id,
+                cwd: value.cwd,
+                branch: value.branch,
+                provider: value.provider,
+                model: value.model,
+                base_url: value.base_url,
+                agent_mode: value.agent_mode,
+                bash_approval: value.bash_approval,
+                created_at: value.created_at,
+                origin_kind: value.lineage.origin_kind,
+                forked_from_thread_id: value.lineage.forked_from_thread_id,
+                history_len: value.history_len,
+                transcript_len: value.transcript_len,
+                updated_at: value.updated_at,
+            },
+            preview: value.preview,
+            compaction: CompactionRecord {
+                compaction_count: value.compaction_count,
+                before_tokens: value.last_compaction_before_tokens,
+                after_tokens: value.last_compaction_after_tokens,
+                recent_file_count: value.last_compaction_recent_file_count,
+                boundary_version: value.last_compaction_boundary_version,
+                replaced_start: None,
+                replaced_end: None,
+                metadata_owner: None,
+                recent_files: Vec::new(),
+                summary: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RolloutTurnItem {
+    pub summary: PersistedTurnSummary,
+    pub entries: Vec<PersistedTurnEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub enum RolloutItem {
+    Compaction(CompactionRecord),
+    PlanState {
+        explanation: Option<String>,
+        steps: Vec<PersistedPlanStep>,
+    },
+    Interaction(PersistedInteraction),
+    SpawnAgent {
+        event_id: String,
+        agent_id: String,
+        name: Option<String>,
+        child_session_id: String,
+        status: String,
+        summary: Option<String>,
+    },
+    Turn(RolloutTurnItem),
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreadSnapshot {
+    pub metadata: ThreadMetadata,
+    pub provenance: ThreadMaterializationProvenance,
+    pub history: Vec<Message>,
+    pub compaction: CompactionRecord,
+    pub plan_explanation: Option<String>,
+    pub plan_steps: Vec<PersistedPlanStep>,
+    pub interactions: Vec<PersistedInteraction>,
+    pub rollout_items: Vec<RolloutItem>,
+}
+
+impl ThreadSnapshot {
+    /// Human-readable provenance description showing the source hierarchy.
+    pub fn provenance_description(&self) -> String {
+        self.provenance.describe()
+    }
+
+    /// Returns true when this snapshot was forked from another thread.
+    pub fn is_fork(&self) -> bool {
+        self.metadata.is_fork()
+    }
+
+    pub fn lineage(&self) -> (&str, Option<&str>) {
+        self.metadata.lineage()
+    }
+}


### PR DESCRIPTION
## Summary

- Extend `rara thread <THREAD_ID>` output with materialization provenance, lineage, rollout event details, and compaction replacement metadata.
- Remove the unused `ThreadStore::latest_thread_id` thin alias.
- Keep documented thread export, summary distillation, and recorder flush boundaries with item-level dead-code rationale.
- Split `src/thread_store.rs` into focused `types`, `format`, and `recorder` submodules so the main materialization file stays under the source-file size limit.
- Record the cleanup checkpoint and narrow the remaining warning-cleanup TODO to `AgentEvent` and TUI palettes.

## Purpose

This removes the thread-store warning group by wiring inspection data into the existing CLI instead of hiding populated thread materialization fields.

## Related Issues

None.

## Testing

- `cargo fmt`
- `cargo check --locked --workspace --all-targets`
- `cargo test --locked thread_cli::tests::`
- `cargo test --locked thread_store::tests::`
