### PR TITLE
fix(tui): keep list picker selections visible

### DIFF
--- a/docs/journal/2026-07-02-list-picker-visibility.md
+++ b/docs/journal/2026-07-02-list-picker-visibility.md
@@ -1,0 +1,33 @@
+# List Picker Visibility
+
+## Summary
+
+RARA list pickers now render with a stateful Ratatui list so selected items stay
+visible when the selection moves beyond the first viewport.
+
+## Background
+
+The generic setup/model picker rendered a plain `List` with per-item styles but
+without `ListState`. When the selected row was outside the visible area, Ratatui
+kept the list offset at zero, which made the active item appear missing.
+
+## Scope
+
+- Added semantic picker foreground and highlight theme tokens.
+- Switched generic list picker rendering to `render_stateful_widget`.
+- Reused the same highlight style for resume and generic pickers.
+- Added focused coverage for list offset behavior.
+
+## Validation
+
+```bash
+cargo test list_picker_state_scrolls_to_selected_item -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
+```
+
+## Follow-Ups
+
+- The broader configurable theme token schema remains open.
+- The setup flow can still be consolidated with the model picker in a later
+  TUI/UX slice.

--- a/docs/journal/2026-07-02-list-picker-visibility.md
+++ b/docs/journal/2026-07-02-list-picker-visibility.md
@@ -16,12 +16,17 @@ kept the list offset at zero, which made the active item appear missing.
 - Added semantic picker foreground and highlight theme tokens.
 - Switched generic list picker rendering to `render_stateful_widget`.
 - Reused the same highlight style for resume and generic pickers.
+- Centralized the resume picker list view so rendering, header counts, and
+  resume selection all use the same filtered thread set.
 - Added focused coverage for list offset behavior.
 
 ## Validation
 
 ```bash
 cargo test list_picker_state_scrolls_to_selected_item -- --nocapture
+cargo test tui::list_picker::tests -- --nocapture
+INSTA_UPDATE=always cargo test provider_picker_renders_as_full_overlay_on_standard_terminal -- --nocapture
+INSTA_UPDATE=always cargo test unified_model_picker_snapshot -- --nocapture
 cargo check --locked --workspace --all-targets
 cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
 ```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -29,6 +29,8 @@ Active backlog only. Keep this file small and current.
       highlighting, picker, and overlay renderers through semantic theme tokens;
       for syntax highlighting, define how the app theme maps to or selects the
       active `syntect` theme.
+- [x] Keep generic setup/list picker selected items visible when the selection
+      moves past the first viewport.
 - [x] Sidebar Plan replaces Todo (PR #597)
 - [x] Approval dock above composer (PR #591, #594, #599)
 - [x] Mouse text selection — drag-select + clipboard copy

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -646,10 +646,7 @@ pub(crate) async fn dispatch_event(
                             start_rebuild_task(app);
                         }
                         ListPickerKind::Resume => {
-                            if let Some(thread_id) = app
-                                .recent_threads
-                                .get(app.resume_picker_idx)
-                                .map(|session| session.metadata.session_id.clone())
+                            if let Some(thread_id) = list_picker::selected_resumable_thread_id(app)
                             {
                                 restore_thread_by_id(thread_id.as_str(), app, agent_slot)?;
                                 app.dismiss_overlay();

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -57,15 +57,7 @@ impl ListPickerKind {
             Self::Model => app.current_model_picker_len(),
             Self::OpenAiEndpointKind => super::state::openai_profile_setup_kinds().len(),
             Self::OpenAiProfile => app.selected_openai_profiles().len() + 1,
-            Self::Resume => app
-                .recent_threads
-                .iter()
-                .filter(|s| s.metadata.session_id != app.snapshot.session_id)
-                .filter(|s| {
-                    resume_workspace_label(&s.metadata.cwd)
-                        == resume_workspace_label(&app.snapshot.cwd)
-                })
-                .count(),
+            Self::Resume => resumable_threads(app).len(),
             Self::AuthMode => AUTH_MODE_ITEM_COUNT,
             Self::ReasoningEffort => app.selected_codex_reasoning_options().len(),
             Self::UnifiedModel => app.all_unified_model_presets().len(),
@@ -283,15 +275,7 @@ impl ListPickerKind {
     }
 
     fn render_resume_items(app: &TuiApp, selected: usize) -> Vec<ListItem<'static>> {
-        let current_id = &app.snapshot.session_id;
-        let summaries: Vec<&ThreadSummary> = app
-            .recent_threads
-            .iter()
-            .filter(|s| &s.metadata.session_id != current_id)
-            .filter(|s| {
-                resume_workspace_label(&s.metadata.cwd) == resume_workspace_label(&app.snapshot.cwd)
-            })
-            .collect();
+        let summaries = resumable_threads(app);
         if summaries.is_empty() {
             return vec![ListItem::new("No threads available.")];
         }
@@ -353,6 +337,23 @@ impl ListPickerKind {
         }
         items
     }
+}
+
+pub(crate) fn selected_resumable_thread_id(app: &TuiApp) -> Option<String> {
+    resumable_threads(app)
+        .get(app.resume_picker_idx)
+        .map(|summary| summary.metadata.session_id.clone())
+}
+
+pub(crate) fn resumable_threads(app: &TuiApp) -> Vec<&ThreadSummary> {
+    app.recent_threads
+        .iter()
+        .filter(|summary| summary.metadata.session_id != app.snapshot.session_id)
+        .filter(|summary| {
+            resume_workspace_label(&summary.metadata.cwd)
+                == resume_workspace_label(&app.snapshot.cwd)
+        })
+        .collect()
 }
 
 fn render_resume_summary_lines(
@@ -531,7 +532,7 @@ fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
     } else {
         "sort=[updated] created"
     };
-    let total = app.recent_threads.len();
+    let total = resumable_threads(app).len();
     let current = if total == 0 {
         0
     } else {
@@ -554,10 +555,7 @@ fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
         chunks[0],
     );
 
-    let mut state = ListState::default();
-    if total > 0 {
-        state.select(Some(app.resume_picker_idx));
-    }
+    let mut state = list_picker_state(app.resume_picker_idx, total);
     f.render_stateful_widget(
         List::new(items)
             .block(Block::default().padding(Padding::horizontal(1)))
@@ -655,8 +653,10 @@ fn resume_picker_key_event(code: KeyCode) -> AppEvent {
 #[cfg(test)]
 mod tests {
     use ratatui::{buffer::Buffer, widgets::StatefulWidget};
+    use tempfile::tempdir;
 
     use super::*;
+    use crate::config::ConfigManager;
     use crate::thread_store::{CompactionRecord, ThreadMetadata};
 
     #[test]
@@ -745,5 +745,51 @@ mod tests {
 
         assert!(state.offset() > 0);
         assert_eq!(state.selected(), Some(15));
+    }
+
+    #[test]
+    fn selected_resumable_thread_id_uses_rendered_resume_items() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.snapshot.session_id = "current-thread".to_string();
+        app.snapshot.cwd = "/tmp/workspaces/rara".to_string();
+        app.recent_threads = vec![
+            thread_summary("current-thread", "/tmp/workspaces/rara"),
+            thread_summary("other-workspace", "/tmp/workspaces/other"),
+            thread_summary("resumable-thread", "/var/tmp/rara"),
+        ];
+        app.resume_picker_idx = 0;
+
+        assert_eq!(
+            selected_resumable_thread_id(&app).as_deref(),
+            Some("resumable-thread")
+        );
+        assert_eq!(ListPickerKind::Resume.item_count(&app), 1);
+    }
+
+    fn thread_summary(session_id: &str, cwd: &str) -> ThreadSummary {
+        ThreadSummary {
+            metadata: ThreadMetadata {
+                session_id: session_id.to_string(),
+                cwd: cwd.to_string(),
+                branch: "main".to_string(),
+                provider: "codex".to_string(),
+                model: "gpt-5.2".to_string(),
+                base_url: None,
+                agent_mode: "execute".to_string(),
+                bash_approval: "suggestion".to_string(),
+                created_at: 0,
+                origin_kind: "direct".to_string(),
+                forked_from_thread_id: None,
+                history_len: 1,
+                transcript_len: 1,
+                updated_at: 0,
+            },
+            preview: format!("User: {session_id}"),
+            compaction: CompactionRecord::default(),
+        }
     }
 }

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -125,10 +125,11 @@ impl ListPickerKind {
     fn selected_style(idx: usize, selected: usize) -> Style {
         if idx == selected {
             Style::default()
-                .fg(TEXT_ACCENT)
+                .fg(PICKER_HIGHLIGHT_FG)
+                .bg(PICKER_HIGHLIGHT_BG)
                 .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(TEXT_PRIMARY)
+            Style::default().fg(PICKER_ITEM_FG)
         }
     }
 
@@ -149,10 +150,7 @@ impl ListPickerKind {
                     .cloned()
                     .unwrap_or(false);
                 let status_indicator = if connected {
-                    ratatui::text::Span::styled(
-                        " ● ",
-                        Style::default().fg(ratatui::style::Color::Green),
-                    )
+                    ratatui::text::Span::styled(" ● ", Style::default().fg(STATUS_SUCCESS))
                 } else {
                     ratatui::text::Span::raw("   ")
                 };
@@ -166,7 +164,7 @@ impl ListPickerKind {
                 ]);
                 let desc_line = ratatui::text::Line::from(ratatui::text::Span::styled(
                     format!("      {}", desc),
-                    Style::default().fg(TEXT_SECONDARY),
+                    Style::default().fg(PICKER_ITEM_MUTED_FG),
                 ));
                 ListItem::new(vec![name_line, desc_line]).style(Self::selected_style(idx, selected))
             })
@@ -246,17 +244,20 @@ impl ListPickerKind {
             .collect()
     }
 
-    fn render_auth_mode_items(_selected: usize) -> Vec<ListItem<'static>> {
-        vec![
-            ListItem::new(ratatui::text::Line::from(
-                "Browser Login (browser-based OAuth)",
-            )),
-            ListItem::new(ratatui::text::Line::from(
-                "Device Code Login (headless/SSH)",
-            )),
-            ListItem::new(ratatui::text::Line::from("API Key")),
-            ListItem::new(ratatui::text::Line::from("Sign Out")),
+    fn render_auth_mode_items(selected: usize) -> Vec<ListItem<'static>> {
+        [
+            "Browser Login (browser-based OAuth)",
+            "Device Code Login (headless/SSH)",
+            "API Key",
+            "Sign Out",
         ]
+        .into_iter()
+        .enumerate()
+        .map(|(idx, label)| {
+            ListItem::new(ratatui::text::Line::from(label))
+                .style(Self::selected_style(idx, selected))
+        })
+        .collect()
     }
 
     fn render_reasoning_effort_items(app: &TuiApp, selected: usize) -> Vec<ListItem<'static>> {
@@ -469,6 +470,7 @@ pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, are
     }
 
     let items = kind.render_items(app);
+    let mut state = list_picker_state(kind.idx(app), items.len());
 
     let block = popup_block();
     let inner = block.inner(area);
@@ -491,9 +493,13 @@ pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, are
         ),
         chunks[0],
     );
-    f.render_widget(
-        List::new(items).block(Block::default().padding(Padding::horizontal(1))),
+    f.render_stateful_widget(
+        List::new(items)
+            .block(Block::default().padding(Padding::horizontal(1)))
+            .highlight_style(list_picker_highlight_style())
+            .highlight_symbol("› "),
         chunks[1],
+        &mut state,
     );
     f.render_widget(
         Paragraph::new(kind.help_text()).alignment(Alignment::Center),
@@ -555,7 +561,7 @@ fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_stateful_widget(
         List::new(items)
             .block(Block::default().padding(Padding::horizontal(1)))
-            .highlight_style(Style::default().fg(TEXT_ACCENT))
+            .highlight_style(list_picker_highlight_style())
             .highlight_symbol("› "),
         chunks[1],
         &mut state,
@@ -570,6 +576,21 @@ fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
         Paragraph::new(footer).alignment(Alignment::Center),
         chunks[2],
     );
+}
+
+fn list_picker_state(selected: usize, item_count: usize) -> ListState {
+    let mut state = ListState::default();
+    if item_count > 0 {
+        state.select(Some(selected.min(item_count.saturating_sub(1))));
+    }
+    state
+}
+
+fn list_picker_highlight_style() -> Style {
+    Style::default()
+        .fg(PICKER_HIGHLIGHT_FG)
+        .bg(PICKER_HIGHLIGHT_BG)
+        .add_modifier(Modifier::BOLD)
 }
 
 // ---------------------------------------------------------------------------
@@ -633,6 +654,8 @@ fn resume_picker_key_event(code: KeyCode) -> AppEvent {
 
 #[cfg(test)]
 mod tests {
+    use ratatui::{buffer::Buffer, widgets::StatefulWidget};
+
     use super::*;
     use crate::thread_store::{CompactionRecord, ThreadMetadata};
 
@@ -704,5 +727,23 @@ mod tests {
             list_picker_key_event(ListPickerKind::Resume, KeyCode::Tab),
             AppEvent::CycleResumeSort
         ));
+    }
+
+    #[test]
+    fn list_picker_state_scrolls_to_selected_item() {
+        let items = (0..20)
+            .map(|idx| ListItem::new(format!("item {idx}")))
+            .collect::<Vec<_>>();
+        let area = Rect::new(0, 0, 20, 5);
+        let mut buffer = Buffer::empty(area);
+        let mut state = list_picker_state(15, items.len());
+
+        List::new(items)
+            .highlight_style(list_picker_highlight_style())
+            .highlight_symbol("› ")
+            .render(area, &mut buffer, &mut state);
+
+        assert!(state.offset() > 0);
+        assert_eq!(state.selected(), Some(15));
     }
 }

--- a/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__provider_picker_standard_terminal.snap
@@ -10,19 +10,19 @@ Ready.
 ──              Provider
 Type a message  Select a provider family.
 
-Start with:        [1] Codex (current)
-  /help    bro        Use Codex with browser login, device-code login, or a Codex AP
-  /model   cho     [2] DeepSeek
-  /status  ins        Use DeepSeek with an API key and model list from api.deepseek.
-  /quit    lea     [3] Kimi
-                      Use Moonshot Kimi with an API key from api.moonshot.cn.
-Prompt ideas:      [4] OpenAI-compatible
-  · Explain th        Use OpenAI-compatible endpoint profiles such as Custom, Kimi,
-  · Find the m     [5] Gemini
-                      Use Google Gemini via AI Studio (API key) or Code Assist (OAut
-                 ● [6] Candle Local
-  Warning  War        Run local Candle models directly in-process.                    er.
-› Ask about th     [7] Ollama
-                      Use an external Ollama server and choose a local tag.
+Start with:     ›    [1] Codex (current)
+  /help    bro          Use Codex with browser login, device-code login, or a Codex
+  /model   cho       [2] DeepSeek
+  /status  ins          Use DeepSeek with an API key and model list from api.deepsee
+  /quit    lea       [3] Kimi
+                        Use Moonshot Kimi with an API key from api.moonshot.cn.
+Prompt ideas:        [4] OpenAI-compatible
+  · Explain th          Use OpenAI-compatible endpoint profiles such as Custom, Kimi
+  · Find the m       [5] Gemini
+                        Use Google Gemini via AI Studio (API key) or Code Assist (OA
+                   ● [6] Candle Local
+  Warning  War          Run local Candle models directly in-process.                  er.
+› Ask about th       [7] Ollama
+                        Use an external Ollama server and choose a local tag.
                           1-9 jump  Up/Down/jk move  Enter apply  Esc back
                                                                                       val=suggestion

--- a/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
@@ -9,16 +9,16 @@ dir   · /workspace/rara
 Read  All Models
 ──    Select a model across all providers.
 Type
-      Codex/gpt-4o
-Star  DeepSeek/deepseek-chat
-  /h  DeepSeek/deepseek-reasoner
-  /m  DeepSeek/deepseek-v4-flash
-  /s  DeepSeek/deepseek-v4-pro
-  /q  DeepSeek/deepseek-v4-preview
-      Kimi/kimi-k2.6
-Prom  Kimi/kimi-k2.5
-  Re  Kimi/kimi-k2-0905-preview
-› As  Kimi/kimi-k2-turbo-preview                                            s.
-      Kimi/kimi-k2-thinking
+      › Codex/gpt-4o
+Star    DeepSeek/deepseek-chat
+  /h    DeepSeek/deepseek-reasoner
+  /m    DeepSeek/deepseek-v4-flash
+  /s    DeepSeek/deepseek-v4-pro
+  /q    DeepSeek/deepseek-v4-preview
+        Kimi/kimi-k2.6
+Prom    Kimi/kimi-k2.5
+  Re    Kimi/kimi-k2-0905-preview
+› As    Kimi/kimi-k2-turbo-preview                                          s.
+        Kimi/kimi-k2-thinking
                      Up/Down/jk move  Enter apply  Esc back
                                                                             tion

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -49,6 +49,12 @@ pub(crate) const TEXT_SECONDARY: Color = NORD3;
 pub(crate) const TEXT_ACCENT: Color = NORD8;
 pub(crate) const TEXT_MUTED: Color = NORD2;
 
+// ── Picker overlays ────────────────────────────────────────────
+pub(crate) const PICKER_ITEM_FG: Color = NORD4;
+pub(crate) const PICKER_ITEM_MUTED_FG: Color = NORD3;
+pub(crate) const PICKER_HIGHLIGHT_FG: Color = NORD6;
+pub(crate) const PICKER_HIGHLIGHT_BG: Color = NORD10;
+
 // ── Message roles ───────────────────────────────────────────────
 pub(crate) const ROLE_USER: Color = NORD9;
 pub(crate) const ROLE_AGENT: Color = NORD8;


### PR DESCRIPTION
## Summary

- Render generic setup/list pickers with `ListState` so selected rows scroll into view.
- Add picker-specific semantic theme tokens and reuse the same highlight style across generic and resume pickers.
- Record the TUI picker visibility checkpoint in the journal and TODO backlog.

## Motivation

The setup/model picker could highlight an item outside the visible viewport without moving the list offset, making it look like the picker had no selectable item. This keeps the active selection visible while preserving the existing picker flow.

## Related Issue

None.

## Testing

```bash
cargo fmt
cargo test list_picker_state_scrolls_to_selected_item -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
git diff --check
```
