### PR TITLE
feat(agent): apply agent definition status metadata

### DIFF
--- a/docs/features/subagent-claude-compat.md
+++ b/docs/features/subagent-claude-compat.md
@@ -94,6 +94,11 @@ not expose a dedicated `/reload-agents` command; this follows Claude Code's
 pattern of refreshing agent definitions through existing runtime/plugin
 refresh boundaries rather than adding an agent-only slash command.
 
+The `/status` extension summary only lists repo-local agent definition records.
+Definitions with `hidden: true` are omitted from listing/status surfaces while
+remaining valid for direct `spawn_agent` resolution. Visible definitions include
+their frontmatter `description` in the status line when present.
+
 ### Subagent Execution Changes
 
 **Before** (current):

--- a/docs/journal/2026-07-03-agent-definition-status-metadata.md
+++ b/docs/journal/2026-07-03-agent-definition-status-metadata.md
@@ -1,0 +1,29 @@
+# Agent Definition Status Metadata
+
+## Summary
+
+RARA now applies Claude-compatible `hidden` and `description` metadata to the
+repo-local agent definition listing used by `/status`.
+
+## Key Decisions
+
+- Keep `hidden` scoped to listing/status behavior for this checkpoint.
+  Hidden definitions remain valid runtime definitions when directly resolved by
+  `spawn_agent`.
+- Include non-empty frontmatter `description` text in visible status lines so
+  imported agent summaries are useful without opening the markdown file.
+- Leave execution semantics for `token_budget` and `permission_mode` as the
+  remaining `AgentDefinition` metadata work.
+
+## Validation
+
+```bash
+cargo test agents_ext::tests -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+git diff --check
+```
+
+## Follow-Ups
+
+- Implement execution semantics for `token_budget` and `permission_mode`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -54,9 +54,10 @@ Active backlog only. Keep this file small and current.
 - [x] Cache Claude-style agent definitions at runtime construction time and
       refresh them through runtime rebuild instead of scanning on each
       `spawn_agent`.
-- [ ] Implement remaining Claude-compatible `AgentDefinition` metadata:
-      `token_budget`, `permission_mode`, `hidden`, and description/listing
-      behavior.
+- [x] Apply Claude-compatible `hidden` and `description` metadata to
+      repo-local agent listing/status behavior.
+- [ ] Implement remaining Claude-compatible `AgentDefinition` execution
+      metadata: `token_budget` and `permission_mode`.
 - [x] Add an end-to-end `spawn_agent` regression test proving custom
       `.rara/agents` definitions affect prompt body, tool filtering,
       `maxTurns`, and `planModeRequired`.

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -68,10 +68,15 @@ impl AgentRegistry {
                 AgentParseStatus::Ok => "ok",
                 AgentParseStatus::ParseError => "parse_error",
             };
-            lines.push(format!(
+            let mut line = format!(
                 "  {}  {}  {}  (disabled)",
                 agent.id, agent.source_path, status
-            ));
+            );
+            if agent.parse_status == AgentParseStatus::Ok && !agent.description.trim().is_empty() {
+                line.push_str("  - ");
+                line.push_str(agent.description.trim());
+            }
+            lines.push(line);
         }
         if lines.is_empty() {
             lines.push("  (none)".to_string());
@@ -90,6 +95,9 @@ impl AgentRegistry {
             .to_string();
         let profile = match record.definition {
             Some(definition) => {
+                if definition.hidden {
+                    return;
+                }
                 let id = definition.name.clone();
                 ImportedAgentProfile {
                     id: id.clone(),
@@ -170,6 +178,12 @@ Generate unit tests for new code paths.
         assert_eq!(reviewer.parse_status, AgentParseStatus::Ok);
         assert!(reviewer.description.contains("Reviews pull requests"));
         assert_eq!(reviewer.source_path, ".rara/agents/code-reviewer.md");
+        assert!(
+            registry
+                .status_lines()
+                .iter()
+                .any(|line| line.contains("Reviews pull requests for correctness and style."))
+        );
     }
 
     #[test]
@@ -253,5 +267,44 @@ Review prompt.
         assert_eq!(agent.label, "canonical-reviewer");
         assert_eq!(agent.source_path, ".rara/agents/reviewer-file.md");
         assert_eq!(agent.parse_status, AgentParseStatus::Ok);
+    }
+
+    #[test]
+    fn discover_repo_agents_hides_hidden_definitions() {
+        let dir = tempdir().expect("tempdir");
+        let agents_dir = dir.path().join(".rara").join("agents");
+        fs::create_dir_all(&agents_dir).expect("mkdir");
+        fs::write(
+            agents_dir.join("visible.md"),
+            r#"---
+name: visible
+description: Visible agent.
+---
+
+Visible prompt.
+"#,
+        )
+        .expect("write visible");
+        fs::write(
+            agents_dir.join("internal.md"),
+            r#"---
+name: internal
+description: Internal agent.
+hidden: true
+---
+
+Internal prompt.
+"#,
+        )
+        .expect("write hidden");
+
+        let registry = discover_repo_agents(dir.path());
+
+        assert!(registry.agents.contains_key("visible"));
+        assert!(!registry.agents.contains_key("internal"));
+        let status_lines = registry.status_lines().join("\n");
+        assert!(status_lines.contains("visible"));
+        assert!(!status_lines.contains("internal"));
+        assert!(!status_lines.contains("Internal agent."));
     }
 }

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -96,6 +96,7 @@ impl AgentRegistry {
         let profile = match record.definition {
             Some(definition) => {
                 if definition.hidden {
+                    self.agents.remove(&definition.name);
                     return;
                 }
                 let id = definition.name.clone();
@@ -306,5 +307,44 @@ Internal prompt.
         assert!(status_lines.contains("visible"));
         assert!(!status_lines.contains("internal"));
         assert!(!status_lines.contains("Internal agent."));
+    }
+
+    #[test]
+    fn hidden_definition_removes_lower_precedence_visible_definition() {
+        let dir = tempdir().expect("tempdir");
+        let legacy_agents_dir = dir.path().join(".claude").join("agents");
+        fs::create_dir_all(&legacy_agents_dir).expect("mkdir legacy");
+        fs::write(
+            legacy_agents_dir.join("helper.md"),
+            r#"---
+name: helper
+description: Legacy visible helper.
+---
+
+Legacy prompt.
+"#,
+        )
+        .expect("write legacy");
+        let rara_agents_dir = dir.path().join(".rara").join("agents");
+        fs::create_dir_all(&rara_agents_dir).expect("mkdir rara");
+        fs::write(
+            rara_agents_dir.join("helper.md"),
+            r#"---
+name: helper
+description: Hidden RARA helper.
+hidden: true
+---
+
+Hidden prompt.
+"#,
+        )
+        .expect("write hidden");
+
+        let registry = discover_repo_agents(dir.path());
+
+        assert!(!registry.agents.contains_key("helper"));
+        let status_lines = registry.status_lines().join("\n");
+        assert!(!status_lines.contains("helper"));
+        assert!(!status_lines.contains("Legacy visible helper."));
     }
 }

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -4,11 +4,8 @@ pub struct AgentDefinition {
     /// Canonical name (also the file stem).
     #[serde(default)]
     pub name: String,
-    /// Short description for /agents listing.
-    /// Reserved for the future /agents listing surface
-    /// (docs/features/subagent-claude-compat.md).
+    /// Short description for agent listing and status surfaces.
     #[serde(default)]
-    #[allow(dead_code)]
     pub description: String,
     /// Allowed tools (Claude Code display names). Empty = all tools.
     #[serde(default)]
@@ -38,11 +35,8 @@ pub struct AgentDefinition {
     /// Whether plan approval is required before action.
     #[serde(default)]
     pub plan_mode_required: bool,
-    /// Hidden from /agents listing (Claude Code compat).
-    /// Reserved for the future /agents listing surface
-    /// (docs/features/subagent-claude-compat.md).
+    /// Hidden from agent listing and status surfaces (Claude Code compat).
     #[serde(default)]
-    #[allow(dead_code)]
     pub hidden: bool,
     /// System prompt — body after frontmatter `---`.
     #[serde(default, skip_deserializing)]


### PR DESCRIPTION
## Summary

- apply `hidden: true` to repo-local agent listing/status projection
- show visible agent frontmatter `description` text in `/status` status lines
- split the remaining `AgentDefinition` metadata TODO so execution metadata stays tracked separately

## Purpose

This completes the listing/status portion of Claude-compatible agent definition
metadata without changing direct `spawn_agent` resolution or the deferred
execution semantics for `token_budget` and `permission_mode`.

## Related Issue

None.

## Testing

```bash
cargo test agents_ext::tests -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets -- -D warnings
git diff --check
```
