### PR TITLE
feat(tools): add shared task creation

### DIFF
--- a/docs/features/shared-task-lists.md
+++ b/docs/features/shared-task-lists.md
@@ -8,13 +8,14 @@ RARA has a session-scoped `todo_write` checklist for the current agent turn, but
 
 - A workspace-local shared task store under `.rara/tasks`.
 - Read-only `task_list` and `task_get` tools that expose Claude-compatible summary and detail shapes.
+- A `task_create` tool that creates pending tasks safely in the shared task store.
 - Field compatibility for `blockedBy` and `activeForm` in stored task JSON.
-- Documentation of the write-side follow-up work before enabling task mutation.
+- Documentation of the remaining update-side follow-up work before enabling task mutation.
 
 ## Non-Goals
 
-- Implementing `task_create` or `task_update` in the first slice.
-- Claiming, ownership conflict resolution, file locks, or task watchers.
+- Implementing `task_update`.
+- Claiming, ownership conflict resolution, dependency mutation, or task watchers.
 - Replacing session-scoped `todo_write`.
 - Syncing shared tasks to GitHub issues, external trackers, or transcript todos.
 
@@ -26,7 +27,7 @@ The shared task store is a file-backed workspace artifact:
 .rara/tasks/<task_list_id>/<task_id>.json
 ```
 
-`task_list_id` is sanitized to an ASCII path segment and defaults to `default`. Each task is one JSON file so later write-side tools can update individual tasks without rewriting a whole task list. The first implementation is read-only and therefore does not need locks yet.
+`task_list_id` is sanitized to an ASCII path segment and defaults to `default`. Each task is one JSON file so later write-side tools can update individual tasks without rewriting a whole task list. `task_create` holds a per-task-list `.lock` file while assigning the next numeric task id and atomically writing the new task file.
 
 `task_id` is treated as an identifier, not a path. Read tools reject empty task IDs, absolute paths, directory separators, and parent-directory traversal fragments before joining with the task-list directory.
 Task-list reads do not follow symlinks: task-list IDs must resolve to real directories, task files must be real files, and each task JSON `id` must match the `<task_id>.json` filename.
@@ -93,17 +94,49 @@ Completed blockers are filtered from `blockedBy` in summary output so available 
 
 Missing tasks return `{ "task": null }`.
 
+`task_create` accepts:
+
+```json
+{
+  "subject": "Implement shared task creation",
+  "description": "Create pending tasks in the shared task store.",
+  "activeForm": "Implementing shared task creation",
+  "metadata": {
+    "source": "agent"
+  }
+}
+```
+
+Created tasks always start as:
+
+- `status`: `pending`
+- `owner`: absent
+- `blocks`: `[]`
+- `blockedBy`: `[]`
+
+`task_create` returns:
+
+```json
+{
+  "task": {
+    "id": "1",
+    "subject": "Implement shared task creation"
+  }
+}
+```
+
 ## Validation Matrix
 
 - Store tests cover sorted file loading, `blockedBy` alias parsing, `activeForm` alias parsing, sanitized task-list IDs, and completed-blocker filtering.
 - Store tests cover path-like `task_id` rejection and file-vs-directory task-list handling.
 - Store tests cover symlink rejection for task-list directories and task files, plus JSON id and filename consistency.
-- Tool tests cover `task_list` summary output, `task_get` detail output, missing tasks, strict schemas, and invalid `task_id` rejection.
+- Store tests cover `task_create` id allocation, pending defaults, atomic file readability, and symlinked task-list rejection.
+- Tool tests cover `task_create` output, strict schemas, empty required-field rejection, `task_list` summary output, `task_get` detail output, missing tasks, and invalid `task_id` rejection.
 - Workspace checks should run `cargo test tasklist`, `cargo test tools::tasklist::tests`, `cargo check --locked --workspace --all-targets`, and `cargo clippy --locked --workspace --all-targets -- -D warnings`.
 
 ## Open Risks
 
-- Write-side tools need file locking, stale-read checks, and conflict handling before multiple agents can safely claim or update tasks.
+- `task_update` still needs stale-read checks and conflict handling before multiple agents can safely claim or update tasks.
 - Team and subagent runtime state still needs a task-list-id propagation contract.
 - TUI rendering for shared tasks is intentionally deferred until the write contract exists.
 

--- a/docs/features/shared-task-lists.md
+++ b/docs/features/shared-task-lists.md
@@ -28,13 +28,14 @@ The shared task store is a file-backed workspace artifact:
 ```
 
 `task_list_id` is sanitized to an ASCII path segment and defaults to `default`. Each task is one JSON file so later write-side tools can update individual tasks without rewriting a whole task list. `task_create` holds a per-task-list `.lock` file while assigning the next numeric task id and atomically writing the new task file.
+Because task creation performs blocking file I/O and file locking, the async tool wrapper must run the store write on a blocking worker instead of directly on the Tokio executor.
 
 `task_id` is treated as an identifier, not a path. Read tools reject empty task IDs, absolute paths, directory separators, and parent-directory traversal fragments before joining with the task-list directory.
 Task-list reads do not follow symlinks: task-list IDs must resolve to real directories, task files must be real files, and each task JSON `id` must match the `<task_id>.json` filename.
 
 The runtime registers one shared `TaskListStore` during tool manager construction and passes it to both read tools. Missing task-list directories are valid and return an empty list.
 
-Tool schemas expose both RARA snake_case `task_list_id` and Claude-compatible camelCase `taskListId`. Callers should send only one of the two names.
+Tool schemas expose both RARA snake_case `task_list_id` and Claude-compatible camelCase `taskListId`. Callers should send only one of the two names. `task_create` also exposes both `activeForm` and `active_form`; sending both aliases in the same call is invalid.
 
 ## Contracts
 

--- a/docs/journal/2026-07-02-shared-task-read-tools.md
+++ b/docs/journal/2026-07-02-shared-task-read-tools.md
@@ -21,6 +21,10 @@ The first slice is intentionally read-only. It lets agents inspect shared work w
 
 ## Remaining Work
 
-- Add write-side `task_create` and `task_update` tools with locks, stale-read checks, and ownership semantics.
+- Add `task_update` with stale-read checks, dependency updates, and ownership semantics.
 - Propagate task-list IDs through team and subagent runtime state.
 - Add watcher/TUI surfaces once mutation semantics exist.
+
+## Task Create Follow-Up
+
+The next slice added `task_create` as the first write-side task tool. It creates pending tasks with no owner and empty dependency lists, assigns the next numeric task id while holding a task-list `.lock` file, and writes the task JSON atomically. This keeps task creation compatible with the existing `task_list` and `task_get` read tools without introducing update, claim, or dependency mutation semantics yet.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -64,8 +64,9 @@ Active backlog only. Keep this file small and current.
 
 - [x] Add read-only `task_list` and `task_get` tools backed by
       `.rara/tasks/<task_list_id>/<task_id>.json`.
-- [ ] Add write-side `task_create` and `task_update` tools with file locking,
-      stale-read protection, owner/claim semantics, and dependency updates.
+- [x] Add `task_create` with file locking and atomic pending-task writes.
+- [ ] Add `task_update` with stale-read protection, owner/claim semantics,
+      and dependency updates.
 - [ ] Propagate task-list IDs through team and subagent runtime state so agents
       coordinate on the same shared task list without an explicit tool input.
 - [ ] Add shared task watcher/TUI surfaces after mutation semantics are stable.

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -37,7 +37,7 @@ use crate::tools::pty::{
     PtyStopTool, PtyWriteTool,
 };
 use crate::tools::skill::SkillTool;
-use crate::tools::tasklist::{TaskGetTool, TaskListTool};
+use crate::tools::tasklist::{TaskCreateTool, TaskGetTool, TaskListTool};
 use crate::tools::todo::TodoWriteTool;
 use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
 use crate::tools::web::{WebFetchTool, WebSearchTool};
@@ -138,6 +138,9 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(EnterPlanModeTool));
     tm.register(Box::new(ExitPlanModeTool));
     tm.register(Box::new(TodoWriteTool));
+    tm.register(Box::new(TaskCreateTool {
+        store: task_list_store.clone(),
+    }));
     tm.register(Box::new(TaskListTool {
         store: task_list_store.clone(),
     }));

--- a/src/tasklist.rs
+++ b/src/tasklist.rs
@@ -1,9 +1,13 @@
 use std::collections::{BTreeMap, HashSet};
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use fs2::FileExt;
+use rara_persistence::atomic_file;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 pub const DEFAULT_TASK_LIST_ID: &str = "default";
 
@@ -58,9 +62,112 @@ impl TaskListStore {
         read_task_file(&path, task_id).map(Some)
     }
 
+    pub fn create_task(&self, task_list_id: &str, input: NewTaskRecord) -> Result<TaskRecord> {
+        let task_list_dir = self.prepare_task_list_dir(task_list_id)?;
+        let lock_file = open_lock_file(&task_list_dir)?;
+        lock_file
+            .lock_exclusive()
+            .with_context(|| format!("lock task list directory {}", task_list_dir.display()))?;
+
+        let result = (|| {
+            let next_id = self.next_task_id_in_dir(&task_list_dir)?;
+            let task = TaskRecord {
+                id: next_id,
+                subject: input.subject,
+                description: input.description,
+                active_form: input.active_form,
+                owner: None,
+                status: TaskStatus::Pending,
+                blocks: Vec::new(),
+                blocked_by: Vec::new(),
+                metadata: input.metadata,
+            };
+            self.write_new_task_file(&task_list_dir, &task)?;
+            Ok(task)
+        })();
+
+        if let Err(err) = lock_file.unlock() {
+            log::warn!(
+                "Failed to unlock task list directory {}: {err}",
+                task_list_dir.display()
+            );
+        }
+        result
+    }
+
     fn task_list_dir(&self, task_list_id: &str) -> PathBuf {
         self.root.join(normalize_task_list_id(task_list_id))
     }
+
+    fn prepare_task_list_dir(&self, task_list_id: &str) -> Result<PathBuf> {
+        fs::create_dir_all(&self.root)
+            .with_context(|| format!("create task root directory {}", self.root.display()))?;
+        if !is_real_directory(&self.root) {
+            anyhow::bail!(
+                "task root path {} is not a real directory",
+                self.root.display()
+            );
+        }
+        let task_list_dir = self.task_list_dir(task_list_id);
+        if task_list_dir.exists() && !is_real_directory(&task_list_dir) {
+            anyhow::bail!(
+                "task list path {} is not a real directory",
+                task_list_dir.display()
+            );
+        }
+        fs::create_dir_all(&task_list_dir)
+            .with_context(|| format!("create task list directory {}", task_list_dir.display()))?;
+        Ok(task_list_dir)
+    }
+
+    fn next_task_id_in_dir(&self, task_list_dir: &Path) -> Result<String> {
+        let mut highest_id = 0u64;
+        for entry in fs::read_dir(task_list_dir)
+            .with_context(|| format!("read task list directory {}", task_list_dir.display()))?
+        {
+            let entry = entry.with_context(|| {
+                format!("read task list directory entry {}", task_list_dir.display())
+            })?;
+            let Some(task_id) = task_id_from_path(&entry.path()) else {
+                continue;
+            };
+            if let Ok(id) = task_id.parse::<u64>() {
+                highest_id = highest_id.max(id);
+            }
+        }
+        Ok((highest_id + 1).to_string())
+    }
+
+    fn write_new_task_file(&self, task_list_dir: &Path, task: &TaskRecord) -> Result<()> {
+        let path = task_list_dir.join(format!("{}.json", task.id));
+        if fs::symlink_metadata(&path).is_ok() {
+            anyhow::bail!("task file {} already exists", path.display());
+        }
+        let tmp_path = task_list_dir.join(format!(".{}.json.tmp-{}", task.id, Uuid::new_v4()));
+        {
+            let mut file = fs::File::create(&tmp_path)
+                .with_context(|| format!("create temporary task file {}", tmp_path.display()))?;
+            let content = serde_json::to_vec_pretty(task).context("serialize task")?;
+            file.write_all(&content)
+                .with_context(|| format!("write temporary task file {}", tmp_path.display()))?;
+            file.sync_all()
+                .with_context(|| format!("sync temporary task file {}", tmp_path.display()))?;
+        }
+        if let Err(err) = atomic_file::replace_file(&tmp_path, &path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(err).with_context(|| format!("replace task file {}", path.display()));
+        }
+        sync_parent_dir_best_effort(task_list_dir);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewTaskRecord {
+    pub subject: String,
+    pub description: String,
+    pub active_form: Option<String>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -205,6 +312,40 @@ fn is_real_file(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+fn open_lock_file(task_list_dir: &Path) -> Result<fs::File> {
+    let lock_path = task_list_dir.join(".lock");
+    match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&lock_path)
+    {
+        Ok(file) => Ok(file),
+        Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+            if !is_real_file(&lock_path) {
+                anyhow::bail!(
+                    "task list lock path {} is not a real file",
+                    lock_path.display()
+                );
+            }
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .with_context(|| format!("open task list lock file {}", lock_path.display()))
+        }
+        Err(err) => {
+            Err(err).with_context(|| format!("create task list lock file {}", lock_path.display()))
+        }
+    }
+}
+
+fn sync_parent_dir_best_effort(path: &Path) {
+    if let Ok(dir) = fs::File::open(path) {
+        let _ = dir.sync_all();
+    }
+}
+
 fn normalize_task_list_id(task_list_id: &str) -> String {
     let normalized = task_list_id
         .trim()
@@ -282,6 +423,77 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["2", "10"]
         );
+    }
+
+    #[test]
+    fn create_task_allocates_next_numeric_id_and_writes_pending_task() {
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
+        fs::create_dir_all(&list_dir).expect("task list dir");
+        write_task(
+            &list_dir,
+            "2",
+            json!({
+                "id": "2",
+                "subject": "Existing task",
+                "status": "completed"
+            }),
+        );
+        write_task(
+            &list_dir,
+            "custom",
+            json!({
+                "id": "custom",
+                "subject": "Non-numeric task",
+                "status": "pending"
+            }),
+        );
+
+        let store = TaskListStore::new(temp.path());
+        let task = store
+            .create_task(
+                DEFAULT_TASK_LIST_ID,
+                NewTaskRecord {
+                    subject: "Implement task_create".to_string(),
+                    description: "Create shared task files.".to_string(),
+                    active_form: Some("Implementing task_create".to_string()),
+                    metadata: BTreeMap::new(),
+                },
+            )
+            .expect("task should be created");
+
+        assert_eq!(task.id, "3");
+        assert_eq!(task.status, TaskStatus::Pending);
+        assert_eq!(task.blocks, Vec::<String>::new());
+        assert_eq!(task.blocked_by, Vec::<String>::new());
+
+        let loaded = store
+            .get_task(DEFAULT_TASK_LIST_ID, "3")
+            .expect("created task should load")
+            .expect("created task should exist");
+        assert_eq!(loaded.subject, "Implement task_create");
+        assert_eq!(
+            loaded.active_form.as_deref(),
+            Some("Implementing task_create")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_task_rejects_symlinked_task_list_directory() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempdir().expect("tempdir");
+        let store = TaskListStore::new(temp.path());
+        let outside = temp.path().join("outside");
+        fs::create_dir_all(&outside).expect("outside dir");
+        symlink(&outside, temp.path().join(DEFAULT_TASK_LIST_ID)).expect("symlink task list");
+
+        let err = store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Create safe task"))
+            .expect_err("symlinked task list directory should fail");
+
+        assert!(err.to_string().contains("is not a real directory"));
     }
 
     #[test]
@@ -494,6 +706,15 @@ mod tests {
             serde_json::to_vec_pretty(&task).expect("serialize task"),
         )
         .expect("write task");
+    }
+
+    fn new_task(subject: &str) -> NewTaskRecord {
+        NewTaskRecord {
+            subject: subject.to_string(),
+            description: "Create a shared task.".to_string(),
+            active_form: None,
+            metadata: BTreeMap::new(),
+        }
     }
 
     fn task(id: &str, status: TaskStatus, blocked_by: Vec<&str>) -> TaskRecord {

--- a/src/tasklist.rs
+++ b/src/tasklist.rs
@@ -144,7 +144,7 @@ impl TaskListStore {
             anyhow::bail!("task file {} already exists", path.display());
         }
         let tmp_path = task_list_dir.join(format!(".{}.json.tmp-{}", task.id, Uuid::new_v4()));
-        {
+        let result = (|| {
             let mut file = fs::File::create(&tmp_path)
                 .with_context(|| format!("create temporary task file {}", tmp_path.display()))?;
             let content = serde_json::to_vec_pretty(task).context("serialize task")?;
@@ -152,11 +152,13 @@ impl TaskListStore {
                 .with_context(|| format!("write temporary task file {}", tmp_path.display()))?;
             file.sync_all()
                 .with_context(|| format!("sync temporary task file {}", tmp_path.display()))?;
-        }
-        if let Err(err) = atomic_file::replace_file(&tmp_path, &path) {
+            atomic_file::replace_file(&tmp_path, &path)
+                .with_context(|| format!("replace task file {}", path.display()))
+        })();
+        if result.is_err() {
             let _ = fs::remove_file(&tmp_path);
-            return Err(err).with_context(|| format!("replace task file {}", path.display()));
         }
+        result?;
         sync_parent_dir_best_effort(task_list_dir);
         Ok(())
     }
@@ -341,8 +343,13 @@ fn open_lock_file(task_list_dir: &Path) -> Result<fs::File> {
 }
 
 fn sync_parent_dir_best_effort(path: &Path) {
-    if let Ok(dir) = fs::File::open(path) {
-        let _ = dir.sync_all();
+    if let Ok(dir) = fs::File::open(path)
+        && let Err(err) = dir.sync_all()
+    {
+        log::warn!(
+            "Failed to sync task list directory {}: {err}",
+            path.display()
+        );
     }
 }
 

--- a/src/tools/tasklist.rs
+++ b/src/tools/tasklist.rs
@@ -7,8 +7,13 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::tasklist::{
-    DEFAULT_TASK_LIST_ID, TaskDetails, TaskListStore, is_valid_task_id, task_list_entries,
+    DEFAULT_TASK_LIST_ID, NewTaskRecord, TaskDetails, TaskListStore, is_valid_task_id,
+    task_list_entries,
 };
+
+pub struct TaskCreateTool {
+    pub store: Arc<TaskListStore>,
+}
 
 pub struct TaskListTool {
     pub store: Arc<TaskListStore>,
@@ -31,6 +36,89 @@ struct TaskGetInput {
     task_id: String,
     #[serde(default, alias = "taskListId")]
     task_list_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskCreateInput {
+    subject: String,
+    description: String,
+    #[serde(default, alias = "activeForm")]
+    active_form: Option<String>,
+    #[serde(default)]
+    metadata: serde_json::Map<String, Value>,
+    #[serde(default, alias = "taskListId")]
+    task_list_id: Option<String>,
+}
+
+#[tool_spec(
+    name = "task_create",
+    description = "Create a new shared project task with pending status. Use this for non-trivial multi-step work after checking task_list to avoid duplicates. New tasks include subject, description, optional activeForm, empty dependencies, no owner, and are readable through task_list and task_get.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "subject": {
+                "type": "string",
+                "description": "Brief actionable task title in imperative form."
+            },
+            "description": {
+                "type": "string",
+                "description": "What needs to be done."
+            },
+            "activeForm": {
+                "type": "string",
+                "description": "Optional present continuous label shown while this task is in_progress, such as 'Fixing authentication bug'."
+            },
+            "active_form": {
+                "type": "string",
+                "description": "RARA-compatible alias for activeForm. Do not send together with activeForm."
+            },
+            "metadata": {
+                "type": "object",
+                "description": "Optional metadata to attach to the task.",
+                "additionalProperties": true
+            },
+            "task_list_id": {
+                "type": "string",
+                "description": "Optional shared task list id. Defaults to the workspace default task list. Do not send together with taskListId."
+            },
+            "taskListId": {
+                "type": "string",
+                "description": "Claude-compatible alias for task_list_id. Do not send together with task_list_id."
+            }
+        },
+        "required": ["subject", "description"],
+        "additionalProperties": false
+    }
+)]
+#[async_trait]
+impl Tool for TaskCreateTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let input = parse_task_create_input(input)?;
+        let subject = normalize_required_text(&input.subject, "subject")?;
+        let description = normalize_required_text(&input.description, "description")?;
+        let active_form = normalize_optional_text(input.active_form.as_deref());
+        let task_list_id = input.task_list_id().to_string();
+        let task = self
+            .store
+            .create_task(
+                &task_list_id,
+                NewTaskRecord {
+                    subject,
+                    description,
+                    active_form,
+                    metadata: input.metadata.into_iter().collect(),
+                },
+            )
+            .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
+
+        Ok(serde_json::json!({
+            "task": {
+                "id": task.id,
+                "subject": task.subject,
+            }
+        }))
+    }
 }
 
 #[tool_spec(
@@ -117,6 +205,16 @@ impl TaskListInput {
     }
 }
 
+impl TaskCreateInput {
+    fn task_list_id(&self) -> &str {
+        self.task_list_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|task_list_id| !task_list_id.is_empty())
+            .unwrap_or(DEFAULT_TASK_LIST_ID)
+    }
+}
+
 impl TaskGetInput {
     fn task_list_id(&self) -> &str {
         self.task_list_id
@@ -127,6 +225,10 @@ impl TaskGetInput {
     }
 }
 
+fn parse_task_create_input(input: Value) -> Result<TaskCreateInput, ToolError> {
+    serde_json::from_value(input).map_err(|err| ToolError::InvalidInput(err.to_string()))
+}
+
 fn parse_task_list_input(input: Value) -> Result<TaskListInput, ToolError> {
     let input = empty_object_for_null(input);
     serde_json::from_value(input).map_err(|err| ToolError::InvalidInput(err.to_string()))
@@ -134,6 +236,23 @@ fn parse_task_list_input(input: Value) -> Result<TaskListInput, ToolError> {
 
 fn parse_task_get_input(input: Value) -> Result<TaskGetInput, ToolError> {
     serde_json::from_value(input).map_err(|err| ToolError::InvalidInput(err.to_string()))
+}
+
+fn normalize_required_text(value: &str, field_name: &str) -> Result<String, ToolError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(ToolError::InvalidInput(format!(
+            "task_create requires a non-empty {field_name}"
+        )));
+    }
+    Ok(value.to_string())
+}
+
+fn normalize_optional_text(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn empty_object_for_null(input: Value) -> Value {
@@ -153,6 +272,66 @@ mod tests {
 
     use super::*;
     use crate::tasklist::DEFAULT_TASK_LIST_ID;
+
+    #[tokio::test]
+    async fn task_create_writes_pending_task() {
+        let temp = tempdir().expect("tempdir");
+        let tool = TaskCreateTool {
+            store: Arc::new(TaskListStore::new(temp.path())),
+        };
+
+        let output = tool
+            .call(json!({
+                "subject": "Implement task_create",
+                "description": "Create shared task files.",
+                "activeForm": "Implementing task_create",
+                "metadata": {"source": "test"}
+            }))
+            .await
+            .expect("task_create should work");
+
+        assert_eq!(output["task"]["id"], "1");
+        assert_eq!(output["task"]["subject"], "Implement task_create");
+
+        let task = tool
+            .store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("task should load")
+            .expect("task should exist");
+        assert_eq!(task.status, crate::tasklist::TaskStatus::Pending);
+        assert_eq!(
+            task.active_form.as_deref(),
+            Some("Implementing task_create")
+        );
+        assert_eq!(task.metadata["source"], "test");
+    }
+
+    #[tokio::test]
+    async fn task_create_rejects_empty_required_fields() {
+        let tool = tool_create();
+
+        let subject_err = tool
+            .call(json!({
+                "subject": " ",
+                "description": "Create shared task files."
+            }))
+            .await
+            .expect_err("empty subject should fail");
+        let description_err = tool
+            .call(json!({
+                "subject": "Implement task_create",
+                "description": " "
+            }))
+            .await
+            .expect_err("empty description should fail");
+
+        assert!(subject_err.to_string().contains("non-empty subject"));
+        assert!(
+            description_err
+                .to_string()
+                .contains("non-empty description")
+        );
+    }
 
     #[tokio::test]
     async fn task_list_returns_summary_entries() {
@@ -230,9 +409,26 @@ mod tests {
 
     #[test]
     fn task_tool_schemas_are_strict() {
+        let task_create_schema = TaskCreateTool::input_schema(&tool_create());
         let task_list_schema = TaskListTool::input_schema(&tool_list());
         let task_get_schema = TaskGetTool::input_schema(&tool_get());
 
+        assert_eq!(
+            task_create_schema.get("additionalProperties"),
+            Some(&json!(false))
+        );
+        assert!(task_create_schema["properties"].get("activeForm").is_some());
+        assert!(
+            task_create_schema["properties"]
+                .get("active_form")
+                .is_some()
+        );
+        assert!(
+            task_create_schema["properties"]
+                .get("task_list_id")
+                .is_some()
+        );
+        assert!(task_create_schema["properties"].get("taskListId").is_some());
         assert_eq!(
             task_list_schema.get("additionalProperties"),
             Some(&json!(false))
@@ -258,6 +454,13 @@ mod tests {
                 .expect_err("invalid task id should fail");
 
             assert!(err.to_string().contains("without path traversal"));
+        }
+    }
+
+    fn tool_create() -> TaskCreateTool {
+        let temp = tempdir().expect("tempdir");
+        TaskCreateTool {
+            store: Arc::new(TaskListStore::new(temp.path())),
         }
     }
 

--- a/src/tools/tasklist.rs
+++ b/src/tools/tasklist.rs
@@ -99,18 +99,22 @@ impl Tool for TaskCreateTool {
         let description = normalize_required_text(&input.description, "description")?;
         let active_form = normalize_optional_text(input.active_form.as_deref());
         let task_list_id = input.task_list_id().to_string();
-        let task = self
-            .store
-            .create_task(
+        let store = self.store.clone();
+        let metadata = input.metadata.into_iter().collect();
+        let task = tokio::task::spawn_blocking(move || {
+            store.create_task(
                 &task_list_id,
                 NewTaskRecord {
                     subject,
                     description,
                     active_form,
-                    metadata: input.metadata.into_iter().collect(),
+                    metadata,
                 },
             )
-            .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
+        })
+        .await
+        .map_err(|err| ToolError::ExecutionFailed(format!("spawn task_create worker: {err}")))?
+        .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
 
         Ok(serde_json::json!({
             "task": {
@@ -226,6 +230,8 @@ impl TaskGetInput {
 }
 
 fn parse_task_create_input(input: Value) -> Result<TaskCreateInput, ToolError> {
+    reject_alias_conflict(&input, "activeForm", "active_form")?;
+    reject_alias_conflict(&input, "taskListId", "task_list_id")?;
     serde_json::from_value(input).map_err(|err| ToolError::InvalidInput(err.to_string()))
 }
 
@@ -253,6 +259,18 @@ fn normalize_optional_text(value: Option<&str>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+fn reject_alias_conflict(input: &Value, left: &str, right: &str) -> Result<(), ToolError> {
+    let Some(object) = input.as_object() else {
+        return Ok(());
+    };
+    if object.contains_key(left) && object.contains_key(right) {
+        return Err(ToolError::InvalidInput(format!(
+            "task_create accepts either {left} or {right}, not both"
+        )));
+    }
+    Ok(())
 }
 
 fn empty_object_for_null(input: Value) -> Value {
@@ -308,7 +326,8 @@ mod tests {
 
     #[tokio::test]
     async fn task_create_rejects_empty_required_fields() {
-        let tool = tool_create();
+        let temp = tempdir().expect("tempdir");
+        let tool = tool_create(temp.path());
 
         let subject_err = tool
             .call(json!({
@@ -330,6 +349,42 @@ mod tests {
             description_err
                 .to_string()
                 .contains("non-empty description")
+        );
+    }
+
+    #[tokio::test]
+    async fn task_create_rejects_alias_conflicts() {
+        let temp = tempdir().expect("tempdir");
+        let tool = tool_create(temp.path());
+
+        let active_form_err = tool
+            .call(json!({
+                "subject": "Implement task_create",
+                "description": "Create shared task files.",
+                "activeForm": "Implementing task_create",
+                "active_form": "Implementing task_create"
+            }))
+            .await
+            .expect_err("mixed activeForm aliases should fail");
+        let task_list_id_err = tool
+            .call(json!({
+                "subject": "Implement task_create",
+                "description": "Create shared task files.",
+                "taskListId": "default",
+                "task_list_id": "default"
+            }))
+            .await
+            .expect_err("mixed task list aliases should fail");
+
+        assert!(
+            active_form_err
+                .to_string()
+                .contains("either activeForm or active_form")
+        );
+        assert!(
+            task_list_id_err
+                .to_string()
+                .contains("either taskListId or task_list_id")
         );
     }
 
@@ -409,7 +464,8 @@ mod tests {
 
     #[test]
     fn task_tool_schemas_are_strict() {
-        let task_create_schema = TaskCreateTool::input_schema(&tool_create());
+        let temp = tempdir().expect("tempdir");
+        let task_create_schema = TaskCreateTool::input_schema(&tool_create(temp.path()));
         let task_list_schema = TaskListTool::input_schema(&tool_list());
         let task_get_schema = TaskGetTool::input_schema(&tool_get());
 
@@ -457,10 +513,9 @@ mod tests {
         }
     }
 
-    fn tool_create() -> TaskCreateTool {
-        let temp = tempdir().expect("tempdir");
+    fn tool_create(path: &std::path::Path) -> TaskCreateTool {
         TaskCreateTool {
-            store: Arc::new(TaskListStore::new(temp.path())),
+            store: Arc::new(TaskListStore::new(path)),
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `task_create` as the first write-side shared task tool.
- Create pending task files under `.rara/tasks/<task_list_id>/<task_id>.json` with task-list locking and atomic writes.
- Update the shared task-list spec, journal, and TODO to leave `task_update`/claim/dependency mutation as the next slice.

## Purpose

This continues the durable task tool work after the read-only `task_list` and `task_get` slice. The new tool mirrors Claude's `TaskCreate` shape for `subject`, `description`, optional `activeForm`, and metadata while keeping update semantics out of scope.

## Related Issue

None.

## Testing

- `cargo fmt`
- `cargo test tasklist`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`
