### PR TITLE
feat(hooks): wire context lifecycle

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -64,6 +64,8 @@ future appserver integrations can use.
   inheritance, child budget, result summary, and restart/reconnect contracts.
 - `shared-task-lists.md`: workspace-local shared task store and
   Claude-compatible read tools for future subagent/team coordination.
+- `hooks-plugin-lifecycle.md`: hook/plugin lifecycle phases, MemoryQuery
+  dispatch, and hook output context injection boundaries.
 - `tui-theme-tokens.md`: configurable semantic TUI theme tokens, renderer
   integration, and embedded syntax theme selection.
 

--- a/docs/features/hooks-plugin-lifecycle.md
+++ b/docs/features/hooks-plugin-lifecycle.md
@@ -1,0 +1,82 @@
+# Hooks And Plugin Lifecycle
+
+## Problem
+
+RARA has several hook surfaces: file-based prompt hooks, runtime-control hook
+declarations, plugin hook registration, command hook output, and memory-query
+callbacks. These surfaces need one lifecycle contract so hook output can become
+observable model context without bypassing safety or retrieval boundaries.
+
+## Scope
+
+- Lifecycle names and timing for hook/plugin integration.
+- Hook output flow into model context and `/context` observability.
+- MemoryQuery hook dispatch from the `search_memory` tool.
+- Plugin hook registration and execution boundaries.
+
+## Non-Goals
+
+- JavaScript, HTTP, or agent-backed hook handlers.
+- Unbounded hook output injection.
+- Hook execution that bypasses sandbox, approval, timeout, or provenance rules.
+- Replacing file-based prompt hooks.
+
+## Architecture
+
+Hook declarations normalize into RARA-owned lifecycle phases:
+
+- `SessionStart`
+- `UserPromptSubmit`
+- `PreToolUse`
+- `PostToolUse`
+- `PostMemoryWrite`
+- `MemoryQuery`
+- `PreCompact`
+- `PostCompact`
+- `Stop`
+
+The in-process `HookRuntime` subscribes to `RuntimeEventBus` events and invokes
+registered callbacks for matching lifecycle phases. Lifecycle phases that do not
+map directly to an `AgentEvent`, such as `MemoryQuery`, must use explicit
+runtime methods instead of overloading unrelated events.
+
+Command hook output is buffered in `HookRuntime`. Before each model turn, the
+agent drains the buffer, injects each output as a system message, and mirrors the
+same output as volatile `hook_output` retrieval candidates. These candidates are
+observable in `/context` but marked non-selectable because the output has already
+entered the model context directly.
+
+## Contracts
+
+- Hook output must be bounded by the hook runtime and drained once.
+- Drained hook output is next-turn context. It must not be reselected by memory
+  retrieval after direct injection.
+- `MemoryQuery` hooks fire before `search_memory` runs and receive the raw query
+  text through a lifecycle callback.
+- Plugin hooks are registered during runtime rebuild/startup before the runtime
+  snapshot is refreshed.
+- Plugin hook failures must be visible through warnings or hook status; silent
+  failure is not allowed.
+- Hook output candidates use `source_type=hook_output`, `scope=turn`, and a
+  session-scoped source reference.
+
+## Validation Matrix
+
+- Hook runtime tests cover `MemoryQuery` dispatch and lifecycle isolation.
+- Agent context tests cover hook-output candidate shape and non-selectability.
+- Tooling checks cover that `search_memory` is registered with a MemoryQuery
+  callback.
+- Workspace validation should run `cargo check --locked --workspace
+  --all-targets` and `cargo clippy --locked --workspace --all-targets --
+  -D warnings`.
+
+## Open Risks
+
+- Command hook execution remains constrained by the current sandbox policy.
+- Hook output is injected directly before the next model turn; later work may
+  route prompt-type hooks through the retrieval budget if a stronger selection
+  policy is needed.
+
+## Source Journals
+
+- `docs/journal/2026-07-04-hooks-context-lifecycle.md`

--- a/docs/features/retrieval-orchestration.md
+++ b/docs/features/retrieval-orchestration.md
@@ -165,9 +165,10 @@ Provider responsibilities:
 - `FileSearchProvider`: produce file candidates from `crates/file-search`;
   it must not inject file contents directly.
 - `McpResourceProvider`: surface referenced MCP resources as candidates.
-- `HookContextProvider`: surface hook output as volatile candidates; current
-  implementation accepts precomputed candidates and keeps them observable but
-  non-injected until hook execution policy is enabled.
+- `HookContextProvider`: surface hook output as volatile candidates. Hook output
+  drained from `HookRuntime` is injected directly as system context before the
+  next model turn and mirrored as non-selectable candidates for `/context`
+  observability.
 - `GraphProvider`: surface graph/vector composed context; current
   implementation accepts precomputed candidates and keeps them observable but
   non-injected until graph confidence policy is enabled.

--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -327,6 +327,8 @@ External applications may declare hooks for lifecycle points such as:
 - `UserPromptSubmit`;
 - `PreToolUse`;
 - `PostToolUse`;
+- `PostMemoryWrite`;
+- `MemoryQuery`;
 - `Stop`;
 - `PreCompact`.
 
@@ -349,6 +351,8 @@ Lifecycle timing is part of the safety boundary:
   original user text;
 - `PostToolUse` output is next-turn context unless the runtime explicitly
   starts a new assembly step;
+- `MemoryQuery` fires before memory retrieval tools run and receives the raw
+  search query through the hook runtime callback path;
 - `PreCompact` output is advisory retain metadata for the compaction lifecycle;
 - `Stop` hooks must be bounded and should not run on prompt-too-long or API
   error paths where hook retry could create a loop.

--- a/docs/journal/2026-07-04-hooks-context-lifecycle.md
+++ b/docs/journal/2026-07-04-hooks-context-lifecycle.md
@@ -1,0 +1,33 @@
+# 2026-07-04 Hooks Context Lifecycle
+
+## Summary
+
+- Wired `MemoryQuery` hook dispatch from the `search_memory` tool.
+- Mirrored drained hook output into volatile `/context` candidates while keeping
+  direct system-message injection before the model turn.
+- Added a canonical hooks/plugin lifecycle spec.
+
+## Background
+
+Hook output already had a runtime buffer and direct system-message injection
+path, but `/context` still described hook output as non-injected. The
+`SearchMemoryTool` also had a TODO for MemoryQuery hooks, so memory queries did
+not reach hook callbacks even when the lifecycle existed in the control-plane
+types.
+
+## Key Decisions
+
+- `MemoryQuery` is dispatched through an explicit `HookRuntime` method because
+  it does not correspond to a normal `AgentEvent` emitted by the agent loop.
+- Hook output candidates are marked non-selectable. The model already receives
+  the output directly as system context, so retrieval selection must not inject
+  it a second time.
+- Hook output candidates are session-scoped volatile records with
+  `source_type=hook_output`.
+
+## Validation
+
+- `cargo test --locked hook_runtime::tests::dispatch_memory_query_invokes_memory_query_hooks`
+- `cargo test --locked hook_output_candidate_is_observable_but_not_reselected`
+- `cargo check --locked --workspace --all-targets`
+- `cargo clippy --locked --workspace --all-targets -- -D warnings`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -99,8 +99,9 @@ Active backlog only. Keep this file small and current.
 
 ## Hooks
 
-- [ ] Hook output injection into model context (blocked on sandbox policy)
-- [ ] Hooks/plugin lifecycle spec
+- [x] Hook output injection into model context; command hook execution remains
+      constrained by sandbox policy.
+- [x] Hooks/plugin lifecycle spec
 
 ## Configuration
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1513,16 +1513,18 @@ Rules:
 }
 
 fn hook_output_candidate(text: &str, index: usize, session_id: &str) -> RetrievalCandidate {
+    use std::fmt::Write as _;
+
     let mut hasher = Sha256::new();
     hasher.update(session_id.as_bytes());
     hasher.update([0]);
-    hasher.update(index.to_le_bytes());
+    hasher.update((index as u64).to_le_bytes());
     hasher.update([0]);
     hasher.update(text.as_bytes());
     let digest = hasher.finalize();
     let mut hex = String::with_capacity(64);
     for byte in digest.as_slice() {
-        hex.push_str(&format!("{byte:02x}"));
+        write!(&mut hex, "{byte:02x}").expect("writing to String cannot fail");
     }
     let id = format!("hook_output:{hex}");
     RetrievalCandidate {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -19,6 +19,7 @@ use rara_tools::tool::ToolOutputStream;
 use rara_tools::tool::{ToolCallContext, ToolManager, ToolProgressEvent};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::context::{
@@ -902,8 +903,14 @@ impl Agent {
             }
             self.ensure_active_plan_step();
             // Inject hook outputs as system messages before the model turn
+            self.hook_output_candidates.clear();
             if let Some(hr) = crate::hook_runtime::get_global_hook_runtime() {
                 let outputs = hr.blocking_drain_outputs();
+                self.hook_output_candidates = outputs
+                    .iter()
+                    .enumerate()
+                    .map(|(index, text)| hook_output_candidate(text, index, &self.session_id))
+                    .collect();
                 for text in outputs {
                     self.history.push(Message {
                         role: "system".to_string(),
@@ -1502,6 +1509,47 @@ Rules:
             Some(token) => context.with_cancellation(token.clone()),
             None => context,
         }
+    }
+}
+
+fn hook_output_candidate(text: &str, index: usize, session_id: &str) -> RetrievalCandidate {
+    let mut hasher = Sha256::new();
+    hasher.update(session_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(index.to_le_bytes());
+    hasher.update([0]);
+    hasher.update(text.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest.as_slice() {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    let id = format!("hook_output:{hex}");
+    RetrievalCandidate {
+        id: id.clone(),
+        source: crate::context::RetrievalSourceRef {
+            source_type: "hook_output".to_string(),
+            source_id: Some(id.clone()),
+            source_path: None,
+            source_uri: None,
+            session_id: Some(session_id.to_string()),
+            thread_id: None,
+            workspace_id: None,
+        },
+        kind: "hook_output".to_string(),
+        scope: "turn".to_string(),
+        label: format!("Hook Output {}", index + 1),
+        detail: "drained before model turn".to_string(),
+        summary: Some(text.to_string()),
+        rank: index,
+        score: None,
+        priority: 60,
+        dedupe_key: Some(id),
+        budget_impact_tokens: None,
+        selection_reason: "hook output is injected directly as system context".to_string(),
+        availability_reason: "available from hook runtime output buffer".to_string(),
+        not_selected_reason: "already injected as direct system context".to_string(),
+        selectable: false,
     }
 }
 

--- a/src/agent/tests/context_view.rs
+++ b/src/agent/tests/context_view.rs
@@ -17,6 +17,21 @@ use crate::runtime_control::{
 use crate::runtime_event_bus::RuntimeEventBus;
 
 #[test]
+fn hook_output_candidate_is_observable_but_not_reselected() {
+    let candidate = super::super::hook_output_candidate("lint hook passed", 0, "session-1");
+
+    assert_eq!(candidate.kind, "hook_output");
+    assert_eq!(candidate.source.source_type, "hook_output");
+    assert_eq!(candidate.source.session_id.as_deref(), Some("session-1"));
+    assert_eq!(candidate.summary.as_deref(), Some("lint hook passed"));
+    assert!(!candidate.selectable);
+    assert_eq!(
+        candidate.not_selected_reason,
+        "already injected as direct system context"
+    );
+}
+
+#[test]
 fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
     let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
     std::fs::write(

--- a/src/context/retrieval_view.rs
+++ b/src/context/retrieval_view.rs
@@ -113,7 +113,7 @@ pub(crate) fn retrieval_source_entries(
             status: hook_output_status.to_string(),
             detail: format!("outputs={}", hook_output_candidates.len()),
             inclusion_reason: if hook_output_status == "available" {
-                "available as volatile hook output; prompt injection remains disabled until hook execution policy is explicit".to_string()
+                "available as volatile hook output and injected directly as system context before the next model turn".to_string()
             } else {
                 "no hook output is available for context selection".to_string()
             },

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -93,6 +93,21 @@ impl HookRuntime {
             .len()
     }
 
+    pub fn dispatch_memory_query(&self, query: &str) {
+        let event = AgentEvent::MemoryAction {
+            message: format!("MemoryQuery: {query}"),
+        };
+        let guard = self
+            .hooks
+            .read()
+            .expect("hook runtime registry lock poisoned");
+        for entry in guard.values() {
+            if entry.lifecycle == HookLifecycle::MemoryQuery {
+                (entry.callback)(&event);
+            }
+        }
+    }
+
     /// Start the hook dispatch loop on a dedicated Tokio task.
     ///
     /// Returns immediately if already started (idempotent).
@@ -177,6 +192,12 @@ pub(crate) fn global_modify_tool_input(tool_name: &str, input: Value) -> Value {
     }
 }
 
+pub(crate) fn global_dispatch_memory_query(query: &str) {
+    if let Some(hr) = GLOBAL_HOOK_RUNTIME.get() {
+        hr.dispatch_memory_query(query);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,5 +265,34 @@ mod tests {
             Box::new(|_| {}),
         );
         assert_eq!(runtime.hook_count(), 1);
+    }
+
+    #[test]
+    fn dispatch_memory_query_invokes_memory_query_hooks() {
+        let bus = Arc::new(RuntimeEventBus::new(4));
+        let runtime = HookRuntime::new(bus);
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen_hook = seen.clone();
+        runtime.register(
+            "memory-query".into(),
+            HookLifecycle::MemoryQuery,
+            Box::new(move |event| {
+                if let AgentEvent::MemoryAction { message } = event {
+                    seen_hook.lock().expect("seen lock").push(message.clone());
+                }
+            }),
+        );
+        runtime.register(
+            "pre-tool-use".into(),
+            HookLifecycle::PreToolUse,
+            Box::new(|_| panic!("pre-tool hook should not fire")),
+        );
+
+        runtime.dispatch_memory_query("repo notes");
+
+        assert_eq!(
+            seen.lock().expect("seen lock").as_slice(),
+            ["MemoryQuery: repo notes"]
+        );
     }
 }

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -134,7 +134,7 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(SearchMemoryTool {
         rara_home: workspace.rara_dir.clone(),
         vdb: Some(vdb.clone()),
-        hook_callback: None, // TODO: wire MemoryQuery hooks
+        hook_callback: Some(Arc::new(crate::hook_runtime::global_dispatch_memory_query)),
     }));
     tm.register(Box::new(LspDiagnosticsTool::new(lsp_manager)));
     tm.register(Box::new(McpToolSearch::new(mcp_tool_cache)));


### PR DESCRIPTION
## Summary

- wire `MemoryQuery` hook dispatch from the `search_memory` tool
- mirror drained hook output as volatile `/context` candidates while preserving direct system-context injection
- update hook output retrieval status copy
- add the canonical hooks/plugin lifecycle spec and journal checkpoint

## Purpose

This completes the Hooks TODOs for model-context hook output injection, MemoryQuery wiring, and the hooks/plugin lifecycle spec.

## Related issues

None.

## Testing

- `cargo fmt`
- `cargo test --locked hook_runtime::tests::dispatch_memory_query_invokes_memory_query_hooks`
- `cargo test --locked hook_output_candidate_is_observable_but_not_reselected`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
