### PR TITLE
chore(runtime): wire agent lifecycle events

### DIFF
--- a/docs/journal/2026-07-01-agent-event-warning-cleanup.md
+++ b/docs/journal/2026-07-01-agent-event-warning-cleanup.md
@@ -1,0 +1,40 @@
+# Agent Event Warning Cleanup
+
+## Summary
+
+The agent-event warning cleanup wires the reserved runtime-control lifecycle
+events into active execution paths:
+
+- Agent model turns now emit `AgentEvent::ModelRequest` before backend calls and
+  `AgentEvent::ModelResponse` after provider responses.
+- TUI query, review, and compact tasks now publish `AgentEvent::AgentStop` for
+  successful or cancelled completion and `AgentEvent::AgentError` for failures.
+- `LlmBackend::model_label` provides model names for structured model events
+  without changing backend request APIs.
+- The unused `RuntimeEventBus::send` convenience wrapper was removed; callers
+  now use provenance-aware `send_with_provenance`.
+
+## Background
+
+`AgentEvent` is the raw event bridge used by local TUI compatibility and the
+structured runtime-control subscriber surface. The lifecycle and model events
+were already mapped into `RuntimeEvent`, hook lifecycle matching, and plugin
+middleware, but no runtime path constructed them.
+
+This change keeps those events out of the TUI transcript conversion path while
+making them visible to ACP, Wire, appserver, and other structured subscribers.
+
+## Validation
+
+```bash
+cargo fmt
+cargo check --locked --workspace --all-targets
+cargo test --locked emits_model_request_and_response_events
+cargo test --locked lifecycle_helper_publishes
+cargo test --locked runtime_event_bus::tests::
+```
+
+## Follow-Ups
+
+- Continue warning cleanup in the TUI command/event palettes and related state
+  display fields.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -78,8 +78,9 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Explicit embedding controls: enable/disable, provider override (low priority)
 - [ ] `/status` context fields for model/provider/thread/retrieval/memory/workspace
-- [ ] Continue warning cleanup for `AgentEvent` and the TUI command/event
-      palettes (see docs/journal/2026-07-01-thread-store-warning-cleanup.md).
+- [ ] Continue warning cleanup for the TUI command/event palettes and related
+      state display fields (see
+      docs/journal/2026-07-01-agent-event-warning-cleanup.md).
 - [ ] Decide the Gemini AI Studio runtime path: either wire `provider=gemini`
       to the native `GeminiBackend::new` API-key backend or remove that native
       API-key path in favor of the current OpenAI-compatible endpoint.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -652,6 +652,8 @@ impl Agent {
         let model_label = self.model_event_label();
         report(AgentEvent::ModelRequest {
             model: model_label.clone(),
+            // Provider token usage is only available after the response.
+            // RuntimeControl documents 0 here as the unknown-count sentinel.
             input_tokens: 0,
         });
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -649,6 +649,12 @@ impl Agent {
             Agent::prepend_memory_context_to_latest_user_message(&mut messages, memory_context);
         }
 
+        let model_label = self.model_event_label();
+        report(AgentEvent::ModelRequest {
+            model: model_label.clone(),
+            input_tokens: 0,
+        });
+
         let mut streamed_any_text_delta = false;
         let mut streamed_any_reasoning_delta = false;
         let response = self
@@ -666,6 +672,13 @@ impl Agent {
                 }
             })
             .await?;
+
+        let response_usage = response.usage.clone().unwrap_or_default();
+        report(AgentEvent::ModelResponse {
+            model: model_label,
+            output_tokens: response_usage.output_tokens,
+            finish_reason: response.stop_reason.clone(),
+        });
 
         if let Some(usage) = &response.usage {
             self.total_input_tokens += usage.input_tokens;
@@ -780,6 +793,13 @@ impl Agent {
         } else {
             metadata
         }
+    }
+
+    fn model_event_label(&self) -> String {
+        self.llm_backend
+            .model_label()
+            .filter(|model| !model.trim().is_empty())
+            .unwrap_or_else(|| "unknown".to_string())
     }
 
     async fn run_agent_loop<F>(

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -673,10 +673,14 @@ impl Agent {
             })
             .await?;
 
-        let response_usage = response.usage.clone().unwrap_or_default();
+        let output_tokens = response
+            .usage
+            .as_ref()
+            .map(|usage| usage.output_tokens)
+            .unwrap_or(0);
         report(AgentEvent::ModelResponse {
             model: model_label,
-            output_tokens: response_usage.output_tokens,
+            output_tokens,
             finish_reason: response.stop_reason.clone(),
         });
 

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -125,6 +125,63 @@ impl LlmBackend for RecoverableRuntimeErrorBackend {
 }
 
 #[tokio::test]
+async fn emits_model_request_and_response_events() {
+    let backend = Arc::new(
+        SequencedBackend::new(vec![LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "done".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage {
+                input_tokens: 11,
+                output_tokens: 22,
+                ..TokenUsage::default()
+            }),
+        }])
+        .with_model_label("test-model"),
+    );
+
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+
+    let mut events = Vec::new();
+    agent
+        .query_with_mode_and_events(
+            "hello".to_string(),
+            super::super::AgentOutputMode::Silent,
+            |event| events.push(event),
+        )
+        .await
+        .expect("query should succeed");
+
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::ModelRequest {
+                model,
+                input_tokens: 0
+            } if model == "test-model"
+        )
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::ModelResponse {
+                model,
+                output_tokens: 22,
+                finish_reason: Some(reason)
+            } if model == "test-model" && reason == "end_turn"
+        )
+    }));
+}
+
+#[tokio::test]
 async fn appends_continuation_after_tool_result() {
     let backend = Arc::new(SequencedBackend::new(vec![
         LlmResponse {

--- a/src/agent/tests/support.rs
+++ b/src/agent/tests/support.rs
@@ -44,6 +44,7 @@ pub(super) struct SequencedBackend {
     responses: Mutex<Vec<LlmResponse>>,
     observed_messages: Mutex<Vec<Vec<Message>>>,
     observed_tools: Mutex<Vec<Vec<String>>>,
+    model_label: Mutex<Option<String>>,
 }
 
 impl SequencedBackend {
@@ -52,7 +53,13 @@ impl SequencedBackend {
             responses: Mutex::new(responses),
             observed_messages: Mutex::new(Vec::new()),
             observed_tools: Mutex::new(Vec::new()),
+            model_label: Mutex::new(None),
         }
+    }
+
+    pub(super) fn with_model_label(self, model_label: impl Into<String>) -> Self {
+        *self.model_label.lock().expect("lock") = Some(model_label.into());
+        self
     }
 
     pub(super) fn observed_tools(&self) -> Vec<Vec<String>> {
@@ -86,6 +93,10 @@ pub(super) fn test_runtime_storage() -> (
 
 #[async_trait]
 impl LlmBackend for SequencedBackend {
+    fn model_label(&self) -> Option<String> {
+        self.model_label.lock().expect("lock").clone()
+    }
+
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         self.observed_messages
             .lock()

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -104,6 +104,10 @@ fn extract_system_prompt(messages: &[Message]) -> (Vec<String>, Vec<Message>) {
 
 #[async_trait]
 impl LlmBackend for BedrockBackend {
+    fn model_label(&self) -> Option<String> {
+        Some(self.client.model_id().to_string())
+    }
+
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         let (system, messages) = extract_system_prompt(messages);
         let response = self

--- a/src/llm/gemini.rs
+++ b/src/llm/gemini.rs
@@ -169,6 +169,10 @@ impl GeminiBackend {
 
 #[async_trait]
 impl LlmBackend for GeminiBackend {
+    fn model_label(&self) -> Option<String> {
+        Some(self.model.clone())
+    }
+
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         let body = build_gemini_request(messages, tools)?;
         let res = self.send_gemini_request(&body, false).await?;

--- a/src/llm/ollama.rs
+++ b/src/llm/ollama.rs
@@ -41,6 +41,10 @@ impl OllamaBackend {
 
 #[async_trait]
 impl LlmBackend for OllamaBackend {
+    fn model_label(&self) -> Option<String> {
+        Some(self.model.clone())
+    }
+
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         let endpoint = format!("{}/api/chat", self.base_url.trim_end_matches('/'));
         let mut body = json!({

--- a/src/llm/openai_compatible.rs
+++ b/src/llm/openai_compatible.rs
@@ -403,6 +403,10 @@ pub async fn fetch_model_context_window(
 
 #[async_trait]
 impl LlmBackend for OpenAiCompatibleBackend {
+    fn model_label(&self) -> Option<String> {
+        Some(self.model.clone())
+    }
+
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         self.ask_with_context(messages, tools, LlmTurnMetadata::default())
             .await

--- a/src/llm/openai_compatible/codex.rs
+++ b/src/llm/openai_compatible/codex.rs
@@ -142,6 +142,10 @@ impl CodexBackend {
 
 #[async_trait]
 impl LlmBackend for CodexBackend {
+    fn model_label(&self) -> Option<String> {
+        Some(self.model.clone())
+    }
+
     async fn ask(&self, m: &[Message], t: &[Value]) -> Result<LlmResponse> {
         self.ask_responses_streaming(
             self.model.as_str(),

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -123,6 +123,10 @@ impl LlmTurnMetadata {
 
 #[async_trait]
 pub trait LlmBackend: Send + Sync {
+    fn model_label(&self) -> Option<String> {
+        None
+    }
+
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse>;
     async fn ask_with_context(
         &self,

--- a/src/local_backend.rs
+++ b/src/local_backend.rs
@@ -131,10 +131,15 @@ fn report_progress(progress: &Option<LocalProgressReporter>, message: String) {
 #[async_trait]
 impl LlmBackend for LocalLlmBackend {
     fn model_label(&self) -> Option<String> {
-        self.runtime
-            .lock()
-            .ok()
-            .map(|runtime| runtime.spec.model_id().to_string())
+        match self.runtime.lock() {
+            Ok(runtime) => Some(runtime.spec.model_id().to_string()),
+            Err(err) => {
+                eprintln!(
+                    "Warning: local model runtime mutex poisoned while reading model label: {err}"
+                );
+                None
+            }
+        }
     }
 
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {

--- a/src/local_backend.rs
+++ b/src/local_backend.rs
@@ -130,6 +130,13 @@ fn report_progress(progress: &Option<LocalProgressReporter>, message: String) {
 
 #[async_trait]
 impl LlmBackend for LocalLlmBackend {
+    fn model_label(&self) -> Option<String> {
+        self.runtime
+            .lock()
+            .ok()
+            .map(|runtime| runtime.spec.model_id().to_string())
+    }
+
     async fn ask(&self, messages: &[Message], tools: &[Value]) -> Result<LlmResponse> {
         let runtime = Arc::clone(&self.runtime);
         let messages = messages.to_vec();

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -89,6 +89,8 @@ pub enum SessionEvent {
     },
     ModelRequest {
         model: String,
+        /// Estimated input tokens for the outgoing request. A value of 0 means
+        /// the provider cannot report the count until the matching response.
         input_tokens: u32,
     },
     ModelResponse {

--- a/src/runtime_event_bus.rs
+++ b/src/runtime_event_bus.rs
@@ -38,13 +38,6 @@ impl RuntimeEventBus {
         }
     }
 
-    /// Push an event to all active subscribers with runtime provenance.
-    /// Returns the number of raw and structured subscribers that received the
-    /// event (may be 0).
-    pub fn send(&self, event: AgentEvent) -> usize {
-        self.send_with_provenance(event, RuntimeProvenance::runtime(None))
-    }
-
     /// Push an event with explicit provenance for protocol-ready subscribers.
     pub fn send_with_provenance(&self, event: AgentEvent, provenance: RuntimeProvenance) -> usize {
         let raw_receivers = self.raw_sender.receiver_count();
@@ -155,7 +148,13 @@ mod tests {
         let mut control = bus.subscribe_control();
 
         assert_eq!(bus.receiver_count(), 2);
-        assert_eq!(bus.send(AgentEvent::AssistantDelta("hello".to_string())), 2);
+        assert_eq!(
+            bus.send_with_provenance(
+                AgentEvent::AssistantDelta("hello".to_string()),
+                RuntimeProvenance::runtime(None),
+            ),
+            2
+        );
 
         assert!(matches!(
             raw.try_recv().expect("raw event"),
@@ -173,10 +172,22 @@ mod tests {
     fn unsubscribed_events_do_not_advance_control_sequence() {
         let bus = RuntimeEventBus::new(8);
 
-        assert_eq!(bus.send(AgentEvent::Status("ignored".to_string())), 0);
+        assert_eq!(
+            bus.send_with_provenance(
+                AgentEvent::Status("ignored".to_string()),
+                RuntimeProvenance::runtime(None),
+            ),
+            0
+        );
 
         let mut raw = bus.subscribe();
-        assert_eq!(bus.send(AgentEvent::Status("raw only".to_string())), 1);
+        assert_eq!(
+            bus.send_with_provenance(
+                AgentEvent::Status("raw only".to_string()),
+                RuntimeProvenance::runtime(None),
+            ),
+            1
+        );
         assert!(matches!(
             raw.try_recv().expect("raw event"),
             AgentEvent::Status(message) if message == "raw only"
@@ -184,7 +195,13 @@ mod tests {
         drop(raw);
 
         let mut control = bus.subscribe_control();
-        assert_eq!(bus.send(AgentEvent::Status("first control".to_string())), 1);
+        assert_eq!(
+            bus.send_with_provenance(
+                AgentEvent::Status("first control".to_string()),
+                RuntimeProvenance::runtime(None),
+            ),
+            1
+        );
 
         let event = control.try_recv().expect("control event");
         assert_eq!(event.sequence, 1);

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -108,7 +108,7 @@ fn forward_event_to_bus(
 }
 
 fn forward_lifecycle_event_to_bus(
-    bus: &Arc<RuntimeEventBus>,
+    bus: &RuntimeEventBus,
     event: AgentEvent,
     provenance: &RuntimeProvenance,
 ) {
@@ -118,7 +118,7 @@ fn forward_lifecycle_event_to_bus(
 }
 
 fn forward_task_result_lifecycle<T>(
-    bus: &Arc<RuntimeEventBus>,
+    bus: &RuntimeEventBus,
     provenance: &RuntimeProvenance,
     result: &anyhow::Result<T>,
 ) {

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -25,7 +25,7 @@ use super::super::state::{
 use super::events::{
     apply_tui_event, convert_agent_event, format_error_chain, format_memory_event_notice,
 };
-use crate::agent::{Agent, AgentOutputMode, BashApprovalDecision};
+use crate::agent::{Agent, AgentEvent, AgentOutputMode, BashApprovalDecision};
 use crate::runtime_control::RuntimeProvenance;
 use crate::runtime_event_bus::RuntimeEventBus;
 
@@ -97,13 +97,59 @@ fn classify_system_warning(warning: &str, default_kind: SystemMessageKind) -> Sy
 /// Avoids the clone cost when nobody is listening (the common TUI-only case).
 fn forward_event_to_bus(
     bus: &Option<Arc<RuntimeEventBus>>,
-    event: &crate::agent::AgentEvent,
+    event: &AgentEvent,
     provenance: &RuntimeProvenance,
 ) {
     if let Some(bus) = bus.as_ref()
         && bus.receiver_count() > 0
     {
         bus.send_with_provenance(event.clone(), provenance.clone());
+    }
+}
+
+fn forward_lifecycle_event_to_bus(
+    bus: &Arc<RuntimeEventBus>,
+    event: AgentEvent,
+    provenance: &RuntimeProvenance,
+) {
+    if bus.receiver_count() > 0 {
+        bus.send_with_provenance(event, provenance.clone());
+    }
+}
+
+fn forward_task_result_lifecycle<T>(
+    bus: &Arc<RuntimeEventBus>,
+    provenance: &RuntimeProvenance,
+    result: &anyhow::Result<T>,
+) {
+    let event = match result {
+        Ok(_) => AgentEvent::AgentStop {
+            reason: "turn complete".to_string(),
+        },
+        Err(err) => {
+            let message = format_error_chain(err);
+            if message.contains("cancelled by user") {
+                AgentEvent::AgentStop {
+                    reason: "cancelled by user".to_string(),
+                }
+            } else {
+                AgentEvent::AgentError {
+                    message,
+                    recoverable: false,
+                }
+            }
+        }
+    };
+    forward_lifecycle_event_to_bus(bus, event, provenance);
+}
+
+fn forward_optional_task_result_lifecycle<T>(
+    bus: &Option<Arc<RuntimeEventBus>>,
+    provenance: &RuntimeProvenance,
+    result: &anyhow::Result<T>,
+) {
+    if let Some(bus) = bus.as_ref() {
+        forward_task_result_lifecycle(bus, provenance, result);
     }
 }
 
@@ -231,7 +277,7 @@ pub(super) fn start_input_control_task(
     agent.set_full_access_mode(app.permission_mode == PermissionMode::FullAccess);
     sync_bash_prefixes_from_config(app, &mut agent);
     agent.set_cancellation_token(Some(cancellation_token.clone()));
-    let _ = bus.send(crate::agent::AgentEvent::AgentStart);
+    forward_lifecycle_event_to_bus(&bus, AgentEvent::AgentStart, &event_provenance);
     let handle = tokio::spawn(async move {
         let tx = sender.clone();
         let provenance =
@@ -243,6 +289,8 @@ pub(super) fn start_input_control_task(
         };
 
         let bus_arg = Some(bus.clone());
+        let lifecycle_bus = bus.clone();
+        let lifecycle_provenance = event_provenance.clone();
         let result = crate::control_plane::dispatch(
             envelope,
             &mcp_manager,
@@ -311,6 +359,7 @@ pub(super) fn start_input_control_task(
         .await;
 
         let result = result.map_err(|e| anyhow::anyhow!("{e}"));
+        forward_task_result_lifecycle(&lifecycle_bus, &lifecycle_provenance, &result);
         TaskCompletion::Query { agent, result }
     });
 
@@ -356,6 +405,8 @@ pub(super) fn start_compact_task(app: &mut TuiApp, mut agent: Agent) {
 
     let handle = tokio::spawn(async move {
         let tx = sender.clone();
+        let lifecycle_bus = bus.clone();
+        let lifecycle_provenance = event_provenance.clone();
         let result = agent
             .compact_now_with_reporter(move |event| {
                 forward_event_to_bus(&bus, &event, &event_provenance);
@@ -364,6 +415,7 @@ pub(super) fn start_compact_task(app: &mut TuiApp, mut agent: Agent) {
                 }
             })
             .await;
+        forward_optional_task_result_lifecycle(&lifecycle_bus, &lifecycle_provenance, &result);
         TaskCompletion::Compact { agent, result }
     });
 
@@ -395,6 +447,8 @@ pub(super) fn start_review_task(app: &mut TuiApp, prompt: String, mut agent: Age
 
     let handle = tokio::spawn(async move {
         let tx = sender.clone();
+        let lifecycle_bus = bus.clone();
+        let lifecycle_provenance = event_provenance.clone();
         let result = agent
             .query_with_mode_and_events(prompt, AgentOutputMode::Silent, move |event| {
                 forward_event_to_bus(&bus, &event, &event_provenance);
@@ -403,6 +457,7 @@ pub(super) fn start_review_task(app: &mut TuiApp, prompt: String, mut agent: Age
                 }
             })
             .await;
+        forward_optional_task_result_lifecycle(&lifecycle_bus, &lifecycle_provenance, &result);
         TaskCompletion::Query { agent, result }
     });
 

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -12,9 +12,10 @@ use tempfile::tempdir;
 use tokio::sync::{Mutex, mpsc};
 
 use super::{
-    emit_query_heartbeat, finish_running_task_if_ready, goal_budget_limit_prompt,
-    goal_continuation_prompt, merge_rebuilt_agent, request_running_task_cancellation,
-    start_oauth_task, start_query_task, try_start_queued_follow_up,
+    emit_query_heartbeat, finish_running_task_if_ready, forward_task_result_lifecycle,
+    goal_budget_limit_prompt, goal_continuation_prompt, merge_rebuilt_agent,
+    request_running_task_cancellation, start_oauth_task, start_query_task,
+    try_start_queued_follow_up,
 };
 use crate::agent::{
     Agent, AgentExecutionMode, BashApprovalMode, Message, PlanStep, PlanStepStatus,
@@ -24,6 +25,10 @@ use crate::llm::{ContentBlock, LlmBackend, LlmResponse, TokenUsage};
 use crate::local_model_server::{LocalModelServerState, LocalModelServerStatus};
 use crate::oauth::OAuthManager;
 use crate::prompt::PromptRuntimeConfig;
+use crate::runtime_control::{
+    ErrorEvent, RuntimeControllerKind, RuntimeEvent, RuntimeProvenance, SessionEvent,
+};
+use crate::runtime_event_bus::RuntimeEventBus;
 use crate::session::SessionManager;
 use crate::tui::state::{
     OAuthLoginMode, RalphGoal, RebuildSuccess, RunningTask, RuntimePhase, TaskCompletion, TaskKind,
@@ -32,6 +37,63 @@ use crate::tui::state::{
 use crate::workspace::WorkspaceMemory;
 
 struct PlainAnswerBackend;
+
+#[test]
+fn lifecycle_helper_publishes_turn_finished_for_success() {
+    let bus = Arc::new(RuntimeEventBus::new(8));
+    let mut control = bus.subscribe_control();
+    let provenance = RuntimeProvenance::local_tui("session-1");
+
+    forward_task_result_lifecycle(&bus, &provenance, &Ok::<_, anyhow::Error>(()));
+
+    let event = control.try_recv().expect("control event");
+    assert_eq!(event.provenance.controller, RuntimeControllerKind::LocalTui);
+    assert!(matches!(
+        event.event,
+        RuntimeEvent::Session(SessionEvent::TurnFinished {
+            reason: Some(reason)
+        }) if reason == "turn complete"
+    ));
+}
+
+#[test]
+fn lifecycle_helper_publishes_turn_finished_for_cancellation() {
+    let bus = Arc::new(RuntimeEventBus::new(8));
+    let mut control = bus.subscribe_control();
+    let provenance = RuntimeProvenance::local_tui("session-1");
+
+    forward_task_result_lifecycle::<()>(
+        &bus,
+        &provenance,
+        &Err(anyhow::anyhow!("cancelled by user")),
+    );
+
+    let event = control.try_recv().expect("control event");
+    assert!(matches!(
+        event.event,
+        RuntimeEvent::Session(SessionEvent::TurnFinished {
+            reason: Some(reason)
+        }) if reason == "cancelled by user"
+    ));
+}
+
+#[test]
+fn lifecycle_helper_publishes_runtime_error_for_failure() {
+    let bus = Arc::new(RuntimeEventBus::new(8));
+    let mut control = bus.subscribe_control();
+    let provenance = RuntimeProvenance::local_tui("session-1");
+
+    forward_task_result_lifecycle::<()>(&bus, &provenance, &Err(anyhow::anyhow!("backend failed")));
+
+    let event = control.try_recv().expect("control event");
+    assert!(matches!(
+        event.event,
+        RuntimeEvent::Error(ErrorEvent::RuntimeError {
+            message,
+            recoverable: false,
+        }) if message == "backend failed"
+    ));
+}
 
 #[test]
 fn goal_continuation_prompt_contains_budget_and_completion_audit() {


### PR DESCRIPTION
## Summary

- Emit `AgentEvent::ModelRequest` and `AgentEvent::ModelResponse` around model backend calls.
- Emit `AgentEvent::AgentStop` and `AgentEvent::AgentError` from TUI task completion boundaries.
- Add `LlmBackend::model_label` so structured model lifecycle events carry backend model names.
- Remove the unused `RuntimeEventBus::send` convenience wrapper in favor of provenance-aware `send_with_provenance`.
- Record the cleanup checkpoint and narrow the remaining warning-cleanup TODO to TUI command/event palettes.

## Purpose

This wires the reserved runtime-control `AgentEvent` lifecycle variants into active execution paths instead of leaving them as dead protocol surface.

## Related Issues

None.

## Testing

- `cargo fmt`
- `cargo check --locked --workspace --all-targets`
- `cargo test --locked emits_model_request_and_response_events`
- `cargo test --locked lifecycle_helper_publishes`
- `cargo test --locked runtime_event_bus::tests::`
