### PR TITLE
feat(planning): persist lifecycle rollout state

### DIFF
--- a/crates/rara-persistence/src/thread_data.rs
+++ b/crates/rara-persistence/src/thread_data.rs
@@ -23,6 +23,21 @@ pub struct PersistedInteraction {
     pub payload: Option<Value>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PersistedPlanLifecycle {
+    pub phase: String,
+    #[serde(default)]
+    pub decision: Option<String>,
+    #[serde(default)]
+    pub feedback: Option<String>,
+    #[serde(default)]
+    pub plan_path: Option<String>,
+    #[serde(default)]
+    pub tool_use_id: Option<String>,
+    #[serde(default)]
+    pub plan_hash: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersistedTurnSummary {
     pub ordinal: usize,
@@ -67,6 +82,8 @@ pub enum PersistedStructuredRolloutEvent {
         explanation: Option<String>,
         steps: Vec<PersistedPlanStep>,
         interactions: Vec<PersistedInteraction>,
+        #[serde(default)]
+        plan_lifecycle: Vec<PersistedPlanLifecycle>,
     },
     PlanState {
         #[serde(default)]
@@ -92,6 +109,12 @@ pub enum PersistedStructuredRolloutEvent {
         #[serde(default)]
         token_budget: Option<i64>,
     },
+    PlanLifecycle {
+        #[serde(default)]
+        recorded_at: Option<i64>,
+        #[serde(flatten)]
+        lifecycle: PersistedPlanLifecycle,
+    },
 }
 
 impl PersistedStructuredRolloutEvent {
@@ -102,6 +125,7 @@ impl PersistedStructuredRolloutEvent {
         let mut explanation = None;
         let mut steps = Vec::new();
         let mut interactions = Vec::new();
+        let mut plan_lifecycle = Vec::new();
         for item in items {
             match item {
                 PersistedStructuredRolloutEvent::RuntimeState {
@@ -109,10 +133,12 @@ impl PersistedStructuredRolloutEvent {
                     explanation: item_explanation,
                     steps: item_steps,
                     interactions: item_interactions,
+                    plan_lifecycle: item_plan_lifecycle,
                 } => {
                     explanation = item_explanation.clone();
                     steps = item_steps.clone();
                     interactions = item_interactions.clone();
+                    plan_lifecycle = item_plan_lifecycle.clone();
                 }
                 PersistedStructuredRolloutEvent::PlanState {
                     recorded_at: _,
@@ -128,6 +154,12 @@ impl PersistedStructuredRolloutEvent {
                 } => {
                     interactions.push(interaction.clone());
                 }
+                PersistedStructuredRolloutEvent::PlanLifecycle {
+                    recorded_at: _,
+                    lifecycle,
+                } => {
+                    plan_lifecycle.push(lifecycle.clone());
+                }
                 PersistedStructuredRolloutEvent::Compaction { .. }
                 | PersistedStructuredRolloutEvent::SpawnAgent { .. } => {}
             }
@@ -138,6 +170,7 @@ impl PersistedStructuredRolloutEvent {
             explanation,
             steps,
             interactions,
+            plan_lifecycle,
         }
     }
 }

--- a/crates/rara-state/src/state_db.rs
+++ b/crates/rara-state/src/state_db.rs
@@ -6,11 +6,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::Result;
 pub use rara_persistence::thread_data::{
     PersistedCompactState, PersistedInteraction, PersistedLegacyRolloutMigration,
-    PersistedLegacyRolloutSource, PersistedPlanStep, PersistedPromptRuntimeState,
-    PersistedRecentThreadRecord, PersistedRecentThreadSummary, PersistedRuntimeRolloutItem,
-    PersistedSessionRuntimeState, PersistedSpawnAgentEdge, PersistedStructuredRolloutEvent,
-    PersistedThreadLineage, PersistedThreadRecord, PersistedTurnEntry, PersistedTurnSummary,
-    turn_preview,
+    PersistedLegacyRolloutSource, PersistedPlanLifecycle, PersistedPlanStep,
+    PersistedPromptRuntimeState, PersistedRecentThreadRecord, PersistedRecentThreadSummary,
+    PersistedRuntimeRolloutItem, PersistedSessionRuntimeState, PersistedSpawnAgentEdge,
+    PersistedStructuredRolloutEvent, PersistedThreadLineage, PersistedThreadRecord,
+    PersistedTurnEntry, PersistedTurnSummary, turn_preview,
 };
 pub use rara_persistence::{thread_rollout_log, thread_turn_log};
 use rusqlite::{Connection, params};

--- a/crates/rara-state/src/state_db/tests.rs
+++ b/crates/rara-state/src/state_db/tests.rs
@@ -3,8 +3,8 @@ use rusqlite::Connection;
 use tempfile::tempdir;
 
 use super::{
-    PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
-    PersistedStructuredRolloutEvent, PersistedTurnEntry, StateDb,
+    PersistedCompactState, PersistedInteraction, PersistedPlanLifecycle, PersistedPlanStep,
+    PersistedPromptRuntimeState, PersistedStructuredRolloutEvent, PersistedTurnEntry, StateDb,
 };
 
 #[test]
@@ -459,15 +459,28 @@ fn load_rollout_events_prefers_append_only_log_without_snapshot_rewrite() -> Res
     )?;
     db.replace_runtime_rollout_events(
         "session-events",
-        &[PersistedStructuredRolloutEvent::PlanState {
-            recorded_at: None,
-            explanation: Some("Structured runtime plan".to_string()),
-            steps: vec![PersistedPlanStep {
-                step_index: 0,
-                status: "pending".to_string(),
-                step: "Inspect thread store".to_string(),
-            }],
-        }],
+        &[
+            PersistedStructuredRolloutEvent::PlanState {
+                recorded_at: None,
+                explanation: Some("Structured runtime plan".to_string()),
+                steps: vec![PersistedPlanStep {
+                    step_index: 0,
+                    status: "pending".to_string(),
+                    step: "Inspect thread store".to_string(),
+                }],
+            },
+            PersistedStructuredRolloutEvent::PlanLifecycle {
+                recorded_at: None,
+                lifecycle: PersistedPlanLifecycle {
+                    phase: "plan_ready".to_string(),
+                    decision: None,
+                    feedback: None,
+                    plan_path: Some(".rara/sessions/session-events/plan.md".to_string()),
+                    tool_use_id: Some("tool-plan".to_string()),
+                    plan_hash: None,
+                },
+            },
+        ],
     )?;
 
     assert!(
@@ -500,11 +513,15 @@ fn load_rollout_events_prefers_append_only_log_without_snapshot_rewrite() -> Res
             explanation,
             steps,
             interactions,
+            plan_lifecycle,
         }
             if explanation.as_deref() == Some("Structured runtime plan")
                 && steps.len() == 1
                 && steps[0].step == "Inspect thread store"
                 && interactions.is_empty()
+                && plan_lifecycle.len() == 1
+                && plan_lifecycle[0].phase == "plan_ready"
+                && plan_lifecycle[0].tool_use_id.as_deref() == Some("tool-plan")
     ));
     Ok(())
 }

--- a/docs/features/planning-mode.md
+++ b/docs/features/planning-mode.md
@@ -139,8 +139,10 @@ with these phases:
 - `plan_rejected`
 
 The current checkpoint records the latest phase and decision metadata derived
-from the plan approval interaction. The complete recovery contract still needs
-enough state to recover after restart:
+from the plan approval interaction. Completed decisions should use structured
+decision metadata rather than parsing UI copy. Thread forks preserve the
+materialized lifecycle records from the source thread. The complete recovery
+contract still needs enough state to recover after restart:
 
 - `session_id`
 - `plan_file_path`

--- a/docs/features/planning-mode.md
+++ b/docs/features/planning-mode.md
@@ -129,7 +129,18 @@ starting implementation.
 
 ### Runtime Persistence
 
-Runtime should persist enough state to recover after restart:
+Runtime persists the current planning lifecycle in the structured rollout log.
+Each runtime-state checkpoint may include one or more plan lifecycle records
+with these phases:
+
+- `plan_ready`
+- `plan_revising`
+- `plan_approved`
+- `plan_rejected`
+
+The current checkpoint records the latest phase and decision metadata derived
+from the plan approval interaction. The complete recovery contract still needs
+enough state to recover after restart:
 
 - `session_id`
 - `plan_file_path`

--- a/docs/journal/2026-07-04-planning-lifecycle-rollout.md
+++ b/docs/journal/2026-07-04-planning-lifecycle-rollout.md
@@ -34,6 +34,10 @@ derived from the plan approval interaction state:
   standalone structured event shape for append-only future slices.
 - Thread materialization includes lifecycle rollout items so CLI and future
   status surfaces can inspect typed phase data.
+- Thread forks preserve materialized planning lifecycle records from the source
+  thread instead of resetting lifecycle state.
+- Completed plan approvals persist a typed `plan_approval:*` source marker so
+  lifecycle decisions do not depend on UI summary copy.
 
 ## Validation
 

--- a/docs/journal/2026-07-04-planning-lifecycle-rollout.md
+++ b/docs/journal/2026-07-04-planning-lifecycle-rollout.md
@@ -1,0 +1,48 @@
+# 2026-07-04 Planning Lifecycle Rollout
+
+## Summary
+
+- Added a typed `PlanLifecycle` structured rollout event.
+- Persisted plan approval lifecycle phases through runtime-state checkpoints.
+- Surfaced plan lifecycle phases in thread snapshot rollout summaries.
+
+## Background
+
+Plan approval already persisted plan snapshots and interaction cards, but the
+planning lifecycle itself was implicit in interaction status and summary text.
+That made it hard for resume, `/status`, `/context`, and protocol adapters to
+distinguish `plan_ready`, `plan_revising`, `plan_approved`, and
+`plan_rejected` without string parsing.
+
+## Scope
+
+The implementation keeps the existing runtime-state checkpoint model:
+`persist_runtime_state` writes the latest plan state, interactions, and plan
+lifecycle into the structured rollout log. The current lifecycle records are
+derived from the plan approval interaction state:
+
+- pending plan approval records `plan_ready`;
+- approved plan decision records `plan_approved`;
+- continue-planning decision records `plan_revising`;
+- rejected plan decision records `plan_rejected`.
+
+## Key Decisions
+
+- `PersistedStructuredRolloutEvent::RuntimeState` now carries
+  `plan_lifecycle` so checkpoint replacement preserves lifecycle metadata.
+- `PersistedStructuredRolloutEvent::PlanLifecycle` remains available as a
+  standalone structured event shape for append-only future slices.
+- Thread materialization includes lifecycle rollout items so CLI and future
+  status surfaces can inspect typed phase data.
+
+## Validation
+
+- `cargo check --locked --workspace --all-targets`
+- focused state persistence tests for pending and completed plan approval
+  lifecycle checkpoints
+
+## Follow-Ups
+
+- Restore pending plan approval after restart from persisted lifecycle state.
+- Add `/status` and `/context` planning lifecycle fields.
+- Persist user feedback for continue-planning and rejected-plan decisions.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -85,7 +85,7 @@ Active backlog only. Keep this file small and current.
 
 - [x] Replace boolean plan approval handling with an explicit decision enum:
       approve, continue planning with feedback, and reject/cancel.
-- [ ] Persist planning lifecycle state in the structured rollout log:
+- [x] Persist planning lifecycle state in the structured rollout log:
       `plan_ready`, `plan_revising`, `plan_approved`, and `plan_rejected`.
 - [ ] Restore pending plan approval after restart and avoid reinjecting an
       approved-plan tool result more than once.

--- a/src/session.rs
+++ b/src/session.rs
@@ -468,6 +468,7 @@ impl SessionManager {
                 PersistedStructuredRolloutEvent::RuntimeState { .. }
                 | PersistedStructuredRolloutEvent::PlanState { .. }
                 | PersistedStructuredRolloutEvent::Interaction { .. }
+                | PersistedStructuredRolloutEvent::PlanLifecycle { .. }
                 | PersistedStructuredRolloutEvent::SpawnAgent { .. } => None,
             })
             .collect::<Vec<_>>();

--- a/src/thread_cli.rs
+++ b/src/thread_cli.rs
@@ -159,6 +159,8 @@ fn format_thread_snapshot(thread: &ThreadSnapshot) -> String {
             "rollout_plan_snapshots={}\n",
             "rollout_plan_snapshot_steps={}\n",
             "rollout_plan_snapshot_explanations={}\n",
+            "rollout_plan_lifecycle={}\n",
+            "rollout_plan_lifecycle_phases={}\n",
             "rollout_interactions={}\n",
             "rollout_interaction_statuses={}\n",
             "rollout_spawn_agents={}\n",
@@ -202,6 +204,8 @@ fn format_thread_snapshot(thread: &ThreadSnapshot) -> String {
         rollout.plan_state_count,
         rollout.plan_state_step_count,
         rollout.plan_state_explanation_count,
+        rollout.plan_lifecycle_count,
+        rollout.plan_lifecycle_phases,
         rollout.interaction_count,
         rollout.interaction_statuses,
         rollout.spawn_agent_count,
@@ -237,6 +241,8 @@ struct RolloutSummary {
     plan_state_count: usize,
     plan_state_step_count: usize,
     plan_state_explanation_count: usize,
+    plan_lifecycle_count: usize,
+    plan_lifecycle_phases: String,
     interaction_count: usize,
     interaction_statuses: String,
     spawn_agent_count: usize,
@@ -247,12 +253,14 @@ fn rollout_summary(thread: &ThreadSnapshot) -> RolloutSummary {
     let mut summary = RolloutSummary {
         turn_ordinals: "-".to_string(),
         compaction_indexes: "-".to_string(),
+        plan_lifecycle_phases: "-".to_string(),
         interaction_statuses: "-".to_string(),
         last_spawn_agent: "-".to_string(),
         ..RolloutSummary::default()
     };
     let mut turn_ordinals = Vec::new();
     let mut compaction_indexes = Vec::new();
+    let mut plan_lifecycle_phases = Vec::new();
     let mut interaction_statuses = Vec::new();
     for item in &thread.rollout_items {
         match item {
@@ -273,6 +281,10 @@ fn rollout_summary(thread: &ThreadSnapshot) -> RolloutSummary {
             crate::thread_store::RolloutItem::Interaction(interaction) => {
                 summary.interaction_count += 1;
                 interaction_statuses.push(format!("{}:{}", interaction.kind, interaction.status));
+            }
+            crate::thread_store::RolloutItem::PlanLifecycle(lifecycle) => {
+                summary.plan_lifecycle_count += 1;
+                plan_lifecycle_phases.push(lifecycle.phase.clone());
             }
             crate::thread_store::RolloutItem::SpawnAgent {
                 event_id,
@@ -305,6 +317,9 @@ fn rollout_summary(thread: &ThreadSnapshot) -> RolloutSummary {
     if !compaction_indexes.is_empty() {
         summary.compaction_indexes = compaction_indexes.join(",");
     }
+    if !plan_lifecycle_phases.is_empty() {
+        summary.plan_lifecycle_phases = plan_lifecycle_phases.join(",");
+    }
     if !interaction_statuses.is_empty() {
         summary.interaction_statuses = interaction_statuses.join(",");
     }
@@ -330,7 +345,9 @@ fn workspace_label(cwd: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use rara_persistence::thread_data::{PersistedTurnEntry, PersistedTurnSummary};
+    use rara_persistence::thread_data::{
+        PersistedPlanLifecycle, PersistedTurnEntry, PersistedTurnSummary,
+    };
     use rara_state::state_db::PersistedInteraction;
 
     use super::{
@@ -429,6 +446,14 @@ mod tests {
                     compaction_count: 4,
                     ..Default::default()
                 }),
+                RolloutItem::PlanLifecycle(PersistedPlanLifecycle {
+                    phase: "plan_approved".to_string(),
+                    decision: Some("approve".to_string()),
+                    feedback: None,
+                    plan_path: None,
+                    tool_use_id: None,
+                    plan_hash: None,
+                }),
                 RolloutItem::Turn(RolloutTurnItem {
                     summary: PersistedTurnSummary {
                         ordinal: 7,
@@ -461,6 +486,8 @@ mod tests {
         assert!(output.contains("interactions=1"));
         assert!(output.contains("turn_ordinals=7"));
         assert!(output.contains("rollout_compaction_indexes=4"));
+        assert!(output.contains("rollout_plan_lifecycle=1"));
+        assert!(output.contains("rollout_plan_lifecycle_phases=plan_approved"));
         assert!(output.contains("rollout_interactions=1"));
         assert!(output.contains("rollout_interaction_statuses=approval:completed"));
         assert!(output.contains("rollout_spawn_agents=1"));

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -225,6 +225,7 @@ impl<'a> ThreadStore<'a> {
                 explanation: materialized.plan_explanation.clone(),
                 steps: materialized.plan_steps.clone(),
                 interactions: materialized.interactions.clone(),
+                plan_lifecycle: Vec::new(),
             }],
         )?;
 
@@ -341,6 +342,7 @@ impl<'a> ThreadStore<'a> {
                     explanation,
                     steps,
                     interactions: runtime_interactions,
+                    plan_lifecycle,
                 } => {
                     saw_runtime_state = true;
                     saw_plan_state = true;
@@ -350,7 +352,8 @@ impl<'a> ThreadStore<'a> {
                     interactions = runtime_interactions.clone();
                     let base_order = rollout_order;
                     let reserved_items = usize::from(!steps.is_empty() || explanation.is_some())
-                        + runtime_interactions.len();
+                        + runtime_interactions.len()
+                        + plan_lifecycle.len();
                     rollout_order += reserved_items.max(1);
                     latest_runtime_state = Some((
                         recorded_at.unwrap_or(0),
@@ -358,6 +361,7 @@ impl<'a> ThreadStore<'a> {
                         explanation,
                         steps,
                         runtime_interactions,
+                        plan_lifecycle,
                     ));
                 }
                 PersistedStructuredRolloutEvent::PlanState {
@@ -388,6 +392,17 @@ impl<'a> ThreadStore<'a> {
                         RolloutItem::Interaction(interaction),
                     );
                 }
+                PersistedStructuredRolloutEvent::PlanLifecycle {
+                    recorded_at,
+                    lifecycle,
+                } => {
+                    push_rollout_item(
+                        &mut ordered_rollout_items,
+                        &mut rollout_order,
+                        recorded_at.unwrap_or(0),
+                        RolloutItem::PlanLifecycle(lifecycle),
+                    );
+                }
                 PersistedStructuredRolloutEvent::SpawnAgent {
                     recorded_at,
                     event_id,
@@ -415,8 +430,14 @@ impl<'a> ThreadStore<'a> {
             }
         }
 
-        if let Some((recorded_at, base_order, explanation, steps, runtime_interactions)) =
-            latest_runtime_state
+        if let Some((
+            recorded_at,
+            base_order,
+            explanation,
+            steps,
+            runtime_interactions,
+            plan_lifecycle,
+        )) = latest_runtime_state
         {
             let mut item_order = base_order;
             if !steps.is_empty() || explanation.is_some() {
@@ -432,6 +453,14 @@ impl<'a> ThreadStore<'a> {
                     recorded_at,
                     item_order,
                     RolloutItem::Interaction(interaction),
+                ));
+                item_order += 1;
+            }
+            for lifecycle in plan_lifecycle {
+                ordered_rollout_items.push((
+                    recorded_at,
+                    item_order,
+                    RolloutItem::PlanLifecycle(lifecycle),
                 ));
                 item_order += 1;
             }
@@ -763,6 +792,7 @@ impl<'a> ThreadStore<'a> {
                 PersistedStructuredRolloutEvent::RuntimeState { .. }
                 | PersistedStructuredRolloutEvent::PlanState { .. }
                 | PersistedStructuredRolloutEvent::Interaction { .. }
+                | PersistedStructuredRolloutEvent::PlanLifecycle { .. }
                 | PersistedStructuredRolloutEvent::SpawnAgent { .. } => None,
             })
             .collect::<Vec<_>>();

--- a/src/thread_store.rs
+++ b/src/thread_store.rs
@@ -182,6 +182,14 @@ impl<'a> ThreadStore<'a> {
             .load_session_runtime_state(source_thread_id)?
             .unwrap_or_default();
         let compact_state = recorder::compact_state_from_record(&materialized.compaction);
+        let plan_lifecycle = materialized
+            .rollout_items
+            .iter()
+            .filter_map(|item| match item {
+                RolloutItem::PlanLifecycle(lifecycle) => Some(lifecycle.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
         let forked_thread_id = Uuid::new_v4().to_string();
         let lineage = PersistedThreadLineage {
             origin_kind: "fork".to_string(),
@@ -225,7 +233,7 @@ impl<'a> ThreadStore<'a> {
                 explanation: materialized.plan_explanation.clone(),
                 steps: materialized.plan_steps.clone(),
                 interactions: materialized.interactions.clone(),
-                plan_lifecycle: Vec::new(),
+                plan_lifecycle,
             }],
         )?;
 

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -885,17 +885,17 @@ fn load_thread_preserves_structured_rollout_event_order() -> Result<()> {
         Some(RolloutItem::Interaction(interaction))
             if interaction.title == "Question"
     ));
-    assert!(snapshot.rollout_items.iter().any(|item| matches!(
-        item,
-        RolloutItem::PlanLifecycle(lifecycle)
+    assert!(matches!(
+        snapshot.rollout_items.get(3),
+        Some(RolloutItem::PlanLifecycle(lifecycle))
             if lifecycle.phase == "plan_ready"
                 && lifecycle.tool_use_id.as_deref() == Some("exit-plan-ordered")
-    )));
-    assert!(snapshot.rollout_items.iter().any(|item| matches!(
-        item,
-        RolloutItem::Compaction(compaction)
+    ));
+    assert!(matches!(
+        snapshot.rollout_items.get(4),
+        Some(RolloutItem::Compaction(compaction))
             if compaction.compaction_count == 2
-    )));
+    ));
     Ok(())
 }
 
@@ -1786,6 +1786,33 @@ fn fork_thread_preserves_materialized_state_and_sets_lineage() -> Result<()> {
             payload: None,
         }],
     )?;
+    state_db.replace_runtime_rollout_events(
+        "source-thread",
+        &[PersistedStructuredRolloutEvent::RuntimeState {
+            recorded_at: None,
+            explanation: Some("Preserve thread continuity.".to_string()),
+            steps: vec![PersistedPlanStep {
+                step_index: 0,
+                status: "in_progress".to_string(),
+                step: "Implement fork lifecycle".to_string(),
+            }],
+            interactions: vec![PersistedInteraction {
+                kind: "approval".to_string(),
+                status: "completed".to_string(),
+                title: "Approved".to_string(),
+                summary: "continue".to_string(),
+                payload: None,
+            }],
+            plan_lifecycle: vec![PersistedPlanLifecycle {
+                phase: "plan_ready".to_string(),
+                decision: None,
+                feedback: None,
+                plan_path: Some(".rara/sessions/source-thread/plan.md".to_string()),
+                tool_use_id: Some("exit-plan-source".to_string()),
+                plan_hash: None,
+            }],
+        }],
+    )?;
     state_db.persist_turn(
         "source-thread",
         0,
@@ -1873,7 +1900,9 @@ fn fork_thread_preserves_materialized_state_and_sets_lineage() -> Result<()> {
             if explanation.as_deref() == Some("Preserve thread continuity.")
                 && steps.len() == 1
                 && interactions.len() == 1
-                && plan_lifecycle.is_empty()
+                && plan_lifecycle.len() == 1
+                && plan_lifecycle[0].phase == "plan_ready"
+                && plan_lifecycle[0].tool_use_id.as_deref() == Some("exit-plan-source")
     )));
 
     Ok(())

--- a/src/thread_store/tests.rs
+++ b/src/thread_store/tests.rs
@@ -6,9 +6,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use rara_memory::vectordb::VectorDB;
 use rara_persistence::thread_data::{
-    PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
-    PersistedRuntimeRolloutItem, PersistedStructuredRolloutEvent, PersistedThreadLineage,
-    PersistedThreadRecord, PersistedTurnEntry,
+    PersistedCompactState, PersistedInteraction, PersistedPlanLifecycle, PersistedPlanStep,
+    PersistedPromptRuntimeState, PersistedRuntimeRolloutItem, PersistedStructuredRolloutEvent,
+    PersistedThreadLineage, PersistedThreadRecord, PersistedTurnEntry,
 };
 use rara_persistence::thread_metadata;
 use rara_persistence::{thread_rollout_log, thread_turn_log};
@@ -541,6 +541,17 @@ fn load_thread_prefers_structured_runtime_rollout_items() -> Result<()> {
                     payload: None,
                 },
             },
+            rara_state::state_db::PersistedStructuredRolloutEvent::PlanLifecycle {
+                recorded_at: None,
+                lifecycle: PersistedPlanLifecycle {
+                    phase: "plan_ready".to_string(),
+                    decision: None,
+                    feedback: None,
+                    plan_path: Some(".rara/sessions/session-runtime-rollout/plan.md".to_string()),
+                    tool_use_id: Some("exit-plan-runtime".to_string()),
+                    plan_hash: None,
+                },
+            },
         ],
     )?;
 
@@ -561,6 +572,12 @@ fn load_thread_prefers_structured_runtime_rollout_items() -> Result<()> {
         snapshot.rollout_items.get(1),
         Some(RolloutItem::Interaction(interaction))
             if interaction.title == "Structured Question" && interaction.summary == "answered"
+    ));
+    assert!(matches!(
+        snapshot.rollout_items.get(2),
+        Some(RolloutItem::PlanLifecycle(lifecycle))
+            if lifecycle.phase == "plan_ready"
+                && lifecycle.tool_use_id.as_deref() == Some("exit-plan-runtime")
     ));
     Ok(())
 }
@@ -822,6 +839,17 @@ fn load_thread_preserves_structured_rollout_event_order() -> Result<()> {
                     payload: None,
                 },
             },
+            rara_state::state_db::PersistedStructuredRolloutEvent::PlanLifecycle {
+                recorded_at: None,
+                lifecycle: PersistedPlanLifecycle {
+                    phase: "plan_ready".to_string(),
+                    decision: None,
+                    feedback: None,
+                    plan_path: Some(".rara/sessions/session-ordered-events/plan.md".to_string()),
+                    tool_use_id: Some("exit-plan-ordered".to_string()),
+                    plan_hash: None,
+                },
+            },
         ],
     )?;
     session_manager.save_compaction_event(
@@ -857,11 +885,17 @@ fn load_thread_preserves_structured_rollout_event_order() -> Result<()> {
         Some(RolloutItem::Interaction(interaction))
             if interaction.title == "Question"
     ));
-    assert!(matches!(
-        snapshot.rollout_items.get(3),
-        Some(RolloutItem::Compaction(compaction))
+    assert!(snapshot.rollout_items.iter().any(|item| matches!(
+        item,
+        RolloutItem::PlanLifecycle(lifecycle)
+            if lifecycle.phase == "plan_ready"
+                && lifecycle.tool_use_id.as_deref() == Some("exit-plan-ordered")
+    )));
+    assert!(snapshot.rollout_items.iter().any(|item| matches!(
+        item,
+        RolloutItem::Compaction(compaction)
             if compaction.compaction_count == 2
-    ));
+    )));
     Ok(())
 }
 
@@ -1033,6 +1067,17 @@ fn thread_recorder_writes_runtime_rollout_events_directly() -> Result<()> {
                     payload: None,
                 },
             },
+            PersistedStructuredRolloutEvent::PlanLifecycle {
+                recorded_at: None,
+                lifecycle: PersistedPlanLifecycle {
+                    phase: "plan_approved".to_string(),
+                    decision: Some("approve".to_string()),
+                    feedback: None,
+                    plan_path: Some(".rara/sessions/session-runtime-recorder/plan.md".to_string()),
+                    tool_use_id: Some("exit-plan-1".to_string()),
+                    plan_hash: None,
+                },
+            },
         ],
     )?;
 
@@ -1046,12 +1091,15 @@ fn thread_recorder_writes_runtime_rollout_events_directly() -> Result<()> {
             explanation: Some(explanation),
             steps,
             interactions,
+            plan_lifecycle,
             ..
         }] if explanation == "Runtime rollout belongs to ThreadRecorder."
             && steps.len() == 1
             && steps[0].step == "append canonical runtime state"
             && interactions.len() == 1
             && interactions[0].title == "Runtime Question"
+            && plan_lifecycle.len() == 1
+            && plan_lifecycle[0].phase == "plan_approved"
     ));
     Ok(())
 }
@@ -1820,10 +1868,12 @@ fn fork_thread_preserves_materialized_state_and_sets_lineage() -> Result<()> {
             explanation,
             steps,
             interactions,
+            plan_lifecycle,
         }
             if explanation.as_deref() == Some("Preserve thread continuity.")
                 && steps.len() == 1
                 && interactions.len() == 1
+                && plan_lifecycle.is_empty()
     )));
 
     Ok(())

--- a/src/thread_store/types.rs
+++ b/src/thread_store/types.rs
@@ -1,6 +1,6 @@
 use rara_persistence::thread_data::{
-    PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedRecentThreadRecord,
-    PersistedThreadRecord, PersistedTurnEntry, PersistedTurnSummary,
+    PersistedCompactState, PersistedInteraction, PersistedPlanLifecycle, PersistedPlanStep,
+    PersistedRecentThreadRecord, PersistedThreadRecord, PersistedTurnEntry, PersistedTurnSummary,
 };
 
 use crate::agent::Message;
@@ -219,6 +219,7 @@ pub enum RolloutItem {
         steps: Vec<PersistedPlanStep>,
     },
     Interaction(PersistedInteraction),
+    PlanLifecycle(PersistedPlanLifecycle),
     SpawnAgent {
         event_id: String,
         agent_id: String,

--- a/src/tui/input_control.rs
+++ b/src/tui/input_control.rs
@@ -173,6 +173,7 @@ pub(crate) fn answer_plan_approval(
             "Plan rejected. Implementation cancelled.",
         ),
     };
+    let source = Some(plan_approval_decision_source(decision).to_string());
 
     if decision == PlanApprovalDecision::Reject {
         let mut agent = agent;
@@ -186,7 +187,7 @@ pub(crate) fn answer_plan_approval(
             InteractionKind::PlanApproval,
             "Plan Decision",
             summary,
-            None,
+            source.clone(),
         );
         app.set_agent_execution_mode(agent.execution_mode);
         app.bottom_pane.notice = Some(notice.to_string());
@@ -200,10 +201,18 @@ pub(crate) fn answer_plan_approval(
         InteractionKind::PlanApproval,
         "Plan Decision",
         summary,
-        None,
+        source,
     );
     start_plan_approval_resume_task(app, decision, agent);
     InputControlOutcome::Answered
+}
+
+pub(crate) fn plan_approval_decision_source(decision: PlanApprovalDecision) -> &'static str {
+    match decision {
+        PlanApprovalDecision::Approve => "plan_approval:approve",
+        PlanApprovalDecision::ContinuePlanning => "plan_approval:continue_planning",
+        PlanApprovalDecision::Reject => "plan_approval:reject",
+    }
 }
 
 pub(crate) fn plan_approval_decision_for_index(index: usize) -> Option<PlanApprovalDecision> {

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -194,6 +194,7 @@ pub(super) fn restore_thread_by_id(
             | RolloutItem::Compaction(_)
             | RolloutItem::PlanState { .. }
             | RolloutItem::Interaction(_)
+            | RolloutItem::PlanLifecycle(_)
             | RolloutItem::SpawnAgent { .. } => {}
         }
     }

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -230,10 +230,17 @@ impl TuiApp {
                 status: "completed".to_string(),
                 title: interaction.title.clone(),
                 summary: interaction.summary.clone(),
-                payload: None,
+                payload: interaction.source.as_ref().map(|source| {
+                    json!({
+                        "source": source,
+                    })
+                }),
             });
             if interaction.kind == InteractionKind::PlanApproval
-                && let Some(lifecycle) = plan_lifecycle_from_completed_summary(&interaction.summary)
+                && let Some(lifecycle) = plan_lifecycle_from_completed_interaction(
+                    &interaction.summary,
+                    interaction.source.as_deref(),
+                )
             {
                 plan_lifecycle.push(lifecycle);
             }
@@ -363,12 +370,15 @@ impl TuiApp {
     }
 }
 
-fn plan_lifecycle_from_completed_summary(summary: &str) -> Option<PersistedPlanLifecycle> {
-    let (phase, decision) = match summary {
-        "Approved. Starting implementation." => ("plan_approved", "approve"),
-        "Sent back for more planning." => ("plan_revising", "continue_planning"),
-        "Rejected. Implementation cancelled." => ("plan_rejected", "reject"),
-        _ => return None,
+fn plan_lifecycle_from_completed_interaction(
+    summary: &str,
+    source: Option<&str>,
+) -> Option<PersistedPlanLifecycle> {
+    let (phase, decision) = match source {
+        Some("plan_approval:approve") => ("plan_approved", "approve"),
+        Some("plan_approval:continue_planning") => ("plan_revising", "continue_planning"),
+        Some("plan_approval:reject") => ("plan_rejected", "reject"),
+        _ => plan_lifecycle_from_completed_summary(summary)?,
     };
     Some(PersistedPlanLifecycle {
         phase: phase.to_string(),
@@ -378,6 +388,15 @@ fn plan_lifecycle_from_completed_summary(summary: &str) -> Option<PersistedPlanL
         tool_use_id: None,
         plan_hash: None,
     })
+}
+
+fn plan_lifecycle_from_completed_summary(summary: &str) -> Option<(&'static str, &'static str)> {
+    match summary {
+        "Approved. Starting implementation." => Some(("plan_approved", "approve")),
+        "Sent back for more planning." => Some(("plan_revising", "continue_planning")),
+        "Rejected. Implementation cancelled." => Some(("plan_rejected", "reject")),
+        _ => None,
+    }
 }
 
 fn resume_thread_matches_query(thread: &crate::thread_store::ThreadSummary, query: &str) -> bool {
@@ -398,25 +417,43 @@ fn resume_thread_matches_query(thread: &crate::thread_store::ThreadSummary, quer
 
 #[cfg(test)]
 mod tests {
-    use super::plan_lifecycle_from_completed_summary;
+    use super::plan_lifecycle_from_completed_interaction;
 
     #[test]
-    fn maps_plan_approval_summaries_to_lifecycle_phases() {
-        let approved =
-            plan_lifecycle_from_completed_summary("Approved. Starting implementation.").unwrap();
+    fn maps_plan_approval_sources_to_lifecycle_phases() {
+        let approved = plan_lifecycle_from_completed_interaction(
+            "copy can change",
+            Some("plan_approval:approve"),
+        )
+        .unwrap();
         assert_eq!(approved.phase, "plan_approved");
         assert_eq!(approved.decision.as_deref(), Some("approve"));
 
-        let revising = plan_lifecycle_from_completed_summary("Sent back for more planning.")
-            .expect("revising lifecycle");
+        let revising = plan_lifecycle_from_completed_interaction(
+            "copy can change",
+            Some("plan_approval:continue_planning"),
+        )
+        .expect("revising lifecycle");
         assert_eq!(revising.phase, "plan_revising");
         assert_eq!(revising.decision.as_deref(), Some("continue_planning"));
 
-        let rejected =
-            plan_lifecycle_from_completed_summary("Rejected. Implementation cancelled.").unwrap();
+        let rejected = plan_lifecycle_from_completed_interaction(
+            "copy can change",
+            Some("plan_approval:reject"),
+        )
+        .unwrap();
         assert_eq!(rejected.phase, "plan_rejected");
         assert_eq!(rejected.decision.as_deref(), Some("reject"));
 
-        assert!(plan_lifecycle_from_completed_summary("other").is_none());
+        assert!(plan_lifecycle_from_completed_interaction("other", None).is_none());
+    }
+
+    #[test]
+    fn keeps_summary_fallback_for_existing_completed_plan_approvals() {
+        let approved =
+            plan_lifecycle_from_completed_interaction("Approved. Starting implementation.", None)
+                .unwrap();
+        assert_eq!(approved.phase, "plan_approved");
+        assert_eq!(approved.decision.as_deref(), Some("approve"));
     }
 }

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use rara_state::state_db::{
-    PersistedCompactState, PersistedInteraction, PersistedPlanStep, PersistedPromptRuntimeState,
-    PersistedStructuredRolloutEvent, PersistedTurnEntry,
+    PersistedCompactState, PersistedInteraction, PersistedPlanLifecycle, PersistedPlanStep,
+    PersistedPromptRuntimeState, PersistedStructuredRolloutEvent, PersistedTurnEntry,
 };
 use serde_json::json;
 
@@ -154,6 +154,7 @@ impl TuiApp {
         }
 
         let mut interactions = Vec::new();
+        let mut plan_lifecycle = Vec::new();
         for interaction in &self.snapshot.pending_interactions {
             match interaction.kind {
                 InteractionKind::RequestInput => {
@@ -187,6 +188,14 @@ impl TuiApp {
                         title: interaction.title.clone(),
                         summary: interaction.summary.clone(),
                         payload: None,
+                    });
+                    plan_lifecycle.push(PersistedPlanLifecycle {
+                        phase: "plan_ready".to_string(),
+                        decision: None,
+                        feedback: None,
+                        plan_path: None,
+                        tool_use_id: None,
+                        plan_hash: None,
                     });
                 }
                 InteractionKind::Approval => {
@@ -223,6 +232,11 @@ impl TuiApp {
                 summary: interaction.summary.clone(),
                 payload: None,
             });
+            if interaction.kind == InteractionKind::PlanApproval
+                && let Some(lifecycle) = plan_lifecycle_from_completed_summary(&interaction.summary)
+            {
+                plan_lifecycle.push(lifecycle);
+            }
         }
 
         if let Err(err) = recorder.replace_interactions(&self.snapshot.session_id, &interactions) {
@@ -245,6 +259,12 @@ impl TuiApp {
             PersistedStructuredRolloutEvent::Interaction {
                 recorded_at: None,
                 interaction,
+            }
+        }));
+        structured_rollout.extend(plan_lifecycle.iter().cloned().map(|lifecycle| {
+            PersistedStructuredRolloutEvent::PlanLifecycle {
+                recorded_at: None,
+                lifecycle,
             }
         }));
         if let Err(err) =
@@ -343,6 +363,23 @@ impl TuiApp {
     }
 }
 
+fn plan_lifecycle_from_completed_summary(summary: &str) -> Option<PersistedPlanLifecycle> {
+    let (phase, decision) = match summary {
+        "Approved. Starting implementation." => ("plan_approved", "approve"),
+        "Sent back for more planning." => ("plan_revising", "continue_planning"),
+        "Rejected. Implementation cancelled." => ("plan_rejected", "reject"),
+        _ => return None,
+    };
+    Some(PersistedPlanLifecycle {
+        phase: phase.to_string(),
+        decision: Some(decision.to_string()),
+        feedback: None,
+        plan_path: None,
+        tool_use_id: None,
+        plan_hash: None,
+    })
+}
+
 fn resume_thread_matches_query(thread: &crate::thread_store::ThreadSummary, query: &str) -> bool {
     let metadata = &thread.metadata;
     [
@@ -357,4 +394,29 @@ fn resume_thread_matches_query(thread: &crate::thread_store::ThreadSummary, quer
     ]
     .into_iter()
     .any(|value| value.to_ascii_lowercase().contains(query))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plan_lifecycle_from_completed_summary;
+
+    #[test]
+    fn maps_plan_approval_summaries_to_lifecycle_phases() {
+        let approved =
+            plan_lifecycle_from_completed_summary("Approved. Starting implementation.").unwrap();
+        assert_eq!(approved.phase, "plan_approved");
+        assert_eq!(approved.decision.as_deref(), Some("approve"));
+
+        let revising = plan_lifecycle_from_completed_summary("Sent back for more planning.")
+            .expect("revising lifecycle");
+        assert_eq!(revising.phase, "plan_revising");
+        assert_eq!(revising.decision.as_deref(), Some("continue_planning"));
+
+        let rejected =
+            plan_lifecycle_from_completed_summary("Rejected. Implementation cancelled.").unwrap();
+        assert_eq!(rejected.phase, "plan_rejected");
+        assert_eq!(rejected.decision.as_deref(), Some("reject"));
+
+        assert!(plan_lifecycle_from_completed_summary("other").is_none());
+    }
 }

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1465,8 +1465,8 @@ fn completed_plan_approval_persists_decision_lifecycle() {
     app.record_completed_interaction(
         InteractionKind::PlanApproval,
         "Plan Decision",
-        "Approved. Starting implementation.",
-        None,
+        "copy can change",
+        Some("plan_approval:approve".to_string()),
     );
 
     let events = app

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1,6 +1,8 @@
 use rara_memory::vectordb::VectorDB;
 use rara_persistence::thread_turn_log;
-use rara_state::state_db::{PersistedCompactState, PersistedPromptRuntimeState, StateDb};
+use rara_state::state_db::{
+    PersistedCompactState, PersistedPromptRuntimeState, PersistedStructuredRolloutEvent, StateDb,
+};
 use rara_tools::tool::ToolManager;
 use tempfile::tempdir;
 
@@ -1419,6 +1421,70 @@ fn active_turn_entries_write_and_clear_live_log() {
     .expect("turn records");
     assert_eq!(turn_records.len(), 1);
     assert_eq!(turn_records[0].entries.len(), 2);
+}
+
+#[test]
+fn pending_plan_approval_persists_plan_ready_lifecycle() {
+    let dir = tempdir().expect("tempdir");
+    let state_db = StateDb::new_for_root_dir(dir.path().join(".rara")).expect("state db");
+    let mut app = TuiApp::new(ConfigManager {
+        path: dir.path().join("config.json"),
+    })
+    .expect("app");
+    app.snapshot.session_id = "plan-ready-session".to_string();
+    app.attach_state_db(std::sync::Arc::new(state_db));
+
+    app.set_pending_plan_approval(true);
+
+    let events = app
+        .state_db
+        .as_ref()
+        .expect("state db")
+        .load_rollout_events("plan-ready-session")
+        .expect("rollout events");
+    assert!(events.iter().any(|event| matches!(
+        event,
+        PersistedStructuredRolloutEvent::RuntimeState {
+            plan_lifecycle,
+            ..
+        } if plan_lifecycle.iter().any(|lifecycle| lifecycle.phase == "plan_ready")
+    )));
+}
+
+#[test]
+fn completed_plan_approval_persists_decision_lifecycle() {
+    let dir = tempdir().expect("tempdir");
+    let state_db = StateDb::new_for_root_dir(dir.path().join(".rara")).expect("state db");
+    let mut app = TuiApp::new(ConfigManager {
+        path: dir.path().join("config.json"),
+    })
+    .expect("app");
+    app.snapshot.session_id = "plan-approved-session".to_string();
+    app.attach_state_db(std::sync::Arc::new(state_db));
+
+    app.record_completed_interaction(
+        InteractionKind::PlanApproval,
+        "Plan Decision",
+        "Approved. Starting implementation.",
+        None,
+    );
+
+    let events = app
+        .state_db
+        .as_ref()
+        .expect("state db")
+        .load_rollout_events("plan-approved-session")
+        .expect("rollout events");
+    assert!(events.iter().any(|event| matches!(
+        event,
+        PersistedStructuredRolloutEvent::RuntimeState {
+            plan_lifecycle,
+            ..
+        } if plan_lifecycle.iter().any(|lifecycle| {
+            lifecycle.phase == "plan_approved"
+                && lifecycle.decision.as_deref() == Some("approve")
+        })
+    )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add typed planning lifecycle records to structured rollout events.
- Persist `plan_ready`, `plan_revising`, `plan_approved`, and `plan_rejected` lifecycle checkpoints from TUI plan approval state.
- Materialize lifecycle records through `ThreadStore` and expose phase counts in `rara thread` snapshot output.
- Update planning-mode docs, journal notes, and the active TODO item.

## Purpose

Plan approval state was previously implicit in pending/completed interaction records. This makes the planning lifecycle queryable from structured rollout state without parsing UI summaries, and prepares the next restore/status slices.

## Related Issue

None.

## Testing

- `cargo fmt`
- `git diff --check`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo test -p rara-state load_rollout_events_prefers_append_only_log_without_snapshot_rewrite`
- `cargo test load_thread_preserves_structured_rollout_event_order`
- `cargo test thread_snapshot_output_surfaces_runtime_metadata_and_rollout_counts`
- `cargo test tui::state::persistence::tests::maps_plan_approval_summaries_to_lifecycle_phases`
- `cargo test tui::state::tests::pending_plan_approval_persists_plan_ready_lifecycle`
- `cargo test tui::state::tests::completed_plan_approval_persists_decision_lifecycle`

The local macOS test binary still emits the known linker `__eh_frame` warning.
