### PR TITLE
feat(tasks): add shared task switching

### DIFF
--- a/docs/features/shared-task-lists.md
+++ b/docs/features/shared-task-lists.md
@@ -205,6 +205,18 @@ Shared task state is included in the runtime snapshot built for each turn. `/sta
 
 The sidebar intentionally follows the existing RARA summary style rather than introducing a new layout: it shows completed/total, open count, ready count, and up to four active shared tasks with the same `[>]` and `[ ]` markers used by the existing todo fallback.
 
+The TUI keeps a lightweight filesystem watcher for the active shared task list.
+It polls the active `.rara/tasks/<task_list_id>/` directory on the regular UI
+tick and fingerprints task JSON filenames, file lengths, and modification
+times. Lock files and temporary writes are ignored. When another process
+changes the active task list, the TUI refreshes the shared task snapshot without
+waiting for a new agent turn.
+
+`/tasks` shows the active task-list ID and compact counts. `/tasks
+<task_list_id>` switches the active task list for runtime context, main-agent
+shared task tool defaults, and future subagents. The command canonicalizes the
+ID with the same path-segment rules used by the task store.
+
 Missing tasks return a non-fatal outcome:
 
 ```json
@@ -228,12 +240,9 @@ Missing tasks return a non-fatal outcome:
 - Tool tests cover default task-list IDs, expected-revision output, claim-owner updates, and stale-update errors.
 - Subagent tests cover read-only and general subagent shared task tool exposure plus Claude-style task tool aliases.
 - TUI tests cover `/status`, `/context`, and sidebar shared task summaries.
+- TUI tests cover active shared task-list switching and watcher refresh after
+  cross-process task writes.
 - Workspace checks should run `cargo test tasklist`, `cargo test tools::tasklist::tests`, `cargo check --locked --workspace --all-targets`, and `cargo clippy --locked --workspace --all-targets -- -D warnings`.
-
-## Open Risks
-
-- The current shared task surface refreshes through runtime snapshots; it is not a live filesystem watcher.
-- Task-list IDs are propagated inside the runtime, but there is not yet a user-facing command for switching the active task list during a TUI session.
 
 ## Source Journals
 

--- a/docs/journal/2026-07-02-shared-task-read-tools.md
+++ b/docs/journal/2026-07-02-shared-task-read-tools.md
@@ -49,4 +49,19 @@ This slice closes the multi-agent coordination gaps left by the first mutation p
 
 The UI follows the existing RARA sidebar summary style after checking Claude Code and OpenCode task displays. Claude keeps expanded tasks in a low-noise region near the composer, while OpenCode shows a collapsible sidebar list only when unfinished work exists. RARA keeps the existing sidebar fallback rule and only shows `Shared Tasks` when there is no active plan, goal, or session-local todo list.
 
-Remaining risk: shared task state refreshes through runtime snapshots. There is still no live filesystem watcher or TUI command for switching the active shared task list during a session.
+## TUI Watcher And Active List Follow-Up
+
+This slice completes the remaining TUI control-plane work for shared tasks:
+
+- The TUI now fingerprints the active `.rara/tasks/<task_list_id>/` directory on
+  the regular UI tick and refreshes the shared task snapshot when task JSON
+  files change outside the current process.
+- `/tasks` shows the active shared task list and compact counts.
+- `/tasks <task_list_id>` switches the active list for runtime context, main
+  shared-task tool defaults, and future subagent defaults.
+- Task-list IDs are canonicalized through the same store path rules, so a user
+  command such as `/tasks team alpha` activates `team-alpha`.
+
+This remains intentionally lighter than an OS notification watcher. The task
+store already writes individual JSON files atomically, and a small polling
+fingerprint avoids adding platform-specific watcher dependencies to the TUI.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -76,9 +76,9 @@ Active backlog only. Keep this file small and current.
       coordinate on the same shared task list without an explicit tool input.
 - [x] Add snapshot-backed shared task status and TUI surfaces after mutation
       semantics are stable.
-- [ ] Add a live filesystem watcher for shared task files if cross-process task
+- [x] Add a live filesystem watcher for shared task files if cross-process task
       changes need to update the TUI without a new runtime snapshot.
-- [ ] Add a user-facing command for switching the active shared task list during
+- [x] Add a user-facing command for switching the active shared task list during
       a TUI session.
 
 ## Planning Control Plane

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -3,7 +3,9 @@ use rara_tools::planning::{ENTER_PLAN_MODE_TOOL_NAME, EXIT_PLAN_MODE_TOOL_NAME};
 use rara_tools::tool::ToolProgressEvent;
 
 use super::*;
+use crate::tasklist::{TaskListStore, canonical_task_list_id};
 use crate::tools::bash::BashCommandInput;
+use crate::tools::tasklist::{TaskCreateTool, TaskGetTool, TaskListTool, TaskUpdateTool};
 use crate::tools::todo::TODO_WRITE_TOOL_NAME;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -194,6 +196,42 @@ impl Agent {
 
     pub fn set_full_access_mode(&mut self, full_access: bool) {
         self.full_access_mode = full_access;
+    }
+
+    pub fn set_task_list_id(&mut self, task_list_id: impl AsRef<str>) -> String {
+        let task_list_id = canonical_task_list_id(task_list_id.as_ref());
+        self.task_list_id = task_list_id.clone();
+        self.refresh_shared_task_tool_defaults();
+        task_list_id
+    }
+
+    fn refresh_shared_task_tool_defaults(&mut self) {
+        let store = std::sync::Arc::new(TaskListStore::new(self.workspace.rara_dir.join("tasks")));
+        let task_list_id = self.task_list_id.clone();
+        if self.tool_manager.get_tool("task_create").is_some() {
+            self.tool_manager.register(Box::new(TaskCreateTool {
+                store: store.clone(),
+                default_task_list_id: task_list_id.clone(),
+            }));
+        }
+        if self.tool_manager.get_tool("task_list").is_some() {
+            self.tool_manager.register(Box::new(TaskListTool {
+                store: store.clone(),
+                default_task_list_id: task_list_id.clone(),
+            }));
+        }
+        if self.tool_manager.get_tool("task_update").is_some() {
+            self.tool_manager.register(Box::new(TaskUpdateTool {
+                store: store.clone(),
+                default_task_list_id: task_list_id.clone(),
+            }));
+        }
+        if self.tool_manager.get_tool("task_get").is_some() {
+            self.tool_manager.register(Box::new(TaskGetTool {
+                store,
+                default_task_list_id: task_list_id,
+            }));
+        }
     }
 
     pub fn is_bash_prefix_approved(&self, request: &BashCommandInput) -> bool {

--- a/src/tasklist.rs
+++ b/src/tasklist.rs
@@ -819,7 +819,7 @@ fn sync_parent_dir_best_effort(path: &Path) {
     }
 }
 
-fn normalize_task_list_id(task_list_id: &str) -> String {
+pub fn canonical_task_list_id(task_list_id: &str) -> String {
     let normalized = task_list_id
         .trim()
         .chars()
@@ -838,6 +838,10 @@ fn normalize_task_list_id(task_list_id: &str) -> String {
     } else {
         normalized
     }
+}
+
+fn normalize_task_list_id(task_list_id: &str) -> String {
+    canonical_task_list_id(task_list_id)
 }
 
 fn sort_tasks_by_id(tasks: &mut [TaskRecord]) {

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -2,7 +2,7 @@
 
 use crate::tui::state::{CommandSpec, LocalCommand, LocalCommandKind, TuiApp};
 
-pub const COMMAND_SPECS: [CommandSpec; 24] = [
+pub const COMMAND_SPECS: [CommandSpec; 25] = [
     CommandSpec {
         category: "Session",
         name: "permissions",
@@ -86,6 +86,13 @@ pub const COMMAND_SPECS: [CommandSpec; 24] = [
         usage: "/compact",
         summary: "Compact the current conversation history immediately.",
         detail: "Force one explicit history compaction pass. Compaction summarizes older turns into a structured summary so the model can continue a long conversation without losing early context. Compaction runs on every message and tool-result batch, but /compact lets you trigger one on demand.",
+    },
+    CommandSpec {
+        category: "Session",
+        name: "tasks",
+        usage: "/tasks [task_list_id]",
+        summary: "Show or switch the active shared task list.",
+        detail: "Without an argument, show the active shared task list and current task counts. With an argument, switch the active shared task list for runtime context, shared task tools, and future subagents.",
     },
     CommandSpec {
         category: "Session",
@@ -194,6 +201,7 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
         "plan" => LocalCommandKind::Plan,
         "approval" => LocalCommandKind::Approval,
         "compact" => LocalCommandKind::Compact,
+        "tasks" | "task-list" => LocalCommandKind::Tasks,
         "model" | "models" => LocalCommandKind::Model,
         "connect" => LocalCommandKind::Connect,
         "base-url" => LocalCommandKind::BaseUrl,

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -131,6 +131,17 @@ fn parses_compact_command() {
 }
 
 #[test]
+fn parses_tasks_command() {
+    let command = parse_local_command("/tasks team alpha").expect("tasks should parse");
+    assert!(matches!(command.kind, LocalCommandKind::Tasks));
+    assert_eq!(command.arg.as_deref(), Some("team alpha"));
+
+    let alias = parse_local_command("/task-list team alpha").expect("task-list should parse");
+    assert!(matches!(alias.kind, LocalCommandKind::Tasks));
+    assert_eq!(alias.arg.as_deref(), Some("team alpha"));
+}
+
+#[test]
 fn parses_login_and_logout_commands() {
     let login = parse_local_command("/login").expect("login should parse");
     assert!(matches!(login.kind, LocalCommandKind::Login));

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -148,6 +148,7 @@ pub async fn run_tui(
                 if let Some(delta) = app.transcript_selection.autoscroll_delta() {
                     app.scroll_transcript(delta);
                 }
+                let _ = app.poll_shared_task_files();
                 needs_redraw = true;
             }
             maybe_event = events.next() => {

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -20,6 +20,7 @@ pub(super) async fn execute_local_command(
     agent_slot: &mut Option<Agent>,
     oauth_manager: &Arc<OAuthManager>,
 ) -> anyhow::Result<bool> {
+    let command_kind = command.kind;
     app.remember_command(match command.kind {
         LocalCommandKind::Approval => "approval",
         LocalCommandKind::BaseUrl => "base-url",
@@ -329,7 +330,9 @@ pub(super) async fn execute_local_command(
             app.open_overlay(Overlay::SkillsPicker);
         }
     }
-    if let Some(agent) = agent_slot.as_ref() {
+    if command_kind != LocalCommandKind::Tasks
+        && let Some(agent) = agent_slot.as_ref()
+    {
         app.sync_snapshot(agent);
     }
     Ok(false)
@@ -553,14 +556,12 @@ fn handle_tasks_command(arg: Option<&str>, app: &mut TuiApp, agent_slot: &mut Op
         return;
     };
 
-    let active = if let Some(agent) = agent_slot.as_mut() {
-        let active = agent.set_task_list_id(requested);
-        app.configure_shared_task_watch(agent.workspace.rara_dir.join("tasks"), &active);
-        active
+    if let Some(agent) = agent_slot.as_mut() {
+        agent.set_task_list_id(requested);
+        app.sync_snapshot(agent);
     } else {
-        app.switch_active_shared_task_list(requested)
-    };
-    app.switch_active_shared_task_list(&active);
+        app.switch_active_shared_task_list(requested);
+    }
     let tasks = &app.snapshot.shared_tasks;
     app.push_notice(format!(
         "Active shared task list: {} ({} total, {} ready).",

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -37,6 +37,7 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Resume => "resume",
         LocalCommandKind::Review => "review",
         LocalCommandKind::Status => "status",
+        LocalCommandKind::Tasks => "tasks",
         LocalCommandKind::Skills => "skills",
         LocalCommandKind::Permissions => "permissions",
         LocalCommandKind::Goal => "goal",
@@ -203,6 +204,9 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Status => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening status".into()));
             app.open_overlay(Overlay::Status(StatusTab::Overview));
+        }
+        LocalCommandKind::Tasks => {
+            handle_tasks_command(command.arg.as_deref(), app, agent_slot);
         }
         LocalCommandKind::Dream => {
             if let Some(agent) = agent_slot.as_mut() {
@@ -535,6 +539,35 @@ fn command_project_root(app: &TuiApp) -> PathBuf {
     mcp_project_root_from_cwd(cwd)
 }
 
+fn handle_tasks_command(arg: Option<&str>, app: &mut TuiApp, agent_slot: &mut Option<Agent>) {
+    app.set_runtime_phase(
+        RuntimePhase::LocalCommand,
+        Some("processing shared task command".into()),
+    );
+    let Some(requested) = arg.map(str::trim).filter(|value| !value.is_empty()) else {
+        let tasks = &app.snapshot.shared_tasks;
+        app.push_notice(format!(
+            "Active shared task list: {} ({} total, {} ready).",
+            tasks.task_list_id, tasks.total, tasks.unblocked
+        ));
+        return;
+    };
+
+    let active = if let Some(agent) = agent_slot.as_mut() {
+        let active = agent.set_task_list_id(requested);
+        app.configure_shared_task_watch(agent.workspace.rara_dir.join("tasks"), &active);
+        active
+    } else {
+        app.switch_active_shared_task_list(requested)
+    };
+    app.switch_active_shared_task_list(&active);
+    let tasks = &app.snapshot.shared_tasks;
+    app.push_notice(format!(
+        "Active shared task list: {} ({} total, {} ready).",
+        tasks.task_list_id, tasks.total, tasks.unblocked
+    ));
+}
+
 fn mcp_project_root_from_cwd(cwd: PathBuf) -> PathBuf {
     for ancestor in cwd.ancestors() {
         if ancestor.join(".mcp.json").is_file() {
@@ -641,24 +674,31 @@ mod tests {
     use std::sync::Arc;
     use std::time::Instant;
 
+    use rara_memory::vectordb::VectorDB;
+    use rara_tools::tool::ToolManager;
     use tokio::sync::mpsc;
 
     use super::{
         execute_local_command, handle_mcp_command, mcp_project_root_from_cwd,
         parse_goal_objective_and_budget, parse_goal_token_budget, spawn_mcp_tool_cache_population,
     };
-    use crate::agent::{AgentEvent, BashApprovalMode};
+    use crate::agent::{Agent, AgentEvent, BashApprovalMode};
     use crate::config::{
         ConfigManager, McpRegistry, McpServerConfig, McpServerScope, McpServerSource,
         McpServerTransport, SourcedMcpServerConfig,
     };
+    use crate::llm::MockLlm;
     use crate::mcp_tool_cache::McpToolCache;
     use crate::oauth::OAuthManager;
     use crate::runtime_event_bus::RuntimeEventBus;
+    use crate::session::SessionManager;
+    use crate::tasklist::{DEFAULT_TASK_LIST_ID, NewTaskRecord, TaskListStore};
+    use crate::tools::tasklist::TaskListTool;
     use crate::tui::state::{
         LocalCommand, LocalCommandKind, Overlay, PermissionMode, RunningTask, TaskCompletion,
         TaskKind, TuiApp,
     };
+    use crate::workspace::WorkspaceMemory;
 
     fn mark_app_busy(app: &mut TuiApp) {
         let (_sender, receiver) = mpsc::unbounded_channel();
@@ -671,6 +711,34 @@ mod tests {
             cancellation_token: None,
             cancellation_requested: false,
         });
+    }
+
+    fn test_agent_with_shared_task_tool(dir: &tempfile::TempDir) -> Agent {
+        let rara_dir = dir.path().join(".rara");
+        fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
+        fs::create_dir_all(rara_dir.join("sessions")).expect("sessions");
+        fs::create_dir_all(rara_dir.join("tool-results")).expect("tool results");
+        let task_store = Arc::new(TaskListStore::new(rara_dir.join("tasks")));
+        let mut tools = ToolManager::new();
+        tools.register(Box::new(TaskListTool {
+            store: task_store,
+            default_task_list_id: DEFAULT_TASK_LIST_ID.to_string(),
+        }));
+        Agent::new(
+            tools,
+            Arc::new(MockLlm),
+            Arc::new(VectorDB::new(
+                &rara_dir.join("lancedb").display().to_string(),
+            )),
+            Arc::new(SessionManager {
+                storage_dir: rara_dir.join("rollouts"),
+                legacy_storage_dir: rara_dir.join("sessions"),
+            }),
+            Arc::new(WorkspaceMemory::from_paths(
+                dir.path().join("workspace"),
+                rara_dir,
+            )),
+        )
     }
 
     #[test]
@@ -1055,6 +1123,57 @@ command = "docs-server"
             app.bottom_pane.notice.as_deref(),
             Some("No active goal. Use /help for /goal details.")
         );
+    }
+
+    #[tokio::test]
+    async fn tasks_command_switches_agent_and_tool_default_list() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let task_store = TaskListStore::new(dir.path().join(".rara/tasks"));
+        task_store
+            .create_task(
+                "team alpha",
+                NewTaskRecord {
+                    subject: "Switch shared task list".to_string(),
+                    description: "Verify active task-list command.".to_string(),
+                    active_form: None,
+                    metadata: Default::default(),
+                },
+            )
+            .expect("create task");
+        let mut app = TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app");
+        let oauth_manager = Arc::new(
+            OAuthManager::new_for_config_dir(dir.path().join("oauth")).expect("oauth manager"),
+        );
+        let mut agent_slot = Some(test_agent_with_shared_task_tool(&dir));
+        app.sync_snapshot(agent_slot.as_ref().expect("agent"));
+
+        execute_local_command(
+            LocalCommand {
+                kind: LocalCommandKind::Tasks,
+                arg: Some("team alpha".to_string()),
+            },
+            &mut app,
+            &mut agent_slot,
+            &oauth_manager,
+        )
+        .await
+        .expect("tasks command should be handled");
+
+        let agent = agent_slot.as_ref().expect("agent");
+        assert_eq!(agent.task_list_id, "team-alpha");
+        assert_eq!(app.snapshot.shared_tasks.task_list_id, "team-alpha");
+        assert_eq!(app.snapshot.shared_tasks.total, 1);
+        let output = agent
+            .tool_manager
+            .get_tool("task_list")
+            .expect("task_list tool")
+            .call(serde_json::json!({}))
+            .await
+            .expect("task list");
+        assert_eq!(output["tasks"][0]["subject"], "Switch shared task list");
     }
 
     #[tokio::test]

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -5,6 +5,7 @@ mod pending_interaction;
 mod persistence;
 mod planning_lifecycle;
 mod runtime_snapshot;
+mod shared_tasks;
 mod state_presets;
 #[cfg(test)]
 mod tests;
@@ -292,6 +293,9 @@ impl TuiApp {
             terminal_focused: true,
             state_db: None,
             state_db_status: None,
+            shared_task_root: None,
+            shared_task_fingerprint: None,
+            shared_task_last_poll: None,
             local_model_server,
             mcp_manager: None,
             lsp_manager: None,

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -11,6 +11,7 @@ use crate::agent::Agent;
 impl TuiApp {
     pub fn sync_snapshot(&mut self, agent: &Agent) {
         let runtime_context = agent.shared_runtime_context();
+        let shared_task_root = agent.workspace.rara_dir.join("tasks");
         let existing_pending_approval_id = self
             .pending_command_approval()
             .and_then(|item| item.approval.as_ref())
@@ -199,6 +200,7 @@ impl TuiApp {
         };
         self.agent_execution_mode = agent.execution_mode;
         self.bash_approval_mode = agent.bash_approval_mode;
+        self.configure_shared_task_watch(shared_task_root, &agent.task_list_id);
         self.populate_skill_picker_entries(agent);
         self.persist_runtime_state();
     }

--- a/src/tui/state/shared_tasks.rs
+++ b/src/tui/state/shared_tasks.rs
@@ -80,6 +80,11 @@ fn shared_task_fingerprint(task_root: &Path, task_list_id: &str) -> String {
     };
     let mut parts = Vec::new();
     for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        if file_name.starts_with('.') {
+            continue;
+        }
         let path = entry.path();
         if path.extension().and_then(|value| value.to_str()) != Some("json") {
             continue;
@@ -97,12 +102,7 @@ fn shared_task_fingerprint(task_root: &Path, task_list_id: &str) -> String {
         let modified = modified
             .map(|duration| format!("{}:{}", duration.as_secs(), duration.subsec_nanos()))
             .unwrap_or_else(|| "-".to_string());
-        parts.push(format!(
-            "{}:{}:{}",
-            entry.file_name().to_string_lossy(),
-            metadata.len(),
-            modified
-        ));
+        parts.push(format!("{}:{}:{}", file_name, metadata.len(), modified));
     }
     parts.sort();
     parts.join("|")
@@ -176,6 +176,40 @@ mod tests {
 
         assert_eq!(active, "team-alpha");
         assert_eq!(app.snapshot.shared_tasks.task_list_id, "team-alpha");
+        assert_eq!(app.snapshot.shared_tasks.total, 1);
+    }
+
+    #[test]
+    fn shared_task_poll_ignores_dotfiles() {
+        let temp = tempdir().expect("tempdir");
+        let task_root = temp.path().join(".rara/tasks");
+        let store = TaskListStore::new(&task_root);
+        store
+            .create_task(
+                DEFAULT_TASK_LIST_ID,
+                NewTaskRecord {
+                    subject: "Track visible tasks".to_string(),
+                    description: "Ignore hidden editor files.".to_string(),
+                    active_form: None,
+                    metadata: Default::default(),
+                },
+            )
+            .expect("create task");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.configure_shared_task_watch(task_root.clone(), DEFAULT_TASK_LIST_ID);
+        app.switch_active_shared_task_list(DEFAULT_TASK_LIST_ID);
+
+        std::fs::write(
+            task_root.join(DEFAULT_TASK_LIST_ID).join(".scratch.json"),
+            "{}",
+        )
+        .expect("write dotfile");
+        app.shared_task_last_poll = Some(Instant::now() - SHARED_TASK_POLL_INTERVAL);
+
+        assert!(!app.poll_shared_task_files());
         assert_eq!(app.snapshot.shared_tasks.total, 1);
     }
 }

--- a/src/tui/state/shared_tasks.rs
+++ b/src/tui/state/shared_tasks.rs
@@ -1,0 +1,181 @@
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant, UNIX_EPOCH};
+
+use super::TuiApp;
+use crate::context::SharedTaskContextView;
+use crate::tasklist::{TaskListStore, canonical_task_list_id};
+
+const SHARED_TASK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+impl TuiApp {
+    pub fn configure_shared_task_watch(&mut self, task_root: PathBuf, task_list_id: &str) {
+        self.shared_task_root = Some(task_root);
+        self.shared_task_fingerprint = self.current_shared_task_fingerprint(task_list_id);
+        self.shared_task_last_poll = Some(Instant::now());
+    }
+
+    pub fn refresh_shared_tasks_from_store(&mut self, task_list_id: &str) {
+        let task_list_id = canonical_task_list_id(task_list_id);
+        let Some(task_root) = self.shared_task_root.as_ref() else {
+            return;
+        };
+        let store = TaskListStore::new(task_root);
+        match store.list_tasks(&task_list_id) {
+            Ok(tasks) => {
+                self.snapshot.shared_tasks = SharedTaskContextView::from_tasks(task_list_id, tasks);
+            }
+            Err(err) => {
+                log::warn!("Failed to refresh shared task list '{task_list_id}': {err}");
+                self.snapshot.shared_tasks =
+                    SharedTaskContextView::from_error(task_list_id, err.to_string());
+            }
+        }
+    }
+
+    pub fn poll_shared_task_files(&mut self) -> bool {
+        if self.shared_task_root.is_none() {
+            return false;
+        }
+        if self
+            .shared_task_last_poll
+            .is_some_and(|last_poll| last_poll.elapsed() < SHARED_TASK_POLL_INTERVAL)
+        {
+            return false;
+        }
+        self.shared_task_last_poll = Some(Instant::now());
+        let task_list_id = self.snapshot.shared_tasks.task_list_id.clone();
+        if task_list_id.is_empty() {
+            return false;
+        }
+        let Some(next_fingerprint) = self.current_shared_task_fingerprint(&task_list_id) else {
+            return false;
+        };
+        if self.shared_task_fingerprint.as_deref() == Some(next_fingerprint.as_str()) {
+            return false;
+        }
+        self.shared_task_fingerprint = Some(next_fingerprint);
+        self.refresh_shared_tasks_from_store(&task_list_id);
+        true
+    }
+
+    pub fn switch_active_shared_task_list(&mut self, task_list_id: &str) -> String {
+        let task_list_id = canonical_task_list_id(task_list_id);
+        self.snapshot.shared_tasks.task_list_id = task_list_id.clone();
+        self.refresh_shared_tasks_from_store(&task_list_id);
+        self.shared_task_fingerprint = self.current_shared_task_fingerprint(&task_list_id);
+        self.shared_task_last_poll = Some(Instant::now());
+        task_list_id
+    }
+
+    fn current_shared_task_fingerprint(&self, task_list_id: &str) -> Option<String> {
+        let task_root = self.shared_task_root.as_ref()?;
+        Some(shared_task_fingerprint(task_root, task_list_id))
+    }
+}
+
+fn shared_task_fingerprint(task_root: &Path, task_list_id: &str) -> String {
+    let task_list_dir = task_root.join(canonical_task_list_id(task_list_id));
+    let Ok(entries) = std::fs::read_dir(&task_list_dir) else {
+        return "missing".to_string();
+    };
+    let mut parts = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if !metadata.is_file() {
+            continue;
+        }
+        let modified = metadata
+            .modified()
+            .ok()
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok());
+        let modified = modified
+            .map(|duration| format!("{}:{}", duration.as_secs(), duration.subsec_nanos()))
+            .unwrap_or_else(|| "-".to_string());
+        parts.push(format!(
+            "{}:{}:{}",
+            entry.file_name().to_string_lossy(),
+            metadata.len(),
+            modified
+        ));
+    }
+    parts.sort();
+    parts.join("|")
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::config::ConfigManager;
+    use crate::tasklist::{DEFAULT_TASK_LIST_ID, NewTaskRecord};
+
+    #[test]
+    fn polls_shared_task_files_when_active_list_changes() {
+        let temp = tempdir().expect("tempdir");
+        let task_root = temp.path().join(".rara/tasks");
+        let store = TaskListStore::new(&task_root);
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.configure_shared_task_watch(task_root.clone(), DEFAULT_TASK_LIST_ID);
+        app.refresh_shared_tasks_from_store(DEFAULT_TASK_LIST_ID);
+        assert_eq!(app.snapshot.shared_tasks.total, 0);
+
+        store
+            .create_task(
+                DEFAULT_TASK_LIST_ID,
+                NewTaskRecord {
+                    subject: "Refresh shared tasks".to_string(),
+                    description: "Detect cross-process updates.".to_string(),
+                    active_form: None,
+                    metadata: Default::default(),
+                },
+            )
+            .expect("create task");
+        app.shared_task_last_poll = Some(Instant::now() - SHARED_TASK_POLL_INTERVAL);
+
+        assert!(app.poll_shared_task_files());
+        assert_eq!(app.snapshot.shared_tasks.total, 1);
+        assert_eq!(
+            app.snapshot.shared_tasks.items[0].subject,
+            "Refresh shared tasks"
+        );
+    }
+
+    #[test]
+    fn switches_active_shared_task_list_with_canonical_id() {
+        let temp = tempdir().expect("tempdir");
+        let task_root = temp.path().join(".rara/tasks");
+        let store = TaskListStore::new(&task_root);
+        store
+            .create_task(
+                "team alpha",
+                NewTaskRecord {
+                    subject: "Use alternate list".to_string(),
+                    description: "Switch the active shared task list.".to_string(),
+                    active_form: None,
+                    metadata: Default::default(),
+                },
+            )
+            .expect("create task");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.configure_shared_task_watch(task_root, DEFAULT_TASK_LIST_ID);
+
+        let active = app.switch_active_shared_task_list("team alpha");
+
+        assert_eq!(active, "team-alpha");
+        assert_eq!(app.snapshot.shared_tasks.task_list_id, "team-alpha");
+        assert_eq!(app.snapshot.shared_tasks.total, 1);
+    }
+}

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -158,6 +158,7 @@ pub enum LocalCommandKind {
     Permissions,
     Logout,
     Review,
+    Tasks,
     /// Reserved for `/dream` command help while consolidation execution is
     /// still tracked as follow-up work (docs/todo.md).
     #[allow(dead_code)]
@@ -755,6 +756,9 @@ pub struct TuiApp {
     pub terminal_focused: bool,
     pub state_db: Option<Arc<StateDb>>,
     pub state_db_status: Option<String>,
+    pub shared_task_root: Option<PathBuf>,
+    pub shared_task_fingerprint: Option<String>,
+    pub shared_task_last_poll: Option<Instant>,
     pub local_model_server: crate::local_model_server::LocalModelServerStatus,
     pub mcp_manager: Option<Arc<McpConnectionManager>>,
     pub lsp_manager: Option<Arc<LspManager>>,


### PR DESCRIPTION
## Summary

- add a lightweight TUI watcher for the active shared task-list directory
- add `/tasks [task_list_id]` to show or switch the active shared task list
- keep agent runtime context, main shared-task tool defaults, and future subagent defaults aligned with the active list
- update shared-task docs, journal notes, and TODO state

## Purpose

This completes the Shared Task Lists TODOs for cross-process TUI refresh and session-local active task-list switching.

## Related issues

None.

## Testing

- `cargo fmt`
- `cargo test --locked tui::state::shared_tasks::tests`
- `cargo test --locked parses_tasks_command`
- `cargo test --locked tasks_command_switches_agent_and_tool_default_list`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
