### PR TITLE
feat(tui): add configurable theme tokens

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -23,8 +23,8 @@ pub use self::mcp::{
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{
     ConfigManager, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState, RaraConfig,
-    SandboxWorkspaceWriteConfig, ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for,
-    workspace_data_dir_for_home,
+    SandboxWorkspaceWriteConfig, TuiConfig, TuiThemeConfig, ensure_rara_home_dir, rara_home_dir,
+    workspace_data_dir_for, workspace_data_dir_for_home,
 };
 pub use self::provider_surface::{
     ConfigValueSource, EffectiveProviderSurface, ResolvedProviderValue,

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -190,6 +190,48 @@ impl SandboxWorkspaceWriteConfig {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TuiConfig {
+    #[serde(default, skip_serializing_if = "TuiThemeConfig::is_default")]
+    pub theme: TuiThemeConfig,
+}
+
+impl TuiConfig {
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct TuiThemeConfig {
+    pub name: String,
+    pub syntax_theme: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub tokens: BTreeMap<String, String>,
+}
+
+impl Default for TuiThemeConfig {
+    fn default() -> Self {
+        Self {
+            name: default_tui_theme_name(),
+            syntax_theme: None,
+            tokens: BTreeMap::new(),
+        }
+    }
+}
+
+impl TuiThemeConfig {
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+fn default_tui_theme_name() -> String {
+    "nord".to_string()
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct RaraConfig {
     pub provider: String,
@@ -230,6 +272,8 @@ pub struct RaraConfig {
     pub sandbox_workspace_write: SandboxWorkspaceWriteConfig,
     #[serde(default, skip_serializing_if = "MemoryConsolidationConfig::is_default")]
     pub memory_consolidation: MemoryConsolidationConfig,
+    #[serde(default, skip_serializing_if = "TuiConfig::is_default")]
+    pub tui: TuiConfig,
 }
 
 impl RaraConfig {
@@ -1084,6 +1128,50 @@ mod tests {
         assert!(!config.sandbox_workspace_write.network_access);
         let json = serde_json::to_string(&config).expect("serialize config");
         assert!(json.contains("sandbox_workspace_write"));
+    }
+
+    #[test]
+    fn loads_tui_theme_config() {
+        let config: RaraConfig = serde_json::from_str(
+            r##"{
+                "provider": "codex",
+                "tui": {
+                    "theme": {
+                        "name": "nord",
+                        "syntax_theme": "Nord",
+                        "tokens": {
+                            "text.accent": "#88c0d0",
+                            "picker.highlight.bg": "ansi:12"
+                        }
+                    }
+                }
+            }"##,
+        )
+        .expect("deserialize config");
+
+        assert_eq!(config.tui.theme.name, "nord");
+        assert_eq!(config.tui.theme.syntax_theme.as_deref(), Some("Nord"));
+        assert_eq!(
+            config
+                .tui
+                .theme
+                .tokens
+                .get("text.accent")
+                .map(String::as_str),
+            Some("#88c0d0")
+        );
+        assert_eq!(
+            config
+                .tui
+                .theme
+                .tokens
+                .get("picker.highlight.bg")
+                .map(String::as_str),
+            Some("ansi:12")
+        );
+
+        let json = serde_json::to_string(&config).expect("serialize config");
+        assert!(json.contains("\"tui\""));
     }
 
     #[test]

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -64,6 +64,8 @@ future appserver integrations can use.
   inheritance, child budget, result summary, and restart/reconnect contracts.
 - `shared-task-lists.md`: workspace-local shared task store and
   Claude-compatible read tools for future subagent/team coordination.
+- `tui-theme-tokens.md`: configurable semantic TUI theme tokens, renderer
+  integration, and embedded syntax theme selection.
 
 ## App Server Architecture
 

--- a/docs/features/tui-theme-tokens.md
+++ b/docs/features/tui-theme-tokens.md
@@ -59,7 +59,8 @@ name. Unknown names fall back to the existing `CatppuccinMocha` default.
 ## Contracts
 
 - Token keys are stable dotted strings such as `text.accent`,
-  `picker.highlight.bg`, `diff.add.fg`, and `markdown.code`.
+  `picker.highlight.bg`, `overlay.highlight.bg`, `diff.add.fg`, and
+  `markdown.code`.
 - A hyphen in config keys is accepted as a dot separator, so
   `picker-highlight-bg` maps to `picker.highlight.bg`.
 - Underscores remain significant for token names such as

--- a/docs/features/tui-theme-tokens.md
+++ b/docs/features/tui-theme-tokens.md
@@ -1,0 +1,92 @@
+# TUI Theme Tokens
+
+## Problem
+
+The TUI had a static Nord palette plus a set of semantic constants, but the
+palette was not configurable and several renderers still referenced raw color
+constants directly. This made picker visibility, diff colors, markdown colors,
+and overlay surfaces hard to tune without changing renderer internals.
+
+## Scope
+
+- Add a structured config surface under `tui.theme`.
+- Resolve named semantic theme tokens at render time.
+- Keep the existing Nord-compatible palette as the default.
+- Route markdown, diff previews, list pickers, command/status/model overlays,
+  setup overlays, and popup surfaces through semantic tokens.
+- Let the TUI choose the active embedded `syntect` theme through config.
+
+## Non-Goals
+
+- No runtime theme picker or live theme reload command.
+- No external theme file format.
+- No custom `syntect` theme loading from disk.
+- No change to layout, key handling, or picker selection behavior.
+
+## Architecture
+
+`RaraConfig` owns a `tui.theme` object:
+
+```json
+{
+  "tui": {
+    "theme": {
+      "name": "nord",
+      "syntax_theme": "Nord",
+      "tokens": {
+        "text.accent": "#88c0d0",
+        "picker.highlight.bg": "ansi:12"
+      }
+    }
+  }
+}
+```
+
+The TUI installs this config when `TuiApp` is constructed. Renderers call
+`theme_color(ThemeToken::...)`; unresolved or invalid token overrides fall back
+to the default Nord-compatible value and log a warning.
+
+Supported color values:
+
+- `#rrggbb`
+- `ansi:N`
+- `reset`
+- Ratatui color names such as `red`, `dark_gray`, and `light_blue`
+
+`syntax_theme` selects an embedded `two-face`/`syntect` theme by case-insensitive
+name. Unknown names fall back to the existing `CatppuccinMocha` default.
+
+## Contracts
+
+- Token keys are stable dotted strings such as `text.accent`,
+  `picker.highlight.bg`, `diff.add.fg`, and `markdown.code`.
+- A hyphen in config keys is accepted as a dot separator, so
+  `picker-highlight-bg` maps to `picker.highlight.bg`.
+- Underscores remain significant for token names such as
+  `surface.bottom_pane.bg`.
+- Invalid token keys and invalid color values are non-fatal and must not break
+  TUI startup.
+- Renderers should depend on semantic tokens instead of raw palette constants.
+- The default theme must preserve the existing Nord-compatible visual baseline.
+
+## Validation Matrix
+
+- Config deserialization accepts `tui.theme.name`, `syntax_theme`, and token
+  overrides.
+- Theme resolution parses supported color grammars and falls back for invalid
+  values.
+- Diff, markdown, picker, and overlay renderers compile against semantic token
+  lookups rather than direct palette constants.
+- Full workspace check and Clippy run without warnings.
+
+## Open Risks
+
+- The active theme is process-local global state, matching the current TUI
+  architecture. A future TUI crate split should pass an explicit theme handle
+  into render contexts.
+- Syntax highlighting currently selects embedded themes only. Loading external
+  `syntect` theme files would need a separate trust and path policy.
+
+## Source Journals
+
+- `docs/journal/2026-07-03-tui-theme-tokens.md`

--- a/docs/journal/2026-07-03-tui-theme-tokens.md
+++ b/docs/journal/2026-07-03-tui-theme-tokens.md
@@ -1,0 +1,39 @@
+# 2026-07-03 TUI Theme Tokens
+
+## What Changed
+
+- Added `tui.theme` config for the TUI theme name, semantic token overrides,
+  and the active embedded syntax highlighting theme.
+- Introduced a semantic `ThemeToken` resolver with Nord-compatible defaults and
+  non-fatal fallback behavior for unknown tokens or invalid colors.
+- Routed markdown, diff preview, list picker, command/status/model overlays,
+  setup overlays, popup panels, and dimmer surfaces through semantic tokens.
+- Made syntax highlighting select an embedded `syntect` theme from
+  `tui.theme.syntax_theme`.
+
+## Why
+
+The previous palette had static constants that could not be configured, while
+some UI paths still used direct colors. That made the TUI hard to tune and left
+theme-related TODOs partially implemented. The new token layer gives renderers a
+stable semantic contract while preserving the current Nord baseline.
+
+## Trade-Offs
+
+- The theme is still installed into process-local global state because current
+  TUI render functions do not carry an explicit render context.
+- Unknown config is accepted with warnings rather than failing startup, because
+  visual customization should not make the terminal unusable.
+- Syntax themes are limited to embedded `two-face` themes for now.
+
+## Verification
+
+- `cargo test -p rara-config loads_tui_theme_config`
+- `cargo test --bin rara tui::theme::tests`
+- `cargo check --locked --workspace --all-targets`
+- `cargo clippy --locked --workspace --all-targets -- -D warnings`
+
+## Remaining Work
+
+- Add a runtime command or settings UI if users need live theme switching.
+- Revisit explicit theme handles during the future TUI crate split.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -24,7 +24,7 @@ Active backlog only. Keep this file small and current.
 - [x] Restore Claude Code-style realtime transcript live-log writes from
       `push_entry` and clear the live log after turn commit so resume can
       recover partial turns after restart.
-- [ ] Introduce an opencode-style configurable TUI theme token schema instead
+- [x] Introduce an opencode-style configurable TUI theme token schema instead
       of static unused palette constants. Wire markdown, diff, syntax
       highlighting, picker, and overlay renderers through semantic theme tokens;
       for syntax highlighting, define how the app theme maps to or selects the

--- a/src/tui/highlight.rs
+++ b/src/tui/highlight.rs
@@ -10,7 +10,7 @@ use syntect::{
     parsing::SyntaxReference,
     util::LinesWithEndings,
 };
-use two_face::theme::EmbeddedThemeName;
+use two_face::theme::{EmbeddedLazyThemeSet, EmbeddedThemeName};
 
 static SYNTAX_SET: OnceLock<syntect::parsing::SyntaxSet> = OnceLock::new();
 static THEME: OnceLock<RwLock<Theme>> = OnceLock::new();
@@ -26,13 +26,37 @@ fn syntax_set() -> &'static syntect::parsing::SyntaxSet {
 }
 
 fn theme_lock() -> &'static RwLock<Theme> {
-    THEME.get_or_init(|| {
-        RwLock::new(
-            two_face::theme::extra()
-                .get(EmbeddedThemeName::CatppuccinMocha)
-                .clone(),
-        )
-    })
+    THEME.get_or_init(|| RwLock::new(default_syntax_theme()))
+}
+
+fn default_syntax_theme() -> Theme {
+    two_face::theme::extra()
+        .get(EmbeddedThemeName::CatppuccinMocha)
+        .clone()
+}
+
+pub(crate) fn install_syntax_theme(name: Option<&str>) {
+    let theme = name
+        .and_then(|name| {
+            let trimmed = name.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            EmbeddedLazyThemeSet::theme_names()
+                .iter()
+                .copied()
+                .find(|candidate| candidate.as_name().eq_ignore_ascii_case(trimmed))
+                .map(|theme_name| two_face::theme::extra().get(theme_name).clone())
+                .or_else(|| {
+                    log::warn!("unknown syntax theme `{trimmed}`, using default syntax theme");
+                    None
+                })
+        })
+        .unwrap_or_else(default_syntax_theme);
+    match theme_lock().write() {
+        Ok(mut active) => *active = theme,
+        Err(poisoned) => *poisoned.into_inner() = theme,
+    }
 }
 
 fn current_syntax_theme() -> Theme {

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -15,7 +15,7 @@ use ratatui::{
 use super::app_event::AppEvent;
 use super::custom_terminal::Frame;
 use super::state::{ListPickerKind, TuiApp};
-use super::theme::*;
+use super::theme::{ThemeToken, theme_color};
 use crate::thread_store::ThreadSummary;
 
 const AUTH_MODE_ITEM_COUNT: usize = 4;
@@ -117,11 +117,11 @@ impl ListPickerKind {
     fn selected_style(idx: usize, selected: usize) -> Style {
         if idx == selected {
             Style::default()
-                .fg(PICKER_HIGHLIGHT_FG)
-                .bg(PICKER_HIGHLIGHT_BG)
+                .fg(theme_color(ThemeToken::PickerHighlightFg))
+                .bg(theme_color(ThemeToken::PickerHighlightBg))
                 .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(PICKER_ITEM_FG)
+            Style::default().fg(theme_color(ThemeToken::PickerItemFg))
         }
     }
 
@@ -142,7 +142,10 @@ impl ListPickerKind {
                     .cloned()
                     .unwrap_or(false);
                 let status_indicator = if connected {
-                    ratatui::text::Span::styled(" ● ", Style::default().fg(STATUS_SUCCESS))
+                    ratatui::text::Span::styled(
+                        " ● ",
+                        Style::default().fg(theme_color(ThemeToken::StatusSuccess)),
+                    )
                 } else {
                     ratatui::text::Span::raw("   ")
                 };
@@ -156,7 +159,7 @@ impl ListPickerKind {
                 ]);
                 let desc_line = ratatui::text::Line::from(ratatui::text::Span::styled(
                     format!("      {}", desc),
-                    Style::default().fg(PICKER_ITEM_MUTED_FG),
+                    Style::default().fg(theme_color(ThemeToken::PickerItemMutedFg)),
                 ));
                 ListItem::new(vec![name_line, desc_line]).style(Self::selected_style(idx, selected))
             })
@@ -488,7 +491,7 @@ pub fn render_list_picker(f: &mut Frame, app: &TuiApp, kind: ListPickerKind, are
     f.render_widget(
         Paragraph::new(kind.description()).block(
             Block::default()
-                .style(Style::default().bg(UI_ELEMENT_BG))
+                .style(Style::default().bg(theme_color(ThemeToken::UiElementBg)))
                 .padding(Padding::horizontal(1))
                 .title(kind.title()),
         ),
@@ -548,7 +551,7 @@ fn render_resume_picker(f: &mut Frame, app: &TuiApp, area: Rect) {
     f.render_widget(
         Paragraph::new(vec![search_line, status_line]).block(
             Block::default()
-                .style(Style::default().bg(UI_ELEMENT_BG))
+                .style(Style::default().bg(theme_color(ThemeToken::UiElementBg)))
                 .padding(Padding::horizontal(1))
                 .title(ListPickerKind::Resume.title()),
         ),
@@ -586,8 +589,8 @@ fn list_picker_state(selected: usize, item_count: usize) -> ListState {
 
 fn list_picker_highlight_style() -> Style {
     Style::default()
-        .fg(PICKER_HIGHLIGHT_FG)
-        .bg(PICKER_HIGHLIGHT_BG)
+        .fg(theme_color(ThemeToken::PickerHighlightFg))
+        .bg(theme_color(ThemeToken::PickerHighlightBg))
         .add_modifier(Modifier::BOLD)
 }
 

--- a/src/tui/markdown_render.rs
+++ b/src/tui/markdown_render.rs
@@ -15,10 +15,7 @@ use self::local_links::{
     is_local_path_like_link, render_local_link_target, should_render_link_destination,
 };
 use crate::tui::highlight::highlight_code_to_lines;
-use crate::tui::theme::{
-    MD_BLOCK_QUOTE, MD_BOLD, MD_CODE, MD_HEADING, MD_ITALIC, MD_LINK, MD_LIST_BULLET, TEXT_MUTED,
-    TEXT_SECONDARY,
-};
+use crate::tui::theme::{ThemeToken, theme_color};
 
 #[derive(Default)]
 struct MarkdownStyles {
@@ -44,23 +41,43 @@ struct MarkdownStyles {
 impl MarkdownStyles {
     fn new() -> Self {
         Self {
-            h1: Style::new().fg(MD_HEADING).bold().underlined(),
-            h2: Style::new().fg(MD_HEADING).bold(),
-            h3: Style::new().fg(MD_HEADING).bold().italic(),
-            h4: Style::new().fg(MD_HEADING).italic(),
-            h5: Style::new().fg(MD_HEADING).italic(),
-            h6: Style::new().fg(MD_HEADING).italic(),
-            code: Style::new().fg(MD_CODE),
-            emphasis: Style::new().fg(MD_ITALIC).italic(),
-            strong: Style::new().fg(MD_BOLD).bold(),
+            h1: Style::new()
+                .fg(theme_color(ThemeToken::MarkdownHeading))
+                .bold()
+                .underlined(),
+            h2: Style::new()
+                .fg(theme_color(ThemeToken::MarkdownHeading))
+                .bold(),
+            h3: Style::new()
+                .fg(theme_color(ThemeToken::MarkdownHeading))
+                .bold()
+                .italic(),
+            h4: Style::new()
+                .fg(theme_color(ThemeToken::MarkdownHeading))
+                .italic(),
+            h5: Style::new()
+                .fg(theme_color(ThemeToken::MarkdownHeading))
+                .italic(),
+            h6: Style::new()
+                .fg(theme_color(ThemeToken::MarkdownHeading))
+                .italic(),
+            code: Style::new().fg(theme_color(ThemeToken::MarkdownCode)),
+            emphasis: Style::new()
+                .fg(theme_color(ThemeToken::MarkdownItalic))
+                .italic(),
+            strong: Style::new()
+                .fg(theme_color(ThemeToken::MarkdownBold))
+                .bold(),
             strikethrough: Style::new().crossed_out(),
-            ordered_list_marker: Style::new().fg(MD_LIST_BULLET),
-            unordered_list_marker: Style::new().fg(MD_LIST_BULLET),
-            link: Style::new().fg(MD_LINK).underlined(),
-            blockquote: Style::new().fg(MD_BLOCK_QUOTE),
-            code_block_lang_tag: Style::new().fg(TEXT_SECONDARY),
+            ordered_list_marker: Style::new().fg(theme_color(ThemeToken::MarkdownListBullet)),
+            unordered_list_marker: Style::new().fg(theme_color(ThemeToken::MarkdownListBullet)),
+            link: Style::new()
+                .fg(theme_color(ThemeToken::MarkdownLink))
+                .underlined(),
+            blockquote: Style::new().fg(theme_color(ThemeToken::MarkdownBlockQuote)),
+            code_block_lang_tag: Style::new().fg(theme_color(ThemeToken::TextSecondary)),
             task_list_marker: Style::new().bold(),
-            footnote: Style::new().fg(TEXT_MUTED),
+            footnote: Style::new().fg(theme_color(ThemeToken::TextMuted)),
         }
     }
 }

--- a/src/tui/render/diff.rs
+++ b/src/tui/render/diff.rs
@@ -4,7 +4,7 @@ use ratatui::{
 };
 
 use crate::tui::render::display_width;
-use crate::tui::theme::*;
+use crate::tui::theme::{ThemeToken, theme_color};
 
 const MAX_DIFF_LINES: usize = 80;
 
@@ -63,7 +63,7 @@ pub(crate) fn render_patch_preview(patch: &str, width: u16) -> Vec<Line<'static>
                 Span::raw("    "),
                 Span::styled(
                     "(no inline diff preview)",
-                    Style::default().fg(TEXT_SECONDARY),
+                    token_fg(ThemeToken::TextSecondary),
                 ),
             ]));
             continue;
@@ -78,7 +78,7 @@ pub(crate) fn render_patch_preview(patch: &str, width: u16) -> Vec<Line<'static>
                             "... {} more diff line(s)",
                             remaining_diff_lines(&files, emitted)
                         ),
-                        Style::default().fg(TEXT_SECONDARY),
+                        token_fg(ThemeToken::TextSecondary),
                     ),
                 ]));
                 return lines;
@@ -107,9 +107,7 @@ pub(crate) fn render_message_diff_preview(
     if let Some(role) = role.filter(|role| !role.is_empty()) {
         lines.push(Line::from(vec![Span::styled(
             role.to_string(),
-            Style::default()
-                .fg(TEXT_SECONDARY)
-                .add_modifier(Modifier::ITALIC),
+            token_fg(ThemeToken::TextSecondary).add_modifier(Modifier::ITALIC),
         )]));
     }
 
@@ -125,9 +123,7 @@ pub(crate) fn render_message_diff_preview(
             Span::raw("  "),
             Span::styled(
                 "diff:",
-                Style::default()
-                    .fg(PHASE_PLANNING)
-                    .add_modifier(Modifier::BOLD),
+                token_fg(ThemeToken::PhasePlanning).add_modifier(Modifier::BOLD),
             ),
         ]));
     }
@@ -197,7 +193,7 @@ fn render_raw_patch_preview(patch: &str, width: u16) -> Vec<Line<'static>> {
                     "  ... {} more diff line(s)",
                     patch.lines().count().saturating_sub(emitted)
                 ),
-                Style::default().fg(TEXT_SECONDARY),
+                token_fg(ThemeToken::TextSecondary),
             )));
             break;
         }
@@ -282,7 +278,7 @@ fn push_current_file(files: &mut Vec<DiffFile>, current: &mut Option<DiffFile>) 
 fn render_summary_header(files: &[DiffFile]) -> Line<'static> {
     let added: usize = files.iter().map(|file| file.added).sum();
     let removed: usize = files.iter().map(|file| file.removed).sum();
-    let mut spans = vec![Span::styled("* ", Style::default().fg(TEXT_SECONDARY))];
+    let mut spans = vec![Span::styled("* ", token_fg(ThemeToken::TextSecondary))];
 
     if let [file] = files {
         spans.push(Span::styled(
@@ -313,7 +309,7 @@ fn render_summary_header(files: &[DiffFile]) -> Line<'static> {
 }
 
 fn render_file_header(file: &DiffFile) -> Line<'static> {
-    let mut spans = vec![Span::styled("  - ", Style::default().fg(TEXT_SECONDARY))];
+    let mut spans = vec![Span::styled("  - ", token_fg(ThemeToken::TextSecondary))];
     spans.extend(path_spans(file));
     spans.push(Span::raw(" "));
     spans.extend(line_count_spans(file.added, file.removed));
@@ -331,9 +327,9 @@ fn path_spans(file: &DiffFile) -> Vec<Span<'static>> {
 fn line_count_spans(added: usize, removed: usize) -> Vec<Span<'static>> {
     vec![
         Span::raw("("),
-        Span::styled(format!("+{added}"), Style::default().fg(STATUS_SUCCESS)),
+        Span::styled(format!("+{added}"), token_fg(ThemeToken::StatusSuccess)),
         Span::raw(" "),
-        Span::styled(format!("-{removed}"), Style::default().fg(STATUS_ERROR)),
+        Span::styled(format!("-{removed}"), token_fg(ThemeToken::StatusError)),
         Span::raw(")"),
     ]
 }
@@ -371,33 +367,27 @@ fn push_wrapped_diff_line(
     let (sign, sign_style, line_bg, content_style) = match kind {
         DiffLineType::Insert => (
             "+",
-            Style::default()
-                .fg(DIFF_ADD_FG)
-                .add_modifier(Modifier::BOLD),
-            Some(DIFF_ADD_BG),
-            Style::default().fg(DIFF_ADD_FG),
+            token_fg(ThemeToken::DiffAddFg).add_modifier(Modifier::BOLD),
+            Some(theme_color(ThemeToken::DiffAddBg)),
+            token_fg(ThemeToken::DiffAddFg),
         ),
         DiffLineType::Delete => (
             "-",
-            Style::default()
-                .fg(DIFF_DEL_FG)
-                .add_modifier(Modifier::BOLD),
-            Some(DIFF_DEL_BG),
-            Style::default().fg(DIFF_DEL_FG).add_modifier(Modifier::DIM),
+            token_fg(ThemeToken::DiffDelFg).add_modifier(Modifier::BOLD),
+            Some(theme_color(ThemeToken::DiffDelBg)),
+            token_fg(ThemeToken::DiffDelFg).add_modifier(Modifier::DIM),
         ),
         DiffLineType::Header => (
             " ",
-            Style::default().fg(TEXT_SECONDARY),
-            Some(DIFF_HUNK_BG),
-            Style::default()
-                .fg(DIFF_HUNK_FG)
-                .add_modifier(Modifier::BOLD),
+            token_fg(ThemeToken::TextSecondary),
+            Some(theme_color(ThemeToken::DiffHunkBg)),
+            token_fg(ThemeToken::DiffHunkFg).add_modifier(Modifier::BOLD),
         ),
         DiffLineType::Context => (
             " ",
-            Style::default().fg(DIFF_CONTEXT_FG),
+            token_fg(ThemeToken::DiffContextFg),
             None,
-            Style::default().fg(DIFF_CONTEXT_FG),
+            token_fg(ThemeToken::DiffContextFg),
         ),
     };
 
@@ -423,6 +413,10 @@ fn push_wrapped_diff_line(
             Line::from(spans)
         })
         .collect()
+}
+
+fn token_fg(token: ThemeToken) -> Style {
+    Style::default().fg(theme_color(token))
 }
 
 fn wrap_plain_text(text: &str, width: usize) -> Vec<String> {

--- a/src/tui/render/diff.rs
+++ b/src/tui/render/diff.rs
@@ -4,7 +4,7 @@ use ratatui::{
 };
 
 use crate::tui::render::display_width;
-use crate::tui::theme::{ThemeToken, theme_color};
+use crate::tui::theme::{ThemeToken, theme_color, token_fg};
 
 const MAX_DIFF_LINES: usize = 80;
 
@@ -413,10 +413,6 @@ fn push_wrapped_diff_line(
             Line::from(spans)
         })
         .collect()
-}
-
-fn token_fg(token: ThemeToken) -> Style {
-    Style::default().fg(theme_color(token))
 }
 
 fn wrap_plain_text(text: &str, width: usize) -> Vec<String> {

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -1,4 +1,4 @@
-use crate::tui::theme::{ThemeToken, theme_color};
+use crate::tui::theme::{ThemeToken, theme_color, token_bg, token_fg};
 #[path = "overlay_setup.rs"]
 mod overlay_setup;
 
@@ -355,15 +355,15 @@ fn panel_text(title: &str, body: &str) -> String {
 
 fn command_list_highlight_style() -> Style {
     Style::default()
-        .fg(theme_color(ThemeToken::BadgeFgDark))
-        .bg(theme_color(ThemeToken::TextSecondary))
+        .fg(theme_color(ThemeToken::OverlayHighlightFg))
+        .bg(theme_color(ThemeToken::OverlayHighlightBg))
         .add_modifier(Modifier::BOLD)
 }
 
 fn help_selected_tab_style() -> Style {
     Style::default()
-        .fg(theme_color(ThemeToken::BadgeFgDark))
-        .bg(theme_color(ThemeToken::TextSecondary))
+        .fg(theme_color(ThemeToken::OverlayHighlightFg))
+        .bg(theme_color(ThemeToken::OverlayHighlightBg))
         .add_modifier(Modifier::BOLD)
 }
 
@@ -732,12 +732,4 @@ fn render_model_search(f: &mut Frame, app: &TuiApp, area: Rect) {
         token_fg(ThemeToken::TextMuted),
     )]);
     f.render_widget(Paragraph::new(footer), chunks[2]);
-}
-
-fn token_fg(token: ThemeToken) -> Style {
-    Style::default().fg(theme_color(token))
-}
-
-fn token_bg(token: ThemeToken) -> Style {
-    Style::default().bg(theme_color(token))
 }

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -1,10 +1,10 @@
-use crate::tui::theme::*;
+use crate::tui::theme::{ThemeToken, theme_color};
 #[path = "overlay_setup.rs"]
 mod overlay_setup;
 
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Flex, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::Padding,
     widgets::{Block, Clear, List, ListItem, ListState, Paragraph, Tabs, Wrap},
@@ -147,7 +147,7 @@ fn render_help_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: HelpTab) {
     f.render_widget(
         Tabs::new(titles)
             .select(selected)
-            .style(Style::default().fg(TEXT_SECONDARY))
+            .style(token_fg(ThemeToken::TextSecondary))
             .highlight_style(help_selected_tab_style()),
         chunks[0],
     );
@@ -247,7 +247,7 @@ fn render_command_palette(f: &mut Frame, app: &TuiApp, area: Rect) {
     let block = popup_block().title_top(Line::from(Span::styled(
         " Command Palette ",
         Style::default()
-            .fg(TEXT_ACCENT)
+            .fg(theme_color(ThemeToken::TextAccent))
             .add_modifier(Modifier::BOLD),
     )));
     let inner = block.inner(area);
@@ -265,12 +265,12 @@ fn render_command_palette(f: &mut Frame, app: &TuiApp, area: Rect) {
 
     // ── Search bar ───────────────────────────────────────────────
     let search_text = if query.is_empty() {
-        Span::styled("  Type to search…", Style::default().fg(TEXT_MUTED))
+        Span::styled("  Type to search…", token_fg(ThemeToken::TextMuted))
     } else {
         Span::styled(
             format!("  /{}", query),
             Style::default()
-                .fg(BADGE_FG_DARK)
+                .fg(theme_color(ThemeToken::BadgeFgDark))
                 .add_modifier(Modifier::BOLD),
         )
     };
@@ -297,8 +297,8 @@ fn render_command_palette(f: &mut Frame, app: &TuiApp, area: Rect) {
     };
     let hints = "↑↓ navigate  ↵ select  Esc close";
     let footer_line = Line::from(vec![
-        Span::styled(count_text, Style::default().fg(TEXT_MUTED)),
-        Span::styled(format!("    {hints}"), Style::default().fg(TEXT_MUTED)),
+        Span::styled(count_text, token_fg(ThemeToken::TextMuted)),
+        Span::styled(format!("    {hints}"), token_fg(ThemeToken::TextMuted)),
     ]);
     f.render_widget(Paragraph::new(footer_line), chunks[2]);
 }
@@ -335,7 +335,7 @@ fn command_palette_item(spec: &CommandSpec) -> ListItem<'static> {
             format!("{full_name:<12}"),
             Style::default().add_modifier(Modifier::BOLD),
         ),
-        Span::styled(spec.summary, Style::default().fg(TEXT_MUTED)),
+        Span::styled(spec.summary, token_fg(ThemeToken::TextMuted)),
     ]))
 }
 
@@ -345,7 +345,7 @@ fn command_palette_line(spec: &CommandSpec) -> Line<'static> {
         format!("{:<11}", spec.usage),
         Style::default().add_modifier(Modifier::BOLD),
     );
-    let summary_span = Span::styled(spec.summary, Style::default().fg(TEXT_MUTED));
+    let summary_span = Span::styled(spec.summary, token_fg(ThemeToken::TextMuted));
     Line::from(vec![name_span, summary_span])
 }
 
@@ -355,15 +355,15 @@ fn panel_text(title: &str, body: &str) -> String {
 
 fn command_list_highlight_style() -> Style {
     Style::default()
-        .fg(BADGE_FG_DARK)
-        .bg(TEXT_SECONDARY)
+        .fg(theme_color(ThemeToken::BadgeFgDark))
+        .bg(theme_color(ThemeToken::TextSecondary))
         .add_modifier(Modifier::BOLD)
 }
 
 fn help_selected_tab_style() -> Style {
     Style::default()
-        .fg(BADGE_FG_DARK)
-        .bg(TEXT_SECONDARY)
+        .fg(theme_color(ThemeToken::BadgeFgDark))
+        .bg(theme_color(ThemeToken::TextSecondary))
         .add_modifier(Modifier::BOLD)
 }
 
@@ -384,14 +384,14 @@ fn render_status_modal(f: &mut Frame, app: &TuiApp, area: Rect, tab: StatusTab) 
     f.render_widget(
         Tabs::new(titles)
             .select(status_tab_index(tab))
-            .style(Style::default().fg(TEXT_SECONDARY))
+            .style(token_fg(ThemeToken::TextSecondary))
             .highlight_style(help_selected_tab_style()),
         chunks[0],
     );
     f.render_widget(Paragraph::new(lines), chunks[1]);
     f.render_widget(
         Paragraph::new("Esc close  1 overview  2 config  3 context  <-> switch")
-            .style(Style::default().fg(Color::DarkGray))
+            .style(token_fg(ThemeToken::TextMuted))
             .alignment(Alignment::Center),
         chunks[2],
     );
@@ -468,7 +468,7 @@ fn popup_rect(area: Rect, max_width: u16, max_height_pct: u16) -> Rect {
 /// Fill the given area with the dimmer background behind popups.
 fn render_dimmer(f: &mut Frame, area: Rect) {
     f.render_widget(
-        Paragraph::new("").style(Style::default().bg(POPUP_DIMMER_BG)),
+        Paragraph::new("").style(token_bg(ThemeToken::PopupDimmerBg)),
         area,
     );
 }
@@ -477,7 +477,7 @@ fn render_dimmer(f: &mut Frame, area: Rect) {
 /// 1-char horizontal padding (opencode color-block style).
 pub(crate) fn popup_block() -> Block<'static> {
     Block::default()
-        .style(Style::default().bg(POPUP_BG))
+        .style(token_bg(ThemeToken::PopupBg))
         .padding(Padding::horizontal(1))
 }
 
@@ -659,7 +659,7 @@ fn render_model_search(f: &mut Frame, app: &TuiApp, area: Rect) {
     let block = popup_block().title_top(Line::from(Span::styled(
         " Model Search ",
         Style::default()
-            .fg(TEXT_ACCENT)
+            .fg(theme_color(ThemeToken::TextAccent))
             .add_modifier(Modifier::BOLD),
     )));
     let inner = block.inner(area);
@@ -676,12 +676,12 @@ fn render_model_search(f: &mut Frame, app: &TuiApp, area: Rect) {
 
     // Search input
     let search_text = if query.is_empty() {
-        Span::styled("  Type to filter models…", Style::default().fg(TEXT_MUTED))
+        Span::styled("  Type to filter models…", token_fg(ThemeToken::TextMuted))
     } else {
         Span::styled(
             format!("  {}", query),
             Style::default()
-                .fg(BADGE_FG_DARK)
+                .fg(theme_color(ThemeToken::BadgeFgDark))
                 .add_modifier(Modifier::BOLD),
         )
     };
@@ -697,12 +697,12 @@ fn render_model_search(f: &mut Frame, app: &TuiApp, area: Rect) {
             );
             let family = Span::styled(
                 p.provider_label.as_str(),
-                Style::default().fg(TEXT_SECONDARY),
+                token_fg(ThemeToken::TextSecondary),
             );
             let window = if let Some(tokens) = p.context_window {
                 Span::styled(
                     format!("  · {: >4.0} K", tokens as f64 / 1000.0),
-                    Style::default().fg(TEXT_MUTED),
+                    token_fg(ThemeToken::TextMuted),
                 )
             } else {
                 Span::raw("")
@@ -715,7 +715,7 @@ fn render_model_search(f: &mut Frame, app: &TuiApp, area: Rect) {
         List::new(items)
             .highlight_style(
                 Style::default()
-                    .fg(TEXT_ACCENT)
+                    .fg(theme_color(ThemeToken::TextAccent))
                     .add_modifier(Modifier::BOLD),
             )
             .highlight_symbol("›  "),
@@ -729,7 +729,15 @@ fn render_model_search(f: &mut Frame, app: &TuiApp, area: Rect) {
             "{} models  ↑↓ navigate  ↵ select  Esc close",
             filtered.len()
         ),
-        Style::default().fg(TEXT_MUTED),
+        token_fg(ThemeToken::TextMuted),
     )]);
     f.render_widget(Paragraph::new(footer), chunks[2]);
+}
+
+fn token_fg(token: ThemeToken) -> Style {
+    Style::default().fg(theme_color(token))
+}
+
+fn token_bg(token: ThemeToken) -> Style {
+    Style::default().bg(theme_color(token))
 }

--- a/src/tui/render/overlay_setup.rs
+++ b/src/tui/render/overlay_setup.rs
@@ -11,7 +11,7 @@ use unicode_width::UnicodeWidthChar;
 use super::Frame;
 use crate::tui::render::bottom_pane::composer::editor_cursor_position;
 use crate::tui::state::{PermissionMode, ProviderFamily, TuiApp};
-use crate::tui::theme::*;
+use crate::tui::theme::{ThemeToken, theme_color};
 
 fn wrapped_text_height(text: &str, area_width: u16) -> u16 {
     let width = area_width.saturating_sub(2).max(1) as usize;
@@ -71,7 +71,7 @@ pub(super) fn render_permission_picker_modal(f: &mut Frame, app: &TuiApp, area: 
                     && idx == app.permission_picker_idx);
             let style = if idx == app.permission_picker_idx {
                 Style::default()
-                    .fg(TEXT_ACCENT)
+                    .fg(theme_color(ThemeToken::TextAccent))
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default()
@@ -101,7 +101,12 @@ pub(super) fn render_permission_picker_modal(f: &mut Frame, app: &TuiApp, area: 
         .split(area);
     f.render_widget(
         Paragraph::new("Choose how RARA handles file edits, commands, and network access. Press Enter to apply the selected mode.")
-            .block(Block::default().style(Style::default().bg(UI_ELEMENT_BG)).padding(Padding::horizontal(1)).title(title)),
+            .block(
+                Block::default()
+                    .style(element_bg())
+                    .padding(Padding::horizontal(1))
+                    .title(title),
+            ),
         chunks[0],
     );
     f.render_widget(List::new(items), chunks[1]);
@@ -138,14 +143,14 @@ pub(super) fn render_base_url_editor_modal(
     let intro = Paragraph::new(intro_text)
         .block(
             Block::default()
-                .style(Style::default().bg(UI_ELEMENT_BG))
+                .style(element_bg())
                 .padding(Padding::horizontal(1))
                 .title(" Base URL "),
         )
         .wrap(Wrap { trim: false });
     let editor = Paragraph::new(app.base_url_input.as_str()).block(
         Block::default()
-            .style(Style::default().bg(UI_ELEMENT_BG))
+            .style(element_bg())
             .padding(Padding::horizontal(1))
             .title(" Value "),
     );
@@ -178,7 +183,7 @@ pub(super) fn render_skills_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect
         Paragraph::new(intro)
             .block(
                 Block::default()
-                    .style(Style::default().bg(UI_ELEMENT_BG))
+                    .style(element_bg())
                     .padding(Padding::horizontal(1))
                     .title(title.as_str()),
             )
@@ -198,7 +203,7 @@ pub(super) fn render_skills_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect
                 let check = if entry.enabled { "✔" } else { "✗" };
                 let style = if selected {
                     Style::default()
-                        .fg(TEXT_ACCENT)
+                        .fg(theme_color(ThemeToken::TextAccent))
                         .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default()
@@ -262,14 +267,14 @@ pub(super) fn render_api_key_editor_modal(
     let intro = Paragraph::new(intro_text)
         .block(
             Block::default()
-                .style(Style::default().bg(UI_ELEMENT_BG))
+                .style(element_bg())
                 .padding(Padding::horizontal(1))
                 .title(title),
         )
         .wrap(Wrap { trim: false });
     let editor = Paragraph::new(app.api_key_input.as_str()).block(
         Block::default()
-            .style(Style::default().bg(UI_ELEMENT_BG))
+            .style(element_bg())
             .padding(Padding::horizontal(1))
             .title(" Value "),
     );
@@ -302,14 +307,14 @@ pub(super) fn render_model_name_editor_modal(
     let intro = Paragraph::new(intro_text)
         .block(
             Block::default()
-                .style(Style::default().bg(UI_ELEMENT_BG))
+                .style(element_bg())
                 .padding(Padding::horizontal(1))
                 .title(" Model Name "),
         )
         .wrap(Wrap { trim: false });
     let editor = Paragraph::new(app.model_name_input.as_str()).block(
         Block::default()
-            .style(Style::default().bg(UI_ELEMENT_BG))
+            .style(element_bg())
             .padding(Padding::horizontal(1))
             .title(" Value "),
     );
@@ -349,14 +354,14 @@ pub(super) fn render_openai_profile_label_editor_modal(
     let intro = Paragraph::new(intro_text)
         .block(
             Block::default()
-                .style(Style::default().bg(UI_ELEMENT_BG))
+                .style(element_bg())
                 .padding(Padding::horizontal(1))
                 .title(" New Endpoint Profile "),
         )
         .wrap(Wrap { trim: false });
     let editor = Paragraph::new(app.openai_profile_label_input.as_str()).block(
         Block::default()
-            .style(Style::default().bg(UI_ELEMENT_BG))
+            .style(element_bg())
             .padding(Padding::horizontal(1))
             .title(" Label "),
     );
@@ -369,4 +374,8 @@ pub(super) fn render_openai_profile_label_editor_modal(
         app.openai_profile_label_cursor_offset(),
         chunks[1],
     ))
+}
+
+fn element_bg() -> Style {
+    Style::default().bg(theme_color(ThemeToken::UiElementBg))
 }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -205,6 +205,7 @@ impl TuiApp {
     pub fn new(cm: ConfigManager) -> anyhow::Result<Self> {
         let mut cfg = cm.load()?;
         cfg.apply_provider_environment_defaults();
+        crate::tui::theme::install_config(&cfg.tui.theme);
         let overlay = None;
         let startup_notice = startup_warning_for_config(&cfg);
         let provider_picker_idx = selected_provider_family_idx_for_config(&cfg);

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -25,6 +25,8 @@ pub(crate) enum ThemeToken {
     PickerItemMutedFg,
     PickerHighlightFg,
     PickerHighlightBg,
+    OverlayHighlightFg,
+    OverlayHighlightBg,
     RoleUser,
     RoleAgent,
     RoleSystem,
@@ -79,6 +81,8 @@ const THEME_TOKENS: &[ThemeToken] = &[
     ThemeToken::PickerItemMutedFg,
     ThemeToken::PickerHighlightFg,
     ThemeToken::PickerHighlightBg,
+    ThemeToken::OverlayHighlightFg,
+    ThemeToken::OverlayHighlightBg,
     ThemeToken::RoleUser,
     ThemeToken::RoleAgent,
     ThemeToken::RoleSystem,
@@ -135,6 +139,8 @@ impl ThemeToken {
             Self::PickerItemMutedFg => "picker.item.muted.fg",
             Self::PickerHighlightFg => "picker.highlight.fg",
             Self::PickerHighlightBg => "picker.highlight.bg",
+            Self::OverlayHighlightFg => "overlay.highlight.fg",
+            Self::OverlayHighlightBg => "overlay.highlight.bg",
             Self::RoleUser => "role.user",
             Self::RoleAgent => "role.agent",
             Self::RoleSystem => "role.system",
@@ -191,6 +197,8 @@ impl ThemeToken {
             Self::PickerItemMutedFg => PICKER_ITEM_MUTED_FG,
             Self::PickerHighlightFg => PICKER_HIGHLIGHT_FG,
             Self::PickerHighlightBg => PICKER_HIGHLIGHT_BG,
+            Self::OverlayHighlightFg => OVERLAY_HIGHLIGHT_FG,
+            Self::OverlayHighlightBg => OVERLAY_HIGHLIGHT_BG,
             Self::RoleUser => ROLE_USER,
             Self::RoleAgent => ROLE_AGENT,
             Self::RoleSystem => ROLE_SYSTEM,
@@ -287,6 +295,14 @@ pub(crate) fn theme_color(token: ThemeToken) -> Color {
     }
 }
 
+pub(crate) fn token_fg(token: ThemeToken) -> ratatui::style::Style {
+    ratatui::style::Style::default().fg(theme_color(token))
+}
+
+pub(crate) fn token_bg(token: ThemeToken) -> ratatui::style::Style {
+    ratatui::style::Style::default().bg(theme_color(token))
+}
+
 pub(crate) fn parse_color_value(value: &str) -> Option<Color> {
     let value = value.trim();
     if value.eq_ignore_ascii_case("reset") {
@@ -302,7 +318,7 @@ pub(crate) fn parse_color_value(value: &str) -> Option<Color> {
 }
 
 fn parse_hex_color(hex: &str) -> Option<Color> {
-    if hex.len() != 6 {
+    if hex.len() != 6 || !hex.is_ascii() {
         return None;
     }
     let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
@@ -377,6 +393,10 @@ pub(crate) const PICKER_ITEM_FG: Color = NORD4;
 pub(crate) const PICKER_ITEM_MUTED_FG: Color = NORD3;
 pub(crate) const PICKER_HIGHLIGHT_FG: Color = NORD6;
 pub(crate) const PICKER_HIGHLIGHT_BG: Color = NORD10;
+
+// ── Overlay highlights ─────────────────────────────────────────
+pub(crate) const OVERLAY_HIGHLIGHT_FG: Color = NORD6;
+pub(crate) const OVERLAY_HIGHLIGHT_BG: Color = NORD3;
 
 // ── Message roles ───────────────────────────────────────────────
 pub(crate) const ROLE_USER: Color = NORD9;
@@ -456,6 +476,7 @@ mod tests {
         assert_eq!(parse_color_value("reset"), Some(Color::Reset));
         assert_eq!(parse_color_value("light_blue"), Some(Color::LightBlue));
         assert_eq!(parse_color_value("not-a-color"), None);
+        assert_eq!(parse_color_value("#한글"), None);
     }
 
     #[test]

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,38 +1,361 @@
 // Semantic color tokens for the TUI.
 //
-// All render-layer code should use these constants instead of raw
-// ratatui::style::Color values so that the color palette can be
-// changed in one place and the visual hierarchy stays consistent.
-//
-// The palette is based on the Nord color scheme. Keep this module limited to
-// tokens that the current renderer consumes; a future configurable theme system
-// should introduce a real token schema instead of unused static constants.
+// Render-layer code should prefer ThemeToken lookups over raw
+// ratatui::style::Color values so the user can override the visible palette
+// without changing renderer internals. The legacy constants below remain as
+// the default Nord-compatible palette and as fallback values for renderers that
+// have not been migrated yet.
+use std::collections::BTreeMap;
+use std::sync::{OnceLock, RwLock};
+
 use ratatui::style::Color;
 
+use crate::config::TuiThemeConfig;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) enum ThemeToken {
+    UiElementBg,
+    PopupBg,
+    PopupDimmerBg,
+    TextPrimary,
+    TextSecondary,
+    TextAccent,
+    TextMuted,
+    PickerItemFg,
+    PickerItemMutedFg,
+    PickerHighlightFg,
+    PickerHighlightBg,
+    RoleUser,
+    RoleAgent,
+    RoleSystem,
+    RolePrefix,
+    PhaseExploring,
+    PhaseExplored,
+    PhasePlanning,
+    PhaseRunning,
+    PhaseRan,
+    StatusSuccess,
+    StatusWarning,
+    StatusError,
+    StatusReady,
+    StatusInfo,
+    SurfaceBottomPaneBg,
+    BadgeFgDark,
+    InteractionSubAgent,
+    PendingCardFg,
+    ToolStderrFg,
+    DiffAddBg,
+    DiffAddFg,
+    DiffDelBg,
+    DiffDelFg,
+    DiffHunkBg,
+    DiffHunkFg,
+    DiffContextFg,
+    MarkdownHeading,
+    MarkdownLink,
+    MarkdownCode,
+    MarkdownBlockQuote,
+    MarkdownListBullet,
+    MarkdownBold,
+    MarkdownItalic,
+    BudgetSystem,
+    BudgetWorkspace,
+    BudgetActive,
+    BudgetHistory,
+    BudgetMemory,
+    BudgetOutput,
+    BudgetFree,
+}
+
+const THEME_TOKENS: &[ThemeToken] = &[
+    ThemeToken::UiElementBg,
+    ThemeToken::PopupBg,
+    ThemeToken::PopupDimmerBg,
+    ThemeToken::TextPrimary,
+    ThemeToken::TextSecondary,
+    ThemeToken::TextAccent,
+    ThemeToken::TextMuted,
+    ThemeToken::PickerItemFg,
+    ThemeToken::PickerItemMutedFg,
+    ThemeToken::PickerHighlightFg,
+    ThemeToken::PickerHighlightBg,
+    ThemeToken::RoleUser,
+    ThemeToken::RoleAgent,
+    ThemeToken::RoleSystem,
+    ThemeToken::RolePrefix,
+    ThemeToken::PhaseExploring,
+    ThemeToken::PhaseExplored,
+    ThemeToken::PhasePlanning,
+    ThemeToken::PhaseRunning,
+    ThemeToken::PhaseRan,
+    ThemeToken::StatusSuccess,
+    ThemeToken::StatusWarning,
+    ThemeToken::StatusError,
+    ThemeToken::StatusReady,
+    ThemeToken::StatusInfo,
+    ThemeToken::SurfaceBottomPaneBg,
+    ThemeToken::BadgeFgDark,
+    ThemeToken::InteractionSubAgent,
+    ThemeToken::PendingCardFg,
+    ThemeToken::ToolStderrFg,
+    ThemeToken::DiffAddBg,
+    ThemeToken::DiffAddFg,
+    ThemeToken::DiffDelBg,
+    ThemeToken::DiffDelFg,
+    ThemeToken::DiffHunkBg,
+    ThemeToken::DiffHunkFg,
+    ThemeToken::DiffContextFg,
+    ThemeToken::MarkdownHeading,
+    ThemeToken::MarkdownLink,
+    ThemeToken::MarkdownCode,
+    ThemeToken::MarkdownBlockQuote,
+    ThemeToken::MarkdownListBullet,
+    ThemeToken::MarkdownBold,
+    ThemeToken::MarkdownItalic,
+    ThemeToken::BudgetSystem,
+    ThemeToken::BudgetWorkspace,
+    ThemeToken::BudgetActive,
+    ThemeToken::BudgetHistory,
+    ThemeToken::BudgetMemory,
+    ThemeToken::BudgetOutput,
+    ThemeToken::BudgetFree,
+];
+
+impl ThemeToken {
+    pub(crate) fn key(self) -> &'static str {
+        match self {
+            Self::UiElementBg => "ui.element.bg",
+            Self::PopupBg => "popup.bg",
+            Self::PopupDimmerBg => "popup.dimmer.bg",
+            Self::TextPrimary => "text.primary",
+            Self::TextSecondary => "text.secondary",
+            Self::TextAccent => "text.accent",
+            Self::TextMuted => "text.muted",
+            Self::PickerItemFg => "picker.item.fg",
+            Self::PickerItemMutedFg => "picker.item.muted.fg",
+            Self::PickerHighlightFg => "picker.highlight.fg",
+            Self::PickerHighlightBg => "picker.highlight.bg",
+            Self::RoleUser => "role.user",
+            Self::RoleAgent => "role.agent",
+            Self::RoleSystem => "role.system",
+            Self::RolePrefix => "role.prefix",
+            Self::PhaseExploring => "phase.exploring",
+            Self::PhaseExplored => "phase.explored",
+            Self::PhasePlanning => "phase.planning",
+            Self::PhaseRunning => "phase.running",
+            Self::PhaseRan => "phase.ran",
+            Self::StatusSuccess => "status.success",
+            Self::StatusWarning => "status.warning",
+            Self::StatusError => "status.error",
+            Self::StatusReady => "status.ready",
+            Self::StatusInfo => "status.info",
+            Self::SurfaceBottomPaneBg => "surface.bottom_pane.bg",
+            Self::BadgeFgDark => "badge.fg.dark",
+            Self::InteractionSubAgent => "interaction.sub_agent",
+            Self::PendingCardFg => "pending.card.fg",
+            Self::ToolStderrFg => "tool.stderr.fg",
+            Self::DiffAddBg => "diff.add.bg",
+            Self::DiffAddFg => "diff.add.fg",
+            Self::DiffDelBg => "diff.del.bg",
+            Self::DiffDelFg => "diff.del.fg",
+            Self::DiffHunkBg => "diff.hunk.bg",
+            Self::DiffHunkFg => "diff.hunk.fg",
+            Self::DiffContextFg => "diff.context.fg",
+            Self::MarkdownHeading => "markdown.heading",
+            Self::MarkdownLink => "markdown.link",
+            Self::MarkdownCode => "markdown.code",
+            Self::MarkdownBlockQuote => "markdown.block_quote",
+            Self::MarkdownListBullet => "markdown.list_bullet",
+            Self::MarkdownBold => "markdown.bold",
+            Self::MarkdownItalic => "markdown.italic",
+            Self::BudgetSystem => "budget.system",
+            Self::BudgetWorkspace => "budget.workspace",
+            Self::BudgetActive => "budget.active",
+            Self::BudgetHistory => "budget.history",
+            Self::BudgetMemory => "budget.memory",
+            Self::BudgetOutput => "budget.output",
+            Self::BudgetFree => "budget.free",
+        }
+    }
+
+    fn default_color(self) -> Color {
+        match self {
+            Self::UiElementBg => UI_ELEMENT_BG,
+            Self::PopupBg => POPUP_BG,
+            Self::PopupDimmerBg => POPUP_DIMMER_BG,
+            Self::TextPrimary => TEXT_PRIMARY,
+            Self::TextSecondary => TEXT_SECONDARY,
+            Self::TextAccent => TEXT_ACCENT,
+            Self::TextMuted => TEXT_MUTED,
+            Self::PickerItemFg => PICKER_ITEM_FG,
+            Self::PickerItemMutedFg => PICKER_ITEM_MUTED_FG,
+            Self::PickerHighlightFg => PICKER_HIGHLIGHT_FG,
+            Self::PickerHighlightBg => PICKER_HIGHLIGHT_BG,
+            Self::RoleUser => ROLE_USER,
+            Self::RoleAgent => ROLE_AGENT,
+            Self::RoleSystem => ROLE_SYSTEM,
+            Self::RolePrefix => ROLE_PREFIX,
+            Self::PhaseExploring => PHASE_EXPLORING,
+            Self::PhaseExplored => PHASE_EXPLORED,
+            Self::PhasePlanning => PHASE_PLANNING,
+            Self::PhaseRunning => PHASE_RUNNING,
+            Self::PhaseRan => PHASE_RAN,
+            Self::StatusSuccess => STATUS_SUCCESS,
+            Self::StatusWarning => STATUS_WARNING,
+            Self::StatusError => STATUS_ERROR,
+            Self::StatusReady => STATUS_READY,
+            Self::StatusInfo => STATUS_INFO,
+            Self::SurfaceBottomPaneBg => SURFACE_BOTTOM_PANE_BG,
+            Self::BadgeFgDark => BADGE_FG_DARK,
+            Self::InteractionSubAgent => INTERACTION_SUB_AGENT,
+            Self::PendingCardFg => PENDING_CARD_FG,
+            Self::ToolStderrFg => TOOL_STDERR_FG,
+            Self::DiffAddBg => DIFF_ADD_BG,
+            Self::DiffAddFg => DIFF_ADD_FG,
+            Self::DiffDelBg => DIFF_DEL_BG,
+            Self::DiffDelFg => DIFF_DEL_FG,
+            Self::DiffHunkBg => DIFF_HUNK_BG,
+            Self::DiffHunkFg => DIFF_HUNK_FG,
+            Self::DiffContextFg => DIFF_CONTEXT_FG,
+            Self::MarkdownHeading => MD_HEADING,
+            Self::MarkdownLink => MD_LINK,
+            Self::MarkdownCode => MD_CODE,
+            Self::MarkdownBlockQuote => MD_BLOCK_QUOTE,
+            Self::MarkdownListBullet => MD_LIST_BULLET,
+            Self::MarkdownBold => MD_BOLD,
+            Self::MarkdownItalic => MD_ITALIC,
+            Self::BudgetSystem => BUDGET_SYSTEM,
+            Self::BudgetWorkspace => BUDGET_WORKSPACE,
+            Self::BudgetActive => BUDGET_ACTIVE,
+            Self::BudgetHistory => BUDGET_HISTORY,
+            Self::BudgetMemory => BUDGET_MEMORY,
+            Self::BudgetOutput => BUDGET_OUTPUT,
+            Self::BudgetFree => BUDGET_FREE,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ResolvedTuiTheme {
+    tokens: BTreeMap<ThemeToken, Color>,
+}
+
+impl ResolvedTuiTheme {
+    fn from_config(config: &TuiThemeConfig) -> Self {
+        let mut tokens = BTreeMap::new();
+        for (key, value) in &config.tokens {
+            let Some(token) = token_from_key(key) else {
+                log::warn!("unknown TUI theme token `{key}`");
+                continue;
+            };
+            let Some(color) = parse_color_value(value) else {
+                log::warn!("invalid TUI theme color `{value}` for token `{key}`");
+                continue;
+            };
+            tokens.insert(token, color);
+        }
+        Self { tokens }
+    }
+
+    fn color(&self, token: ThemeToken) -> Color {
+        self.tokens
+            .get(&token)
+            .copied()
+            .unwrap_or_else(|| token.default_color())
+    }
+}
+
+static ACTIVE_THEME: OnceLock<RwLock<ResolvedTuiTheme>> = OnceLock::new();
+
+fn theme_lock() -> &'static RwLock<ResolvedTuiTheme> {
+    ACTIVE_THEME.get_or_init(|| RwLock::new(ResolvedTuiTheme::default()))
+}
+
+pub(crate) fn install_config(config: &TuiThemeConfig) {
+    let theme = ResolvedTuiTheme::from_config(config);
+    match theme_lock().write() {
+        Ok(mut active) => *active = theme,
+        Err(poisoned) => *poisoned.into_inner() = theme,
+    }
+    crate::tui::highlight::install_syntax_theme(config.syntax_theme.as_deref());
+}
+
+pub(crate) fn theme_color(token: ThemeToken) -> Color {
+    match theme_lock().read() {
+        Ok(active) => active.color(token),
+        Err(poisoned) => poisoned.into_inner().color(token),
+    }
+}
+
+pub(crate) fn parse_color_value(value: &str) -> Option<Color> {
+    let value = value.trim();
+    if value.eq_ignore_ascii_case("reset") {
+        return Some(Color::Reset);
+    }
+    if let Some(hex) = value.strip_prefix('#') {
+        return parse_hex_color(hex);
+    }
+    if let Some(index) = value.strip_prefix("ansi:") {
+        return index.parse::<u8>().ok().map(Color::Indexed);
+    }
+    color_name(value)
+}
+
+fn parse_hex_color(hex: &str) -> Option<Color> {
+    if hex.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+    Some(Color::Rgb(r, g, b))
+}
+
+fn color_name(value: &str) -> Option<Color> {
+    match value.to_ascii_lowercase().as_str() {
+        "black" => Some(Color::Black),
+        "red" => Some(Color::Red),
+        "green" => Some(Color::Green),
+        "yellow" => Some(Color::Yellow),
+        "blue" => Some(Color::Blue),
+        "magenta" => Some(Color::Magenta),
+        "cyan" => Some(Color::Cyan),
+        "gray" | "grey" => Some(Color::Gray),
+        "dark_gray" | "dark_grey" | "darkgray" | "darkgrey" => Some(Color::DarkGray),
+        "light_red" | "lightred" => Some(Color::LightRed),
+        "light_green" | "lightgreen" => Some(Color::LightGreen),
+        "light_yellow" | "lightyellow" => Some(Color::LightYellow),
+        "light_blue" | "lightblue" => Some(Color::LightBlue),
+        "light_magenta" | "lightmagenta" => Some(Color::LightMagenta),
+        "light_cyan" | "lightcyan" => Some(Color::LightCyan),
+        "white" => Some(Color::White),
+        _ => None,
+    }
+}
+
+fn token_from_key(key: &str) -> Option<ThemeToken> {
+    let normalized = key.trim().replace('-', ".").to_ascii_lowercase();
+    THEME_TOKENS
+        .iter()
+        .copied()
+        .find(|token| token.key() == normalized)
+}
+
 // See https://www.nordtheme.com/docs/colors-and-palettes
-#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD0: Color = Color::Rgb(0x2E, 0x34, 0x40); // Polar Night (darkest bg)
 pub(crate) const NORD1: Color = Color::Rgb(0x3B, 0x42, 0x52); // Polar Night
-#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD2: Color = Color::Rgb(0x43, 0x4C, 0x5E); // Polar Night
-#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD3: Color = Color::Rgb(0x4C, 0x56, 0x6A); // Polar Night (lightest bg)
-#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD4: Color = Color::Rgb(0xD8, 0xDE, 0xE9); // Snow Storm (darkest fg)
-#[allow(dead_code)] // Nord palette — reserved for future UI use
-pub(crate) const NORD5: Color = Color::Rgb(0xE5, 0xE9, 0xF0); // Snow Storm
-#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD6: Color = Color::Rgb(0xEC, 0xEF, 0xF4); // Snow Storm (brightest fg)
 pub(crate) const NORD7: Color = Color::Rgb(0x8F, 0xBC, 0xBB); // Frost (green-cyan)
 pub(crate) const NORD8: Color = Color::Rgb(0x88, 0xC0, 0xD0); // Frost (cyan)
 pub(crate) const NORD9: Color = Color::Rgb(0x81, 0xA1, 0xC1); // Frost (blue-gray)
-#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD10: Color = Color::Rgb(0x5E, 0x81, 0xAC); // Frost (dark blue)
 pub(crate) const NORD11: Color = Color::Rgb(0xBF, 0x61, 0x6A); // Aurora (red)
 pub(crate) const NORD12: Color = Color::Rgb(0xD0, 0x87, 0x70); // Aurora (orange)
 pub(crate) const NORD13: Color = Color::Rgb(0xEB, 0xCB, 0x8B); // Aurora (yellow)
 pub(crate) const NORD14: Color = Color::Rgb(0xA3, 0xBE, 0x8C); // Aurora (green)
-#[allow(dead_code)] // Nord palette — reserved for future UI use
 pub(crate) const NORD15: Color = Color::Rgb(0xB4, 0x8E, 0xAD); // Aurora (purple)
 
 // ── UI surface colors ───────────────────────────────────────────
@@ -116,3 +439,47 @@ pub(crate) const BUDGET_HISTORY: Color = NORD13;
 pub(crate) const BUDGET_MEMORY: Color = NORD15;
 pub(crate) const BUDGET_OUTPUT: Color = NORD3;
 pub(crate) const BUDGET_FREE: Color = NORD2;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn parses_supported_theme_color_values() {
+        assert_eq!(
+            parse_color_value("#88c0d0"),
+            Some(Color::Rgb(0x88, 0xc0, 0xd0))
+        );
+        assert_eq!(parse_color_value("ansi:12"), Some(Color::Indexed(12)));
+        assert_eq!(parse_color_value("reset"), Some(Color::Reset));
+        assert_eq!(parse_color_value("light_blue"), Some(Color::LightBlue));
+        assert_eq!(parse_color_value("not-a-color"), None);
+    }
+
+    #[test]
+    fn resolves_configured_token_overrides() {
+        let mut tokens = BTreeMap::new();
+        tokens.insert("text.accent".to_string(), "#112233".to_string());
+        tokens.insert("surface.bottom_pane.bg".to_string(), "reset".to_string());
+        tokens.insert("unknown.token".to_string(), "#ffffff".to_string());
+        tokens.insert("text-muted".to_string(), "ansi:8".to_string());
+        tokens.insert("text.primary".to_string(), "invalid".to_string());
+        let config = TuiThemeConfig {
+            name: "test".to_string(),
+            syntax_theme: None,
+            tokens,
+        };
+
+        let theme = ResolvedTuiTheme::from_config(&config);
+
+        assert_eq!(
+            theme.color(ThemeToken::TextAccent),
+            Color::Rgb(0x11, 0x22, 0x33)
+        );
+        assert_eq!(theme.color(ThemeToken::SurfaceBottomPaneBg), Color::Reset);
+        assert_eq!(theme.color(ThemeToken::TextMuted), Color::Indexed(8));
+        assert_eq!(theme.color(ThemeToken::TextPrimary), TEXT_PRIMARY);
+    }
+}


### PR DESCRIPTION
## Summary

- add `tui.theme` config for semantic token overrides and embedded syntax theme selection
- route markdown, diff preview, list picker, and overlay renderers through semantic TUI tokens
- document the theme token contract and close the TUI/UX TODO item

## Purpose

This replaces the previous static-only palette path with an opencode-style configurable theme token schema while preserving the current Nord-compatible defaults.

## Related issue

None.

## Testing

- `cargo fmt`
- `cargo test -p rara-config loads_tui_theme_config`
- `cargo test --bin rara tui::theme::tests`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`

Note: the focused `cargo test --bin rara tui::theme::tests` run passes but emits the existing macOS linker warning about `__eh_frame section too large`.
