### PR TITLE
feat(agent): enforce definition token budget

### DIFF
--- a/docs/features/subagent-claude-compat.md
+++ b/docs/features/subagent-claude-compat.md
@@ -116,6 +116,14 @@ are parsed ASCII case-insensitively:
 Invalid `permissionMode` values fail the `spawn_agent` request before creating
 a subagent.
 
+`tokenBudget` is an optional positive token budget for a spawned subagent. RARA
+counts model input and output tokens reported by the provider. Cache hit and
+miss counters remain visible in telemetry but are not added to the budget total.
+When a budgeted subagent reaches or exceeds its budget, RARA stops before
+starting another model turn, returns `status: "budget_limited"`, and persists
+the budget on the parent spawn-agent edge. Invalid non-positive or oversized
+values fail the `spawn_agent` request before creating a subagent.
+
 ### Subagent Execution Changes
 
 **Before** (current):

--- a/docs/journal/2026-07-03-agent-definition-permission-mode.md
+++ b/docs/journal/2026-07-03-agent-definition-permission-mode.md
@@ -44,4 +44,5 @@ git diff --check
 
 ## Follow-Ups
 
-- Implement `AgentDefinition.token_budget` enforcement.
+- `AgentDefinition.token_budget` enforcement landed in
+  `docs/journal/2026-07-03-agent-definition-token-budget.md`.

--- a/docs/journal/2026-07-03-agent-definition-token-budget.md
+++ b/docs/journal/2026-07-03-agent-definition-token-budget.md
@@ -1,0 +1,45 @@
+# Agent Definition Token Budget
+
+## Summary
+
+RARA now applies Claude-compatible `AgentDefinition.tokenBudget` values to
+spawned subagent execution.
+
+## Scope
+
+This checkpoint covers subagent runtime enforcement:
+
+- `tokenBudget` must be a positive token count that fits in `u32`.
+- Budget accounting uses provider-reported model input plus output tokens.
+- Cache hit and miss counters remain visible telemetry and are not added to the
+  budget total.
+- A budgeted subagent that reaches or exceeds its budget stops before starting
+  another model turn and returns `status: "budget_limited"`.
+- Parent spawn-agent edges persist the configured `tokenBudget`.
+
+## Key Decisions
+
+- Enforce the budget in the shared `Agent` loop rather than only in
+  `spawn_agent`, so background, team, and direct subagent entrypoints share the
+  same behavior.
+- Treat budget exhaustion as a soft stop instead of an error; the subagent can
+  still return the work and tool results already produced before the limit was
+  reached.
+- Reject invalid budgets before subagent creation so malformed frontmatter does
+  not start work with an unintended unlimited budget.
+
+## Validation
+
+```bash
+cargo test spawn_agent_definition_token_budget_stops_after_budget_exhaustion -- --nocapture
+cargo test agent_token_budget_rejects_invalid_values -- --nocapture
+cargo test spawn_agent_definition_affects_prompt_tools_max_turns_and_plan_mode -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+git diff --check
+```
+
+## Follow-Ups
+
+- No remaining `AgentDefinition` execution metadata follow-up is open after
+  `tokenBudget` and `permissionMode`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -58,7 +58,7 @@ Active backlog only. Keep this file small and current.
       repo-local agent listing/status behavior.
 - [x] Apply Claude-compatible `AgentDefinition.permission_mode` to subagent
       execution policy.
-- [ ] Implement remaining Claude-compatible `AgentDefinition` execution
+- [x] Implement remaining Claude-compatible `AgentDefinition` execution
       metadata: `token_budget`.
 - [x] Add an end-to-end `spawn_agent` regression test proving custom
       `.rara/agents` definitions affect prompt body, tool filtering,

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -186,6 +186,8 @@ pub struct Agent {
     pub aux_total_cache_miss_tokens: u32,
     pub tool_result_store: ToolResultStore,
     pub max_turns: Option<usize>,
+    pub token_budget: Option<u32>,
+    pub token_budget_exhausted: bool,
     pub execution_mode: AgentExecutionMode,
     pub bash_approval_mode: BashApprovalMode,
     pub full_access_mode: bool,
@@ -355,6 +357,8 @@ impl Agent {
             }),
             execution_mode: AgentExecutionMode::Execute,
             max_turns: None,
+            token_budget: None,
+            token_budget_exhausted: false,
             bash_approval_mode: BashApprovalMode::Always,
             full_access_mode: false,
             current_plan: Vec::new(),
@@ -880,6 +884,19 @@ impl Agent {
                     Some("max_turns_reached".to_string());
                 report(AgentEvent::Status(format!(
                     "Agent reached max-turns limit ({max})",
+                )));
+                break;
+            }
+            if let Some(budget) = self.token_budget
+                && self.total_model_tokens() >= budget
+            {
+                self.token_budget_exhausted = true;
+                self.last_agent_turn_trace.loop_outcome = Some("stopped".to_string());
+                self.last_agent_turn_trace.continuation_phase =
+                    Some("token_budget_exhausted".to_string());
+                report(AgentEvent::Status(format!(
+                    "Agent reached token budget ({}/{budget})",
+                    self.total_model_tokens()
                 )));
                 break;
             }

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -158,6 +158,16 @@ impl Agent {
         };
     }
 
+    pub fn set_token_budget(&mut self, token_budget: Option<u32>) {
+        self.token_budget = token_budget;
+        self.token_budget_exhausted = false;
+    }
+
+    pub fn total_model_tokens(&self) -> u32 {
+        self.total_input_tokens
+            .saturating_add(self.total_output_tokens)
+    }
+
     pub fn execution_mode_label(&self) -> &'static str {
         match self.execution_mode {
             AgentExecutionMode::Execute => "execute",

--- a/src/session.rs
+++ b/src/session.rs
@@ -408,6 +408,7 @@ impl SessionManager {
         child_session_id: &str,
         status: &str,
         summary: Option<&str>,
+        token_budget: Option<u32>,
     ) -> Result<()> {
         self.append_rollout_event(
             session_id,
@@ -419,7 +420,7 @@ impl SessionManager {
                 child_session_id: child_session_id.to_string(),
                 status: status.to_string(),
                 summary: summary.map(str::to_string),
-                token_budget: None,
+                token_budget: token_budget.map(i64::from),
             },
         )?;
         Ok(())

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -107,6 +107,7 @@ fn load_thread_aggregates_history_state_and_rollout_items() -> Result<()> {
         "child-session-1",
         "done",
         Some("Child completed."),
+        Some(4096),
     )?;
 
     let store = ThreadStore::new(&session_manager, &state_db);
@@ -117,6 +118,7 @@ fn load_thread_aggregates_history_state_and_rollout_items() -> Result<()> {
     assert_eq!(spawn_edges.len(), 1);
     assert_eq!(spawn_edges[0].agent_id, "worker-1");
     assert_eq!(spawn_edges[0].child_session_id, "child-session-1");
+    assert_eq!(spawn_edges[0].token_budget, Some(4096));
     assert_eq!(
         snapshot.provenance.metadata_source,
         ThreadMetadataSource::StateDb

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -34,8 +34,11 @@ use crate::thread_store::{ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeSta
 use crate::tools::tasklist::{TaskCreateTool, TaskGetTool, TaskListTool, TaskUpdateTool};
 use crate::workspace::WorkspaceMemory;
 
+#[path = "agent_budget.rs"]
+mod agent_budget;
 #[path = "agent_permission.rs"]
 mod agent_permission;
+use agent_budget::{agent_token_budget, parse_agent_token_budget};
 use agent_permission::{agent_permission_mode, parse_agent_permission_mode};
 
 #[derive(Clone, Copy, Debug)]
@@ -395,6 +398,8 @@ impl AgentTool {
             "summary": result.summary,
             "cache_hit_tokens": result.total_cache_hit_tokens,
             "cache_miss_tokens": result.total_cache_miss_tokens,
+            "token_budget": result.token_budget,
+            "token_budget_exhausted": result.token_budget_exhausted,
             "persistence_error": result.persistence_error,
             "request_user_input": result
                 .request_user_input
@@ -1130,6 +1135,8 @@ pub(crate) struct SubAgentResult {
     pub(crate) total_output_tokens: u32,
     pub(crate) total_cache_hit_tokens: u32,
     pub(crate) total_cache_miss_tokens: u32,
+    pub(crate) token_budget: Option<u32>,
+    pub(crate) token_budget_exhausted: bool,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1154,6 +1161,7 @@ pub(crate) async fn run_sub_agent(
     agent_definitions: AgentDefinitionCache,
 ) -> Result<SubAgentResult, ToolError> {
     let permission_mode = agent_permission_mode(definition)?;
+    let token_budget = agent_token_budget(definition)?;
     let tool_manager = if let Some(def) = definition {
         build_filtered_tool_manager(kind, def, workspace.rara_dir.join("tasks"), &task_list_id)
     } else {
@@ -1185,6 +1193,7 @@ pub(crate) async fn run_sub_agent(
     });
     sub.set_bash_approval_mode(permission_mode.bash_approval_mode(plan_required));
     sub.set_full_access_mode(permission_mode.full_access_mode(plan_required));
+    sub.set_token_budget(token_budget);
     let role_prompt = subagent_role_prompt(kind, definition);
     let appended_prompt = match definition
         .map(|d| d.system_prompt.trim())
@@ -1224,8 +1233,18 @@ pub(crate) async fn run_sub_agent(
         })?
         .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
 
-    let status = kind.result_status();
-    let summary = latest_assistant_text(&sub).unwrap_or_else(|| "Sub-agent finished.".to_string());
+    let status = if sub.token_budget_exhausted {
+        "budget_limited"
+    } else {
+        kind.result_status()
+    };
+    let mut summary =
+        latest_assistant_text(&sub).unwrap_or_else(|| "Sub-agent finished.".to_string());
+    if sub.token_budget_exhausted {
+        let budget = sub.token_budget.unwrap_or_default();
+        let used = sub.total_model_tokens();
+        summary = format!("Token budget exhausted: {used} / {budget} tokens. {summary}");
+    }
 
     let persistence_error = parent_session_id.and_then(|parent_session_id| {
         persist_subagent_edge(
@@ -1237,6 +1256,7 @@ pub(crate) async fn run_sub_agent(
             &sub,
             status,
             &summary,
+            token_budget,
         )
         .err()
         .map(|err| err.to_string())
@@ -1251,6 +1271,8 @@ pub(crate) async fn run_sub_agent(
         total_cache_miss_tokens: sub.total_cache_miss_tokens,
         status,
         summary,
+        token_budget,
+        token_budget_exhausted: sub.token_budget_exhausted,
         persistence_error,
         plan: (!sub.current_plan.is_empty()).then_some(sub.current_plan.clone()),
         plan_explanation: sub.plan_explanation.clone(),
@@ -1269,6 +1291,7 @@ fn persist_subagent_edge(
     sub: &Agent,
     status: &str,
     summary: &str,
+    token_budget: Option<u32>,
 ) -> anyhow::Result<()> {
     write_subagent_sidechain(session_manager, parent_session_id, agent_id, sub)?;
     persist_subagent_runtime_state(session_manager, workspace, parent_session_id, sub)?;
@@ -1280,6 +1303,7 @@ fn persist_subagent_edge(
         &sub.session_id,
         status,
         Some(summary),
+        token_budget,
     )
 }
 
@@ -1476,6 +1500,8 @@ fn serialize_team_result(name: &str, result: SubAgentResult) -> Value {
         "summary": result.summary,
         "cache_hit_tokens": result.total_cache_hit_tokens,
         "cache_miss_tokens": result.total_cache_miss_tokens,
+        "token_budget": result.token_budget,
+        "token_budget_exhausted": result.token_budget_exhausted,
         "persistence_error": result.persistence_error,
         "plan": result.plan.as_ref().map(|steps| serialize_plan_steps(steps)),
         "plan_explanation": result.plan_explanation,

--- a/src/tools/agent_budget.rs
+++ b/src/tools/agent_budget.rs
@@ -1,0 +1,24 @@
+use rara_tools::tool::ToolError;
+
+use crate::tools::agent::AgentDefinition;
+
+pub(super) fn agent_token_budget(
+    definition: Option<&AgentDefinition>,
+) -> Result<Option<u32>, ToolError> {
+    let Some(raw) = definition.and_then(|definition| definition.token_budget) else {
+        return Ok(None);
+    };
+    parse_agent_token_budget(raw)
+}
+
+pub(super) fn parse_agent_token_budget(raw: i64) -> Result<Option<u32>, ToolError> {
+    if raw <= 0 {
+        return Err(ToolError::InvalidInput(format!(
+            "tokenBudget must be a positive token count; got {raw}"
+        )));
+    }
+    let budget = u32::try_from(raw).map_err(|_| {
+        ToolError::InvalidInput(format!("tokenBudget exceeds maximum u32 value; got {raw}"))
+    })?;
+    Ok(Some(budget))
+}

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -20,10 +20,7 @@ pub struct AgentDefinition {
     /// Max tool-calling turns. 0 = system default.
     #[serde(default)]
     pub max_turns: usize,
-    /// Reserved for per-agent context budgets.
-    /// Will be activated with subagent budget enforcement
-    /// (docs/features/subagent-claude-compat.md).
-    #[allow(dead_code)]
+    /// Positive token budget for spawned subagent execution.
     pub token_budget: Option<i64>,
     /// Claude-compatible permission mode override for spawned subagents.
     #[serde(default)]

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -19,11 +19,12 @@ use super::{
     BackgroundSubAgentRecord, BackgroundSubAgentStore, SubAgentKind, SubagentProgress,
     TEAM_CREATE_CONCURRENCY_LIMIT, append_subagent_prompt, build_filtered_tool_manager,
     build_read_only_tool_manager, build_subagent_tool_manager, home_dir_from_vars,
-    latest_assistant_text_from_history, parse_agent_permission_mode, parse_team_task_kind,
-    resolve_kind_definition, resolve_spawn_agent_definition, validate_agent_id_label,
+    latest_assistant_text_from_history, parse_agent_permission_mode, parse_agent_token_budget,
+    parse_team_task_kind, resolve_kind_definition, resolve_spawn_agent_definition,
+    validate_agent_id_label,
 };
 use crate::agent::Message;
-use crate::llm::{ContentBlock, EmbeddingBackend, LlmBackend, LlmResponse, MockLlm};
+use crate::llm::{ContentBlock, EmbeddingBackend, LlmBackend, LlmResponse, MockLlm, TokenUsage};
 use crate::prompt::PromptRuntimeConfig;
 use crate::session::SessionManager;
 use crate::session_transcript::{load_transcript, model_visible_messages};
@@ -57,6 +58,10 @@ struct ObservedModelRequest {
 struct DefinitionRegressionBackend {
     calls: Arc<AtomicUsize>,
     observed: Arc<Mutex<Vec<ObservedModelRequest>>>,
+}
+
+struct BudgetedToolBackend {
+    calls: Arc<AtomicUsize>,
 }
 
 fn mock_embedding_backend() -> Arc<dyn EmbeddingBackend> {
@@ -231,6 +236,49 @@ impl LlmBackend for DefinitionRegressionBackend {
             stop_reason: Some("tool_use".to_string()),
             usage: None,
         })
+    }
+
+    async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0; 4])
+    }
+
+    async fn summarize(&self, _messages: &[Message], _instruction: &str) -> anyhow::Result<String> {
+        Ok("summary".to_string())
+    }
+}
+
+#[async_trait]
+impl LlmBackend for BudgetedToolBackend {
+    async fn ask(
+        &self,
+        _messages: &[Message],
+        _tools: &[serde_json::Value],
+    ) -> anyhow::Result<LlmResponse> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst);
+        if call == 0 {
+            Ok(LlmResponse {
+                content: vec![ContentBlock::ToolUse {
+                    id: "read-fixture".to_string(),
+                    name: "read_file".to_string(),
+                    input: json!({ "path": "fixture.txt" }),
+                }],
+                stop_reason: Some("tool_use".to_string()),
+                usage: Some(TokenUsage {
+                    input_tokens: 8,
+                    output_tokens: 7,
+                    cache_hit_tokens: 0,
+                    cache_miss_tokens: 0,
+                }),
+            })
+        } else {
+            Ok(LlmResponse {
+                content: vec![ContentBlock::Text {
+                    text: "second model turn should not run".to_string(),
+                }],
+                stop_reason: Some("end_turn".to_string()),
+                usage: Some(TokenUsage::default()),
+            })
+        }
     }
 
     async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
@@ -914,6 +962,94 @@ Custom reviewer prompt from workspace definition.
         tool_names,
         vec!["grep".to_string(), "read_file".to_string()]
     );
+}
+
+#[tokio::test]
+async fn spawn_agent_definition_token_budget_stops_after_budget_exhaustion() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().join("workspace");
+    let rara_dir = temp.path().join(".rara-runtime");
+    let agents_dir = root.join(".rara").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("agents dir");
+    std::fs::write(root.join("fixture.txt"), "fixture contents").expect("fixture file");
+    std::fs::write(
+        agents_dir.join("budget-reviewer.md"),
+        r#"---
+name: budget-reviewer
+description: Reviews with a token budget
+tools: [Read]
+tokenBudget: 10
+---
+
+Review with a small budget.
+"#,
+    )
+    .expect("agent definition");
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let tool = AgentTool {
+        backend: Arc::new(BudgetedToolBackend {
+            calls: calls.clone(),
+        }),
+        embedding_backend: mock_embedding_backend(),
+        vdb: Arc::new(VectorDB::new(
+            &rara_dir.join("lancedb").display().to_string(),
+        )),
+        session_manager: Arc::new(
+            SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
+        ),
+        workspace: Arc::new(WorkspaceMemory::from_paths(root.clone(), rara_dir.clone())),
+        prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
+        background_subagents: Arc::new(BackgroundSubAgentStore::default()),
+        agent_definitions: test_agent_definition_cache(&root),
+    };
+
+    let mut progress = |_| {};
+    let result = tool
+        .call_with_context_events(
+            json!({
+                "name": "Budget Reviewer",
+                "instruction": "Inspect fixture.txt and report findings."
+            }),
+            ToolCallContext::default().with_session_id("parent-session"),
+            &mut progress,
+        )
+        .await
+        .expect("spawn_agent result");
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(result["status"], "budget_limited");
+    assert_eq!(result["token_budget"], 10);
+    assert_eq!(result["token_budget_exhausted"], true);
+    assert!(
+        result["summary"]
+            .as_str()
+            .expect("summary")
+            .contains("Token budget exhausted: 15 / 10 tokens")
+    );
+
+    let events =
+        thread_rollout_log::load_rollout_events(&rara_dir.join("rollouts"), "parent-session")
+            .expect("rollout events");
+    assert!(matches!(
+        events.as_slice(),
+        [PersistedStructuredRolloutEvent::SpawnAgent {
+            status,
+            token_budget: Some(10),
+            ..
+        }] if status == "budget_limited"
+    ));
+}
+
+#[test]
+fn agent_token_budget_rejects_invalid_values() {
+    let zero = parse_agent_token_budget(0).expect_err("zero should fail");
+    assert!(matches!(zero, ToolError::InvalidInput(message) if message.contains("positive")));
+
+    let oversized =
+        parse_agent_token_budget(i64::from(u32::MAX) + 1).expect_err("oversized should fail");
+    assert!(matches!(oversized, ToolError::InvalidInput(message) if message.contains("maximum")));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Enforce `AgentDefinition.tokenBudget` for spawned subagents.
- Stop budgeted subagents before starting another model turn once provider-reported input + output tokens reach the budget.
- Persist configured budgets on spawn-agent edges and expose budget status in `spawn_agent` / team results.
- Update the subagent compatibility spec, journal, and TODO state.

## Purpose

This completes the remaining Claude-compatible `AgentDefinition` execution metadata after `permissionMode`.

## Related Issues

None.

## Testing

- `cargo test spawn_agent_definition_token_budget_stops_after_budget_exhaustion -- --nocapture`
- `cargo test agent_token_budget_rejects_invalid_values -- --nocapture`
- `cargo test spawn_agent_definition_affects_prompt_tools_max_turns_and_plan_mode -- --nocapture`
- `cargo test load_thread_aggregates_history_state_and_rollout_items -- --nocapture`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`
