### PR TITLE
fix(tui): keep shell approval actions visible

### DIFF
--- a/docs/journal/2026-07-05-shell-approval-actions.md
+++ b/docs/journal/2026-07-05-shell-approval-actions.md
@@ -1,0 +1,28 @@
+# Shell Approval Action Visibility
+
+## Summary
+
+The shell approval dock now keeps its action row visible when the approval
+detail includes command and working-directory lines.
+
+## Background
+
+The bottom-pane interaction panel has a fixed five-row height. Shell approval
+details could fill those rows before the action buttons were rendered, so the
+user could see the pending command but not the selectable approval items.
+
+## Scope
+
+- Keep detail text compact inside the dock panel.
+- Render approval actions as a fixed final row when detail text is present.
+- Add a render regression test for a standard-height terminal with a pending
+  shell approval.
+
+## Validation
+
+```bash
+cargo test --locked tui::render::tests::shell_approval_panel_keeps_actions_visible
+cargo test --locked tui::render::tests
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+```

--- a/src/tui/render/bottom_pane/mod.rs
+++ b/src/tui/render/bottom_pane/mod.rs
@@ -119,21 +119,12 @@ fn render_interaction_panel(f: &mut Frame, panel: &view::InteractionPanelView, a
             )));
         }
     } else {
-        for line in panel.detail.lines() {
+        let action_line = interaction_action_line(panel);
+        let detail_rows = usize::from(area.height).saturating_sub(2);
+        for line in panel.detail.lines().take(detail_rows) {
             lines.push(Line::from(format!("  {}", line)));
         }
-        lines.push(Line::from(""));
-        let button_line: String = panel
-            .actions
-            .iter()
-            .enumerate()
-            .map(|(i, a)| {
-                let prefix = if i == panel.selected { "▸" } else { " " };
-                format!("{}[{}] {}", prefix, a.key, a.label)
-            })
-            .collect::<Vec<_>>()
-            .join("    ");
-        lines.push(Line::from(format!("  {}", button_line)));
+        lines.push(Line::from(format!("  {}", action_line)));
     }
 
     let block = Block::default();
@@ -141,4 +132,17 @@ fn render_interaction_panel(f: &mut Frame, panel: &view::InteractionPanelView, a
         .block(block)
         .wrap(Wrap { trim: false });
     f.render_widget(para, area);
+}
+
+fn interaction_action_line(panel: &view::InteractionPanelView) -> String {
+    panel
+        .actions
+        .iter()
+        .enumerate()
+        .map(|(i, action)| {
+            let prefix = if i == panel.selected { "▸" } else { " " };
+            format!("{}[{}] {}", prefix, action.key, action.label)
+        })
+        .collect::<Vec<_>>()
+        .join("    ")
 }

--- a/src/tui/render/bottom_pane/mod.rs
+++ b/src/tui/render/bottom_pane/mod.rs
@@ -120,7 +120,7 @@ fn render_interaction_panel(f: &mut Frame, panel: &view::InteractionPanelView, a
         }
     } else {
         let action_line = interaction_action_line(panel);
-        let detail_rows = usize::from(area.height).saturating_sub(2);
+        let detail_rows = usize::from(area.height).saturating_sub(3);
         for line in panel.detail.lines().take(detail_rows) {
             lines.push(Line::from(format!("  {}", line)));
         }

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -17,10 +17,12 @@ use super::{
     tool_action_label, transcript_scroll_offset, transcript_viewport, transcript_visual_row_count,
 };
 use crate::config::{ConfigManager, OpenAiEndpointKind, RaraConfig};
+use crate::tools::bash::BashCommandInput;
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::{
-    ListPickerKind, Overlay, PlanningApprovalStatus, PlanningLifecycleSnapshot, ProviderFamily,
-    RuntimeSnapshot, StatusTab, TranscriptEntry, TranscriptTurn, TuiApp,
+    InteractionKind, ListPickerKind, Overlay, PendingApprovalSnapshot, PendingInteractionSnapshot,
+    PlanningApprovalStatus, PlanningLifecycleSnapshot, ProviderFamily, RuntimeSnapshot, StatusTab,
+    TranscriptEntry, TranscriptTurn, TuiApp,
 };
 
 fn provider_family_idx(family: ProviderFamily) -> usize {
@@ -140,6 +142,44 @@ fn transcript_render_stays_above_bottom_pane() {
     assert!(transcript.contains("TRANSCRIPT_SENTINEL"));
     assert!(!bottom.contains("TRANSCRIPT_SENTINEL"));
     assert!(bottom.contains("composer text"));
+}
+
+#[test]
+fn shell_approval_panel_keeps_actions_visible() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot
+        .pending_interactions
+        .push(PendingInteractionSnapshot {
+            kind: InteractionKind::Approval,
+            title: "Shell Approval".into(),
+            summary: "cargo check 2>&1 | head -80".into(),
+            options: Vec::new(),
+            note: None,
+            approval: Some(PendingApprovalSnapshot {
+                tool_use_id: "toolu_123".into(),
+                command: "cargo check 2>&1 | head -80".into(),
+                allow_net: false,
+                payload: BashCommandInput {
+                    command: Some("cargo check 2>&1 | head -80".into()),
+                    cwd: Some("/home/hawkingrei/devel/opensource/rara".into()),
+                    ..Default::default()
+                },
+            }),
+            source: None,
+            created_at_epoch_seconds: None,
+        });
+
+    let rendered = render_screen_text(&mut app, 80, 14);
+
+    assert!(rendered.contains("Permission Required"));
+    assert!(rendered.contains("[1] Allow once"));
+    assert!(rendered.contains("[2] Allow prefix"));
+    assert!(rendered.contains("[3] Allow always"));
+    assert!(rendered.contains("[4] Deny"));
 }
 
 #[test]

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -183,6 +183,33 @@ fn shell_approval_panel_keeps_actions_visible() {
 }
 
 #[test]
+fn interaction_panel_keeps_actions_visible_with_three_detail_lines() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.snapshot
+        .pending_interactions
+        .push(PendingInteractionSnapshot {
+            kind: InteractionKind::RequestInput,
+            title: "line one\nline two\nline three".into(),
+            summary: "answer planning question".into(),
+            options: Vec::new(),
+            note: None,
+            approval: None,
+            source: Some("plan_agent".into()),
+            created_at_epoch_seconds: None,
+        });
+
+    let rendered = render_screen_text(&mut app, 80, 14);
+
+    assert!(rendered.contains("Planning Question"));
+    assert!(rendered.contains("[Enter] Continue Plan"));
+    assert!(rendered.contains("[I] Start Implementation"));
+}
+
+#[test]
 fn bottom_pane_background_covers_hint_and_footer_rows() {
     let temp = tempdir().expect("tempdir");
     let mut app = TuiApp::new(ConfigManager {


### PR DESCRIPTION
## Summary

- Keep bottom-pane shell approval action buttons visible when command details are present.
- Add a focused render regression test for a standard-height terminal.
- Record the TUI fix in a dated implementation journal.

## Motivation

The shell approval dock used a fixed five-row panel. Command and working-directory
details could consume the visible rows before the action buttons were rendered,
leaving the user unable to see the selectable approval items.

## Related Issue

None.

## Testing

- `cargo test --locked tui::render::tests::shell_approval_panel_keeps_actions_visible`
- `cargo test --locked tui::render::tests`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
