### PR TITLE
feat(agent): cache agent definitions

### DIFF
--- a/docs/features/subagent-claude-compat.md
+++ b/docs/features/subagent-claude-compat.md
@@ -71,9 +71,9 @@ pub struct AgentDefinition {
 }
 ```
 
-### Loading
+### Loading And Runtime Cache
 
-`load_agent_definitions()` scans:
+`AgentDefinitionCache::load()` scans:
 1. Built-in agents (General, Explore, Plan) — hardcoded in RARA.
 2. `~/.claude/agents/*.md` files in the user home.
 3. `~/.rara/agents/*.md` files in the user home.
@@ -84,6 +84,15 @@ Resolves conflicts by loading lower-precedence roots first. Workspace agents
 override user agents, and `.rara/agents` overrides `.claude/agents` at the same
 scope. Built-in agents are always available as "general", "explore", "plan"
 when no custom definition with the requested name is loaded.
+
+The cache is constructed with the runtime and shared by the `spawn_agent`
+tool and `/status` extension summary. Running `spawn_agent` must resolve
+against the cached registry instead of scanning the filesystem on every call.
+After editing `.rara/agents` or `.claude/agents`, the existing runtime keeps
+its previous snapshot until the runtime is rebuilt. RARA intentionally does
+not expose a dedicated `/reload-agents` command; this follows Claude Code's
+pattern of refreshing agent definitions through existing runtime/plugin
+refresh boundaries rather than adding an agent-only slash command.
 
 ### Subagent Execution Changes
 
@@ -165,7 +174,7 @@ TUI subagent sidebar shows:
 ## Implementation Plan
 
 1. Add `AgentDefinition` struct and YAML parsing.
-2. Add `load_agent_definitions()` scanning `.rara/agents/` with
+2. Add `AgentDefinitionCache::load()` scanning `.rara/agents/` with
    `.claude/agents/` compatibility.
 3. Extend `SubAgentKind` → `AgentDefinition` mapping.
 4. Add tool filtering to subagent spawning.

--- a/docs/journal/2026-07-02-rara-agent-definition-discovery.md
+++ b/docs/journal/2026-07-02-rara-agent-definition-discovery.md
@@ -41,7 +41,7 @@ cargo clippy --locked --workspace --all-targets -- -D warnings
 
 ## Follow-Ups
 
-- Cache agent definitions at runtime construction time and add an explicit
-  reload path.
+- Cache agent definitions at runtime construction time and refresh them through
+  runtime rebuild.
 - Add end-to-end `spawn_agent` coverage for prompt body, tool filtering,
   `maxTurns`, and `planModeRequired`.

--- a/docs/journal/2026-07-03-agent-definition-cache.md
+++ b/docs/journal/2026-07-03-agent-definition-cache.md
@@ -1,0 +1,50 @@
+# Agent Definition Runtime Cache
+
+## Summary
+
+RARA now loads Claude-compatible agent definitions into an
+`AgentDefinitionCache` when the runtime is constructed. `spawn_agent` resolves
+custom agent definitions from that cache, and `/status` derives its imported
+agent summary from the same cached load records.
+
+## Background
+
+The previous implementation could scan `.rara/agents` and `.claude/agents`
+from multiple call sites. That kept execution and status display consistent
+after the parser unification work, but it still left filesystem discovery on
+the hot `spawn_agent` path.
+
+Claude Code keeps agent definitions behind a cache and refreshes that cache
+from broader runtime/plugin refresh boundaries. RARA follows that shape:
+editing an agent definition does not mutate the running session immediately.
+The next runtime rebuild constructs a new cache snapshot.
+
+## Key Decisions
+
+- Keep `.rara/agents` as the preferred workspace path and `.claude/agents` as
+  the compatibility path.
+- Construct `AgentDefinitionCache` during runtime bootstrap and share it with
+  the `AgentTool` and the top-level `Agent`.
+- Resolve `spawn_agent` definitions from the cached registry instead of
+  rescanning the filesystem per spawn.
+- Project `/status` imported-agent lines from cached load records so execution
+  and display cannot drift.
+- Do not add a dedicated `/reload-agents` slash command. Runtime rebuild is the
+  refresh boundary for now, matching the broader Claude Code pattern rather
+  than creating a RARA-only command surface.
+
+## Validation
+
+```bash
+cargo test agent_definition_cache_refreshes_on_new_runtime_cache -- --nocapture
+cargo test spawn_agent_definition_affects_prompt_tools_max_turns_and_plan_mode -- --nocapture
+cargo test agents_ext::tests -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+```
+
+## Follow-Ups
+
+- Implement the remaining Claude-compatible `AgentDefinition` metadata:
+  `token_budget`, `permission_mode`, `hidden`, and description/listing
+  behavior.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,8 +51,9 @@ Active backlog only. Keep this file small and current.
       task store so teams/subagents can coordinate beyond session-local `todo_write`.
 - [x] Unify `.rara/agents` parsing for execution and `/status` discovery so
       `AgentDefinition` and `ImportedAgentProfile` cannot drift.
-- [ ] Cache Claude-style agent definitions at runtime construction time and
-      expose an explicit reload path instead of scanning on each `spawn_agent`.
+- [x] Cache Claude-style agent definitions at runtime construction time and
+      refresh them through runtime rebuild instead of scanning on each
+      `spawn_agent`.
 - [ ] Implement remaining Claude-compatible `AgentDefinition` metadata:
       `token_budget`, `permission_mode`, `hidden`, and description/listing
       behavior.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -49,6 +49,7 @@ use crate::tool_result::{
     default_tool_result_store_dir, enforce_tool_result_batch_budget,
     project_tool_results_for_context, repair_tool_result_history,
 };
+use crate::tools::agent::{AgentDefinitionCache, AgentDefinitionLoadRecord};
 use crate::tools::bash::BashCommandInput;
 use crate::tools::todo::TODO_WRITE_TOOL_NAME;
 use crate::workspace::WorkspaceMemory;
@@ -194,6 +195,7 @@ pub struct Agent {
     pub pending_approval: Option<PendingApproval>,
     pub todo_state: Option<TodoState>,
     pub task_list_id: String,
+    pub agent_definitions: AgentDefinitionCache,
     pub completed_user_input: Option<CompletedInteraction>,
     pub completed_approval: Option<CompletedInteraction>,
     pub approved_bash_prefixes: Vec<String>,
@@ -339,6 +341,7 @@ impl Agent {
             pending_approval: None,
             todo_state: None,
             task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
+            agent_definitions: AgentDefinitionCache::load(root.clone()),
             completed_user_input: None,
             completed_approval: None,
             approved_bash_prefixes: Vec::new(),
@@ -369,6 +372,10 @@ impl Agent {
     pub async fn query(&mut self, prompt: String) -> Result<()> {
         self.query_with_mode(prompt, AgentOutputMode::Terminal)
             .await
+    }
+
+    pub fn agent_definition_records(&self) -> Vec<AgentDefinitionLoadRecord> {
+        self.agent_definitions.records()
     }
 
     pub async fn query_with_mode(

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -261,6 +261,7 @@ impl Agent {
         )
     }
 
+    #[cfg(test)]
     pub fn new_with_embedding_backend(
         tool_manager: ToolManager,
         llm_backend: Arc<dyn LlmBackend>,
@@ -268,6 +269,27 @@ impl Agent {
         vdb: Arc<VectorDB>,
         session_manager: Arc<SessionManager>,
         workspace: Arc<WorkspaceMemory>,
+    ) -> Self {
+        let agent_definitions = AgentDefinitionCache::load(workspace.root.clone());
+        Self::new_with_embedding_backend_and_agent_definitions(
+            tool_manager,
+            llm_backend,
+            embedding_backend,
+            vdb,
+            session_manager,
+            workspace,
+            agent_definitions,
+        )
+    }
+
+    pub fn new_with_embedding_backend_and_agent_definitions(
+        tool_manager: ToolManager,
+        llm_backend: Arc<dyn LlmBackend>,
+        embedding_backend: Arc<dyn EmbeddingBackend>,
+        vdb: Arc<VectorDB>,
+        session_manager: Arc<SessionManager>,
+        workspace: Arc<WorkspaceMemory>,
+        agent_definitions: AgentDefinitionCache,
     ) -> Self {
         let root = workspace.root.clone();
         let memory_store = Arc::new(MemoryStore::new_with_embedding_backend(
@@ -341,7 +363,7 @@ impl Agent {
             pending_approval: None,
             todo_state: None,
             task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
-            agent_definitions: AgentDefinitionCache::load(root.clone()),
+            agent_definitions,
             completed_user_input: None,
             completed_approval: None,
             approved_bash_prefixes: Vec::new(),
@@ -446,6 +468,7 @@ impl Agent {
                     let workspace = self.workspace.clone();
                     let scheduler = self.consolidation_scheduler.clone();
                     let task_list_id = self.task_list_id.clone();
+                    let agent_definitions = self.agent_definitions.clone();
                     std::thread::spawn(move || {
                         let rt = tokio::runtime::Builder::new_current_thread()
                             .enable_all()
@@ -478,6 +501,7 @@ impl Agent {
                                 workspace,
                                 prompt_config,
                                 task_list_id,
+                                agent_definitions,
                             )
                             .await;
                             match result {

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use serde::Serialize;
 
-use crate::tools::agent::{AgentDefinitionLoadRecord, discover_workspace_agent_definition_records};
+use crate::tools::agent::AgentDefinitionLoadRecord;
 
 /// A Claude-compatible imported agent definition, normalised into
 /// a RARA-owned profile object.
@@ -52,11 +52,12 @@ impl AgentRegistry {
         }
     }
 
-    /// Discover agent profiles from a repository root directory.
-    pub fn discover_repo_agents(&mut self, repo_root: &Path) {
-        for record in discover_workspace_agent_definition_records(repo_root) {
-            self.insert_record(record, repo_root);
+    pub fn from_records(records: Vec<AgentDefinitionLoadRecord>, repo_root: &Path) -> Self {
+        let mut registry = Self::new();
+        for record in records {
+            registry.insert_record(record, repo_root);
         }
+        registry
     }
 
     /// For /context and /status: list each discovered agent with path and status.
@@ -122,6 +123,13 @@ mod tests {
 
     use super::*;
 
+    fn discover_repo_agents(repo_root: &Path) -> AgentRegistry {
+        AgentRegistry::from_records(
+            crate::tools::agent::discover_workspace_agent_definition_records(repo_root),
+            repo_root,
+        )
+    }
+
     #[test]
     fn discovers_agents_from_directory() {
         let dir = tempdir().expect("tempdir");
@@ -152,8 +160,7 @@ Generate unit tests for new code paths.
         )
         .expect("write");
 
-        let mut registry = AgentRegistry::new();
-        registry.discover_repo_agents(dir.path());
+        let registry = discover_repo_agents(dir.path());
 
         assert_eq!(registry.agents.len(), 2);
 
@@ -172,8 +179,7 @@ Generate unit tests for new code paths.
         fs::create_dir_all(&agents_dir).expect("mkdir");
         fs::write(agents_dir.join("empty.md"), "").expect("write");
 
-        let mut registry = AgentRegistry::new();
-        registry.discover_repo_agents(dir.path());
+        let registry = discover_repo_agents(dir.path());
 
         let agent = registry.agents.get("empty").expect("empty agent");
         assert_eq!(agent.parse_status, AgentParseStatus::ParseError);
@@ -210,8 +216,7 @@ RARA prompt.
         )
         .expect("write");
 
-        let mut registry = AgentRegistry::new();
-        registry.discover_repo_agents(dir.path());
+        let registry = discover_repo_agents(dir.path());
 
         let agent = registry.agents.get("helper").expect("helper");
         assert_eq!(agent.label, "helper");
@@ -237,8 +242,7 @@ Review prompt.
         )
         .expect("write");
 
-        let mut registry = AgentRegistry::new();
-        registry.discover_repo_agents(dir.path());
+        let registry = discover_repo_agents(dir.path());
 
         assert!(!registry.agents.contains_key("reviewer-file"));
         let agent = registry

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -34,6 +34,7 @@ use crate::sandbox::SandboxManager;
 use crate::session::SessionManager;
 use crate::shell_env::capture_shell_environment_snapshot;
 use crate::skill::SkillScope;
+use crate::tools::agent::AgentDefinitionCache;
 use crate::tui::state::GoalHandle;
 use crate::workspace::WorkspaceMemory;
 
@@ -55,6 +56,7 @@ pub(crate) struct RuntimeBootstrap {
     pub mcp_tool_cache: McpToolCache,
     pub mcp_manager: Arc<McpConnectionManager>,
     pub lsp_manager: Arc<LspManager>,
+    pub agent_definitions: AgentDefinitionCache,
 }
 
 impl RuntimeBootstrap {
@@ -88,6 +90,7 @@ impl RuntimeBootstrap {
             self.session_manager,
             self.workspace,
         );
+        agent.agent_definitions = self.agent_definitions;
         agent.set_prompt_config(self.prompt_config);
         agent.set_prompt_source_registry(self.prompt_source_registry.clone());
         agent.set_skill_source_registry(self.skill_source_registry.clone());
@@ -215,6 +218,7 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
             body: format!("## {}\n\n{}", h.phase.as_str(), h.body),
         })
         .collect();
+    let agent_definitions = AgentDefinitionCache::load(workspace.root.clone());
     let tool_manager = create_full_tool_manager(
         backend.clone(),
         embedding_backend.clone(),
@@ -229,6 +233,7 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
         goal_handle.clone(),
         mcp_tool_cache.clone(),
         lsp_manager.clone(),
+        agent_definitions.clone(),
     );
     let mut warnings = prompt_config.warnings.clone();
     warnings.extend(embedding_warnings);
@@ -251,6 +256,7 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
         mcp_tool_cache,
         mcp_manager,
         lsp_manager,
+        agent_definitions,
     })
 }
 

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -82,15 +82,15 @@ impl RuntimeBootstrap {
         Arc<HookRegistry>,
         Arc<LspManager>,
     ) {
-        let mut agent = Agent::new_with_embedding_backend(
+        let mut agent = Agent::new_with_embedding_backend_and_agent_definitions(
             self.tool_manager,
             self.backend,
             self.embedding_backend,
             self.vdb,
             self.session_manager,
             self.workspace,
+            self.agent_definitions,
         );
-        agent.agent_definitions = self.agent_definitions;
         agent.set_prompt_config(self.prompt_config);
         agent.set_prompt_source_registry(self.prompt_source_registry.clone());
         agent.set_skill_source_registry(self.skill_source_registry.clone());

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -188,7 +188,7 @@ pub(super) fn create_full_tool_manager(
         prompt_config: prompt_config.clone(),
         background_subagents: background_subagents.clone(),
         task_list_id: task_list_id.clone(),
-        agent_definitions,
+        agent_definitions: agent_definitions.clone(),
     }));
     tm.register(Box::new(ExploreAgentTool {
         backend: backend.clone(),
@@ -199,6 +199,7 @@ pub(super) fn create_full_tool_manager(
         prompt_config: prompt_config.clone(),
         background_subagents: background_subagents.clone(),
         task_list_id: task_list_id.clone(),
+        agent_definitions: agent_definitions.clone(),
     }));
     tm.register(Box::new(PlanAgentTool {
         backend: backend.clone(),
@@ -209,6 +210,7 @@ pub(super) fn create_full_tool_manager(
         prompt_config: prompt_config.clone(),
         background_subagents: background_subagents.clone(),
         task_list_id: task_list_id.clone(),
+        agent_definitions: agent_definitions.clone(),
     }));
     tm.register(Box::new(TeamCreateTool {
         backend,
@@ -218,6 +220,7 @@ pub(super) fn create_full_tool_manager(
         workspace,
         prompt_config,
         task_list_id,
+        agent_definitions,
     }));
     tm.register(Box::new(SubAgentResumeTool {
         background_subagents: background_subagents.clone(),

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -25,8 +25,8 @@ use crate::skill::SkillManager;
 use crate::tasklist::DEFAULT_TASK_LIST_ID;
 use crate::tasklist::TaskListStore;
 use crate::tools::agent::{
-    AgentTool, BackgroundSubAgentStore, ExploreAgentTool, PlanAgentTool, SubAgentListTool,
-    SubAgentResumeTool, SubAgentStopTool, TeamCreateTool,
+    AgentDefinitionCache, AgentTool, BackgroundSubAgentStore, ExploreAgentTool, PlanAgentTool,
+    SubAgentListTool, SubAgentResumeTool, SubAgentStopTool, TeamCreateTool,
 };
 use crate::tools::bash::BashTool;
 use crate::tools::context::RetrieveSessionContextTool;
@@ -65,6 +65,7 @@ pub(super) fn create_full_tool_manager(
     goal_handle: GoalHandle,
     mcp_tool_cache: McpToolCache,
     lsp_manager: Arc<LspManager>,
+    agent_definitions: AgentDefinitionCache,
 ) -> ToolManager {
     let mut tm = ToolManager::new();
     let vector_db_uri = vector_db_uri_for_workspace(&workspace);
@@ -187,6 +188,7 @@ pub(super) fn create_full_tool_manager(
         prompt_config: prompt_config.clone(),
         background_subagents: background_subagents.clone(),
         task_list_id: task_list_id.clone(),
+        agent_definitions,
     }));
     tm.register(Box::new(ExploreAgentTool {
         backend: backend.clone(),

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{
-    Arc, Mutex,
+    Arc, Mutex, RwLock,
     atomic::{AtomicBool, Ordering},
 };
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -286,6 +286,7 @@ pub struct AgentTool {
     pub prompt_config: PromptRuntimeConfig,
     pub background_subagents: Arc<BackgroundSubAgentStore>,
     pub task_list_id: String,
+    pub agent_definitions: AgentDefinitionCache,
 }
 
 #[tool_spec(
@@ -340,7 +341,7 @@ impl AgentTool {
             .as_str()
             .ok_or(ToolError::InvalidInput("instruction".into()))?;
         let agent_id = next_subagent_id(SubAgentKind::General, Some(name));
-        let definition = resolve_spawn_agent_definition(&self.workspace.root, &agent_label);
+        let definition = resolve_spawn_agent_definition(&self.agent_definitions, &agent_label);
         if i.get("run_in_background")
             .and_then(Value::as_bool)
             .unwrap_or(false)
@@ -1598,9 +1599,12 @@ fn resolve_kind_definition(kind: SubAgentKind) -> AgentDefinition {
     })
 }
 
-fn resolve_spawn_agent_definition(workspace_root: &Path, normalized_name: &str) -> AgentDefinition {
-    let registry = load_agent_definitions(workspace_root);
-    resolve_agent(normalized_name, &registry)
+fn resolve_spawn_agent_definition(
+    cache: &AgentDefinitionCache,
+    normalized_name: &str,
+) -> AgentDefinition {
+    cache
+        .resolve(normalized_name)
         .unwrap_or_else(|| fallback_spawn_agent_definition(normalized_name))
 }
 

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{
-    Arc, Mutex, RwLock,
+    Arc, Mutex,
     atomic::{AtomicBool, Ordering},
 };
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -360,6 +360,7 @@ impl AgentTool {
                 workspace: self.workspace.clone(),
                 prompt_config: self.prompt_config.clone(),
                 task_list_id: self.task_list_id.clone(),
+                agent_definitions: self.agent_definitions.clone(),
             })?;
             return Ok(task.to_json());
         }
@@ -379,6 +380,7 @@ impl AgentTool {
             self.workspace.clone(),
             self.prompt_config.clone(),
             self.task_list_id.clone(),
+            self.agent_definitions.clone(),
         )
         .await?;
         Ok(json!({
@@ -407,6 +409,7 @@ pub struct ExploreAgentTool {
     pub prompt_config: PromptRuntimeConfig,
     pub background_subagents: Arc<BackgroundSubAgentStore>,
     pub task_list_id: String,
+    pub agent_definitions: AgentDefinitionCache,
 }
 
 #[tool_spec(
@@ -470,6 +473,7 @@ impl ExploreAgentTool {
                 workspace: self.workspace.clone(),
                 prompt_config: self.prompt_config.clone(),
                 task_list_id: self.task_list_id.clone(),
+                agent_definitions: self.agent_definitions.clone(),
             })?;
             return Ok(task.to_json());
         }
@@ -489,6 +493,7 @@ impl ExploreAgentTool {
             self.workspace.clone(),
             self.prompt_config.clone(),
             self.task_list_id.clone(),
+            self.agent_definitions.clone(),
         )
         .await?;
         Ok(json!({
@@ -516,6 +521,7 @@ pub struct PlanAgentTool {
     pub prompt_config: PromptRuntimeConfig,
     pub background_subagents: Arc<BackgroundSubAgentStore>,
     pub task_list_id: String,
+    pub agent_definitions: AgentDefinitionCache,
 }
 
 #[tool_spec(
@@ -579,6 +585,7 @@ impl PlanAgentTool {
                 workspace: self.workspace.clone(),
                 prompt_config: self.prompt_config.clone(),
                 task_list_id: self.task_list_id.clone(),
+                agent_definitions: self.agent_definitions.clone(),
             })?;
             return Ok(task.to_json());
         }
@@ -598,6 +605,7 @@ impl PlanAgentTool {
             self.workspace.clone(),
             self.prompt_config.clone(),
             self.task_list_id.clone(),
+            self.agent_definitions.clone(),
         )
         .await?;
         Ok(json!({
@@ -629,6 +637,7 @@ pub struct TeamCreateTool {
     pub workspace: Arc<WorkspaceMemory>,
     pub prompt_config: PromptRuntimeConfig,
     pub task_list_id: String,
+    pub agent_definitions: AgentDefinitionCache,
 }
 
 const BACKGROUND_SUBAGENT_COMPLETED_RETENTION: usize = 64;
@@ -658,6 +667,7 @@ struct BackgroundSubAgentStart {
     workspace: Arc<WorkspaceMemory>,
     prompt_config: PromptRuntimeConfig,
     task_list_id: String,
+    agent_definitions: AgentDefinitionCache,
 }
 
 #[derive(Clone, Debug)]
@@ -740,6 +750,7 @@ impl BackgroundSubAgentStore {
                 start.workspace,
                 start.prompt_config,
                 start.task_list_id,
+                start.agent_definitions,
             )
             .await;
             store.finish(&agent_id, result);
@@ -1060,6 +1071,7 @@ impl TeamCreateTool {
             let workspace = self.workspace.clone();
             let prompt_config = self.prompt_config.clone();
             let task_list_id = self.task_list_id.clone();
+            let agent_definitions = self.agent_definitions.clone();
             let parent_session_id = parent_session_id.map(str::to_string);
             let agent_id = next_subagent_id(task.kind, Some(&task.name));
 
@@ -1080,6 +1092,7 @@ impl TeamCreateTool {
                     workspace,
                     prompt_config,
                     task_list_id,
+                    agent_definitions,
                 )
                 .await?;
                 Ok::<_, ToolError>(serialize_team_result(&task.name, result))
@@ -1134,19 +1147,21 @@ pub(crate) async fn run_sub_agent(
     workspace: Arc<WorkspaceMemory>,
     prompt_config: PromptRuntimeConfig,
     task_list_id: String,
+    agent_definitions: AgentDefinitionCache,
 ) -> Result<SubAgentResult, ToolError> {
     let tool_manager = if let Some(def) = definition {
         build_filtered_tool_manager(kind, def, workspace.rara_dir.join("tasks"), &task_list_id)
     } else {
         build_subagent_tool_manager(kind, workspace.rara_dir.join("tasks"), &task_list_id)
     };
-    let mut sub = Agent::new_with_embedding_backend(
+    let mut sub = Agent::new_with_embedding_backend_and_agent_definitions(
         tool_manager,
         backend,
         embedding_backend,
         vdb,
         session_manager.clone(),
         workspace.clone(),
+        agent_definitions,
     );
     if let Some(session_id) = session_id {
         sub.session_id = session_id;

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -73,7 +73,7 @@ struct AgentDefinitionCacheState {
 /// `.claude/agents`.
 #[derive(Clone, Debug)]
 pub struct AgentDefinitionCache {
-    state: Arc<RwLock<AgentDefinitionCacheState>>,
+    state: Arc<AgentDefinitionCacheState>,
 }
 
 impl AgentDefinitionCache {
@@ -81,27 +81,28 @@ impl AgentDefinitionCache {
         let workspace_root = workspace_root.into();
         let state = load_agent_definition_cache_state(&workspace_root);
         Self {
-            state: Arc::new(RwLock::new(state)),
+            state: Arc::new(state),
         }
     }
 
     pub fn resolve(&self, name: &str) -> Option<AgentDefinition> {
-        match self.state.read() {
-            Ok(state) => resolve_agent(name, &state.registry),
-            Err(err) => {
-                log::warn!("failed to read agent definition cache: {err}");
-                builtin_agent_definition(name)
-            }
-        }
+        resolve_agent(name, &self.state.registry)
     }
 
     pub fn records(&self) -> Vec<AgentDefinitionLoadRecord> {
-        match self.state.read() {
-            Ok(state) => state.records.clone(),
-            Err(err) => {
-                log::warn!("failed to read agent definition cache records: {err}");
-                Vec::new()
+        self.state.records.clone()
+    }
+
+    #[cfg(test)]
+    pub fn from_records_for_test(records: Vec<AgentDefinitionLoadRecord>) -> Self {
+        let mut registry = AgentRegistry::new();
+        for record in &records {
+            if let Some(definition) = &record.definition {
+                registry.insert(definition.name.clone(), definition.clone());
             }
+        }
+        Self {
+            state: Arc::new(AgentDefinitionCacheState { registry, records }),
         }
     }
 }
@@ -118,10 +119,7 @@ fn load_agent_definition_cache_state(workspace_root: &Path) -> AgentDefinitionCa
                 log::warn!(
                     "failed to load agent definition {}: {}",
                     record.source_path.display(),
-                    record
-                        .error
-                        .clone()
-                        .unwrap_or_else(|| "parse error".to_string())
+                    record.error.as_deref().unwrap_or("parse error")
                 );
             }
         }

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -60,34 +60,73 @@ pub struct AgentDefinitionLoadRecord {
     pub error: Option<String>,
 }
 
-/// Load Claude-compatible agent definitions from RARA and compatibility roots.
-///
-/// Each .md file must contain a YAML frontmatter block delimited by `---`.
-/// The body after the closing `---` becomes `AgentDefinition::system_prompt`.
-///
-/// Built-in agents (general/explore/plan) are always available and do not
-/// require an agent definition file. Custom definitions can override built-in
-/// names or define net new agents. RARA-native `.rara/agents` roots take
-/// precedence over legacy Claude `.claude/agents` compatibility roots.
-pub fn load_agent_definitions(workspace_root: &Path) -> AgentRegistry {
-    let mut registry = AgentRegistry::new();
+#[derive(Clone, Debug)]
+struct AgentDefinitionCacheState {
+    registry: AgentRegistry,
+    records: Vec<AgentDefinitionLoadRecord>,
+}
 
-    for record in discover_agent_definition_records(workspace_root) {
-        match record.definition {
+/// Shared runtime cache for Claude-compatible agent definitions.
+///
+/// A cache is loaded once when the runtime agent is constructed. Rebuilding the
+/// runtime constructs a new cache after editing `.rara/agents` or
+/// `.claude/agents`.
+#[derive(Clone, Debug)]
+pub struct AgentDefinitionCache {
+    state: Arc<RwLock<AgentDefinitionCacheState>>,
+}
+
+impl AgentDefinitionCache {
+    pub fn load(workspace_root: impl Into<PathBuf>) -> Self {
+        let workspace_root = workspace_root.into();
+        let state = load_agent_definition_cache_state(&workspace_root);
+        Self {
+            state: Arc::new(RwLock::new(state)),
+        }
+    }
+
+    pub fn resolve(&self, name: &str) -> Option<AgentDefinition> {
+        match self.state.read() {
+            Ok(state) => resolve_agent(name, &state.registry),
+            Err(err) => {
+                log::warn!("failed to read agent definition cache: {err}");
+                builtin_agent_definition(name)
+            }
+        }
+    }
+
+    pub fn records(&self) -> Vec<AgentDefinitionLoadRecord> {
+        match self.state.read() {
+            Ok(state) => state.records.clone(),
+            Err(err) => {
+                log::warn!("failed to read agent definition cache records: {err}");
+                Vec::new()
+            }
+        }
+    }
+}
+
+fn load_agent_definition_cache_state(workspace_root: &Path) -> AgentDefinitionCacheState {
+    let records = discover_agent_definition_records(workspace_root);
+    let mut registry = AgentRegistry::new();
+    for record in &records {
+        match &record.definition {
             Some(definition) => {
-                registry.insert(definition.name.clone(), definition);
+                registry.insert(definition.name.clone(), definition.clone());
             }
             None => {
                 log::warn!(
                     "failed to load agent definition {}: {}",
                     record.source_path.display(),
-                    record.error.unwrap_or_else(|| "parse error".to_string())
+                    record
+                        .error
+                        .clone()
+                        .unwrap_or_else(|| "parse error".to_string())
                 );
             }
         }
     }
-
-    registry
+    AgentDefinitionCacheState { registry, records }
 }
 
 pub fn discover_agent_definition_records(workspace_root: &Path) -> Vec<AgentDefinitionLoadRecord> {
@@ -98,6 +137,7 @@ pub fn discover_agent_definition_records(workspace_root: &Path) -> Vec<AgentDefi
     records
 }
 
+#[cfg(test)]
 pub fn discover_workspace_agent_definition_records(
     workspace_root: &Path,
 ) -> Vec<AgentDefinitionLoadRecord> {

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -412,6 +412,7 @@ async fn team_create_runs_real_subagents_in_order() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -466,6 +467,7 @@ async fn team_create_validates_all_tasks_before_running_subagents() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -508,6 +510,7 @@ async fn team_create_rejects_non_string_kind_before_running_subagents() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -549,6 +552,7 @@ async fn team_create_rejects_unstable_explicit_name_before_running_subagents() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -629,6 +633,7 @@ async fn team_create_limits_concurrent_subagents() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -665,6 +670,7 @@ async fn team_create_writes_parent_scoped_sidechain_transcripts() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -928,6 +934,7 @@ async fn background_subagent_resume_returns_completed_summary_without_inline_sid
             &rara_dir.join("lancedb").display().to_string(),
         )),
         session_manager,
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -1001,6 +1008,7 @@ async fn background_subagent_stop_marks_running_task_cancelled() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -1097,9 +1105,10 @@ async fn background_plan_agent_resume_returns_plan_state() {
             &rara_dir.join("lancedb").display().to_string(),
         )),
         session_manager: Arc::new(
-            SessionManager::new_for_rara_dir(rara_dir).expect("session manager"),
+            SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
-        workspace: Arc::new(WorkspaceMemory::from_paths(root, temp.path().join(".rara"))),
+        agent_definitions: test_agent_definition_cache(&root),
+        workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
         background_subagents: background_subagents.clone(),
@@ -1157,6 +1166,7 @@ async fn plan_agent_writes_parent_scoped_sidechain_transcript() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -1234,6 +1244,7 @@ async fn subagent_without_parent_context_does_not_write_sidechain() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -1279,6 +1290,7 @@ async fn subagent_returns_result_when_sidechain_persistence_fails() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
@@ -1325,6 +1337,7 @@ async fn team_create_rejects_too_many_tasks() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
+        agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -15,12 +15,12 @@ use tempfile::tempdir;
 use tokio::time::{Duration, sleep};
 
 use super::{
-    AgentDefinition, BACKGROUND_SUBAGENT_COMPLETED_RETENTION, BackgroundSubAgentRecord,
-    BackgroundSubAgentStore, SubAgentKind, SubagentProgress, TEAM_CREATE_CONCURRENCY_LIMIT,
-    append_subagent_prompt, build_filtered_tool_manager, build_read_only_tool_manager,
-    build_subagent_tool_manager, home_dir_from_vars, latest_assistant_text_from_history,
-    parse_team_task_kind, resolve_kind_definition, resolve_spawn_agent_definition,
-    validate_agent_id_label,
+    AgentDefinition, AgentDefinitionCache, BACKGROUND_SUBAGENT_COMPLETED_RETENTION,
+    BackgroundSubAgentRecord, BackgroundSubAgentStore, SubAgentKind, SubagentProgress,
+    TEAM_CREATE_CONCURRENCY_LIMIT, append_subagent_prompt, build_filtered_tool_manager,
+    build_read_only_tool_manager, build_subagent_tool_manager, home_dir_from_vars,
+    latest_assistant_text_from_history, parse_team_task_kind, resolve_kind_definition,
+    resolve_spawn_agent_definition, validate_agent_id_label,
 };
 use crate::agent::Message;
 use crate::llm::{ContentBlock, EmbeddingBackend, LlmBackend, LlmResponse, MockLlm};
@@ -73,6 +73,10 @@ fn test_task_store() -> Arc<TaskListStore> {
 
 fn test_task_list_id() -> String {
     DEFAULT_TASK_LIST_ID.to_string()
+}
+
+fn test_agent_definition_cache(root: &std::path::Path) -> AgentDefinitionCache {
+    AgentDefinitionCache::load(root)
 }
 
 fn record_peak(current: usize, peak: &AtomicUsize) {
@@ -585,10 +589,11 @@ async fn spawn_agent_rejects_name_that_normalizes_empty_before_running_subagent(
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
-        workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+        workspace: Arc::new(WorkspaceMemory::from_paths(root.clone(), rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
         background_subagents: Arc::new(BackgroundSubAgentStore::default()),
+        agent_definitions: test_agent_definition_cache(&root),
     };
 
     let err = tool
@@ -750,10 +755,11 @@ async fn spawn_agent_writes_parent_scoped_sidechain_transcript() {
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
-        workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
+        workspace: Arc::new(WorkspaceMemory::from_paths(root.clone(), rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
         background_subagents: Arc::new(BackgroundSubAgentStore::default()),
+        agent_definitions: test_agent_definition_cache(&root),
     };
 
     let mut progress = |_| {};
@@ -853,10 +859,11 @@ Custom reviewer prompt from workspace definition.
         session_manager: Arc::new(
             SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
         ),
-        workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+        workspace: Arc::new(WorkspaceMemory::from_paths(root.clone(), rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
         task_list_id: test_task_list_id(),
         background_subagents: Arc::new(BackgroundSubAgentStore::default()),
+        agent_definitions: test_agent_definition_cache(&root),
     };
 
     let mut progress = |_| {};
@@ -1472,14 +1479,16 @@ fn resolve_kind_definition_explore_no_plan_mode() {
 #[test]
 fn resolve_spawn_agent_definition_resolves_builtin() {
     let temp = tempdir().expect("tempdir");
-    let def = resolve_spawn_agent_definition(temp.path(), "explore");
+    let cache = test_agent_definition_cache(temp.path());
+    let def = resolve_spawn_agent_definition(&cache, "explore");
     assert_eq!(def.name, "explore");
 }
 
 #[test]
 fn resolve_spawn_agent_definition_falls_back_for_unknown() {
     let temp = tempdir().expect("tempdir");
-    let def = resolve_spawn_agent_definition(temp.path(), "unknown-agent");
+    let cache = test_agent_definition_cache(temp.path());
+    let def = resolve_spawn_agent_definition(&cache, "unknown-agent");
     assert_eq!(def.name, "unknown-agent");
     assert!(!def.plan_mode_required);
 }
@@ -1505,7 +1514,8 @@ Review the assigned change and report concrete findings.
     )
     .expect("agent definition");
 
-    let def = resolve_spawn_agent_definition(temp.path(), "code-reviewer");
+    let cache = test_agent_definition_cache(temp.path());
+    let def = resolve_spawn_agent_definition(&cache, "code-reviewer");
 
     assert_eq!(def.name, "code-reviewer");
     assert_eq!(def.description, "Reviews code changes");
@@ -1549,7 +1559,8 @@ RARA prompt.
     )
     .expect("rara agent definition");
 
-    let def = resolve_spawn_agent_definition(temp.path(), "helper");
+    let cache = test_agent_definition_cache(temp.path());
+    let def = resolve_spawn_agent_definition(&cache, "helper");
 
     assert_eq!(def.description, "RARA helper");
     assert_eq!(def.tools, vec!["Read", "Grep"]);
@@ -1572,7 +1583,8 @@ Review the change.
     )
     .expect("agent definition");
 
-    let def = resolve_spawn_agent_definition(temp.path(), "reviewer");
+    let cache = test_agent_definition_cache(temp.path());
+    let def = resolve_spawn_agent_definition(&cache, "reviewer");
 
     assert_eq!(def.name, "reviewer");
     assert_eq!(def.description, "");
@@ -1595,12 +1607,54 @@ Help with the task.
     )
     .expect("agent definition");
 
-    let def = resolve_spawn_agent_definition(temp.path(), "helper");
+    let cache = test_agent_definition_cache(temp.path());
+    let def = resolve_spawn_agent_definition(&cache, "helper");
 
     assert_eq!(def.name, "helper");
     assert_eq!(def.description, "");
     assert!(def.tools.is_empty());
     assert_eq!(def.system_prompt, "Help with the task.");
+}
+
+#[test]
+fn agent_definition_cache_refreshes_on_new_runtime_cache() {
+    let temp = tempdir().expect("tempdir");
+    let agents_dir = temp.path().join(".rara").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("agents dir");
+    std::fs::write(
+        agents_dir.join("helper.md"),
+        r#"---
+name: helper
+description: Initial helper
+---
+
+Initial prompt.
+"#,
+    )
+    .expect("agent definition");
+    let cache = test_agent_definition_cache(temp.path());
+    let first = resolve_spawn_agent_definition(&cache, "helper");
+    assert_eq!(first.description, "Initial helper");
+
+    std::fs::write(
+        agents_dir.join("helper.md"),
+        r#"---
+name: helper
+description: Reloaded helper
+---
+
+Reloaded prompt.
+"#,
+    )
+    .expect("updated agent definition");
+
+    let stale = resolve_spawn_agent_definition(&cache, "helper");
+    assert_eq!(stale.description, "Initial helper");
+
+    let reloaded_cache = test_agent_definition_cache(temp.path());
+    let reloaded = resolve_spawn_agent_definition(&reloaded_cache, "helper");
+    assert_eq!(reloaded.description, "Reloaded helper");
+    assert_eq!(reloaded.system_prompt, "Reloaded prompt.");
 }
 
 #[test]
@@ -1630,7 +1684,8 @@ Review the assigned change.
     .expect("agent definition");
 
     let label = validate_agent_id_label("Code Reviewer").expect("label");
-    let def = resolve_spawn_agent_definition(temp.path(), &label);
+    let cache = test_agent_definition_cache(temp.path());
+    let def = resolve_spawn_agent_definition(&cache, &label);
 
     assert_eq!(label, "code-reviewer");
     assert_eq!(def.name, "code-reviewer");

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -218,8 +218,12 @@ fn discover_extension_counts(cwd: &str, agent: &Agent) -> (usize, usize, Vec<Str
     let root = std::path::Path::new(cwd);
     let mut hook_registry = crate::hooks::HookRegistry::new();
     hook_registry.discover_repo_hooks(root);
-    let agent_registry =
-        crate::agents_ext::AgentRegistry::from_records(agent.agent_definition_records(), root);
+    let records = agent
+        .agent_definition_records()
+        .into_iter()
+        .filter(|record| record.source_path.starts_with(root))
+        .collect();
+    let agent_registry = crate::agents_ext::AgentRegistry::from_records(records, root);
     let agent_count = agent_registry.agents.len();
     let agent_status_lines = if agent_count == 0 {
         Vec::new()

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -108,7 +108,7 @@ impl TuiApp {
                 interaction.source.as_deref(),
             );
         }
-        let ext_counts = discover_extension_counts(&runtime_context.cwd);
+        let ext_counts = discover_extension_counts(&runtime_context.cwd, agent);
         let runtime_hook_count = self
             .hook_runtime
             .as_ref()
@@ -214,12 +214,12 @@ impl TuiApp {
     }
 }
 
-fn discover_extension_counts(cwd: &str) -> (usize, usize, Vec<String>) {
+fn discover_extension_counts(cwd: &str, agent: &Agent) -> (usize, usize, Vec<String>) {
     let root = std::path::Path::new(cwd);
     let mut hook_registry = crate::hooks::HookRegistry::new();
-    let mut agent_registry = crate::agents_ext::AgentRegistry::new();
     hook_registry.discover_repo_hooks(root);
-    agent_registry.discover_repo_agents(root);
+    let agent_registry =
+        crate::agents_ext::AgentRegistry::from_records(agent.agent_definition_records(), root);
     let agent_count = agent_registry.agents.len();
     let agent_status_lines = if agent_count == 0 {
         Vec::new()

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -16,6 +16,7 @@ use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
 use crate::config::{DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL};
 use crate::llm::MockLlm;
 use crate::session::SessionManager;
+use crate::tools::agent::{AgentDefinitionCache, AgentDefinitionLoadRecord};
 use crate::tools::bash::BashCommandInput;
 use crate::tui::command::palette_commands;
 use crate::workspace::WorkspaceMemory;
@@ -332,6 +333,60 @@ Reloaded prompt.
             .extension_agent_status_lines
             .iter()
             .any(|line| line.contains("status-cache-after"))
+    );
+}
+
+#[test]
+fn sync_snapshot_counts_only_repo_agent_definition_records() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path().join("workspace");
+    let rara_dir = root.join(".rara");
+    std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+    std::fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+    let home_root = dir.path().join("home");
+    let mut app = TuiApp::new(ConfigManager {
+        path: root.join("config.json"),
+    })
+    .expect("app");
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        std::sync::Arc::new(MockLlm),
+        std::sync::Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        std::sync::Arc::new(SessionManager {
+            storage_dir: rara_dir.join("rollouts"),
+            legacy_storage_dir: rara_dir.join("sessions"),
+        }),
+        std::sync::Arc::new(WorkspaceMemory::from_paths(root.clone(), rara_dir)),
+    );
+    agent.agent_definitions = AgentDefinitionCache::from_records_for_test(vec![
+        AgentDefinitionLoadRecord {
+            id: "repo-agent".to_string(),
+            source_path: root.join(".rara").join("agents").join("repo-agent.md"),
+            definition: None,
+            error: Some("parse error".to_string()),
+        },
+        AgentDefinitionLoadRecord {
+            id: "home-agent".to_string(),
+            source_path: home_root.join(".rara").join("agents").join("home-agent.md"),
+            definition: None,
+            error: Some("parse error".to_string()),
+        },
+    ]);
+
+    app.sync_snapshot(&agent);
+
+    assert_eq!(app.snapshot.extension_agent_count, 1);
+    assert!(
+        app.snapshot
+            .extension_agent_status_lines
+            .iter()
+            .any(|line| line.contains("repo-agent"))
+    );
+    assert!(
+        !app.snapshot
+            .extension_agent_status_lines
+            .iter()
+            .any(|line| line.contains("home-agent"))
     );
 }
 

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -270,6 +270,72 @@ async fn sync_snapshot_reports_registered_runtime_hooks() {
 }
 
 #[test]
+fn sync_snapshot_uses_cached_agent_definition_records() {
+    let dir = tempdir().expect("tempdir");
+    let root = dir.path().to_path_buf();
+    let rara_dir = root.join(".rara");
+    std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+    std::fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+    let agents_dir = rara_dir.join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("agents");
+    let agent_path = agents_dir.join("status-cache-test.md");
+    std::fs::write(
+        &agent_path,
+        r#"---
+name: status-cache-before
+description: Cached before sync.
+---
+
+Cached prompt.
+"#,
+    )
+    .expect("agent definition");
+    let mut app = TuiApp::new(ConfigManager {
+        path: root.join("config.json"),
+    })
+    .expect("app");
+    let agent = Agent::new(
+        ToolManager::new(),
+        std::sync::Arc::new(MockLlm),
+        std::sync::Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        std::sync::Arc::new(SessionManager {
+            storage_dir: rara_dir.join("rollouts"),
+            legacy_storage_dir: rara_dir.join("sessions"),
+        }),
+        std::sync::Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+    );
+    std::fs::write(
+        &agent_path,
+        r#"---
+name: status-cache-after
+description: Should require a runtime rebuild.
+---
+
+Reloaded prompt.
+"#,
+    )
+    .expect("updated agent definition");
+
+    app.sync_snapshot(&agent);
+
+    assert!(
+        app.snapshot
+            .extension_agent_status_lines
+            .iter()
+            .any(|line| {
+                line.contains("status-cache-before")
+                    && line.contains(".rara/agents/status-cache-test.md")
+            })
+    );
+    assert!(
+        !app.snapshot
+            .extension_agent_status_lines
+            .iter()
+            .any(|line| line.contains("status-cache-after"))
+    );
+}
+
+#[test]
 fn parse_repo_slug_supports_common_github_remote_forms() {
     assert_eq!(
         parse_repo_slug("git@github.com:hawkingrei/rara.git").as_deref(),


### PR DESCRIPTION
## Summary

- cache Claude-compatible agent definitions at runtime construction time
- resolve `spawn_agent` from the shared runtime cache instead of scanning per call
- derive `/status` imported-agent lines from cached load records
- document the runtime rebuild refresh boundary and close the TODO item

## Purpose

This follows the Claude Code shape more closely: agent definitions are cached
inside the runtime and refreshed through broader runtime rebuild boundaries,
without adding a RARA-only `/reload-agents` slash command.

## Related Issue

None.

## Testing

```bash
cargo test agent_definition_cache_refreshes_on_new_runtime_cache -- --nocapture
cargo test spawn_agent_definition_affects_prompt_tools_max_turns_and_plan_mode -- --nocapture
cargo test agents_ext::tests -- --nocapture
cargo test sync_snapshot_uses_cached_agent_definition_records -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets -- -D warnings
git diff --check
```
