### PR TITLE
fix(agent): apply custom spawn agent tools

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,7 +56,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Implement remaining Claude-compatible `AgentDefinition` metadata:
       `token_budget`, `permission_mode`, `hidden`, and description/listing
       behavior.
-- [ ] Add an end-to-end `spawn_agent` regression test proving custom
+- [x] Add an end-to-end `spawn_agent` regression test proving custom
       `.rara/agents` definitions affect prompt body, tool filtering,
       `maxTurns`, and `planModeRequired`.
 

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1156,12 +1156,13 @@ pub(crate) async fn run_sub_agent(
     } else {
         kind.execution_mode()
     });
+    let role_prompt = subagent_role_prompt(kind, definition);
     let appended_prompt = match definition
         .map(|d| d.system_prompt.trim())
         .filter(|prompt| !prompt.is_empty())
     {
-        Some(system_prompt) => format!("{}\n\n{}", kind.append_prompt(), system_prompt),
-        None => kind.append_prompt().to_string(),
+        Some(system_prompt) => format!("{role_prompt}\n\n{system_prompt}"),
+        None => role_prompt,
     };
     sub.set_prompt_config(append_subagent_prompt(prompt_config, &appended_prompt));
     sub.task_list_id = task_list_id;
@@ -1362,6 +1363,23 @@ pub(crate) fn build_subagent_tool_manager(
         }));
         tool_manager
     }
+}
+
+fn build_custom_spawn_agent_tool_manager(
+    task_root: PathBuf,
+    default_task_list_id: &str,
+) -> ToolManager {
+    let task_store = Arc::new(TaskListStore::new(task_root));
+    let mut tool_manager = build_read_only_tool_manager(task_store.clone(), default_task_list_id);
+    tool_manager.register(Box::new(TaskCreateTool {
+        store: task_store.clone(),
+        default_task_list_id: default_task_list_id.to_string(),
+    }));
+    tool_manager.register(Box::new(TaskUpdateTool {
+        store: task_store,
+        default_task_list_id: default_task_list_id.to_string(),
+    }));
+    tool_manager
 }
 
 fn normalize_team_tasks(tasks: &[Value]) -> Result<Vec<TeamTask>, ToolError> {
@@ -1586,6 +1604,25 @@ fn resolve_spawn_agent_definition(workspace_root: &Path, normalized_name: &str) 
         .unwrap_or_else(|| fallback_spawn_agent_definition(normalized_name))
 }
 
+fn subagent_role_prompt(kind: SubAgentKind, definition: Option<&AgentDefinition>) -> String {
+    if matches!(kind, SubAgentKind::General) && definition.is_some_and(|d| !d.tools.is_empty()) {
+        return concat!(
+            "## Sub-Agent Role\n",
+            "- You are a custom workspace sub-agent.\n",
+            "- Treat the assigned instruction as the complete task contract.\n",
+            "- Honor every constraint in the assigned instruction, including workspace, branch, network, and output limits.\n",
+            "- Stay inside the current workspace unless the assigned instruction explicitly allows another path.\n",
+            "- Repository inspection is allowed only through the read-only tools exposed to you.\n",
+            "- You may use shared task-list tools to inspect, claim, update, or complete project tasks when they are exposed.\n",
+            "- You do not have shell, editing, patching, browser, or agent-spawning tools in this role.\n",
+            "- If the assigned instruction requires unavailable tools, report the limitation and answer from the available context.\n",
+            "- Do not delegate to another agent or spawn sub-agents; complete the assigned work directly."
+        )
+        .to_string();
+    }
+    kind.append_prompt().to_string()
+}
+
 fn fallback_spawn_agent_definition(name: &str) -> AgentDefinition {
     AgentDefinition {
         token_budget: None,
@@ -1608,7 +1645,11 @@ fn build_filtered_tool_manager(
     task_root: PathBuf,
     default_task_list_id: &str,
 ) -> ToolManager {
-    let mut tm = build_subagent_tool_manager(kind, task_root, default_task_list_id);
+    let mut tm = if matches!(kind, SubAgentKind::General) && !definition.tools.is_empty() {
+        build_custom_spawn_agent_tool_manager(task_root, default_task_list_id)
+    } else {
+        build_subagent_tool_manager(kind, task_root, default_task_list_id)
+    };
 
     if !definition.tools.is_empty() {
         let allowed: std::collections::HashSet<&str> = definition

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
 };
 
@@ -47,6 +47,17 @@ struct PeakBackend {
 struct PlanStateBackend;
 
 struct SlowBackend;
+
+#[derive(Default)]
+struct ObservedModelRequest {
+    messages: Vec<Message>,
+    tool_names: Vec<String>,
+}
+
+struct DefinitionRegressionBackend {
+    calls: Arc<AtomicUsize>,
+    observed: Arc<Mutex<Vec<ObservedModelRequest>>>,
+}
 
 fn mock_embedding_backend() -> Arc<dyn EmbeddingBackend> {
     Arc::new(MockLlm)
@@ -189,6 +200,65 @@ impl LlmBackend for SlowBackend {
 
     async fn summarize(&self, _messages: &[Message], _instruction: &str) -> anyhow::Result<String> {
         Ok("summary".to_string())
+    }
+}
+
+#[async_trait]
+impl LlmBackend for DefinitionRegressionBackend {
+    async fn ask(
+        &self,
+        messages: &[Message],
+        tools: &[serde_json::Value],
+    ) -> anyhow::Result<LlmResponse> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.observed
+            .lock()
+            .expect("observed requests lock")
+            .push(ObservedModelRequest {
+                messages: messages.to_vec(),
+                tool_names: tool_schema_names(tools),
+            });
+        Ok(LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "read-fixture".to_string(),
+                name: "read_file".to_string(),
+                input: json!({ "path": "fixture.txt" }),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: None,
+        })
+    }
+
+    async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0; 4])
+    }
+
+    async fn summarize(&self, _messages: &[Message], _instruction: &str) -> anyhow::Result<String> {
+        Ok("summary".to_string())
+    }
+}
+
+fn tool_schema_names(tools: &[serde_json::Value]) -> Vec<String> {
+    tools
+        .iter()
+        .filter_map(|tool| tool.get("name").and_then(serde_json::Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
+
+fn message_text(message: &Message) -> String {
+    match &message.content {
+        serde_json::Value::String(text) => text.clone(),
+        serde_json::Value::Array(parts) => parts
+            .iter()
+            .filter_map(|part| {
+                part.get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string)
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        value => value.to_string(),
     }
 }
 
@@ -743,6 +813,94 @@ async fn spawn_agent_writes_parent_scoped_sidechain_transcript() {
         Some("parent-session")
     );
     assert!(!child.history.is_empty());
+}
+
+#[tokio::test]
+async fn spawn_agent_definition_affects_prompt_tools_max_turns_and_plan_mode() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().join("workspace");
+    let rara_dir = temp.path().join(".rara-runtime");
+    let agents_dir = root.join(".rara").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("agents dir");
+    std::fs::write(root.join("fixture.txt"), "fixture contents").expect("fixture file");
+    std::fs::write(
+        agents_dir.join("code-reviewer.md"),
+        r#"---
+name: code-reviewer
+description: Reviews code changes
+tools: [Read, Grep]
+disallowedTools: [Bash]
+maxTurns: 1
+planModeRequired: true
+---
+
+Custom reviewer prompt from workspace definition.
+"#,
+    )
+    .expect("agent definition");
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let tool = AgentTool {
+        backend: Arc::new(DefinitionRegressionBackend {
+            calls: calls.clone(),
+            observed: observed.clone(),
+        }),
+        embedding_backend: mock_embedding_backend(),
+        vdb: Arc::new(VectorDB::new(
+            &rara_dir.join("lancedb").display().to_string(),
+        )),
+        session_manager: Arc::new(
+            SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
+        ),
+        workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+        prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
+        background_subagents: Arc::new(BackgroundSubAgentStore::default()),
+    };
+
+    let mut progress = |_| {};
+    let result = tool
+        .call_with_context_events(
+            json!({
+                "name": "Code Reviewer",
+                "instruction": "Inspect fixture.txt and report findings."
+            }),
+            ToolCallContext::default().with_session_id("parent-session"),
+            &mut progress,
+        )
+        .await
+        .expect("spawn_agent result");
+
+    assert_eq!(result["status"], "done");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "maxTurns: 1 should stop after the first tool-calling turn"
+    );
+    let observed = observed.lock().expect("observed requests lock");
+    let request = observed.first().expect("captured model request");
+    let system_prompt = request
+        .messages
+        .iter()
+        .find(|message| message.role == "system")
+        .map(message_text)
+        .expect("system prompt");
+    assert!(system_prompt.contains("Planning mode is active."));
+    assert!(system_prompt.contains("You are a custom workspace sub-agent."));
+    assert!(system_prompt.contains(
+        "Repository inspection is allowed only through the read-only tools exposed to you."
+    ));
+    assert!(!system_prompt.contains("You do not have repository"));
+    assert!(!system_prompt.contains("answer only from the provided instruction/context"));
+    assert!(system_prompt.contains("Custom reviewer prompt from workspace definition."));
+
+    let mut tool_names = request.tool_names.clone();
+    tool_names.sort();
+    assert_eq!(
+        tool_names,
+        vec!["grep".to_string(), "read_file".to_string()]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Add an end-to-end `spawn_agent` regression for workspace `.rara/agents` definitions.
- Verify custom agent definitions affect prompt body, tool schemas, `maxTurns`, and `planModeRequired`.
- Allow custom general `spawn_agent` definitions with explicit tool whitelists to expose read-only repo tools plus shared task tools before filtering.
- Mark the corresponding TODO item complete.

## Purpose

Custom `.rara/agents` definitions were parsed, but the real `spawn_agent` path did not prove that those definitions affected execution. The new regression covers the full tool call path and catches the tool filtering gap for custom general agents.

## Related Issues

None.

## Testing

- `cargo fmt`
- `cargo test spawn_agent_definition_affects_prompt_tools_max_turns_and_plan_mode`
- `cargo test tools::agent::tests`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`
