### PR TITLE
fix(planning): restore pending plan approvals

### DIFF
--- a/docs/features/planning-mode.md
+++ b/docs/features/planning-mode.md
@@ -141,8 +141,8 @@ with these phases:
 The current checkpoint records the latest phase and decision metadata derived
 from the plan approval interaction. Completed decisions should use structured
 decision metadata rather than parsing UI copy. Thread forks preserve the
-materialized lifecycle records from the source thread. The complete recovery
-contract still needs enough state to recover after restart:
+materialized lifecycle records from the source thread. The recovery contract
+records enough state to recover a pending approval after restart:
 
 - `session_id`
 - `plan_file_path`
@@ -152,11 +152,16 @@ contract still needs enough state to recover after restart:
 - approved plan version or content hash
 - timestamp of submission and decision
 
-This state should be recorded in the structured rollout log rather than only in memory. On resume:
+This state should be recorded in the structured rollout log rather than only in
+memory. On resume, the latest lifecycle phase is authoritative:
 
-- if a plan is pending approval, the TUI should restore the approval card;
-- if a plan was approved but execution did not continue, the runtime should be able to inject the approved-plan result once;
-- if a plan was rejected or sent back for revision, the model should receive structured feedback and remain in planning mode.
+- `plan_ready` restores the approval card and, when present, the
+  `exit_plan_mode` tool-use id so approving the restored plan injects the tool
+  result once;
+- `plan_approved`, `plan_rejected`, and `plan_revising` must not reopen an
+  older pending approval card;
+- if a plan was rejected or sent back for revision, the model should receive
+  structured feedback and remain in planning mode.
 
 ### Tool Permissions
 

--- a/docs/journal/2026-07-04-planning-lifecycle-rollout.md
+++ b/docs/journal/2026-07-04-planning-lifecycle-rollout.md
@@ -38,15 +38,19 @@ derived from the plan approval interaction state:
   thread instead of resetting lifecycle state.
 - Completed plan approvals persist a typed `plan_approval:*` source marker so
   lifecycle decisions do not depend on UI summary copy.
+- Session restore uses the latest planning lifecycle phase to recover a pending
+  approval card and the `exit_plan_mode` tool-use id. Terminal lifecycle phases
+  do not reopen older pending approvals.
 
 ## Validation
 
 - `cargo check --locked --workspace --all-targets`
 - focused state persistence tests for pending and completed plan approval
   lifecycle checkpoints
+- `cargo test tui::session_restore::tests::restore_session_recovers_pending_plan_approval_from_lifecycle`
+- `cargo test tui::session_restore::tests::restore_session_does_not_reopen_completed_plan_approval`
 
 ## Follow-Ups
 
-- Restore pending plan approval after restart from persisted lifecycle state.
 - Add `/status` and `/context` planning lifecycle fields.
 - Persist user feedback for continue-planning and rejected-plan decisions.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -87,7 +87,7 @@ Active backlog only. Keep this file small and current.
       approve, continue planning with feedback, and reject/cancel.
 - [x] Persist planning lifecycle state in the structured rollout log:
       `plan_ready`, `plan_revising`, `plan_approved`, and `plan_rejected`.
-- [ ] Restore pending plan approval after restart and avoid reinjecting an
+- [x] Restore pending plan approval after restart and avoid reinjecting an
       approved-plan tool result more than once.
 - [ ] Expose planning lifecycle fields in `/status` and `/context`: plan path,
       approval status, pending age, last decision, and approved plan revision.

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -146,6 +146,18 @@ impl Agent {
         self.pending_plan_exit_tool_id.is_some()
     }
 
+    pub fn pending_plan_exit_tool_id(&self) -> Option<&str> {
+        self.pending_plan_exit_tool_id.as_deref()
+    }
+
+    pub fn restore_pending_plan_exit_approval(&mut self, tool_id: &str) {
+        if tool_id.trim().is_empty() {
+            return;
+        }
+        self.pending_plan_exit_tool_id = Some(tool_id.to_string());
+        self.execution_mode = AgentExecutionMode::Plan;
+    }
+
     pub fn set_execution_mode(&mut self, mode: AgentExecutionMode) {
         self.execution_mode = mode;
     }

--- a/src/tui/input_control.rs
+++ b/src/tui/input_control.rs
@@ -182,7 +182,7 @@ pub(crate) fn answer_plan_approval(
             *agent_slot = Some(agent);
             return InputControlOutcome::Rejected;
         }
-        app.set_pending_plan_approval(false);
+        app.clear_pending_plan_approval();
         app.record_completed_interaction(
             InteractionKind::PlanApproval,
             "Plan Decision",
@@ -196,7 +196,7 @@ pub(crate) fn answer_plan_approval(
         return InputControlOutcome::Answered;
     }
 
-    app.set_pending_plan_approval(false);
+    app.clear_pending_plan_approval();
     app.record_completed_interaction(
         InteractionKind::PlanApproval,
         "Plan Decision",

--- a/src/tui/plan_display.rs
+++ b/src/tui/plan_display.rs
@@ -172,7 +172,7 @@ mod tests {
 
         assert!(!should_show_updated_plan(&app));
 
-        app.set_pending_plan_approval(true);
+        app.show_pending_plan_approval(None);
         assert!(should_show_updated_plan(&app));
     }
 }

--- a/src/tui/render/cells/cells_tests/active_plan.rs
+++ b/src/tui/render/cells/cells_tests/active_plan.rs
@@ -25,7 +25,7 @@ fn active_turn_cell_renders_plan_approval_as_interaction_card() {
     ];
     app.snapshot.plan_explanation =
         Some("The current discovery path is hardcoded and should be generalized.".into());
-    app.set_pending_plan_approval(true);
+    app.show_pending_plan_approval(None);
 
     let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
         .display_lines(100)

--- a/src/tui/render/cells_tests/active_plan.rs
+++ b/src/tui/render/cells_tests/active_plan.rs
@@ -25,7 +25,7 @@ fn active_turn_cell_renders_plan_approval_as_interaction_card() {
     ];
     app.snapshot.plan_explanation =
         Some("The current discovery path is hardcoded and should be generalized.".into());
-    app.set_pending_plan_approval(true);
+    app.show_pending_plan_approval(None);
 
     let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
         .display_lines(100)

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -134,7 +134,7 @@ pub(super) async fn execute_local_command(
                 RuntimePhase::LocalCommand,
                 Some("entering planning mode".into()),
             );
-            app.set_pending_plan_approval(false);
+            app.clear_pending_plan_approval();
             app.permission_mode = PermissionMode::Custom;
             app.set_agent_execution_mode(AgentExecutionMode::Plan);
             if let Some(agent) = agent_slot.as_mut() {
@@ -632,7 +632,7 @@ pub(crate) fn apply_permission_mode(
         RuntimePhase::LocalCommand,
         Some("updating permissions".into()),
     );
-    app.set_pending_plan_approval(false);
+    app.clear_pending_plan_approval();
 }
 
 #[cfg(test)]

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -809,11 +809,12 @@ pub(crate) async fn finish_running_task_if_ready(
                         let plan_ready =
                             agent.last_query_produced_plan() && !agent.current_plan.is_empty();
                         let pending_exit_plan_approval = agent.has_pending_plan_exit_approval();
-                        app.set_pending_plan_approval_with_tool_id(
-                            plan_ready
-                                && (query_started_in_plan_mode || pending_exit_plan_approval),
-                            agent.pending_plan_exit_tool_id(),
-                        );
+                        if plan_ready && (query_started_in_plan_mode || pending_exit_plan_approval)
+                        {
+                            app.show_pending_plan_approval(agent.pending_plan_exit_tool_id());
+                        } else {
+                            app.clear_pending_plan_approval();
+                        }
                         if plan_ready && !query_started_in_plan_mode && !pending_exit_plan_approval
                         {
                             app.release_pending_follow_ups();
@@ -939,7 +940,7 @@ pub(crate) async fn finish_running_task_if_ready(
                     );
                     app.clear_active_live_sections();
 
-                    app.set_pending_plan_approval(false);
+                    app.clear_pending_plan_approval();
                     *agent_slot = Some(agent);
                     if let Some(agent) = agent_slot.as_ref() {
                         app.sync_snapshot(agent);

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -809,9 +809,10 @@ pub(crate) async fn finish_running_task_if_ready(
                         let plan_ready =
                             agent.last_query_produced_plan() && !agent.current_plan.is_empty();
                         let pending_exit_plan_approval = agent.has_pending_plan_exit_approval();
-                        app.set_pending_plan_approval(
+                        app.set_pending_plan_approval_with_tool_id(
                             plan_ready
                                 && (query_started_in_plan_mode || pending_exit_plan_approval),
+                            agent.pending_plan_exit_tool_id(),
                         );
                         if plan_ready && !query_started_in_plan_mode && !pending_exit_plan_approval
                         {

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -5,8 +5,8 @@ use rara_state::state_db::StateDb;
 
 use super::state::{GoalStatus, RalphGoal, TranscriptEntry, TranscriptTurn, TuiApp};
 use crate::agent::{
-    Agent, BashApprovalMode, CompactBoundaryMetadata, CompletedInteraction, PendingApproval,
-    PendingUserInput, PlanStep, PlanStepStatus, latest_compact_boundary_metadata,
+    Agent, AgentExecutionMode, BashApprovalMode, CompactBoundaryMetadata, CompletedInteraction,
+    PendingApproval, PendingUserInput, PlanStep, PlanStepStatus, latest_compact_boundary_metadata,
 };
 use crate::thread_store::{CompactionRecord, RolloutItem, ThreadStore};
 use crate::tools::bash::BashCommandInput;
@@ -86,6 +86,7 @@ pub(super) fn restore_thread_by_id(
         agent.current_plan.clear();
     }
     agent.plan_explanation = plan_explanation;
+    let latest_plan_lifecycle = latest_plan_lifecycle(&rollout_items);
     agent.pending_user_input = None;
     agent.pending_approval = None;
     agent.completed_user_input = None;
@@ -213,6 +214,38 @@ pub(super) fn restore_thread_by_id(
             .collect();
     }
     app.sync_snapshot(agent);
+    let pending_plan_tool_id = latest_plan_lifecycle
+        .as_ref()
+        .and_then(|(phase, tool_use_id)| {
+            (phase == "plan_ready")
+                .then_some(tool_use_id.as_deref())
+                .flatten()
+        });
+    if latest_plan_lifecycle
+        .as_ref()
+        .is_some_and(|(phase, _)| phase == "plan_ready")
+    {
+        agent.set_execution_mode(AgentExecutionMode::Plan);
+    }
+    if let Some(tool_id) = pending_plan_tool_id {
+        agent.restore_pending_plan_exit_approval(tool_id);
+        app.sync_snapshot(agent);
+        app.set_pending_plan_approval_with_tool_id(true, Some(tool_id));
+        app.set_runtime_phase(
+            super::state::RuntimePhase::Idle,
+            Some("awaiting plan approval".into()),
+        );
+    } else if latest_plan_lifecycle
+        .as_ref()
+        .is_some_and(|(phase, _)| phase == "plan_ready")
+    {
+        app.sync_snapshot(agent);
+        app.set_pending_plan_approval_with_tool_id(true, None);
+        app.set_runtime_phase(
+            super::state::RuntimePhase::Idle,
+            Some("awaiting plan approval".into()),
+        );
+    }
 
     // Restore any persisted goal so it survives across sessions.
     if let Some(db) = app.state_db.as_ref()
@@ -241,6 +274,15 @@ pub(super) fn restore_thread_by_id(
 
     app.bottom_pane.notice = Some(format!("Resumed thread {thread_id}."));
     Ok(())
+}
+
+fn latest_plan_lifecycle(rollout_items: &[RolloutItem]) -> Option<(String, Option<String>)> {
+    rollout_items.iter().rev().find_map(|item| match item {
+        RolloutItem::PlanLifecycle(lifecycle) => {
+            Some((lifecycle.phase.clone(), lifecycle.tool_use_id.clone()))
+        }
+        _ => None,
+    })
 }
 
 fn apply_compaction_record(agent: &mut Agent, compaction: &CompactionRecord) {
@@ -280,7 +322,7 @@ mod tests {
     use crate::llm::MockLlm;
     use crate::prompt::PromptRuntimeConfig;
     use crate::todo::{TodoItem, TodoState, TodoStatus};
-    use crate::tui::state::TuiApp;
+    use crate::tui::state::{ActivePendingInteractionKind, InteractionKind, TuiApp};
     use crate::workspace::WorkspaceMemory;
 
     #[test]
@@ -755,5 +797,185 @@ mod tests {
             restored_app.snapshot.assembly_entries,
             runtime.assembly.entries
         );
+    }
+
+    #[test]
+    fn restore_session_recovers_pending_plan_approval_from_lifecycle() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("repo");
+        let rara_dir = root.join(".rara");
+        fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+        fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+        fs::create_dir_all(rara_dir.join("tool-results")).expect("tool results");
+        fs::write(root.join("AGENTS.md"), "repo rules").expect("agents");
+
+        let session_manager = Arc::new(crate::session::SessionManager {
+            storage_dir: rara_dir.join("rollouts"),
+            legacy_storage_dir: rara_dir.join("sessions"),
+        });
+        let workspace = Arc::new(WorkspaceMemory::from_paths(root.clone(), rara_dir.clone()));
+        let backend = Arc::new(MockLlm);
+        let state_db = Arc::new(StateDb::new_for_root_dir(rara_dir.clone()).expect("state db"));
+
+        let mut original_agent = Agent::new(
+            ToolManager::new(),
+            backend.clone(),
+            Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager.clone(),
+            workspace.clone(),
+        );
+        original_agent.session_id = "session-pending-plan-approval".to_string();
+        original_agent.set_execution_mode(AgentExecutionMode::Plan);
+        original_agent.current_plan = vec![PlanStep {
+            step: "Restore plan approval".to_string(),
+            status: PlanStepStatus::Pending,
+        }];
+        original_agent.plan_explanation = Some("Recover the pending approval card.".to_string());
+        original_agent.history.push(Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"resume approval"}]),
+        });
+        session_manager
+            .save_session(&original_agent.session_id, &original_agent.history)
+            .expect("save session");
+
+        let mut original_app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        original_app.attach_state_db(state_db.clone());
+        original_app.sync_snapshot(&original_agent);
+        original_app.set_pending_plan_approval_with_tool_id(true, Some("exit-plan-restore"));
+
+        let restored_agent = Agent::new(
+            ToolManager::new(),
+            backend,
+            Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager,
+            workspace,
+        );
+        let mut restored_slot = Some(restored_agent);
+        let mut restored_app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config-restored.json"),
+        })
+        .expect("restored app");
+        restored_app.attach_state_db(state_db);
+
+        restore_thread_by_id(
+            original_agent.session_id.as_str(),
+            &mut restored_app,
+            &mut restored_slot,
+        )
+        .expect("restore thread");
+
+        let restored_agent = restored_slot.expect("restored agent");
+        assert_eq!(restored_agent.execution_mode, AgentExecutionMode::Plan);
+        assert!(restored_agent.has_pending_plan_exit_approval());
+        assert_eq!(
+            restored_agent.pending_plan_exit_tool_id(),
+            Some("exit-plan-restore")
+        );
+        assert!(restored_app.has_pending_plan_approval());
+        assert_eq!(
+            restored_app
+                .active_pending_interaction()
+                .map(|interaction| interaction.kind),
+            Some(ActivePendingInteractionKind::PlanApproval)
+        );
+        assert_eq!(
+            restored_app
+                .pending_plan_approval_interaction()
+                .and_then(|interaction| interaction.source.as_deref()),
+            Some("exit_plan_mode:exit-plan-restore")
+        );
+    }
+
+    #[test]
+    fn restore_session_does_not_reopen_completed_plan_approval() {
+        let temp = tempdir().expect("tempdir");
+        let root = temp.path().join("repo");
+        let rara_dir = root.join(".rara");
+        fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+        fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+        fs::create_dir_all(rara_dir.join("tool-results")).expect("tool results");
+        fs::write(root.join("AGENTS.md"), "repo rules").expect("agents");
+
+        let session_manager = Arc::new(crate::session::SessionManager {
+            storage_dir: rara_dir.join("rollouts"),
+            legacy_storage_dir: rara_dir.join("sessions"),
+        });
+        let workspace = Arc::new(WorkspaceMemory::from_paths(root.clone(), rara_dir.clone()));
+        let backend = Arc::new(MockLlm);
+        let state_db = Arc::new(StateDb::new_for_root_dir(rara_dir.clone()).expect("state db"));
+
+        let mut original_agent = Agent::new(
+            ToolManager::new(),
+            backend.clone(),
+            Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager.clone(),
+            workspace.clone(),
+        );
+        original_agent.session_id = "session-completed-plan-approval".to_string();
+        original_agent.set_execution_mode(AgentExecutionMode::Plan);
+        original_agent.current_plan = vec![PlanStep {
+            step: "Do not reopen approval".to_string(),
+            status: PlanStepStatus::Pending,
+        }];
+        original_agent.plan_explanation = Some("Completed approvals stay completed.".to_string());
+        original_agent.history.push(Message {
+            role: "user".to_string(),
+            content: json!([{"type":"text","text":"resume completed approval"}]),
+        });
+        session_manager
+            .save_session(&original_agent.session_id, &original_agent.history)
+            .expect("save session");
+
+        let mut original_app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        original_app.attach_state_db(state_db.clone());
+        original_app.sync_snapshot(&original_agent);
+        original_app.set_pending_plan_approval_with_tool_id(true, Some("exit-plan-completed"));
+        original_app.set_pending_plan_approval(false);
+        original_app.record_completed_interaction(
+            InteractionKind::PlanApproval,
+            "Plan Decision",
+            "copy can change",
+            Some("plan_approval:approve".to_string()),
+        );
+
+        let restored_agent = Agent::new(
+            ToolManager::new(),
+            backend,
+            Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            session_manager,
+            workspace,
+        );
+        let mut restored_slot = Some(restored_agent);
+        let mut restored_app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config-restored.json"),
+        })
+        .expect("restored app");
+        restored_app.attach_state_db(state_db);
+
+        restore_thread_by_id(
+            original_agent.session_id.as_str(),
+            &mut restored_app,
+            &mut restored_slot,
+        )
+        .expect("restore thread");
+
+        let restored_agent = restored_slot.expect("restored agent");
+        assert!(!restored_agent.has_pending_plan_exit_approval());
+        assert!(!restored_app.has_pending_plan_approval());
     }
 }

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -216,31 +216,18 @@ pub(super) fn restore_thread_by_id(
     app.sync_snapshot(agent);
     let pending_plan_tool_id = latest_plan_lifecycle
         .as_ref()
-        .and_then(|(phase, tool_use_id)| {
-            (phase == "plan_ready")
-                .then_some(tool_use_id.as_deref())
-                .flatten()
-        });
+        .filter(|(phase, _)| phase == "plan_ready")
+        .and_then(|(_, tool_use_id)| tool_use_id.as_deref());
     if latest_plan_lifecycle
         .as_ref()
         .is_some_and(|(phase, _)| phase == "plan_ready")
     {
         agent.set_execution_mode(AgentExecutionMode::Plan);
-    }
-    if let Some(tool_id) = pending_plan_tool_id {
-        agent.restore_pending_plan_exit_approval(tool_id);
+        if let Some(tool_id) = pending_plan_tool_id {
+            agent.restore_pending_plan_exit_approval(tool_id);
+        }
         app.sync_snapshot(agent);
-        app.set_pending_plan_approval_with_tool_id(true, Some(tool_id));
-        app.set_runtime_phase(
-            super::state::RuntimePhase::Idle,
-            Some("awaiting plan approval".into()),
-        );
-    } else if latest_plan_lifecycle
-        .as_ref()
-        .is_some_and(|(phase, _)| phase == "plan_ready")
-    {
-        app.sync_snapshot(agent);
-        app.set_pending_plan_approval_with_tool_id(true, None);
+        app.show_pending_plan_approval(pending_plan_tool_id);
         app.set_runtime_phase(
             super::state::RuntimePhase::Idle,
             Some("awaiting plan approval".into()),
@@ -847,7 +834,7 @@ mod tests {
         .expect("app");
         original_app.attach_state_db(state_db.clone());
         original_app.sync_snapshot(&original_agent);
-        original_app.set_pending_plan_approval_with_tool_id(true, Some("exit-plan-restore"));
+        original_app.show_pending_plan_approval(Some("exit-plan-restore"));
 
         let restored_agent = Agent::new(
             ToolManager::new(),
@@ -942,8 +929,8 @@ mod tests {
         .expect("app");
         original_app.attach_state_db(state_db.clone());
         original_app.sync_snapshot(&original_agent);
-        original_app.set_pending_plan_approval_with_tool_id(true, Some("exit-plan-completed"));
-        original_app.set_pending_plan_approval(false);
+        original_app.show_pending_plan_approval(Some("exit-plan-completed"));
+        original_app.clear_pending_plan_approval();
         original_app.record_completed_interaction(
             InteractionKind::PlanApproval,
             "Plan Decision",

--- a/src/tui/state/pending_interaction.rs
+++ b/src/tui/state/pending_interaction.rs
@@ -45,7 +45,7 @@ impl TuiApp {
         }
     }
 
-    fn plan_approval_interaction(&self) -> PendingInteractionSnapshot {
+    fn plan_approval_interaction(&self, tool_use_id: Option<&str>) -> PendingInteractionSnapshot {
         PendingInteractionSnapshot {
             kind: InteractionKind::PlanApproval,
             title: "Plan Ready".to_string(),
@@ -57,18 +57,22 @@ impl TuiApp {
             options: Vec::new(),
             note: None,
             approval: None,
-            source: None,
+            source: tool_use_id.map(|id| format!("exit_plan_mode:{id}")),
         }
     }
 
-    pub(super) fn set_plan_approval_interaction(&mut self, pending: bool) {
+    pub(super) fn set_plan_approval_interaction(
+        &mut self,
+        pending: bool,
+        tool_use_id: Option<&str>,
+    ) {
         self.snapshot
             .pending_interactions
             .retain(|item| item.kind != InteractionKind::PlanApproval);
         if pending {
             self.snapshot
                 .pending_interactions
-                .push(self.plan_approval_interaction());
+                .push(self.plan_approval_interaction(tool_use_id));
         }
     }
 
@@ -156,7 +160,15 @@ impl TuiApp {
     }
 
     pub fn set_pending_plan_approval(&mut self, pending: bool) {
-        self.set_plan_approval_interaction(pending);
+        self.set_pending_plan_approval_with_tool_id(pending, None);
+    }
+
+    pub fn set_pending_plan_approval_with_tool_id(
+        &mut self,
+        pending: bool,
+        tool_use_id: Option<&str>,
+    ) {
+        self.set_plan_approval_interaction(pending, tool_use_id);
         self.persist_runtime_state();
     }
 

--- a/src/tui/state/pending_interaction.rs
+++ b/src/tui/state/pending_interaction.rs
@@ -61,19 +61,23 @@ impl TuiApp {
         }
     }
 
-    pub(super) fn set_plan_approval_interaction(
-        &mut self,
-        pending: bool,
-        tool_use_id: Option<&str>,
-    ) {
+    fn clear_plan_approval_interaction(&mut self) {
         self.snapshot
             .pending_interactions
             .retain(|item| item.kind != InteractionKind::PlanApproval);
-        if pending {
-            self.snapshot
-                .pending_interactions
-                .push(self.plan_approval_interaction(tool_use_id));
-        }
+    }
+
+    pub fn show_pending_plan_approval(&mut self, tool_use_id: Option<&str>) {
+        self.clear_plan_approval_interaction();
+        self.snapshot
+            .pending_interactions
+            .push(self.plan_approval_interaction(tool_use_id));
+        self.persist_runtime_state();
+    }
+
+    pub fn clear_pending_plan_approval(&mut self) {
+        self.clear_plan_approval_interaction();
+        self.persist_runtime_state();
     }
 
     pub fn set_agent_execution_mode(&mut self, mode: AgentExecutionMode) {
@@ -157,19 +161,6 @@ impl TuiApp {
                 .map(|interaction| interaction.options.len().min(3))
                 .unwrap_or(0),
         }
-    }
-
-    pub fn set_pending_plan_approval(&mut self, pending: bool) {
-        self.set_pending_plan_approval_with_tool_id(pending, None);
-    }
-
-    pub fn set_pending_plan_approval_with_tool_id(
-        &mut self,
-        pending: bool,
-        tool_use_id: Option<&str>,
-    ) {
-        self.set_plan_approval_interaction(pending, tool_use_id);
-        self.persist_runtime_state();
     }
 
     pub fn pending_request_input(&self) -> Option<&PendingInteractionSnapshot> {

--- a/src/tui/state/persistence.rs
+++ b/src/tui/state/persistence.rs
@@ -182,19 +182,24 @@ impl TuiApp {
                     });
                 }
                 InteractionKind::PlanApproval => {
+                    let tool_use_id = plan_approval_tool_use_id(interaction.source.as_deref());
                     interactions.push(PersistedInteraction {
                         kind: "plan_approval".to_string(),
                         status: "pending".to_string(),
                         title: interaction.title.clone(),
                         summary: interaction.summary.clone(),
-                        payload: None,
+                        payload: interaction.source.as_ref().map(|source| {
+                            json!({
+                                "source": source,
+                            })
+                        }),
                     });
                     plan_lifecycle.push(PersistedPlanLifecycle {
                         phase: "plan_ready".to_string(),
                         decision: None,
                         feedback: None,
                         plan_path: None,
-                        tool_use_id: None,
+                        tool_use_id,
                         plan_hash: None,
                     });
                 }
@@ -397,6 +402,14 @@ fn plan_lifecycle_from_completed_summary(summary: &str) -> Option<(&'static str,
         "Rejected. Implementation cancelled." => Some(("plan_rejected", "reject")),
         _ => None,
     }
+}
+
+fn plan_approval_tool_use_id(source: Option<&str>) -> Option<String> {
+    source
+        .and_then(|value| value.strip_prefix("exit_plan_mode:"))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn resume_thread_matches_query(thread: &crate::thread_store::ThreadSummary, query: &str) -> bool {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1434,7 +1434,7 @@ fn pending_plan_approval_persists_plan_ready_lifecycle() {
     app.snapshot.session_id = "plan-ready-session".to_string();
     app.attach_state_db(std::sync::Arc::new(state_db));
 
-    app.set_pending_plan_approval(true);
+    app.show_pending_plan_approval(None);
 
     let events = app
         .state_db

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -242,7 +242,7 @@ impl TuiApp {
         self.bottom_pane.pending_follow_up_messages.clear();
         self.bottom_pane.queued_follow_up_messages.clear();
         self.running_tool_boundary_count = 0;
-        self.set_plan_approval_interaction(false, None);
+        self.clear_pending_plan_approval();
         self.bottom_pane.notice = Some("Cleared local transcript view.".into());
     }
 

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -242,7 +242,7 @@ impl TuiApp {
         self.bottom_pane.pending_follow_up_messages.clear();
         self.bottom_pane.queued_follow_up_messages.clear();
         self.running_tool_boundary_count = 0;
-        self.set_plan_approval_interaction(false);
+        self.set_plan_approval_interaction(false, None);
         self.bottom_pane.notice = Some("Cleared local transcript view.".into());
     }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -323,7 +323,7 @@ async fn pending_plan_approval_blocks_plain_submit() {
         crate::protocol_sources::MemoryControlHandler::new(bus.clone()),
     ));
 
-    app.set_pending_plan_approval(true);
+    app.show_pending_plan_approval(None);
     app.bottom_pane.input = "start implementation".into();
 
     let mut agent_slot = None;
@@ -355,7 +355,7 @@ fn pending_plan_approval_number_shortcuts_work_in_local_and_ssh() {
             path: temp.path().join("config.json"),
         })
         .expect("build tui app");
-        app.set_pending_plan_approval(true);
+        app.show_pending_plan_approval(None);
 
         assert_eq!(app.active_pending_option_count(), 3);
         assert!(matches!(


### PR DESCRIPTION
## Summary

- Restore pending plan approval state from the latest persisted planning lifecycle during thread resume.
- Persist the `exit_plan_mode` tool-use id on `plan_ready` lifecycle records so restored approvals can inject the approved-plan tool result once.
- Keep terminal lifecycle phases from reopening older pending plan approval cards, and update the planning spec, journal, and TODO.

## Purpose

This closes the next Planning Control Plane TODO after lifecycle persistence: a restarted TUI should resume at the pending approval card instead of losing the approval state or reusing a completed plan approval.

## Related issues

None.

## Testing

- `cargo fmt`
- `git diff --check`
- `cargo test tui::session_restore::tests::restore_session_recovers_pending_plan_approval_from_lifecycle`
- `cargo test tui::session_restore::tests::restore_session_does_not_reopen_completed_plan_approval`
- `cargo test tui::state::tests::pending_plan_approval_persists_plan_ready_lifecycle`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked`
