### PR TITLE
feat(tools): add shared task updates

### DIFF
--- a/docs/features/shared-task-lists.md
+++ b/docs/features/shared-task-lists.md
@@ -9,13 +9,13 @@ RARA has a session-scoped `todo_write` checklist for the current agent turn, but
 - A workspace-local shared task store under `.rara/tasks`.
 - Read-only `task_list` and `task_get` tools that expose Claude-compatible summary and detail shapes.
 - A `task_create` tool that creates pending tasks safely in the shared task store.
+- A `task_update` tool that updates task fields, status, metadata, dependencies, and deletions under the same task-list lock.
 - Field compatibility for `blockedBy` and `activeForm` in stored task JSON.
-- Documentation of the remaining update-side follow-up work before enabling task mutation.
+- Documentation of the remaining stale-read and ownership follow-up work before enabling multiple agents to claim tasks concurrently.
 
 ## Non-Goals
 
-- Implementing `task_update`.
-- Claiming, ownership conflict resolution, dependency mutation, or task watchers.
+- Stale-read protection, ownership conflict resolution, or task watchers.
 - Replacing session-scoped `todo_write`.
 - Syncing shared tasks to GitHub issues, external trackers, or transcript todos.
 
@@ -27,15 +27,15 @@ The shared task store is a file-backed workspace artifact:
 .rara/tasks/<task_list_id>/<task_id>.json
 ```
 
-`task_list_id` is sanitized to an ASCII path segment and defaults to `default`. Each task is one JSON file so later write-side tools can update individual tasks without rewriting a whole task list. `task_create` holds a per-task-list `.lock` file while assigning the next numeric task id and atomically writing the new task file.
-Because task creation performs blocking file I/O and file locking, the async tool wrapper must run the store write on a blocking worker instead of directly on the Tokio executor.
+`task_list_id` is sanitized to an ASCII path segment and defaults to `default`. Each task is one JSON file so write-side tools can update individual tasks without rewriting a whole task list. `task_create` holds a per-task-list `.lock` file while assigning the next numeric task id and atomically writing the new task file. `task_update` uses the same lock while rewriting a task file, adding dependency edges, or deleting a task.
+Because task creation and updates perform blocking file I/O and file locking, async tool wrappers must run store writes on a blocking worker instead of directly on the Tokio executor.
 
 `task_id` is treated as an identifier, not a path. Read tools reject empty task IDs, absolute paths, directory separators, and parent-directory traversal fragments before joining with the task-list directory.
 Task-list reads do not follow symlinks: task-list IDs must resolve to real directories, task files must be real files, and each task JSON `id` must match the `<task_id>.json` filename.
 
-The runtime registers one shared `TaskListStore` during tool manager construction and passes it to both read tools. Missing task-list directories are valid and return an empty list.
+The runtime registers one shared `TaskListStore` during tool manager construction and passes it to the shared task tools. Missing task-list directories are valid and return an empty list.
 
-Tool schemas expose both RARA snake_case `task_list_id` and Claude-compatible camelCase `taskListId`. Callers should send only one of the two names. `task_create` also exposes both `activeForm` and `active_form`; sending both aliases in the same call is invalid.
+Tool schemas expose both RARA snake_case `task_list_id` and Claude-compatible camelCase `taskListId`. Callers should send only one of the two names. `task_create` and `task_update` also expose both `activeForm` and `active_form`; sending both aliases in the same call is invalid.
 
 ## Contracts
 
@@ -126,20 +126,70 @@ Created tasks always start as:
 }
 ```
 
+`task_update` accepts partial updates:
+
+```json
+{
+  "taskId": "1",
+  "status": "in_progress",
+  "owner": "agent-a",
+  "metadata": {
+    "priority": "high",
+    "obsolete": null
+  },
+  "addBlockedBy": ["2"]
+}
+```
+
+The update contract is:
+
+- `status` accepts `pending`, `in_progress`, `completed`, or `deleted`.
+- `deleted` removes the task file and removes stale `blocks` / `blockedBy` references from remaining tasks.
+- `subject`, `description`, `activeForm`, and `owner` replace the stored field. Empty `activeForm` or `owner` clears that optional field.
+- `metadata` merges into the stored metadata map; a `null` value deletes that key.
+- `addBlocks` and `addBlockedBy` add bidirectional dependency edges and deduplicate repeated task IDs.
+
+`task_update` returns:
+
+```json
+{
+  "success": true,
+  "taskId": "1",
+  "updatedFields": ["metadata", "owner", "status"],
+  "statusChange": {
+    "from": "pending",
+    "to": "in_progress"
+  }
+}
+```
+
+Missing tasks return a non-fatal outcome:
+
+```json
+{
+  "success": false,
+  "taskId": "missing",
+  "updatedFields": [],
+  "error": "Task not found"
+}
+```
+
 ## Validation Matrix
 
 - Store tests cover sorted file loading, `blockedBy` alias parsing, `activeForm` alias parsing, sanitized task-list IDs, and completed-blocker filtering.
 - Store tests cover path-like `task_id` rejection and file-vs-directory task-list handling.
 - Store tests cover symlink rejection for task-list directories and task files, plus JSON id and filename consistency.
 - Store tests cover `task_create` id allocation, pending defaults, atomic file readability, and symlinked task-list rejection.
-- Tool tests cover `task_create` output, strict schemas, empty required-field rejection, `task_list` summary output, `task_get` detail output, missing tasks, and invalid `task_id` rejection.
+- Store tests cover `task_update` field changes, metadata merge/delete, status-change reporting, dependency edge updates, and deletion cleanup.
+- Tool tests cover `task_create` output, strict schemas, empty required-field rejection, `task_update` status/owner/metadata changes, deleted status handling, alias conflict rejection, invalid dependency IDs, `task_list` summary output, `task_get` detail output, missing tasks, and invalid `task_id` rejection.
 - Workspace checks should run `cargo test tasklist`, `cargo test tools::tasklist::tests`, `cargo check --locked --workspace --all-targets`, and `cargo clippy --locked --workspace --all-targets -- -D warnings`.
 
 ## Open Risks
 
-- `task_update` still needs stale-read checks and conflict handling before multiple agents can safely claim or update tasks.
+- `task_update` still needs revision or timestamp based stale-read checks before multiple agents can safely claim or update tasks concurrently.
+- Owner claim semantics are still only a field update; conflicting claims are not rejected yet.
 - Team and subagent runtime state still needs a task-list-id propagation contract.
-- TUI rendering for shared tasks is intentionally deferred until the write contract exists.
+- TUI rendering for shared tasks is intentionally deferred until watcher and mutation semantics are stable.
 
 ## Source Journals
 

--- a/docs/journal/2026-07-02-shared-task-read-tools.md
+++ b/docs/journal/2026-07-02-shared-task-read-tools.md
@@ -21,10 +21,17 @@ The first slice is intentionally read-only. It lets agents inspect shared work w
 
 ## Remaining Work
 
-- Add `task_update` with stale-read checks, dependency updates, and ownership semantics.
+- Add revision or timestamp based stale-read checks for `task_update`.
+- Add explicit owner claim semantics instead of treating owner as a plain field update.
 - Propagate task-list IDs through team and subagent runtime state.
 - Add watcher/TUI surfaces once mutation semantics exist.
 
 ## Task Create Follow-Up
 
 The next slice added `task_create` as the first write-side task tool. It creates pending tasks with no owner and empty dependency lists, assigns the next numeric task id while holding a task-list `.lock` file, and writes the task JSON atomically. This keeps task creation compatible with the existing `task_list` and `task_get` read tools without introducing update, claim, or dependency mutation semantics yet.
+
+## Task Update Follow-Up
+
+This slice added `task_update` as the first mutation tool for existing shared tasks. The tool updates subject, description, `activeForm`, owner, status, metadata, dependency edges, and deletion while holding the task-list `.lock` file. Dependency updates maintain both sides of the `blocks` / `blockedBy` edge, and deletion removes stale references from remaining tasks.
+
+The implementation intentionally keeps owner as a plain field update for now. It does not yet require a caller-supplied revision or last-read timestamp, so concurrent claim/update conflict prevention remains follow-up work before this can be treated as a full multi-agent coordination primitive.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -65,8 +65,10 @@ Active backlog only. Keep this file small and current.
 - [x] Add read-only `task_list` and `task_get` tools backed by
       `.rara/tasks/<task_list_id>/<task_id>.json`.
 - [x] Add `task_create` with file locking and atomic pending-task writes.
-- [ ] Add `task_update` with stale-read protection, owner/claim semantics,
-      and dependency updates.
+- [x] Add `task_update` with field, status, metadata, dependency, and delete
+      mutations under the task-list lock.
+- [ ] Add revision or timestamp based stale-read protection for `task_update`.
+- [ ] Add owner/claim semantics that reject conflicting concurrent claims.
 - [ ] Propagate task-list IDs through team and subagent runtime state so agents
       coordinate on the same shared task list without an explicit tool input.
 - [ ] Add shared task watcher/TUI surfaces after mutation semantics are stable.

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -37,7 +37,7 @@ use crate::tools::pty::{
     PtyStopTool, PtyWriteTool,
 };
 use crate::tools::skill::SkillTool;
-use crate::tools::tasklist::{TaskCreateTool, TaskGetTool, TaskListTool};
+use crate::tools::tasklist::{TaskCreateTool, TaskGetTool, TaskListTool, TaskUpdateTool};
 use crate::tools::todo::TodoWriteTool;
 use crate::tools::vector::{RememberExperienceTool, RetrieveExperienceTool};
 use crate::tools::web::{WebFetchTool, WebSearchTool};
@@ -142,6 +142,9 @@ pub(super) fn create_full_tool_manager(
         store: task_list_store.clone(),
     }));
     tm.register(Box::new(TaskListTool {
+        store: task_list_store.clone(),
+    }));
+    tm.register(Box::new(TaskUpdateTool {
         store: task_list_store.clone(),
     }));
     tm.register(Box::new(TaskGetTool {

--- a/src/tasklist.rs
+++ b/src/tasklist.rs
@@ -95,6 +95,124 @@ impl TaskListStore {
         result
     }
 
+    pub fn update_task(
+        &self,
+        task_list_id: &str,
+        task_id: &str,
+        update: TaskUpdate,
+    ) -> Result<TaskUpdateOutcome> {
+        let task_id = task_id.trim();
+        if !is_valid_task_id(task_id) {
+            anyhow::bail!("invalid task id '{task_id}'");
+        }
+        let task_list_dir = self.prepare_task_list_dir(task_list_id)?;
+        let lock_file = open_lock_file(&task_list_dir)?;
+        lock_file
+            .lock_exclusive()
+            .with_context(|| format!("lock task list directory {}", task_list_dir.display()))?;
+
+        let result = (|| {
+            if update.delete {
+                let task_path = task_list_dir.join(format!("{task_id}.json"));
+                if !is_real_file(&task_path) {
+                    return Ok(TaskUpdateOutcome::not_found(task_id));
+                }
+                fs::remove_file(&task_path)
+                    .with_context(|| format!("delete task file {}", task_path.display()))?;
+                self.remove_task_references(&task_list_dir, task_id)?;
+                sync_parent_dir_best_effort(&task_list_dir);
+                return Ok(TaskUpdateOutcome {
+                    success: true,
+                    task_id: task_id.to_string(),
+                    updated_fields: vec!["deleted".to_string()],
+                    status_change: None,
+                    error: None,
+                });
+            }
+
+            let Some(mut task) = self.get_task_from_dir(&task_list_dir, task_id)? else {
+                return Ok(TaskUpdateOutcome::not_found(task_id));
+            };
+            let old_status = task.status.clone();
+            let mut updated_fields = Vec::new();
+
+            apply_text_update(
+                &mut task.subject,
+                update.subject,
+                "subject",
+                &mut updated_fields,
+            );
+            apply_text_update(
+                &mut task.description,
+                update.description,
+                "description",
+                &mut updated_fields,
+            );
+            apply_optional_text_update(
+                &mut task.active_form,
+                update.active_form,
+                "activeForm",
+                &mut updated_fields,
+            );
+            apply_optional_text_update(&mut task.owner, update.owner, "owner", &mut updated_fields);
+
+            if let Some(status) = update.status
+                && task.status != status
+            {
+                task.status = status;
+                updated_fields.push("status".to_string());
+            }
+
+            if !update.metadata.is_empty() {
+                merge_metadata(&mut task.metadata, update.metadata);
+                updated_fields.push("metadata".to_string());
+            }
+
+            for blocked_task_id in &update.add_blocks {
+                self.ensure_dependency_can_be_added(&task_list_dir, task_id, blocked_task_id)?;
+            }
+            for blocker_task_id in &update.add_blocked_by {
+                self.ensure_dependency_can_be_added(&task_list_dir, blocker_task_id, task_id)?;
+            }
+
+            self.write_task_file(&task_list_dir, &task)?;
+
+            if !update.add_blocks.is_empty() {
+                for blocked_task_id in update.add_blocks {
+                    self.add_dependency(&task_list_dir, task_id, &blocked_task_id)?;
+                }
+                updated_fields.push("blocks".to_string());
+            }
+            if !update.add_blocked_by.is_empty() {
+                for blocker_task_id in update.add_blocked_by {
+                    self.add_dependency(&task_list_dir, &blocker_task_id, task_id)?;
+                }
+                updated_fields.push("blockedBy".to_string());
+            }
+
+            updated_fields.sort();
+            updated_fields.dedup();
+            Ok(TaskUpdateOutcome {
+                success: true,
+                task_id: task_id.to_string(),
+                updated_fields,
+                status_change: (old_status != task.status).then_some(StatusChange {
+                    from: old_status,
+                    to: task.status,
+                }),
+                error: None,
+            })
+        })();
+
+        if let Err(err) = lock_file.unlock() {
+            log::warn!(
+                "Failed to unlock task list directory {}: {err}",
+                task_list_dir.display()
+            );
+        }
+        result
+    }
+
     fn task_list_dir(&self, task_list_id: &str) -> PathBuf {
         self.root.join(normalize_task_list_id(task_list_id))
     }
@@ -143,6 +261,23 @@ impl TaskListStore {
         if fs::symlink_metadata(&path).is_ok() {
             anyhow::bail!("task file {} already exists", path.display());
         }
+        self.write_task_file_at_path(task_list_dir, task, path)
+    }
+
+    fn write_task_file(&self, task_list_dir: &Path, task: &TaskRecord) -> Result<()> {
+        let path = task_list_dir.join(format!("{}.json", task.id));
+        if !is_real_file(&path) {
+            anyhow::bail!("task file {} is not a real file", path.display());
+        }
+        self.write_task_file_at_path(task_list_dir, task, path)
+    }
+
+    fn write_task_file_at_path(
+        &self,
+        task_list_dir: &Path,
+        task: &TaskRecord,
+        path: PathBuf,
+    ) -> Result<()> {
         let tmp_path = task_list_dir.join(format!(".{}.json.tmp-{}", task.id, Uuid::new_v4()));
         let result = (|| {
             let mut file = fs::File::create(&tmp_path)
@@ -162,6 +297,79 @@ impl TaskListStore {
         sync_parent_dir_best_effort(task_list_dir);
         Ok(())
     }
+
+    fn get_task_from_dir(&self, task_list_dir: &Path, task_id: &str) -> Result<Option<TaskRecord>> {
+        let path = task_list_dir.join(format!("{task_id}.json"));
+        if !is_real_file(&path) {
+            return Ok(None);
+        }
+        read_task_file(&path, task_id).map(Some)
+    }
+
+    fn add_dependency(
+        &self,
+        task_list_dir: &Path,
+        blocker_id: &str,
+        blocked_id: &str,
+    ) -> Result<()> {
+        self.ensure_dependency_can_be_added(task_list_dir, blocker_id, blocked_id)?;
+        let Some(mut blocker) = self.get_task_from_dir(task_list_dir, blocker_id)? else {
+            anyhow::bail!("blocking task '{blocker_id}' not found");
+        };
+        let Some(mut blocked) = self.get_task_from_dir(task_list_dir, blocked_id)? else {
+            anyhow::bail!("blocked task '{blocked_id}' not found");
+        };
+        push_unique(&mut blocker.blocks, blocked_id.to_string());
+        push_unique(&mut blocked.blocked_by, blocker_id.to_string());
+        self.write_task_file(task_list_dir, &blocker)?;
+        self.write_task_file(task_list_dir, &blocked)?;
+        Ok(())
+    }
+
+    fn ensure_dependency_can_be_added(
+        &self,
+        task_list_dir: &Path,
+        blocker_id: &str,
+        blocked_id: &str,
+    ) -> Result<()> {
+        if !is_valid_task_id(blocker_id)
+            || !is_valid_task_id(blocked_id)
+            || blocker_id == blocked_id
+        {
+            anyhow::bail!("invalid task dependency '{blocker_id}' -> '{blocked_id}'");
+        }
+        if self.get_task_from_dir(task_list_dir, blocker_id)?.is_none() {
+            anyhow::bail!("blocking task '{blocker_id}' not found");
+        }
+        if self.get_task_from_dir(task_list_dir, blocked_id)?.is_none() {
+            anyhow::bail!("blocked task '{blocked_id}' not found");
+        }
+        Ok(())
+    }
+
+    fn remove_task_references(&self, task_list_dir: &Path, task_id: &str) -> Result<()> {
+        for entry in fs::read_dir(task_list_dir)
+            .with_context(|| format!("read task list directory {}", task_list_dir.display()))?
+        {
+            let entry = entry.with_context(|| {
+                format!("read task list directory entry {}", task_list_dir.display())
+            })?;
+            let Some(other_id) = task_id_from_path(&entry.path()) else {
+                continue;
+            };
+            let Some(mut task) = self.get_task_from_dir(task_list_dir, &other_id)? else {
+                continue;
+            };
+            let old_blocks_len = task.blocks.len();
+            let old_blocked_by_len = task.blocked_by.len();
+            task.blocks.retain(|id| id != task_id);
+            task.blocked_by.retain(|id| id != task_id);
+            if task.blocks.len() != old_blocks_len || task.blocked_by.len() != old_blocked_by_len {
+                self.write_task_file(task_list_dir, &task)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -170,6 +378,50 @@ pub struct NewTaskRecord {
     pub description: String,
     pub active_form: Option<String>,
     pub metadata: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TaskUpdate {
+    pub subject: Option<String>,
+    pub description: Option<String>,
+    pub active_form: Option<Option<String>>,
+    pub owner: Option<Option<String>>,
+    pub status: Option<TaskStatus>,
+    pub metadata: BTreeMap<String, serde_json::Value>,
+    pub add_blocks: Vec<String>,
+    pub add_blocked_by: Vec<String>,
+    pub delete: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskUpdateOutcome {
+    pub success: bool,
+    pub task_id: String,
+    pub updated_fields: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_change: Option<StatusChange>,
+}
+
+impl TaskUpdateOutcome {
+    fn not_found(task_id: &str) -> Self {
+        Self {
+            success: false,
+            task_id: task_id.to_string(),
+            updated_fields: Vec::new(),
+            error: Some("Task not found".to_string()),
+            status_change: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusChange {
+    pub from: TaskStatus,
+    pub to: TaskStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -197,6 +449,53 @@ pub enum TaskStatus {
     Pending,
     InProgress,
     Completed,
+}
+
+fn apply_text_update(
+    target: &mut String,
+    update: Option<String>,
+    field_name: &str,
+    updated_fields: &mut Vec<String>,
+) {
+    if let Some(update) = update
+        && *target != update
+    {
+        *target = update;
+        updated_fields.push(field_name.to_string());
+    }
+}
+
+fn apply_optional_text_update(
+    target: &mut Option<String>,
+    update: Option<Option<String>>,
+    field_name: &str,
+    updated_fields: &mut Vec<String>,
+) {
+    if let Some(update) = update
+        && *target != update
+    {
+        *target = update;
+        updated_fields.push(field_name.to_string());
+    }
+}
+
+fn merge_metadata(
+    target: &mut BTreeMap<String, serde_json::Value>,
+    updates: BTreeMap<String, serde_json::Value>,
+) {
+    for (key, value) in updates {
+        if value.is_null() {
+            target.remove(&key);
+        } else {
+            target.insert(key, value);
+        }
+    }
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -483,6 +782,161 @@ mod tests {
             loaded.active_form.as_deref(),
             Some("Implementing task_create")
         );
+    }
+
+    #[test]
+    fn update_task_changes_fields_and_metadata() {
+        let temp = tempdir().expect("tempdir");
+        let store = TaskListStore::new(temp.path());
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Create safe task"))
+            .expect("task should be created");
+
+        let outcome = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    subject: Some("Update safe task".to_string()),
+                    description: Some("Update a shared task.".to_string()),
+                    active_form: Some(Some("Updating safe task".to_string())),
+                    owner: Some(Some("agent-a".to_string())),
+                    status: Some(TaskStatus::InProgress),
+                    metadata: BTreeMap::from([
+                        ("keep".to_string(), json!("yes")),
+                        ("drop".to_string(), serde_json::Value::Null),
+                    ]),
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("task should update");
+
+        assert!(outcome.success);
+        assert_eq!(
+            outcome.status_change.as_ref().map(|change| &change.to),
+            Some(&TaskStatus::InProgress)
+        );
+        let task = store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("task should load")
+            .expect("task should exist");
+        assert_eq!(task.subject, "Update safe task");
+        assert_eq!(task.description, "Update a shared task.");
+        assert_eq!(task.active_form.as_deref(), Some("Updating safe task"));
+        assert_eq!(task.owner.as_deref(), Some("agent-a"));
+        assert_eq!(task.metadata["keep"], "yes");
+        assert!(!task.metadata.contains_key("drop"));
+    }
+
+    #[test]
+    fn update_task_adds_bidirectional_dependencies() {
+        let temp = tempdir().expect("tempdir");
+        let store = TaskListStore::new(temp.path());
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Prepare dependency"))
+            .expect("first task should be created");
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Use dependency"))
+            .expect("second task should be created");
+
+        let outcome = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "2",
+                TaskUpdate {
+                    add_blocked_by: vec!["1".to_string()],
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("dependency should update");
+
+        assert_eq!(outcome.updated_fields, vec!["blockedBy"]);
+        let blocker = store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("blocker should load")
+            .expect("blocker should exist");
+        let blocked = store
+            .get_task(DEFAULT_TASK_LIST_ID, "2")
+            .expect("blocked should load")
+            .expect("blocked should exist");
+        assert_eq!(blocker.blocks, vec!["2"]);
+        assert_eq!(blocked.blocked_by, vec!["1"]);
+    }
+
+    #[test]
+    fn update_task_delete_removes_task_and_dependency_references() {
+        let temp = tempdir().expect("tempdir");
+        let store = TaskListStore::new(temp.path());
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Prepare dependency"))
+            .expect("first task should be created");
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Use dependency"))
+            .expect("second task should be created");
+        store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "2",
+                TaskUpdate {
+                    add_blocked_by: vec!["1".to_string()],
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("dependency should update");
+
+        let outcome = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    delete: true,
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("task should delete");
+
+        assert!(outcome.success);
+        assert_eq!(outcome.updated_fields, vec!["deleted"]);
+        assert!(
+            store
+                .get_task(DEFAULT_TASK_LIST_ID, "1")
+                .expect("deleted task read should be valid")
+                .is_none()
+        );
+        let remaining = store
+            .get_task(DEFAULT_TASK_LIST_ID, "2")
+            .expect("remaining task should load")
+            .expect("remaining task should exist");
+        assert!(remaining.blocked_by.is_empty());
+    }
+
+    #[test]
+    fn update_task_missing_dependency_does_not_write_field_updates() {
+        let temp = tempdir().expect("tempdir");
+        let store = TaskListStore::new(temp.path());
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Keep original subject"))
+            .expect("task should be created");
+
+        let err = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    subject: Some("Do not persist this".to_string()),
+                    add_blocks: vec!["2".to_string()],
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect_err("missing dependency should fail");
+
+        assert!(err.to_string().contains("blocked task '2' not found"));
+        let task = store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("task should load")
+            .expect("task should exist");
+        assert_eq!(task.subject, "Keep original subject");
+        assert!(task.blocks.is_empty());
     }
 
     #[cfg(unix)]

--- a/src/tasklist.rs
+++ b/src/tasklist.rs
@@ -114,12 +114,12 @@ impl TaskListStore {
         let result = (|| {
             if update.delete {
                 let task_path = task_list_dir.join(format!("{task_id}.json"));
-                if !is_real_file(&task_path) {
+                let Some(task) = self.get_task_from_dir(&task_list_dir, task_id)? else {
                     return Ok(TaskUpdateOutcome::not_found(task_id));
-                }
+                };
+                self.remove_known_task_references(&task_list_dir, task_id, &task)?;
                 fs::remove_file(&task_path)
                     .with_context(|| format!("delete task file {}", task_path.display()))?;
-                self.remove_task_references(&task_list_dir, task_id)?;
                 sync_parent_dir_best_effort(&task_list_dir);
                 return Ok(TaskUpdateOutcome {
                     success: true,
@@ -168,27 +168,15 @@ impl TaskListStore {
                 updated_fields.push("metadata".to_string());
             }
 
-            for blocked_task_id in &update.add_blocks {
-                self.ensure_dependency_can_be_added(&task_list_dir, task_id, blocked_task_id)?;
-            }
-            for blocker_task_id in &update.add_blocked_by {
-                self.ensure_dependency_can_be_added(&task_list_dir, blocker_task_id, task_id)?;
-            }
-
+            self.apply_dependency_updates(
+                &task_list_dir,
+                task_id,
+                &mut task,
+                &update.add_blocks,
+                &update.add_blocked_by,
+                &mut updated_fields,
+            )?;
             self.write_task_file(&task_list_dir, &task)?;
-
-            if !update.add_blocks.is_empty() {
-                for blocked_task_id in update.add_blocks {
-                    self.add_dependency(&task_list_dir, task_id, &blocked_task_id)?;
-                }
-                updated_fields.push("blocks".to_string());
-            }
-            if !update.add_blocked_by.is_empty() {
-                for blocker_task_id in update.add_blocked_by {
-                    self.add_dependency(&task_list_dir, &blocker_task_id, task_id)?;
-                }
-                updated_fields.push("blockedBy".to_string());
-            }
 
             updated_fields.sort();
             updated_fields.dedup();
@@ -306,67 +294,111 @@ impl TaskListStore {
         read_task_file(&path, task_id).map(Some)
     }
 
-    fn add_dependency(
+    fn apply_dependency_updates(
         &self,
         task_list_dir: &Path,
-        blocker_id: &str,
-        blocked_id: &str,
+        task_id: &str,
+        task: &mut TaskRecord,
+        add_blocks: &[String],
+        add_blocked_by: &[String],
+        updated_fields: &mut Vec<String>,
     ) -> Result<()> {
-        self.ensure_dependency_can_be_added(task_list_dir, blocker_id, blocked_id)?;
-        let Some(mut blocker) = self.get_task_from_dir(task_list_dir, blocker_id)? else {
-            anyhow::bail!("blocking task '{blocker_id}' not found");
-        };
-        let Some(mut blocked) = self.get_task_from_dir(task_list_dir, blocked_id)? else {
-            anyhow::bail!("blocked task '{blocked_id}' not found");
-        };
-        push_unique(&mut blocker.blocks, blocked_id.to_string());
-        push_unique(&mut blocked.blocked_by, blocker_id.to_string());
-        self.write_task_file(task_list_dir, &blocker)?;
-        self.write_task_file(task_list_dir, &blocked)?;
+        let mut related_tasks = BTreeMap::new();
+        for blocked_id in add_blocks {
+            self.ensure_valid_dependency(task_id, blocked_id)?;
+            if !related_tasks.contains_key(blocked_id) {
+                related_tasks.insert(
+                    blocked_id.clone(),
+                    self.load_dependency_task(task_list_dir, blocked_id, "blocked")?,
+                );
+            }
+        }
+        for blocker_id in add_blocked_by {
+            self.ensure_valid_dependency(blocker_id, task_id)?;
+            if !related_tasks.contains_key(blocker_id) {
+                related_tasks.insert(
+                    blocker_id.clone(),
+                    self.load_dependency_task(task_list_dir, blocker_id, "blocking")?,
+                );
+            }
+        }
+
+        for blocked_id in add_blocks {
+            let blocked = related_tasks
+                .get_mut(blocked_id)
+                .expect("dependency task was loaded");
+            push_unique(&mut blocked.blocked_by, task_id.to_string());
+            push_unique(&mut task.blocks, blocked_id.clone());
+        }
+        if !add_blocks.is_empty() {
+            updated_fields.push("blocks".to_string());
+        }
+
+        for blocker_id in add_blocked_by {
+            let blocker = related_tasks
+                .get_mut(blocker_id)
+                .expect("dependency task was loaded");
+            push_unique(&mut blocker.blocks, task_id.to_string());
+            push_unique(&mut task.blocked_by, blocker_id.clone());
+        }
+        if !add_blocked_by.is_empty() {
+            updated_fields.push("blockedBy".to_string());
+        }
+
+        for related_task in related_tasks.values() {
+            self.write_task_file(task_list_dir, related_task)?;
+        }
         Ok(())
     }
 
-    fn ensure_dependency_can_be_added(
-        &self,
-        task_list_dir: &Path,
-        blocker_id: &str,
-        blocked_id: &str,
-    ) -> Result<()> {
+    fn ensure_valid_dependency(&self, blocker_id: &str, blocked_id: &str) -> Result<()> {
         if !is_valid_task_id(blocker_id)
             || !is_valid_task_id(blocked_id)
             || blocker_id == blocked_id
         {
             anyhow::bail!("invalid task dependency '{blocker_id}' -> '{blocked_id}'");
         }
-        if self.get_task_from_dir(task_list_dir, blocker_id)?.is_none() {
-            anyhow::bail!("blocking task '{blocker_id}' not found");
-        }
-        if self.get_task_from_dir(task_list_dir, blocked_id)?.is_none() {
-            anyhow::bail!("blocked task '{blocked_id}' not found");
-        }
         Ok(())
     }
 
-    fn remove_task_references(&self, task_list_dir: &Path, task_id: &str) -> Result<()> {
-        for entry in fs::read_dir(task_list_dir)
-            .with_context(|| format!("read task list directory {}", task_list_dir.display()))?
-        {
-            let entry = entry.with_context(|| {
-                format!("read task list directory entry {}", task_list_dir.display())
-            })?;
-            let Some(other_id) = task_id_from_path(&entry.path()) else {
+    fn load_dependency_task(
+        &self,
+        task_list_dir: &Path,
+        task_id: &str,
+        role: &str,
+    ) -> Result<TaskRecord> {
+        self.get_task_from_dir(task_list_dir, task_id)?
+            .with_context(|| format!("{role} task '{task_id}' not found"))
+    }
+
+    fn remove_known_task_references(
+        &self,
+        task_list_dir: &Path,
+        task_id: &str,
+        task: &TaskRecord,
+    ) -> Result<()> {
+        let mut related_tasks = BTreeMap::new();
+        for related_id in task.blocked_by.iter().chain(task.blocks.iter()) {
+            if !is_valid_task_id(related_id) || related_id == task_id {
+                log::warn!(
+                    "Skipping invalid task dependency reference '{related_id}' while deleting task '{task_id}'"
+                );
                 continue;
-            };
-            let Some(mut task) = self.get_task_from_dir(task_list_dir, &other_id)? else {
-                continue;
-            };
-            let old_blocks_len = task.blocks.len();
-            let old_blocked_by_len = task.blocked_by.len();
-            task.blocks.retain(|id| id != task_id);
-            task.blocked_by.retain(|id| id != task_id);
-            if task.blocks.len() != old_blocks_len || task.blocked_by.len() != old_blocked_by_len {
-                self.write_task_file(task_list_dir, &task)?;
             }
+            if related_tasks.contains_key(related_id) {
+                continue;
+            }
+            if let Some(related_task) = self.get_task_from_dir(task_list_dir, related_id)? {
+                related_tasks.insert(related_id.clone(), related_task);
+            }
+        }
+
+        for related_task in related_tasks.values_mut() {
+            related_task.blocks.retain(|id| id != task_id);
+            related_task.blocked_by.retain(|id| id != task_id);
+        }
+        for related_task in related_tasks.values() {
+            self.write_task_file(task_list_dir, related_task)?;
         }
         Ok(())
     }

--- a/src/tools/tasklist.rs
+++ b/src/tools/tasklist.rs
@@ -217,6 +217,10 @@ impl Tool for TaskCreateTool {
                 "description": "Claude-compatible alias for task_list_id. Do not send together with task_list_id."
             }
         },
+        "oneOf": [
+            {"required": ["task_id"]},
+            {"required": ["taskId"]}
+        ],
         "additionalProperties": false
     }
 )]
@@ -794,6 +798,13 @@ mod tests {
         );
         assert!(task_update_schema["properties"].get("task_id").is_some());
         assert!(task_update_schema["properties"].get("taskId").is_some());
+        assert_eq!(
+            task_update_schema.get("oneOf"),
+            Some(&json!([
+                {"required": ["task_id"]},
+                {"required": ["taskId"]}
+            ]))
+        );
         assert!(task_update_schema["properties"].get("activeForm").is_some());
         assert!(
             task_update_schema["properties"]

--- a/src/tools/tasklist.rs
+++ b/src/tools/tasklist.rs
@@ -7,8 +7,8 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::tasklist::{
-    DEFAULT_TASK_LIST_ID, NewTaskRecord, TaskDetails, TaskListStore, is_valid_task_id,
-    task_list_entries,
+    DEFAULT_TASK_LIST_ID, NewTaskRecord, TaskDetails, TaskListStore, TaskStatus, TaskUpdate,
+    is_valid_task_id, task_list_entries,
 };
 
 pub struct TaskCreateTool {
@@ -16,6 +16,10 @@ pub struct TaskCreateTool {
 }
 
 pub struct TaskListTool {
+    pub store: Arc<TaskListStore>,
+}
+
+pub struct TaskUpdateTool {
     pub store: Arc<TaskListStore>,
 }
 
@@ -45,6 +49,31 @@ struct TaskCreateInput {
     description: String,
     #[serde(default, alias = "activeForm")]
     active_form: Option<String>,
+    #[serde(default)]
+    metadata: serde_json::Map<String, Value>,
+    #[serde(default, alias = "taskListId")]
+    task_list_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskUpdateInput {
+    #[serde(alias = "taskId")]
+    task_id: String,
+    #[serde(default)]
+    subject: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default, alias = "activeForm")]
+    active_form: Option<String>,
+    #[serde(default)]
+    owner: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default, alias = "addBlocks")]
+    add_blocks: Vec<String>,
+    #[serde(default, alias = "addBlockedBy")]
+    add_blocked_by: Vec<String>,
     #[serde(default)]
     metadata: serde_json::Map<String, Value>,
     #[serde(default, alias = "taskListId")]
@@ -122,6 +151,98 @@ impl Tool for TaskCreateTool {
                 "subject": task.subject,
             }
         }))
+    }
+}
+
+#[tool_spec(
+    name = "task_update",
+    description = "Update a shared project task. Use task_get first to inspect the latest task state. Supports status changes including deleted, subject, description, activeForm, owner, metadata merge/delete, addBlocks, and addBlockedBy.",
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "Task identifier from task_list or task_get."
+            },
+            "taskId": {
+                "type": "string",
+                "description": "Claude-compatible alias for task_id. Do not send together with task_id."
+            },
+            "subject": {
+                "type": "string",
+                "description": "New imperative task title."
+            },
+            "description": {
+                "type": "string",
+                "description": "New task description."
+            },
+            "activeForm": {
+                "type": "string",
+                "description": "Present continuous label shown while this task is in_progress."
+            },
+            "active_form": {
+                "type": "string",
+                "description": "RARA-compatible alias for activeForm. Do not send together with activeForm."
+            },
+            "owner": {
+                "type": "string",
+                "description": "New task owner. Send an empty string to clear the owner."
+            },
+            "status": {
+                "type": "string",
+                "enum": ["pending", "in_progress", "completed", "deleted"],
+                "description": "New task status. Use deleted to permanently remove the task."
+            },
+            "addBlocks": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Task IDs that cannot start until this task completes."
+            },
+            "addBlockedBy": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Task IDs that must complete before this task can start."
+            },
+            "metadata": {
+                "type": "object",
+                "description": "Metadata keys to merge into the task. Set a key to null to delete it.",
+                "additionalProperties": true
+            },
+            "task_list_id": {
+                "type": "string",
+                "description": "Optional shared task list id. Defaults to the workspace default task list. Do not send together with taskListId."
+            },
+            "taskListId": {
+                "type": "string",
+                "description": "Claude-compatible alias for task_list_id. Do not send together with task_list_id."
+            }
+        },
+        "additionalProperties": false
+    }
+)]
+#[async_trait]
+impl Tool for TaskUpdateTool {
+    async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        let input = parse_task_update_input(input)?;
+        let task_id = input.task_id.trim().to_string();
+        if !is_valid_task_id(&task_id) {
+            return Err(ToolError::InvalidInput(
+                "task_update requires a valid, non-empty task_id without path traversal characters"
+                    .to_string(),
+            ));
+        }
+        let task_list_id = input.task_list_id().to_string();
+        let update = normalize_task_update(input)?;
+        let store = self.store.clone();
+        let outcome =
+            tokio::task::spawn_blocking(move || store.update_task(&task_list_id, &task_id, update))
+                .await
+                .map_err(|err| {
+                    ToolError::ExecutionFailed(format!("spawn task_update worker: {err}"))
+                })?
+                .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
+
+        serde_json::to_value(outcome).map_err(|err| ToolError::ExecutionFailed(err.to_string()))
     }
 }
 
@@ -219,6 +340,16 @@ impl TaskCreateInput {
     }
 }
 
+impl TaskUpdateInput {
+    fn task_list_id(&self) -> &str {
+        self.task_list_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|task_list_id| !task_list_id.is_empty())
+            .unwrap_or(DEFAULT_TASK_LIST_ID)
+    }
+}
+
 impl TaskGetInput {
     fn task_list_id(&self) -> &str {
         self.task_list_id
@@ -230,6 +361,13 @@ impl TaskGetInput {
 }
 
 fn parse_task_create_input(input: Value) -> Result<TaskCreateInput, ToolError> {
+    reject_alias_conflict(&input, "activeForm", "active_form")?;
+    reject_alias_conflict(&input, "taskListId", "task_list_id")?;
+    serde_json::from_value(input).map_err(|err| ToolError::InvalidInput(err.to_string()))
+}
+
+fn parse_task_update_input(input: Value) -> Result<TaskUpdateInput, ToolError> {
+    reject_alias_conflict(&input, "taskId", "task_id")?;
     reject_alias_conflict(&input, "activeForm", "active_form")?;
     reject_alias_conflict(&input, "taskListId", "task_list_id")?;
     serde_json::from_value(input).map_err(|err| ToolError::InvalidInput(err.to_string()))
@@ -261,13 +399,63 @@ fn normalize_optional_text(value: Option<&str>) -> Option<String> {
         .map(str::to_string)
 }
 
+fn normalize_task_update(input: TaskUpdateInput) -> Result<TaskUpdate, ToolError> {
+    let status = match input.status.as_deref().map(str::trim) {
+        None | Some("") => None,
+        Some("pending") => Some(TaskStatus::Pending),
+        Some("in_progress") => Some(TaskStatus::InProgress),
+        Some("completed") => Some(TaskStatus::Completed),
+        Some("deleted") => None,
+        Some(other) => {
+            return Err(ToolError::InvalidInput(format!(
+                "task_update received invalid status '{other}'"
+            )));
+        }
+    };
+    let delete = input.status.as_deref().map(str::trim) == Some("deleted");
+
+    Ok(TaskUpdate {
+        subject: normalize_optional_text(input.subject.as_deref()),
+        description: normalize_optional_text(input.description.as_deref()),
+        active_form: input
+            .active_form
+            .as_deref()
+            .map(|value| normalize_optional_text(Some(value))),
+        owner: input
+            .owner
+            .as_deref()
+            .map(|value| normalize_optional_text(Some(value))),
+        status,
+        metadata: input.metadata.into_iter().collect(),
+        add_blocks: normalize_task_ids(input.add_blocks, "addBlocks")?,
+        add_blocked_by: normalize_task_ids(input.add_blocked_by, "addBlockedBy")?,
+        delete,
+    })
+}
+
+fn normalize_task_ids(values: Vec<String>, field_name: &str) -> Result<Vec<String>, ToolError> {
+    let mut task_ids = Vec::new();
+    for value in values {
+        let task_id = value.trim();
+        if !is_valid_task_id(task_id) {
+            return Err(ToolError::InvalidInput(format!(
+                "task_update received invalid task id in {field_name}"
+            )));
+        }
+        if !task_ids.iter().any(|existing| existing == task_id) {
+            task_ids.push(task_id.to_string());
+        }
+    }
+    Ok(task_ids)
+}
+
 fn reject_alias_conflict(input: &Value, left: &str, right: &str) -> Result<(), ToolError> {
     let Some(object) = input.as_object() else {
         return Ok(());
     };
     if object.contains_key(left) && object.contains_key(right) {
         return Err(ToolError::InvalidInput(format!(
-            "task_create accepts either {left} or {right}, not both"
+            "task tools accept either {left} or {right}, not both"
         )));
     }
     Ok(())
@@ -389,6 +577,114 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn task_update_changes_status_owner_and_metadata() {
+        let temp = tempdir().expect("tempdir");
+        let tool = tool_update(temp.path());
+        tool.store
+            .create_task(
+                DEFAULT_TASK_LIST_ID,
+                NewTaskRecord {
+                    subject: "Implement task_update".to_string(),
+                    description: "Update shared task files.".to_string(),
+                    active_form: None,
+                    metadata: Default::default(),
+                },
+            )
+            .expect("task should be created");
+
+        let output = tool
+            .call(json!({
+                "taskId": "1",
+                "status": "in_progress",
+                "owner": "agent-a",
+                "metadata": {"priority": "high"}
+            }))
+            .await
+            .expect("task_update should work");
+
+        assert_eq!(output["success"], true);
+        assert_eq!(output["taskId"], "1");
+        assert_eq!(
+            output["updatedFields"],
+            json!(["metadata", "owner", "status"])
+        );
+        assert_eq!(output["statusChange"]["from"], "pending");
+        assert_eq!(output["statusChange"]["to"], "in_progress");
+
+        let task = tool
+            .store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("task should load")
+            .expect("task should exist");
+        assert_eq!(task.status, TaskStatus::InProgress);
+        assert_eq!(task.owner.as_deref(), Some("agent-a"));
+        assert_eq!(task.metadata["priority"], "high");
+    }
+
+    #[tokio::test]
+    async fn task_update_deletes_task_with_deleted_status() {
+        let temp = tempdir().expect("tempdir");
+        let tool = tool_update(temp.path());
+        tool.store
+            .create_task(
+                DEFAULT_TASK_LIST_ID,
+                NewTaskRecord {
+                    subject: "Remove obsolete task".to_string(),
+                    description: "Delete a shared task file.".to_string(),
+                    active_form: None,
+                    metadata: Default::default(),
+                },
+            )
+            .expect("task should be created");
+
+        let output = tool
+            .call(json!({
+                "task_id": "1",
+                "status": "deleted"
+            }))
+            .await
+            .expect("task_update should delete task");
+
+        assert_eq!(output["success"], true);
+        assert_eq!(output["updatedFields"], json!(["deleted"]));
+        assert!(
+            tool.store
+                .get_task(DEFAULT_TASK_LIST_ID, "1")
+                .expect("deleted task read should be valid")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn task_update_rejects_alias_conflicts_and_invalid_dependency_ids() {
+        let temp = tempdir().expect("tempdir");
+        let tool = tool_update(temp.path());
+
+        let alias_err = tool
+            .call(json!({
+                "taskId": "1",
+                "task_id": "1",
+                "status": "pending"
+            }))
+            .await
+            .expect_err("mixed task id aliases should fail");
+        let dependency_err = tool
+            .call(json!({
+                "task_id": "1",
+                "addBlocks": ["../secret"]
+            }))
+            .await
+            .expect_err("invalid dependency id should fail");
+
+        assert!(alias_err.to_string().contains("either taskId or task_id"));
+        assert!(
+            dependency_err
+                .to_string()
+                .contains("invalid task id in addBlocks")
+        );
+    }
+
+    #[tokio::test]
     async fn task_list_returns_summary_entries() {
         let temp = tempdir().expect("tempdir");
         let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
@@ -467,6 +763,7 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let task_create_schema = TaskCreateTool::input_schema(&tool_create(temp.path()));
         let task_list_schema = TaskListTool::input_schema(&tool_list());
+        let task_update_schema = TaskUpdateTool::input_schema(&tool_update(temp.path()));
         let task_get_schema = TaskGetTool::input_schema(&tool_get());
 
         assert_eq!(
@@ -491,6 +788,18 @@ mod tests {
         );
         assert!(task_list_schema["properties"].get("task_list_id").is_some());
         assert!(task_list_schema["properties"].get("taskListId").is_some());
+        assert_eq!(
+            task_update_schema.get("additionalProperties"),
+            Some(&json!(false))
+        );
+        assert!(task_update_schema["properties"].get("task_id").is_some());
+        assert!(task_update_schema["properties"].get("taskId").is_some());
+        assert!(task_update_schema["properties"].get("activeForm").is_some());
+        assert!(
+            task_update_schema["properties"]
+                .get("active_form")
+                .is_some()
+        );
         assert_eq!(
             task_get_schema.get("additionalProperties"),
             Some(&json!(false))
@@ -523,6 +832,12 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         TaskListTool {
             store: Arc::new(TaskListStore::new(temp.path())),
+        }
+    }
+
+    fn tool_update(path: &std::path::Path) -> TaskUpdateTool {
+        TaskUpdateTool {
+            store: Arc::new(TaskListStore::new(path)),
         }
     }
 


### PR DESCRIPTION
## Summary

- add the `task_update` tool and register it with the shared task tools
- support status, owner, text fields, metadata merge/delete, dependency edges, and deletion under the task-list lock
- update the shared task-list spec, journal, and TODO split for remaining stale-read and claim semantics

## Related Issue

None.

## Testing

- `cargo fmt`
- `cargo test tasklist`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`

