### PR TITLE
feat(todo): support activeForm labels

### DIFF
--- a/docs/features/todo-runtime.md
+++ b/docs/features/todo-runtime.md
@@ -77,6 +77,10 @@ label used while the item is `in_progress`, matching Claude Code's `activeForm` 
 JSON stores the Rust-style `active_form` field, while `todo_write` accepts both `activeForm` and
 `active_form` for compatibility.
 
+Runtime summaries keep `active_item` as the canonical active `content` value so callers can match it
+back to a todo item. Display surfaces that want the present-continuous label should use the separate
+`active_label` summary field, which falls back to `content` when `active_form` is absent.
+
 ### 3) Tool Surface
 
 RARA should expose a dedicated todo tool, aligned with Claude Code's `TodoWrite` concept but adapted

--- a/docs/features/todo-runtime.md
+++ b/docs/features/todo-runtime.md
@@ -53,6 +53,7 @@ The minimum model is:
     {
       "id": "todo-1",
       "content": "Inspect the command parser",
+      "active_form": "Inspecting the command parser",
       "status": "in_progress",
       "updated_at": 1777584000
     }
@@ -70,6 +71,11 @@ Valid item status values:
 
 At most one item should be `in_progress` unless the runtime later gains explicit parallel-agent todo
 ownership.
+
+`content` is the stable imperative checklist label. `active_form` is an optional present-continuous
+label used while the item is `in_progress`, matching Claude Code's `activeForm` tool input. Runtime
+JSON stores the Rust-style `active_form` field, while `todo_write` accepts both `activeForm` and
+`active_form` for compatibility.
 
 ### 3) Tool Surface
 
@@ -89,6 +95,8 @@ contract:
 - use `todo_write` proactively for complex multi-step execution, not for trivial one-step work;
 - resend the full working set when statuses, blockers, order, or validation work changes;
 - keep at most one `in_progress` item unless multi-agent ownership exists later;
+- provide `content` and `activeForm` for each new tool call so the static checklist and active
+  progress label remain distinct;
 - prefer concrete execution items such as bug reproduction, focused tests, or final verification;
 - do not treat implementation as effectively complete while the relevant verification item is still
   pending or failing.
@@ -177,7 +185,7 @@ The first runtime slice implements Claude-style write semantics without automati
 conversion:
 
 - `todo_write` accepts a complete replacement list and normalizes item ids, statuses, timestamps,
-  and the single-`in_progress` invariant.
+  optional `activeForm`/`active_form` labels, and the single-`in_progress` invariant.
 - Successful writes update `Agent.todo_state`, atomically persist
   `.rara/sessions/<session_id>/todo.json`, and restore that state when the session is resumed.
 - Runtime context exposes todo state as structured data so future `/context`, compaction, and

--- a/docs/journal/2026-07-02-todo-active-form.md
+++ b/docs/journal/2026-07-02-todo-active-form.md
@@ -1,0 +1,40 @@
+# Todo Active Form
+
+## Summary
+
+RARA now accepts Claude-compatible `activeForm` labels in `todo_write` input
+and stores them as `active_form` on session todo items. The active todo summary
+uses `active_form` while preserving `content` as the stable imperative checklist
+label.
+
+## Background
+
+Claude Code's compact `TodoWrite` guidance distinguishes:
+
+- `content`: imperative work item shown in the checklist;
+- `activeForm`: present-continuous label shown while the item is in progress.
+
+RARA already had session-local `todo_write` persistence and display, but it only
+tracked `content` and `status`.
+
+## Scope
+
+- Add optional `active_form` to `TodoItem`.
+- Accept both `activeForm` and `active_form` in `todo_write` input.
+- Require `activeForm` in the advertised tool schema for new model calls while
+  keeping old persisted JSON and direct normalizer callers compatible.
+- Keep shared `TaskList` / `TaskGet` task-store support as a separate follow-up.
+
+## Validation
+
+```bash
+cargo test todo::tests -- --nocapture
+cargo test tools::todo::tests -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+```
+
+## Follow-Ups
+
+- Add a shared `.rara/tasks/<task_list_id>/` store and read-only TaskList /
+  TaskGet tools for team/subagent coordination.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -47,6 +47,8 @@ Active backlog only. Keep this file small and current.
 - [x] Subagent token_budget field (PR #601)
 - [ ] Subagent restart/reconnect — built-in capability, not a separate tool
 - [x] Subagent context budget design — token_budget on AgentDefinition
+- [ ] Add shared TaskList/TaskGet runtime tools backed by a `.rara/tasks/<task_list_id>/`
+      task store so teams/subagents can coordinate beyond session-local `todo_write`.
 - [x] Unify `.rara/agents` parsing for execution and `/status` discovery so
       `AgentDefinition` and `ImportedAgentProfile` cannot drift.
 - [ ] Cache Claude-style agent definitions at runtime construction time and

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -458,6 +458,10 @@ async fn todo_write_updates_session_state_and_emits_event() {
         Some("Implement todo runtime")
     );
     assert_eq!(
+        state.summary().active_label.as_deref(),
+        Some("Implement todo runtime")
+    );
+    assert_eq!(
         session_manager
             .load_todo_state("todo-session")
             .expect("todo state should load"),

--- a/src/session.rs
+++ b/src/session.rs
@@ -995,6 +995,7 @@ mod tests {
             items: vec![crate::todo::TodoItem {
                 id: "todo-1".to_string(),
                 content: "Implement todo runtime".to_string(),
+                active_form: None,
                 status: crate::todo::TodoStatus::InProgress,
                 updated_at: 42,
             }],

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -15,6 +15,8 @@ pub struct TodoState {
 pub struct TodoItem {
     pub id: String,
     pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_form: Option<String>,
     pub status: TodoStatus,
     pub updated_at: i64,
 }
@@ -51,7 +53,12 @@ impl TodoState {
                 TodoStatus::InProgress => {
                     summary.in_progress += 1;
                     if summary.active_item.is_none() {
-                        summary.active_item = Some(item.content.clone());
+                        summary.active_item = Some(
+                            item.active_form
+                                .as_deref()
+                                .unwrap_or(&item.content)
+                                .to_string(),
+                        );
                     }
                 }
                 TodoStatus::Completed => summary.completed += 1,
@@ -102,6 +109,13 @@ pub fn normalize_todo_write_input(input: &Value) -> Result<TodoState> {
         if status == TodoStatus::InProgress {
             in_progress_count += 1;
         }
+        let active_form = object
+            .get("activeForm")
+            .or_else(|| object.get("active_form"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|active_form| !active_form.is_empty())
+            .map(str::to_string);
         let id = object
             .get("id")
             .and_then(Value::as_str)
@@ -115,6 +129,7 @@ pub fn normalize_todo_write_input(input: &Value) -> Result<TodoState> {
         items.push(TodoItem {
             id,
             content: content.to_string(),
+            active_form,
             status,
             updated_at,
         });
@@ -182,8 +197,8 @@ mod tests {
     fn normalizes_todo_write_input() {
         let state = normalize_todo_write_input(&json!({
             "todos": [
-                {"content": "Inspect planning runtime", "status": "in_progress"},
-                {"id": "verify", "content": "Run focused tests", "status": "pending"}
+                {"content": "Inspect planning runtime", "activeForm": "Inspecting planning runtime", "status": "in_progress"},
+                {"id": "verify", "content": "Run focused tests", "activeForm": "Running focused tests", "status": "pending"}
             ]
         }))
         .expect("todo input should normalize");
@@ -194,7 +209,28 @@ mod tests {
         assert_eq!(state.items[1].id, "verify");
         assert_eq!(
             state.summary().active_item.as_deref(),
-            Some("Inspect planning runtime")
+            Some("Inspecting planning runtime")
+        );
+    }
+
+    #[test]
+    fn active_form_is_optional_and_snake_case_compatible() {
+        let state = normalize_todo_write_input(&json!({
+            "todos": [
+                {"content": "Inspect planning runtime", "active_form": "Inspecting planning runtime", "status": "in_progress"},
+                {"content": "Run focused tests", "status": "pending"}
+            ]
+        }))
+        .expect("todo input should normalize");
+
+        assert_eq!(
+            state.items[0].active_form.as_deref(),
+            Some("Inspecting planning runtime")
+        );
+        assert_eq!(state.items[1].active_form, None);
+        assert_eq!(
+            state.summary().active_item.as_deref(),
+            Some("Inspecting planning runtime")
         );
     }
 

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -53,11 +53,11 @@ impl TodoState {
                 TodoStatus::InProgress => {
                     summary.in_progress += 1;
                     if summary.active_item.is_none() {
-                        summary.active_item = Some(
+                        summary.active_item = Some(item.content.clone());
+                        summary.active_label = Some(
                             item.active_form
-                                .as_deref()
-                                .unwrap_or(&item.content)
-                                .to_string(),
+                                .clone()
+                                .unwrap_or_else(|| item.content.clone()),
                         );
                     }
                 }
@@ -77,6 +77,8 @@ pub struct TodoSummary {
     pub completed: usize,
     pub cancelled: usize,
     pub active_item: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_label: Option<String>,
 }
 
 pub fn normalize_todo_write_input(input: &Value) -> Result<TodoState> {
@@ -111,11 +113,18 @@ pub fn normalize_todo_write_input(input: &Value) -> Result<TodoState> {
         }
         let active_form = object
             .get("activeForm")
-            .or_else(|| object.get("active_form"))
             .and_then(Value::as_str)
             .map(str::trim)
             .filter(|active_form| !active_form.is_empty())
-            .map(str::to_string);
+            .map(str::to_string)
+            .or_else(|| {
+                object
+                    .get("active_form")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|active_form| !active_form.is_empty())
+                    .map(str::to_string)
+            });
         let id = object
             .get("id")
             .and_then(Value::as_str)
@@ -152,7 +161,7 @@ pub fn format_todo_update(state: &TodoState) -> String {
         "Todo Updated: {} total, {} pending, {} in progress, {} completed, {} cancelled",
         summary.total, summary.pending, summary.in_progress, summary.completed, summary.cancelled
     )];
-    if let Some(active) = summary.active_item {
+    if let Some(active) = summary.active_label.or(summary.active_item) {
         lines.push(format!("Active: {active}"));
     }
     for item in state.items.iter().take(8) {
@@ -209,6 +218,10 @@ mod tests {
         assert_eq!(state.items[1].id, "verify");
         assert_eq!(
             state.summary().active_item.as_deref(),
+            Some("Inspect planning runtime")
+        );
+        assert_eq!(
+            state.summary().active_label.as_deref(),
             Some("Inspecting planning runtime")
         );
     }
@@ -230,6 +243,38 @@ mod tests {
         assert_eq!(state.items[1].active_form, None);
         assert_eq!(
             state.summary().active_item.as_deref(),
+            Some("Inspect planning runtime")
+        );
+        assert_eq!(
+            state.summary().active_label.as_deref(),
+            Some("Inspecting planning runtime")
+        );
+    }
+
+    #[test]
+    fn active_form_falls_back_to_snake_case_after_empty_camel_case() {
+        let state = normalize_todo_write_input(&json!({
+            "todos": [
+                {
+                    "content": "Inspect planning runtime",
+                    "activeForm": "",
+                    "active_form": "Inspecting planning runtime",
+                    "status": "in_progress"
+                }
+            ]
+        }))
+        .expect("todo input should normalize");
+
+        assert_eq!(
+            state.items[0].active_form.as_deref(),
+            Some("Inspecting planning runtime")
+        );
+        assert_eq!(
+            state.summary().active_item.as_deref(),
+            Some("Inspect planning runtime")
+        );
+        assert_eq!(
+            state.summary().active_label.as_deref(),
             Some("Inspecting planning runtime")
         );
     }

--- a/src/tools/todo.rs
+++ b/src/tools/todo.rs
@@ -11,7 +11,7 @@ pub struct TodoWriteTool;
 
 #[tool_spec(
     name = "todo_write",
-    description = "Create or replace the session todo list for complex multi-step execution. Use this proactively once work has multiple concrete steps or verification work worth tracking; do not use it for trivial one-step tasks or to request plan approval. Re-send the full working set whenever statuses, order, blockers, or validation steps change. Keep at most one item in_progress, update statuses promptly, and prefer concrete execution items such as reproducing a bug, running a focused test, or final verification. Do not mark an item completed until the underlying implementation or validation is actually done.",
+    description = "Create or replace the session todo list for complex multi-step execution. Use this proactively once work has multiple concrete steps or verification work worth tracking; do not use it for trivial one-step tasks or to request plan approval. Re-send the full working set whenever statuses, order, blockers, or validation steps change. Keep at most one item in_progress, update statuses promptly, and provide both content (imperative) and activeForm (present continuous label shown while in progress) for each item. Prefer concrete execution items such as reproducing a bug, running a focused test, or final verification. Do not mark an item completed until the underlying implementation or validation is actually done.",
     input_schema = {
         "type": "object",
         "properties": {
@@ -29,13 +29,17 @@ pub struct TodoWriteTool;
                             "type": "string",
                             "description": "Short imperative task description. Prefer concrete work items such as 'Reproduce failing behavior' or 'Run focused regression test'."
                         },
+                        "activeForm": {
+                            "type": "string",
+                            "description": "Present continuous label shown while this item is in_progress, such as 'Running focused tests'."
+                        },
                         "status": {
                             "type": "string",
                             "enum": ["pending", "in_progress", "completed", "cancelled"],
                             "description": "Current task status. Keep at most one item in_progress, and do not mark completed until the relevant implementation or verification work is actually done."
                         }
                     },
-                    "required": ["content", "status"],
+                    "required": ["content", "status", "activeForm"],
                     "additionalProperties": false
                 }
             }
@@ -66,8 +70,8 @@ mod tests {
         let result = tool
             .call(json!({
                 "todos": [
-                    {"content": "Implement todo_write", "status": "in_progress"},
-                    {"content": "Run tests", "status": "pending"}
+                    {"content": "Implement todo_write", "activeForm": "Implementing todo_write", "status": "in_progress"},
+                    {"content": "Run tests", "activeForm": "Running tests", "status": "pending"}
                 ]
             }))
             .await
@@ -85,6 +89,13 @@ mod tests {
         let schema = TodoWriteTool.input_schema();
 
         assert_eq!(schema["additionalProperties"], false);
+        assert!(
+            schema["properties"]["todos"]["items"]["required"]
+                .as_array()
+                .expect("required fields")
+                .iter()
+                .any(|field| field == "activeForm")
+        );
         assert_eq!(
             schema["properties"]["todos"]["items"]["additionalProperties"],
             false
@@ -98,12 +109,15 @@ mod tests {
         assert!(description.contains("multiple concrete steps"));
         assert!(description.contains("verification work worth tracking"));
         assert!(description.contains("Re-send the full working set"));
+        assert!(description.contains("activeForm"));
+        assert!(description.contains("present continuous"));
         assert!(description.contains("running a focused test"));
         assert!(description.contains("underlying implementation or validation"));
 
         let schema = tool.input_schema().to_string();
         assert!(schema.contains("entire working set"));
         assert!(schema.contains("Reproduce failing behavior"));
+        assert!(schema.contains("Running focused tests"));
         assert!(schema.contains("relevant implementation or verification work"));
     }
 }

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -332,7 +332,11 @@ fn todo_summary_line(app: &TuiApp) -> String {
     if summary.total == 0 {
         return "none".to_string();
     }
-    let active = summary.active_item.as_deref().unwrap_or("-");
+    let active = summary
+        .active_label
+        .as_deref()
+        .or(summary.active_item.as_deref())
+        .unwrap_or("-");
     format!(
         "{} total, {} pending, {} in_progress, {} completed, {} cancelled, active={}",
         summary.total,

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -555,6 +555,7 @@ fn status_context_text_includes_prompt_sources_and_plan_state() {
                 completed: 1,
                 cancelled: 0,
                 active_item: Some("Wire todo state into /context".into()),
+                active_label: None,
             },
             updated_at: Some(1_777_584_000),
             items: vec![
@@ -623,6 +624,7 @@ fn status_runtime_text_reports_todo_summary() {
                 completed: 0,
                 cancelled: 0,
                 active_item: Some("Run focused tests".into()),
+                active_label: Some("Running focused tests".into()),
             },
             updated_at: Some(1_777_584_000),
             items: vec![
@@ -639,7 +641,7 @@ fn status_runtime_text_reports_todo_summary() {
 
     let rendered = status_runtime_text(&app);
     assert!(rendered.contains(
-        "todo=2 total, 1 pending, 1 in_progress, 0 completed, 0 cancelled, active=Run focused tests"
+        "todo=2 total, 1 pending, 1 in_progress, 0 completed, 0 cancelled, active=Running focused tests"
     ));
 }
 

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -327,6 +327,7 @@ mod tests {
             items: vec![TodoItem {
                 id: "todo-1".to_string(),
                 content: "Restore todo state".to_string(),
+                active_form: None,
                 status: TodoStatus::InProgress,
                 updated_at: 42,
             }],


### PR DESCRIPTION
## Summary

- add optional `active_form` storage to session todo items
- accept Claude-compatible `activeForm` and Rust-style `active_form` in `todo_write`
- advertise `activeForm` in the strict `todo_write` schema and guidance
- update todo runtime docs and track shared TaskList/TaskGet as a follow-up

## Purpose

Claude's TodoWrite guidance separates the imperative checklist label
(`content`) from the present-continuous active label (`activeForm`). This keeps
RARA's session-local todo runtime compatible with that contract while preserving
older persisted todo JSON.

## Related Issue

None.

## Testing

```bash
cargo test todo::tests -- --nocapture
cargo test tools::todo::tests -- --nocapture
cargo test save_and_load_todo_state_roundtrips_session_artifact -- --nocapture
cargo test restore_session_keeps_runtime_context_and_snapshot_aligned -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets -- -D warnings
git diff --check
```
