### PR TITLE
feat(agent): apply definition permission mode

### DIFF
--- a/docs/features/subagent-claude-compat.md
+++ b/docs/features/subagent-claude-compat.md
@@ -99,6 +99,23 @@ Definitions with `hidden: true` are omitted from listing/status surfaces while
 remaining valid for direct `spawn_agent` resolution. Visible definitions include
 their frontmatter `description` in the status line when present.
 
+`permissionMode` controls the spawned subagent's local execution policy. Values
+are parsed ASCII case-insensitively:
+
+- `default` and omitted values keep the subagent's normal execution mode.
+- `acceptEdits`, `accept-edits`, and `accept_edits` keep execute mode but
+  require bash approval for mutable shell commands.
+- `auto` keeps execute mode with the normal auto policy.
+- `plan`, `readOnly`, `read-only`, and `read_only` force plan mode and a
+  read-only tool manager.
+- `bypassPermissions`, `bypass-permissions`, `bypass_permissions`,
+  `fullAccess`, `full-access`, and `full_access` enable full-access approval
+  bypass unless `planModeRequired` is also set, in which case plan mode takes
+  precedence.
+
+Invalid `permissionMode` values fail the `spawn_agent` request before creating
+a subagent.
+
 ### Subagent Execution Changes
 
 **Before** (current):

--- a/docs/journal/2026-07-03-agent-definition-permission-mode.md
+++ b/docs/journal/2026-07-03-agent-definition-permission-mode.md
@@ -1,0 +1,47 @@
+# Agent Definition Permission Mode
+
+## Summary
+
+RARA now applies Claude-compatible `AgentDefinition.permissionMode` values to
+spawned subagent execution policy.
+
+## Scope
+
+This checkpoint covers runtime policy only:
+
+- `default` and omitted values keep the subagent's normal mode.
+- `acceptEdits` keeps execute mode but requires bash approval for mutable shell
+  commands.
+- `auto` keeps execute mode with the normal auto policy.
+- `plan` and `readOnly` force plan mode and read-only subagent tools.
+- `bypassPermissions` and `fullAccess` enable full-access approval bypass unless
+  `planModeRequired` is set, because plan mode takes precedence.
+
+Values are parsed ASCII case-insensitively, and invalid values fail the
+`spawn_agent` request before creating a subagent.
+
+## Key Decisions
+
+- Treat `planModeRequired` as stronger than any permission mode, matching the
+  Claude Code pattern where plan mode takes precedence over bypass permissions.
+- Force the read-only tool manager for `permissionMode: plan` so shared task
+  mutation tools are not available in read-only subagents.
+- Keep parser aliases explicit in the error message so users can self-correct
+  invalid frontmatter without reading the source.
+- Keep `token_budget` as the remaining execution metadata follow-up.
+
+## Validation
+
+```bash
+cargo test filtered_tool_manager_permission_mode_plan_forces_read_only_tools -- --nocapture
+cargo test filtered_tool_manager_rejects_unknown_permission_mode -- --nocapture
+cargo test agent_permission_mode_maps_runtime_permissions -- --nocapture
+cargo test agent_permission_mode_accepts_case_insensitive_aliases -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+git diff --check
+```
+
+## Follow-Ups
+
+- Implement `AgentDefinition.token_budget` enforcement.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -56,8 +56,10 @@ Active backlog only. Keep this file small and current.
       `spawn_agent`.
 - [x] Apply Claude-compatible `hidden` and `description` metadata to
       repo-local agent listing/status behavior.
+- [x] Apply Claude-compatible `AgentDefinition.permission_mode` to subagent
+      execution policy.
 - [ ] Implement remaining Claude-compatible `AgentDefinition` execution
-      metadata: `token_budget` and `permission_mode`.
+      metadata: `token_budget`.
 - [x] Add an end-to-end `spawn_agent` regression test proving custom
       `.rara/agents` definitions affect prompt body, tool filtering,
       `maxTurns`, and `planModeRequired`.

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -34,6 +34,10 @@ use crate::thread_store::{ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeSta
 use crate::tools::tasklist::{TaskCreateTool, TaskGetTool, TaskListTool, TaskUpdateTool};
 use crate::workspace::WorkspaceMemory;
 
+#[path = "agent_permission.rs"]
+mod agent_permission;
+use agent_permission::{agent_permission_mode, parse_agent_permission_mode};
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum SubAgentKind {
     General,
@@ -1149,11 +1153,16 @@ pub(crate) async fn run_sub_agent(
     task_list_id: String,
     agent_definitions: AgentDefinitionCache,
 ) -> Result<SubAgentResult, ToolError> {
+    let permission_mode = agent_permission_mode(definition)?;
     let tool_manager = if let Some(def) = definition {
         build_filtered_tool_manager(kind, def, workspace.rara_dir.join("tasks"), &task_list_id)
     } else {
-        build_subagent_tool_manager(kind, workspace.rara_dir.join("tasks"), &task_list_id)
-    };
+        Ok(build_subagent_tool_manager(
+            kind,
+            workspace.rara_dir.join("tasks"),
+            &task_list_id,
+        ))
+    }?;
     let mut sub = Agent::new_with_embedding_backend_and_agent_definitions(
         tool_manager,
         backend,
@@ -1167,11 +1176,15 @@ pub(crate) async fn run_sub_agent(
         sub.session_id = session_id;
     }
     sub.set_cancellation_token(cancellation_token);
-    sub.set_execution_mode(if definition.is_some_and(|d| d.plan_mode_required) {
+    let plan_required =
+        definition.is_some_and(|d| d.plan_mode_required) || permission_mode.requires_plan_mode();
+    sub.set_execution_mode(if plan_required {
         AgentExecutionMode::Plan
     } else {
         kind.execution_mode()
     });
+    sub.set_bash_approval_mode(permission_mode.bash_approval_mode(plan_required));
+    sub.set_full_access_mode(permission_mode.full_access_mode(plan_required));
     let role_prompt = subagent_role_prompt(kind, definition);
     let appended_prompt = match definition
         .map(|d| d.system_prompt.trim())
@@ -1663,8 +1676,14 @@ fn build_filtered_tool_manager(
     definition: &AgentDefinition,
     task_root: PathBuf,
     default_task_list_id: &str,
-) -> ToolManager {
-    let mut tm = if matches!(kind, SubAgentKind::General) && !definition.tools.is_empty() {
+) -> Result<ToolManager, ToolError> {
+    let permission_mode =
+        parse_agent_permission_mode(definition.permission_mode.as_deref().unwrap_or_default())?;
+    let force_read_only = definition.plan_mode_required || permission_mode.requires_plan_mode();
+    let mut tm = if force_read_only {
+        let task_store = Arc::new(TaskListStore::new(task_root));
+        build_read_only_tool_manager(task_store, default_task_list_id)
+    } else if matches!(kind, SubAgentKind::General) && !definition.tools.is_empty() {
         build_custom_spawn_agent_tool_manager(task_root, default_task_list_id)
     } else {
         build_subagent_tool_manager(kind, task_root, default_task_list_id)
@@ -1687,7 +1706,7 @@ fn build_filtered_tool_manager(
         tm.retain(|name| !blocked.contains(name));
     }
 
-    tm
+    Ok(tm)
 }
 
 #[cfg(test)]

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -25,12 +25,8 @@ pub struct AgentDefinition {
     /// (docs/features/subagent-claude-compat.md).
     #[allow(dead_code)]
     pub token_budget: Option<i64>,
-    /// Permission mode (e.g. "acceptEdits", "default").
-    /// Reserved for per-agent permission overrides.
-    /// Will be activated with subagent permission-mode resolution
-    /// (docs/features/subagent-claude-compat.md).
+    /// Claude-compatible permission mode override for spawned subagents.
     #[serde(default)]
-    #[allow(dead_code)]
     pub permission_mode: Option<String>,
     /// Whether plan approval is required before action.
     #[serde(default)]

--- a/src/tools/agent_permission.rs
+++ b/src/tools/agent_permission.rs
@@ -1,0 +1,56 @@
+use rara_tools::tool::ToolError;
+
+use crate::agent::BashApprovalMode;
+use crate::tools::agent::AgentDefinition;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum AgentPermissionMode {
+    Default,
+    AcceptEdits,
+    Auto,
+    Plan,
+    BypassPermissions,
+}
+
+impl AgentPermissionMode {
+    pub(super) fn requires_plan_mode(self) -> bool {
+        matches!(self, Self::Plan)
+    }
+
+    pub(super) fn bash_approval_mode(self, plan_required: bool) -> BashApprovalMode {
+        if plan_required || matches!(self, Self::AcceptEdits) {
+            BashApprovalMode::Suggestion
+        } else {
+            BashApprovalMode::Always
+        }
+    }
+
+    pub(super) fn full_access_mode(self, plan_required: bool) -> bool {
+        !plan_required && matches!(self, Self::BypassPermissions)
+    }
+}
+
+pub(super) fn agent_permission_mode(
+    definition: Option<&AgentDefinition>,
+) -> Result<AgentPermissionMode, ToolError> {
+    let Some(raw) = definition.and_then(|definition| definition.permission_mode.as_deref()) else {
+        return Ok(AgentPermissionMode::Default);
+    };
+    parse_agent_permission_mode(raw)
+}
+
+pub(super) fn parse_agent_permission_mode(raw: &str) -> Result<AgentPermissionMode, ToolError> {
+    let trimmed = raw.trim();
+    let normalized = trimmed.to_ascii_lowercase();
+    match normalized.as_str() {
+        "" | "default" => Ok(AgentPermissionMode::Default),
+        "acceptedits" | "accept-edits" | "accept_edits" => Ok(AgentPermissionMode::AcceptEdits),
+        "auto" => Ok(AgentPermissionMode::Auto),
+        "plan" | "readonly" | "read-only" | "read_only" => Ok(AgentPermissionMode::Plan),
+        "bypasspermissions" | "bypass-permissions" | "bypass_permissions" | "fullaccess"
+        | "full-access" | "full_access" => Ok(AgentPermissionMode::BypassPermissions),
+        _ => Err(ToolError::InvalidInput(format!(
+            "permissionMode must be one of default, acceptEdits, accept-edits, auto, plan, readOnly, read-only, bypassPermissions, bypass-permissions, fullAccess, or full-access; got {trimmed}"
+        ))),
+    }
+}

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -19,8 +19,8 @@ use super::{
     BackgroundSubAgentRecord, BackgroundSubAgentStore, SubAgentKind, SubagentProgress,
     TEAM_CREATE_CONCURRENCY_LIMIT, append_subagent_prompt, build_filtered_tool_manager,
     build_read_only_tool_manager, build_subagent_tool_manager, home_dir_from_vars,
-    latest_assistant_text_from_history, parse_team_task_kind, resolve_kind_definition,
-    resolve_spawn_agent_definition, validate_agent_id_label,
+    latest_assistant_text_from_history, parse_agent_permission_mode, parse_team_task_kind,
+    resolve_kind_definition, resolve_spawn_agent_definition, validate_agent_id_label,
 };
 use crate::agent::Message;
 use crate::llm::{ContentBlock, EmbeddingBackend, LlmBackend, LlmResponse, MockLlm};
@@ -1384,7 +1384,8 @@ fn filtered_tool_manager_respects_tools_whitelist() {
         &definition,
         test_task_root(),
         DEFAULT_TASK_LIST_ID,
-    );
+    )
+    .expect("filtered manager");
     assert!(manager.get_tool("grep").is_some());
     assert!(manager.get_tool("read_file").is_some());
     assert!(manager.get_tool("glob").is_none());
@@ -1411,7 +1412,8 @@ fn filtered_tool_manager_maps_task_tool_aliases() {
         &definition,
         test_task_root(),
         DEFAULT_TASK_LIST_ID,
-    );
+    )
+    .expect("filtered manager");
     assert!(manager.get_tool("task_list").is_some());
     assert!(manager.get_tool("task_get").is_some());
     assert!(manager.get_tool("read_file").is_none());
@@ -1437,7 +1439,8 @@ fn filtered_tool_manager_respects_disallowed_tools_blacklist() {
         &definition,
         test_task_root(),
         DEFAULT_TASK_LIST_ID,
-    );
+    )
+    .expect("filtered manager");
     assert!(manager.get_tool("read_file").is_some());
     assert!(manager.get_tool("list_files").is_some());
     assert!(manager.get_tool("grep").is_none());
@@ -1464,7 +1467,8 @@ fn filtered_tool_manager_disallowed_takes_precedence_over_tools() {
         &definition,
         test_task_root(),
         DEFAULT_TASK_LIST_ID,
-    );
+    )
+    .expect("filtered manager");
     assert!(
         manager.get_tool("read_file").is_some(),
         "Read should be allowed"
@@ -1472,6 +1476,119 @@ fn filtered_tool_manager_disallowed_takes_precedence_over_tools() {
     assert!(
         manager.get_tool("grep").is_none(),
         "Grep should be blocked by disallowed_tools"
+    );
+}
+
+#[test]
+fn filtered_tool_manager_permission_mode_plan_forces_read_only_tools() {
+    let definition = AgentDefinition {
+        token_budget: None,
+        name: "custom".into(),
+        description: "custom".into(),
+        tools: vec![],
+        disallowed_tools: vec![],
+        model: None,
+        max_turns: 0,
+        plan_mode_required: false,
+        permission_mode: Some("plan".into()),
+        hidden: false,
+        system_prompt: String::new(),
+    };
+
+    let manager = build_filtered_tool_manager(
+        SubAgentKind::General,
+        &definition,
+        test_task_root(),
+        DEFAULT_TASK_LIST_ID,
+    )
+    .expect("filtered manager");
+
+    assert!(manager.get_tool("read_file").is_some());
+    assert!(manager.get_tool("task_get").is_some());
+    assert!(manager.get_tool("task_create").is_none());
+    assert!(manager.get_tool("task_update").is_none());
+}
+
+#[test]
+fn filtered_tool_manager_rejects_unknown_permission_mode() {
+    let definition = AgentDefinition {
+        token_budget: None,
+        name: "custom".into(),
+        description: "custom".into(),
+        tools: vec![],
+        disallowed_tools: vec![],
+        model: None,
+        max_turns: 0,
+        plan_mode_required: false,
+        permission_mode: Some("surprise".into()),
+        hidden: false,
+        system_prompt: String::new(),
+    };
+
+    let err = match build_filtered_tool_manager(
+        SubAgentKind::General,
+        &definition,
+        test_task_root(),
+        DEFAULT_TASK_LIST_ID,
+    ) {
+        Ok(_) => panic!("invalid permission mode should fail"),
+        Err(err) => err,
+    };
+
+    assert!(
+        matches!(err, ToolError::InvalidInput(message) if message.contains("permissionMode")
+            && message.contains("readOnly")
+            && message.contains("fullAccess"))
+    );
+}
+
+#[test]
+fn agent_permission_mode_maps_runtime_permissions() {
+    assert_eq!(
+        parse_agent_permission_mode("acceptEdits")
+            .expect("acceptEdits")
+            .bash_approval_mode(false),
+        crate::agent::BashApprovalMode::Suggestion
+    );
+    assert!(
+        !parse_agent_permission_mode("acceptEdits")
+            .expect("acceptEdits")
+            .full_access_mode(false)
+    );
+
+    let plan = parse_agent_permission_mode("plan").expect("plan");
+    assert!(plan.requires_plan_mode());
+    assert_eq!(
+        plan.bash_approval_mode(true),
+        crate::agent::BashApprovalMode::Suggestion
+    );
+
+    let bypass = parse_agent_permission_mode("bypassPermissions").expect("bypass");
+    assert_eq!(
+        bypass.bash_approval_mode(false),
+        crate::agent::BashApprovalMode::Always
+    );
+    assert!(bypass.full_access_mode(false));
+    assert!(!bypass.full_access_mode(true));
+}
+
+#[test]
+fn agent_permission_mode_accepts_case_insensitive_aliases() {
+    assert!(
+        parse_agent_permission_mode("Plan")
+            .expect("Plan")
+            .requires_plan_mode()
+    );
+    assert!(
+        parse_agent_permission_mode("BYPASSPERMISSIONS")
+            .expect("BYPASSPERMISSIONS")
+            .full_access_mode(false)
+    );
+    assert_eq!(
+        parse_agent_permission_mode("acceptedits")
+            .expect("acceptedits")
+            .bash_approval_mode(false),
+        crate::agent::BashApprovalMode::Suggestion
     );
 }
 


### PR DESCRIPTION
## Summary

- Apply Claude-compatible `AgentDefinition.permissionMode` to spawned subagent execution policy.
- Force read-only tools for `plan` / `readOnly` definitions and reject invalid permission modes before subagent creation.
- Update the subagent compatibility spec, journal, and TODO state for the remaining `token_budget` follow-up.

## Purpose

This closes the implemented part of the remaining `AgentDefinition` execution metadata gap. It follows the Claude Code precedence rule where required plan mode wins over permission bypass.

## Related Issues

None.

## Testing

- `cargo test filtered_tool_manager_permission_mode_plan_forces_read_only_tools -- --nocapture`
- `cargo test filtered_tool_manager_rejects_unknown_permission_mode -- --nocapture`
- `cargo test agent_permission_mode_maps_runtime_permissions -- --nocapture`
- `cargo test spawn_agent_definition_affects_prompt_tools_max_turns_and_plan_mode -- --nocapture`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`
