### PR TITLE
feat(context): add file-search retrieval policy

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -22,9 +22,9 @@ pub use self::mcp::{
 };
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{
-    ConfigManager, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState, RaraConfig,
-    SandboxWorkspaceWriteConfig, TuiConfig, TuiThemeConfig, ensure_rara_home_dir, rara_home_dir,
-    workspace_data_dir_for, workspace_data_dir_for_home,
+    ConfigManager, ContextFileSearchPolicy, OpenAiEndpointKind, OpenAiEndpointProfile,
+    ProviderConfigState, RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig, TuiThemeConfig,
+    ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for, workspace_data_dir_for_home,
 };
 pub use self::provider_surface::{
     ConfigValueSource, EffectiveProviderSurface, ResolvedProviderValue,

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -68,6 +68,25 @@ fn default_consolidation_model() -> String {
 fn default_consolidation_reasoning_effort() -> String {
     super::defaults::DEFAULT_CONSOLIDATION_REASONING_EFFORT.into()
 }
+
+/// Controls whether fuzzy path matches enter automatic retrieval context.
+///
+/// `paths_only` keeps file search as a low-priority candidate source that only
+/// exposes path/provenance metadata. It does not read or inject file contents.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextFileSearchPolicy {
+    Off,
+    #[default]
+    PathsOnly,
+}
+
+impl ContextFileSearchPolicy {
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProviderConfigState {
     #[serde(
@@ -272,6 +291,8 @@ pub struct RaraConfig {
     pub sandbox_workspace_write: SandboxWorkspaceWriteConfig,
     #[serde(default, skip_serializing_if = "MemoryConsolidationConfig::is_default")]
     pub memory_consolidation: MemoryConsolidationConfig,
+    #[serde(default, skip_serializing_if = "ContextFileSearchPolicy::is_default")]
+    pub context_file_search: ContextFileSearchPolicy,
     #[serde(default, skip_serializing_if = "TuiConfig::is_default")]
     pub tui: TuiConfig,
 }
@@ -1041,8 +1062,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        ConfigManager, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState, RaraConfig,
-        workspace_data_dir_for_home,
+        ConfigManager, ContextFileSearchPolicy, OpenAiEndpointKind, OpenAiEndpointProfile,
+        ProviderConfigState, RaraConfig, workspace_data_dir_for_home,
     };
     use crate::defaults::{
         DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL,
@@ -1111,6 +1132,32 @@ mod tests {
         .expect("deserialize config");
 
         assert!(config.sandbox_workspace_write.network_access);
+    }
+
+    #[test]
+    fn context_file_search_defaults_to_paths_only_and_is_omitted() {
+        let config = RaraConfig::default();
+
+        assert_eq!(
+            config.context_file_search,
+            ContextFileSearchPolicy::PathsOnly
+        );
+
+        let json = serde_json::to_string(&config).expect("serialize config");
+        assert!(!json.contains("context_file_search"));
+    }
+
+    #[test]
+    fn context_file_search_can_disable_automatic_retrieval_candidates() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "codex",
+                "context_file_search": "off"
+            }"#,
+        )
+        .expect("deserialize config");
+
+        assert_eq!(config.context_file_search, ContextFileSearchPolicy::Off);
     }
 
     #[test]

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -226,6 +226,7 @@ pub struct PromptRuntimeConfig {
     pub compact_prompt: Option<String>,
     pub protocol_prompt_sources: Vec<PromptSource>,
     pub available_skills: Vec<PromptSkillSummary>,
+    pub context_file_search: rara_config::ContextFileSearchPolicy,
     /// Hook prompt entries, each tagged with its lifecycle phase.
     /// Populated at startup from `.claude/hooks/*.md`.
     pub hook_prompt_entries: Vec<HookPromptEntry>,
@@ -258,6 +259,7 @@ impl PromptRuntimeConfig {
             compact_prompt,
             protocol_prompt_sources: Vec::new(),
             available_skills: Vec::new(),
+            context_file_search: config.context_file_search,
             hook_prompt_entries: Vec::new(),
             warnings,
         }

--- a/docs/features/context-file-routing.md
+++ b/docs/features/context-file-routing.md
@@ -7,30 +7,37 @@
 ## Overview
 
 `crates/file-search` provides fuzzy file search via `search_files(pattern, roots, opts)`.
-Currently it is only used by the TUI file picker (`src/tools/file.rs` `list_files`).
+It is the shared backend for explicit file-selection flows such as the TUI file
+picker and the `list_files` tool.
 
-This spec defines how file-search results become context candidates that flow through
-the existing `memory_selection` pipeline, alongside retrieved memory and workspace
-prompt sources — without automatic injection.
+This spec also defines the narrow automatic-retrieval bridge: when enabled,
+file-search results become low-priority paths-only `RetrievalCandidate` values
+that flow through the existing `memory_selection` pipeline. They expose path and
+provenance only; they do not read or inject file contents.
 
 ---
 
 ## Design Goals
 
-1. **Candidates only** — file-search produces `MemorySelectionItemContextEntry`
-   candidates; the existing selection logic decides which to include.
+1. **Shared backend** — explicit TUI file suggestions and `list_files` use the
+   same `rara-file-search` backend as context routing.
 
-2. **Provenance** — every candidate carries an explicit origin (`file_search`,
+2. **Paths only** — automatic retrieval produces `RetrievalCandidate` values
+   that contain path/provenance metadata only. File contents stay behind
+   explicit tools such as `read_file`.
+
+3. **Optional routing** — `context_file_search = "paths_only"` is the default;
+   `context_file_search = "off"` disables automatic file-search candidates
+   without affecting explicit picker/list-files flows.
+
+4. **Provenance** — every candidate carries an explicit origin (`file_search`,
    match score, file path) for auditability.
 
-3. **Token budget** — each candidate estimates its token cost. The
-   `MemorySelection` budget allocator decides how many fit.
+5. **Token budget** — each automatic candidate estimates the cost of its
+   manifest text only. It must not charge or imply file-content injection.
 
-4. **Stable ordering** — candidates are ordered deterministically by (score
+6. **Stable ordering** — candidates are ordered deterministically by (score
    descending, path ascending) so repeated runs produce the same list.
-
-5. **Single interface** — the same candidate provider serves both the TUI picker
-   (listFiles) and the context routing path.
 
 ---
 
@@ -42,47 +49,35 @@ prompt sources — without automatic injection.
 /// A file match returned by the file-search engine, ready for context routing.
 #[derive(Debug, Clone)]
 pub struct FileSearchCandidate {
-    /// Absolute workspace-relative display path.
+    /// Workspace-relative display path.
     pub path: String,
-    /// Full absolute path on disk.
-    pub full_path: String,
     /// Match score from nucleo (0.0–1.0).
     pub score: f64,
-    /// Whether this was a fuzzy-name match or a content-grep match.
-    pub match_type: FileMatchType,
-    /// Estimated token count for the file content (capped).
+    /// Estimated token count for the path/provenance candidate.
     pub token_budget: usize,
     /// Human-readable provenance label.
     pub provenance: String,
 }
-
-#[derive(Debug, Clone, Copy)]
-pub enum FileMatchType {
-    /// Matched on file name.
-    Name,
-    /// Matched on file content (future: content_grep).
-    Content,
-}
 ```
 
-### Conversion to `MemorySelectionItemContextEntry`
+### Conversion to `RetrievalCandidate`
 
 ```rust
 impl FileSearchCandidate {
-    fn to_context_entry(&self, order: usize) -> MemorySelectionItemContextEntry {
-        MemorySelectionItemContextEntry {
-            order,
-            kind: "file_search".to_string(),
+    fn to_retrieval_candidate(&self, rank: usize) -> RetrievalCandidate {
+        RetrievalCandidate {
+            kind: "file_search".into(),
+            scope: "workspace".into(),
             label: self.path.clone(),
-            detail: self.provenance.clone(),
-            selection_reason: format!(
-                "candidate from file search (score {:.3}, match_type {:?})",
-                self.score, self.match_type
-            ),
+            detail: format!("{}; paths_only; content_not_read", self.provenance),
+            priority: 80 + rank,
             budget_impact_tokens: Some(self.token_budget),
-            priority: (self.score * 1000.0) as usize,
-            selectable: true,
-            dropped_reason: None,
+            selection_reason: format!(
+                "paths-only candidate from file search (score {:.3}); file contents were not read",
+                self.score
+            ),
+            // source.source_path is the same workspace-relative path.
+            // Other fields omitted here for brevity.
         }
     }
 }
@@ -91,7 +86,7 @@ impl FileSearchCandidate {
 ### Provenance format
 
 ```
-provenance = "file_search(name_match, score=0.82, root=/workspace)"
+provenance = "file_search(name_match, score=0.820)"
 ```
 
 ---
@@ -118,32 +113,37 @@ impl FileSearchCandidateProvider {
         max_results: usize,
     ) -> Vec<FileSearchCandidate>;
 
-    /// Produce context entries ready for MemorySelection.
-    /// Each entry carries provenance, budget, and a stable order.
-    pub fn context_candidates(
+    /// Produce paths-only retrieval candidates ready for MemorySelection.
+    /// Each candidate carries provenance, path budget, and stable order.
+    pub fn retrieval_candidates(
         &self,
         query: &str,
         max_results: usize,
-    ) -> Vec<MemorySelectionItemContextEntry>;
+    ) -> Vec<RetrievalCandidate>;
 }
 ```
 
 ### Token budget estimation
 
 ```rust
-fn estimate_file_token_budget(path: &Path, max_bytes: usize) -> usize {
-    match std::fs::read_to_string(path) {
-        Ok(content) => estimate_text_tokens(
-            &content.chars().take(max_bytes).collect::<String>()
-        ),
-        Err(_) => 0,
-    }
+fn estimate_path_candidate_tokens(path: &Path) -> usize {
+    let path_tokens = path.to_string_lossy().len().div_ceil(4);
+    path_tokens.max(1)
 }
 ```
 
-Hueristic: read up to `MAX_FILE_CANDIDATE_BYTES` (default 8 KiB) of the file, count
-tokens.  The budget allocator in `memory_selection` subtracts this from the
-`selection_budget`.
+Heuristic: charge only the path/provenance manifest. The provider must not open
+the file for automatic retrieval.
+
+## Configuration
+
+```toml
+# Default. Explicit file picker/list_files behavior is unchanged.
+context_file_search = "paths_only"
+
+# Disable only automatic file-search retrieval candidates.
+context_file_search = "off"
+```
 
 ---
 
@@ -163,8 +163,8 @@ pub(crate) fn memory_selection(
     vdb_uri: Option<&str>,
     retrieved_memory_candidates: &[RetrievedMemoryCandidate],
     selection_budget: Option<usize>,
-    // NEW: file-search candidates from the provider
-    file_search_candidates: &[MemorySelectionItemContextEntry],
+    file_search_candidates: &[RetrievalCandidate],
+    graph_context_candidates: &[RetrievalCandidate],
 ) -> MemorySelectionContextView;
 ```
 
@@ -174,12 +174,12 @@ pub(crate) fn memory_selection(
 rara_file_search::search_files("pattern", [workspace_root], opts)
         │
         ▼
-FileSearchCandidateProvider::context_candidates(query, max)
+FileSearchCandidateProvider::retrieval_candidates(query, max)
         │  ┌─ provenance: "file_search(name_match, score=0.82)"
-        │  ├─ token_budget: estimate_file_token_budget(path)
-        │  └─ priority: score-derived
+        │  ├─ token_budget: estimate_path_candidate_tokens(path)
+        │  └─ priority: low-priority paths-only source
         ▼
-MemorySelectionItemContextEntry (kind = "file_search")
+RetrievalCandidate (kind = "file_search", source_path = path)
         │
         ▼
 memory_selection()                ← existing budget allocator
@@ -188,7 +188,7 @@ memory_selection()                ← existing budget allocator
 MemorySelectionContextView.available_items   ← "file_search" category
         │
         ▼
-ContextAssembler                 ← decides whether to include
+ContextAssembler                 ← may expose selected manifest only
 ```
 
 ---
@@ -196,11 +196,13 @@ ContextAssembler                 ← decides whether to include
 ## What NOT to do
 
 - ❌ Do NOT auto-inject file contents into the prompt.
+- ❌ Do NOT read file contents while producing automatic file-search
+  candidates.
 - ❌ Do NOT modify `PromptSource` or the workspace prompt source list.
 - ❌ Do NOT bypass the `memory_selection` budget allocator.
 - ❌ Do NOT add a separate "file search" prompt block — candidates are just
   candidates.
-- ❌ Do NOT break the existing `listFiles` TUI picker — it continues to use
+- ❌ Do NOT break the existing `list_files` tool or TUI picker — they continue to use
   `FileSearchCandidateProvider::search()` directly.
 
 ---
@@ -217,7 +219,7 @@ This produces a deterministic list that survives repeated calls.
 
 ## Future
 
-- `grep_files()` for content-search candidates (match_type = Content)
+- `grep_files()` for explicit content-search tools, not automatic injection.
 - `FileSearchCache` with incremental re-scan (session-style)
 - TUI inline file-search picker (Ctrl-F in composer)
 - Context-budget-aware truncation hints (“this file is too large; read

--- a/docs/features/retrieval-orchestration.md
+++ b/docs/features/retrieval-orchestration.md
@@ -17,7 +17,7 @@ RARA already has several recall-like sources:
 - compacted history source descriptors;
 - active turn state such as plans, pending interactions, latest request, and
   recent tool results;
-- future file-search candidates from `crates/file-search`;
+- optional paths-only file-search candidates from `crates/file-search`;
 - future MCP resources, hook output, and protocol-registered sources.
 
 Without a retrieval orchestration boundary, each source can leak directly into
@@ -87,6 +87,10 @@ Current code already has part of this shape:
   candidate boundary for direct memory/session retrieval inputs;
 - file-search, MCP resource, hook-output, and graph-context sources enter the
   same orchestration boundary as precomputed candidate providers;
+- file-search candidates are controlled by `context_file_search`; the default
+  `paths_only` policy exposes low-priority path/provenance candidates, while
+  `off` disables only automatic file-search retrieval and leaves explicit
+  picker/list-files flows unchanged;
 - `memory_selection()` ranks selected/available/dropped entries;
 - `SharedRuntimeContext.retrieval.memory_selection` is consumed by `/context`.
 
@@ -162,8 +166,8 @@ Provider responsibilities:
 - `MemoryStoreProvider`: search workspace/thread `MemoryRecord`s through
   LanceDB-backed APIs.
 - `SessionShardProvider`: search per-session context shards.
-- `FileSearchProvider`: produce file candidates from `crates/file-search`;
-  it must not inject file contents directly.
+- `FileSearchProvider`: produce paths-only file candidates from
+  `crates/file-search`; it must not read or inject file contents directly.
 - `McpResourceProvider`: surface referenced MCP resources as candidates.
 - `HookContextProvider`: surface hook output as volatile candidates. Hook output
   drained from `HookRuntime` is injected directly as system context before the
@@ -183,7 +187,7 @@ Initial priority order:
 1. active fixed context already selected by owner layers;
 2. focused session/thread context relevant to the current request;
 3. workspace memory records;
-4. file candidates;
+4. file candidates, as low-priority paths-only manifests;
 5. MCP resource candidates;
 6. hook output;
 7. graph expansion candidates until graph confidence is proven.

--- a/docs/journal/2026-07-05-file-search-context-policy.md
+++ b/docs/journal/2026-07-05-file-search-context-policy.md
@@ -1,0 +1,44 @@
+# File Search Context Policy
+
+## What Changed
+
+RARA now treats file search as a shared backend with two explicit consumers:
+
+- explicit user-facing file discovery, including TUI file suggestions and
+  `list_files`;
+- optional automatic retrieval candidates controlled by `context_file_search`.
+
+The default `context_file_search = "paths_only"` policy keeps fuzzy file-path
+matches visible to `MemorySelection` and `/context`, but the candidates carry
+only path and provenance metadata. `context_file_search = "off"` disables only
+the automatic retrieval bridge.
+
+## Why
+
+The previous context-file-routing plan left two behaviors easy to conflate:
+using `rara-file-search` for explicit file selection, and letting fuzzy matches
+enter automatic context retrieval. Keeping both is useful, but automatic
+retrieval must not imply that file contents were read or injected.
+
+The paths-only policy preserves observability and ranking experiments while
+leaving content access behind explicit tools such as `read_file`.
+
+## Trade-offs
+
+- File-search candidates can still appear in `/context`, but they are
+  intentionally low priority.
+- Token budget estimates charge only the path/provenance manifest, not file
+  content.
+- The policy is coarse-grained for now: automatic routing is either disabled or
+  paths-only.
+
+## Verification
+
+- Config tests cover default omission and explicit `off` deserialization.
+- File-search provider tests cover paths-only budget estimation and retrieval
+  candidate metadata.
+
+## Remaining Work
+
+No open follow-up is required for the two-track policy. Future explicit content
+search should remain separate from automatic file-content injection.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -19,6 +19,9 @@ Active backlog only. Keep this file small and current.
 
 ## TUI / UX
 
+- [x] Keep `rara-file-search` as the shared backend for TUI file suggestions
+      and `list_files`; keep automatic retrieval as optional low-priority
+      paths-only `RetrievalCandidate` / `MemorySelection` input.
 - [x] Refactor ~7 large methods out of `impl TuiApp` to enable file split.
 - [x] Restore Claude Code-style realtime transcript live-log writes from
       `push_entry` and clear the live log after turn commit so resume can

--- a/src/agent/memory_retrieval.rs
+++ b/src/agent/memory_retrieval.rs
@@ -18,6 +18,10 @@ impl Agent {
     }
 
     pub(super) fn refresh_file_search_candidates(&mut self) {
+        if self.prompt_config.context_file_search == crate::config::ContextFileSearchPolicy::Off {
+            self.file_search_candidates = Vec::new();
+            return;
+        }
         let query = latest_user_text(&self.history);
         if query.is_empty() {
             self.file_search_candidates = Vec::new();

--- a/src/context/file_search_provider.rs
+++ b/src/context/file_search_provider.rs
@@ -62,7 +62,7 @@ impl FileSearchCandidateProvider {
             .into_iter()
             .map(|m| {
                 let path = display_path(&self.workspace_root, &m.path);
-                let token_budget = estimate_path_candidate_tokens(Path::new(&path));
+                let token_budget = estimate_path_candidate_tokens(&path);
                 FileSearchCandidate {
                     path,
                     score: m.score as f64,
@@ -141,8 +141,8 @@ fn provenance_label(score: f64) -> String {
 }
 
 /// Heuristic token estimate for a paths-only candidate.
-fn estimate_path_candidate_tokens(path: &Path) -> usize {
-    let path_tokens = path.to_string_lossy().len().div_ceil(4);
+fn estimate_path_candidate_tokens(path: &str) -> usize {
+    let path_tokens = path.len().div_ceil(4);
     path_tokens.max(1)
 }
 
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn estimate_path_candidate_budget_does_not_read_file_contents() {
-        let budget = estimate_path_candidate_tokens(Path::new("/nonexistent/file.txt"));
+        let budget = estimate_path_candidate_tokens("/nonexistent/file.txt");
         assert!(budget > 0);
     }
 

--- a/src/context/file_search_provider.rs
+++ b/src/context/file_search_provider.rs
@@ -1,11 +1,11 @@
 //! File-search candidate provider for context routing.
 //!
-//! Wraps `rara_file_search::search_files()` to produce
-//! `MemorySelectionItemContextEntry` candidates that flow through the
-//! existing `memory_selection` budget allocator.
+//! Wraps `rara_file_search::search_files()` to produce paths-only
+//! `RetrievalCandidate` values that flow through the existing
+//! `memory_selection` budget allocator.
 //!
-//! Candidates are NOT auto-injected — the selection logic decides
-//! which files to include based on token budget and priority.
+//! Candidates are NOT content injections. They only expose the matched path and
+//! provenance so `/context` can explain why a file surfaced.
 
 use std::path::{Path, PathBuf};
 
@@ -13,9 +13,7 @@ use anyhow::Context;
 use rara_file_search::FileSearchOptions;
 
 use crate::context::retrieval_provider::stable_retrieval_text_id;
-use crate::context::runtime::{
-    MemorySelectionItemContextEntry, RetrievalCandidate, RetrievalSourceRef,
-};
+use crate::context::runtime::{RetrievalCandidate, RetrievalSourceRef};
 
 /// A file match from the file-search engine, ready for context routing.
 #[derive(Debug, Clone)]
@@ -24,7 +22,7 @@ pub struct FileSearchCandidate {
     pub path: String,
     /// Match score from nucleo (0.0–1.0).
     pub score: f64,
-    /// Estimated token count for the file content (capped).
+    /// Estimated token count for the path/provenance candidate.
     pub token_budget: usize,
     /// Human-readable provenance label.
     pub provenance: String,
@@ -63,38 +61,14 @@ impl FileSearchCandidateProvider {
         results
             .into_iter()
             .map(|m| {
-                let full_path = self.workspace_root.join(&m.path);
+                let path = display_path(&self.workspace_root, &m.path);
+                let token_budget = estimate_path_candidate_tokens(Path::new(&path));
                 FileSearchCandidate {
-                    path: display_path(&self.workspace_root, &m.path),
+                    path,
                     score: m.score as f64,
-                    token_budget: estimate_file_token_budget(&full_path),
+                    token_budget,
                     provenance: provenance_label(m.score as f64),
                 }
-            })
-            .collect()
-    }
-
-    /// Produce `MemorySelectionItemContextEntry` candidates for the
-    /// `memory_selection` budget allocator.
-    ///
-    /// Each candidate carries provenance, budget, and a stable order
-    /// (score descending, path ascending).
-    #[allow(dead_code)] // TODO: file search provider — activate when file search context is wired in.
-    pub fn context_candidates(
-        &self,
-        query: &str,
-        max_results: usize,
-    ) -> Vec<MemorySelectionItemContextEntry> {
-        self.retrieval_candidates(query, max_results)
-            .into_iter()
-            .map(|candidate| MemorySelectionItemContextEntry {
-                order: candidate.rank,
-                kind: candidate.kind,
-                label: candidate.label,
-                detail: candidate.detail,
-                selection_reason: candidate.selection_reason,
-                budget_impact_tokens: candidate.budget_impact_tokens,
-                dropped_reason: None,
             })
             .collect()
     }
@@ -129,18 +103,22 @@ impl FileSearchCandidateProvider {
                     kind: "file_search".to_string(),
                     scope: "workspace".to_string(),
                     label: c.path,
-                    detail: c.provenance,
+                    detail: format!("{}; paths_only; content_not_read", c.provenance),
                     summary: None,
                     rank,
                     score: Some(c.score as f32),
-                    priority: 30 + rank,
+                    priority: 80 + rank,
                     dedupe_key: None,
                     budget_impact_tokens: Some(c.token_budget),
-                    selection_reason: format!("candidate from file search (score {:.3})", c.score),
+                    selection_reason: format!(
+                        "paths-only candidate from file search (score {:.3}); file contents were not read",
+                        c.score
+                    ),
                     availability_reason:
-                        "available because file search matched the current turn query".to_string(),
+                        "available because fuzzy path search matched the current turn query; this candidate carries only the path and provenance"
+                            .to_string(),
                     not_selected_reason:
-                        "not selected after ranking the file-search candidate against the current memory-selection budget"
+                        "not selected after ranking this low-priority paths-only file-search candidate against the current memory-selection budget"
                             .to_string(),
                     selectable: true,
                 }
@@ -162,18 +140,10 @@ fn provenance_label(score: f64) -> String {
     format!("file_search(name_match, score={:.3})", score)
 }
 
-/// Heuristic token estimate: read up to 8 KiB of the file, count chars / 4.
-/// Returns 0 if the file cannot be read.
-fn estimate_file_token_budget(path: &Path) -> usize {
-    const MAX_BYTES: usize = 8192;
-    match std::fs::read_to_string(path) {
-        Ok(content) => {
-            let preview: String = content.chars().take(MAX_BYTES).collect();
-            // Rough estimate: ~4 chars per token for English text.
-            preview.len() / 4
-        }
-        Err(_) => 0,
-    }
+/// Heuristic token estimate for a paths-only candidate.
+fn estimate_path_candidate_tokens(path: &Path) -> usize {
+    let path_tokens = path.to_string_lossy().len().div_ceil(4);
+    path_tokens.max(1)
 }
 
 #[cfg(test)]
@@ -188,18 +158,9 @@ mod tests {
     }
 
     #[test]
-    fn estimate_file_token_budget_readable() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("test.txt");
-        std::fs::write(&path, "hello world").unwrap();
-        let budget = estimate_file_token_budget(&path);
+    fn estimate_path_candidate_budget_does_not_read_file_contents() {
+        let budget = estimate_path_candidate_tokens(Path::new("/nonexistent/file.txt"));
         assert!(budget > 0);
-    }
-
-    #[test]
-    fn estimate_file_token_budget_missing() {
-        let budget = estimate_file_token_budget(Path::new("/nonexistent/file.txt"));
-        assert_eq!(budget, 0);
     }
 
     #[test]
@@ -213,23 +174,30 @@ mod tests {
         assert!(!candidates.is_empty());
         assert_eq!(candidates[0].path, "hello.rs");
         assert!(candidates[0].score > 0.0);
-        assert!(candidates[0].token_budget > 0);
+        assert_eq!(candidates[0].token_budget, 2);
         assert!(candidates[0].provenance.contains("file_search"));
     }
 
     #[test]
-    fn context_candidates_have_stable_order() {
+    fn retrieval_candidates_are_low_priority_paths_only() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("a.rs"), "a").unwrap();
         std::fs::write(dir.path().join("b.rs"), "b").unwrap();
 
         let provider = FileSearchCandidateProvider::new(dir.path().to_path_buf(), false);
-        let entries = provider.context_candidates(".rs", 10);
+        let entries = provider.retrieval_candidates(".rs", 10);
         // Both .rs files match; stable ordering by score then path
         assert_eq!(entries.len(), 2);
-        assert!(entries[0].order < entries[1].order);
+        assert!(entries[0].rank < entries[1].rank);
         // label is the display path
         assert!(entries.iter().all(|e| e.label.ends_with(".rs")));
         assert!(entries.iter().all(|e| e.kind == "file_search"));
+        assert!(entries.iter().all(|e| e.priority >= 80));
+        assert!(entries.iter().all(|e| e.detail.contains("paths_only")));
+        assert!(
+            entries
+                .iter()
+                .all(|e| e.selection_reason.contains("contents were not read"))
+        );
     }
 }


### PR DESCRIPTION
## Summary

- add `context_file_search` config with `paths_only` default and `off` opt-out
- keep automatic file-search retrieval candidates paths-only and low priority
- stop estimating automatic file-search candidate budget from file contents
- update context-file-routing and retrieval orchestration docs, plus journal/TODO

## Purpose

This keeps `rara-file-search` as the shared backend for explicit TUI file suggestions and `list_files`, while making automatic retrieval a narrow, auditable path/provenance signal. Automatic file-search candidates no longer read or imply injection of file contents.

## Related Issue

None.

## Testing

- `cargo fmt`
- `cargo test --locked -p rara-config context_file_search`
- `cargo test --locked context::file_search_provider`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
