### PR TITLE
feat(tui): surface planning lifecycle status

### DIFF
--- a/docs/features/planning-mode.md
+++ b/docs/features/planning-mode.md
@@ -218,12 +218,28 @@ The current plan artifact should be part of runtime context:
 - approved plan hash or revision id;
 - execution progress against the approved plan, if available.
 
+The current `/status` runtime and overview surfaces expose the lifecycle as a
+derived snapshot:
+
+- `planning_status`;
+- `plan_path`;
+- `planning_pending_age`;
+- `planning_last_decision`;
+- `approved_plan_revision`;
+- `exit_plan_tool`, when a pending `exit_plan_mode` approval is waiting.
+
 `/context` should expose more detail:
 
 - plan source and path;
 - prompt/runtime sections that mention plan mode;
 - whether current context included the approved plan;
 - whether compacted context retained the plan artifact reference.
+
+The current `/context` overlay and text surface include a Planning Lifecycle
+section with plan path, approval status, pending age, last decision, approved
+revision, and pending `exit_plan_mode` tool-use id when present. Pending age and
+approved revision render as `-` until runtime checkpoints persist submission
+timestamps and plan hashes.
 
 ### Recovery Scenarios
 

--- a/docs/journal/2026-07-04-planning-lifecycle-rollout.md
+++ b/docs/journal/2026-07-04-planning-lifecycle-rollout.md
@@ -5,6 +5,7 @@
 - Added a typed `PlanLifecycle` structured rollout event.
 - Persisted plan approval lifecycle phases through runtime-state checkpoints.
 - Surfaced plan lifecycle phases in thread snapshot rollout summaries.
+- Exposed the derived planning lifecycle in `/status` and `/context`.
 
 ## Background
 
@@ -41,6 +42,12 @@ derived from the plan approval interaction state:
 - Session restore uses the latest planning lifecycle phase to recover a pending
   approval card and the `exit_plan_mode` tool-use id. Terminal lifecycle phases
   do not reopen older pending approvals.
+- `RuntimeSnapshot` now carries a derived `PlanningLifecycleSnapshot` so
+  `/status` and `/context` share one parsing boundary instead of duplicating
+  interaction-source string parsing in renderers.
+- Pending age and approved revision are explicit nullable fields in the
+  snapshot. They render as `-` until checkpoint records include submission
+  timestamps and plan hashes.
 
 ## Validation
 
@@ -49,8 +56,11 @@ derived from the plan approval interaction state:
   lifecycle checkpoints
 - `cargo test tui::session_restore::tests::restore_session_recovers_pending_plan_approval_from_lifecycle`
 - `cargo test tui::session_restore::tests::restore_session_does_not_reopen_completed_plan_approval`
+- focused planning lifecycle snapshot derivation tests
+- focused `/status` runtime/context and overview rendering tests
 
 ## Follow-Ups
 
-- Add `/status` and `/context` planning lifecycle fields.
 - Persist user feedback for continue-planning and rejected-plan decisions.
+- Persist plan submission timestamps and plan hashes so pending age and
+  approved revision can render concrete values.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -89,10 +89,13 @@ Active backlog only. Keep this file small and current.
       `plan_ready`, `plan_revising`, `plan_approved`, and `plan_rejected`.
 - [x] Restore pending plan approval after restart and avoid reinjecting an
       approved-plan tool result more than once.
-- [ ] Expose planning lifecycle fields in `/status` and `/context`: plan path,
+- [x] Expose planning lifecycle fields in `/status` and `/context`: plan path,
       approval status, pending age, last decision, and approved plan revision.
 - [ ] Support continue-planning feedback so rejecting a plan can carry user
       instructions back into planning mode instead of only a generic retry.
+- [ ] Persist plan submission timestamps and approved plan hashes so `/status`
+      and `/context` can render concrete pending age and approved revision
+      values instead of `-`.
 
 ## Hooks
 

--- a/src/tui/command/status.rs
+++ b/src/tui/command/status.rs
@@ -327,171 +327,7 @@ fn render_context_observability(app: &TuiApp) -> String {
     )
 }
 
-fn todo_summary_line(app: &TuiApp) -> String {
-    let summary = &app.snapshot.todo.summary;
-    if summary.total == 0 {
-        return "none".to_string();
-    }
-    let active = summary
-        .active_label
-        .as_deref()
-        .or(summary.active_item.as_deref())
-        .unwrap_or("-");
-    format!(
-        "{} total, {} pending, {} in_progress, {} completed, {} cancelled, active={}",
-        summary.total,
-        summary.pending,
-        summary.in_progress,
-        summary.completed,
-        summary.cancelled,
-        truncate_preview(active, 80)
-    )
-}
-
-fn shared_task_summary_line(app: &TuiApp) -> String {
-    let tasks = &app.snapshot.shared_tasks;
-    if let Some(error) = tasks.error.as_deref() {
-        return format!(
-            "list={} error={}",
-            tasks.task_list_id,
-            truncate_preview(error, 80)
-        );
-    }
-    if tasks.total == 0 {
-        return format!("list={} none", tasks.task_list_id);
-    }
-    format!(
-        "list={} {} total, {} pending, {} in_progress, {} completed, {} unblocked, {} owned",
-        tasks.task_list_id,
-        tasks.total,
-        tasks.pending,
-        tasks.in_progress,
-        tasks.completed,
-        tasks.unblocked,
-        tasks.owned,
-    )
-}
-
-fn render_todo_context(app: &TuiApp) -> String {
-    let summary = &app.snapshot.todo.summary;
-    if summary.total == 0 {
-        return "Todo\n  artifact: -\n  items: none".to_string();
-    }
-    let artifact = app.snapshot.todo_artifact_path.as_deref().unwrap_or("-");
-    let updated_at = app
-        .snapshot
-        .todo
-        .updated_at
-        .map(format_unix_timestamp_utc)
-        .unwrap_or_else(|| "-".to_string());
-    let active = summary.active_item.as_deref();
-    let items = if app.snapshot.todo.items.is_empty() {
-        "  items: none".to_string()
-    } else {
-        let rendered_items = app
-            .snapshot
-            .todo
-            .items
-            .iter()
-            .take(8)
-            .map(|(id, status, content)| {
-                let suffix = if active == Some(content.as_str()) {
-                    format!("{id}, active")
-                } else {
-                    id.to_string()
-                };
-                format!(
-                    "    - [{status}] {} ({suffix})",
-                    truncate_preview(content, 100)
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
-        let omitted = app.snapshot.todo.items.len().saturating_sub(8);
-        if omitted == 0 {
-            format!("  items:\n{rendered_items}")
-        } else {
-            format!("  items:\n{rendered_items}\n    ... {omitted} more")
-        }
-    };
-    format!(
-        "Todo\n  artifact: {artifact}\n  updated_at: {updated_at}\n  total: {}  pending: {}  in_progress: {}  completed: {}  cancelled: {}\n{}",
-        summary.total,
-        summary.pending,
-        summary.in_progress,
-        summary.completed,
-        summary.cancelled,
-        items,
-    )
-}
-
-fn render_shared_tasks_context(app: &TuiApp) -> String {
-    let tasks = &app.snapshot.shared_tasks;
-    if let Some(error) = tasks.error.as_deref() {
-        return format!(
-            "Shared Tasks\n  list: {}\n  error: {}",
-            tasks.task_list_id,
-            truncate_preview(error, 120)
-        );
-    }
-    if tasks.total == 0 {
-        return format!(
-            "Shared Tasks\n  list: {}\n  tasks: none",
-            tasks.task_list_id
-        );
-    }
-    let rendered_items = tasks
-        .items
-        .iter()
-        .take(8)
-        .map(|task| {
-            let owner = task.owner.as_deref().unwrap_or("-");
-            let blockers = if task.blocked_by.is_empty() {
-                "-".to_string()
-            } else {
-                task.blocked_by.join(",")
-            };
-            format!(
-                "    - [{}] #{} rev={} owner={} blockedBy={} {}",
-                task.status,
-                task.id,
-                task.revision,
-                owner,
-                blockers,
-                truncate_preview(task.subject.as_str(), 90)
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    let omitted = tasks.items.len().saturating_sub(8);
-    let omitted = if omitted == 0 {
-        String::new()
-    } else {
-        format!("\n    ... {omitted} more")
-    };
-    format!(
-        "Shared Tasks\n  list: {}\n  total: {}  pending: {}  in_progress: {}  completed: {}  unblocked: {}  owned: {}\n  tasks:\n{}{}",
-        tasks.task_list_id,
-        tasks.total,
-        tasks.pending,
-        tasks.in_progress,
-        tasks.completed,
-        tasks.unblocked,
-        tasks.owned,
-        rendered_items,
-        omitted,
-    )
-}
-
-fn format_unix_timestamp_utc(timestamp: i64) -> String {
-    let format =
-        time::macros::format_description!("[year]-[month]-[day] [hour]:[minute]:[second] UTC");
-
-    OffsetDateTime::from_unix_timestamp(timestamp)
-        .ok()
-        .and_then(|dt| dt.format(&format).ok())
-        .unwrap_or_else(|| "invalid timestamp".to_string())
-}
+include!("status_sections.rs");
 
 /// Reserved for the richer `/status` context tab tracked in docs/todo.md.
 #[allow(dead_code)]
@@ -595,6 +431,7 @@ pub fn status_context_text(app: &TuiApp) -> String {
             app.snapshot.plan_explanation.as_deref().unwrap_or("-"),
             plan_lines
         ),
+        render_planning_lifecycle_context(app),
         render_todo_context(app),
         render_shared_tasks_context(app),
         format!("Pending\n{}", pending_interactions),
@@ -692,7 +529,7 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
         crate::local_model_server::LocalModelServerState::Error => "error",
     };
     format!(
-        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nauxiliary_model={}\nauxiliary_model_source={}\nauxiliary_route={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\ntodo={}\nshared_tasks={}\nembedding_state={}\nembedding_backend={}\nembedding_model={}\nembedding_detail={}\ndevice={}\ndtype={}\nterminal_name={}\nterminal_user_agent={}\nterminal_term={}\nterminal_term_program={}\nterminal_multiplexer={}\nterminal_remote={}\nterminal_history_mode={}\nterminal_focused={}\nterminal_width_columns={}\nphase={}\ndetail={}",
+        "provider={}\nendpoint_profile={}\nendpoint_kind={}\nmodel={}\nmodel_source={}\nauxiliary_model={}\nauxiliary_model_source={}\nauxiliary_route={}\nbase_url={}\nbase_url_source={}\nrevision={}\nrevision_source={}\nagent_mode={}\nbash_approval={}\nmode={}\napi_key={}\napi_key_source={}\ncodex_auth_mode={}\ncodex_endpoint_kind={}\nthinking={}\nreasoning_summary={}\nreasoning_summary_source={}\nreasoning_effort={}\nreasoning_effort_source={}\nplanning_status={}\nplan_path={}\nplanning_pending_age={}\nplanning_last_decision={}\napproved_plan_revision={}\nexit_plan_tool={}\ntodo={}\nshared_tasks={}\nembedding_state={}\nembedding_backend={}\nembedding_model={}\nembedding_detail={}\ndevice={}\ndtype={}\nterminal_name={}\nterminal_user_agent={}\nterminal_term={}\nterminal_term_program={}\nterminal_multiplexer={}\nterminal_remote={}\nterminal_history_mode={}\nterminal_focused={}\nterminal_width_columns={}\nphase={}\ndetail={}",
         surface.provider,
         endpoint_profile,
         endpoint_kind,
@@ -719,6 +556,18 @@ pub fn status_runtime_text(app: &TuiApp) -> String {
             .reasoning_effort
             .display_or(reasoning_effort_label.as_str()),
         surface.reasoning_effort.source.label(),
+        app.snapshot.planning_lifecycle.approval_status.label(),
+        app.snapshot
+            .planning_lifecycle
+            .plan_path
+            .as_deref()
+            .unwrap_or("-"),
+        app.snapshot.planning_lifecycle.pending_age_label(),
+        app.snapshot.planning_lifecycle.last_decision_label(),
+        app.snapshot
+            .planning_lifecycle
+            .approved_plan_revision_label(),
+        app.snapshot.planning_lifecycle.tool_use_id_label(),
         todo_summary_line(app),
         shared_task_summary_line(app),
         embedding_state,

--- a/src/tui/command/status_sections.rs
+++ b/src/tui/command/status_sections.rs
@@ -1,0 +1,183 @@
+fn todo_summary_line(app: &TuiApp) -> String {
+    let summary = &app.snapshot.todo.summary;
+    if summary.total == 0 {
+        return "none".to_string();
+    }
+    let active = summary
+        .active_label
+        .as_deref()
+        .or(summary.active_item.as_deref())
+        .unwrap_or("-");
+    format!(
+        "{} total, {} pending, {} in_progress, {} completed, {} cancelled, active={}",
+        summary.total,
+        summary.pending,
+        summary.in_progress,
+        summary.completed,
+        summary.cancelled,
+        truncate_preview(active, 80)
+    )
+}
+
+fn shared_task_summary_line(app: &TuiApp) -> String {
+    let tasks = &app.snapshot.shared_tasks;
+    if let Some(error) = tasks.error.as_deref() {
+        return format!(
+            "list={} error={}",
+            tasks.task_list_id,
+            truncate_preview(error, 80)
+        );
+    }
+    if tasks.total == 0 {
+        return format!("list={} none", tasks.task_list_id);
+    }
+    format!(
+        "list={} {} total, {} pending, {} in_progress, {} completed, {} unblocked, {} owned",
+        tasks.task_list_id,
+        tasks.total,
+        tasks.pending,
+        tasks.in_progress,
+        tasks.completed,
+        tasks.unblocked,
+        tasks.owned,
+    )
+}
+
+fn render_todo_context(app: &TuiApp) -> String {
+    let summary = &app.snapshot.todo.summary;
+    if summary.total == 0 {
+        return "Todo\n  artifact: -\n  items: none".to_string();
+    }
+    let artifact = app.snapshot.todo_artifact_path.as_deref().unwrap_or("-");
+    let updated_at = app
+        .snapshot
+        .todo
+        .updated_at
+        .map(format_unix_timestamp_utc)
+        .unwrap_or_else(|| "-".to_string());
+    let active = summary.active_item.as_deref();
+    let items = if app.snapshot.todo.items.is_empty() {
+        "  items: none".to_string()
+    } else {
+        let rendered_items = app
+            .snapshot
+            .todo
+            .items
+            .iter()
+            .take(8)
+            .map(|(id, status, content)| {
+                let suffix = if active == Some(content.as_str()) {
+                    format!("{id}, active")
+                } else {
+                    id.to_string()
+                };
+                format!(
+                    "    - [{status}] {} ({suffix})",
+                    truncate_preview(content, 100)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let omitted = app.snapshot.todo.items.len().saturating_sub(8);
+        if omitted == 0 {
+            format!("  items:\n{rendered_items}")
+        } else {
+            format!("  items:\n{rendered_items}\n    ... {omitted} more")
+        }
+    };
+    format!(
+        "Todo\n  artifact: {artifact}\n  updated_at: {updated_at}\n  total: {}  pending: {}  in_progress: {}  completed: {}  cancelled: {}\n{}",
+        summary.total,
+        summary.pending,
+        summary.in_progress,
+        summary.completed,
+        summary.cancelled,
+        items,
+    )
+}
+
+fn render_planning_lifecycle_context(app: &TuiApp) -> String {
+    let lifecycle = &app.snapshot.planning_lifecycle;
+    let tool_line = lifecycle
+        .tool_use_id
+        .as_ref()
+        .map(|tool_use_id| format!("\n  exit_plan_tool: {tool_use_id}"))
+        .unwrap_or_default();
+    format!(
+        "Planning Lifecycle\n  plan_path: {}\n  approval_status: {}\n  pending_age: {}\n  last_decision: {}\n  approved_plan_revision: {}{}",
+        lifecycle.plan_path.as_deref().unwrap_or("-"),
+        lifecycle.approval_status.label(),
+        lifecycle.pending_age_label(),
+        lifecycle.last_decision_label(),
+        lifecycle.approved_plan_revision_label(),
+        tool_line,
+    )
+}
+
+fn render_shared_tasks_context(app: &TuiApp) -> String {
+    let tasks = &app.snapshot.shared_tasks;
+    if let Some(error) = tasks.error.as_deref() {
+        return format!(
+            "Shared Tasks\n  list: {}\n  error: {}",
+            tasks.task_list_id,
+            truncate_preview(error, 120)
+        );
+    }
+    if tasks.total == 0 {
+        return format!(
+            "Shared Tasks\n  list: {}\n  tasks: none",
+            tasks.task_list_id
+        );
+    }
+    let rendered_items = tasks
+        .items
+        .iter()
+        .take(8)
+        .map(|task| {
+            let owner = task.owner.as_deref().unwrap_or("-");
+            let blockers = if task.blocked_by.is_empty() {
+                "-".to_string()
+            } else {
+                task.blocked_by.join(",")
+            };
+            format!(
+                "    - [{}] #{} rev={} owner={} blockedBy={} {}",
+                task.status,
+                task.id,
+                task.revision,
+                owner,
+                blockers,
+                truncate_preview(task.subject.as_str(), 90)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let omitted = tasks.items.len().saturating_sub(8);
+    let omitted = if omitted == 0 {
+        String::new()
+    } else {
+        format!("\n    ... {omitted} more")
+    };
+    format!(
+        "Shared Tasks\n  list: {}\n  total: {}  pending: {}  in_progress: {}  completed: {}  unblocked: {}  owned: {}\n  tasks:\n{}{}",
+        tasks.task_list_id,
+        tasks.total,
+        tasks.pending,
+        tasks.in_progress,
+        tasks.completed,
+        tasks.unblocked,
+        tasks.owned,
+        rendered_items,
+        omitted,
+    )
+}
+
+fn format_unix_timestamp_utc(timestamp: i64) -> String {
+    let format =
+        time::macros::format_description!("[year]-[month]-[day] [hour]:[minute]:[second] UTC");
+
+    OffsetDateTime::from_unix_timestamp(timestamp)
+        .ok()
+        .and_then(|dt| dt.format(&format).ok())
+        .unwrap_or_else(|| "invalid timestamp".to_string())
+}

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -12,7 +12,9 @@ use crate::context::{
     PromptSourceContextEntry, SharedTaskContextItem, SharedTaskContextView, TodoContextView,
 };
 use crate::todo::TodoSummary;
-use crate::tui::state::{LocalCommandKind, RuntimeSnapshot, TuiApp};
+use crate::tui::state::{
+    LocalCommandKind, PlanningApprovalStatus, PlanningLifecycleSnapshot, RuntimeSnapshot, TuiApp,
+};
 
 #[test]
 fn parses_model_command_argument() {
@@ -352,6 +354,12 @@ fn status_runtime_text_reports_effective_provider_surface_sources() {
     assert!(rendered.contains("terminal_history_mode="));
     assert!(rendered.contains("terminal_width_columns="));
     assert!(rendered.contains("reasoning_summary_source=legacy_global"));
+    assert!(rendered.contains("planning_status=none"));
+    assert!(rendered.contains("plan_path=-"));
+    assert!(rendered.contains("planning_pending_age=-"));
+    assert!(rendered.contains("planning_last_decision=-"));
+    assert!(rendered.contains("approved_plan_revision=-"));
+    assert!(rendered.contains("exit_plan_tool=-"));
 }
 
 #[test]
@@ -381,6 +389,12 @@ fn status_context_text_includes_prompt_sources_and_plan_state() {
         last_compaction_boundary_version: Some(1),
         last_compaction_boundary_before_tokens: Some(12_000),
         last_compaction_boundary_recent_file_count: Some(2),
+        planning_lifecycle: PlanningLifecycleSnapshot {
+            plan_path: Some(".rara/sessions/session-123/plan.md".into()),
+            approval_status: PlanningApprovalStatus::Pending,
+            tool_use_id: Some("exit-tool-123".into()),
+            ..PlanningLifecycleSnapshot::default()
+        },
         compaction_source_entries: vec![crate::context::CompactionSourceContextEntry {
             order: 1,
             kind: "compacted_summary".into(),
@@ -601,6 +615,13 @@ fn status_context_text_includes_prompt_sources_and_plan_state() {
     assert!(rendered.contains("Retrieval-ready"));
     assert!(rendered.contains("Plan"));
     assert!(rendered.contains("[pending] Implement /context"));
+    assert!(rendered.contains("Planning Lifecycle"));
+    assert!(rendered.contains("plan_path: .rara/sessions/session-123/plan.md"));
+    assert!(rendered.contains("approval_status: pending"));
+    assert!(rendered.contains("pending_age: -"));
+    assert!(rendered.contains("last_decision: -"));
+    assert!(rendered.contains("approved_plan_revision: -"));
+    assert!(rendered.contains("exit_plan_tool: exit-tool-123"));
     assert!(rendered.contains("Todo"));
     assert!(rendered.contains("artifact: /workspace/rara/.rara/sessions/session-123/todo.json"));
     assert!(rendered.contains("updated_at: 2026-04-30 21:20:00 UTC"));

--- a/src/tui/context_display.rs
+++ b/src/tui/context_display.rs
@@ -332,6 +332,57 @@ pub(crate) fn render_context_lines(app: &TuiApp, available_width: u16) -> Vec<Li
             Color::Yellow,
         );
     }
+    section_spacer(&mut lines);
+
+    // ── Planning Lifecycle ──
+    section_header(&mut lines, "Planning Lifecycle");
+    let lifecycle = &snap.planning_lifecycle;
+    kv(
+        &mut lines,
+        "status",
+        lifecycle.approval_status.label(),
+        match lifecycle.approval_status {
+            crate::tui::state::PlanningApprovalStatus::None => TEXT_MUTED,
+            crate::tui::state::PlanningApprovalStatus::Pending => Color::Yellow,
+            crate::tui::state::PlanningApprovalStatus::Approved => STATUS_SUCCESS,
+            crate::tui::state::PlanningApprovalStatus::Revising => STATUS_INFO,
+            crate::tui::state::PlanningApprovalStatus::Rejected => Color::Red,
+        },
+    );
+    kv(
+        &mut lines,
+        "plan path",
+        lifecycle.plan_path.as_deref().unwrap_or("-"),
+        TEXT_SECONDARY,
+    );
+    kv(
+        &mut lines,
+        "pending age",
+        lifecycle.pending_age_label(),
+        TEXT_MUTED,
+    );
+    kv(
+        &mut lines,
+        "last decision",
+        lifecycle.last_decision_label(),
+        TEXT_MUTED,
+    );
+    kv(
+        &mut lines,
+        "revision",
+        lifecycle.approved_plan_revision_label(),
+        TEXT_MUTED,
+    );
+    if lifecycle.tool_use_id.is_some() {
+        kv(
+            &mut lines,
+            "exit tool",
+            lifecycle.tool_use_id_label(),
+            TEXT_MUTED,
+        );
+    }
+    section_spacer(&mut lines);
+
     // ── Assembly ──
     render_assembly_layer(
         &mut lines,

--- a/src/tui/render/snapshots/rara__tui__render__tests__context_overlay_typical_budget.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__context_overlay_typical_budget.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tui/render/tests.rs
-assertion_line: 1156
+assertion_line: 1227
 expression: rendered
 ---
 Context Usage
@@ -43,6 +43,16 @@ Active Turn
 
   mode           execute
   step 0         [pending] Implement /context
+
+Planning Lifecycle
+
+  status         pending
+  plan path      .rara/sessions/session-abc/plan.md
+  pending age    -
+  last decision  -
+  revision       -
+  exit tool      exit-plan-abc
+
 Stable Instructions
 
   project_instruction AGENTS.md  240 tokens

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -19,8 +19,8 @@ use super::{
 use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::{
-    ListPickerKind, Overlay, ProviderFamily, RuntimeSnapshot, StatusTab, TranscriptEntry,
-    TranscriptTurn, TuiApp,
+    ListPickerKind, Overlay, PlanningApprovalStatus, PlanningLifecycleSnapshot, ProviderFamily,
+    RuntimeSnapshot, StatusTab, TranscriptEntry, TranscriptTurn, TuiApp,
 };
 
 fn provider_family_idx(family: ProviderFamily) -> usize {
@@ -1172,6 +1172,12 @@ fn context_overlay_snapshot_with_typical_budget() {
         compaction_count: 1,
         last_compaction_before_tokens: Some(12_000),
         last_compaction_after_tokens: Some(4_500),
+        planning_lifecycle: PlanningLifecycleSnapshot {
+            plan_path: Some(".rara/sessions/session-abc/plan.md".into()),
+            approval_status: PlanningApprovalStatus::Pending,
+            tool_use_id: Some("exit-plan-abc".into()),
+            ..PlanningLifecycleSnapshot::default()
+        },
         plan_steps: vec![("pending".into(), "Implement /context".into())],
         plan_explanation: Some("Adding Claude Code-style context display".into()),
         assembly_entries: vec![

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -3,6 +3,7 @@ mod bottom_pane_model;
 mod overlay_state;
 mod pending_interaction;
 mod persistence;
+mod planning_lifecycle;
 mod runtime_snapshot;
 mod state_presets;
 #[cfg(test)]
@@ -15,6 +16,9 @@ use std::sync::atomic::AtomicBool;
 
 use unicode_width::UnicodeWidthChar;
 
+pub use self::planning_lifecycle::{
+    PlanningApprovalDecision, PlanningApprovalStatus, PlanningLifecycleSnapshot,
+};
 pub use self::state_presets::{
     current_model_presets, openai_compatible_preset_kind, selected_preset_idx_for_config,
     selected_provider_family_idx_for_config,

--- a/src/tui/state/planning_lifecycle.rs
+++ b/src/tui/state/planning_lifecycle.rs
@@ -1,0 +1,205 @@
+use super::types::{CompletedInteractionSnapshot, InteractionKind, PendingInteractionSnapshot};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PlanningApprovalStatus {
+    #[default]
+    None,
+    Pending,
+    Approved,
+    Revising,
+    Rejected,
+}
+
+impl PlanningApprovalStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            PlanningApprovalStatus::None => "none",
+            PlanningApprovalStatus::Pending => "pending",
+            PlanningApprovalStatus::Approved => "approved",
+            PlanningApprovalStatus::Revising => "revising",
+            PlanningApprovalStatus::Rejected => "rejected",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlanningApprovalDecision {
+    Approve,
+    ContinuePlanning,
+    Reject,
+}
+
+impl PlanningApprovalDecision {
+    pub fn label(self) -> &'static str {
+        match self {
+            PlanningApprovalDecision::Approve => "approve",
+            PlanningApprovalDecision::ContinuePlanning => "continue_planning",
+            PlanningApprovalDecision::Reject => "reject",
+        }
+    }
+}
+
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub struct PlanningLifecycleSnapshot {
+    pub plan_path: Option<String>,
+    pub approval_status: PlanningApprovalStatus,
+    pub pending_age: Option<String>,
+    pub last_decision: Option<PlanningApprovalDecision>,
+    pub approved_plan_revision: Option<String>,
+    pub tool_use_id: Option<String>,
+}
+
+impl PlanningLifecycleSnapshot {
+    pub fn from_interactions(
+        session_id: &str,
+        pending_interactions: &[PendingInteractionSnapshot],
+        completed_interactions: &[CompletedInteractionSnapshot],
+    ) -> Self {
+        let plan_path = if session_id.is_empty() {
+            None
+        } else {
+            Some(format!(".rara/sessions/{session_id}/plan.md"))
+        };
+        let pending_plan = pending_interactions
+            .iter()
+            .find(|item| item.kind == InteractionKind::PlanApproval);
+        let completed_decision = completed_interactions
+            .iter()
+            .rev()
+            .find(|item| item.kind == InteractionKind::PlanApproval)
+            .and_then(plan_decision_from_completed_interaction);
+
+        let approval_status = if pending_plan.is_some() {
+            PlanningApprovalStatus::Pending
+        } else {
+            match completed_decision {
+                Some(PlanningApprovalDecision::Approve) => PlanningApprovalStatus::Approved,
+                Some(PlanningApprovalDecision::ContinuePlanning) => {
+                    PlanningApprovalStatus::Revising
+                }
+                Some(PlanningApprovalDecision::Reject) => PlanningApprovalStatus::Rejected,
+                None => PlanningApprovalStatus::None,
+            }
+        };
+
+        Self {
+            plan_path,
+            approval_status,
+            pending_age: None,
+            last_decision: completed_decision,
+            approved_plan_revision: None,
+            tool_use_id: pending_plan
+                .and_then(|item| plan_approval_tool_use_id(item.source.as_deref())),
+        }
+    }
+
+    pub fn pending_age_label(&self) -> &str {
+        self.pending_age.as_deref().unwrap_or("-")
+    }
+
+    pub fn last_decision_label(&self) -> &str {
+        self.last_decision
+            .map(PlanningApprovalDecision::label)
+            .unwrap_or("-")
+    }
+
+    pub fn approved_plan_revision_label(&self) -> &str {
+        self.approved_plan_revision.as_deref().unwrap_or("-")
+    }
+
+    pub fn tool_use_id_label(&self) -> &str {
+        self.tool_use_id.as_deref().unwrap_or("-")
+    }
+}
+
+fn plan_decision_from_completed_interaction(
+    interaction: &CompletedInteractionSnapshot,
+) -> Option<PlanningApprovalDecision> {
+    match interaction.source.as_deref() {
+        Some("plan_approval:approve") => Some(PlanningApprovalDecision::Approve),
+        Some("plan_approval:continue_planning") => Some(PlanningApprovalDecision::ContinuePlanning),
+        Some("plan_approval:reject") => Some(PlanningApprovalDecision::Reject),
+        _ => plan_decision_from_completed_summary(&interaction.summary),
+    }
+}
+
+fn plan_decision_from_completed_summary(summary: &str) -> Option<PlanningApprovalDecision> {
+    match summary {
+        "Approved. Starting implementation." => Some(PlanningApprovalDecision::Approve),
+        "Sent back for more planning." => Some(PlanningApprovalDecision::ContinuePlanning),
+        "Rejected. Implementation cancelled." => Some(PlanningApprovalDecision::Reject),
+        _ => None,
+    }
+}
+
+fn plan_approval_tool_use_id(source: Option<&str>) -> Option<String> {
+    source
+        .and_then(|value| value.strip_prefix("exit_plan_mode:"))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CompletedInteractionSnapshot, InteractionKind, PendingInteractionSnapshot,
+        PlanningApprovalDecision, PlanningApprovalStatus, PlanningLifecycleSnapshot,
+    };
+
+    #[test]
+    fn derives_pending_plan_lifecycle_from_pending_interaction() {
+        let snapshot = PlanningLifecycleSnapshot::from_interactions(
+            "session-123",
+            &[PendingInteractionSnapshot {
+                kind: InteractionKind::PlanApproval,
+                title: "Plan Approval".into(),
+                summary: "Plan ready".into(),
+                options: Vec::new(),
+                note: None,
+                approval: None,
+                source: Some("exit_plan_mode:tool-123".into()),
+            }],
+            &[CompletedInteractionSnapshot {
+                kind: InteractionKind::PlanApproval,
+                title: "Plan Decision".into(),
+                summary: "Sent back for more planning.".into(),
+                source: Some("plan_approval:continue_planning".into()),
+            }],
+        );
+
+        assert_eq!(
+            snapshot.plan_path.as_deref(),
+            Some(".rara/sessions/session-123/plan.md")
+        );
+        assert_eq!(snapshot.approval_status, PlanningApprovalStatus::Pending);
+        assert_eq!(
+            snapshot.last_decision,
+            Some(PlanningApprovalDecision::ContinuePlanning)
+        );
+        assert_eq!(snapshot.tool_use_id.as_deref(), Some("tool-123"));
+        assert_eq!(snapshot.pending_age_label(), "-");
+        assert_eq!(snapshot.approved_plan_revision_label(), "-");
+    }
+
+    #[test]
+    fn derives_approved_plan_lifecycle_from_completed_interaction() {
+        let snapshot = PlanningLifecycleSnapshot::from_interactions(
+            "session-456",
+            &[],
+            &[CompletedInteractionSnapshot {
+                kind: InteractionKind::PlanApproval,
+                title: "Plan Decision".into(),
+                summary: "Approved. Starting implementation.".into(),
+                source: Some("plan_approval:approve".into()),
+            }],
+        );
+
+        assert_eq!(snapshot.approval_status, PlanningApprovalStatus::Approved);
+        assert_eq!(
+            snapshot.last_decision,
+            Some(PlanningApprovalDecision::Approve)
+        );
+        assert_eq!(snapshot.tool_use_id, None);
+    }
+}

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -3,7 +3,8 @@ use std::sync::atomic::Ordering;
 
 use super::{
     CompletedInteractionSnapshot, InteractionKind, PendingApprovalSnapshot,
-    PendingInteractionSnapshot, RuntimeSnapshot, SkillPickerEntry, TuiApp,
+    PendingInteractionSnapshot, PlanningLifecycleSnapshot, RuntimeSnapshot, SkillPickerEntry,
+    TuiApp,
 };
 use crate::agent::Agent;
 
@@ -114,6 +115,11 @@ impl TuiApp {
             .as_ref()
             .map(|runtime| runtime.hook_count())
             .unwrap_or(0);
+        let planning_lifecycle = PlanningLifecycleSnapshot::from_interactions(
+            &runtime_context.session_id,
+            &pending_interactions,
+            &completed_interactions,
+        );
         self.snapshot = RuntimeSnapshot {
             cwd: runtime_context.cwd,
             branch: runtime_context.branch,
@@ -149,6 +155,7 @@ impl TuiApp {
             compaction_source_entries: runtime_context.compaction.source_entries,
             plan_steps: runtime_context.plan.steps,
             plan_explanation: runtime_context.plan.explanation,
+            planning_lifecycle,
             pending_interactions,
             completed_interactions,
             todo_artifact_path: if agent.todo_state.is_some() {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -13,6 +13,7 @@ use tokio::task::JoinHandle;
 use super::super::markdown_stream::MarkdownStreamCollector;
 use super::super::queued_input::PendingFollowUpMessage;
 use super::bottom_pane_model::BottomPaneModel;
+use super::planning_lifecycle::PlanningLifecycleSnapshot;
 use crate::agent::{Agent, AgentExecutionMode, BashApprovalMode};
 use crate::codex_model_catalog::CodexModelOption;
 use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
@@ -264,6 +265,7 @@ pub struct RuntimeSnapshot {
     pub compaction_source_entries: Vec<CompactionSourceContextEntry>,
     pub plan_steps: Vec<(String, String)>,
     pub plan_explanation: Option<String>,
+    pub planning_lifecycle: PlanningLifecycleSnapshot,
     pub pending_interactions: Vec<PendingInteractionSnapshot>,
     pub completed_interactions: Vec<CompletedInteractionSnapshot>,
     pub todo: crate::context::TodoContextView,

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -7,7 +7,7 @@ use std::sync::atomic::Ordering;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
-use crate::tui::state::{StatusTab, TuiApp};
+use crate::tui::state::{PlanningApprovalStatus, StatusTab, TuiApp};
 
 pub(crate) fn render_status_lines(app: &TuiApp, tab: StatusTab) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
@@ -73,6 +73,10 @@ fn render_overview_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
         app.bash_approval_mode_label(),
         Color::DarkGray,
     );
+
+    section_spacer(lines);
+    section_header(lines, "Planning");
+    render_planning_lifecycle_status(app, lines);
 
     section_spacer(lines);
     section_header(lines, "Workspace");
@@ -269,6 +273,7 @@ fn render_context_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
         ),
         Color::LightBlue,
     );
+    render_planning_lifecycle_summary(app, lines);
 
     section_spacer(lines);
     section_header(lines, "More Detail");
@@ -334,6 +339,74 @@ fn render_local_embedding_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
     kv(lines, "backend", &status.backend, Color::DarkGray);
     kv(lines, "model", &status.model, Color::LightBlue);
     kv(lines, "detail", &status.detail, Color::DarkGray);
+}
+
+fn render_planning_lifecycle_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
+    let lifecycle = &app.snapshot.planning_lifecycle;
+    kv(
+        lines,
+        "status",
+        lifecycle.approval_status.label(),
+        planning_status_color(lifecycle.approval_status),
+    );
+    kv(
+        lines,
+        "plan",
+        lifecycle.plan_path.as_deref().unwrap_or("-"),
+        Color::DarkGray,
+    );
+    kv(
+        lines,
+        "pending_age",
+        lifecycle.pending_age_label(),
+        Color::DarkGray,
+    );
+    kv(
+        lines,
+        "decision",
+        lifecycle.last_decision_label(),
+        Color::DarkGray,
+    );
+    kv(
+        lines,
+        "revision",
+        lifecycle.approved_plan_revision_label(),
+        Color::DarkGray,
+    );
+    if lifecycle.tool_use_id.is_some() {
+        kv(
+            lines,
+            "exit_plan_tool",
+            lifecycle.tool_use_id_label(),
+            Color::DarkGray,
+        );
+    }
+}
+
+fn render_planning_lifecycle_summary(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
+    let lifecycle = &app.snapshot.planning_lifecycle;
+    kv(
+        lines,
+        "planning",
+        &format!(
+            "status={} plan={} decision={} revision={}",
+            lifecycle.approval_status.label(),
+            lifecycle.plan_path.as_deref().unwrap_or("-"),
+            lifecycle.last_decision_label(),
+            lifecycle.approved_plan_revision_label(),
+        ),
+        planning_status_color(lifecycle.approval_status),
+    );
+}
+
+fn planning_status_color(status: PlanningApprovalStatus) -> Color {
+    match status {
+        PlanningApprovalStatus::None => Color::DarkGray,
+        PlanningApprovalStatus::Pending => Color::Yellow,
+        PlanningApprovalStatus::Approved => Color::LightGreen,
+        PlanningApprovalStatus::Revising => Color::LightBlue,
+        PlanningApprovalStatus::Rejected => Color::Red,
+    }
 }
 
 fn format_metric(n: u64) -> String {
@@ -421,7 +494,9 @@ mod tests {
 
     use super::render_status_lines;
     use crate::config::ConfigManager;
-    use crate::tui::state::{RuntimeSnapshot, StatusTab, TuiApp};
+    use crate::tui::state::{
+        PlanningApprovalStatus, PlanningLifecycleSnapshot, RuntimeSnapshot, StatusTab, TuiApp,
+    };
 
     #[test]
     fn overview_status_reports_local_embedding_component() {
@@ -466,5 +541,34 @@ mod tests {
         assert!(rendered.contains("agents"));
         assert!(rendered.contains("code-reviewer"));
         assert!(rendered.contains(".rara/agents/code-reviewer.md"));
+    }
+
+    #[test]
+    fn overview_status_reports_planning_lifecycle() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.snapshot = RuntimeSnapshot {
+            planning_lifecycle: PlanningLifecycleSnapshot {
+                plan_path: Some(".rara/sessions/session-123/plan.md".into()),
+                approval_status: PlanningApprovalStatus::Pending,
+                tool_use_id: Some("exit-tool-123".into()),
+                ..PlanningLifecycleSnapshot::default()
+            },
+            ..RuntimeSnapshot::default()
+        };
+
+        let rendered = render_status_lines(&app, StatusTab::Overview)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Planning\n"));
+        assert!(rendered.contains("status         pending"));
+        assert!(rendered.contains(".rara/sessions/session-123/plan.md"));
+        assert!(rendered.contains("exit-tool-123"));
     }
 }


### PR DESCRIPTION
## Summary

- add a shared planning lifecycle snapshot derived from pending and completed plan approval interactions
- expose planning lifecycle fields in `/status` runtime/context text and the status overview/context overlays
- update `/context` snapshot coverage and planning lifecycle docs/TODO state
- split status helper code and lifecycle parsing into smaller modules to keep touched files under the size limit

## Purpose

This completes the planning control-plane TODO for showing plan path, approval status, pending age, last decision, and approved plan revision in user-facing status/context surfaces.

## Related Issue

None.

## Testing

- `cargo test tui::state::planning_lifecycle::tests`
- `cargo test tui::command::status_sections::tests`
- `cargo test tui::status_display::tests`
- `cargo test tui::command::tests::status_runtime_text_reports_effective_provider_surface_sources`
- `cargo test tui::command::tests::status_context_text_includes_prompt_sources_and_plan_state`
- `cargo test tui::render::tests::context_overlay_snapshot_with_typical_budget`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
