### PR TITLE
feat(tools): add shared task read tools

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -62,6 +62,8 @@ future appserver integrations can use.
   and compact TUI contracts aligned with Codex 0.130.
 - `subagent-context-optimization.md`: bounded parent/child subagent context
   inheritance, child budget, result summary, and restart/reconnect contracts.
+- `shared-task-lists.md`: workspace-local shared task store and
+  Claude-compatible read tools for future subagent/team coordination.
 
 ## App Server Architecture
 

--- a/docs/features/shared-task-lists.md
+++ b/docs/features/shared-task-lists.md
@@ -32,6 +32,8 @@ The shared task store is a file-backed workspace artifact:
 
 The runtime registers one shared `TaskListStore` during tool manager construction and passes it to both read tools. Missing task-list directories are valid and return an empty list.
 
+Tool schemas expose both RARA snake_case `task_list_id` and Claude-compatible camelCase `taskListId`. Callers should send only one of the two names.
+
 ## Contracts
 
 Task files use this minimum shape:

--- a/docs/features/shared-task-lists.md
+++ b/docs/features/shared-task-lists.md
@@ -1,0 +1,105 @@
+# Shared Task Lists
+
+## Problem
+
+RARA has a session-scoped `todo_write` checklist for the current agent turn, but it does not yet have a shared task surface that can coordinate project work across subagents or future teams. Claude Code now treats `TaskCreate`, `TaskGet`, `TaskList`, and `TaskUpdate` as the durable task-list family while `TodoWrite` remains a session checklist fallback. RARA needs the same separation so session progress and shared backlog state do not drift into one artifact.
+
+## Scope
+
+- A workspace-local shared task store under `.rara/tasks`.
+- Read-only `task_list` and `task_get` tools that expose Claude-compatible summary and detail shapes.
+- Field compatibility for `blockedBy` and `activeForm` in stored task JSON.
+- Documentation of the write-side follow-up work before enabling task mutation.
+
+## Non-Goals
+
+- Implementing `task_create` or `task_update` in the first slice.
+- Claiming, ownership conflict resolution, file locks, or task watchers.
+- Replacing session-scoped `todo_write`.
+- Syncing shared tasks to GitHub issues, external trackers, or transcript todos.
+
+## Architecture
+
+The shared task store is a file-backed workspace artifact:
+
+```text
+.rara/tasks/<task_list_id>/<task_id>.json
+```
+
+`task_list_id` is sanitized to an ASCII path segment and defaults to `default`. Each task is one JSON file so later write-side tools can update individual tasks without rewriting a whole task list. The first implementation is read-only and therefore does not need locks yet.
+
+The runtime registers one shared `TaskListStore` during tool manager construction and passes it to both read tools. Missing task-list directories are valid and return an empty list.
+
+## Contracts
+
+Task files use this minimum shape:
+
+```json
+{
+  "id": "1",
+  "subject": "Implement shared task read tools",
+  "description": "Expose task_list and task_get.",
+  "activeForm": "Implementing shared task read tools",
+  "owner": "agent-a",
+  "status": "pending",
+  "blocks": ["2"],
+  "blockedBy": []
+}
+```
+
+Valid status values are:
+
+- `pending`
+- `in_progress`
+- `completed`
+
+`task_list` returns:
+
+```json
+{
+  "tasks": [
+    {
+      "id": "1",
+      "subject": "Implement shared task read tools",
+      "status": "pending",
+      "owner": "agent-a",
+      "blockedBy": []
+    }
+  ]
+}
+```
+
+Completed blockers are filtered from `blockedBy` in summary output so available work can be found directly from `task_list`.
+
+`task_get` returns full details:
+
+```json
+{
+  "task": {
+    "id": "1",
+    "subject": "Implement shared task read tools",
+    "description": "Expose task_list and task_get.",
+    "status": "pending",
+    "blocks": ["2"],
+    "blockedBy": []
+  }
+}
+```
+
+Missing tasks return `{ "task": null }`.
+
+## Validation Matrix
+
+- Store tests cover sorted file loading, `blockedBy` alias parsing, `activeForm` alias parsing, sanitized task-list IDs, and completed-blocker filtering.
+- Tool tests cover `task_list` summary output, `task_get` detail output, missing tasks, strict schemas, and empty `task_id` rejection.
+- Workspace checks should run `cargo test tasklist`, `cargo test tools::tasklist::tests`, `cargo check --locked --workspace --all-targets`, and `cargo clippy --locked --workspace --all-targets -- -D warnings`.
+
+## Open Risks
+
+- Write-side tools need file locking, stale-read checks, and conflict handling before multiple agents can safely claim or update tasks.
+- Team and subagent runtime state still needs a task-list-id propagation contract.
+- TUI rendering for shared tasks is intentionally deferred until the write contract exists.
+
+## Source Journals
+
+- `docs/journal/2026-07-02-shared-task-read-tools.md`

--- a/docs/features/shared-task-lists.md
+++ b/docs/features/shared-task-lists.md
@@ -29,6 +29,7 @@ The shared task store is a file-backed workspace artifact:
 `task_list_id` is sanitized to an ASCII path segment and defaults to `default`. Each task is one JSON file so later write-side tools can update individual tasks without rewriting a whole task list. The first implementation is read-only and therefore does not need locks yet.
 
 `task_id` is treated as an identifier, not a path. Read tools reject empty task IDs, absolute paths, directory separators, and parent-directory traversal fragments before joining with the task-list directory.
+Task-list reads do not follow symlinks: task-list IDs must resolve to real directories, task files must be real files, and each task JSON `id` must match the `<task_id>.json` filename.
 
 The runtime registers one shared `TaskListStore` during tool manager construction and passes it to both read tools. Missing task-list directories are valid and return an empty list.
 
@@ -96,6 +97,7 @@ Missing tasks return `{ "task": null }`.
 
 - Store tests cover sorted file loading, `blockedBy` alias parsing, `activeForm` alias parsing, sanitized task-list IDs, and completed-blocker filtering.
 - Store tests cover path-like `task_id` rejection and file-vs-directory task-list handling.
+- Store tests cover symlink rejection for task-list directories and task files, plus JSON id and filename consistency.
 - Tool tests cover `task_list` summary output, `task_get` detail output, missing tasks, strict schemas, and invalid `task_id` rejection.
 - Workspace checks should run `cargo test tasklist`, `cargo test tools::tasklist::tests`, `cargo check --locked --workspace --all-targets`, and `cargo clippy --locked --workspace --all-targets -- -D warnings`.
 

--- a/docs/features/shared-task-lists.md
+++ b/docs/features/shared-task-lists.md
@@ -28,6 +28,8 @@ The shared task store is a file-backed workspace artifact:
 
 `task_list_id` is sanitized to an ASCII path segment and defaults to `default`. Each task is one JSON file so later write-side tools can update individual tasks without rewriting a whole task list. The first implementation is read-only and therefore does not need locks yet.
 
+`task_id` is treated as an identifier, not a path. Read tools reject empty task IDs, absolute paths, directory separators, and parent-directory traversal fragments before joining with the task-list directory.
+
 The runtime registers one shared `TaskListStore` during tool manager construction and passes it to both read tools. Missing task-list directories are valid and return an empty list.
 
 ## Contracts
@@ -91,7 +93,8 @@ Missing tasks return `{ "task": null }`.
 ## Validation Matrix
 
 - Store tests cover sorted file loading, `blockedBy` alias parsing, `activeForm` alias parsing, sanitized task-list IDs, and completed-blocker filtering.
-- Tool tests cover `task_list` summary output, `task_get` detail output, missing tasks, strict schemas, and empty `task_id` rejection.
+- Store tests cover path-like `task_id` rejection and file-vs-directory task-list handling.
+- Tool tests cover `task_list` summary output, `task_get` detail output, missing tasks, strict schemas, and invalid `task_id` rejection.
 - Workspace checks should run `cargo test tasklist`, `cargo test tools::tasklist::tests`, `cargo check --locked --workspace --all-targets`, and `cargo clippy --locked --workspace --all-targets -- -D warnings`.
 
 ## Open Risks

--- a/docs/journal/2026-07-02-shared-task-read-tools.md
+++ b/docs/journal/2026-07-02-shared-task-read-tools.md
@@ -1,0 +1,26 @@
+# Shared Task Read Tools
+
+## What Changed
+
+- Added a workspace-local shared task store under `.rara/tasks/<task_list_id>/<task_id>.json`.
+- Added read-only `task_list` and `task_get` tools.
+- Matched Claude-compatible task field names in tool output, including `blockedBy`.
+- Accepted stored `blockedBy` and `activeForm` aliases so existing Claude-style task JSON can be read directly.
+
+## Why
+
+Claude Code's public tools reference lists `TaskCreate`, `TaskGet`, `TaskList`, and `TaskUpdate` as the durable task-list tool family, with `TodoWrite` disabled by default in favor of those tools as of Claude Code 2.1.142. RARA already has a session-scoped `todo_write` checklist, so shared tasks should be modeled as a separate workspace artifact instead of stretching session todos into a multi-agent backlog.
+
+The first slice is intentionally read-only. It lets agents inspect shared work without introducing file-locking, claim, or stale-update semantics before those contracts are designed.
+
+## Trade-Offs
+
+- The tool names use RARA snake_case (`task_list`, `task_get`) while output fields remain Claude-compatible (`blockedBy`).
+- `task_list_id` is optional and defaults to `default`; explicit team/subagent task-list propagation remains follow-up work.
+- Invalid task JSON is skipped with a warning during list reads, but `task_get` surfaces parse failures for the requested task.
+
+## Remaining Work
+
+- Add write-side `task_create` and `task_update` tools with locks, stale-read checks, and ownership semantics.
+- Propagate task-list IDs through team and subagent runtime state.
+- Add watcher/TUI surfaces once mutation semantics exist.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -58,6 +58,16 @@ Active backlog only. Keep this file small and current.
       `.rara/agents` definitions affect prompt body, tool filtering,
       `maxTurns`, and `planModeRequired`.
 
+## Shared Task Lists
+
+- [x] Add read-only `task_list` and `task_get` tools backed by
+      `.rara/tasks/<task_list_id>/<task_id>.json`.
+- [ ] Add write-side `task_create` and `task_update` tools with file locking,
+      stale-read protection, owner/claim semantics, and dependency updates.
+- [ ] Propagate task-list IDs through team and subagent runtime state so agents
+      coordinate on the same shared task list without an explicit tool input.
+- [ ] Add shared task watcher/TUI surfaces after mutation semantics are stable.
+
 ## Planning Control Plane
 
 - [ ] Replace boolean plan approval handling with an explicit decision enum:

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ mod session_promotion;
 mod session_transcript;
 mod shell_env;
 mod skill;
+mod tasklist;
 mod thread_cli;
 mod thread_store;
 mod todo;

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -22,6 +22,7 @@ use crate::prompt::PromptRuntimeConfig;
 use crate::sandbox::SandboxManager;
 use crate::session::SessionManager;
 use crate::skill::SkillManager;
+use crate::tasklist::TaskListStore;
 use crate::tools::agent::{
     AgentTool, BackgroundSubAgentStore, ExploreAgentTool, PlanAgentTool, SubAgentListTool,
     SubAgentResumeTool, SubAgentStopTool, TeamCreateTool,
@@ -36,6 +37,7 @@ use crate::tools::pty::{
     PtyStopTool, PtyWriteTool,
 };
 use crate::tools::skill::SkillTool;
+use crate::tools::tasklist::{TaskGetTool, TaskListTool};
 use crate::tools::todo::TodoWriteTool;
 use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
 use crate::tools::web::{WebFetchTool, WebSearchTool};
@@ -72,6 +74,7 @@ pub(super) fn create_full_tool_manager(
     let pty_sessions = Arc::new(
         PtySessionStore::new(workspace.rara_dir.join("pty-sessions")).expect("pty session store"),
     );
+    let task_list_store = Arc::new(TaskListStore::new(workspace.rara_dir.join("tasks")));
     let background_subagents = BACKGROUND_SUBAGENTS
         .get_or_init(|| Arc::new(BackgroundSubAgentStore::default()))
         .clone();
@@ -135,6 +138,12 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(EnterPlanModeTool));
     tm.register(Box::new(ExitPlanModeTool));
     tm.register(Box::new(TodoWriteTool));
+    tm.register(Box::new(TaskListTool {
+        store: task_list_store.clone(),
+    }));
+    tm.register(Box::new(TaskGetTool {
+        store: task_list_store,
+    }));
     tm.register(Box::new(RememberExperienceTool {
         llm_backend: backend.clone(),
         embedding_backend: embedding_backend.clone(),

--- a/src/tasklist.rs
+++ b/src/tasklist.rs
@@ -1,0 +1,344 @@
+use std::collections::{BTreeMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_TASK_LIST_ID: &str = "default";
+
+#[derive(Debug, Clone)]
+pub struct TaskListStore {
+    root: PathBuf,
+}
+
+impl TaskListStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn list_tasks(&self, task_list_id: &str) -> Result<Vec<TaskRecord>> {
+        let task_list_dir = self.task_list_dir(task_list_id);
+        if !task_list_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut tasks = Vec::new();
+        for entry in fs::read_dir(&task_list_dir)
+            .with_context(|| format!("read task list directory {}", task_list_dir.display()))?
+        {
+            let entry = entry.with_context(|| {
+                format!("read task list directory entry {}", task_list_dir.display())
+            })?;
+            let path = entry.path();
+            if !is_task_file(&path) {
+                continue;
+            }
+            match read_task_file(&path) {
+                Ok(task) => tasks.push(task),
+                Err(err) => log::warn!("Failed to read task file {}: {err}", path.display()),
+            }
+        }
+        sort_tasks_by_id(&mut tasks);
+        Ok(tasks)
+    }
+
+    pub fn get_task(&self, task_list_id: &str, task_id: &str) -> Result<Option<TaskRecord>> {
+        let task_id = task_id.trim();
+        if task_id.is_empty() {
+            return Ok(None);
+        }
+
+        let path = self
+            .task_list_dir(task_list_id)
+            .join(format!("{task_id}.json"));
+        if !path.exists() {
+            return Ok(None);
+        }
+        read_task_file(&path).map(Some)
+    }
+
+    fn task_list_dir(&self, task_list_id: &str) -> PathBuf {
+        self.root.join(normalize_task_list_id(task_list_id))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaskRecord {
+    pub id: String,
+    pub subject: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default, alias = "activeForm")]
+    pub active_form: Option<String>,
+    #[serde(default)]
+    pub owner: Option<String>,
+    pub status: TaskStatus,
+    #[serde(default)]
+    pub blocks: Vec<String>,
+    #[serde(default, alias = "blockedBy")]
+    pub blocked_by: Vec<String>,
+    #[serde(default)]
+    pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskListEntry {
+    pub id: String,
+    pub subject: String,
+    pub status: TaskStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    pub blocked_by: Vec<String>,
+}
+
+impl TaskListEntry {
+    pub fn from_task(task: &TaskRecord, completed_task_ids: &HashSet<&str>) -> Self {
+        let blocked_by = task
+            .blocked_by
+            .iter()
+            .filter(|task_id| !completed_task_ids.contains(task_id.as_str()))
+            .cloned()
+            .collect();
+        Self {
+            id: task.id.clone(),
+            subject: task.subject.clone(),
+            status: task.status.clone(),
+            owner: task.owner.clone(),
+            blocked_by,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskDetails {
+    pub id: String,
+    pub subject: String,
+    pub description: String,
+    pub status: TaskStatus,
+    pub blocks: Vec<String>,
+    pub blocked_by: Vec<String>,
+}
+
+impl From<TaskRecord> for TaskDetails {
+    fn from(task: TaskRecord) -> Self {
+        Self {
+            id: task.id,
+            subject: task.subject,
+            description: task.description,
+            status: task.status,
+            blocks: task.blocks,
+            blocked_by: task.blocked_by,
+        }
+    }
+}
+
+pub fn task_list_entries(tasks: &[TaskRecord]) -> Vec<TaskListEntry> {
+    let completed_task_ids = tasks
+        .iter()
+        .filter(|task| task.status == TaskStatus::Completed)
+        .map(|task| task.id.as_str())
+        .collect::<HashSet<_>>();
+    tasks
+        .iter()
+        .map(|task| TaskListEntry::from_task(task, &completed_task_ids))
+        .collect()
+}
+
+fn read_task_file(path: &Path) -> Result<TaskRecord> {
+    let bytes = fs::read(path).with_context(|| format!("read task file {}", path.display()))?;
+    serde_json::from_slice(&bytes).with_context(|| format!("parse task file {}", path.display()))
+}
+
+fn is_task_file(path: &Path) -> bool {
+    path.is_file()
+        && path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+        && path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_none_or(|name| !name.starts_with('.'))
+}
+
+fn normalize_task_list_id(task_list_id: &str) -> String {
+    let normalized = task_list_id
+        .trim()
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    if normalized.is_empty() {
+        DEFAULT_TASK_LIST_ID.to_string()
+    } else {
+        normalized
+    }
+}
+
+fn sort_tasks_by_id(tasks: &mut [TaskRecord]) {
+    tasks.sort_by(
+        |left, right| match (left.id.parse::<u64>(), right.id.parse::<u64>()) {
+            (Ok(left_id), Ok(right_id)) => left_id.cmp(&right_id),
+            (Ok(_), Err(_)) => std::cmp::Ordering::Less,
+            (Err(_), Ok(_)) => std::cmp::Ordering::Greater,
+            (Err(_), Err(_)) => left.id.cmp(&right.id),
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn list_tasks_reads_sorted_task_files() {
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
+        fs::create_dir_all(&list_dir).expect("task list dir");
+        write_task(
+            &list_dir,
+            "10",
+            json!({
+                "id": "10",
+                "subject": "Later task",
+                "status": "pending"
+            }),
+        );
+        write_task(
+            &list_dir,
+            "2",
+            json!({
+                "id": "2",
+                "subject": "Earlier task",
+                "status": "in_progress"
+            }),
+        );
+
+        let store = TaskListStore::new(temp.path());
+        let tasks = store
+            .list_tasks(DEFAULT_TASK_LIST_ID)
+            .expect("tasks should load");
+
+        assert_eq!(
+            tasks
+                .iter()
+                .map(|task| task.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["2", "10"]
+        );
+    }
+
+    #[test]
+    fn list_entries_filter_completed_blockers() {
+        let tasks = vec![
+            task("1", TaskStatus::Completed, vec![]),
+            task("2", TaskStatus::Pending, vec!["1", "3"]),
+            task("3", TaskStatus::Pending, vec![]),
+        ];
+
+        let entries = task_list_entries(&tasks);
+
+        assert_eq!(entries[1].blocked_by, vec!["3"]);
+    }
+
+    #[test]
+    fn get_task_reads_camel_case_aliases() {
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
+        fs::create_dir_all(&list_dir).expect("task list dir");
+        write_task(
+            &list_dir,
+            "42",
+            json!({
+                "id": "42",
+                "subject": "Implement shared task read tools",
+                "description": "Expose TaskList and TaskGet-compatible output.",
+                "activeForm": "Implementing shared task read tools",
+                "status": "pending",
+                "blocks": ["43"],
+                "blockedBy": ["41"]
+            }),
+        );
+
+        let store = TaskListStore::new(temp.path());
+        let task = store
+            .get_task(DEFAULT_TASK_LIST_ID, "42")
+            .expect("task should load")
+            .expect("task should exist");
+
+        assert_eq!(
+            task.active_form.as_deref(),
+            Some("Implementing shared task read tools")
+        );
+        assert_eq!(task.blocked_by, vec!["41"]);
+    }
+
+    #[test]
+    fn task_list_id_is_sanitized() {
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join("team-alpha");
+        fs::create_dir_all(&list_dir).expect("task list dir");
+        write_task(
+            &list_dir,
+            "1",
+            json!({
+                "id": "1",
+                "subject": "Sanitized task list",
+                "status": "pending"
+            }),
+        );
+
+        let store = TaskListStore::new(temp.path());
+        let tasks = store
+            .list_tasks("team/alpha")
+            .expect("sanitized list should load");
+
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].id, "1");
+    }
+
+    fn write_task(dir: &Path, id: &str, task: serde_json::Value) {
+        fs::write(
+            dir.join(format!("{id}.json")),
+            serde_json::to_vec_pretty(&task).expect("serialize task"),
+        )
+        .expect("write task");
+    }
+
+    fn task(id: &str, status: TaskStatus, blocked_by: Vec<&str>) -> TaskRecord {
+        TaskRecord {
+            id: id.to_string(),
+            subject: format!("Task {id}"),
+            description: String::new(),
+            active_form: None,
+            owner: None,
+            status,
+            blocks: Vec::new(),
+            blocked_by: blocked_by.into_iter().map(str::to_string).collect(),
+            metadata: BTreeMap::new(),
+        }
+    }
+}

--- a/src/tasklist.rs
+++ b/src/tasklist.rs
@@ -19,7 +19,7 @@ impl TaskListStore {
 
     pub fn list_tasks(&self, task_list_id: &str) -> Result<Vec<TaskRecord>> {
         let task_list_dir = self.task_list_dir(task_list_id);
-        if !task_list_dir.is_dir() {
+        if !is_real_directory(&task_list_dir) {
             return Ok(Vec::new());
         }
 
@@ -31,10 +31,10 @@ impl TaskListStore {
                 format!("read task list directory entry {}", task_list_dir.display())
             })?;
             let path = entry.path();
-            if !is_task_file(&path) {
+            let Some(task_id) = task_id_from_path(&path) else {
                 continue;
-            }
-            match read_task_file(&path) {
+            };
+            match read_task_file(&path, &task_id) {
                 Ok(task) => tasks.push(task),
                 Err(err) => log::warn!("Failed to read task file {}: {err}", path.display()),
             }
@@ -52,10 +52,10 @@ impl TaskListStore {
         let path = self
             .task_list_dir(task_list_id)
             .join(format!("{task_id}.json"));
-        if !path.is_file() {
+        if !is_real_file(&path) {
             return Ok(None);
         }
-        read_task_file(&path).map(Some)
+        read_task_file(&path, task_id).map(Some)
     }
 
     fn task_list_dir(&self, task_list_id: &str) -> PathBuf {
@@ -164,21 +164,45 @@ pub fn is_valid_task_id(task_id: &str) -> bool {
         && !Path::new(task_id).is_absolute()
 }
 
-fn read_task_file(path: &Path) -> Result<TaskRecord> {
+fn read_task_file(path: &Path, expected_task_id: &str) -> Result<TaskRecord> {
     let bytes = fs::read(path).with_context(|| format!("read task file {}", path.display()))?;
-    serde_json::from_slice(&bytes).with_context(|| format!("parse task file {}", path.display()))
+    let task: TaskRecord = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse task file {}", path.display()))?;
+    anyhow::ensure!(
+        is_valid_task_id(&task.id) && task.id == expected_task_id,
+        "task id '{}' does not match file id '{}'",
+        task.id,
+        expected_task_id
+    );
+    Ok(task)
 }
 
-fn is_task_file(path: &Path) -> bool {
-    path.is_file()
-        && path
-            .extension()
-            .and_then(|extension| extension.to_str())
-            .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
-        && path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_none_or(|name| !name.starts_with('.'))
+fn task_id_from_path(path: &Path) -> Option<String> {
+    if !is_real_file(path) {
+        return None;
+    }
+    let file_name = path.file_name()?.to_str()?;
+    if file_name.starts_with('.') {
+        return None;
+    }
+    let extension = path.extension()?.to_str()?;
+    if !extension.eq_ignore_ascii_case("json") {
+        return None;
+    }
+    let task_id = path.file_stem()?.to_str()?;
+    is_valid_task_id(task_id).then(|| task_id.to_string())
+}
+
+fn is_real_directory(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_dir())
+        .unwrap_or(false)
+}
+
+fn is_real_file(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|metadata| metadata.file_type().is_file())
+        .unwrap_or(false)
 }
 
 fn normalize_task_list_id(task_list_id: &str) -> String {
@@ -356,6 +380,112 @@ mod tests {
                 "task id {task_id:?} should be rejected by the store"
             );
         }
+    }
+
+    #[test]
+    fn list_tasks_skips_task_files_with_mismatched_ids() {
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
+        fs::create_dir_all(&list_dir).expect("task list dir");
+        write_task(
+            &list_dir,
+            "1",
+            json!({
+                "id": "2",
+                "subject": "Mismatched task id",
+                "status": "pending"
+            }),
+        );
+
+        let store = TaskListStore::new(temp.path());
+        let tasks = store
+            .list_tasks(DEFAULT_TASK_LIST_ID)
+            .expect("mismatched ids should be skipped");
+
+        assert!(tasks.is_empty());
+    }
+
+    #[test]
+    fn get_task_rejects_task_file_with_mismatched_id() {
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
+        fs::create_dir_all(&list_dir).expect("task list dir");
+        write_task(
+            &list_dir,
+            "1",
+            json!({
+                "id": "2",
+                "subject": "Mismatched task id",
+                "status": "pending"
+            }),
+        );
+
+        let store = TaskListStore::new(temp.path());
+        let err = store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect_err("mismatched task id should fail direct reads");
+
+        assert!(err.to_string().contains("does not match file id"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn list_tasks_does_not_follow_symlinked_task_list_directory() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("tempdir");
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&outside).expect("outside dir");
+        write_task(
+            &outside,
+            "1",
+            json!({
+                "id": "1",
+                "subject": "Outside task",
+                "status": "pending"
+            }),
+        );
+        symlink(&outside, temp.path().join(DEFAULT_TASK_LIST_ID)).expect("symlink task list");
+
+        let store = TaskListStore::new(temp.path());
+        let tasks = store
+            .list_tasks(DEFAULT_TASK_LIST_ID)
+            .expect("symlinked list dir should be ignored");
+
+        assert!(tasks.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn task_reads_do_not_follow_symlinked_task_files() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&list_dir).expect("task list dir");
+        fs::create_dir_all(&outside).expect("outside dir");
+        write_task(
+            &outside,
+            "1",
+            json!({
+                "id": "1",
+                "subject": "Outside task",
+                "status": "pending"
+            }),
+        );
+        symlink(outside.join("1.json"), list_dir.join("1.json")).expect("symlink task file");
+
+        let store = TaskListStore::new(temp.path());
+        let tasks = store
+            .list_tasks(DEFAULT_TASK_LIST_ID)
+            .expect("symlinked task file should be skipped");
+        let task = store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("symlinked task file should not be read");
+
+        assert!(tasks.is_empty());
+        assert!(task.is_none());
     }
 
     fn write_task(dir: &Path, id: &str, task: serde_json::Value) {

--- a/src/tasklist.rs
+++ b/src/tasklist.rs
@@ -19,7 +19,7 @@ impl TaskListStore {
 
     pub fn list_tasks(&self, task_list_id: &str) -> Result<Vec<TaskRecord>> {
         let task_list_dir = self.task_list_dir(task_list_id);
-        if !task_list_dir.exists() {
+        if !task_list_dir.is_dir() {
             return Ok(Vec::new());
         }
 
@@ -45,14 +45,14 @@ impl TaskListStore {
 
     pub fn get_task(&self, task_list_id: &str, task_id: &str) -> Result<Option<TaskRecord>> {
         let task_id = task_id.trim();
-        if task_id.is_empty() {
+        if !is_valid_task_id(task_id) {
             return Ok(None);
         }
 
         let path = self
             .task_list_dir(task_list_id)
             .join(format!("{task_id}.json"));
-        if !path.exists() {
+        if !path.is_file() {
             return Ok(None);
         }
         read_task_file(&path).map(Some)
@@ -153,6 +153,15 @@ pub fn task_list_entries(tasks: &[TaskRecord]) -> Vec<TaskListEntry> {
         .iter()
         .map(|task| TaskListEntry::from_task(task, &completed_task_ids))
         .collect()
+}
+
+pub fn is_valid_task_id(task_id: &str) -> bool {
+    let task_id = task_id.trim();
+    !task_id.is_empty()
+        && !task_id.contains('/')
+        && !task_id.contains('\\')
+        && !task_id.contains("..")
+        && !Path::new(task_id).is_absolute()
 }
 
 fn read_task_file(path: &Path) -> Result<TaskRecord> {
@@ -318,6 +327,35 @@ mod tests {
 
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].id, "1");
+    }
+
+    #[test]
+    fn list_tasks_returns_empty_when_list_path_is_not_directory() {
+        let temp = tempdir().expect("tempdir");
+        fs::write(temp.path().join(DEFAULT_TASK_LIST_ID), b"not a directory").expect("write file");
+
+        let store = TaskListStore::new(temp.path());
+        let tasks = store
+            .list_tasks(DEFAULT_TASK_LIST_ID)
+            .expect("file path should be treated as no task list");
+
+        assert!(tasks.is_empty());
+    }
+
+    #[test]
+    fn get_task_rejects_path_like_ids() {
+        let temp = tempdir().expect("tempdir");
+        let store = TaskListStore::new(temp.path());
+
+        for task_id in ["../secret", "nested/task", "nested\\task", "/tmp/task"] {
+            let task = store
+                .get_task(DEFAULT_TASK_LIST_ID, task_id)
+                .expect("invalid task id should not hit the filesystem");
+            assert!(
+                task.is_none(),
+                "task id {task_id:?} should be rejected by the store"
+            );
+        }
     }
 
     fn write_task(dir: &Path, id: &str, task: serde_json::Value) {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -7,6 +7,7 @@ pub mod lsp;
 pub mod mcp_tool_search;
 pub mod pty;
 pub mod skill;
+pub mod tasklist;
 pub mod todo;
 pub mod vector;
 pub mod web;

--- a/src/tools/tasklist.rs
+++ b/src/tools/tasklist.rs
@@ -1,0 +1,264 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use rara_tool_macros::tool_spec;
+use rara_tools::tool::{Tool, ToolError};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::tasklist::{DEFAULT_TASK_LIST_ID, TaskDetails, TaskListStore, task_list_entries};
+
+pub struct TaskListTool {
+    pub store: Arc<TaskListStore>,
+}
+
+pub struct TaskGetTool {
+    pub store: Arc<TaskListStore>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskListInput {
+    #[serde(default, alias = "taskListId")]
+    task_list_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskGetInput {
+    task_id: String,
+    #[serde(default, alias = "taskListId")]
+    task_list_id: Option<String>,
+}
+
+#[tool_spec(
+    name = "task_list",
+    description = "List shared project tasks with their current status. Use this to find pending, unowned, unblocked work before creating duplicate tasks or after completing assigned work. Results are returned in task ID order and include only summary fields; call task_get with a specific task_id before starting or updating a task.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "task_list_id": {
+                "type": "string",
+                "description": "Optional shared task list id. Defaults to the workspace default task list."
+            }
+        },
+        "additionalProperties": false
+    }
+)]
+#[async_trait]
+impl Tool for TaskListTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let input = parse_task_list_input(input)?;
+        let tasks = self
+            .store
+            .list_tasks(input.task_list_id())
+            .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
+        Ok(serde_json::json!({ "tasks": task_list_entries(&tasks) }))
+    }
+}
+
+#[tool_spec(
+    name = "task_get",
+    description = "Retrieve full details for a specific shared task. Use this before starting work to verify the task is still current and that blockedBy is empty, and before any future update operation to avoid stale task state.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Task identifier from task_list."
+            },
+            "task_list_id": {
+                "type": "string",
+                "description": "Optional shared task list id. Defaults to the workspace default task list."
+            }
+        },
+        "required": ["task_id"],
+        "additionalProperties": false
+    }
+)]
+#[async_trait]
+impl Tool for TaskGetTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let input = parse_task_get_input(input)?;
+        let task_id = input.task_id.trim();
+        if task_id.is_empty() {
+            return Err(ToolError::InvalidInput(
+                "task_get requires a non-empty task_id".to_string(),
+            ));
+        }
+
+        let task = self
+            .store
+            .get_task(input.task_list_id(), task_id)
+            .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?
+            .map(TaskDetails::from);
+        Ok(serde_json::json!({ "task": task }))
+    }
+}
+
+impl TaskListInput {
+    fn task_list_id(&self) -> &str {
+        self.task_list_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|task_list_id| !task_list_id.is_empty())
+            .unwrap_or(DEFAULT_TASK_LIST_ID)
+    }
+}
+
+impl TaskGetInput {
+    fn task_list_id(&self) -> &str {
+        self.task_list_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|task_list_id| !task_list_id.is_empty())
+            .unwrap_or(DEFAULT_TASK_LIST_ID)
+    }
+}
+
+fn parse_task_list_input(input: Value) -> Result<TaskListInput, ToolError> {
+    let input = empty_object_for_null(input);
+    serde_json::from_value(input).map_err(|err| ToolError::InvalidInput(err.to_string()))
+}
+
+fn parse_task_get_input(input: Value) -> Result<TaskGetInput, ToolError> {
+    serde_json::from_value(input).map_err(|err| ToolError::InvalidInput(err.to_string()))
+}
+
+fn empty_object_for_null(input: Value) -> Value {
+    if input.is_null() {
+        serde_json::json!({})
+    } else {
+        input
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::tasklist::DEFAULT_TASK_LIST_ID;
+
+    #[tokio::test]
+    async fn task_list_returns_summary_entries() {
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
+        fs::create_dir_all(&list_dir).expect("task list dir");
+        write_task(
+            &list_dir,
+            "1",
+            json!({
+                "id": "1",
+                "subject": "Prepare shared store",
+                "status": "completed"
+            }),
+        );
+        write_task(
+            &list_dir,
+            "2",
+            json!({
+                "id": "2",
+                "subject": "Add read tools",
+                "status": "pending",
+                "owner": "agent-a",
+                "blockedBy": ["1", "3"]
+            }),
+        );
+
+        let tool = TaskListTool {
+            store: Arc::new(TaskListStore::new(temp.path())),
+        };
+        let output = tool.call(json!({})).await.expect("task_list should work");
+
+        assert_eq!(output["tasks"][0]["id"], "1");
+        assert_eq!(output["tasks"][1]["owner"], "agent-a");
+        assert_eq!(output["tasks"][1]["blockedBy"], json!(["3"]));
+    }
+
+    #[tokio::test]
+    async fn task_get_returns_full_details_or_null() {
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
+        fs::create_dir_all(&list_dir).expect("task list dir");
+        write_task(
+            &list_dir,
+            "2",
+            json!({
+                "id": "2",
+                "subject": "Add read tools",
+                "description": "Expose summary and detail reads.",
+                "status": "pending",
+                "blocks": ["3"],
+                "blockedBy": ["1"]
+            }),
+        );
+
+        let tool = TaskGetTool {
+            store: Arc::new(TaskListStore::new(temp.path())),
+        };
+        let output = tool
+            .call(json!({ "task_id": "2" }))
+            .await
+            .expect("task_get should work");
+        let missing = tool
+            .call(json!({ "task_id": "missing" }))
+            .await
+            .expect("missing task should be valid");
+
+        assert_eq!(
+            output["task"]["description"],
+            "Expose summary and detail reads."
+        );
+        assert_eq!(output["task"]["blockedBy"], json!(["1"]));
+        assert!(missing["task"].is_null());
+    }
+
+    #[test]
+    fn task_tool_schemas_are_strict() {
+        assert_eq!(
+            TaskListTool::input_schema(&tool_list()).get("additionalProperties"),
+            Some(&json!(false))
+        );
+        assert_eq!(
+            TaskGetTool::input_schema(&tool_get()).get("additionalProperties"),
+            Some(&json!(false))
+        );
+    }
+
+    #[tokio::test]
+    async fn task_get_rejects_empty_task_id() {
+        let tool = tool_get();
+        let err = tool
+            .call(json!({ "task_id": " " }))
+            .await
+            .expect_err("empty task id should fail");
+
+        assert!(err.to_string().contains("non-empty task_id"));
+    }
+
+    fn tool_list() -> TaskListTool {
+        let temp = tempdir().expect("tempdir");
+        TaskListTool {
+            store: Arc::new(TaskListStore::new(temp.path())),
+        }
+    }
+
+    fn tool_get() -> TaskGetTool {
+        let temp = tempdir().expect("tempdir");
+        TaskGetTool {
+            store: Arc::new(TaskListStore::new(temp.path())),
+        }
+    }
+
+    fn write_task(dir: &std::path::Path, id: &str, task: serde_json::Value) {
+        fs::write(
+            dir.join(format!("{id}.json")),
+            serde_json::to_vec_pretty(&task).expect("serialize task"),
+        )
+        .expect("write task");
+    }
+}

--- a/src/tools/tasklist.rs
+++ b/src/tools/tasklist.rs
@@ -6,7 +6,9 @@ use rara_tools::tool::{Tool, ToolError};
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::tasklist::{DEFAULT_TASK_LIST_ID, TaskDetails, TaskListStore, task_list_entries};
+use crate::tasklist::{
+    DEFAULT_TASK_LIST_ID, TaskDetails, TaskListStore, is_valid_task_id, task_list_entries,
+};
 
 pub struct TaskListTool {
     pub store: Arc<TaskListStore>,
@@ -65,7 +67,7 @@ impl Tool for TaskListTool {
         "properties": {
             "task_id": {
                 "type": "string",
-                "description": "Task identifier from task_list."
+                "description": "Task identifier from task_list. Must be a single task id, not a path."
             },
             "task_list_id": {
                 "type": "string",
@@ -81,9 +83,10 @@ impl Tool for TaskGetTool {
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
         let input = parse_task_get_input(input)?;
         let task_id = input.task_id.trim();
-        if task_id.is_empty() {
+        if !is_valid_task_id(task_id) {
             return Err(ToolError::InvalidInput(
-                "task_get requires a non-empty task_id".to_string(),
+                "task_get requires a valid, non-empty task_id without path traversal characters"
+                    .to_string(),
             ));
         }
 
@@ -230,14 +233,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn task_get_rejects_empty_task_id() {
+    async fn task_get_rejects_invalid_task_id() {
         let tool = tool_get();
-        let err = tool
-            .call(json!({ "task_id": " " }))
-            .await
-            .expect_err("empty task id should fail");
 
-        assert!(err.to_string().contains("non-empty task_id"));
+        for task_id in [" ", "../secret", "nested/task", "nested\\task", "/tmp/task"] {
+            let err = tool
+                .call(json!({ "task_id": task_id }))
+                .await
+                .expect_err("invalid task id should fail");
+
+            assert!(err.to_string().contains("without path traversal"));
+        }
     }
 
     fn tool_list() -> TaskListTool {

--- a/src/tools/tasklist.rs
+++ b/src/tools/tasklist.rs
@@ -41,7 +41,11 @@ struct TaskGetInput {
         "properties": {
             "task_list_id": {
                 "type": "string",
-                "description": "Optional shared task list id. Defaults to the workspace default task list."
+                "description": "Optional shared task list id. Defaults to the workspace default task list. Do not send together with taskListId."
+            },
+            "taskListId": {
+                "type": "string",
+                "description": "Claude-compatible alias for task_list_id. Do not send together with task_list_id."
             }
         },
         "additionalProperties": false
@@ -71,7 +75,11 @@ impl Tool for TaskListTool {
             },
             "task_list_id": {
                 "type": "string",
-                "description": "Optional shared task list id. Defaults to the workspace default task list."
+                "description": "Optional shared task list id. Defaults to the workspace default task list. Do not send together with taskListId."
+            },
+            "taskListId": {
+                "type": "string",
+                "description": "Claude-compatible alias for task_list_id. Do not send together with task_list_id."
             }
         },
         "required": ["task_id"],
@@ -222,14 +230,21 @@ mod tests {
 
     #[test]
     fn task_tool_schemas_are_strict() {
+        let task_list_schema = TaskListTool::input_schema(&tool_list());
+        let task_get_schema = TaskGetTool::input_schema(&tool_get());
+
         assert_eq!(
-            TaskListTool::input_schema(&tool_list()).get("additionalProperties"),
+            task_list_schema.get("additionalProperties"),
             Some(&json!(false))
         );
+        assert!(task_list_schema["properties"].get("task_list_id").is_some());
+        assert!(task_list_schema["properties"].get("taskListId").is_some());
         assert_eq!(
-            TaskGetTool::input_schema(&tool_get()).get("additionalProperties"),
+            task_get_schema.get("additionalProperties"),
             Some(&json!(false))
         );
+        assert!(task_get_schema["properties"].get("task_list_id").is_some());
+        assert!(task_get_schema["properties"].get("taskListId").is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add a workspace-local shared task store under `.rara/tasks/<task_list_id>/<task_id>.json`.
- Add read-only `task_list` and `task_get` tools with Claude-compatible `blockedBy` output.
- Document the shared task-list contract and remaining write-side follow-ups.

## Purpose

This keeps session-scoped `todo_write` separate from shared project/task-list coordination. The first slice is read-only so agents can inspect shared task state before RARA commits to mutation, locking, ownership, and watcher semantics.

## Related Issue

None.

## Testing

- `cargo fmt`
- `cargo test tasklist`
- `cargo test tools::tasklist::tests`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`
