### PR TITLE
fix(agent): load Claude-compatible definitions from .rara agents

### DIFF
--- a/docs/features/repo-extension-surface.md
+++ b/docs/features/repo-extension-surface.md
@@ -10,7 +10,7 @@ The initial target is compatibility with:
 - repo context files that describe local project rules, conventions, and active
   workspace facts;
 - native RARA skills under `.agents/skills/`;
-- Claude-style agent definitions under `.claude/agents/`;
+- Claude-compatible agent definitions under `.rara/agents/`;
 - Claude-style lifecycle hooks under `.claude/hooks/`.
 
 This document defines discovery, precedence, compatibility boundaries, and a
@@ -35,7 +35,8 @@ not a byte-for-byte clone of Claude Code runtime semantics.
 
 That means:
 
-- RARA may normalize Claude agent files into RARA-owned imported-agent objects;
+- RARA may normalize Claude-format agent files into RARA-owned imported-agent
+  objects;
 - RARA may normalize Claude hook declarations into RARA-owned hook-definition
   objects;
 - actual execution still has to respect RARA thread, context, sandbox, and tool
@@ -116,7 +117,8 @@ invented as an unowned prompt prefix.
 The first rollout should not:
 
 - execute arbitrary hook files on discovery;
-- treat imported Claude agents as first-class RARA child threads immediately;
+- treat imported Claude-compatible agents as first-class RARA child threads
+  immediately;
 - merge all extension types into one generic opaque plugin loader;
 - introduce a marketplace or remote-install protocol.
 
@@ -151,9 +153,14 @@ They remain the authoritative skill format for direct runtime use.
 
 ### Imported Agent Definitions
 
-Claude-style repo-local agents live under:
+RARA-native repo-local agents live under:
 
-- `.claude/agents/*.md`
+- `.rara/agents/*.md`
+
+These files use the same frontmatter-plus-body format as Claude Code's
+`.claude/agents/*.md` files. RARA may still import `.claude/agents/*.md` as a
+legacy compatibility path, but `.rara/agents` is the canonical RARA location and
+has higher precedence for same-name definitions.
 
 RARA should treat these as **importable agent profiles**, not as raw prompt
 files.
@@ -165,13 +172,15 @@ as:
   - `id`
   - `label`
   - `source_path`
-  - `source_kind = "claude_agent"`
+  - `source_kind = "rara_agent"`
   - `prompt_body`
   - `tools_policy`
   - `description`
+  - `parse_status`
 
-The first cut may leave `tools_policy` partially inferred or unknown, but the
-object boundary should exist.
+The status projection and runtime execution path should share the same
+Claude-compatible parser so `ImportedAgentProfile` cannot drift from
+`AgentDefinition`.
 
 ### Imported Hook Definitions
 
@@ -207,6 +216,7 @@ RARA should distinguish:
 The initial repository-scoped roots are:
 
 - `<workspace>/.agents/skills/`
+- `<workspace>/.rara/agents/`
 - `<workspace>/.claude/agents/`
 - `<workspace>/.claude/hooks/`
 
@@ -249,12 +259,12 @@ See [Verify Skill](verify-skill.md) for the detailed verification contract.
 
 ### Imported Agents
 
-Imported Claude agents should remain in their own namespace and should not
+Imported RARA agents should remain in their own namespace and should not
 silently override native RARA skills or built-in sub-agent kinds.
 
 That means:
 
-- a Claude agent named `planner` should not replace RARA's built-in planning
+- an imported agent named `planner` should not replace RARA's built-in planning
   mode;
 - collisions should be surfaced as compatibility warnings or namespace-qualified
   entries.
@@ -275,7 +285,7 @@ Once discovery lands, `/status` or equivalent debug surfaces should be able to
 show:
 
 - discovered native skills;
-- discovered imported Claude agents;
+- discovered imported RARA/Claude-compatible agents;
 - discovered imported Claude hooks;
 - source path;
 - precedence or override status;
@@ -291,7 +301,8 @@ debuggable.
 
 Deliver:
 
-- discovery of `.agents/skills/`, `.claude/agents/`, `.claude/hooks/`;
+- discovery of `.agents/skills/`, `.rara/agents/`, `.claude/agents/`,
+  `.claude/hooks/`;
 - normalized metadata objects;
 - source-aware status reporting;
 - precedence/override visibility.
@@ -305,7 +316,7 @@ Do not yet:
 
 Deliver:
 
-- map imported Claude agents into explicit RARA agent profiles;
+- map imported Claude-compatible agents into explicit RARA agent profiles;
 - allow opt-in invocation through a RARA-owned delegation/runtime surface;
 - keep parent/child thread contracts owned by `ThreadStore`, not by imported
   file formats.
@@ -349,7 +360,8 @@ Imported extensions must not bypass RARA-owned runtime boundaries.
 
 That means:
 
-- imported Claude agents still run through RARA sub-agent/thread contracts;
+- imported Claude-compatible agents still run through RARA sub-agent/thread
+  contracts;
 - imported hooks still operate through RARA lifecycle events;
 - repo context and repo-local skills still enter through source discovery and
   context assembly instead of bypassing prompt ownership;

--- a/docs/features/subagent-claude-compat.md
+++ b/docs/features/subagent-claude-compat.md
@@ -3,7 +3,7 @@
 ## Summary
 
 Extend RARA's subagent system (`src/tools/agent.rs`) to support
-Claude Code-compatible agent definitions loaded from `.claude/agents/`
+Claude Code-compatible agent definitions loaded from `.rara/agents/`
 with tool permission scoping, progress tracking, and task resume.
 
 This makes RARA's subagent behavior consistent with Claude Code's
@@ -14,7 +14,9 @@ infrastructure.
 
 ### Agent Definition Format
 
-Compatible with Claude Code's `.claude/agents/*.md` frontmatter.
+Compatible with Claude Code's `.claude/agents/*.md` frontmatter. RARA's
+canonical project-local location is `.rara/agents/*.md`; `.claude/agents/*.md`
+is a legacy compatibility import path.
 The YAML frontmatter block defines the agent:
 
 ```markdown
@@ -37,8 +39,8 @@ You are a code reviewer. When reviewing code, check for:
 Report findings with file:line references.
 ```
 
-RARA reads the frontmatter block only (ignores the markdown body for now;
-the body can serve as the default system prompt for the subagent).
+RARA reads the frontmatter block and uses the markdown body as the default
+system prompt for the subagent.
 
 ### `AgentDefinition` Type
 
@@ -73,11 +75,15 @@ pub struct AgentDefinition {
 
 `load_agent_definitions()` scans:
 1. Built-in agents (General, Explore, Plan) — hardcoded in RARA.
-2. `.claude/agents/*.md` files in the workspace root.
-3. `~/.claude/agents/*.md` files in the user home.
+2. `~/.claude/agents/*.md` files in the user home.
+3. `~/.rara/agents/*.md` files in the user home.
+4. `.claude/agents/*.md` files in the workspace root.
+5. `.rara/agents/*.md` files in the workspace root.
 
-Resolves conflicts: project agents override user agents, built-in agents
-are always available as "general", "explore", "plan".
+Resolves conflicts by loading lower-precedence roots first. Workspace agents
+override user agents, and `.rara/agents` overrides `.claude/agents` at the same
+scope. Built-in agents are always available as "general", "explore", "plan"
+when no custom definition with the requested name is loaded.
 
 ### Subagent Execution Changes
 
@@ -159,7 +165,8 @@ TUI subagent sidebar shows:
 ## Implementation Plan
 
 1. Add `AgentDefinition` struct and YAML parsing.
-2. Add `load_agent_definitions()` scanning `.claude/agents/`.
+2. Add `load_agent_definitions()` scanning `.rara/agents/` with
+   `.claude/agents/` compatibility.
 3. Extend `SubAgentKind` → `AgentDefinition` mapping.
 4. Add tool filtering to subagent spawning.
 5. Add `SubagentProgress` tracking.

--- a/docs/journal/2026-07-02-rara-agent-definition-discovery.md
+++ b/docs/journal/2026-07-02-rara-agent-definition-discovery.md
@@ -1,0 +1,47 @@
+# RARA Agent Definition Discovery
+
+## Summary
+
+RARA now treats `.rara/agents/*.md` as the canonical project-local location for
+custom subagent definitions while keeping `.claude/agents/*.md` as a legacy
+compatibility import path. Both locations use the Claude-compatible YAML
+frontmatter plus markdown body format.
+
+## Background
+
+Agent execution and `/status` discovery previously parsed imported agent files
+through separate code paths. Execution used the `AgentDefinition` frontmatter
+parser, while status discovery inferred labels and descriptions from markdown
+headings. That made runtime behavior and explainability able to drift.
+
+## Key Decisions
+
+- Use one Claude-compatible parser for both execution and status projection.
+- Load lower-precedence roots first, then let later roots override same-name
+  definitions.
+- Keep `.claude/agents` as compatibility input, but make `.rara/agents` the
+  preferred RARA path and highest-precedence workspace root.
+- Keep `/status` scoped to workspace extension files; execution continues to
+  support home and workspace roots.
+
+## Validation
+
+```bash
+cargo test agents_ext::tests -- --nocapture
+cargo test tools::agent_test::resolve_spawn_agent_definition_loads_workspace_agent -- --nocapture
+cargo test tools::agent_test::rara_agent_definition_overrides_legacy_claude_definition -- --nocapture
+cargo test tools::agent_test::spawn_agent_definition_lookup_uses_normalized_label -- --nocapture
+cargo test agent_definition_uses_filename_when_frontmatter_omits_name -- --nocapture
+cargo test agent_definition_accepts_empty_frontmatter -- --nocapture
+cargo test agent_home_dir_falls_back_to_userprofile -- --nocapture
+cargo test discover_repo_agents_uses_frontmatter_name_as_id -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+```
+
+## Follow-Ups
+
+- Cache agent definitions at runtime construction time and add an explicit
+  reload path.
+- Add end-to-end `spawn_agent` coverage for prompt body, tool filtering,
+  `maxTurns`, and `planModeRequired`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -47,7 +47,7 @@ Active backlog only. Keep this file small and current.
 - [x] Subagent token_budget field (PR #601)
 - [ ] Subagent restart/reconnect — built-in capability, not a separate tool
 - [x] Subagent context budget design — token_budget on AgentDefinition
-- [ ] Unify `.claude/agents` parsing for execution and `/status` discovery so
+- [x] Unify `.rara/agents` parsing for execution and `/status` discovery so
       `AgentDefinition` and `ImportedAgentProfile` cannot drift.
 - [ ] Cache Claude-style agent definitions at runtime construction time and
       expose an explicit reload path instead of scanning on each `spawn_agent`.
@@ -55,7 +55,7 @@ Active backlog only. Keep this file small and current.
       `token_budget`, `permission_mode`, `hidden`, and description/listing
       behavior.
 - [ ] Add an end-to-end `spawn_agent` regression test proving custom
-      `.claude/agents` definitions affect prompt body, tool filtering,
+      `.rara/agents` definitions affect prompt body, tool filtering,
       `maxTurns`, and `planModeRequired`.
 
 ## Planning Control Plane

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -1,33 +1,31 @@
-// Imported agent definitions from Claude-style repo extensions.
+// Imported agent definitions from RARA repo extensions.
 //
-// Discovers `.claude/agents/*.md` files, normalises them into
-// RARA-owned ImportedAgentProfile objects, and surfaces them.
-//
-// Execution is explicitly deferred — these are discovery and
-// normalisation only. Execution will go through RARA's
-// thread/sub-agent model when implemented.
+// Discovers `.rara/agents/*.md` plus legacy `.claude/agents/*.md` files that
+// use the Claude-compatible frontmatter format, normalises them into RARA-owned
+// ImportedAgentProfile objects, and surfaces them through /status.
 
 use std::collections::HashMap;
-use std::fs;
 use std::path::Path;
 
 use serde::Serialize;
 
-/// A Claude-style imported agent definition, normalised into
+use crate::tools::agent::{AgentDefinitionLoadRecord, discover_workspace_agent_definition_records};
+
+/// A Claude-compatible imported agent definition, normalised into
 /// a RARA-owned profile object.
 #[derive(Debug, Clone, Serialize)]
 pub struct ImportedAgentProfile {
-    /// Unique id derived from source file stem.
+    /// Canonical agent id from parsed frontmatter; falls back to file stem on parse errors.
     pub id: String,
-    /// Human-readable label (from first heading or filename).
+    /// Human-readable label for status display.
     pub label: String,
     /// Repository-relative source path.
     pub source_path: String,
-    /// Where this agent originated (currently always "claude_agent").
+    /// Where this agent originated.
     pub source_kind: String,
-    /// The raw markdown body.
+    /// Markdown body after the frontmatter block.
     pub prompt_body: String,
-    /// Short description extracted from the first non-heading line.
+    /// Short description from parsed frontmatter, or parse error detail.
     pub description: String,
     /// Whether the file could be read successfully.
     pub parse_status: AgentParseStatus,
@@ -41,115 +39,24 @@ pub enum AgentParseStatus {
     ParseError,
 }
 
-/// Discovers Claude-style agent profiles and stores their normalised
-/// definitions. Execution is currently not wired — this is discovery-only.
+/// Discovers RARA-local Claude-compatible agent profiles and stores their
+/// normalised definitions for status display.
 pub struct AgentRegistry {
     pub agents: HashMap<String, ImportedAgentProfile>,
-    pub load_warnings: Vec<String>,
 }
 
 impl AgentRegistry {
     pub fn new() -> Self {
         Self {
             agents: HashMap::new(),
-            load_warnings: Vec::new(),
-        }
-    }
-
-    /// Scan a directory for `.md` agent definition files.
-    pub fn discover_from_dir(&mut self, dir: &Path) {
-        if !dir.exists() {
-            return;
-        }
-        let entries = match fs::read_dir(dir) {
-            Ok(entries) => entries,
-            Err(err) => {
-                self.load_warnings
-                    .push(format!("agent dir {}: {err}", dir.display()));
-                return;
-            }
-        };
-
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_file() {
-                continue;
-            }
-            let Some(ext) = path.extension().and_then(|s| s.to_str()) else {
-                continue;
-            };
-            if ext != "md" {
-                continue;
-            }
-
-            let id = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("unknown")
-                .to_string();
-            let source_path = path
-                .strip_prefix(dir)
-                .unwrap_or(&path)
-                .display()
-                .to_string();
-
-            let body = match fs::read_to_string(&path) {
-                Ok(content) => content,
-                Err(err) => {
-                    self.agents.insert(
-                        id.clone(),
-                        ImportedAgentProfile {
-                            id,
-                            label: source_path.clone(),
-                            source_path,
-                            source_kind: "claude_agent".to_string(),
-                            prompt_body: String::new(),
-                            description: format!("read error: {err}"),
-                            parse_status: AgentParseStatus::ParseError,
-                        },
-                    );
-                    continue;
-                }
-            };
-
-            if body.trim().is_empty() {
-                self.agents.insert(
-                    id.clone(),
-                    ImportedAgentProfile {
-                        id,
-                        label: source_path.clone(),
-                        source_path,
-                        source_kind: "claude_agent".to_string(),
-                        prompt_body: String::new(),
-                        description: "empty file".to_string(),
-                        parse_status: AgentParseStatus::ParseError,
-                    },
-                );
-                continue;
-            }
-
-            let label = extract_agent_label(&body, &id);
-            let description = extract_agent_description(&body);
-
-            self.agents.insert(
-                id.clone(),
-                ImportedAgentProfile {
-                    id,
-                    label,
-                    source_path,
-                    source_kind: "claude_agent".to_string(),
-                    prompt_body: body,
-                    description,
-                    parse_status: AgentParseStatus::Ok,
-                },
-            );
         }
     }
 
     /// Discover agent profiles from a repository root directory.
     pub fn discover_repo_agents(&mut self, repo_root: &Path) {
-        let agents_dir = repo_root.join(".claude").join("agents");
-        self.discover_from_dir(&agents_dir);
+        for record in discover_workspace_agent_definition_records(repo_root) {
+            self.insert_record(record, repo_root);
+        }
     }
 
     /// For /context and /status: list each discovered agent with path and status.
@@ -171,37 +78,40 @@ impl AgentRegistry {
         lines.sort();
         lines
     }
-}
 
-/// Extract a human-readable label from the first Markdown heading,
-/// falling back to the file stem.
-fn extract_agent_label(body: &str, fallback_id: &str) -> String {
-    for line in body.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix('#') {
-            let rest = rest.trim_start_matches('#').trim();
-            if !rest.is_empty() {
-                return rest.to_string();
+    fn insert_record(&mut self, record: AgentDefinitionLoadRecord, base_dir: &Path) {
+        let fallback_id = record.id.clone();
+        let source_path = record
+            .source_path
+            .strip_prefix(base_dir)
+            .unwrap_or(&record.source_path)
+            .display()
+            .to_string();
+        let profile = match record.definition {
+            Some(definition) => {
+                let id = definition.name.clone();
+                ImportedAgentProfile {
+                    id: id.clone(),
+                    label: id,
+                    source_path,
+                    source_kind: "rara_agent".to_string(),
+                    prompt_body: definition.system_prompt,
+                    description: definition.description,
+                    parse_status: AgentParseStatus::Ok,
+                }
             }
-        }
+            None => ImportedAgentProfile {
+                id: fallback_id.clone(),
+                label: fallback_id,
+                source_path,
+                source_kind: "rara_agent".to_string(),
+                prompt_body: String::new(),
+                description: record.error.unwrap_or_else(|| "parse error".to_string()),
+                parse_status: AgentParseStatus::ParseError,
+            },
+        };
+        self.agents.insert(profile.id.clone(), profile);
     }
-    fallback_id.to_string()
-}
-
-/// Extract a short description from the first non-empty, non-heading line.
-fn extract_agent_description(body: &str) -> String {
-    for line in body.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        let desc: String = trimmed.chars().take(120).collect();
-        if desc.len() < trimmed.len() {
-            return format!("{desc}...");
-        }
-        return desc;
-    }
-    "no description".to_string()
 }
 
 #[cfg(test)]
@@ -215,59 +125,129 @@ mod tests {
     #[test]
     fn discovers_agents_from_directory() {
         let dir = tempdir().expect("tempdir");
-        let agents_dir = dir.path().join(".claude").join("agents");
+        let agents_dir = dir.path().join(".rara").join("agents");
         fs::create_dir_all(&agents_dir).expect("mkdir");
         fs::write(
             agents_dir.join("code-reviewer.md"),
-            "# Code Reviewer\n\nReviews pull requests for correctness and style.\n",
+            r#"---
+name: code-reviewer
+description: Reviews pull requests for correctness and style.
+tools: [Read, Grep]
+---
+
+Review pull requests for correctness and style.
+"#,
         )
         .expect("write");
         fs::write(
             agents_dir.join("test-writer.md"),
-            "# Test Writer\n\nGenerates unit tests for new code paths.\n",
+            r#"---
+name: test-writer
+description: Generates unit tests for new code paths.
+tools: [Read, Write]
+---
+
+Generate unit tests for new code paths.
+"#,
         )
         .expect("write");
 
         let mut registry = AgentRegistry::new();
-        registry.discover_from_dir(&agents_dir);
+        registry.discover_repo_agents(dir.path());
 
         assert_eq!(registry.agents.len(), 2);
 
         let reviewer = registry.agents.get("code-reviewer").expect("reviewer");
-        assert_eq!(reviewer.label, "Code Reviewer");
-        assert_eq!(reviewer.source_kind, "claude_agent");
+        assert_eq!(reviewer.label, "code-reviewer");
+        assert_eq!(reviewer.source_kind, "rara_agent");
         assert_eq!(reviewer.parse_status, AgentParseStatus::Ok);
         assert!(reviewer.description.contains("Reviews pull requests"));
+        assert_eq!(reviewer.source_path, ".rara/agents/code-reviewer.md");
     }
 
     #[test]
     fn empty_agent_file_is_parse_error() {
         let dir = tempdir().expect("tempdir");
-        let agents_dir = dir.path().join(".claude").join("agents");
+        let agents_dir = dir.path().join(".rara").join("agents");
         fs::create_dir_all(&agents_dir).expect("mkdir");
         fs::write(agents_dir.join("empty.md"), "").expect("write");
 
         let mut registry = AgentRegistry::new();
-        registry.discover_from_dir(&agents_dir);
+        registry.discover_repo_agents(dir.path());
 
         let agent = registry.agents.get("empty").expect("empty agent");
         assert_eq!(agent.parse_status, AgentParseStatus::ParseError);
     }
 
     #[test]
-    fn agent_label_falls_back_to_filename() {
+    fn discover_repo_agents_prefers_rara_agents() {
         let dir = tempdir().expect("tempdir");
         let agents_dir = dir.path().join(".claude").join("agents");
         fs::create_dir_all(&agents_dir).expect("mkdir");
-        fs::write(agents_dir.join("helper.md"), "Just a helpful assistant.\n").expect("write");
+        fs::write(
+            agents_dir.join("helper.md"),
+            r#"---
+name: helper
+description: Legacy helper.
+---
+
+Legacy prompt.
+"#,
+        )
+        .expect("write");
+
+        let rara_agents_dir = dir.path().join(".rara").join("agents");
+        fs::create_dir_all(&rara_agents_dir).expect("mkdir");
+        fs::write(
+            rara_agents_dir.join("helper.md"),
+            r#"---
+name: helper
+description: RARA helper.
+---
+
+RARA prompt.
+"#,
+        )
+        .expect("write");
 
         let mut registry = AgentRegistry::new();
-        registry.discover_from_dir(&agents_dir);
+        registry.discover_repo_agents(dir.path());
 
         let agent = registry.agents.get("helper").expect("helper");
-        // First non-heading line is the description; no heading → fallback to filename
         assert_eq!(agent.label, "helper");
-        assert_eq!(agent.description, "Just a helpful assistant.");
+        assert_eq!(agent.description, "RARA helper.");
+        assert_eq!(agent.source_path, ".rara/agents/helper.md");
+        assert_eq!(agent.parse_status, AgentParseStatus::Ok);
+    }
+
+    #[test]
+    fn discover_repo_agents_uses_frontmatter_name_as_id() {
+        let dir = tempdir().expect("tempdir");
+        let agents_dir = dir.path().join(".rara").join("agents");
+        fs::create_dir_all(&agents_dir).expect("mkdir");
+        fs::write(
+            agents_dir.join("reviewer-file.md"),
+            r#"---
+name: canonical-reviewer
+description: Review code.
+---
+
+Review prompt.
+"#,
+        )
+        .expect("write");
+
+        let mut registry = AgentRegistry::new();
+        registry.discover_repo_agents(dir.path());
+
+        assert!(!registry.agents.contains_key("reviewer-file"));
+        let agent = registry
+            .agents
+            .get("canonical-reviewer")
+            .expect("canonical reviewer");
+        assert_eq!(agent.id, "canonical-reviewer");
+        assert_eq!(agent.label, "canonical-reviewer");
+        assert_eq!(agent.source_path, ".rara/agents/reviewer-file.md");
         assert_eq!(agent.parse_status, AgentParseStatus::Ok);
     }
 }

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -57,7 +57,7 @@ pub(super) fn agent_tool_to_internal_name(name: &str) -> &str {
     }
 }
 
-// Agent definition matching Claude Code .claude/agents/*.md format.
+// Agent definition matching RARA .rara/agents/*.md files with Claude-compatible frontmatter.
 include!("agent_def.rs");
 
 /// Progress tracking for a subagent (Claude Code AgentProgress compatible).

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -2,10 +2,12 @@
 #[serde(rename_all = "camelCase")]
 pub struct AgentDefinition {
     /// Canonical name (also the file stem).
+    #[serde(default)]
     pub name: String,
     /// Short description for /agents listing.
     /// Reserved for the future /agents listing surface
     /// (docs/features/subagent-claude-compat.md).
+    #[serde(default)]
     #[allow(dead_code)]
     pub description: String,
     /// Allowed tools (Claude Code display names). Empty = all tools.
@@ -50,35 +52,94 @@ pub struct AgentDefinition {
 /// Loaded agent definition registry.
 pub type AgentRegistry = HashMap<String, AgentDefinition>;
 
-/// Load agent definitions from `.claude/agents/**/*.md`.
+#[derive(Clone, Debug)]
+pub struct AgentDefinitionLoadRecord {
+    pub id: String,
+    pub source_path: PathBuf,
+    pub definition: Option<AgentDefinition>,
+    pub error: Option<String>,
+}
+
+/// Load Claude-compatible agent definitions from RARA and compatibility roots.
 ///
 /// Each .md file must contain a YAML frontmatter block delimited by `---`.
 /// The body after the closing `---` becomes `AgentDefinition::system_prompt`.
 ///
 /// Built-in agents (general/explore/plan) are always available and do not
-/// require a .claude/agents/ file.  Custom definitions can override built-in
-/// names or define net new agents.
-/// Load agent definitions from `.claude/agents/` in the workspace root
-/// and `~/.claude/agents/*.md` (global config).  Workspace definitions
-/// take precedence when names collide.
+/// require an agent definition file. Custom definitions can override built-in
+/// names or define net new agents. RARA-native `.rara/agents` roots take
+/// precedence over legacy Claude `.claude/agents` compatibility roots.
 pub fn load_agent_definitions(workspace_root: &Path) -> AgentRegistry {
     let mut registry = AgentRegistry::new();
 
-    // 1. Home-directory agents (lower precedence)
-    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
-        scan_agents_dir(&home.join(".claude").join("agents"), &mut registry);
+    for record in discover_agent_definition_records(workspace_root) {
+        match record.definition {
+            Some(definition) => {
+                registry.insert(definition.name.clone(), definition);
+            }
+            None => {
+                log::warn!(
+                    "failed to load agent definition {}: {}",
+                    record.source_path.display(),
+                    record.error.unwrap_or_else(|| "parse error".to_string())
+                );
+            }
+        }
     }
-
-    // 2. Workspace agents (higher precedence — overwrites home)
-    scan_agents_dir(
-        &workspace_root.join(".claude").join("agents"),
-        &mut registry,
-    );
 
     registry
 }
 
-fn scan_agents_dir(agents_dir: &Path, registry: &mut AgentRegistry) {
+pub fn discover_agent_definition_records(workspace_root: &Path) -> Vec<AgentDefinitionLoadRecord> {
+    let mut records = Vec::new();
+    for dir in agent_definition_dirs(workspace_root) {
+        scan_agent_records_dir(&dir, &mut records);
+    }
+    records
+}
+
+pub fn discover_workspace_agent_definition_records(
+    workspace_root: &Path,
+) -> Vec<AgentDefinitionLoadRecord> {
+    let mut records = Vec::new();
+    for dir in workspace_agent_definition_dirs(workspace_root) {
+        scan_agent_records_dir(&dir, &mut records);
+    }
+    records
+}
+
+fn agent_definition_dirs(workspace_root: &Path) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(home) = home_dir_from_env() {
+        dirs.extend(agent_definition_dirs_for_root(&home));
+    }
+    dirs.extend(workspace_agent_definition_dirs(workspace_root));
+    dirs
+}
+
+fn home_dir_from_env() -> Option<PathBuf> {
+    home_dir_from_vars(std::env::var_os("HOME"), std::env::var_os("USERPROFILE"))
+}
+
+pub(super) fn home_dir_from_vars(
+    home: Option<std::ffi::OsString>,
+    userprofile: Option<std::ffi::OsString>,
+) -> Option<PathBuf> {
+    home.or(userprofile).map(PathBuf::from)
+}
+
+fn workspace_agent_definition_dirs(workspace_root: &Path) -> Vec<PathBuf> {
+    agent_definition_dirs_for_root(workspace_root)
+}
+
+fn agent_definition_dirs_for_root(root: &Path) -> Vec<PathBuf> {
+    vec![
+        root.join(".claude").join("agents"),
+        root.join(".rara").join("agents"),
+    ]
+}
+
+fn scan_agent_records_dir(agents_dir: &Path, records: &mut Vec<AgentDefinitionLoadRecord>) {
     if !agents_dir.exists() || !agents_dir.is_dir() {
         return;
     }
@@ -97,28 +158,59 @@ fn scan_agents_dir(agents_dir: &Path, registry: &mut AgentRegistry) {
             continue;
         }
 
-        let content = match std::fs::read_to_string(path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-
-        let name = path
+        let id = path
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("")
             .to_string();
-        if name.is_empty() {
+        if id.is_empty() {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(err) => {
+                records.push(AgentDefinitionLoadRecord {
+                    id,
+                    source_path: path.to_path_buf(),
+                    definition: None,
+                    error: Some(format!("read error: {err}")),
+                });
+                continue;
+            }
+        };
+
+        if content.trim().is_empty() {
+            records.push(AgentDefinitionLoadRecord {
+                id,
+                source_path: path.to_path_buf(),
+                definition: None,
+                error: Some("empty file".to_string()),
+            });
             continue;
         }
 
         let (frontmatter, body) = split_frontmatter(&content);
-        let mut def: AgentDefinition = match serde_yaml::from_str(&frontmatter) {
+        let frontmatter_yaml = if frontmatter.trim().is_empty() {
+            "{}"
+        } else {
+            frontmatter.as_str()
+        };
+        let mut def: AgentDefinition = match serde_yaml::from_str(frontmatter_yaml) {
             Ok(d) => d,
-            Err(_) => continue,
+            Err(err) => {
+                records.push(AgentDefinitionLoadRecord {
+                    id,
+                    source_path: path.to_path_buf(),
+                    definition: None,
+                    error: Some(format!("frontmatter parse error: {err}")),
+                });
+                continue;
+            }
         };
 
         if def.name.is_empty() {
-            def.name = name.clone();
+            def.name = id.clone();
         }
 
         // disallowedTools > tools
@@ -127,7 +219,12 @@ fn scan_agents_dir(agents_dir: &Path, registry: &mut AgentRegistry) {
         }
 
         def.system_prompt = body.trim().to_string();
-        registry.insert(def.name.clone(), def);
+        records.push(AgentDefinitionLoadRecord {
+            id,
+            source_path: path.to_path_buf(),
+            definition: Some(def),
+            error: None,
+        });
     }
 }
 

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -17,8 +17,9 @@ use super::{
     AgentDefinition, BACKGROUND_SUBAGENT_COMPLETED_RETENTION, BackgroundSubAgentRecord,
     BackgroundSubAgentStore, SubAgentKind, SubagentProgress, TEAM_CREATE_CONCURRENCY_LIMIT,
     append_subagent_prompt, build_filtered_tool_manager, build_read_only_tool_manager,
-    build_subagent_tool_manager, latest_assistant_text_from_history, parse_team_task_kind,
-    resolve_kind_definition, resolve_spawn_agent_definition, validate_agent_id_label,
+    build_subagent_tool_manager, home_dir_from_vars, latest_assistant_text_from_history,
+    parse_team_task_kind, resolve_kind_definition, resolve_spawn_agent_definition,
+    validate_agent_id_label,
 };
 use crate::agent::Message;
 use crate::llm::{ContentBlock, EmbeddingBackend, LlmBackend, LlmResponse, MockLlm};
@@ -1245,7 +1246,7 @@ fn resolve_spawn_agent_definition_falls_back_for_unknown() {
 #[test]
 fn resolve_spawn_agent_definition_loads_workspace_agent() {
     let temp = tempdir().expect("tempdir");
-    let agents_dir = temp.path().join(".claude").join("agents");
+    let agents_dir = temp.path().join(".rara").join("agents");
     std::fs::create_dir_all(&agents_dir).expect("agents dir");
     std::fs::write(
         agents_dir.join("code-reviewer.md"),
@@ -1275,9 +1276,104 @@ Review the assigned change and report concrete findings.
 }
 
 #[test]
+fn rara_agent_definition_overrides_legacy_claude_definition() {
+    let temp = tempdir().expect("tempdir");
+    let claude_agents_dir = temp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&claude_agents_dir).expect("claude agents dir");
+    std::fs::write(
+        claude_agents_dir.join("helper.md"),
+        r#"---
+name: helper
+description: Legacy helper
+tools: [Read]
+---
+
+Legacy prompt.
+"#,
+    )
+    .expect("legacy agent definition");
+
+    let rara_agents_dir = temp.path().join(".rara").join("agents");
+    std::fs::create_dir_all(&rara_agents_dir).expect("rara agents dir");
+    std::fs::write(
+        rara_agents_dir.join("helper.md"),
+        r#"---
+name: helper
+description: RARA helper
+tools: [Read, Grep]
+---
+
+RARA prompt.
+"#,
+    )
+    .expect("rara agent definition");
+
+    let def = resolve_spawn_agent_definition(temp.path(), "helper");
+
+    assert_eq!(def.description, "RARA helper");
+    assert_eq!(def.tools, vec!["Read", "Grep"]);
+    assert_eq!(def.system_prompt, "RARA prompt.");
+}
+
+#[test]
+fn agent_definition_uses_filename_when_frontmatter_omits_name() {
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join(".rara").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("agents dir");
+    std::fs::write(
+        agents_dir.join("reviewer.md"),
+        r#"---
+tools: [Read]
+---
+
+Review the change.
+"#,
+    )
+    .expect("agent definition");
+
+    let def = resolve_spawn_agent_definition(temp.path(), "reviewer");
+
+    assert_eq!(def.name, "reviewer");
+    assert_eq!(def.description, "");
+    assert_eq!(def.tools, vec!["Read"]);
+    assert_eq!(def.system_prompt, "Review the change.");
+}
+
+#[test]
+fn agent_definition_accepts_empty_frontmatter() {
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join(".rara").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("agents dir");
+    std::fs::write(
+        agents_dir.join("helper.md"),
+        r#"---
+---
+
+Help with the task.
+"#,
+    )
+    .expect("agent definition");
+
+    let def = resolve_spawn_agent_definition(temp.path(), "helper");
+
+    assert_eq!(def.name, "helper");
+    assert_eq!(def.description, "");
+    assert!(def.tools.is_empty());
+    assert_eq!(def.system_prompt, "Help with the task.");
+}
+
+#[test]
+fn agent_home_dir_falls_back_to_userprofile() {
+    let home = home_dir_from_vars(None, Some(std::ffi::OsString::from("C:\\Users\\rara")))
+        .expect("home fallback");
+
+    assert_eq!(home, std::path::PathBuf::from("C:\\Users\\rara"));
+}
+
+#[test]
 fn spawn_agent_definition_lookup_uses_normalized_label() {
     let temp = tempdir().expect("tempdir");
-    let agents_dir = temp.path().join(".claude").join("agents");
+    let agents_dir = temp.path().join(".rara").join("agents");
     std::fs::create_dir_all(&agents_dir).expect("agents dir");
     std::fs::write(
         agents_dir.join("code-reviewer.md"),

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -452,7 +452,7 @@ mod tests {
         app.snapshot = RuntimeSnapshot {
             extension_agent_count: 1,
             extension_agent_status_lines: vec![
-                "  code-reviewer  .claude/agents/code-reviewer.md  ok  (disabled)".to_string(),
+                "  code-reviewer  .rara/agents/code-reviewer.md  ok  (disabled)".to_string(),
             ],
             ..RuntimeSnapshot::default()
         };
@@ -465,6 +465,6 @@ mod tests {
 
         assert!(rendered.contains("agents"));
         assert!(rendered.contains("code-reviewer"));
-        assert!(rendered.contains(".claude/agents/code-reviewer.md"));
+        assert!(rendered.contains(".rara/agents/code-reviewer.md"));
     }
 }


### PR DESCRIPTION
## Summary

- make `.rara/agents/*.md` the canonical workspace location for Claude-compatible agent definitions
- reuse the `AgentDefinition` frontmatter parser for `/status` imported-agent projection
- keep `.claude/agents/*.md` as a lower-precedence compatibility import path
- update focused tests, feature specs, journal, and TODO tracking

## Purpose

This prevents execution-time `AgentDefinition` parsing and `/status`
`ImportedAgentProfile` discovery from drifting while moving RARA-owned agent
definitions under `.rara/agents`.

## Related Issue

None.

## Testing

```bash
cargo test agents_ext::tests -- --nocapture
cargo test resolve_spawn_agent_definition_loads_workspace_agent -- --nocapture
cargo test rara_agent_definition_overrides_legacy_claude_definition -- --nocapture
cargo test spawn_agent_definition_lookup_uses_normalized_label -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets -- -D warnings
```
