### PR TITLE
feat: add headless exec command

### DIFF
--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -47,7 +47,9 @@ parallel agent implementation.
 Recommended components:
 
 - `rara exec` headless execution mode that reuses the normal agent loop
-  without TUI chrome.
+  without TUI chrome. Initial support includes prompt/stdin input,
+  `--json` JSONL events, explicit cwd selection, run/task metadata, and
+  `--output-last-message`.
 - A Harbor installed-agent adapter that invokes `rara exec` for the task and
   converts RARA's structured output into ATIF-compatible trajectory artifacts.
 - `rara eval terminal-bench` may be added later as a convenience wrapper, but
@@ -95,7 +97,7 @@ have a headless path.
 
 ### Headless Execution Contract
 
-`rara exec` should be the stable automation surface:
+`rara exec` is the stable automation surface:
 
 - accept a prompt argument, stdin, or `-` for stdin-only prompts;
 - support explicit cwd selection for task workspaces;
@@ -106,10 +108,12 @@ have a headless path.
 - fail fast when interactive approval, user input, or auth refresh is required
   in headless mode.
 
-The JSONL event schema should be RARA-owned and stable. It should include turn
-start/completion/failure events, assistant messages, command execution items,
-file-change items, tool-result summaries, usage metadata, and final failure
-reasons.
+The JSONL event schema is RARA-owned and stable enough for the Harbor adapter
+boundary. It includes thread start, turn start/completion/failure, assistant
+message items, reasoning items, tool call/result/progress items, memory/todo
+status items, model usage items, and final failure reasons. Later revisions can
+add richer command exit metadata and file-change grouping without requiring a
+benchmark-specific runtime.
 
 ### Tool Contract
 
@@ -182,4 +186,4 @@ Each trial should end with one of:
 
 ## Source Journals
 
-- None yet. Add a dated journal entry when the first adapter or smoke run lands.
+- `docs/journal/2026-07-05-rara-exec-headless.md`

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -15,6 +15,8 @@ from failures, and final task verification. These are core RARA capabilities.
 
 RARA should support a Terminal-Bench-compatible evaluation path that can:
 
+- run under Harbor's Terminal-Bench tutorial flow:
+  `harbor run -d terminal-bench/terminal-bench-2 -a <rara-agent>`;
 - run RARA inside the benchmark task container;
 - map benchmark task instructions into a single RARA session;
 - expose the working directory and terminal environment without requiring TUI
@@ -44,8 +46,12 @@ parallel agent implementation.
 
 Recommended components:
 
-- `rara eval terminal-bench` command or an equivalent Harbor agent adapter.
-- Headless execution mode that reuses the normal agent loop without TUI chrome.
+- `rara exec` headless execution mode that reuses the normal agent loop
+  without TUI chrome.
+- A Harbor installed-agent adapter that invokes `rara exec` for the task and
+  converts RARA's structured output into ATIF-compatible trajectory artifacts.
+- `rara eval terminal-bench` may be added later as a convenience wrapper, but
+  the first integration target is Harbor compatibility.
 - Stable workspace setup contract:
   - cwd points at the benchmark task workspace;
   - all edits happen inside the task workspace unless the benchmark explicitly
@@ -66,6 +72,7 @@ Recommended components:
   - sandbox mode;
   - token and tool-loop limits;
   - task id;
+  - Harbor run id / trial id when provided by the harness;
   - start/end timestamps;
   - pass/fail result when provided by the harness.
 
@@ -77,9 +84,32 @@ The benchmark adapter must present RARA as a terminal agent that can receive one
 task instruction, operate inside the provided workspace, and stop with a final
 answer when the task is complete.
 
+For Harbor, the adapter should be an installed agent wrapper rather than a
+benchmark-specific RARA runtime. The wrapper owns Harbor-specific plumbing:
+reading the task input, invoking `rara exec`, and writing ATIF trajectory output.
+RARA owns the generic headless agent execution and event stream.
+
 The adapter must not require interactive TUI-only features. Any configuration
 that is currently only exposed through `/model`, `/auth`, or overlays must also
 have a headless path.
+
+### Headless Execution Contract
+
+`rara exec` should be the stable automation surface:
+
+- accept a prompt argument, stdin, or `-` for stdin-only prompts;
+- support explicit cwd selection for task workspaces;
+- support scriptable provider/model/API-key selection through existing config
+  and CLI overrides;
+- emit JSONL trajectory events when requested;
+- optionally write the final assistant message to a file;
+- fail fast when interactive approval, user input, or auth refresh is required
+  in headless mode.
+
+The JSONL event schema should be RARA-owned and stable. It should include turn
+start/completion/failure events, assistant messages, command execution items,
+file-change items, tool-result summaries, usage metadata, and final failure
+reasons.
 
 ### Tool Contract
 
@@ -123,6 +153,9 @@ Each trial should end with one of:
 ## Validation Matrix
 
 - Run a small smoke subset locally through the adapter.
+- Run Harbor's Terminal-Bench tutorial command with a RARA installed agent and
+  record the exact `harbor run` invocation.
+- Confirm the Harbor run receives an ATIF-compatible trajectory artifact.
 - Confirm failures include enough trajectory data to reproduce the final
   decision.
 - Confirm headless configuration can select provider/model/API key without TUI

--- a/docs/journal/2026-07-05-rara-exec-headless.md
+++ b/docs/journal/2026-07-05-rara-exec-headless.md
@@ -1,0 +1,46 @@
+# RARA Exec Headless
+
+## Summary
+
+Added the first Codex-style headless automation surface for RARA:
+`rara exec`.
+
+The command reuses the normal agent loop without TUI chrome and supports:
+
+- prompt argument, stdin, and `-` stdin-only prompt handling;
+- `--cwd` / `-C` task workspace selection;
+- `--json` JSONL trajectory events;
+- `--run-id` and `--task-id` metadata for external harnesses;
+- `--output-last-message` for harnesses that need a final answer file.
+
+## Background
+
+Harbor's Terminal-Bench tutorial drives agents through an installed-agent
+adapter. RARA needs a stable non-interactive surface that such an adapter can
+invoke before adding Harbor-specific packaging and ATIF conversion.
+
+Codex's `codex exec` shape is the closest reference: a generic headless
+automation surface first, benchmark wrappers second.
+
+## Key Decisions
+
+- Keep benchmark logic outside the core agent runtime.
+- Make `rara exec --json` the reusable automation boundary.
+- Emit a RARA-owned JSONL event schema instead of exposing internal runtime
+  events directly.
+- Defer Harbor installed-agent packaging and ATIF conversion to the next slice.
+
+## Validation
+
+- `cargo test exec_consumer`
+- `cargo test app_cli::tests::clap_parses_exec_command_for_headless_harnesses`
+- `cargo check --locked --workspace --all-targets`
+- `cargo clippy --locked --workspace --all-targets -- -D warnings`
+- `cargo run --locked -- --provider mock exec --json --run-id smoke --task-id smoke-task "Say hello"`
+
+## Follow-Ups
+
+- Add the Harbor installed-agent adapter that invokes `rara exec --json`.
+- Convert RARA JSONL events into ATIF-compatible trajectory artifacts.
+- Run Harbor's Terminal-Bench tutorial command with the RARA adapter and record
+  the exact invocation.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -44,6 +44,14 @@ Active backlog only. Keep this file small and current.
 - [x] Tool result compression — ToolResultProjectionPolicy + model_preview_bash_output
 - [x] Context file routing — FileSearchCandidateProvider → retrieval pipeline (spec-only PR #606)
 
+## Benchmark / Evaluation
+
+- [ ] Add Harbor-compatible Terminal-Bench integration. Start with a
+      Codex-style `rara exec --json` headless surface plus a Harbor installed
+      agent adapter that runs inside the benchmark task workspace, supports
+      scriptable provider/model configuration, and writes ATIF-compatible
+      trajectory logs. See `docs/features/terminal-bench-evaluation.md`.
+
 ## Agent / Subagent
 
 - [x] Subagent token_budget field (PR #601)

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -46,11 +46,10 @@ Active backlog only. Keep this file small and current.
 
 ## Benchmark / Evaluation
 
-- [ ] Add Harbor-compatible Terminal-Bench integration. Start with a
-      Codex-style `rara exec --json` headless surface plus a Harbor installed
-      agent adapter that runs inside the benchmark task workspace, supports
-      scriptable provider/model configuration, and writes ATIF-compatible
-      trajectory logs. See `docs/features/terminal-bench-evaluation.md`.
+- [ ] Add Harbor-compatible Terminal-Bench integration. Build the Harbor
+      installed-agent adapter on top of `rara exec --json`, run inside the
+      benchmark task workspace, and write ATIF-compatible trajectory logs. See
+      `docs/features/terminal-bench-evaluation.md`.
 
 ## Agent / Subagent
 

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Result, bail};
@@ -87,6 +88,33 @@ struct ModelsShowArgs {
     profile_id: String,
 }
 
+#[derive(Debug, clap::Args)]
+struct ExecArgs {
+    /// Print headless execution events to stdout as JSONL.
+    #[arg(long, default_value_t = false)]
+    json: bool,
+
+    /// Working directory for the headless run.
+    #[arg(long = "cwd", short = 'C', value_name = "DIR")]
+    cwd: Option<PathBuf>,
+
+    /// Write the final assistant message to this file.
+    #[arg(long = "output-last-message", short = 'o', value_name = "FILE")]
+    output_last_message: Option<PathBuf>,
+
+    /// External benchmark or harness run id to include in JSONL metadata.
+    #[arg(long = "run-id", value_name = "ID")]
+    run_id: Option<String>,
+
+    /// External benchmark task id to include in JSONL metadata.
+    #[arg(long = "task-id", value_name = "ID")]
+    task_id: Option<String>,
+
+    /// Initial instructions. If omitted, or if `-` is used, read from stdin.
+    #[arg(value_name = "PROMPT")]
+    prompt: Option<String>,
+}
+
 #[derive(Debug, clap::Subcommand)]
 enum ModelsCommands {
     /// List configured models
@@ -109,6 +137,8 @@ enum Commands {
     Ask {
         prompt: String,
     },
+    /// Run RARA non-interactively for automation and evaluation harnesses.
+    Exec(ExecArgs),
     Fork {
         #[arg(value_name = "THREAD_ID")]
         thread_id: String,
@@ -164,6 +194,7 @@ pub(crate) async fn run_cli() -> Result<()> {
         Commands::Models(cmd) => run_models_command(&config, cmd)?,
         Commands::Plugin(cmd) => run_plugin_command(cmd)?,
         Commands::Ask { prompt } => run_ask_command(&config, prompt).await?,
+        Commands::Exec(args) => run_exec_command(&config, args).await?,
         Commands::Fork { thread_id } => thread_cli::run_fork_command(&thread_id)?,
         Commands::Distill { thread_id } => run_distill_command(&config, &thread_id).await?,
         Commands::Thread { thread_id } => thread_cli::run_thread_command(&thread_id)?,
@@ -259,6 +290,27 @@ async fn run_print_command(config: &RaraConfig, prompt: String) -> Result<()> {
     let event_bus = bootstrap.event_bus.clone();
     let agent = bootstrap.into_agent();
     let consumer = PrintConsumer::new(agent, event_bus, prompt);
+    consumer.run().await
+}
+
+async fn run_exec_command(config: &RaraConfig, args: ExecArgs) -> Result<()> {
+    if let Some(cwd) = args.cwd.as_deref() {
+        std::env::set_current_dir(cwd)
+            .map_err(|err| anyhow::anyhow!("failed to switch cwd to {}: {err}", cwd.display()))?;
+    }
+    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+    emit_bootstrap_warnings(&bootstrap.warnings);
+    let agent = bootstrap.into_agent();
+    let consumer = crate::exec_consumer::ExecConsumer::new(
+        agent,
+        crate::exec_consumer::ExecRunOptions {
+            prompt: args.prompt,
+            json: args.json,
+            output_last_message: args.output_last_message,
+            run_id: args.run_id,
+            task_id: args.task_id,
+        },
+    );
     consumer.run().await
 }
 
@@ -382,6 +434,7 @@ fn startup_resume_target_for_command(command: &Commands) -> Option<StartupResume
         | Commands::Models(..)
         | Commands::Plugin(..)
         | Commands::Ask { .. }
+        | Commands::Exec(..)
         | Commands::Distill { .. }
         | Commands::Fork { .. }
         | Commands::Thread { .. }
@@ -636,6 +689,36 @@ mod tests {
     }
 
     #[test]
+    fn clap_parses_exec_command_for_headless_harnesses() {
+        let cli = Cli::try_parse_from([
+            "rara",
+            "exec",
+            "--json",
+            "-C",
+            "task-workspace",
+            "--run-id",
+            "run-1",
+            "--task-id",
+            "task-1",
+            "--output-last-message",
+            "final.txt",
+            "-",
+        ])
+        .expect("parse exec");
+        match cli.command.expect("command") {
+            Commands::Exec(args) => {
+                assert!(args.json);
+                assert_eq!(args.cwd, Some(PathBuf::from("task-workspace")));
+                assert_eq!(args.run_id.as_deref(), Some("run-1"));
+                assert_eq!(args.task_id.as_deref(), Some("task-1"));
+                assert_eq!(args.output_last_message, Some(PathBuf::from("final.txt")));
+                assert_eq!(args.prompt.as_deref(), Some("-"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
     fn clap_parses_thread_resume_with_last() {
         let cli = Cli::try_parse_from(["rara", "resume", "--last"]).expect("parse resume --last");
         match cli.command.expect("command") {
@@ -706,6 +789,17 @@ mod tests {
             }),
             Some(StartupResumeTarget::ThreadId(thread_id)) if thread_id == "thread-123"
         ));
+        assert!(
+            startup_resume_target_for_command(&Commands::Exec(ExecArgs {
+                json: true,
+                cwd: None,
+                output_last_message: None,
+                run_id: None,
+                task_id: None,
+                prompt: Some("hello".to_string()),
+            }))
+            .is_none()
+        );
     }
 
     // --- connect / models CLI parsing ---

--- a/src/exec_consumer.rs
+++ b/src/exec_consumer.rs
@@ -54,6 +54,10 @@ impl ExecConsumer {
 
         match result {
             Ok(()) => {
+                processor.update_usage(
+                    self.agent.total_input_tokens,
+                    self.agent.total_output_tokens,
+                );
                 if processor.final_message().is_none() {
                     let message =
                         "headless exec completed without a final assistant message".to_string();
@@ -72,6 +76,10 @@ impl ExecConsumer {
                 Ok(())
             }
             Err(err) => {
+                processor.update_usage(
+                    self.agent.total_input_tokens,
+                    self.agent.total_output_tokens,
+                );
                 processor.emit_turn_failed(err.to_string())?;
                 Err(err)
             }
@@ -212,6 +220,11 @@ impl ExecJsonlProcessor {
         self.final_message.as_deref()
     }
 
+    fn update_usage(&mut self, input_tokens: u32, output_tokens: u32) {
+        self.usage.input_tokens = input_tokens;
+        self.usage.output_tokens = output_tokens;
+    }
+
     fn next_item_id(&mut self) -> String {
         let id = format!("item_{}", self.next_item_id);
         self.next_item_id += 1;
@@ -251,7 +264,9 @@ impl ExecJsonlProcessor {
             AgentEvent::AgentStart => Ok(()),
             AgentEvent::AgentStop { .. } => Ok(()),
             AgentEvent::AssistantText(text) => {
-                self.final_message = Some(text.clone());
+                self.final_message
+                    .get_or_insert_with(String::new)
+                    .push_str(&text);
                 self.emit_item(ExecItemDetails::AgentMessage { text })
             }
             AgentEvent::AssistantDelta(delta) => {
@@ -449,5 +464,53 @@ mod tests {
 
         assert_eq!(processor.final_message(), Some("done"));
         assert_eq!(processor.next_item_id, 2);
+    }
+
+    #[test]
+    fn processor_appends_assistant_text_parts() {
+        let mut processor = ExecJsonlProcessor::new(test_metadata(), false);
+
+        processor
+            .process_event(AgentEvent::AssistantText("first ".to_string()))
+            .expect("first assistant text");
+        processor
+            .process_event(AgentEvent::AssistantText("second ".to_string()))
+            .expect("second assistant text");
+        processor
+            .process_event(AgentEvent::AssistantDelta("third".to_string()))
+            .expect("assistant delta");
+
+        assert_eq!(processor.final_message(), Some("first second third"));
+    }
+
+    #[test]
+    fn processor_updates_usage_from_final_agent_totals() {
+        let mut processor = ExecJsonlProcessor::new(test_metadata(), false);
+
+        processor
+            .process_event(AgentEvent::ModelRequest {
+                model: "mock".to_string(),
+                input_tokens: 0,
+            })
+            .expect("model request");
+        processor
+            .process_event(AgentEvent::ModelResponse {
+                model: "mock".to_string(),
+                output_tokens: 2,
+                finish_reason: Some("stop".to_string()),
+            })
+            .expect("model response");
+        processor.update_usage(13, 7);
+
+        assert_eq!(processor.usage.input_tokens, 13);
+        assert_eq!(processor.usage.output_tokens, 7);
+    }
+
+    fn test_metadata() -> ExecRunMetadata {
+        ExecRunMetadata {
+            session_id: "session-1".to_string(),
+            run_id: Some("run-1".to_string()),
+            task_id: Some("task-1".to_string()),
+        }
     }
 }

--- a/src/exec_consumer.rs
+++ b/src/exec_consumer.rs
@@ -1,0 +1,453 @@
+use std::fs;
+use std::io::{self, IsTerminal, Read};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use rara_tools::tool::ToolOutputStream;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use crate::agent::{Agent, AgentEvent, AgentOutputMode};
+
+#[derive(Debug, Clone)]
+pub struct ExecRunOptions {
+    pub prompt: Option<String>,
+    pub json: bool,
+    pub output_last_message: Option<PathBuf>,
+    pub run_id: Option<String>,
+    pub task_id: Option<String>,
+}
+
+pub struct ExecConsumer {
+    agent: Agent,
+    options: ExecRunOptions,
+}
+
+impl ExecConsumer {
+    pub fn new(agent: Agent, options: ExecRunOptions) -> Self {
+        Self { agent, options }
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        let prompt = read_exec_prompt(self.options.prompt.clone())?;
+        let mut processor = ExecJsonlProcessor::new(
+            ExecRunMetadata {
+                session_id: self.agent.session_id.clone(),
+                run_id: self.options.run_id.clone(),
+                task_id: self.options.task_id.clone(),
+            },
+            self.options.json,
+        );
+
+        processor.emit_thread_started()?;
+        processor.emit_turn_started()?;
+
+        let result = self
+            .agent
+            .query_with_mode_and_events(prompt, AgentOutputMode::Silent, |event| {
+                if let Err(err) = processor.process_event(event) {
+                    eprintln!("failed to process exec event: {err}");
+                }
+            })
+            .await;
+
+        match result {
+            Ok(()) => {
+                if processor.final_message().is_none() {
+                    let message =
+                        "headless exec completed without a final assistant message".to_string();
+                    processor.emit_turn_failed(message.clone())?;
+                    bail!("{message}");
+                }
+                processor.emit_turn_completed()?;
+                if !self.options.json
+                    && let Some(message) = processor.final_message()
+                {
+                    println!("{message}");
+                }
+                if let Some(path) = self.options.output_last_message.as_deref() {
+                    write_last_message(path, processor.final_message())?;
+                }
+                Ok(())
+            }
+            Err(err) => {
+                processor.emit_turn_failed(err.to_string())?;
+                Err(err)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecRunMetadata {
+    pub session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ExecEvent {
+    #[serde(rename = "thread.started")]
+    ThreadStarted {
+        metadata: ExecRunMetadata,
+        timestamp: String,
+    },
+    #[serde(rename = "turn.started")]
+    TurnStarted { timestamp: String },
+    #[serde(rename = "turn.completed")]
+    TurnCompleted {
+        usage: ExecUsage,
+        final_message: Option<String>,
+        timestamp: String,
+    },
+    #[serde(rename = "turn.failed")]
+    TurnFailed { error: ExecError, timestamp: String },
+    #[serde(rename = "item.completed")]
+    ItemCompleted { item: ExecItem },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecUsage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExecError {
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ExecItem {
+    pub id: String,
+    #[serde(flatten)]
+    pub details: ExecItemDetails,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ExecItemDetails {
+    Status {
+        message: String,
+    },
+    AgentMessage {
+        text: String,
+    },
+    Reasoning {
+        text: String,
+    },
+    ToolCall {
+        name: String,
+        input: Value,
+    },
+    ToolResult {
+        name: String,
+        content: String,
+        is_error: bool,
+    },
+    ToolProgress {
+        name: String,
+        stream: ExecToolStream,
+        chunk: String,
+    },
+    MemoryAction {
+        message: String,
+    },
+    TodoUpdated,
+    ModelRequest {
+        model: String,
+        input_tokens: u32,
+    },
+    ModelResponse {
+        model: String,
+        output_tokens: u32,
+        finish_reason: Option<String>,
+    },
+    Error {
+        message: String,
+        recoverable: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecToolStream {
+    Stdout,
+    Stderr,
+}
+
+impl From<ToolOutputStream> for ExecToolStream {
+    fn from(value: ToolOutputStream) -> Self {
+        match value {
+            ToolOutputStream::Stdout => Self::Stdout,
+            ToolOutputStream::Stderr => Self::Stderr,
+        }
+    }
+}
+
+struct ExecJsonlProcessor {
+    metadata: ExecRunMetadata,
+    emit_json: bool,
+    next_item_id: u64,
+    final_message: Option<String>,
+    usage: ExecUsage,
+}
+
+impl ExecJsonlProcessor {
+    fn new(metadata: ExecRunMetadata, emit_json: bool) -> Self {
+        Self {
+            metadata,
+            emit_json,
+            next_item_id: 0,
+            final_message: None,
+            usage: ExecUsage::default(),
+        }
+    }
+
+    fn final_message(&self) -> Option<&str> {
+        self.final_message.as_deref()
+    }
+
+    fn next_item_id(&mut self) -> String {
+        let id = format!("item_{}", self.next_item_id);
+        self.next_item_id += 1;
+        id
+    }
+
+    fn emit_thread_started(&self) -> Result<()> {
+        self.emit(ExecEvent::ThreadStarted {
+            metadata: self.metadata.clone(),
+            timestamp: timestamp_now(),
+        })
+    }
+
+    fn emit_turn_started(&self) -> Result<()> {
+        self.emit(ExecEvent::TurnStarted {
+            timestamp: timestamp_now(),
+        })
+    }
+
+    fn emit_turn_completed(&self) -> Result<()> {
+        self.emit(ExecEvent::TurnCompleted {
+            usage: self.usage.clone(),
+            final_message: self.final_message.clone(),
+            timestamp: timestamp_now(),
+        })
+    }
+
+    fn emit_turn_failed(&self, message: String) -> Result<()> {
+        self.emit(ExecEvent::TurnFailed {
+            error: ExecError { message },
+            timestamp: timestamp_now(),
+        })
+    }
+
+    fn process_event(&mut self, event: AgentEvent) -> Result<()> {
+        match event {
+            AgentEvent::AgentStart => Ok(()),
+            AgentEvent::AgentStop { .. } => Ok(()),
+            AgentEvent::AssistantText(text) => {
+                self.final_message = Some(text.clone());
+                self.emit_item(ExecItemDetails::AgentMessage { text })
+            }
+            AgentEvent::AssistantDelta(delta) => {
+                self.final_message
+                    .get_or_insert_with(String::new)
+                    .push_str(delta.as_str());
+                self.emit_item(ExecItemDetails::AgentMessage { text: delta })
+            }
+            AgentEvent::AssistantThinkingDelta(text) => {
+                self.emit_item(ExecItemDetails::Reasoning { text })
+            }
+            AgentEvent::Status(message) => self.emit_item(ExecItemDetails::Status { message }),
+            AgentEvent::ToolUse { name, input } => {
+                self.emit_item(ExecItemDetails::ToolCall { name, input })
+            }
+            AgentEvent::ToolResult {
+                name,
+                content,
+                is_error,
+            } => self.emit_item(ExecItemDetails::ToolResult {
+                name,
+                content,
+                is_error,
+            }),
+            AgentEvent::ToolProgress {
+                name,
+                stream,
+                chunk,
+            } => self.emit_item(ExecItemDetails::ToolProgress {
+                name,
+                stream: stream.into(),
+                chunk,
+            }),
+            AgentEvent::MemoryAction { message } => {
+                self.emit_item(ExecItemDetails::MemoryAction { message })
+            }
+            AgentEvent::TodoUpdated(_) => self.emit_item(ExecItemDetails::TodoUpdated),
+            AgentEvent::ModelRequest {
+                model,
+                input_tokens,
+            } => {
+                self.usage.input_tokens = input_tokens;
+                self.emit_item(ExecItemDetails::ModelRequest {
+                    model,
+                    input_tokens,
+                })
+            }
+            AgentEvent::ModelResponse {
+                model,
+                output_tokens,
+                finish_reason,
+            } => {
+                self.usage.output_tokens = self.usage.output_tokens.saturating_add(output_tokens);
+                self.emit_item(ExecItemDetails::ModelResponse {
+                    model,
+                    output_tokens,
+                    finish_reason,
+                })
+            }
+            AgentEvent::AgentError {
+                message,
+                recoverable,
+            } => self.emit_item(ExecItemDetails::Error {
+                message,
+                recoverable,
+            }),
+            AgentEvent::McpStatusUpdated(_) | AgentEvent::McpStatusLoadFailed { .. } => Ok(()),
+        }
+    }
+
+    fn emit_item(&mut self, details: ExecItemDetails) -> Result<()> {
+        let item = ExecItem {
+            id: self.next_item_id(),
+            details,
+        };
+        self.emit(ExecEvent::ItemCompleted { item })
+    }
+
+    fn emit(&self, event: ExecEvent) -> Result<()> {
+        if self.emit_json {
+            emit_jsonl(&event)?;
+        }
+        Ok(())
+    }
+}
+
+fn emit_jsonl(event: &ExecEvent) -> Result<()> {
+    println!("{}", serde_json::to_string(event)?);
+    Ok(())
+}
+
+fn timestamp_now() -> String {
+    OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+fn write_last_message(path: &std::path::Path, message: Option<&str>) -> Result<()> {
+    let message = message.unwrap_or_default();
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    fs::write(path, message).with_context(|| format!("failed to write {}", path.display()))
+}
+
+pub fn read_exec_prompt(prompt: Option<String>) -> Result<String> {
+    let stdin_is_terminal = io::stdin().is_terminal();
+    let stdin = if stdin_is_terminal {
+        None
+    } else {
+        Some(read_stdin_to_string()?)
+    };
+    resolve_exec_prompt(prompt, stdin)
+}
+
+fn read_stdin_to_string() -> Result<String> {
+    let mut input = String::new();
+    io::stdin()
+        .read_to_string(&mut input)
+        .context("failed to read prompt from stdin")?;
+    Ok(input)
+}
+
+fn resolve_exec_prompt(prompt: Option<String>, stdin: Option<String>) -> Result<String> {
+    match (prompt, stdin) {
+        (Some(prompt), Some(stdin)) if prompt == "-" => require_non_empty_stdin(stdin),
+        (Some(prompt), Some(stdin)) if stdin.trim().is_empty() => Ok(prompt),
+        (Some(prompt), Some(stdin)) => Ok(format!("{prompt}\n\n<stdin>\n{stdin}</stdin>")),
+        (Some(prompt), None) if prompt == "-" => bail!("No prompt provided via stdin."),
+        (Some(prompt), None) => Ok(prompt),
+        (None, Some(stdin)) => require_non_empty_stdin(stdin),
+        (None, None) => bail!("No prompt provided via stdin."),
+    }
+}
+
+fn require_non_empty_stdin(stdin: String) -> Result<String> {
+    if stdin.trim().is_empty() {
+        bail!("No prompt provided via stdin.");
+    }
+    Ok(stdin)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn prompt_argument_appends_non_empty_stdin_block() {
+        let prompt = resolve_exec_prompt(Some("Summarize this".to_string()), Some("data\n".into()))
+            .expect("prompt");
+
+        assert_eq!(prompt, "Summarize this\n\n<stdin>\ndata\n</stdin>");
+    }
+
+    #[test]
+    fn dash_prompt_reads_stdin_as_prompt() {
+        let prompt = resolve_exec_prompt(Some("-".to_string()), Some("from stdin\n".into()))
+            .expect("prompt");
+
+        assert_eq!(prompt, "from stdin\n");
+    }
+
+    #[test]
+    fn missing_prompt_rejects_empty_stdin() {
+        let err = resolve_exec_prompt(None, Some(String::new())).expect_err("empty stdin");
+
+        assert_eq!(err.to_string(), "No prompt provided via stdin.");
+    }
+
+    #[test]
+    fn processor_maps_agent_events_to_exec_items() {
+        let mut processor = ExecJsonlProcessor::new(
+            ExecRunMetadata {
+                session_id: "session-1".to_string(),
+                run_id: Some("run-1".to_string()),
+                task_id: Some("task-1".to_string()),
+            },
+            false,
+        );
+
+        processor
+            .process_event(AgentEvent::AssistantText("done".to_string()))
+            .expect("assistant event");
+        processor
+            .process_event(AgentEvent::ToolUse {
+                name: "bash".to_string(),
+                input: json!({"cmd": "true"}),
+            })
+            .expect("tool event");
+
+        assert_eq!(processor.final_message(), Some("done"));
+        assert_eq!(processor.next_item_id, 2);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod context;
 mod control_plane;
 mod control_tokens;
 mod embedding;
+mod exec_consumer;
 mod google_oauth;
 mod hook_registry;
 mod hook_runtime;


### PR DESCRIPTION
## Summary

- add `rara exec` for headless automation and evaluation harnesses
- support prompt/stdin input, `--json`, `--cwd`, run/task metadata, and `--output-last-message`
- emit a RARA-owned JSONL trajectory stream from the normal agent loop
- update the Terminal-Bench/Harbor spec, TODO, and journal

## Purpose

This is the first Harbor Terminal-Bench integration slice. It follows the Codex `exec` pattern: build a reusable headless execution surface first, then add a Harbor installed-agent adapter on top of it in a later slice.

## Related Issue

None.

## Testing

- `cargo test --locked exec_consumer`
- `cargo test --locked app_cli::tests`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo run --locked -- --provider mock exec --json --run-id smoke --task-id smoke-task "Say hello"`
