### PR TITLE
feat(tui): add explicit plan approval decisions

### DIFF
--- a/crates/rara-app-server/src/runtime_control.rs
+++ b/crates/rara-app-server/src/runtime_control.rs
@@ -111,11 +111,30 @@ pub enum SessionControlRequest {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum InputControlRequest {
-    SubmitUserPrompt { prompt: String },
-    AnswerPendingInput { answer: String },
-    AnswerPlanApproval { approved: bool },
-    AnswerShellApproval { decision: ShellApprovalDecision },
-    SubmitFollowUp { prompt: String },
+    SubmitUserPrompt {
+        prompt: String,
+    },
+    AnswerPendingInput {
+        answer: String,
+    },
+    AnswerPlanApproval {
+        decision: PlanApprovalDecision,
+        feedback: Option<String>,
+    },
+    AnswerShellApproval {
+        decision: ShellApprovalDecision,
+    },
+    SubmitFollowUp {
+        prompt: String,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanApprovalDecision {
+    Approve,
+    ContinuePlanning,
+    Reject,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/docs/features/planning-mode.md
+++ b/docs/features/planning-mode.md
@@ -113,12 +113,19 @@ Allowed transitions:
 - `execute -> planning`: user runs `/plan` or the model calls `enter_plan_mode`.
 - `planning -> plan_ready`: model emits `<proposed_plan>` and calls `exit_plan_mode`.
 - `plan_ready -> plan_approved`: user approves the plan.
-- `plan_ready -> plan_revising`: user asks to continue planning or edits/rejects the plan with feedback.
+- `plan_ready -> plan_revising`: user asks to continue planning or sends the
+  plan back with feedback.
 - `plan_revising -> plan_ready`: model updates the plan and calls `exit_plan_mode` again.
 - `plan_approved -> execute`: runtime injects the approved-plan tool result and resumes the agent loop.
 - `plan_ready -> plan_rejected`: user cancels the implementation request.
 
 User imperative text such as "continue", "implement", or "go ahead" must not skip `plan_ready -> plan_approved`; approval must come from the structured TUI interaction.
+
+The control-plane decision is explicit: `AnswerPlanApproval` carries one of
+`approve`, `continue_planning`, or `reject`. `approve` resumes execution with
+the saved plan, `continue_planning` keeps the agent in planning mode and asks it
+to revise the plan, and `reject` clears the pending plan approval without
+starting implementation.
 
 ### Runtime Persistence
 

--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -141,7 +141,7 @@ The first typed request set should include these families.
 
 - submit user prompt;
 - answer pending request input;
-- answer plan approval;
+- answer plan approval with an explicit decision;
 - answer shell approval;
 - submit follow-up while a turn is running.
 
@@ -164,7 +164,8 @@ intents:
 - regular composer submit -> `SubmitUserPrompt`;
 - busy-turn follow-up -> `SubmitFollowUp`;
 - pending request-user-input answer -> `AnswerPendingInput`;
-- plan approval choice -> `AnswerPlanApproval`;
+- plan approval choice -> `AnswerPlanApproval { decision }`, where
+  `decision` is `approve`, `continue_planning`, or `reject`;
 - shell approval choice -> `AnswerShellApproval`;
 - busy-turn cancel from local `Esc` or protocol cancel -> `CancelCurrentTurn`.
 

--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -164,8 +164,9 @@ intents:
 - regular composer submit -> `SubmitUserPrompt`;
 - busy-turn follow-up -> `SubmitFollowUp`;
 - pending request-user-input answer -> `AnswerPendingInput`;
-- plan approval choice -> `AnswerPlanApproval { decision }`, where
-  `decision` is `approve`, `continue_planning`, or `reject`;
+- plan approval choice -> `AnswerPlanApproval { decision, feedback }`, where
+  `decision` is `approve`, `continue_planning`, or `reject`, and optional
+  `feedback` gives the agent revision or rejection context;
 - shell approval choice -> `AnswerShellApproval`;
 - busy-turn cancel from local `Esc` or protocol cancel -> `CancelCurrentTurn`.
 

--- a/docs/features/support-acp-integration.md
+++ b/docs/features/support-acp-integration.md
@@ -76,7 +76,7 @@ Required intent mapping:
 | submit a prompt | `InputControlRequest::SubmitUserPrompt` |
 | submit while a turn is busy | `InputControlRequest::SubmitFollowUp` |
 | answer a request-input prompt | `InputControlRequest::AnswerPendingInput` |
-| approve or deny a plan | `InputControlRequest::AnswerPlanApproval` |
+| approve, continue, or reject a plan | `InputControlRequest::AnswerPlanApproval` |
 | approve or deny a shell command | `InputControlRequest::AnswerShellApproval` |
 | cancel the current turn | `SessionControlRequest::CancelCurrentTurn` |
 | request preemption | `SessionControlRequest::InterruptCurrentTurn` |

--- a/docs/journal/2026-07-03-plan-approval-decisions.md
+++ b/docs/journal/2026-07-03-plan-approval-decisions.md
@@ -1,0 +1,44 @@
+# 2026-07-03 Plan Approval Decisions
+
+## Summary
+
+- Replaced boolean plan approval control input with an explicit
+  `PlanApprovalDecision` enum.
+- Added `approve`, `continue_planning`, and `reject` decision handling across
+  the control plane, agent continuation, and TUI pending interaction flow.
+- Updated the plan approval dock copy to use short action labels:
+  `approve`, `keep planning`, and `reject`.
+
+## Background
+
+The previous `AnswerPlanApproval { approved: bool }` shape collapsed two
+different non-approval outcomes into one path. That made it hard to distinguish
+"keep planning" from "cancel this implementation request" and kept the TUI copy
+too close to a yes/no prompt.
+
+Claude Code separates final plan approval from clarification questions, and
+Codex-style review decisions use explicit semantic outcomes. RARA now follows
+that direction with a narrow plan-approval decision enum.
+
+## Scope
+
+- `approve` resumes execution with the approved plan.
+- `continue_planning` resumes the agent loop in planning mode.
+- `reject` clears the pending approval, records the decision, and does not
+  start a new model turn.
+- The control request carries optional feedback for protocol adapters. The TUI
+  does not collect free-form feedback yet.
+
+## Validation
+
+- `cargo test tui::tests::pending_plan_approval_number_shortcuts_work_in_local_and_ssh`
+- `cargo test tui::tests::plan_approval_reject_clears_pending_without_starting_task`
+- `cargo check --locked --workspace --all-targets`
+- `cargo clippy --locked --workspace --all-targets -- -D warnings`
+
+## Follow-Ups
+
+- Persist planning lifecycle decisions in the structured rollout log.
+- Restore pending plan approval after restart.
+- Add editable approval UI if continue/reject feedback should be collected from
+  the local TUI.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -84,7 +84,7 @@ Active backlog only. Keep this file small and current.
 
 ## Planning Control Plane
 
-- [ ] Replace boolean plan approval handling with an explicit decision enum:
+- [x] Replace boolean plan approval handling with an explicit decision enum:
       approve, continue planning with feedback, and reject/cancel.
 - [ ] Persist planning lifecycle state in the structured rollout log:
       `plan_ready`, `plan_revising`, `plan_approved`, and `plan_rejected`.

--- a/src/agent/control_handler.rs
+++ b/src/agent/control_handler.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::Ordering;
 use anyhow::{Result, anyhow};
 
 use crate::agent::{Agent, AgentEvent, AgentOutputMode, BashApprovalDecision};
-use crate::runtime_control::{InputControlRequest, SessionControlRequest};
+use crate::runtime_control::{InputControlRequest, PlanApprovalDecision, SessionControlRequest};
 
 impl Agent {
     /// Handle a session control request.
@@ -48,14 +48,28 @@ impl Agent {
                 self.query_with_mode_and_events(answer.clone(), AgentOutputMode::Silent, report)
                     .await?;
             }
-            InputControlRequest::AnswerPlanApproval { approved } => {
-                self.resume_after_plan_approval_with_events(
-                    !*approved,
-                    AgentOutputMode::Silent,
-                    report,
-                )
-                .await?;
-            }
+            InputControlRequest::AnswerPlanApproval { decision, feedback } => match decision {
+                PlanApprovalDecision::Approve => {
+                    self.resume_after_plan_approval_with_events(
+                        false,
+                        AgentOutputMode::Silent,
+                        report,
+                    )
+                    .await?;
+                }
+                PlanApprovalDecision::ContinuePlanning => {
+                    self.resume_after_plan_approval_with_feedback_events(
+                        true,
+                        feedback.as_deref(),
+                        AgentOutputMode::Silent,
+                        report,
+                    )
+                    .await?;
+                }
+                PlanApprovalDecision::Reject => {
+                    self.reject_pending_plan_approval(feedback.as_deref())?;
+                }
+            },
             InputControlRequest::AnswerShellApproval { decision } => {
                 let decision = BashApprovalDecision::from(*decision);
                 self.answer_pending_approval_with_events(decision, AgentOutputMode::Silent, report)

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -428,6 +428,25 @@ impl Agent {
         &mut self,
         continue_planning: bool,
         output_mode: AgentOutputMode,
+        report: F,
+    ) -> Result<()>
+    where
+        F: FnMut(AgentEvent) + Send,
+    {
+        self.resume_after_plan_approval_with_feedback_events(
+            continue_planning,
+            None,
+            output_mode,
+            report,
+        )
+        .await
+    }
+
+    pub async fn resume_after_plan_approval_with_feedback_events<F>(
+        &mut self,
+        continue_planning: bool,
+        feedback: Option<&str>,
+        output_mode: AgentOutputMode,
         mut report: F,
     ) -> Result<()>
     where
@@ -443,9 +462,16 @@ impl Agent {
                 "Continuing plan refinement from the current plan state.".to_string(),
             ));
             if let Some(tool_id) = pending_plan_exit_tool_id {
+                let feedback = feedback
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(|value| format!("\nUser feedback: {value}"))
+                    .unwrap_or_default();
                 self.push_history_message(tool_result_message(
                     &tool_id,
-                    "User chose to continue planning. Revise the plan and call exit_plan_mode again when it is ready for approval.".to_string(),
+                    format!(
+                        "User chose to continue planning. Revise the plan and call exit_plan_mode again when it is ready for approval.{feedback}"
+                    ),
                     false,
                 ));
             }
@@ -475,6 +501,26 @@ impl Agent {
         }
 
         self.run_agent_loop(output_mode, &mut report).await
+    }
+
+    pub fn reject_pending_plan_approval(&mut self, feedback: Option<&str>) -> Result<()> {
+        self.pending_user_input = None;
+        self.pending_approval = None;
+        let pending_plan_exit_tool_id = self.pending_plan_exit_tool_id.take();
+        self.execution_mode = AgentExecutionMode::Execute;
+        if let Some(tool_id) = pending_plan_exit_tool_id {
+            let feedback = feedback
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(|value| format!("\nUser feedback: {value}"))
+                .unwrap_or_default();
+            self.push_history_message(tool_result_message(
+                &tool_id,
+                format!("User rejected the plan. Do not start implementation.{feedback}"),
+                true,
+            ));
+        }
+        self.checkpoint_session()
     }
 
     pub(super) fn capture_plan_from_text(&mut self, text: &str) -> Result<bool> {

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -1,10 +1,11 @@
 pub use rara_app_server::runtime_control::{
     ApprovalControlRequest, HookControlRequest, HookLifecycle, InputControlRequest,
     McpControlRequest, MemoryControlRequest, MemoryRecordControlPatch, MemoryScope,
-    OutputSubscriptionRequest, PromptSourceControlRequest, PromptSourceLifetime,
-    PromptSourceRegistration, RuntimeControlEnvelope, RuntimeControlRequest, RuntimeControllerKind,
-    RuntimeProvenance, RuntimeSourceAuthorship, RuntimeSourceTrust, SessionControlRequest,
-    ShellApprovalDecision, SkillSourceControlRequest, SourceLayer, SourceScope,
+    OutputSubscriptionRequest, PlanApprovalDecision, PromptSourceControlRequest,
+    PromptSourceLifetime, PromptSourceRegistration, RuntimeControlEnvelope, RuntimeControlRequest,
+    RuntimeControllerKind, RuntimeProvenance, RuntimeSourceAuthorship, RuntimeSourceTrust,
+    SessionControlRequest, ShellApprovalDecision, SkillSourceControlRequest, SourceLayer,
+    SourceScope,
 };
 use rara_tools::tool::ToolOutputStream;
 use serde::{Deserialize, Serialize};

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -231,6 +231,8 @@ pub(crate) async fn dispatch_event(
                         if let Some(decision) = input_control::plan_approval_decision_for_index(idx)
                         {
                             input_control::answer_plan_approval(app, agent_slot, decision);
+                        } else {
+                            app.push_notice("Invalid plan approval option.");
                         }
                     }
                     ActivePendingInteractionKind::ShellApproval => {

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -202,7 +202,11 @@ pub(crate) async fn dispatch_event(
         }
         AppEvent::MoveApprovalSelection(delta) => {
             if app.active_pending_interaction().is_some_and(|interaction| {
-                interaction.kind == ActivePendingInteractionKind::ShellApproval
+                matches!(
+                    interaction.kind,
+                    ActivePendingInteractionKind::ShellApproval
+                        | ActivePendingInteractionKind::PlanApproval
+                )
             }) {
                 let max_idx = app.active_pending_option_count().saturating_sub(1) as i32;
                 let next = (app.approval_picker_idx as i32 + delta).clamp(0, max_idx);
@@ -224,8 +228,9 @@ pub(crate) async fn dispatch_event(
             if let Some(interaction) = app.active_pending_interaction() {
                 match interaction.kind {
                     ActivePendingInteractionKind::PlanApproval => {
-                        if let 0 | 1 = idx {
-                            input_control::answer_plan_approval(app, agent_slot, idx == 0);
+                        if let Some(decision) = input_control::plan_approval_decision_for_index(idx)
+                        {
+                            input_control::answer_plan_approval(app, agent_slot, decision);
                         }
                     }
                     ActivePendingInteractionKind::ShellApproval => {

--- a/src/tui/input_control.rs
+++ b/src/tui/input_control.rs
@@ -1,6 +1,7 @@
 use crate::agent::{Agent, BashApprovalDecision};
 use crate::runtime_control::{
-    InputEvent, RuntimeEvent, SessionControlRequest, SessionEvent, ShellApprovalDecision,
+    InputEvent, PlanApprovalDecision, RuntimeEvent, SessionControlRequest, SessionEvent,
+    ShellApprovalDecision,
 };
 use crate::tui::runtime::{
     request_running_task_cancellation, start_input_control_task, start_pending_approval_task,
@@ -148,7 +149,7 @@ pub(crate) fn answer_pending_input(
 pub(crate) fn answer_plan_approval(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
-    approved: bool,
+    decision: PlanApprovalDecision,
 ) -> InputControlOutcome {
     if !app.has_pending_plan_approval() {
         app.push_notice("No pending plan approval.");
@@ -159,8 +160,53 @@ pub(crate) fn answer_plan_approval(
         return InputControlOutcome::Rejected;
     };
     app.set_pending_plan_approval(false);
-    start_plan_approval_resume_task(app, !approved, agent);
+
+    let (summary, notice) = match decision {
+        PlanApprovalDecision::Approve => (
+            "Approved. Starting implementation.",
+            "Plan approved. Continuing with implementation.",
+        ),
+        PlanApprovalDecision::ContinuePlanning => (
+            "Sent back for more planning.",
+            "Continuing plan refinement.",
+        ),
+        PlanApprovalDecision::Reject => (
+            "Rejected. Implementation cancelled.",
+            "Plan rejected. Implementation cancelled.",
+        ),
+    };
+    app.record_completed_interaction(
+        InteractionKind::PlanApproval,
+        "Plan Decision",
+        summary,
+        None,
+    );
+
+    if decision == PlanApprovalDecision::Reject {
+        let mut agent = agent;
+        if let Err(err) = agent.reject_pending_plan_approval(None) {
+            app.push_notice(format!("Failed to record plan rejection: {err}"));
+            *agent_slot = Some(agent);
+            return InputControlOutcome::Rejected;
+        }
+        app.set_agent_execution_mode(agent.execution_mode);
+        app.bottom_pane.notice = Some(notice.to_string());
+        app.set_runtime_phase(RuntimePhase::Idle, Some("plan cancelled".into()));
+        *agent_slot = Some(agent);
+        return InputControlOutcome::Answered;
+    }
+
+    start_plan_approval_resume_task(app, decision, agent);
     InputControlOutcome::Answered
+}
+
+pub(crate) fn plan_approval_decision_for_index(index: usize) -> Option<PlanApprovalDecision> {
+    match index {
+        0 => Some(PlanApprovalDecision::Approve),
+        1 => Some(PlanApprovalDecision::ContinuePlanning),
+        2 => Some(PlanApprovalDecision::Reject),
+        _ => None,
+    }
 }
 
 pub(crate) fn answer_shell_approval(

--- a/src/tui/input_control.rs
+++ b/src/tui/input_control.rs
@@ -159,8 +159,6 @@ pub(crate) fn answer_plan_approval(
         app.push_notice("Approval is still preparing. Try again.");
         return InputControlOutcome::Rejected;
     };
-    app.set_pending_plan_approval(false);
-
     let (summary, notice) = match decision {
         PlanApprovalDecision::Approve => (
             "Approved. Starting implementation.",
@@ -175,12 +173,6 @@ pub(crate) fn answer_plan_approval(
             "Plan rejected. Implementation cancelled.",
         ),
     };
-    app.record_completed_interaction(
-        InteractionKind::PlanApproval,
-        "Plan Decision",
-        summary,
-        None,
-    );
 
     if decision == PlanApprovalDecision::Reject {
         let mut agent = agent;
@@ -189,6 +181,13 @@ pub(crate) fn answer_plan_approval(
             *agent_slot = Some(agent);
             return InputControlOutcome::Rejected;
         }
+        app.set_pending_plan_approval(false);
+        app.record_completed_interaction(
+            InteractionKind::PlanApproval,
+            "Plan Decision",
+            summary,
+            None,
+        );
         app.set_agent_execution_mode(agent.execution_mode);
         app.bottom_pane.notice = Some(notice.to_string());
         app.set_runtime_phase(RuntimePhase::Idle, Some("plan cancelled".into()));
@@ -196,6 +195,13 @@ pub(crate) fn answer_plan_approval(
         return InputControlOutcome::Answered;
     }
 
+    app.set_pending_plan_approval(false);
+    app.record_completed_interaction(
+        InteractionKind::PlanApproval,
+        "Plan Decision",
+        summary,
+        None,
+    );
     start_plan_approval_resume_task(app, decision, agent);
     InputControlOutcome::Answered
 }

--- a/src/tui/interaction_text.rs
+++ b/src/tui/interaction_text.rs
@@ -25,7 +25,7 @@ pub fn pending_interaction_card_title(kind: ActivePendingInteractionKind) -> &'s
 pub fn pending_interaction_hint_text(kind: ActivePendingInteractionKind) -> &'static str {
     match kind {
         ActivePendingInteractionKind::PlanApproval => {
-            "plan ready  1 start implementation  2 continue planning"
+            "plan ready  1 approve  2 keep planning  3 reject"
         }
         ActivePendingInteractionKind::ShellApproval => {
             "approval required  up/down select  enter apply  1-4 shortcut"
@@ -41,9 +41,7 @@ pub fn pending_interaction_shortcut_text(
     kind: ActivePendingInteractionKind,
 ) -> Option<&'static str> {
     match kind {
-        ActivePendingInteractionKind::PlanApproval => {
-            Some("1 start implementation  2 continue planning")
-        }
+        ActivePendingInteractionKind::PlanApproval => None,
         ActivePendingInteractionKind::ShellApproval => None,
         ActivePendingInteractionKind::PlanningQuestion
         | ActivePendingInteractionKind::ExplorationQuestion
@@ -54,7 +52,7 @@ pub fn pending_interaction_shortcut_text(
 
 pub fn status_plan_approval_text(app: &TuiApp) -> String {
     let _ = app;
-    "Plan ready for implementation.\n\n1. Start implementation now\n2. Continue planning and refine the plan".to_string()
+    "Plan ready for review.\n\n1 approve\n2 keep planning\n3 reject".to_string()
 }
 
 pub fn pending_interaction_detail_text(app: &TuiApp, kind: ActivePendingInteractionKind) -> String {
@@ -208,9 +206,10 @@ mod tests {
         .expect("app");
 
         let rendered = status_plan_approval_text(&app);
-        assert!(rendered.contains("Plan ready for implementation."));
-        assert!(rendered.contains("1. Start implementation now"));
-        assert!(rendered.contains("2. Continue planning and refine the plan"));
+        assert!(rendered.contains("Plan ready for review."));
+        assert!(rendered.contains("1 approve"));
+        assert!(rendered.contains("2 keep planning"));
+        assert!(rendered.contains("3 reject"));
         assert!(!rendered.contains("1. yes"));
     }
 
@@ -220,7 +219,7 @@ mod tests {
             pending_interaction_hint_text(
                 crate::tui::state::ActivePendingInteractionKind::PlanApproval
             ),
-            "plan ready  1 start implementation  2 continue planning"
+            "plan ready  1 approve  2 keep planning  3 reject"
         );
         assert_eq!(
             pending_interaction_hint_text(
@@ -236,7 +235,7 @@ mod tests {
             pending_interaction_shortcut_text(
                 crate::tui::state::ActivePendingInteractionKind::PlanApproval
             ),
-            Some("1 start implementation  2 continue planning")
+            None
         );
         assert_eq!(
             pending_interaction_shortcut_text(

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -130,10 +130,14 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             {
                 return AppEvent::SelectPendingOption(index);
             }
-            // Shell approval: Enter always selects, even with text in the composer.
+            // Approval cards: Enter always selects, even with text in the composer.
             // j/k navigation requires empty composer so regular typing works.
             if app.active_pending_interaction().is_some_and(|interaction| {
-                interaction.kind == super::state::ActivePendingInteractionKind::ShellApproval
+                matches!(
+                    interaction.kind,
+                    super::state::ActivePendingInteractionKind::ShellApproval
+                        | super::state::ActivePendingInteractionKind::PlanApproval
+                )
             }) {
                 if code == KeyCode::Enter && modifiers.is_empty() {
                     return AppEvent::SelectPendingOption(app.approval_picker_idx);
@@ -148,7 +152,11 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
                         }
                         _ => {}
                     }
-                    if let KeyCode::F(num @ 1..=4) = code {
+                    if app.active_pending_interaction().is_some_and(|interaction| {
+                        interaction.kind
+                            == super::state::ActivePendingInteractionKind::ShellApproval
+                    }) && let KeyCode::F(num @ 1..=4) = code
+                    {
                         return AppEvent::SelectPendingOption((num - 1) as usize);
                     }
                 }

--- a/src/tui/render/bottom_pane/mod.rs
+++ b/src/tui/render/bottom_pane/mod.rs
@@ -110,22 +110,31 @@ fn render_interaction_panel(f: &mut Frame, panel: &view::InteractionPanelView, a
     let mut lines: Vec<Line<'static>> = Vec::new();
     lines.push(Line::from(format!("  ⚠  {}", panel.title)));
     lines.push(Line::from(""));
-    for line in panel.detail.lines() {
-        lines.push(Line::from(format!("  {}", line)));
-    }
-    lines.push(Line::from(""));
-    // Action buttons
-    let button_line: String = panel
-        .actions
-        .iter()
-        .enumerate()
-        .map(|(i, a)| {
+    if panel.detail.is_empty() {
+        for (i, action) in panel.actions.iter().enumerate() {
             let prefix = if i == panel.selected { "▸" } else { " " };
-            format!("{}[{}] {}", prefix, a.key, a.label)
-        })
-        .collect::<Vec<_>>()
-        .join("    ");
-    lines.push(Line::from(format!("  {}", button_line)));
+            lines.push(Line::from(format!(
+                "  {prefix}{} {}",
+                action.key, action.label
+            )));
+        }
+    } else {
+        for line in panel.detail.lines() {
+            lines.push(Line::from(format!("  {}", line)));
+        }
+        lines.push(Line::from(""));
+        let button_line: String = panel
+            .actions
+            .iter()
+            .enumerate()
+            .map(|(i, a)| {
+                let prefix = if i == panel.selected { "▸" } else { " " };
+                format!("{}[{}] {}", prefix, a.key, a.label)
+            })
+            .collect::<Vec<_>>()
+            .join("    ");
+        lines.push(Line::from(format!("  {}", button_line)));
+    }
 
     let block = Block::default();
     let para = Paragraph::new(lines)

--- a/src/tui/render/bottom_pane/view_builder.rs
+++ b/src/tui/render/bottom_pane/view_builder.rs
@@ -106,7 +106,7 @@ pub(super) fn activity_status_line(app: &TuiApp) -> (&'static str, Color, String
         };
         let detail = match pending.kind {
             ActivePendingInteractionKind::PlanApproval => {
-                "choose whether to start implementation or continue planning".to_string()
+                "approve, keep planning, or reject the proposed plan".to_string()
             }
             ActivePendingInteractionKind::ShellApproval => app
                 .pending_command_approval()
@@ -278,10 +278,31 @@ fn build_interaction_panel(app: &TuiApp) -> Option<InteractionPanelView> {
             ],
             selected: app.approval_picker_idx,
         }),
-        ActivePendingInteractionKind::PlanApproval
-        | ActivePendingInteractionKind::PlanningQuestion => Some(InteractionPanelView {
+        ActivePendingInteractionKind::PlanApproval => Some(InteractionPanelView {
+            title: "Plan Approval",
+            detail: String::new(),
+            actions: vec![
+                InteractionAction {
+                    key: "1",
+                    label: "approve",
+                },
+                InteractionAction {
+                    key: "2",
+                    label: "keep planning",
+                },
+                InteractionAction {
+                    key: "3",
+                    label: "reject",
+                },
+            ],
+            selected: app.approval_picker_idx,
+        }),
+        ActivePendingInteractionKind::PlanningQuestion => Some(InteractionPanelView {
             title: "Planning Question",
-            detail: compact_shell_approval_detail(app),
+            detail: app
+                .pending_request_input()
+                .map(|interaction| interaction.title.clone())
+                .unwrap_or_default(),
             actions: vec![
                 InteractionAction {
                     key: "Enter",

--- a/src/tui/render/bottom_pane_tests.rs
+++ b/src/tui/render/bottom_pane_tests.rs
@@ -101,8 +101,9 @@ fn activity_status_line_prefers_pending_interactions() {
 
     let (label, _, detail) = activity_status_line(&app);
     assert_eq!(label, "Plan Approval");
-    assert!(detail.contains("start implementation"));
-    assert!(detail.contains("continue planning"));
+    assert!(detail.contains("approve"));
+    assert!(detail.contains("keep planning"));
+    assert!(detail.contains("reject"));
 }
 
 #[test]

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -45,8 +45,12 @@ pub fn start_pending_approval_task(
     tasks::start_pending_approval_task(app, selection, agent);
 }
 
-pub fn start_plan_approval_resume_task(app: &mut TuiApp, continue_planning: bool, agent: Agent) {
-    tasks::start_plan_approval_resume_task(app, continue_planning, agent);
+pub fn start_plan_approval_resume_task(
+    app: &mut TuiApp,
+    decision: crate::runtime_control::PlanApprovalDecision,
+    agent: Agent,
+) {
+    tasks::start_plan_approval_resume_task(app, decision, agent);
 }
 
 pub fn start_rebuild_task(app: &mut TuiApp) {

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -532,17 +532,26 @@ pub(super) fn start_pending_approval_task(
 
 pub(super) fn start_plan_approval_resume_task(
     app: &mut TuiApp,
-    continue_planning: bool,
+    decision: crate::runtime_control::PlanApprovalDecision,
     agent: Agent,
 ) {
-    let notice = if continue_planning {
-        "Continuing plan refinement."
-    } else {
-        "Plan approved. Continuing with implementation."
+    let (notice, phase_detail) = match decision {
+        crate::runtime_control::PlanApprovalDecision::Approve => (
+            "Plan approved. Continuing with implementation.",
+            "resuming approved plan",
+        ),
+        crate::runtime_control::PlanApprovalDecision::ContinuePlanning => {
+            ("Continuing plan refinement.", "resuming plan refinement")
+        }
+        crate::runtime_control::PlanApprovalDecision::Reject => (
+            "Plan rejected. Implementation cancelled.",
+            "cancelling plan",
+        ),
     };
 
     let request = crate::runtime_control::InputControlRequest::AnswerPlanApproval {
-        approved: !continue_planning,
+        decision,
+        feedback: None,
     };
 
     start_input_control_task(
@@ -551,17 +560,15 @@ pub(super) fn start_plan_approval_resume_task(
         request,
         notice.to_string(),
         RuntimePhase::ProcessingResponse,
-        Some(if continue_planning {
-            "resuming plan refinement".into()
-        } else {
-            "resuming approved plan".into()
-        }),
+        Some(phase_detail.into()),
     );
 }
 
 fn start_automatic_plan_implementation_task(app: &mut TuiApp, agent: Agent) {
-    let request =
-        crate::runtime_control::InputControlRequest::AnswerPlanApproval { approved: true };
+    let request = crate::runtime_control::InputControlRequest::AnswerPlanApproval {
+        decision: crate::runtime_control::PlanApprovalDecision::Approve,
+        feedback: None,
+    };
 
     start_input_control_task(
         app,

--- a/src/tui/state/pending_interaction.rs
+++ b/src/tui/state/pending_interaction.rs
@@ -143,7 +143,7 @@ impl TuiApp {
             return 0;
         };
         match pending.kind {
-            ActivePendingInteractionKind::PlanApproval => 2,
+            ActivePendingInteractionKind::PlanApproval => 3,
             ActivePendingInteractionKind::ShellApproval => 4,
             ActivePendingInteractionKind::PlanningQuestion
             | ActivePendingInteractionKind::ExplorationQuestion

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -133,9 +133,7 @@ pub(crate) fn apply_openai_model_picker_action(
 }
 
 fn handle_pending_plan_approval_submit(app: &mut TuiApp) {
-    app.push_notice(
-        "A plan is waiting for approval. Press 1 to start implementation or 2 to continue planning.",
-    );
+    app.push_notice("A plan is waiting for review. Use the approval actions above the input.");
 }
 
 pub(crate) fn clamp_command_palette_selection(app: &mut TuiApp) {

--- a/src/tui/submit/pending.rs
+++ b/src/tui/submit/pending.rs
@@ -19,7 +19,9 @@ pub(super) fn handle_pending_option_submit(
     };
     match interaction.kind {
         ActivePendingInteractionKind::PlanApproval => {
-            input_control::answer_plan_approval(app, agent_slot, index == 0);
+            if let Some(decision) = input_control::plan_approval_decision_for_index(index) {
+                input_control::answer_plan_approval(app, agent_slot, decision);
+            }
             true
         }
         ActivePendingInteractionKind::ShellApproval => {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -342,8 +342,43 @@ async fn pending_plan_approval_blocks_plain_submit() {
         app.bottom_pane
             .notice
             .as_deref()
-            .is_some_and(|value| value.contains("Press 1 to start implementation"))
+            .is_some_and(|value| value.contains("approval actions above the input"))
     );
+}
+
+#[test]
+fn pending_plan_approval_number_shortcuts_work_in_local_and_ssh() {
+    for ssh in [false, true] {
+        let _ssh_env = super::terminal_ui::test_env::set_ssh_session(ssh);
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("build tui app");
+        app.set_pending_plan_approval(true);
+
+        assert_eq!(app.active_pending_option_count(), 3);
+        assert!(matches!(
+            map_key_to_event(key(KeyCode::Char('1')), &app),
+            AppEvent::SelectPendingOption(0)
+        ));
+        assert!(matches!(
+            map_key_to_event(key(KeyCode::Char('2')), &app),
+            AppEvent::SelectPendingOption(1)
+        ));
+        assert!(matches!(
+            map_key_to_event(key(KeyCode::Char('3')), &app),
+            AppEvent::SelectPendingOption(2)
+        ));
+        assert!(matches!(
+            map_key_to_event(key(KeyCode::Down), &app),
+            AppEvent::MoveApprovalSelection(1)
+        ));
+        assert!(matches!(
+            map_key_to_event(key(KeyCode::Enter), &app),
+            AppEvent::SelectPendingOption(0)
+        ));
+    }
 }
 
 #[tokio::test]
@@ -394,6 +429,62 @@ async fn submit_numeric_input_handles_pending_shell_approval() {
             .notice
             .as_deref()
             .is_some_and(|value| value.contains("Approval is still preparing"))
+    );
+}
+
+#[tokio::test]
+async fn plan_approval_reject_clears_pending_without_starting_task() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let bus = Arc::new(crate::runtime_event_bus::RuntimeEventBus::new(10));
+    app.event_bus = Some(bus.clone());
+    app.prompt_source_registry = Some(Arc::new(
+        crate::protocol_sources::PromptSourceRegistry::new(bus.clone()),
+    ));
+    app.skill_source_registry = Some(Arc::new(crate::protocol_sources::SkillSourceRegistry::new(
+        bus.clone(),
+    )));
+    app.hook_registry = Some(Arc::new(crate::hook_registry::HookRegistry::new(
+        bus.clone(),
+    )));
+    app.mcp_manager = Some(Arc::new(
+        crate::mcp_connection_manager::McpConnectionManager::new(
+            Arc::new(crate::config::McpRegistry::empty()),
+            bus.clone(),
+        ),
+    ));
+    app.memory_handler = Some(Arc::new(
+        crate::protocol_sources::MemoryControlHandler::new(bus.clone()),
+    ));
+
+    add_pending_plan_approval(&mut app);
+
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = Some(test_agent_for_pending_approval(&temp));
+
+    dispatch_event(
+        AppEvent::SelectPendingOption(2),
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("reject plan");
+
+    assert!(!app.has_pending_plan_approval());
+    assert!(app.bottom_pane.running_task.is_none());
+    assert!(agent_slot.is_some());
+    assert_eq!(app.agent_execution_mode_label(), "execute");
+    assert_eq!(
+        app.completed_interaction(InteractionKind::PlanApproval)
+            .map(|interaction| interaction.summary.as_str()),
+        Some("Rejected. Implementation cancelled.")
     );
 }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -489,6 +489,45 @@ async fn plan_approval_reject_clears_pending_without_starting_task() {
 }
 
 #[tokio::test]
+async fn invalid_plan_approval_selection_keeps_pending_with_notice() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+
+    add_pending_plan_approval(&mut app);
+
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = Some(test_agent_for_pending_approval(&temp));
+
+    dispatch_event(
+        AppEvent::SelectPendingOption(3),
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("reject invalid plan selection");
+
+    assert!(app.has_pending_plan_approval());
+    assert!(agent_slot.is_some());
+    assert!(
+        app.bottom_pane
+            .notice
+            .as_deref()
+            .is_some_and(|value| value.contains("Invalid plan approval option"))
+    );
+    assert!(
+        app.completed_interaction(InteractionKind::PlanApproval)
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn empty_submit_keeps_shell_approval_on_card_surface() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {


### PR DESCRIPTION
## Summary

- Replace boolean plan approval control requests with an explicit `PlanApprovalDecision`.
- Add approve, keep-planning, and reject handling across agent control, TUI shortcuts, and pending interaction rendering.
- Document the runtime contract and mark the completed planning-control TODO item.

## Purpose

Planning approval needs to distinguish "continue planning" from "reject/cancel" instead of overloading a boolean. The TUI also now presents the choice in a compact action list:

```text
1 approve
2 keep planning
3 reject
```

## Related Issue

None.

## Testing

- `cargo fmt`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `git diff --check`
- `cargo test tui::interaction_text::tests`
- `cargo test tui::tests::pending_plan_approval_number_shortcuts_work_in_local_and_ssh`
- `cargo test tui::tests::plan_approval_reject_clears_pending_without_starting_task`
- `cargo test active_turn_cell_renders_plan_approval_as_interaction_card`

The focused test binaries still emit the known macOS linker `__eh_frame` warning.
