### PR TITLE
feat(agent): reconnect completed subagents

### DIFF
--- a/docs/features/session-transcript.md
+++ b/docs/features/session-transcript.md
@@ -211,7 +211,7 @@ terminal cells and transcript-detail surfaces.
 | Write sub-agent sidechain | File is under `subagents/`; entries carry `is_sidechain = true`. |
 | Record sub-agent spawn edge | Parent rollout events include one `spawn_agent` edge summary with child identity. |
 | Run background sub-agent | Tool result returns `agent_id`, `session_id`, and `status = running` without inlining the child transcript. |
-| Resume background sub-agent | `subagent_resume` returns the live status or final summary without loading the sidechain into parent context. |
+| Resume background sub-agent | `subagent_resume` returns the live status or, after runtime restart, reconnects to the current thread's persisted completed sidechain result without loading the sidechain into parent context. |
 | Stop background sub-agent | `subagent_stop` marks an in-process running sub-agent as `cancelled` and requests model cancellation. |
 | Legacy history backfill | `history.json` and `transcript.jsonl` are both backfilled. |
 | Transcript-first restore | `transcript.jsonl` wins over a stale `history.json` snapshot. |
@@ -232,13 +232,16 @@ terminal cells and transcript-detail surfaces.
   still return structured results without writing detached sidechain files.
 - Sidechain persistence failures are reported through `persistence_error`; they
   do not abort an otherwise completed foreground sub-agent call.
-- `StateDb` indexes parent/child spawn edges from rollout events. In-process
-  background sub-agent control now exposes `subagent_list`, `subagent_resume`,
-  and `subagent_stop`; cross-process restart/reattach still needs a durable
-  task registry above the sidechain transcript contract.
+- `StateDb` indexes parent/child spawn edges from rollout events. Background
+  sub-agent control exposes `subagent_list`, `subagent_resume`, and
+  `subagent_stop`; restart/reconnect can reattach to completed persisted
+  sidechain results, but continuing a still-running task after process exit
+  still needs a durable task registry above the sidechain transcript contract.
 - Context compaction must preserve transcript boundaries and avoid injecting
   summaries before stable prompt-prefix sources.
-- Background sub-agent execution is still local to the active RARA process.
+- Background sub-agent execution is still local to the active RARA process; a
+  process exit stops in-flight child execution even though completed results can
+  be reconnected later.
 
 ## Source Journals
 
@@ -246,3 +249,4 @@ terminal cells and transcript-detail surfaces.
 - 2026-05-05-subagent-sidechain-transcripts.md
 - 2026-05-05-subagent-spawn-edge-index.md
 - 2026-05-05-subagent-background-control.md
+- 2026-07-03-subagent-reconnect.md

--- a/docs/journal/2026-05-05-subagent-background-control.md
+++ b/docs/journal/2026-05-05-subagent-background-control.md
@@ -14,9 +14,11 @@ top of the existing parent-scoped sidechain transcript contract.
   - preallocated child `session_id`;
   - `status = running`;
   - parent session metadata when available.
-- `subagent_list` lists live in-process background sub-agents.
+- `subagent_list` lists live in-process background sub-agents and current-thread
+  persisted completed sub-agent edges after runtime restart.
 - `subagent_resume` returns the current status or completed summary for a
-  background sub-agent.
+  background sub-agent, including completed persisted sidechain results after
+  runtime restart.
 - `subagent_stop` marks a running background sub-agent as `cancelled` and sets
   the model cancellation token.
 
@@ -29,8 +31,9 @@ rollouts/<parent_session_id>/subagents/agent-<agent_id>.jsonl
 
 ## Boundaries
 
-- This is not a cross-process task registry.
-- Restart/reattach after the RARA process exits remains future work.
+- This is not a cross-process task registry for still-running tasks.
+- Restart/reattach after the RARA process exits is supported only for completed
+  persisted sub-agent results.
 - `team_create` remains a synchronous aggregation tool.
 - Completed background sub-agents still persist the same sidechain transcript
   and spawn-edge event as foreground sub-agents.

--- a/docs/journal/2026-07-03-subagent-reconnect.md
+++ b/docs/journal/2026-07-03-subagent-reconnect.md
@@ -1,0 +1,45 @@
+# Subagent Restart Reconnect
+
+## Summary
+
+RARA can now reconnect `subagent_resume` and `subagent_list` to completed
+subagent results persisted in the current parent thread after the runtime
+restarts.
+
+## Scope
+
+- `subagent_resume` first checks the live in-process background store.
+- If the live store does not know the `agent_id`, it reads the current parent
+  thread's durable spawn-agent rollout edges and returns the completed result
+  metadata when present.
+- `subagent_list` merges live in-process records with current-thread durable
+  completed spawn-agent edges.
+- Sidechain transcript contents remain out of parent model context.
+- No new tool is added; the existing subagent control tools gain reconnect
+  behavior.
+
+## Key Decisions
+
+- Reconnect uses parent-scoped rollout events instead of scanning every
+  sidechain transcript path.
+- Persisted reconnect records are marked with `kind = "reconnected"` because
+  the original subagent kind is not part of the durable spawn edge.
+- In-flight execution remains process-local. If the RARA process exits while a
+  background subagent is still running, this change does not restart or continue
+  that task.
+
+## Validation
+
+```bash
+cargo test subagent_resume_reconnects_completed_sidechain_after_store_restart -- --nocapture
+cargo test background_subagent_resume_returns_completed_summary_without_inline_sidechain -- --nocapture
+cargo test background_plan_agent_resume_returns_plan_state -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+git diff --check
+```
+
+## Follow-Ups
+
+- A durable task registry would be required before RARA can restart or continue
+  still-running subagents after process exit.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -45,7 +45,7 @@ Active backlog only. Keep this file small and current.
 ## Agent / Subagent
 
 - [x] Subagent token_budget field (PR #601)
-- [ ] Subagent restart/reconnect — built-in capability, not a separate tool
+- [x] Subagent restart/reconnect — built-in capability, not a separate tool
 - [x] Subagent context budget design — token_budget on AgentDefinition
 - [x] Add shared TaskList/TaskGet runtime tools backed by a `.rara/tasks/<task_list_id>/`
       task store so teams/subagents can coordinate beyond session-local `todo_write`.

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -216,7 +216,7 @@ pub(super) fn create_full_tool_manager(
         backend,
         embedding_backend,
         vdb,
-        session_manager,
+        session_manager: session_manager.clone(),
         workspace,
         prompt_config,
         task_list_id,
@@ -224,9 +224,11 @@ pub(super) fn create_full_tool_manager(
     }));
     tm.register(Box::new(SubAgentResumeTool {
         background_subagents: background_subagents.clone(),
+        session_manager: session_manager.clone(),
     }));
     tm.register(Box::new(SubAgentListTool {
         background_subagents: background_subagents.clone(),
+        session_manager: session_manager.clone(),
     }));
     tm.register(Box::new(SubAgentStopTool {
         background_subagents,

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -38,8 +38,11 @@ use crate::workspace::WorkspaceMemory;
 mod agent_budget;
 #[path = "agent_permission.rs"]
 mod agent_permission;
+#[path = "agent_reconnect.rs"]
+mod agent_reconnect;
 use agent_budget::{agent_token_budget, parse_agent_token_budget};
 use agent_permission::{agent_permission_mode, parse_agent_permission_mode};
+use agent_reconnect::{durable_subagent_record, durable_subagent_records};
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum SubAgentKind {
@@ -688,7 +691,7 @@ struct BackgroundSubAgentRecord {
     progress: SubagentProgress,
     kind: &'static str,
     parent_session_id: Option<String>,
-    status: &'static str,
+    status: String,
     summary: Option<String>,
     error: Option<String>,
     persistence_error: Option<String>,
@@ -713,7 +716,7 @@ impl BackgroundSubAgentStore {
             ),
             kind: start.kind.label(),
             parent_session_id: start.parent_session_id.clone(),
-            status: "running",
+            status: "running".to_string(),
             summary: None,
             error: None,
             persistence_error: None,
@@ -802,7 +805,7 @@ impl BackgroundSubAgentStore {
         if record.status != "running" {
             return Ok(record.clone());
         }
-        record.status = "cancelled";
+        record.status = "cancelled".to_string();
         record.finished_at = Some(unix_timestamp_secs());
         let stopped = record.clone();
         let token = inner.cancellations.remove(agent_id);
@@ -834,7 +837,7 @@ impl BackgroundSubAgentStore {
                 record.progress.total_output_tokens = result.total_output_tokens as usize;
                 record.progress.total_cache_hit_tokens = result.total_cache_hit_tokens as usize;
                 record.progress.total_cache_miss_tokens = result.total_cache_miss_tokens as usize;
-                record.status = result.status;
+                record.status = result.status.to_string();
                 record.summary = Some(result.summary);
                 record.persistence_error = result.persistence_error;
                 record.plan = result.plan;
@@ -843,7 +846,7 @@ impl BackgroundSubAgentStore {
                 record.error = None;
             }
             Err(err) => {
-                record.status = "failed";
+                record.status = "failed".to_string();
                 record.error = Some(err.to_string());
             }
         }
@@ -926,11 +929,12 @@ fn unix_timestamp_secs() -> u64 {
 
 pub struct SubAgentResumeTool {
     pub background_subagents: Arc<BackgroundSubAgentStore>,
+    pub session_manager: Arc<SessionManager>,
 }
 
 #[tool_spec(
     name = "subagent_resume",
-    description = "Resume observing a background sub-agent by agent_id. Returns the running status or the completed result summary without reading the sidechain transcript into parent context.",
+    description = "Resume observing a background sub-agent by agent_id. Returns live in-process status, or reconnects to the current thread's persisted completed sidechain result after a runtime restart, without reading the sidechain transcript into parent context.",
     input_schema = {
         "type": "object",
         "properties": {
@@ -945,20 +949,41 @@ pub struct SubAgentResumeTool {
 #[async_trait]
 impl Tool for SubAgentResumeTool {
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        self.call_with_context_events(input, ToolCallContext::default(), &mut |_| {})
+            .await
+    }
+
+    async fn call_with_context_events(
+        &self,
+        input: Value,
+        context: ToolCallContext,
+        _report: &mut (dyn FnMut(rara_tools::tool::ToolProgressEvent) + Send),
+    ) -> Result<Value, ToolError> {
         let agent_id = input["agent_id"]
             .as_str()
             .ok_or(ToolError::InvalidInput("agent_id".into()))?;
-        Ok(self.background_subagents.get(agent_id)?.to_json())
+        match self.background_subagents.get(agent_id) {
+            Ok(record) => Ok(record.to_json()),
+            Err(err) => {
+                let Some(parent_session_id) = context.session_id() else {
+                    return Err(err);
+                };
+                durable_subagent_record(&self.session_manager, parent_session_id, agent_id)?
+                    .map(|record| record.to_json())
+                    .ok_or(err)
+            }
+        }
     }
 }
 
 pub struct SubAgentListTool {
     pub background_subagents: Arc<BackgroundSubAgentStore>,
+    pub session_manager: Arc<SessionManager>,
 }
 
 #[tool_spec(
     name = "subagent_list",
-    description = "List in-process background sub-agents for this RARA runtime. Completed sidechain transcripts remain on disk; this list is for live background control.",
+    description = "List in-process background sub-agents plus persisted completed sub-agent edges for the current thread. Sidechain transcripts remain on disk and are not loaded into parent context.",
     input_schema = {
         "type": "object",
         "properties": {}
@@ -967,11 +992,32 @@ pub struct SubAgentListTool {
 #[async_trait]
 impl Tool for SubAgentListTool {
     async fn call(&self, _input: Value) -> Result<Value, ToolError> {
+        self.call_with_context_events(json!({}), ToolCallContext::default(), &mut |_| {})
+            .await
+    }
+
+    async fn call_with_context_events(
+        &self,
+        _input: Value,
+        context: ToolCallContext,
+        _report: &mut (dyn FnMut(rara_tools::tool::ToolProgressEvent) + Send),
+    ) -> Result<Value, ToolError> {
         let mut agents = self
             .background_subagents
             .list()?
             .into_iter()
             .collect::<Vec<_>>();
+        if let Some(parent_session_id) = context.session_id() {
+            let live_ids = agents
+                .iter()
+                .map(|record| record.agent_id.clone())
+                .collect::<std::collections::HashSet<_>>();
+            for record in durable_subagent_records(&self.session_manager, parent_session_id)? {
+                if !live_ids.contains(&record.agent_id) {
+                    agents.push(record);
+                }
+            }
+        }
         agents.sort_by(|left, right| {
             left.started_at
                 .cmp(&right.started_at)

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1008,13 +1008,22 @@ impl Tool for SubAgentListTool {
             .into_iter()
             .collect::<Vec<_>>();
         if let Some(parent_session_id) = context.session_id() {
-            let live_ids = agents
+            let mut live_ids = agents
                 .iter()
                 .map(|record| record.agent_id.clone())
                 .collect::<std::collections::HashSet<_>>();
-            for record in durable_subagent_records(&self.session_manager, parent_session_id)? {
-                if !live_ids.contains(&record.agent_id) {
-                    agents.push(record);
+            match durable_subagent_records(&self.session_manager, parent_session_id) {
+                Ok(records) => {
+                    for record in records {
+                        if live_ids.insert(record.agent_id.clone()) {
+                            agents.push(record);
+                        }
+                    }
+                }
+                Err(err) => {
+                    log::warn!(
+                        "failed to retrieve durable sub-agent records for parent session {parent_session_id}: {err}"
+                    );
                 }
             }
         }

--- a/src/tools/agent_reconnect.rs
+++ b/src/tools/agent_reconnect.rs
@@ -1,0 +1,66 @@
+use rara_persistence::thread_data::PersistedStructuredRolloutEvent;
+use rara_persistence::thread_rollout_log;
+use rara_tools::tool::ToolError;
+
+use super::{BackgroundSubAgentRecord, SubagentProgress};
+use crate::session::SessionManager;
+
+pub(super) fn durable_subagent_record(
+    session_manager: &SessionManager,
+    parent_session_id: &str,
+    agent_id: &str,
+) -> Result<Option<BackgroundSubAgentRecord>, ToolError> {
+    let records = durable_subagent_records(session_manager, parent_session_id)?;
+    Ok(records
+        .into_iter()
+        .rev()
+        .find(|record| record.agent_id == agent_id))
+}
+
+pub(super) fn durable_subagent_records(
+    session_manager: &SessionManager,
+    parent_session_id: &str,
+) -> Result<Vec<BackgroundSubAgentRecord>, ToolError> {
+    let events =
+        thread_rollout_log::load_rollout_events(&session_manager.storage_dir, parent_session_id)
+            .map_err(|err| {
+                ToolError::ExecutionFailed(format!(
+                    "failed to load sub-agent rollout events for {parent_session_id}: {err}"
+                ))
+            })?;
+    let mut records = Vec::new();
+    for event in events {
+        let PersistedStructuredRolloutEvent::SpawnAgent {
+            recorded_at,
+            agent_id,
+            name,
+            child_session_id,
+            status,
+            summary,
+            ..
+        } = event
+        else {
+            continue;
+        };
+        let timestamp = recorded_at.and_then(|value| u64::try_from(value).ok());
+        records.push(BackgroundSubAgentRecord {
+            progress: SubagentProgress::new(name.clone().unwrap_or_else(|| "sub-agent".into())),
+            kind: "reconnected",
+            parent_session_id: Some(parent_session_id.to_string()),
+            status,
+            agent_id,
+            session_id: child_session_id,
+            name,
+            model: None,
+            summary,
+            error: None,
+            persistence_error: None,
+            plan: None,
+            plan_explanation: None,
+            request_user_input: None,
+            started_at: timestamp.unwrap_or_default(),
+            finished_at: timestamp,
+        });
+    }
+    Ok(records)
+}

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -31,8 +31,8 @@ use crate::session_transcript::{load_transcript, model_visible_messages};
 use crate::tasklist::{DEFAULT_TASK_LIST_ID, TaskListStore};
 use crate::thread_store::{ThreadMetadataSource, ThreadStore};
 use crate::tools::agent::{
-    AgentTool, ExploreAgentTool, PlanAgentTool, SubAgentResumeTool, SubAgentStopTool,
-    TeamCreateTool,
+    AgentTool, ExploreAgentTool, PlanAgentTool, SubAgentListTool, SubAgentResumeTool,
+    SubAgentStopTool, TeamCreateTool,
 };
 use crate::workspace::WorkspaceMemory;
 
@@ -1069,7 +1069,7 @@ async fn background_subagent_resume_returns_completed_summary_without_inline_sid
         vdb: Arc::new(VectorDB::new(
             &rara_dir.join("lancedb").display().to_string(),
         )),
-        session_manager,
+        session_manager: session_manager.clone(),
         agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir.clone())),
         prompt_config: PromptRuntimeConfig::default(),
@@ -1078,6 +1078,7 @@ async fn background_subagent_resume_returns_completed_summary_without_inline_sid
     };
     let resume = SubAgentResumeTool {
         background_subagents,
+        session_manager,
     };
 
     let mut progress = |_| {};
@@ -1129,21 +1130,110 @@ async fn background_subagent_resume_returns_completed_summary_without_inline_sid
 }
 
 #[tokio::test]
+async fn subagent_resume_reconnects_completed_sidechain_after_store_restart() {
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().join("workspace");
+    let rara_dir = temp.path().join(".rara");
+    std::fs::create_dir_all(&root).expect("workspace");
+    let live_store = Arc::new(BackgroundSubAgentStore::default());
+    let session_manager =
+        Arc::new(SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"));
+    let tool = ExploreAgentTool {
+        backend: Arc::new(CountingBackend {
+            calls: Arc::new(AtomicUsize::new(0)),
+        }),
+        embedding_backend: mock_embedding_backend(),
+        vdb: Arc::new(VectorDB::new(
+            &rara_dir.join("lancedb").display().to_string(),
+        )),
+        session_manager: session_manager.clone(),
+        agent_definitions: test_agent_definition_cache(&root),
+        workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
+        prompt_config: PromptRuntimeConfig::default(),
+        task_list_id: test_task_list_id(),
+        background_subagents: live_store,
+    };
+
+    let mut progress = |_| {};
+    let started = tool
+        .call_with_context_events(
+            json!({
+                "instruction": "inspect this in the background",
+                "run_in_background": true
+            }),
+            ToolCallContext::default().with_session_id("parent-session"),
+            &mut progress,
+        )
+        .await
+        .expect("background start");
+    let agent_id = started["agent_id"].as_str().expect("agent_id");
+
+    let reconnect_store = Arc::new(BackgroundSubAgentStore::default());
+    let resume = SubAgentResumeTool {
+        background_subagents: reconnect_store.clone(),
+        session_manager: session_manager.clone(),
+    };
+    let list = SubAgentListTool {
+        background_subagents: reconnect_store,
+        session_manager,
+    };
+
+    let mut reconnected = None;
+    for _ in 0..20 {
+        let status = resume
+            .call_with_context_events(
+                json!({ "agent_id": agent_id }),
+                ToolCallContext::default().with_session_id("parent-session"),
+                &mut |_| {},
+            )
+            .await;
+        if let Ok(status) = status {
+            reconnected = Some(status);
+            break;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+
+    let reconnected = reconnected.expect("durable sub-agent result");
+    assert_eq!(reconnected["agent_id"], agent_id);
+    assert_eq!(reconnected["status"], "explored");
+    assert_eq!(reconnected["parent_session_id"], "parent-session");
+    assert_eq!(reconnected["kind"], "reconnected");
+    assert!(
+        reconnected["summary"]
+            .as_str()
+            .expect("summary")
+            .starts_with("counted")
+    );
+
+    let listed = list
+        .call_with_context_events(
+            json!({}),
+            ToolCallContext::default().with_session_id("parent-session"),
+            &mut |_| {},
+        )
+        .await
+        .expect("subagent list");
+    let agents = listed["subagents"].as_array().expect("subagents");
+    assert!(agents.iter().any(|record| record["agent_id"] == agent_id));
+}
+
+#[tokio::test]
 async fn background_subagent_stop_marks_running_task_cancelled() {
     let temp = tempdir().expect("tempdir");
     let root = temp.path().join("workspace");
     let rara_dir = temp.path().join(".rara");
     std::fs::create_dir_all(&root).expect("workspace");
     let background_subagents = Arc::new(BackgroundSubAgentStore::default());
+    let session_manager =
+        Arc::new(SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"));
     let tool = ExploreAgentTool {
         backend: Arc::new(SlowBackend),
         embedding_backend: mock_embedding_backend(),
         vdb: Arc::new(VectorDB::new(
             &rara_dir.join("lancedb").display().to_string(),
         )),
-        session_manager: Arc::new(
-            SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
-        ),
+        session_manager: session_manager.clone(),
         agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
@@ -1155,6 +1245,7 @@ async fn background_subagent_stop_marks_running_task_cancelled() {
     };
     let resume = SubAgentResumeTool {
         background_subagents,
+        session_manager,
     };
 
     let mut progress = |_| {};
@@ -1202,7 +1293,7 @@ fn background_subagent_store_prunes_old_completed_records() {
                     progress: SubagentProgress::new("test".to_string()),
                     kind: "general",
                     parent_session_id: None,
-                    status: "done",
+                    status: "done".to_string(),
                     summary: Some(format!("summary {idx}")),
                     error: None,
                     persistence_error: None,
@@ -1234,15 +1325,15 @@ async fn background_plan_agent_resume_returns_plan_state() {
     let rara_dir = temp.path().join(".rara");
     std::fs::create_dir_all(&root).expect("workspace");
     let background_subagents = Arc::new(BackgroundSubAgentStore::default());
+    let session_manager =
+        Arc::new(SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"));
     let tool = PlanAgentTool {
         backend: Arc::new(PlanStateBackend),
         embedding_backend: mock_embedding_backend(),
         vdb: Arc::new(VectorDB::new(
             &rara_dir.join("lancedb").display().to_string(),
         )),
-        session_manager: Arc::new(
-            SessionManager::new_for_rara_dir(rara_dir.clone()).expect("session manager"),
-        ),
+        session_manager: session_manager.clone(),
         agent_definitions: test_agent_definition_cache(&root),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
@@ -1251,6 +1342,7 @@ async fn background_plan_agent_resume_returns_plan_state() {
     };
     let resume = SubAgentResumeTool {
         background_subagents,
+        session_manager,
     };
 
     let mut progress = |_| {};

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -1179,7 +1179,7 @@ async fn subagent_resume_reconnects_completed_sidechain_after_store_restart() {
     };
 
     let mut reconnected = None;
-    for _ in 0..20 {
+    for _ in 0..50 {
         let status = resume
             .call_with_context_events(
                 json!({ "agent_id": agent_id }),
@@ -1191,7 +1191,7 @@ async fn subagent_resume_reconnects_completed_sidechain_after_store_restart() {
             reconnected = Some(status);
             break;
         }
-        sleep(Duration::from_millis(10)).await;
+        sleep(Duration::from_millis(20)).await;
     }
 
     let reconnected = reconnected.expect("durable sub-agent result");


### PR DESCRIPTION
## Summary

- Reconnect `subagent_resume` to completed persisted subagent results after runtime restart.
- Merge current-thread persisted subagent edges into `subagent_list` without loading sidechain transcript content into parent context.
- Keep in-flight execution process-local and document that still-running task restart needs a durable task registry.

## Purpose

This closes the TODO for built-in subagent restart/reconnect without adding another tool surface.

## Related Issues

None.

## Testing

- `cargo test subagent_resume_reconnects_completed_sidechain_after_store_restart -- --nocapture`
- `cargo test background_subagent_resume_returns_completed_summary_without_inline_sidechain -- --nocapture`
- `cargo test background_plan_agent_resume_returns_plan_state -- --nocapture`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`
