### PR TITLE
fix(tui): recover live transcript turns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10853,6 +10853,7 @@ dependencies = [
  "lance-index",
  "lancedb",
  "libc",
+ "log",
  "nix 0.31.3",
  "nom 8.0.0",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ serde_yaml = "0.9"
 reqwest = { version = "0.13", features = ["blocking", "json", "stream"] }
 async-trait = "0.1"
 anyhow = "1.0"
+log = "0.4"
 thiserror = "2.0"
 time = { version = "0.3", features = ["formatting", "macros"] }
 owo-colors = "4.0"

--- a/crates/rara-persistence/src/thread_turn_log.rs
+++ b/crates/rara-persistence/src/thread_turn_log.rs
@@ -146,18 +146,12 @@ pub fn replace_live_entries(
 }
 
 /// Remove the live log so resume doesn't load a stale partial turn.
-pub fn clear_live_log(root_dir: &Path, session_id: &str) -> bool {
+pub fn clear_live_log(root_dir: &Path, session_id: &str) -> Result<()> {
     let path = root_dir.join(session_id).join(LIVE_LOG_FILE);
     match fs::remove_file(&path) {
-        Ok(()) => true,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
-        Err(e) => {
-            log::error!(
-                "failed to clear live log for session {session_id}: {e} (path: {})",
-                path.display()
-            );
-            false
-        }
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e).with_context(|| format!("clear live log {}", path.display())),
     }
 }
 

--- a/crates/rara-persistence/src/thread_turn_log.rs
+++ b/crates/rara-persistence/src/thread_turn_log.rs
@@ -126,15 +126,18 @@ pub fn append_rollout_fragment(
 }
 
 /// Remove the live log so resume doesn't load a stale partial turn.
-pub fn clear_live_log(root_dir: &Path, session_id: &str) {
+pub fn clear_live_log(root_dir: &Path, session_id: &str) -> bool {
     let path = root_dir.join(session_id).join(LIVE_LOG_FILE);
-    if let Err(e) = fs::remove_file(&path)
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        log::error!(
-            "failed to clear live log for session {session_id}: {e} (path: {})",
-            path.display()
-        );
+    match fs::remove_file(&path) {
+        Ok(()) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(e) => {
+            log::error!(
+                "failed to clear live log for session {session_id}: {e} (path: {})",
+                path.display()
+            );
+            false
+        }
     }
 }
 

--- a/crates/rara-persistence/src/thread_turn_log.rs
+++ b/crates/rara-persistence/src/thread_turn_log.rs
@@ -125,6 +125,26 @@ pub fn append_rollout_fragment(
     Ok(())
 }
 
+/// Replace the live log with the current active-turn entries.
+pub fn replace_live_entries(
+    root_dir: &Path,
+    session_id: &str,
+    entries: &[PersistedTurnEntry],
+) -> Result<()> {
+    let dir = root_dir.join(session_id);
+    fs::create_dir_all(&dir)?;
+    let path = dir.join(LIVE_LOG_FILE);
+    let tmp_path = dir.join("live.jsonl.tmp");
+    let mut data = Vec::new();
+    for entry in entries {
+        serde_json::to_writer(&mut data, entry)?;
+        data.push(b'\n');
+    }
+    fs::write(&tmp_path, data).with_context(|| format!("write live log {}", tmp_path.display()))?;
+    crate::atomic_file::replace_file(&tmp_path, &path)
+        .with_context(|| format!("replace live log {}", path.display()))
+}
+
 /// Remove the live log so resume doesn't load a stale partial turn.
 pub fn clear_live_log(root_dir: &Path, session_id: &str) -> bool {
     let path = root_dir.join(session_id).join(LIVE_LOG_FILE);

--- a/docs/features/threads.md
+++ b/docs/features/threads.md
@@ -100,6 +100,11 @@ Current backend slice:
 - Committed TUI turns are appended to per-session `turns.jsonl` through
   `ThreadRecorder`; `ThreadStore` prefers that log and only falls back to
   `StateDb` turn rows for older sessions.
+- In-progress TUI turns are written entry-by-entry to per-session `live.jsonl`.
+  The TUI clears that live log immediately after committing a full turn to
+  `turns.jsonl`; resume loads any remaining live entries back into the active
+  turn so an interrupted process can recover partial transcript output without
+  treating it as a committed turn.
 - Runtime compaction writes also go through `ThreadRecorder`, so manual/auto
   compaction and fork replay share the same structured rollout event boundary.
 - `export_thread_markdown(session_id) -> String` renders a portable markdown

--- a/docs/journal/2026-07-02-tui-live-log-recovery.md
+++ b/docs/journal/2026-07-02-tui-live-log-recovery.md
@@ -1,0 +1,42 @@
+# TUI Live Log Recovery
+
+## Summary
+
+Connected the existing per-session `live.jsonl` transcript log to the TUI
+active-turn lifecycle.
+
+## What Changed
+
+- `TuiApp` now writes transcript entries to the live log as they are appended.
+- Active-turn rewrites, such as final assistant text replacement, rewrite the
+  live log so restart recovery does not restore stale intermediate text.
+- Committing a turn to `turns.jsonl` clears the live log so resume only restores
+  genuinely incomplete turns.
+- Thread resume loads remaining live entries into `active_turn` after committed
+  turns are restored.
+
+## Design Notes
+
+Claude Code's resume path treats persisted transcript data as the source of
+truth and detects interrupted turns while deserializing. RARA keeps the existing
+committed-turn contract intact and uses `live.jsonl` as a small side log for
+only the uncommitted active turn.
+
+## Validation
+
+```bash
+cargo fmt
+cargo test tui::state::tests::active_turn_entries_write_and_clear_live_log -- --nocapture
+cargo test tui::session_restore::tests::restore_session_recovers_live_active_turn_entries -- --nocapture
+cargo test tui::state::tests -- --nocapture
+cargo test tui::session_restore::tests -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
+git diff --check
+```
+
+## Follow-Up
+
+Terminal event payloads are still restored through their text transcript shape,
+matching committed turn persistence. Preserving typed terminal payloads across
+live recovery would require extending `PersistedTurnEntry`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -21,7 +21,7 @@ Active backlog only. Keep this file small and current.
 ## TUI / UX
 
 - [x] Refactor ~7 large methods out of `impl TuiApp` to enable file split.
-- [ ] Restore Claude Code-style realtime transcript live-log writes from
+- [x] Restore Claude Code-style realtime transcript live-log writes from
       `push_entry` and clear the live log after turn commit so resume can
       recover partial turns after restart.
 - [ ] Introduce an opencode-style configurable TUI theme token schema instead

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -197,10 +197,15 @@ pub(super) fn restore_thread_by_id(
             | RolloutItem::SpawnAgent { .. } => {}
         }
     }
-    if !turns.is_empty() {
-        app.restore_committed_turns(turns);
-    } else {
-        app.reset_transcript();
+    let rollout_root = state_db.rollout_root();
+    app.restore_committed_turns(turns);
+    let live_entries =
+        rara_persistence::thread_turn_log::load_live_entries(&rollout_root, thread_id);
+    if !live_entries.is_empty() {
+        app.active_turn.entries = live_entries
+            .into_iter()
+            .map(|entry| TranscriptEntry::new(entry.role, entry.message))
+            .collect();
     }
     app.sync_snapshot(agent);
 
@@ -259,7 +264,7 @@ mod tests {
     use std::fs;
 
     use rara_memory::vectordb::VectorDB;
-    use rara_state::state_db::StateDb;
+    use rara_state::state_db::{PersistedTurnEntry, StateDb};
     use rara_tools::tool::ToolManager;
     use serde_json::json;
     use tempfile::tempdir;
@@ -520,6 +525,102 @@ mod tests {
         let restored_agent = restored_slot.expect("restored agent");
         assert_eq!(restored_agent.session_id, "session-without-history");
         assert_eq!(restored_app.snapshot.session_id, "session-without-history");
+    }
+
+    #[test]
+    fn restore_session_recovers_live_active_turn_entries() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("repo");
+        let rara_dir = root.join(".rara");
+        fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+        fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+        fs::create_dir_all(rara_dir.join("tool-results")).expect("tool results");
+
+        let session_manager = Arc::new(crate::session::SessionManager {
+            storage_dir: rara_dir.join("rollouts"),
+            legacy_storage_dir: rara_dir.join("sessions"),
+        });
+        let workspace = Arc::new(WorkspaceMemory::from_paths(root.clone(), rara_dir.clone()));
+        let backend = Arc::new(MockLlm);
+        let mut original_agent = Agent::new(
+            ToolManager::new(),
+            backend.clone(),
+            Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager.clone(),
+            workspace.clone(),
+        );
+        original_agent.session_id = "session-live-active-turn".to_string();
+        original_agent.history.push(Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"recover active turn"}]),
+        });
+        session_manager
+            .save_session(&original_agent.session_id, &original_agent.history)
+            .expect("save session");
+
+        let state_db = Arc::new(StateDb::new_for_root_dir(rara_dir.clone()).expect("state db"));
+        let mut original_app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        original_app.attach_state_db(state_db.clone());
+        original_app.sync_snapshot(&original_agent);
+        rara_persistence::thread_turn_log::append_rollout_fragment(
+            &state_db.rollout_root(),
+            &original_agent.session_id,
+            &PersistedTurnEntry {
+                role: "You".to_string(),
+                message: "recover active turn".to_string(),
+            },
+        )
+        .expect("write live user entry");
+        rara_persistence::thread_turn_log::append_rollout_fragment(
+            &state_db.rollout_root(),
+            &original_agent.session_id,
+            &PersistedTurnEntry {
+                role: "Agent".to_string(),
+                message: "partial answer".to_string(),
+            },
+        )
+        .expect("write live agent entry");
+
+        let restored_agent = Agent::new(
+            ToolManager::new(),
+            backend,
+            Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager,
+            workspace,
+        );
+        let mut restored_slot = Some(restored_agent);
+        let mut restored_app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config-restored.json"),
+        })
+        .expect("restored app");
+        restored_app.attach_state_db(state_db);
+
+        restore_thread_by_id(
+            original_agent.session_id.as_str(),
+            &mut restored_app,
+            &mut restored_slot,
+        )
+        .expect("restore thread");
+
+        assert_eq!(restored_app.committed_turns.len(), 0);
+        assert_eq!(restored_app.active_turn.entries.len(), 2);
+        assert_eq!(restored_app.active_turn.entries[0].role, "You");
+        assert_eq!(
+            restored_app.active_turn.entries[0].message,
+            "recover active turn"
+        );
+        assert_eq!(restored_app.active_turn.entries[1].role, "Agent");
+        assert_eq!(
+            restored_app.active_turn.entries[1].message,
+            "partial answer"
+        );
     }
 
     #[test]

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -198,7 +198,11 @@ pub(super) fn restore_thread_by_id(
         }
     }
     let rollout_root = state_db.rollout_root();
-    app.restore_committed_turns(turns);
+    if !turns.is_empty() {
+        app.restore_committed_turns(turns);
+    } else {
+        app.reset_transcript();
+    }
     let live_entries =
         rara_persistence::thread_turn_log::load_live_entries(&rollout_root, thread_id);
     if !live_entries.is_empty() {
@@ -514,6 +518,9 @@ mod tests {
         })
         .expect("restored app");
         restored_app.attach_state_db(state_db);
+        restored_app.bottom_pane.pending_planning_suggestion =
+            Some("stale planning suggestion".to_string());
+        restored_app.queue_follow_up_message("stale queued follow-up");
 
         restore_thread_by_id(
             original_agent.session_id.as_str(),
@@ -611,6 +618,13 @@ mod tests {
 
         assert_eq!(restored_app.committed_turns.len(), 0);
         assert_eq!(restored_app.active_turn.entries.len(), 2);
+        assert!(
+            restored_app
+                .bottom_pane
+                .pending_planning_suggestion
+                .is_none()
+        );
+        assert!(restored_app.pop_queued_follow_up_message().is_none());
         assert_eq!(restored_app.active_turn.entries[0].role, "You");
         assert_eq!(
             restored_app.active_turn.entries[0].message,

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -300,22 +300,19 @@ impl TuiApp {
         let Some((root_dir, session_id)) = self.live_log_context() else {
             return;
         };
-        if !rara_persistence::thread_turn_log::clear_live_log(&root_dir, &session_id) {
-            log::warn!("live transcript rewrite skipped for session {session_id}: clear failed");
-            return;
-        }
-        for entry in entries.iter().map(|entry| PersistedTurnEntry {
-            role: entry.role.clone(),
-            message: entry.message.clone(),
-        }) {
-            if let Err(err) = rara_persistence::thread_turn_log::append_rollout_fragment(
-                &root_dir,
-                &session_id,
-                &entry,
-            ) {
-                log::warn!("live transcript rewrite failed for session {session_id}: {err}");
-                return;
-            }
+        let entries = entries
+            .iter()
+            .map(|entry| PersistedTurnEntry {
+                role: entry.role.clone(),
+                message: entry.message.clone(),
+            })
+            .collect::<Vec<_>>();
+        if let Err(err) = rara_persistence::thread_turn_log::replace_live_entries(
+            &root_dir,
+            &session_id,
+            &entries,
+        ) {
+            log::warn!("live transcript rewrite failed for session {session_id}: {err}");
         }
     }
 

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -322,14 +322,15 @@ impl TuiApp {
         let Some((root_dir, session_id)) = self.live_log_context() else {
             return true;
         };
-        let cleared = rara_persistence::thread_turn_log::clear_live_log(&root_dir, &session_id);
-        if !cleared {
+        if let Err(err) = rara_persistence::thread_turn_log::clear_live_log(&root_dir, &session_id)
+        {
             self.state_db_status = Some(state_db_status_error(
                 "live log clear failed",
-                format!("session {session_id}"),
+                err.to_string(),
             ));
+            return false;
         }
-        cleared
+        true
     }
 
     fn live_log_context(&self) -> Option<(PathBuf, String)> {

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -300,7 +300,10 @@ impl TuiApp {
         let Some((root_dir, session_id)) = self.live_log_context() else {
             return;
         };
-        rara_persistence::thread_turn_log::clear_live_log(&root_dir, &session_id);
+        if !rara_persistence::thread_turn_log::clear_live_log(&root_dir, &session_id) {
+            log::warn!("live transcript rewrite skipped for session {session_id}: clear failed");
+            return;
+        }
         for entry in entries.iter().map(|entry| PersistedTurnEntry {
             role: entry.role.clone(),
             message: entry.message.clone(),

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -261,12 +261,12 @@ impl TuiApp {
         self.state_db_status = Some(state_db_status);
     }
 
-    pub(super) fn persist_turn(&mut self, ordinal: usize, turn: &TranscriptTurn) {
+    pub(super) fn persist_turn(&mut self, ordinal: usize, turn: &TranscriptTurn) -> bool {
         let Some(state_db) = self.state_db.as_ref() else {
-            return;
+            return true;
         };
         if self.snapshot.session_id.is_empty() {
-            return;
+            return true;
         }
         let recorder = ThreadRecorder::new(state_db);
         let entries = turn
@@ -280,7 +280,9 @@ impl TuiApp {
         if let Err(err) = recorder.persist_turn(&self.snapshot.session_id, ordinal, &entries) {
             self.state_db_status =
                 Some(state_db_status_error("turn write failed", err.to_string()));
+            return false;
         }
+        true
     }
 
     pub(crate) fn record_entry_realtime(&self, entry: &PersistedTurnEntry) {

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -7,7 +7,9 @@ use rara_state::state_db::{
 };
 use serde_json::json;
 
-use super::{InteractionKind, StateDb, TranscriptTurn, TuiApp, state_db_status_error};
+use super::{
+    InteractionKind, StateDb, TranscriptEntry, TranscriptTurn, TuiApp, state_db_status_error,
+};
 use crate::thread_store::{ThreadRecorder, ThreadRuntimeState, ThreadStore};
 
 const RESUME_PICKER_THREAD_LIMIT: usize = 200;
@@ -281,10 +283,6 @@ impl TuiApp {
         }
     }
 
-    /// Realtime per-entry write to the live log (Claude Code style).
-    /// Will be called from push_entry so resume can recover partial turns.
-    /// Reserved for restoring partial-turn resume recovery (docs/todo.md).
-    #[allow(dead_code)]
     pub(crate) fn record_entry_realtime(&self, entry: &PersistedTurnEntry) {
         let Some((root_dir, session_id)) = self.live_log_context() else {
             return;
@@ -294,13 +292,30 @@ impl TuiApp {
             &session_id,
             entry,
         ) {
-            eprintln!("live write failed: {e}");
+            log::warn!("live transcript write failed for session {session_id}: {e}");
         }
     }
 
-    /// Clear the live log after a turn is committed.
-    /// Reserved for restoring partial-turn resume recovery (docs/todo.md).
-    #[allow(dead_code)]
+    pub(crate) fn replace_live_log_entries(&self, entries: &[TranscriptEntry]) {
+        let Some((root_dir, session_id)) = self.live_log_context() else {
+            return;
+        };
+        rara_persistence::thread_turn_log::clear_live_log(&root_dir, &session_id);
+        for entry in entries.iter().map(|entry| PersistedTurnEntry {
+            role: entry.role.clone(),
+            message: entry.message.clone(),
+        }) {
+            if let Err(err) = rara_persistence::thread_turn_log::append_rollout_fragment(
+                &root_dir,
+                &session_id,
+                &entry,
+            ) {
+                log::warn!("live transcript rewrite failed for session {session_id}: {err}");
+                return;
+            }
+        }
+    }
+
     pub(crate) fn clear_live_log(&self) {
         let Some((root_dir, session_id)) = self.live_log_context() else {
             return;

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -318,11 +318,18 @@ impl TuiApp {
         }
     }
 
-    pub(crate) fn clear_live_log(&self) {
+    pub(crate) fn clear_live_log(&mut self) -> bool {
         let Some((root_dir, session_id)) = self.live_log_context() else {
-            return;
+            return true;
         };
-        rara_persistence::thread_turn_log::clear_live_log(&root_dir, &session_id);
+        let cleared = rara_persistence::thread_turn_log::clear_live_log(&root_dir, &session_id);
+        if !cleared {
+            self.state_db_status = Some(state_db_status_error(
+                "live log clear failed",
+                format!("session {session_id}"),
+            ));
+        }
+        cleared
     }
 
     fn live_log_context(&self) -> Option<(PathBuf, String)> {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -7,8 +7,8 @@ use tempfile::tempdir;
 use super::{
     ActivePendingInteractionKind, AgentMarkdownStreamState, InteractionKind, ListPickerKind,
     Overlay, PROVIDER_FAMILIES, PendingInteractionSnapshot, ProviderFamily, RuntimeSnapshot,
-    TranscriptEntry, TranscriptTurn, TuiApp, input_requests_command_palette, parse_repo_slug,
-    state_db_status_error,
+    SystemMessageKind, TranscriptEntry, TranscriptTurn, TuiApp, input_requests_command_palette,
+    parse_repo_slug, state_db_status_error,
 };
 use crate::agent::{Agent, PendingApproval};
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
@@ -1298,6 +1298,72 @@ fn active_turn_entries_write_and_clear_live_log() {
     .expect("turn records");
     assert_eq!(turn_records.len(), 1);
     assert_eq!(turn_records[0].entries.len(), 2);
+}
+
+#[test]
+fn push_system_redacts_live_log_entries() {
+    let dir = tempdir().expect("tempdir");
+    let state_db = StateDb::new_for_root_dir(dir.path().join(".rara")).expect("state db");
+    let mut app = TuiApp::new(ConfigManager {
+        path: dir.path().join("config.json"),
+    })
+    .expect("app");
+    app.attach_state_db(std::sync::Arc::new(state_db));
+    app.snapshot.session_id = "live-redaction-session".to_string();
+
+    app.push_system(
+        "token=supersecretvalue Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
+        SystemMessageKind::Other,
+    );
+
+    let live_entries = thread_turn_log::load_live_entries(
+        &app.state_db.as_ref().unwrap().rollout_root(),
+        "live-redaction-session",
+    );
+    assert_eq!(live_entries.len(), 1);
+    assert!(live_entries[0].message.contains("[REDACTED_SECRET]"));
+    assert!(!live_entries[0].message.contains("supersecretvalue"));
+    assert!(
+        !live_entries[0]
+            .message
+            .contains("abcdefghijklmnopqrstuvwxyz")
+    );
+}
+
+#[test]
+fn active_turn_commit_keeps_live_log_when_turn_persist_fails() {
+    let dir = tempdir().expect("tempdir");
+    let state_db = StateDb::new_for_root_dir(dir.path().join(".rara")).expect("state db");
+    let mut app = TuiApp::new(ConfigManager {
+        path: dir.path().join("config.json"),
+    })
+    .expect("app");
+    app.attach_state_db(std::sync::Arc::new(state_db));
+    app.snapshot.session_id = "live-persist-failure-session".to_string();
+
+    app.push_entry("You", "keep me");
+    app.push_entry("Agent", "until canonical write succeeds");
+    let rollout_root = app.state_db.as_ref().unwrap().rollout_root();
+    let session_dir = rollout_root.join("live-persist-failure-session");
+    std::fs::create_dir(session_dir.join("turns.jsonl")).expect("turns path directory");
+
+    app.finalize_active_turn();
+
+    let live_entries =
+        thread_turn_log::load_live_entries(&rollout_root, "live-persist-failure-session");
+    assert_eq!(live_entries.len(), 2);
+    assert!(app.committed_turns.is_empty());
+    assert_eq!(app.active_turn.entries.len(), 2);
+    assert_eq!(app.active_turn.entries[0].message, "keep me");
+    assert_eq!(
+        app.active_turn.entries[1].message,
+        "until canonical write succeeds"
+    );
+    assert!(
+        app.state_db_status
+            .as_deref()
+            .is_some_and(|status| status.contains("turn write failed"))
+    );
 }
 
 #[test]

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1300,6 +1300,38 @@ fn active_turn_entries_write_and_clear_live_log() {
     assert_eq!(turn_records[0].entries.len(), 2);
 }
 
+#[test]
+fn reset_transcript_clears_live_log() {
+    let dir = tempdir().expect("tempdir");
+    let state_db = StateDb::new_for_root_dir(dir.path().join(".rara")).expect("state db");
+    let mut app = TuiApp::new(ConfigManager {
+        path: dir.path().join("config.json"),
+    })
+    .expect("app");
+    app.attach_state_db(std::sync::Arc::new(state_db));
+    app.snapshot.session_id = "live-reset-session".to_string();
+
+    app.push_entry("You", "clear me");
+    assert_eq!(
+        thread_turn_log::load_live_entries(
+            &app.state_db.as_ref().unwrap().rollout_root(),
+            "live-reset-session"
+        )
+        .len(),
+        1
+    );
+
+    app.reset_transcript();
+
+    assert!(
+        thread_turn_log::load_live_entries(
+            &app.state_db.as_ref().unwrap().rollout_root(),
+            "live-reset-session"
+        )
+        .is_empty()
+    );
+}
+
 // ── Command palette selection persistence ──────────────────────────
 
 /// Typing more characters while the palette is open should NOT reset

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1,4 +1,5 @@
 use rara_memory::vectordb::VectorDB;
+use rara_persistence::thread_turn_log;
 use rara_state::state_db::{PersistedCompactState, PersistedPromptRuntimeState, StateDb};
 use rara_tools::tool::ToolManager;
 use tempfile::tempdir;
@@ -1257,6 +1258,46 @@ fn restore_committed_turns_sets_inserted_counter_to_match() {
 
     assert_eq!(app.committed_turns.len(), n);
     assert_eq!(app.active_turn.entries.len(), 0);
+}
+
+#[test]
+fn active_turn_entries_write_and_clear_live_log() {
+    let dir = tempdir().expect("tempdir");
+    let state_db = StateDb::new_for_root_dir(dir.path().join(".rara")).expect("state db");
+    let mut app = TuiApp::new(ConfigManager {
+        path: dir.path().join("config.json"),
+    })
+    .expect("app");
+    app.attach_state_db(std::sync::Arc::new(state_db));
+    app.snapshot.session_id = "live-entry-session".to_string();
+
+    app.push_entry("You", "hello");
+    app.push_entry("Agent", "hi");
+
+    let live_entries = thread_turn_log::load_live_entries(
+        &app.state_db.as_ref().unwrap().rollout_root(),
+        "live-entry-session",
+    );
+    assert_eq!(live_entries.len(), 2);
+    assert_eq!(live_entries[0].role, "You");
+    assert_eq!(live_entries[0].message, "hello");
+    assert_eq!(live_entries[1].role, "Agent");
+    assert_eq!(live_entries[1].message, "hi");
+
+    app.finalize_active_turn();
+
+    let live_entries = thread_turn_log::load_live_entries(
+        &app.state_db.as_ref().unwrap().rollout_root(),
+        "live-entry-session",
+    );
+    assert!(live_entries.is_empty());
+    let turn_records = thread_turn_log::load_turn_records(
+        &app.state_db.as_ref().unwrap().rollout_root(),
+        "live-entry-session",
+    )
+    .expect("turn records");
+    assert_eq!(turn_records.len(), 1);
+    assert_eq!(turn_records[0].entries.len(), 2);
 }
 
 // ── Command palette selection persistence ──────────────────────────

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -113,7 +113,7 @@ impl TuiApp {
     }
 
     pub fn push_system(&mut self, message: impl Into<String>, kind: SystemMessageKind) {
-        let entry = TranscriptEntry::system(message, kind);
+        let entry = TranscriptEntry::system(redact_secrets(message.into()), kind);
         self.record_entry_realtime(&PersistedTurnEntry {
             role: entry.role.clone(),
             message: entry.message.clone(),
@@ -341,10 +341,15 @@ impl TuiApp {
             self.clear_active_live_sections();
             return;
         }
-        let mut turn = std::mem::take(&mut self.active_turn);
-        turn.thinking_duration = self.active_live.thinking_started_at.map(|s| s.elapsed());
+        self.active_turn.thinking_duration =
+            self.active_live.thinking_started_at.map(|s| s.elapsed());
         let ordinal = self.committed_turns.len();
-        self.persist_turn(ordinal, &turn);
+        let turn_to_persist = self.active_turn.clone();
+        if !self.persist_turn(ordinal, &turn_to_persist) {
+            self.clear_active_live_sections();
+            return;
+        }
+        let turn = std::mem::take(&mut self.active_turn);
         self.committed_turns.push(turn);
         self.clear_live_log();
         self.invalidate_committed_render_cache();

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use rara_persistence::redaction::redact_secrets;
+use rara_state::state_db::PersistedTurnEntry;
 use ratatui::text::Line;
 
 use super::{
@@ -92,23 +93,32 @@ impl TuiApp {
         if role == "You" && !self.active_turn.entries.is_empty() {
             self.commit_active_turn();
         }
-        self.active_turn
-            .entries
-            .push(TranscriptEntry::new(role, message));
+        let entry = TranscriptEntry::new(role, message);
+        self.record_entry_realtime(&PersistedTurnEntry {
+            role: entry.role.clone(),
+            message: entry.message.clone(),
+        });
+        self.active_turn.entries.push(entry);
         self.reset_transcript_scroll_if_following_tail();
     }
 
     pub fn push_terminal_event(&mut self, event: TerminalEvent) {
-        self.active_turn
-            .entries
-            .push(TranscriptEntry::terminal_event(event));
+        let entry = TranscriptEntry::terminal_event(event);
+        self.record_entry_realtime(&PersistedTurnEntry {
+            role: entry.role.clone(),
+            message: entry.message.clone(),
+        });
+        self.active_turn.entries.push(entry);
         self.reset_transcript_scroll_if_following_tail();
     }
 
     pub fn push_system(&mut self, message: impl Into<String>, kind: SystemMessageKind) {
-        self.active_turn
-            .entries
-            .push(TranscriptEntry::system(message, kind));
+        let entry = TranscriptEntry::system(message, kind);
+        self.record_entry_realtime(&PersistedTurnEntry {
+            role: entry.role.clone(),
+            message: entry.message.clone(),
+        });
+        self.active_turn.entries.push(entry);
         self.reset_transcript_scroll_if_following_tail();
     }
 
@@ -198,6 +208,7 @@ impl TuiApp {
         }
 
         if Self::replace_current_agent_segment_message(&mut self.active_turn, message.clone()) {
+            self.replace_live_log_entries(&self.active_turn.entries);
             self.reset_transcript_scroll_if_following_tail();
             return;
         }
@@ -334,6 +345,7 @@ impl TuiApp {
         let ordinal = self.committed_turns.len();
         self.persist_turn(ordinal, &turn);
         self.committed_turns.push(turn);
+        self.clear_live_log();
         self.invalidate_committed_render_cache();
         self.reset_transcript_scroll_if_following_tail();
         self.clear_active_live_sections();

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -232,6 +232,7 @@ impl TuiApp {
     pub fn reset_transcript(&mut self) {
         self.committed_turns.clear();
         self.active_turn.entries.clear();
+        self.clear_live_log();
         self.invalidate_committed_render_cache();
         self.transcript_scroll = 0;
         self.agent_markdown_stream = None;
@@ -358,6 +359,7 @@ impl TuiApp {
     pub fn restore_committed_turns(&mut self, turns: Vec<TranscriptTurn>) {
         self.committed_turns = turns;
         self.active_turn.entries.clear();
+        self.clear_live_log();
         self.invalidate_committed_render_cache();
         self.transcript_scroll = 0;
         self.agent_markdown_stream = None;


### PR DESCRIPTION
## Summary

- Write active TUI transcript entries to the per-session `live.jsonl` log as they are appended.
- Clear `live.jsonl` after the active turn is committed to `turns.jsonl`.
- Restore any remaining live entries into `active_turn` when resuming a thread.
- Mark the live-log recovery TODO complete and document the thread contract.

## Motivation

This completes one TUI/UX TODO item: partial turns should survive restart without being treated as committed transcript turns. The implementation follows the existing RARA thread storage shape by using `live.jsonl` as a side log for only the in-progress active turn, while committed turns remain owned by `turns.jsonl`.

Claude Code's recovery path inspired the restart behavior: persisted transcript data should be enough to identify and recover an interrupted turn. RARA keeps that recovery local to the TUI active turn instead of changing the model-visible history contract.

## Related Issue

None.

## Testing

```bash
cargo fmt
cargo test tui::state::tests::active_turn_entries_write_and_clear_live_log -- --nocapture
cargo test tui::session_restore::tests::restore_session_recovers_live_active_turn_entries -- --nocapture
cargo test tui::state::tests -- --nocapture
cargo test tui::session_restore::tests -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
git diff --check
```
