### PR TITLE
feat(tools): coordinate shared task lists

### DIFF
--- a/docs/features/shared-task-lists.md
+++ b/docs/features/shared-task-lists.md
@@ -10,14 +10,17 @@ RARA has a session-scoped `todo_write` checklist for the current agent turn, but
 - Read-only `task_list` and `task_get` tools that expose Claude-compatible summary and detail shapes.
 - A `task_create` tool that creates pending tasks safely in the shared task store.
 - A `task_update` tool that updates task fields, status, metadata, dependencies, and deletions under the same task-list lock.
+- Revision and update-time fields that let `task_update` reject stale writes.
+- Explicit owner claim and release semantics that reject conflicting owners.
+- Runtime propagation of the default task-list ID into team and subagent tool managers.
+- `/status`, `/context`, and sidebar-style summaries for shared task progress.
 - Field compatibility for `blockedBy` and `activeForm` in stored task JSON.
-- Documentation of the remaining stale-read and ownership follow-up work before enabling multiple agents to claim tasks concurrently.
 
 ## Non-Goals
 
-- Stale-read protection, ownership conflict resolution, or task watchers.
 - Replacing session-scoped `todo_write`.
 - Syncing shared tasks to GitHub issues, external trackers, or transcript todos.
+- A live filesystem event stream for shared task files.
 
 ## Architecture
 
@@ -30,12 +33,16 @@ The shared task store is a file-backed workspace artifact:
 `task_list_id` is sanitized to an ASCII path segment and defaults to `default`. Each task is one JSON file so write-side tools can update individual tasks without rewriting a whole task list. `task_create` holds a per-task-list `.lock` file while assigning the next numeric task id and atomically writing the new task file. `task_update` uses the same lock while rewriting a task file, adding dependency edges, or deleting a task.
 Because task creation and updates perform blocking file I/O and file locking, async tool wrappers must run store writes on a blocking worker instead of directly on the Tokio executor.
 
+Each stored task carries a monotonically increasing `revision` and an `updatedAt` Unix timestamp. `task_update` may include `expectedRevision` to reject stale reads before applying field, metadata, dependency, owner, or status changes. Successful non-delete mutations bump both values while holding the task-list lock.
+
 `task_id` is treated as an identifier, not a path. Read tools reject empty task IDs, absolute paths, directory separators, and parent-directory traversal fragments before joining with the task-list directory.
 Task-list reads do not follow symlinks: task-list IDs must resolve to real directories, task files must be real files, and each task JSON `id` must match the `<task_id>.json` filename.
 
 The runtime registers one shared `TaskListStore` during tool manager construction and passes it to the shared task tools. Missing task-list directories are valid and return an empty list.
 
 Tool schemas expose both RARA snake_case `task_list_id` and Claude-compatible camelCase `taskListId`. Callers should send only one of the two names. `task_create` and `task_update` also expose both `activeForm` and `active_form`; sending both aliases in the same call is invalid.
+
+The main runtime registers shared task tools with a default task-list ID and passes that ID into subagent and team-created tool managers. Callers may still override the task list explicitly, but ordinary parent/subagent coordination uses the same list without repeating `taskListId` on every tool call.
 
 ## Contracts
 
@@ -50,7 +57,9 @@ Task files use this minimum shape:
   "owner": "agent-a",
   "status": "pending",
   "blocks": ["2"],
-  "blockedBy": []
+  "blockedBy": [],
+  "revision": 1,
+  "updatedAt": 1782990000
 }
 ```
 
@@ -70,7 +79,9 @@ Valid status values are:
       "subject": "Implement shared task read tools",
       "status": "pending",
       "owner": "agent-a",
-      "blockedBy": []
+      "blockedBy": [],
+      "revision": 1,
+      "updatedAt": 1782990000
     }
   ]
 }
@@ -88,7 +99,10 @@ Completed blockers are filtered from `blockedBy` in summary output so available 
     "description": "Expose task_list and task_get.",
     "status": "pending",
     "blocks": ["2"],
-    "blockedBy": []
+    "blockedBy": [],
+    "owner": "agent-a",
+    "revision": 1,
+    "updatedAt": 1782990000
   }
 }
 ```
@@ -114,6 +128,8 @@ Created tasks always start as:
 - `owner`: absent
 - `blocks`: `[]`
 - `blockedBy`: `[]`
+- `revision`: `1`
+- `updatedAt`: current Unix timestamp
 
 `task_create` returns:
 
@@ -131,8 +147,9 @@ Created tasks always start as:
 ```json
 {
   "taskId": "1",
+  "expectedRevision": 1,
   "status": "in_progress",
-  "owner": "agent-a",
+  "claimOwner": "agent-a",
   "metadata": {
     "priority": "high",
     "obsolete": null
@@ -146,6 +163,10 @@ The update contract is:
 - `status` accepts `pending`, `in_progress`, `completed`, or `deleted`.
 - `deleted` removes the task file and removes stale `blocks` / `blockedBy` references from remaining tasks.
 - `subject`, `description`, `activeForm`, and `owner` replace the stored field. Empty `activeForm` or `owner` clears that optional field.
+- `expectedRevision` rejects the update when the stored task revision has changed since the caller last read it.
+- `claimOwner` sets owner only when the task is unowned or already owned by the same caller.
+- `releaseOwner` clears owner only when the stored owner matches the caller.
+- `owner` remains available for direct assignment but cannot be mixed with `claimOwner` or `releaseOwner`.
 - `metadata` merges into the stored metadata map; a `null` value deletes that key.
 - `addBlocks` and `addBlockedBy` add bidirectional dependency edges and deduplicate repeated task IDs.
 
@@ -156,12 +177,33 @@ The update contract is:
   "success": true,
   "taskId": "1",
   "updatedFields": ["metadata", "owner", "status"],
+  "revision": 2,
+  "updatedAt": 1782990123,
   "statusChange": {
     "from": "pending",
     "to": "in_progress"
   }
 }
 ```
+
+Stale or conflicting writes return a non-fatal outcome with the current revision:
+
+```json
+{
+  "success": false,
+  "taskId": "1",
+  "updatedFields": [],
+  "revision": 3,
+  "updatedAt": 1782990199,
+  "error": "Task revision mismatch"
+}
+```
+
+## TUI Display
+
+Shared task state is included in the runtime snapshot built for each turn. `/status` includes a compact shared-task summary, `/context` shows the current task-list ID and the first shared task items with revision, owner, and blockers, and the wide sidebar falls back to a compact `Shared Tasks` section when there is no active plan, goal, or session-local todo list.
+
+The sidebar intentionally follows the existing RARA summary style rather than introducing a new layout: it shows completed/total, open count, ready count, and up to four active shared tasks with the same `[>]` and `[ ]` markers used by the existing todo fallback.
 
 Missing tasks return a non-fatal outcome:
 
@@ -181,15 +223,17 @@ Missing tasks return a non-fatal outcome:
 - Store tests cover symlink rejection for task-list directories and task files, plus JSON id and filename consistency.
 - Store tests cover `task_create` id allocation, pending defaults, atomic file readability, and symlinked task-list rejection.
 - Store tests cover `task_update` field changes, metadata merge/delete, status-change reporting, dependency edge updates, and deletion cleanup.
+- Store tests cover stale `expectedRevision` rejection, owner claim conflicts, and owner release validation.
 - Tool tests cover `task_create` output, strict schemas, empty required-field rejection, `task_update` status/owner/metadata changes, deleted status handling, alias conflict rejection, invalid dependency IDs, `task_list` summary output, `task_get` detail output, missing tasks, and invalid `task_id` rejection.
+- Tool tests cover default task-list IDs, expected-revision output, claim-owner updates, and stale-update errors.
+- Subagent tests cover read-only and general subagent shared task tool exposure plus Claude-style task tool aliases.
+- TUI tests cover `/status`, `/context`, and sidebar shared task summaries.
 - Workspace checks should run `cargo test tasklist`, `cargo test tools::tasklist::tests`, `cargo check --locked --workspace --all-targets`, and `cargo clippy --locked --workspace --all-targets -- -D warnings`.
 
 ## Open Risks
 
-- `task_update` still needs revision or timestamp based stale-read checks before multiple agents can safely claim or update tasks concurrently.
-- Owner claim semantics are still only a field update; conflicting claims are not rejected yet.
-- Team and subagent runtime state still needs a task-list-id propagation contract.
-- TUI rendering for shared tasks is intentionally deferred until watcher and mutation semantics are stable.
+- The current shared task surface refreshes through runtime snapshots; it is not a live filesystem watcher.
+- Task-list IDs are propagated inside the runtime, but there is not yet a user-facing command for switching the active task list during a TUI session.
 
 ## Source Journals
 

--- a/docs/journal/2026-07-02-shared-task-read-tools.md
+++ b/docs/journal/2026-07-02-shared-task-read-tools.md
@@ -35,3 +35,18 @@ The next slice added `task_create` as the first write-side task tool. It creates
 This slice added `task_update` as the first mutation tool for existing shared tasks. The tool updates subject, description, `activeForm`, owner, status, metadata, dependency edges, and deletion while holding the task-list `.lock` file. Dependency updates maintain both sides of the `blocks` / `blockedBy` edge, and deletion removes stale references from remaining tasks.
 
 The implementation intentionally keeps owner as a plain field update for now. It does not yet require a caller-supplied revision or last-read timestamp, so concurrent claim/update conflict prevention remains follow-up work before this can be treated as a full multi-agent coordination primitive.
+
+## Shared Coordination Follow-Up
+
+This slice closes the multi-agent coordination gaps left by the first mutation pass:
+
+- `task_update` now accepts `expectedRevision` / `expected_revision` and rejects stale writes with the current revision and timestamp.
+- Stored task files now carry `revision` and `updatedAt`; successful non-delete updates bump both fields.
+- `claimOwner` / `claim_owner` claims unowned tasks and rejects conflicting owners. `releaseOwner` / `release_owner` only clears ownership when the caller matches the stored owner.
+- Runtime tool construction propagates one default task-list ID into parent tools, team tools, and subagent tool managers so ordinary coordination does not require repeating `taskListId`.
+- General subagents now expose shared task tools but still do not expose repository, shell, browser, editing, or recursive agent tools.
+- `/status`, `/context`, and the wide sidebar expose shared task progress from the runtime snapshot.
+
+The UI follows the existing RARA sidebar summary style after checking Claude Code and OpenCode task displays. Claude keeps expanded tasks in a low-noise region near the composer, while OpenCode shows a collapsible sidebar list only when unfinished work exists. RARA keeps the existing sidebar fallback rule and only shows `Shared Tasks` when there is no active plan, goal, or session-local todo list.
+
+Remaining risk: shared task state refreshes through runtime snapshots. There is still no live filesystem watcher or TUI command for switching the active shared task list during a session.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -47,7 +47,7 @@ Active backlog only. Keep this file small and current.
 - [x] Subagent token_budget field (PR #601)
 - [ ] Subagent restart/reconnect — built-in capability, not a separate tool
 - [x] Subagent context budget design — token_budget on AgentDefinition
-- [ ] Add shared TaskList/TaskGet runtime tools backed by a `.rara/tasks/<task_list_id>/`
+- [x] Add shared TaskList/TaskGet runtime tools backed by a `.rara/tasks/<task_list_id>/`
       task store so teams/subagents can coordinate beyond session-local `todo_write`.
 - [x] Unify `.rara/agents` parsing for execution and `/status` discovery so
       `AgentDefinition` and `ImportedAgentProfile` cannot drift.
@@ -67,11 +67,16 @@ Active backlog only. Keep this file small and current.
 - [x] Add `task_create` with file locking and atomic pending-task writes.
 - [x] Add `task_update` with field, status, metadata, dependency, and delete
       mutations under the task-list lock.
-- [ ] Add revision or timestamp based stale-read protection for `task_update`.
-- [ ] Add owner/claim semantics that reject conflicting concurrent claims.
-- [ ] Propagate task-list IDs through team and subagent runtime state so agents
+- [x] Add revision or timestamp based stale-read protection for `task_update`.
+- [x] Add owner/claim semantics that reject conflicting concurrent claims.
+- [x] Propagate task-list IDs through team and subagent runtime state so agents
       coordinate on the same shared task list without an explicit tool input.
-- [ ] Add shared task watcher/TUI surfaces after mutation semantics are stable.
+- [x] Add snapshot-backed shared task status and TUI surfaces after mutation
+      semantics are stable.
+- [ ] Add a live filesystem watcher for shared task files if cross-process task
+      changes need to update the TUI without a new runtime snapshot.
+- [ ] Add a user-facing command for switching the active shared task list during
+      a TUI session.
 
 ## Planning Control Plane
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -41,6 +41,7 @@ use crate::memory_store::MemoryStore;
 use crate::prompt::{self, PromptMode, PromptRuntimeConfig};
 use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 use crate::session::SessionManager;
+use crate::tasklist::DEFAULT_TASK_LIST_ID;
 use crate::thread_store::ThreadRecorder;
 use crate::todo::TodoState;
 use crate::tool_result::{
@@ -192,6 +193,7 @@ pub struct Agent {
     pub pending_user_input: Option<PendingUserInput>,
     pub pending_approval: Option<PendingApproval>,
     pub todo_state: Option<TodoState>,
+    pub task_list_id: String,
     pub completed_user_input: Option<CompletedInteraction>,
     pub completed_approval: Option<CompletedInteraction>,
     pub approved_bash_prefixes: Vec<String>,
@@ -336,6 +338,7 @@ impl Agent {
             pending_user_input: None,
             pending_approval: None,
             todo_state: None,
+            task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
             completed_user_input: None,
             completed_approval: None,
             approved_bash_prefixes: Vec::new(),
@@ -435,6 +438,7 @@ impl Agent {
                     let session_manager = self.session_manager.clone();
                     let workspace = self.workspace.clone();
                     let scheduler = self.consolidation_scheduler.clone();
+                    let task_list_id = self.task_list_id.clone();
                     std::thread::spawn(move || {
                         let rt = tokio::runtime::Builder::new_current_thread()
                             .enable_all()
@@ -466,6 +470,7 @@ impl Agent {
                                 session_manager,
                                 workspace,
                                 prompt_config,
+                                task_list_id,
                             )
                             .await;
                             match result {

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -3,10 +3,11 @@ use std::time::Duration;
 use super::*;
 use crate::context::{
     AssembledContext, AssembledTurnContext, ContextAssembler, RuntimeContextInputs,
-    RuntimeInteractionInput,
+    RuntimeInteractionInput, SharedTaskContextView,
 };
 use crate::prompt::{PromptSource, PromptSourceKind};
 use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
+use crate::tasklist::TaskListStore;
 use crate::tool_result::ToolResultProjectionPolicy;
 
 impl Agent {
@@ -66,6 +67,7 @@ impl Agent {
                 .collect(),
             plan_explanation: self.plan_explanation.clone(),
             todo_state: self.todo_state.clone(),
+            shared_tasks: self.shared_task_context_view(),
             compact_state: self.compact_state.clone(),
             history: &self.history,
             vdb_uri: self.vdb.uri(),
@@ -79,6 +81,20 @@ impl Agent {
             tool_result_projection_policy: self.tool_result_projection_policy(),
             tool_result_projection_report: self.last_tool_result_projection_report.clone(),
             agent_turn_trace: self.last_agent_turn_trace.clone(),
+        }
+    }
+
+    fn shared_task_context_view(&self) -> SharedTaskContextView {
+        let store = TaskListStore::new(self.workspace.rara_dir.join("tasks"));
+        match store.list_tasks(&self.task_list_id) {
+            Ok(tasks) => SharedTaskContextView::from_tasks(self.task_list_id.clone(), tasks),
+            Err(err) => {
+                log::warn!(
+                    "Failed to read shared task list '{}': {err}",
+                    self.task_list_id
+                );
+                SharedTaskContextView::from_error(self.task_list_id.clone(), err.to_string())
+            }
         }
     }
 

--- a/src/context/assembler/mod.rs
+++ b/src/context/assembler/mod.rs
@@ -10,7 +10,7 @@ use crate::context::{
     ContextCompactionObservationView, ContextObservabilityView, MicrocompactProjectionContextView,
     PlanContextView, PromptContextView, RetrievalCandidate, RetrievalContextView,
     RetrievalObservationView, RetrievalRequest, RetrievedMemoryCandidate, SharedRuntimeContext,
-    TodoContextView, retrieval_candidates,
+    SharedTaskContextView, TodoContextView, retrieval_candidates,
 };
 use crate::llm::{ContextBudget, LlmBackend};
 use crate::prompt::{self, EffectivePrompt, HookLifecycle, PromptMode, PromptRuntimeConfig};
@@ -44,6 +44,7 @@ pub struct RuntimeContextInputs<'a> {
     pub plan_steps: Vec<(PlanStepStatus, String)>,
     pub plan_explanation: Option<String>,
     pub todo_state: Option<TodoState>,
+    pub shared_tasks: SharedTaskContextView,
     pub compact_state: CompactState,
     pub history: &'a [Message],
     pub vdb_uri: &'a str,
@@ -301,6 +302,7 @@ impl<'a> ContextAssembler<'a> {
                 inputs.plan_explanation,
             ),
             todo: TodoContextView::from_state(inputs.todo_state),
+            shared_tasks: inputs.shared_tasks,
             compaction,
             retrieval,
             observability,
@@ -375,6 +377,7 @@ mod tests {
                 plan_steps: vec![(PlanStepStatus::Pending, "inspect bootstrap".to_string())],
                 plan_explanation: Some("Keep one assembly path.".to_string()),
                 todo_state: None,
+                shared_tasks: SharedTaskContextView::default(),
                 compact_state: crate::agent::CompactState {
                     estimated_history_tokens: 1234,
                     context_window_tokens: Some(8192),
@@ -471,6 +474,7 @@ mod tests {
                 plan_steps: vec![(PlanStepStatus::Pending, "inspect bootstrap".to_string())],
                 plan_explanation: Some("Keep one assembly path.".to_string()),
                 todo_state: None,
+                shared_tasks: SharedTaskContextView::default(),
                 compact_state: crate::agent::CompactState {
                     estimated_history_tokens: 1234,
                     context_window_tokens: Some(8192),
@@ -560,6 +564,7 @@ mod tests {
                 plan_steps: Vec::new(),
                 plan_explanation: None,
                 todo_state: None,
+                shared_tasks: SharedTaskContextView::default(),
                 compact_state: crate::agent::CompactState {
                     estimated_history_tokens: 1234,
                     context_window_tokens: Some(1_500),
@@ -642,6 +647,7 @@ mod tests {
                 plan_steps: Vec::new(),
                 plan_explanation: None,
                 todo_state: None,
+                shared_tasks: SharedTaskContextView::default(),
                 compact_state: crate::agent::CompactState {
                     context_window_tokens: Some(200_000),
                     compact_threshold_tokens: 190_000,
@@ -722,6 +728,7 @@ mod tests {
                 plan_steps: vec![(PlanStepStatus::Pending, "inspect bootstrap".to_string())],
                 plan_explanation: Some("Keep one assembly path.".to_string()),
                 todo_state: None,
+                shared_tasks: SharedTaskContextView::default(),
                 compact_state: crate::agent::CompactState {
                     context_window_tokens: Some(8_192),
                     compact_threshold_tokens: 7_000,

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -36,6 +36,6 @@ pub use self::runtime::{
     RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalBudgetContextView, RetrievalCandidate,
     RetrievalCandidateContextEntry, RetrievalContextView, RetrievalObservationView,
     RetrievalOrchestrationView, RetrievalProviderStatus, RetrievalSourceContextEntry,
-    RetrievalSourceRef, RetrievedMemoryCandidate, SharedRuntimeContext, TodoContextView,
-    is_retrieved_memory_kind,
+    RetrievalSourceRef, RetrievedMemoryCandidate, SharedRuntimeContext, SharedTaskContextItem,
+    SharedTaskContextView, TodoContextView, is_retrieved_memory_kind,
 };

--- a/src/context/runtime.rs
+++ b/src/context/runtime.rs
@@ -1,5 +1,6 @@
 use crate::agent::{CompactState, PlanStepStatus};
 use crate::prompt::{EffectivePrompt, PromptSource};
+use crate::tasklist::{TaskRecord, TaskStatus};
 use crate::todo::{TodoState, TodoSummary};
 use crate::tool_result::{ToolResultProjectionPolicy, ToolResultProjectionReport};
 
@@ -172,6 +173,91 @@ impl TodoContextView {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SharedTaskContextView {
+    pub task_list_id: String,
+    pub total: usize,
+    pub pending: usize,
+    pub in_progress: usize,
+    pub completed: usize,
+    pub unblocked: usize,
+    pub owned: usize,
+    pub items: Vec<SharedTaskContextItem>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SharedTaskContextItem {
+    pub id: String,
+    pub subject: String,
+    pub status: String,
+    pub revision: u64,
+    pub owner: Option<String>,
+    pub blocked_by: Vec<String>,
+}
+
+impl SharedTaskContextView {
+    pub fn from_tasks(task_list_id: String, tasks: Vec<TaskRecord>) -> Self {
+        let completed_ids = tasks
+            .iter()
+            .filter(|task| task.status == TaskStatus::Completed)
+            .map(|task| task.id.clone())
+            .collect::<std::collections::HashSet<_>>();
+        let mut view = Self {
+            task_list_id,
+            total: tasks.len(),
+            pending: 0,
+            in_progress: 0,
+            completed: 0,
+            unblocked: 0,
+            owned: 0,
+            items: Vec::new(),
+            error: None,
+        };
+        for task in tasks {
+            match task.status {
+                TaskStatus::Pending => view.pending += 1,
+                TaskStatus::InProgress => view.in_progress += 1,
+                TaskStatus::Completed => view.completed += 1,
+            }
+            if task.owner.is_some() {
+                view.owned += 1;
+            }
+            let active_blockers = task
+                .blocked_by
+                .iter()
+                .filter(|task_id| !completed_ids.contains(*task_id))
+                .cloned()
+                .collect::<Vec<_>>();
+            if task.status != TaskStatus::Completed && active_blockers.is_empty() {
+                view.unblocked += 1;
+            }
+            view.items.push(SharedTaskContextItem {
+                id: task.id,
+                subject: task.subject,
+                status: match task.status {
+                    TaskStatus::Pending => "pending",
+                    TaskStatus::InProgress => "in_progress",
+                    TaskStatus::Completed => "completed",
+                }
+                .to_string(),
+                revision: task.revision,
+                owner: task.owner,
+                blocked_by: active_blockers,
+            });
+        }
+        view
+    }
+
+    pub fn from_error(task_list_id: String, error: String) -> Self {
+        Self {
+            task_list_id,
+            error: Some(error),
+            ..Self::default()
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContextBudgetView {
     pub context_window_tokens: Option<usize>,
@@ -283,6 +369,7 @@ pub struct SharedRuntimeContext {
     pub prompt: PromptContextView,
     pub plan: PlanContextView,
     pub todo: TodoContextView,
+    pub shared_tasks: SharedTaskContextView,
     pub compaction: CompactionContextView,
     pub retrieval: RetrievalContextView,
     pub observability: ContextObservabilityView,

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -22,6 +22,7 @@ use crate::prompt::PromptRuntimeConfig;
 use crate::sandbox::SandboxManager;
 use crate::session::SessionManager;
 use crate::skill::SkillManager;
+use crate::tasklist::DEFAULT_TASK_LIST_ID;
 use crate::tasklist::TaskListStore;
 use crate::tools::agent::{
     AgentTool, BackgroundSubAgentStore, ExploreAgentTool, PlanAgentTool, SubAgentListTool,
@@ -75,6 +76,7 @@ pub(super) fn create_full_tool_manager(
         PtySessionStore::new(workspace.rara_dir.join("pty-sessions")).expect("pty session store"),
     );
     let task_list_store = Arc::new(TaskListStore::new(workspace.rara_dir.join("tasks")));
+    let task_list_id = DEFAULT_TASK_LIST_ID.to_string();
     let background_subagents = BACKGROUND_SUBAGENTS
         .get_or_init(|| Arc::new(BackgroundSubAgentStore::default()))
         .clone();
@@ -140,15 +142,19 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(TodoWriteTool));
     tm.register(Box::new(TaskCreateTool {
         store: task_list_store.clone(),
+        default_task_list_id: task_list_id.clone(),
     }));
     tm.register(Box::new(TaskListTool {
         store: task_list_store.clone(),
+        default_task_list_id: task_list_id.clone(),
     }));
     tm.register(Box::new(TaskUpdateTool {
         store: task_list_store.clone(),
+        default_task_list_id: task_list_id.clone(),
     }));
     tm.register(Box::new(TaskGetTool {
         store: task_list_store,
+        default_task_list_id: task_list_id.clone(),
     }));
     tm.register(Box::new(RememberExperienceTool {
         llm_backend: backend.clone(),
@@ -180,6 +186,7 @@ pub(super) fn create_full_tool_manager(
         workspace: workspace.clone(),
         prompt_config: prompt_config.clone(),
         background_subagents: background_subagents.clone(),
+        task_list_id: task_list_id.clone(),
     }));
     tm.register(Box::new(ExploreAgentTool {
         backend: backend.clone(),
@@ -189,6 +196,7 @@ pub(super) fn create_full_tool_manager(
         workspace: workspace.clone(),
         prompt_config: prompt_config.clone(),
         background_subagents: background_subagents.clone(),
+        task_list_id: task_list_id.clone(),
     }));
     tm.register(Box::new(PlanAgentTool {
         backend: backend.clone(),
@@ -198,6 +206,7 @@ pub(super) fn create_full_tool_manager(
         workspace: workspace.clone(),
         prompt_config: prompt_config.clone(),
         background_subagents: background_subagents.clone(),
+        task_list_id: task_list_id.clone(),
     }));
     tm.register(Box::new(TeamCreateTool {
         backend,
@@ -206,6 +215,7 @@ pub(super) fn create_full_tool_manager(
         session_manager,
         workspace,
         prompt_config,
+        task_list_id,
     }));
     tm.register(Box::new(SubAgentResumeTool {
         background_subagents: background_subagents.clone(),

--- a/src/tasklist.rs
+++ b/src/tasklist.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use fs2::FileExt;
@@ -78,6 +79,8 @@ impl TaskListStore {
                 active_form: input.active_form,
                 owner: None,
                 status: TaskStatus::Pending,
+                revision: 1,
+                updated_at: unix_timestamp_secs(),
                 blocks: Vec::new(),
                 blocked_by: Vec::new(),
                 metadata: input.metadata,
@@ -125,6 +128,8 @@ impl TaskListStore {
                     success: true,
                     task_id: task_id.to_string(),
                     updated_fields: vec!["deleted".to_string()],
+                    revision: None,
+                    updated_at: None,
                     status_change: None,
                     error: None,
                 });
@@ -133,6 +138,15 @@ impl TaskListStore {
             let Some(mut task) = self.get_task_from_dir(&task_list_dir, task_id)? else {
                 return Ok(TaskUpdateOutcome::not_found(task_id));
             };
+            if let Some(expected_revision) = update.expected_revision
+                && task.revision != expected_revision
+            {
+                return Ok(TaskUpdateOutcome::stale(
+                    task_id,
+                    task.revision,
+                    task.updated_at,
+                ));
+            }
             let old_status = task.status.clone();
             let mut updated_fields = Vec::new();
 
@@ -154,6 +168,19 @@ impl TaskListStore {
                 "activeForm",
                 &mut updated_fields,
             );
+            if let Some(conflict) = apply_owner_claim_update(
+                &mut task.owner,
+                update.claim_owner.as_deref(),
+                update.release_owner.as_deref(),
+                &mut updated_fields,
+            ) {
+                return Ok(TaskUpdateOutcome::conflict(
+                    task_id,
+                    task.revision,
+                    task.updated_at,
+                    conflict,
+                ));
+            }
             apply_optional_text_update(&mut task.owner, update.owner, "owner", &mut updated_fields);
 
             if let Some(status) = update.status
@@ -176,7 +203,10 @@ impl TaskListStore {
                 &update.add_blocked_by,
                 &mut updated_fields,
             )?;
-            self.write_task_file(&task_list_dir, &task)?;
+            if !updated_fields.is_empty() {
+                bump_task_revision(&mut task);
+                self.write_task_file(&task_list_dir, &task)?;
+            }
 
             updated_fields.sort();
             updated_fields.dedup();
@@ -188,6 +218,8 @@ impl TaskListStore {
                     from: old_status,
                     to: task.status,
                 }),
+                revision: Some(task.revision),
+                updated_at: Some(task.updated_at),
                 error: None,
             })
         })();
@@ -327,7 +359,9 @@ impl TaskListStore {
             let blocked = related_tasks
                 .get_mut(blocked_id)
                 .expect("dependency task was loaded");
-            push_unique(&mut blocked.blocked_by, task_id.to_string());
+            if push_unique(&mut blocked.blocked_by, task_id.to_string()) {
+                bump_task_revision(blocked);
+            }
             push_unique(&mut task.blocks, blocked_id.clone());
         }
         if !add_blocks.is_empty() {
@@ -338,7 +372,9 @@ impl TaskListStore {
             let blocker = related_tasks
                 .get_mut(blocker_id)
                 .expect("dependency task was loaded");
-            push_unique(&mut blocker.blocks, task_id.to_string());
+            if push_unique(&mut blocker.blocks, task_id.to_string()) {
+                bump_task_revision(blocker);
+            }
             push_unique(&mut task.blocked_by, blocker_id.clone());
         }
         if !add_blocked_by.is_empty() {
@@ -414,10 +450,13 @@ pub struct NewTaskRecord {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TaskUpdate {
+    pub expected_revision: Option<u64>,
     pub subject: Option<String>,
     pub description: Option<String>,
     pub active_form: Option<Option<String>>,
     pub owner: Option<Option<String>>,
+    pub claim_owner: Option<String>,
+    pub release_owner: Option<String>,
     pub status: Option<TaskStatus>,
     pub metadata: BTreeMap<String, serde_json::Value>,
     pub add_blocks: Vec<String>,
@@ -432,9 +471,13 @@ pub struct TaskUpdateOutcome {
     pub task_id: String,
     pub updated_fields: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
+    pub revision: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_change: Option<StatusChange>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 impl TaskUpdateOutcome {
@@ -443,7 +486,33 @@ impl TaskUpdateOutcome {
             success: false,
             task_id: task_id.to_string(),
             updated_fields: Vec::new(),
+            revision: None,
+            updated_at: None,
             error: Some("Task not found".to_string()),
+            status_change: None,
+        }
+    }
+
+    fn stale(task_id: &str, current_revision: u64, updated_at: u64) -> Self {
+        Self {
+            success: false,
+            task_id: task_id.to_string(),
+            updated_fields: Vec::new(),
+            revision: Some(current_revision),
+            updated_at: Some(updated_at),
+            error: Some("Task revision mismatch".to_string()),
+            status_change: None,
+        }
+    }
+
+    fn conflict(task_id: &str, current_revision: u64, updated_at: u64, error: String) -> Self {
+        Self {
+            success: false,
+            task_id: task_id.to_string(),
+            updated_fields: Vec::new(),
+            revision: Some(current_revision),
+            updated_at: Some(updated_at),
+            error: Some(error),
             status_change: None,
         }
     }
@@ -467,6 +536,10 @@ pub struct TaskRecord {
     #[serde(default)]
     pub owner: Option<String>,
     pub status: TaskStatus,
+    #[serde(default)]
+    pub revision: u64,
+    #[serde(default, rename = "updatedAt")]
+    pub updated_at: u64,
     #[serde(default)]
     pub blocks: Vec<String>,
     #[serde(default, alias = "blockedBy")]
@@ -511,6 +584,45 @@ fn apply_optional_text_update(
     }
 }
 
+fn apply_owner_claim_update(
+    owner: &mut Option<String>,
+    claim_owner: Option<&str>,
+    release_owner: Option<&str>,
+    updated_fields: &mut Vec<String>,
+) -> Option<String> {
+    if let Some(claim_owner) = claim_owner {
+        match owner.as_deref() {
+            Some(existing) if existing != claim_owner => {
+                return Some(format!("Task already owned by {existing}"));
+            }
+            Some(_) => {}
+            None => {
+                *owner = Some(claim_owner.to_string());
+                updated_fields.push("owner".to_string());
+            }
+        }
+    }
+
+    if let Some(release_owner) = release_owner {
+        match owner.as_deref() {
+            Some(existing) if existing != release_owner => {
+                return Some(format!("Task is owned by {existing}, not {release_owner}"));
+            }
+            Some(_) => {
+                *owner = None;
+                updated_fields.push("owner".to_string());
+            }
+            None => {}
+        }
+    }
+    None
+}
+
+fn bump_task_revision(task: &mut TaskRecord) {
+    task.revision = task.revision.saturating_add(1);
+    task.updated_at = unix_timestamp_secs();
+}
+
 fn merge_metadata(
     target: &mut BTreeMap<String, serde_json::Value>,
     updates: BTreeMap<String, serde_json::Value>,
@@ -524,10 +636,19 @@ fn merge_metadata(
     }
 }
 
-fn push_unique(values: &mut Vec<String>, value: String) {
+fn push_unique(values: &mut Vec<String>, value: String) -> bool {
     if !values.iter().any(|existing| existing == &value) {
         values.push(value);
+        return true;
     }
+    false
+}
+
+fn unix_timestamp_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -536,6 +657,8 @@ pub struct TaskListEntry {
     pub id: String,
     pub subject: String,
     pub status: TaskStatus,
+    pub revision: u64,
+    pub updated_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owner: Option<String>,
     pub blocked_by: Vec<String>,
@@ -553,6 +676,8 @@ impl TaskListEntry {
             id: task.id.clone(),
             subject: task.subject.clone(),
             status: task.status.clone(),
+            revision: task.revision,
+            updated_at: task.updated_at,
             owner: task.owner.clone(),
             blocked_by,
         }
@@ -566,6 +691,10 @@ pub struct TaskDetails {
     pub subject: String,
     pub description: String,
     pub status: TaskStatus,
+    pub revision: u64,
+    pub updated_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
     pub blocks: Vec<String>,
     pub blocked_by: Vec<String>,
 }
@@ -577,6 +706,9 @@ impl From<TaskRecord> for TaskDetails {
             subject: task.subject,
             description: task.description,
             status: task.status,
+            revision: task.revision,
+            updated_at: task.updated_at,
+            owner: task.owner,
             blocks: task.blocks,
             blocked_by: task.blocked_by,
         }
@@ -606,7 +738,7 @@ pub fn is_valid_task_id(task_id: &str) -> bool {
 
 fn read_task_file(path: &Path, expected_task_id: &str) -> Result<TaskRecord> {
     let bytes = fs::read(path).with_context(|| format!("read task file {}", path.display()))?;
-    let task: TaskRecord = serde_json::from_slice(&bytes)
+    let mut task: TaskRecord = serde_json::from_slice(&bytes)
         .with_context(|| format!("parse task file {}", path.display()))?;
     anyhow::ensure!(
         is_valid_task_id(&task.id) && task.id == expected_task_id,
@@ -614,6 +746,9 @@ fn read_task_file(path: &Path, expected_task_id: &str) -> Result<TaskRecord> {
         task.id,
         expected_task_id
     );
+    if task.revision == 0 {
+        task.revision = 1;
+    }
     Ok(task)
 }
 
@@ -844,6 +979,7 @@ mod tests {
             .expect("task should update");
 
         assert!(outcome.success);
+        assert_eq!(outcome.revision, Some(2));
         assert_eq!(
             outcome.status_change.as_ref().map(|change| &change.to),
             Some(&TaskStatus::InProgress)
@@ -856,8 +992,179 @@ mod tests {
         assert_eq!(task.description, "Update a shared task.");
         assert_eq!(task.active_form.as_deref(), Some("Updating safe task"));
         assert_eq!(task.owner.as_deref(), Some("agent-a"));
+        assert_eq!(task.revision, 2);
         assert_eq!(task.metadata["keep"], "yes");
         assert!(!task.metadata.contains_key("drop"));
+    }
+
+    #[test]
+    fn update_task_rejects_stale_expected_revision() {
+        let temp = tempdir().expect("tempdir");
+        let store = TaskListStore::new(temp.path());
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Keep original subject"))
+            .expect("task should be created");
+        store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    subject: Some("First update".to_string()),
+                    expected_revision: Some(1),
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("first update should work");
+
+        let outcome = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    subject: Some("Stale update".to_string()),
+                    expected_revision: Some(1),
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("stale update should return outcome");
+
+        assert!(!outcome.success);
+        assert_eq!(outcome.revision, Some(2));
+        assert_eq!(outcome.error.as_deref(), Some("Task revision mismatch"));
+        let task = store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("task should load")
+            .expect("task should exist");
+        assert_eq!(task.subject, "First update");
+        assert_eq!(task.revision, 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn update_task_noop_does_not_write_task_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().expect("tempdir");
+        let list_dir = temp.path().join(DEFAULT_TASK_LIST_ID);
+        let store = TaskListStore::new(temp.path());
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("No-op update"))
+            .expect("task should be created");
+
+        fs::set_permissions(&list_dir, fs::Permissions::from_mode(0o555))
+            .expect("make task list read-only");
+        let outcome = store.update_task(
+            DEFAULT_TASK_LIST_ID,
+            "1",
+            TaskUpdate {
+                expected_revision: Some(1),
+                ..TaskUpdate::default()
+            },
+        );
+        fs::set_permissions(&list_dir, fs::Permissions::from_mode(0o755))
+            .expect("restore task list permissions");
+        let outcome = outcome.expect("no-op update should not need a file write");
+
+        assert!(outcome.success);
+        assert!(outcome.updated_fields.is_empty());
+        assert_eq!(outcome.revision, Some(1));
+    }
+
+    #[test]
+    fn update_task_claim_owner_rejects_conflicting_claim() {
+        let temp = tempdir().expect("tempdir");
+        let store = TaskListStore::new(temp.path());
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Claim task"))
+            .expect("task should be created");
+
+        let claimed = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    claim_owner: Some("agent-a".to_string()),
+                    expected_revision: Some(1),
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("claim should work");
+        let conflict = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    claim_owner: Some("agent-b".to_string()),
+                    expected_revision: claimed.revision,
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("conflict should return outcome");
+
+        assert!(!conflict.success);
+        assert_eq!(
+            conflict.error.as_deref(),
+            Some("Task already owned by agent-a")
+        );
+        let task = store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("task should load")
+            .expect("task should exist");
+        assert_eq!(task.owner.as_deref(), Some("agent-a"));
+    }
+
+    #[test]
+    fn update_task_release_owner_requires_matching_owner() {
+        let temp = tempdir().expect("tempdir");
+        let store = TaskListStore::new(temp.path());
+        store
+            .create_task(DEFAULT_TASK_LIST_ID, new_task("Release task"))
+            .expect("task should be created");
+        let claimed = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    claim_owner: Some("agent-a".to_string()),
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("claim should work");
+
+        let wrong_release = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    release_owner: Some("agent-b".to_string()),
+                    expected_revision: claimed.revision,
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("wrong release should return outcome");
+        assert!(!wrong_release.success);
+        assert_eq!(
+            wrong_release.error.as_deref(),
+            Some("Task is owned by agent-a, not agent-b")
+        );
+
+        let released = store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    release_owner: Some("agent-a".to_string()),
+                    expected_revision: claimed.revision,
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("release should work");
+        assert!(released.success);
+        let task = store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("task should load")
+            .expect("task should exist");
+        assert!(task.owner.is_none());
     }
 
     #[test]
@@ -1218,6 +1525,8 @@ mod tests {
             active_form: None,
             owner: None,
             status,
+            revision: 1,
+            updated_at: 0,
             blocks: Vec::new(),
             blocked_by: blocked_by.into_iter().map(str::to_string).collect(),
             metadata: BTreeMap::new(),

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -29,7 +29,9 @@ use crate::llm::{EmbeddingBackend, LlmBackend};
 use crate::prompt::PromptRuntimeConfig;
 use crate::session::SessionManager;
 use crate::session_transcript::{self, TranscriptScope};
+use crate::tasklist::TaskListStore;
 use crate::thread_store::{ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeState};
+use crate::tools::tasklist::{TaskCreateTool, TaskGetTool, TaskListTool, TaskUpdateTool};
 use crate::workspace::WorkspaceMemory;
 
 #[derive(Clone, Copy, Debug)]
@@ -52,6 +54,10 @@ pub(super) fn agent_tool_to_internal_name(name: &str) -> &str {
         "Grep" => "grep",
         "WebSearch" => "web_search",
         "WebFetch" => "web_fetch",
+        "TaskCreate" => "task_create",
+        "TaskList" => "task_list",
+        "TaskGet" => "task_get",
+        "TaskUpdate" => "task_update",
         "Task" | "spawn_agent" => "spawn_agent",
         n => n,
     }
@@ -132,7 +138,7 @@ macro_rules! strict_read_only_subagent_prompt {
             "- Do not run shell commands, scripts, redirection, heredocs, or any workaround that changes filesystem, process, network, git, or repository state.\n",
             "- Bash, PTY, editing, patching, and agent-spawning tools are intentionally unavailable.\n",
             // Keep this prompt list synchronized with build_read_only_tool_manager().
-            "- Use only the read-only repository inspection tools available to you: read_file, list_files, glob, grep.\n",
+            "- Use only the read-only repository inspection tools available to you: read_file, list_files, glob, grep, task_list, task_get.\n",
             "- If the assigned instruction requires mutation, report the limitation and provide the evidence-backed findings or plan instead of attempting a workaround."
         )
     };
@@ -168,11 +174,12 @@ impl SubAgentKind {
             SubAgentKind::General => {
                 concat!(
                     "## Sub-Agent Role\n",
-                    "- You are a no-tool reasoning sub-agent.\n",
+                    "- You are a shared-task worker sub-agent.\n",
                     "- Treat the assigned instruction as the complete task contract.\n",
                     "- Honor every constraint in the assigned instruction, including workspace, branch, network, and output limits.\n",
                     "- Stay inside the current workspace unless the assigned instruction explicitly allows another path.\n",
                     "- You do not have repository, shell, editing, patching, or browser tools in this role.\n",
+                    "- You may use shared task-list tools to inspect, claim, update, or complete project tasks.\n",
                     "- If the assigned instruction requires inspection or mutation, report the limitation and answer only from the provided instruction/context.\n",
                     "- Do not delegate to another agent or spawn sub-agents; complete the assigned work directly."
                 )
@@ -278,11 +285,12 @@ pub struct AgentTool {
     pub workspace: Arc<WorkspaceMemory>,
     pub prompt_config: PromptRuntimeConfig,
     pub background_subagents: Arc<BackgroundSubAgentStore>,
+    pub task_list_id: String,
 }
 
 #[tool_spec(
     name = "spawn_agent",
-    description = "Spawn a no-tool reasoning sub-agent. It cannot inspect files, run shell commands, edit files, or spawn other agents; use explore_agent or plan_agent for read-only repository inspection.",
+    description = "Spawn a shared-task worker sub-agent. It cannot inspect files, run shell commands, edit files, or spawn other agents; it can inspect and update shared task-list entries. Use explore_agent or plan_agent for read-only repository inspection.",
     input_schema = {
         "type": "object",
         "properties": {
@@ -350,6 +358,7 @@ impl AgentTool {
                 session_manager: self.session_manager.clone(),
                 workspace: self.workspace.clone(),
                 prompt_config: self.prompt_config.clone(),
+                task_list_id: self.task_list_id.clone(),
             })?;
             return Ok(task.to_json());
         }
@@ -368,6 +377,7 @@ impl AgentTool {
             self.session_manager.clone(),
             self.workspace.clone(),
             self.prompt_config.clone(),
+            self.task_list_id.clone(),
         )
         .await?;
         Ok(json!({
@@ -395,6 +405,7 @@ pub struct ExploreAgentTool {
     pub workspace: Arc<WorkspaceMemory>,
     pub prompt_config: PromptRuntimeConfig,
     pub background_subagents: Arc<BackgroundSubAgentStore>,
+    pub task_list_id: String,
 }
 
 #[tool_spec(
@@ -457,6 +468,7 @@ impl ExploreAgentTool {
                 session_manager: self.session_manager.clone(),
                 workspace: self.workspace.clone(),
                 prompt_config: self.prompt_config.clone(),
+                task_list_id: self.task_list_id.clone(),
             })?;
             return Ok(task.to_json());
         }
@@ -475,6 +487,7 @@ impl ExploreAgentTool {
             self.session_manager.clone(),
             self.workspace.clone(),
             self.prompt_config.clone(),
+            self.task_list_id.clone(),
         )
         .await?;
         Ok(json!({
@@ -501,6 +514,7 @@ pub struct PlanAgentTool {
     pub workspace: Arc<WorkspaceMemory>,
     pub prompt_config: PromptRuntimeConfig,
     pub background_subagents: Arc<BackgroundSubAgentStore>,
+    pub task_list_id: String,
 }
 
 #[tool_spec(
@@ -563,6 +577,7 @@ impl PlanAgentTool {
                 session_manager: self.session_manager.clone(),
                 workspace: self.workspace.clone(),
                 prompt_config: self.prompt_config.clone(),
+                task_list_id: self.task_list_id.clone(),
             })?;
             return Ok(task.to_json());
         }
@@ -581,6 +596,7 @@ impl PlanAgentTool {
             self.session_manager.clone(),
             self.workspace.clone(),
             self.prompt_config.clone(),
+            self.task_list_id.clone(),
         )
         .await?;
         Ok(json!({
@@ -611,6 +627,7 @@ pub struct TeamCreateTool {
     pub session_manager: Arc<SessionManager>,
     pub workspace: Arc<WorkspaceMemory>,
     pub prompt_config: PromptRuntimeConfig,
+    pub task_list_id: String,
 }
 
 const BACKGROUND_SUBAGENT_COMPLETED_RETENTION: usize = 64;
@@ -639,6 +656,7 @@ struct BackgroundSubAgentStart {
     session_manager: Arc<SessionManager>,
     workspace: Arc<WorkspaceMemory>,
     prompt_config: PromptRuntimeConfig,
+    task_list_id: String,
 }
 
 #[derive(Clone, Debug)]
@@ -720,6 +738,7 @@ impl BackgroundSubAgentStore {
                 start.session_manager,
                 start.workspace,
                 start.prompt_config,
+                start.task_list_id,
             )
             .await;
             store.finish(&agent_id, result);
@@ -1039,6 +1058,7 @@ impl TeamCreateTool {
             let session_manager = self.session_manager.clone();
             let workspace = self.workspace.clone();
             let prompt_config = self.prompt_config.clone();
+            let task_list_id = self.task_list_id.clone();
             let parent_session_id = parent_session_id.map(str::to_string);
             let agent_id = next_subagent_id(task.kind, Some(&task.name));
 
@@ -1058,6 +1078,7 @@ impl TeamCreateTool {
                     session_manager,
                     workspace,
                     prompt_config,
+                    task_list_id,
                 )
                 .await?;
                 Ok::<_, ToolError>(serialize_team_result(&task.name, result))
@@ -1111,11 +1132,12 @@ pub(crate) async fn run_sub_agent(
     session_manager: Arc<SessionManager>,
     workspace: Arc<WorkspaceMemory>,
     prompt_config: PromptRuntimeConfig,
+    task_list_id: String,
 ) -> Result<SubAgentResult, ToolError> {
     let tool_manager = if let Some(def) = definition {
-        build_filtered_tool_manager(kind, def)
+        build_filtered_tool_manager(kind, def, workspace.rara_dir.join("tasks"), &task_list_id)
     } else {
-        build_subagent_tool_manager(kind)
+        build_subagent_tool_manager(kind, workspace.rara_dir.join("tasks"), &task_list_id)
     };
     let mut sub = Agent::new_with_embedding_backend(
         tool_manager,
@@ -1142,6 +1164,7 @@ pub(crate) async fn run_sub_agent(
         None => kind.append_prompt().to_string(),
     };
     sub.set_prompt_config(append_subagent_prompt(prompt_config, &appended_prompt));
+    sub.task_list_id = task_list_id;
 
     let def_max_turns = definition
         .and_then(|d| {
@@ -1290,21 +1313,54 @@ fn persist_subagent_runtime_state(
     Ok(())
 }
 
-fn build_read_only_tool_manager() -> ToolManager {
+fn build_read_only_tool_manager(
+    task_store: Arc<TaskListStore>,
+    default_task_list_id: &str,
+) -> ToolManager {
     // Keep this registration set synchronized with strict_read_only_subagent_prompt!().
     let mut tool_manager = ToolManager::new();
     tool_manager.register(Box::new(ReadFileTool::default()));
     tool_manager.register(Box::new(ListFilesTool));
     tool_manager.register(Box::new(GlobTool));
     tool_manager.register(Box::new(GrepTool));
+    tool_manager.register(Box::new(TaskListTool {
+        store: task_store.clone(),
+        default_task_list_id: default_task_list_id.to_string(),
+    }));
+    tool_manager.register(Box::new(TaskGetTool {
+        store: task_store,
+        default_task_list_id: default_task_list_id.to_string(),
+    }));
     tool_manager
 }
 
-pub(crate) fn build_subagent_tool_manager(kind: SubAgentKind) -> ToolManager {
+pub(crate) fn build_subagent_tool_manager(
+    kind: SubAgentKind,
+    task_root: PathBuf,
+    default_task_list_id: &str,
+) -> ToolManager {
+    let task_store = Arc::new(TaskListStore::new(task_root));
     if kind.read_only() {
-        build_read_only_tool_manager()
+        build_read_only_tool_manager(task_store, default_task_list_id)
     } else {
-        ToolManager::new()
+        let mut tool_manager = ToolManager::new();
+        tool_manager.register(Box::new(TaskCreateTool {
+            store: task_store.clone(),
+            default_task_list_id: default_task_list_id.to_string(),
+        }));
+        tool_manager.register(Box::new(TaskListTool {
+            store: task_store.clone(),
+            default_task_list_id: default_task_list_id.to_string(),
+        }));
+        tool_manager.register(Box::new(TaskUpdateTool {
+            store: task_store.clone(),
+            default_task_list_id: default_task_list_id.to_string(),
+        }));
+        tool_manager.register(Box::new(TaskGetTool {
+            store: task_store,
+            default_task_list_id: default_task_list_id.to_string(),
+        }));
+        tool_manager
     }
 }
 
@@ -1546,8 +1602,13 @@ fn fallback_spawn_agent_definition(name: &str) -> AgentDefinition {
     }
 }
 
-fn build_filtered_tool_manager(kind: SubAgentKind, definition: &AgentDefinition) -> ToolManager {
-    let mut tm = build_subagent_tool_manager(kind);
+fn build_filtered_tool_manager(
+    kind: SubAgentKind,
+    definition: &AgentDefinition,
+    task_root: PathBuf,
+    default_task_list_id: &str,
+) -> ToolManager {
+    let mut tm = build_subagent_tool_manager(kind, task_root, default_task_list_id);
 
     if !definition.tools.is_empty() {
         let allowed: std::collections::HashSet<&str> = definition

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -26,6 +27,7 @@ use crate::llm::{ContentBlock, EmbeddingBackend, LlmBackend, LlmResponse, MockLl
 use crate::prompt::PromptRuntimeConfig;
 use crate::session::SessionManager;
 use crate::session_transcript::{load_transcript, model_visible_messages};
+use crate::tasklist::{DEFAULT_TASK_LIST_ID, TaskListStore};
 use crate::thread_store::{ThreadMetadataSource, ThreadStore};
 use crate::tools::agent::{
     AgentTool, ExploreAgentTool, PlanAgentTool, SubAgentResumeTool, SubAgentStopTool,
@@ -48,6 +50,18 @@ struct SlowBackend;
 
 fn mock_embedding_backend() -> Arc<dyn EmbeddingBackend> {
     Arc::new(MockLlm)
+}
+
+fn test_task_root() -> PathBuf {
+    std::env::temp_dir().join(format!("rara-agent-test-{}", uuid::Uuid::new_v4()))
+}
+
+fn test_task_store() -> Arc<TaskListStore> {
+    Arc::new(TaskListStore::new(test_task_root()))
+}
+
+fn test_task_list_id() -> String {
+    DEFAULT_TASK_LIST_ID.to_string()
 }
 
 fn record_peak(current: usize, peak: &AtomicUsize) {
@@ -180,12 +194,16 @@ impl LlmBackend for SlowBackend {
 
 #[test]
 fn read_only_subagent_manager_excludes_mutating_and_agent_tools() {
-    let manager = build_read_only_tool_manager();
+    let manager = build_read_only_tool_manager(test_task_store(), DEFAULT_TASK_LIST_ID);
     assert!(manager.get_tool("read_file").is_some());
     assert!(manager.get_tool("list_files").is_some());
     assert!(manager.get_tool("glob").is_some());
     assert!(manager.get_tool("grep").is_some());
     assert!(manager.get_tool("search_files").is_none());
+    assert!(manager.get_tool("task_list").is_some());
+    assert!(manager.get_tool("task_get").is_some());
+    assert!(manager.get_tool("task_create").is_none());
+    assert!(manager.get_tool("task_update").is_none());
     assert!(manager.get_tool("write_file").is_none());
     assert!(manager.get_tool("apply_patch").is_none());
     assert!(manager.get_tool("bash").is_none());
@@ -204,11 +222,19 @@ fn read_only_subagent_manager_excludes_mutating_and_agent_tools() {
 
 #[test]
 fn general_subagent_manager_does_not_expose_recursive_agent_tools() {
-    let manager = build_subagent_tool_manager(SubAgentKind::General);
+    let manager = build_subagent_tool_manager(
+        SubAgentKind::General,
+        test_task_root(),
+        DEFAULT_TASK_LIST_ID,
+    );
     assert!(manager.get_tool("spawn_agent").is_none());
     assert!(manager.get_tool("explore_agent").is_none());
     assert!(manager.get_tool("plan_agent").is_none());
     assert!(manager.get_tool("team_create").is_none());
+    assert!(manager.get_tool("task_list").is_some());
+    assert!(manager.get_tool("task_get").is_some());
+    assert!(manager.get_tool("task_create").is_some());
+    assert!(manager.get_tool("task_update").is_some());
     assert!(manager.get_tool("bash").is_none());
     assert!(manager.get_tool("pty_start").is_none());
 }
@@ -236,11 +262,12 @@ fn subagent_prompt_requires_instruction_constraints_and_workspace_boundary() {
 }
 
 #[test]
-fn general_subagent_prompt_declares_no_tool_access() {
+fn general_subagent_prompt_declares_shared_task_worker_access() {
     let prompt = SubAgentKind::General.append_prompt();
 
-    assert!(prompt.contains("no-tool reasoning sub-agent"));
+    assert!(prompt.contains("shared-task worker sub-agent"));
     assert!(prompt.contains("do not have repository, shell, editing, patching, or browser tools"));
+    assert!(prompt.contains("shared task-list tools"));
     assert!(prompt.contains("answer only from the provided instruction/context"));
 }
 
@@ -313,6 +340,7 @@ async fn team_create_runs_real_subagents_in_order() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
     };
 
     let result = tool
@@ -366,6 +394,7 @@ async fn team_create_validates_all_tasks_before_running_subagents() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
     };
 
     let err = tool
@@ -407,6 +436,7 @@ async fn team_create_rejects_non_string_kind_before_running_subagents() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
     };
 
     let err = tool
@@ -447,6 +477,7 @@ async fn team_create_rejects_unstable_explicit_name_before_running_subagents() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
     };
 
     let err = tool
@@ -486,6 +517,7 @@ async fn spawn_agent_rejects_name_that_normalizes_empty_before_running_subagent(
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
         background_subagents: Arc::new(BackgroundSubAgentStore::default()),
     };
 
@@ -524,6 +556,7 @@ async fn team_create_limits_concurrent_subagents() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
     };
     let tasks = (0..8)
         .map(|idx| json!({ "kind": "general", "instruction": format!("task {idx}") }))
@@ -559,6 +592,7 @@ async fn team_create_writes_parent_scoped_sidechain_transcripts() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
     };
 
     let mut progress = |_| {};
@@ -648,6 +682,7 @@ async fn spawn_agent_writes_parent_scoped_sidechain_transcript() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
         background_subagents: Arc::new(BackgroundSubAgentStore::default()),
     };
 
@@ -730,6 +765,7 @@ async fn background_subagent_resume_returns_completed_summary_without_inline_sid
         session_manager,
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
         background_subagents: background_subagents.clone(),
     };
     let resume = SubAgentResumeTool {
@@ -802,6 +838,7 @@ async fn background_subagent_stop_marks_running_task_cancelled() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
         background_subagents: background_subagents.clone(),
     };
     let stop = SubAgentStopTool {
@@ -899,6 +936,7 @@ async fn background_plan_agent_resume_returns_plan_state() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, temp.path().join(".rara"))),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
         background_subagents: background_subagents.clone(),
     };
     let resume = SubAgentResumeTool {
@@ -956,6 +994,7 @@ async fn plan_agent_writes_parent_scoped_sidechain_transcript() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
         background_subagents: Arc::new(BackgroundSubAgentStore::default()),
     };
 
@@ -1032,6 +1071,7 @@ async fn subagent_without_parent_context_does_not_write_sidechain() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
         background_subagents: Arc::new(BackgroundSubAgentStore::default()),
     };
 
@@ -1076,6 +1116,7 @@ async fn subagent_returns_result_when_sidechain_persistence_fails() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
         background_subagents: Arc::new(BackgroundSubAgentStore::default()),
     };
 
@@ -1121,6 +1162,7 @@ async fn team_create_rejects_too_many_tasks() {
         ),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
     };
 
     let tasks = (0..9)
@@ -1136,7 +1178,7 @@ async fn team_create_rejects_too_many_tasks() {
 
 #[test]
 fn tool_manager_retain_filters_tools_by_name() {
-    let mut manager = build_read_only_tool_manager();
+    let mut manager = build_read_only_tool_manager(test_task_store(), DEFAULT_TASK_LIST_ID);
     assert!(manager.get_tool("grep").is_some());
     assert!(manager.get_tool("glob").is_some());
     manager.retain(|name| name == "grep");
@@ -1159,11 +1201,42 @@ fn filtered_tool_manager_respects_tools_whitelist() {
         hidden: false,
         system_prompt: String::new(),
     };
-    let manager = build_filtered_tool_manager(SubAgentKind::Explore, &definition);
+    let manager = build_filtered_tool_manager(
+        SubAgentKind::Explore,
+        &definition,
+        test_task_root(),
+        DEFAULT_TASK_LIST_ID,
+    );
     assert!(manager.get_tool("grep").is_some());
     assert!(manager.get_tool("read_file").is_some());
     assert!(manager.get_tool("glob").is_none());
     assert!(manager.get_tool("list_files").is_none());
+}
+
+#[test]
+fn filtered_tool_manager_maps_task_tool_aliases() {
+    let definition = AgentDefinition {
+        token_budget: None,
+        name: "custom".into(),
+        description: "custom".into(),
+        tools: vec!["TaskList".into(), "TaskGet".into()],
+        disallowed_tools: vec![],
+        model: None,
+        max_turns: 0,
+        plan_mode_required: false,
+        permission_mode: None,
+        hidden: false,
+        system_prompt: String::new(),
+    };
+    let manager = build_filtered_tool_manager(
+        SubAgentKind::Explore,
+        &definition,
+        test_task_root(),
+        DEFAULT_TASK_LIST_ID,
+    );
+    assert!(manager.get_tool("task_list").is_some());
+    assert!(manager.get_tool("task_get").is_some());
+    assert!(manager.get_tool("read_file").is_none());
 }
 
 #[test]
@@ -1181,7 +1254,12 @@ fn filtered_tool_manager_respects_disallowed_tools_blacklist() {
         hidden: false,
         system_prompt: String::new(),
     };
-    let manager = build_filtered_tool_manager(SubAgentKind::Explore, &definition);
+    let manager = build_filtered_tool_manager(
+        SubAgentKind::Explore,
+        &definition,
+        test_task_root(),
+        DEFAULT_TASK_LIST_ID,
+    );
     assert!(manager.get_tool("read_file").is_some());
     assert!(manager.get_tool("list_files").is_some());
     assert!(manager.get_tool("grep").is_none());
@@ -1203,7 +1281,12 @@ fn filtered_tool_manager_disallowed_takes_precedence_over_tools() {
         hidden: false,
         system_prompt: String::new(),
     };
-    let manager = build_filtered_tool_manager(SubAgentKind::Explore, &definition);
+    let manager = build_filtered_tool_manager(
+        SubAgentKind::Explore,
+        &definition,
+        test_task_root(),
+        DEFAULT_TASK_LIST_ID,
+    );
     assert!(
         manager.get_tool("read_file").is_some(),
         "Read should be allowed"

--- a/src/tools/tasklist.rs
+++ b/src/tools/tasklist.rs
@@ -13,18 +13,22 @@ use crate::tasklist::{
 
 pub struct TaskCreateTool {
     pub store: Arc<TaskListStore>,
+    pub default_task_list_id: String,
 }
 
 pub struct TaskListTool {
     pub store: Arc<TaskListStore>,
+    pub default_task_list_id: String,
 }
 
 pub struct TaskUpdateTool {
     pub store: Arc<TaskListStore>,
+    pub default_task_list_id: String,
 }
 
 pub struct TaskGetTool {
     pub store: Arc<TaskListStore>,
+    pub default_task_list_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -60,6 +64,8 @@ struct TaskCreateInput {
 struct TaskUpdateInput {
     #[serde(alias = "taskId")]
     task_id: String,
+    #[serde(default, alias = "expectedRevision")]
+    expected_revision: Option<u64>,
     #[serde(default)]
     subject: Option<String>,
     #[serde(default)]
@@ -68,6 +74,10 @@ struct TaskUpdateInput {
     active_form: Option<String>,
     #[serde(default)]
     owner: Option<String>,
+    #[serde(default, alias = "claimOwner")]
+    claim_owner: Option<String>,
+    #[serde(default, alias = "releaseOwner")]
+    release_owner: Option<String>,
     #[serde(default)]
     status: Option<String>,
     #[serde(default, alias = "addBlocks")]
@@ -127,7 +137,7 @@ impl Tool for TaskCreateTool {
         let subject = normalize_required_text(&input.subject, "subject")?;
         let description = normalize_required_text(&input.description, "description")?;
         let active_form = normalize_optional_text(input.active_form.as_deref());
-        let task_list_id = input.task_list_id().to_string();
+        let task_list_id = input.task_list_id(&self.default_task_list_id).to_string();
         let store = self.store.clone();
         let metadata = input.metadata.into_iter().collect();
         let task = tokio::task::spawn_blocking(move || {
@@ -168,6 +178,16 @@ impl Tool for TaskCreateTool {
                 "type": "string",
                 "description": "Claude-compatible alias for task_id. Do not send together with task_id."
             },
+            "expectedRevision": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Task revision observed from task_get or task_list. If it no longer matches, the update returns success=false without writing."
+            },
+            "expected_revision": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "RARA-compatible alias for expectedRevision."
+            },
             "subject": {
                 "type": "string",
                 "description": "New imperative task title."
@@ -187,6 +207,22 @@ impl Tool for TaskCreateTool {
             "owner": {
                 "type": "string",
                 "description": "New task owner. Send an empty string to clear the owner."
+            },
+            "claimOwner": {
+                "type": "string",
+                "description": "Claim the task for this owner only when it is currently unowned or already owned by the same value. Do not send with owner or releaseOwner."
+            },
+            "claim_owner": {
+                "type": "string",
+                "description": "RARA-compatible alias for claimOwner."
+            },
+            "releaseOwner": {
+                "type": "string",
+                "description": "Release the task only when the current owner matches this value. Do not send with owner or claimOwner."
+            },
+            "release_owner": {
+                "type": "string",
+                "description": "RARA-compatible alias for releaseOwner."
             },
             "status": {
                 "type": "string",
@@ -235,7 +271,7 @@ impl Tool for TaskUpdateTool {
                     .to_string(),
             ));
         }
-        let task_list_id = input.task_list_id().to_string();
+        let task_list_id = input.task_list_id(&self.default_task_list_id).to_string();
         let update = normalize_task_update(input)?;
         let store = self.store.clone();
         let outcome =
@@ -274,7 +310,7 @@ impl Tool for TaskListTool {
         let input = parse_task_list_input(input)?;
         let tasks = self
             .store
-            .list_tasks(input.task_list_id())
+            .list_tasks(input.task_list_id(&self.default_task_list_id))
             .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?;
         Ok(serde_json::json!({ "tasks": task_list_entries(&tasks) }))
     }
@@ -317,7 +353,7 @@ impl Tool for TaskGetTool {
 
         let task = self
             .store
-            .get_task(input.task_list_id(), task_id)
+            .get_task(input.task_list_id(&self.default_task_list_id), task_id)
             .map_err(|err| ToolError::ExecutionFailed(err.to_string()))?
             .map(TaskDetails::from);
         Ok(serde_json::json!({ "task": task }))
@@ -325,42 +361,42 @@ impl Tool for TaskGetTool {
 }
 
 impl TaskListInput {
-    fn task_list_id(&self) -> &str {
+    fn task_list_id<'a>(&'a self, default_task_list_id: &'a str) -> &'a str {
         self.task_list_id
             .as_deref()
             .map(str::trim)
             .filter(|task_list_id| !task_list_id.is_empty())
-            .unwrap_or(DEFAULT_TASK_LIST_ID)
+            .unwrap_or(default_task_list_id)
     }
 }
 
 impl TaskCreateInput {
-    fn task_list_id(&self) -> &str {
+    fn task_list_id<'a>(&'a self, default_task_list_id: &'a str) -> &'a str {
         self.task_list_id
             .as_deref()
             .map(str::trim)
             .filter(|task_list_id| !task_list_id.is_empty())
-            .unwrap_or(DEFAULT_TASK_LIST_ID)
+            .unwrap_or(default_task_list_id)
     }
 }
 
 impl TaskUpdateInput {
-    fn task_list_id(&self) -> &str {
+    fn task_list_id<'a>(&'a self, default_task_list_id: &'a str) -> &'a str {
         self.task_list_id
             .as_deref()
             .map(str::trim)
             .filter(|task_list_id| !task_list_id.is_empty())
-            .unwrap_or(DEFAULT_TASK_LIST_ID)
+            .unwrap_or(default_task_list_id)
     }
 }
 
 impl TaskGetInput {
-    fn task_list_id(&self) -> &str {
+    fn task_list_id<'a>(&'a self, default_task_list_id: &'a str) -> &'a str {
         self.task_list_id
             .as_deref()
             .map(str::trim)
             .filter(|task_list_id| !task_list_id.is_empty())
-            .unwrap_or(DEFAULT_TASK_LIST_ID)
+            .unwrap_or(default_task_list_id)
     }
 }
 
@@ -372,7 +408,10 @@ fn parse_task_create_input(input: Value) -> Result<TaskCreateInput, ToolError> {
 
 fn parse_task_update_input(input: Value) -> Result<TaskUpdateInput, ToolError> {
     reject_alias_conflict(&input, "taskId", "task_id")?;
+    reject_alias_conflict(&input, "expectedRevision", "expected_revision")?;
     reject_alias_conflict(&input, "activeForm", "active_form")?;
+    reject_alias_conflict(&input, "claimOwner", "claim_owner")?;
+    reject_alias_conflict(&input, "releaseOwner", "release_owner")?;
     reject_alias_conflict(&input, "taskListId", "task_list_id")?;
     serde_json::from_value(input).map_err(|err| ToolError::InvalidInput(err.to_string()))
 }
@@ -404,6 +443,16 @@ fn normalize_optional_text(value: Option<&str>) -> Option<String> {
 }
 
 fn normalize_task_update(input: TaskUpdateInput) -> Result<TaskUpdate, ToolError> {
+    if input.owner.is_some() && (input.claim_owner.is_some() || input.release_owner.is_some()) {
+        return Err(ToolError::InvalidInput(
+            "task_update accepts owner or claimOwner/releaseOwner, not both".to_string(),
+        ));
+    }
+    if input.claim_owner.is_some() && input.release_owner.is_some() {
+        return Err(ToolError::InvalidInput(
+            "task_update accepts claimOwner or releaseOwner, not both".to_string(),
+        ));
+    }
     let status = match input.status.as_deref().map(str::trim) {
         None | Some("") => None,
         Some("pending") => Some(TaskStatus::Pending),
@@ -419,6 +468,7 @@ fn normalize_task_update(input: TaskUpdateInput) -> Result<TaskUpdate, ToolError
     let delete = input.status.as_deref().map(str::trim) == Some("deleted");
 
     Ok(TaskUpdate {
+        expected_revision: input.expected_revision,
         subject: normalize_optional_text(input.subject.as_deref()),
         description: normalize_optional_text(input.description.as_deref()),
         active_form: input
@@ -429,6 +479,8 @@ fn normalize_task_update(input: TaskUpdateInput) -> Result<TaskUpdate, ToolError
             .owner
             .as_deref()
             .map(|value| normalize_optional_text(Some(value))),
+        claim_owner: normalize_optional_text(input.claim_owner.as_deref()),
+        release_owner: normalize_optional_text(input.release_owner.as_deref()),
         status,
         metadata: input.metadata.into_iter().collect(),
         add_blocks: normalize_task_ids(input.add_blocks, "addBlocks")?,
@@ -488,6 +540,7 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let tool = TaskCreateTool {
             store: Arc::new(TaskListStore::new(temp.path())),
+            default_task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
         };
 
         let output = tool
@@ -514,6 +567,35 @@ mod tests {
             Some("Implementing task_create")
         );
         assert_eq!(task.metadata["source"], "test");
+    }
+
+    #[tokio::test]
+    async fn task_create_uses_tool_default_task_list_id() {
+        let temp = tempdir().expect("tempdir");
+        let tool = TaskCreateTool {
+            store: Arc::new(TaskListStore::new(temp.path())),
+            default_task_list_id: "team-a".to_string(),
+        };
+
+        tool.call(json!({
+            "subject": "Create team task",
+            "description": "Create a task in the tool default list."
+        }))
+        .await
+        .expect("task_create should use default task list id");
+
+        assert!(
+            tool.store
+                .get_task("team-a", "1")
+                .expect("team task should load")
+                .is_some()
+        );
+        assert!(
+            tool.store
+                .get_task(DEFAULT_TASK_LIST_ID, "1")
+                .expect("default task lookup should work")
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -614,6 +696,7 @@ mod tests {
         );
         assert_eq!(output["statusChange"]["from"], "pending");
         assert_eq!(output["statusChange"]["to"], "in_progress");
+        assert_eq!(output["revision"], 2);
 
         let task = tool
             .store
@@ -623,6 +706,83 @@ mod tests {
         assert_eq!(task.status, TaskStatus::InProgress);
         assert_eq!(task.owner.as_deref(), Some("agent-a"));
         assert_eq!(task.metadata["priority"], "high");
+    }
+
+    #[tokio::test]
+    async fn task_update_claims_owner_with_expected_revision() {
+        let temp = tempdir().expect("tempdir");
+        let tool = tool_update(temp.path());
+        tool.store
+            .create_task(
+                DEFAULT_TASK_LIST_ID,
+                NewTaskRecord {
+                    subject: "Claim through tool".to_string(),
+                    description: "Claim a shared task file.".to_string(),
+                    active_form: None,
+                    metadata: Default::default(),
+                },
+            )
+            .expect("task should be created");
+
+        let output = tool
+            .call(json!({
+                "task_id": "1",
+                "expectedRevision": 1,
+                "claimOwner": "agent-a"
+            }))
+            .await
+            .expect("task_update should claim task");
+
+        assert_eq!(output["success"], true);
+        assert_eq!(output["updatedFields"], json!(["owner"]));
+        assert_eq!(output["revision"], 2);
+        let task = tool
+            .store
+            .get_task(DEFAULT_TASK_LIST_ID, "1")
+            .expect("task should load")
+            .expect("task should exist");
+        assert_eq!(task.owner.as_deref(), Some("agent-a"));
+    }
+
+    #[tokio::test]
+    async fn task_update_reports_stale_expected_revision() {
+        let temp = tempdir().expect("tempdir");
+        let tool = tool_update(temp.path());
+        tool.store
+            .create_task(
+                DEFAULT_TASK_LIST_ID,
+                NewTaskRecord {
+                    subject: "Reject stale update".to_string(),
+                    description: "Reject a stale shared task update.".to_string(),
+                    active_form: None,
+                    metadata: Default::default(),
+                },
+            )
+            .expect("task should be created");
+        tool.store
+            .update_task(
+                DEFAULT_TASK_LIST_ID,
+                "1",
+                TaskUpdate {
+                    subject: Some("Current subject".to_string()),
+                    expected_revision: Some(1),
+                    ..TaskUpdate::default()
+                },
+            )
+            .expect("first update should work");
+
+        let output = tool
+            .call(json!({
+                "task_id": "1",
+                "expectedRevision": 1,
+                "subject": "Stale subject"
+            }))
+            .await
+            .expect("stale update should return outcome");
+
+        assert_eq!(output["success"], false);
+        assert_eq!(output["revision"], 2);
+        assert_eq!(output["error"], "Task revision mismatch");
     }
 
     #[tokio::test]
@@ -716,6 +876,7 @@ mod tests {
 
         let tool = TaskListTool {
             store: Arc::new(TaskListStore::new(temp.path())),
+            default_task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
         };
         let output = tool.call(json!({})).await.expect("task_list should work");
 
@@ -744,6 +905,7 @@ mod tests {
 
         let tool = TaskGetTool {
             store: Arc::new(TaskListStore::new(temp.path())),
+            default_task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
         };
         let output = tool
             .call(json!({ "task_id": "2" }))
@@ -798,6 +960,12 @@ mod tests {
         );
         assert!(task_update_schema["properties"].get("task_id").is_some());
         assert!(task_update_schema["properties"].get("taskId").is_some());
+        assert!(
+            task_update_schema["properties"]
+                .get("expectedRevision")
+                .is_some()
+        );
+        assert!(task_update_schema["properties"].get("claimOwner").is_some());
         assert_eq!(
             task_update_schema.get("oneOf"),
             Some(&json!([
@@ -836,6 +1004,7 @@ mod tests {
     fn tool_create(path: &std::path::Path) -> TaskCreateTool {
         TaskCreateTool {
             store: Arc::new(TaskListStore::new(path)),
+            default_task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
         }
     }
 
@@ -843,12 +1012,14 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         TaskListTool {
             store: Arc::new(TaskListStore::new(temp.path())),
+            default_task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
         }
     }
 
     fn tool_update(path: &std::path::Path) -> TaskUpdateTool {
         TaskUpdateTool {
             store: Arc::new(TaskListStore::new(path)),
+            default_task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
         }
     }
 
@@ -856,6 +1027,7 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         TaskGetTool {
             store: Arc::new(TaskListStore::new(temp.path())),
+            default_task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
         }
     }
 

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -348,6 +348,30 @@ fn todo_summary_line(app: &TuiApp) -> String {
     )
 }
 
+fn shared_task_summary_line(app: &TuiApp) -> String {
+    let tasks = &app.snapshot.shared_tasks;
+    if let Some(error) = tasks.error.as_deref() {
+        return format!(
+            "list={} error={}",
+            tasks.task_list_id,
+            truncate_preview(error, 80)
+        );
+    }
+    if tasks.total == 0 {
+        return format!("list={} none", tasks.task_list_id);
+    }
+    format!(
+        "list={} {} total, {} pending, {} in_progress, {} completed, {} unblocked, {} owned",
+        tasks.task_list_id,
+        tasks.total,
+        tasks.pending,
+        tasks.in_progress,
+        tasks.completed,
+        tasks.unblocked,
+        tasks.owned,
+    )
+}
+
 fn render_todo_context(app: &TuiApp) -> String {
     let summary = &app.snapshot.todo.summary;
     if summary.total == 0 {
@@ -398,6 +422,64 @@ fn render_todo_context(app: &TuiApp) -> String {
         summary.completed,
         summary.cancelled,
         items,
+    )
+}
+
+fn render_shared_tasks_context(app: &TuiApp) -> String {
+    let tasks = &app.snapshot.shared_tasks;
+    if let Some(error) = tasks.error.as_deref() {
+        return format!(
+            "Shared Tasks\n  list: {}\n  error: {}",
+            tasks.task_list_id,
+            truncate_preview(error, 120)
+        );
+    }
+    if tasks.total == 0 {
+        return format!(
+            "Shared Tasks\n  list: {}\n  tasks: none",
+            tasks.task_list_id
+        );
+    }
+    let rendered_items = tasks
+        .items
+        .iter()
+        .take(8)
+        .map(|task| {
+            let owner = task.owner.as_deref().unwrap_or("-");
+            let blockers = if task.blocked_by.is_empty() {
+                "-".to_string()
+            } else {
+                task.blocked_by.join(",")
+            };
+            format!(
+                "    - [{}] #{} rev={} owner={} blockedBy={} {}",
+                task.status,
+                task.id,
+                task.revision,
+                owner,
+                blockers,
+                truncate_preview(task.subject.as_str(), 90)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let omitted = tasks.items.len().saturating_sub(8);
+    let omitted = if omitted == 0 {
+        String::new()
+    } else {
+        format!("\n    ... {omitted} more")
+    };
+    format!(
+        "Shared Tasks\n  list: {}\n  total: {}  pending: {}  in_progress: {}  completed: {}  unblocked: {}  owned: {}\n  tasks:\n{}{}",
+        tasks.task_list_id,
+        tasks.total,
+        tasks.pending,
+        tasks.in_progress,
+        tasks.completed,
+        tasks.unblocked,
+        tasks.owned,
+        rendered_items,
+        omitted,
     )
 }
 
@@ -514,6 +596,7 @@ pub fn status_context_text(app: &TuiApp) -> String {
             plan_lines
         ),
         render_todo_context(app),
+        render_shared_tasks_context(app),
         format!("Pending\n{}", pending_interactions),
         render_context_assembly_entries(app, "stable_instructions", "Stable Instructions"),
         render_context_assembly_entries(
@@ -609,7 +692,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
         crate::local_model_server::LocalModelServerState::Error => "error",
     };
     format!(
-        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nauxiliary_model={}\nauxiliary_model_source={}\nauxiliary_route={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\ntodo={}\nembedding_state={}\nembedding_backend={}\nembedding_model={}\nembedding_detail={}\ndevice={}\ndtype={}\nterminal_name={}\nterminal_user_agent={}\nterminal_term={}\nterminal_term_program={}\nterminal_multiplexer={}\nterminal_remote={}\nterminal_history_mode={}\nterminal_focused={}\nterminal_width_columns={}\nphase={}\ndetail={}",
+        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nauxiliary_model={}\nauxiliary_model_source={}\nauxiliary_route={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\ntodo={}\nshared_tasks={}\nembedding_state={}\nembedding_backend={}\nembedding_model={}\nembedding_detail={}\ndevice={}\ndtype={}\nterminal_name={}\nterminal_user_agent={}\nterminal_term={}\nterminal_term_program={}\nterminal_multiplexer={}\nterminal_remote={}\nterminal_history_mode={}\nterminal_focused={}\nterminal_width_columns={}\nphase={}\ndetail={}",
         surface.provider,
         endpoint_profile,
         endpoint_kind,
@@ -637,6 +720,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
             .display_or(reasoning_effort_label.as_str()),
         surface.reasoning_effort.source.label(),
         todo_summary_line(app),
+        shared_task_summary_line(app),
         embedding_state,
         app.local_model_server.backend,
         app.local_model_server.model,

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -8,7 +8,9 @@ use super::{
     status_prompt_sources_text, status_resources_text, status_runtime_text,
 };
 use crate::config::{ConfigManager, OpenAiEndpointKind};
-use crate::context::{PromptSourceContextEntry, TodoContextView};
+use crate::context::{
+    PromptSourceContextEntry, SharedTaskContextItem, SharedTaskContextView, TodoContextView,
+};
 use crate::todo::TodoSummary;
 use crate::tui::state::{LocalCommandKind, RuntimeSnapshot, TuiApp};
 
@@ -643,6 +645,65 @@ fn status_runtime_text_reports_todo_summary() {
     assert!(rendered.contains(
         "todo=2 total, 1 pending, 1 in_progress, 0 completed, 0 cancelled, active=Running focused tests"
     ));
+}
+
+#[test]
+fn status_runtime_text_reports_shared_task_summary() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.snapshot.shared_tasks = SharedTaskContextView {
+        task_list_id: "default".into(),
+        total: 3,
+        pending: 1,
+        in_progress: 1,
+        completed: 1,
+        unblocked: 2,
+        owned: 1,
+        items: Vec::new(),
+        error: None,
+    };
+
+    let rendered = status_runtime_text(&app);
+    assert!(rendered.contains(
+        "shared_tasks=list=default 3 total, 1 pending, 1 in_progress, 1 completed, 2 unblocked, 1 owned"
+    ));
+}
+
+#[test]
+fn status_context_text_reports_shared_task_items() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.snapshot.shared_tasks = SharedTaskContextView {
+        task_list_id: "default".into(),
+        total: 1,
+        pending: 1,
+        in_progress: 0,
+        completed: 0,
+        unblocked: 1,
+        owned: 1,
+        items: vec![SharedTaskContextItem {
+            id: "1".into(),
+            subject: "Wire shared task status".into(),
+            status: "pending".into(),
+            revision: 7,
+            owner: Some("agent-a".into()),
+            blocked_by: Vec::new(),
+        }],
+        error: None,
+    };
+
+    let rendered = status_context_text(&app);
+    assert!(rendered.contains("Shared Tasks"));
+    assert!(rendered.contains("list: default"));
+    assert!(
+        rendered.contains("[pending] #1 rev=7 owner=agent-a blockedBy=- Wire shared task status")
+    );
 }
 
 #[test]

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -269,7 +269,7 @@ fn push_plan_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bool {
     if plan_steps.is_empty() && goal.is_none() {
         let todo_items = &app.snapshot.todo;
         if todo_items.items.is_empty() {
-            return false;
+            return push_shared_tasks_section(lines, app);
         }
         lines.push(Line::from(super::section_label("Todo", TEXT_SECONDARY)));
         let open = todo_items.summary.pending + todo_items.summary.in_progress;
@@ -361,6 +361,57 @@ fn push_plan_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bool {
                 Style::default().fg(TEXT_MUTED),
             )));
         }
+    }
+    true
+}
+
+fn push_shared_tasks_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bool {
+    let tasks = &app.snapshot.shared_tasks;
+    if tasks.items.is_empty() || tasks.items.iter().all(|item| item.status == "completed") {
+        return false;
+    }
+    lines.push(Line::from(super::section_label(
+        "Shared Tasks",
+        TEXT_SECONDARY,
+    )));
+    let open = tasks.pending + tasks.in_progress;
+    lines.push(Line::from(Span::styled(
+        format!(
+            "{}/{} · {open} open · {} ready",
+            tasks.completed, tasks.total, tasks.unblocked
+        ),
+        Style::default().fg(TEXT_MUTED),
+    )));
+    for item in tasks
+        .items
+        .iter()
+        .filter(|item| item.status != "completed")
+        .take(4)
+    {
+        let marker = match item.status.as_str() {
+            "in_progress" => "[>]",
+            _ => "[ ]",
+        };
+        let color = match item.status.as_str() {
+            "in_progress" => STATUS_WARNING,
+            _ => TEXT_SECONDARY,
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{marker} {}", item.subject),
+            Style::default().fg(color),
+        )));
+    }
+    let hidden = tasks
+        .items
+        .iter()
+        .filter(|item| item.status != "completed")
+        .count()
+        .saturating_sub(4);
+    if hidden > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("... {hidden} more"),
+            Style::default().fg(TEXT_MUTED),
+        )));
     }
     true
 }

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -6,7 +6,7 @@ use super::{
     push_plan_section, push_session_info,
 };
 use crate::config::ConfigManager;
-use crate::context::TodoContextView;
+use crate::context::{SharedTaskContextItem, SharedTaskContextView, TodoContextView};
 use crate::todo::TodoSummary;
 use crate::tui::state::{
     InteractionKind, PendingInteractionSnapshot, RuntimeSnapshot, TranscriptEntry, TranscriptTurn,
@@ -142,6 +142,58 @@ fn push_session_info_short_session_id_not_truncated() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(text.contains("abc"), "short id should appear as-is");
+}
+
+#[test]
+fn push_plan_section_falls_back_to_shared_tasks_when_local_todo_is_empty() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot = RuntimeSnapshot {
+        shared_tasks: SharedTaskContextView {
+            task_list_id: "default".into(),
+            total: 3,
+            pending: 1,
+            in_progress: 1,
+            completed: 1,
+            unblocked: 2,
+            owned: 1,
+            items: vec![
+                SharedTaskContextItem {
+                    id: "task-a".into(),
+                    subject: "Claim next shared task".into(),
+                    status: "in_progress".into(),
+                    revision: 2,
+                    owner: Some("agent-a".into()),
+                    blocked_by: Vec::new(),
+                },
+                SharedTaskContextItem {
+                    id: "task-b".into(),
+                    subject: "Review shared task output".into(),
+                    status: "pending".into(),
+                    revision: 1,
+                    owner: None,
+                    blocked_by: Vec::new(),
+                },
+            ],
+            error: None,
+        },
+        ..RuntimeSnapshot::default()
+    };
+
+    let mut lines = Vec::new();
+    assert!(push_plan_section(&mut lines, &app));
+    let text: String = lines
+        .iter()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("Shared Tasks"));
+    assert!(text.contains("1/3 · 2 open · 2 ready"));
+    assert!(text.contains("[>] Claim next shared task"));
+    assert!(text.contains("[ ] Review shared task output"));
 }
 
 // ── push_model_badge ────────────────────────────────────────────────

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -163,6 +163,7 @@ impl TuiApp {
                 None
             },
             todo: runtime_context.todo,
+            shared_tasks: runtime_context.shared_tasks,
             prompt_base_kind: runtime_context.prompt.base_prompt_kind,
             prompt_section_keys: runtime_context.prompt.section_keys,
             prompt_source_entries: runtime_context.prompt.source_entries,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -268,6 +268,7 @@ pub struct RuntimeSnapshot {
     pub completed_interactions: Vec<CompletedInteractionSnapshot>,
     pub todo: crate::context::TodoContextView,
     pub todo_artifact_path: Option<String>,
+    pub shared_tasks: crate::context::SharedTaskContextView,
     pub prompt_base_kind: String,
     pub prompt_section_keys: Vec<String>,
     pub prompt_source_entries: Vec<PromptSourceContextEntry>,


### PR DESCRIPTION
## Summary

- Add shared task revisions, update timestamps, stale-write rejection, and owner claim/release semantics.
- Propagate the default shared task-list ID through parent, team, and subagent tool managers.
- Surface shared task state in runtime context, `/status`, `/context`, and the existing sidebar fallback style.
- Update shared task specs, journal, and TODOs, including remaining live watcher and task-list switching follow-ups.

## Purpose

Complete the shared task-list coordination follow-ups so subagents can claim and update project tasks against the same workspace task list without silently overwriting stale state.

## Related Issues

None.

## Testing

- `cargo fmt`
- `cargo test tasklist`
- `cargo test tui::command::tests`
- `cargo test general_subagent_manager_does_not_expose_recursive_agent_tools`
- `cargo test filtered_tool_manager_maps_task_tool_aliases`
- `cargo test push_plan_section_falls_back_to_shared_tasks_when_local_todo_is_empty`
- `cargo test read_only_subagent_manager_excludes_mutating_and_agent_tools`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`
