### PR TITLE
fix(tui): compact bash completion status

### DIFF
--- a/docs/journal/2026-07-05-bash-completion-rendering.md
+++ b/docs/journal/2026-07-05-bash-completion-rendering.md
@@ -1,0 +1,32 @@
+# Bash Completion Rendering
+
+## Summary
+
+Active TUI turns now render bash completion as a compact status line instead of
+showing a raw `bash finished with exit code 0` tool-result sentence at the
+bottom of the transcript.
+
+## Background
+
+While the model was streaming thinking text, the active turn renderer could
+append the latest successful bash result as a fallback message. This made the
+UI look like thinking had stalled behind a stale `bash finished with exit code
+0` line.
+
+## Scope
+
+- Suppress the latest tool-result fallback while live thinking or live events
+  are already visible.
+- Render bash completion fallbacks as `✓ bash` for success and `✗ bash · exit
+  N` for failure.
+- Keep raw tool-result text unchanged for model context and persistence.
+
+## Validation
+
+```bash
+cargo test --locked active_turn_cell_hides_successful_bash_result_while_thinking
+cargo test --locked active_turn_cell_renders_bash_completion_as_status_line
+cargo test --locked tui::render::cells::tests
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+```

--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -547,6 +547,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 self.cwd,
             )));
         } else if !has_active_pending_interaction
+            && !has_live_thinking
+            && !has_live_events
             && let Some((role, tool_result)) = latest_tool_result
         {
             cells.push(Box::new(RespondingCell::from_tool_result(

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -1660,6 +1660,48 @@ fn active_turn_cell_renders_bash_completion_as_status_line() {
 }
 
 #[test]
+fn active_turn_cell_marks_truncated_bash_completion_body() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.runtime_phase_detail = Some("tool completed".into());
+    let body = (1..=20)
+        .map(|idx| format!("line {idx}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    app.active_turn = TranscriptTurn {
+        thinking_duration: None,
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Run checks".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool Result".into(),
+                message: format!("bash finished with exit code 0\n{body}"),
+                payload: None,
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("✓ bash"));
+    assert!(rendered.contains("line 1"));
+    assert!(rendered.contains("... 8 more line(s)"));
+    assert!(!rendered.contains("line 20"));
+}
+
+#[test]
 fn active_turn_cell_prefers_responding_over_system_notice_while_sending_prompt() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -1583,6 +1583,83 @@ fn active_turn_cell_prefers_responding_over_tool_result_while_processing_respons
 }
 
 #[test]
+fn active_turn_cell_hides_successful_bash_result_while_thinking() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::ProcessingResponse;
+    app.runtime_phase_detail = Some("thinking".into());
+    app.active_turn = TranscriptTurn {
+        thinking_duration: None,
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Review the repository".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool Result".into(),
+                message: "bash finished with exit code 0".into(),
+                payload: None,
+            },
+        ],
+    };
+    app.append_agent_thinking_delta("checking the result\n");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Thinking"));
+    assert!(rendered.contains("checking the result"));
+    assert!(!rendered.contains("bash finished with exit code 0"));
+    assert!(!rendered.contains("✓ bash"));
+}
+
+#[test]
+fn active_turn_cell_renders_bash_completion_as_status_line() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::RunningTool;
+    app.runtime_phase_detail = Some("tool completed".into());
+    app.active_turn = TranscriptTurn {
+        thinking_duration: None,
+        entries: vec![
+            TranscriptEntry {
+                role: "You".into(),
+                message: "Run checks".into(),
+                payload: None,
+            },
+            TranscriptEntry {
+                role: "Tool Result".into(),
+                message: "bash finished with exit code 0\nDuration: 12 ms".into(),
+                payload: None,
+            },
+        ],
+    };
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("✓ bash"));
+    assert!(rendered.contains("Duration: 12 ms"));
+    assert!(!rendered.contains("Tool Result"));
+    assert!(!rendered.contains("bash finished with exit code 0"));
+}
+
+#[test]
 fn active_turn_cell_prefers_responding_over_system_notice_while_sending_prompt() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {

--- a/src/tui/render/cells/responding_cell.rs
+++ b/src/tui/render/cells/responding_cell.rs
@@ -218,18 +218,28 @@ fn bash_completion_lines(
         return Some(rendered);
     }
 
-    rendered.extend(
-        lines
-            .map(str::trim_end)
-            .filter(|line| !line.is_empty())
-            .take(body_budget)
-            .map(|line| {
-                Line::from(Span::styled(
-                    format!("  {line}"),
-                    Style::default().fg(TEXT_SECONDARY),
-                ))
-            }),
-    );
+    let body_lines = lines
+        .map(str::trim_end)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    let truncated = body_lines.len() > body_budget;
+    let capped = if truncated {
+        body_budget.saturating_sub(1)
+    } else {
+        body_lines.len().min(body_budget)
+    };
+    rendered.extend(body_lines.iter().take(capped).map(|line| {
+        Line::from(Span::styled(
+            format!("  {line}"),
+            Style::default().fg(TEXT_SECONDARY),
+        ))
+    }));
+    if truncated {
+        rendered.push(Line::from(Span::styled(
+            format!("  ... {} more line(s)", body_lines.len() - capped),
+            Style::default().fg(TEXT_SECONDARY),
+        )));
+    }
     Some(rendered)
 }
 

--- a/src/tui/render/cells/responding_cell.rs
+++ b/src/tui/render/cells/responding_cell.rs
@@ -152,7 +152,9 @@ impl HistoryCell for RespondingCell<'_> {
                 message,
                 max_lines,
             } => {
-                if let Some(cell) = LspDiagnosticsCell::from_message(message) {
+                if let Some(lines) = bash_completion_lines(role, message, *max_lines) {
+                    lines
+                } else if let Some(cell) = LspDiagnosticsCell::from_message(message) {
                     cell.display_lines(width)
                 } else if let Some(lines) = render_message_diff_preview(Some(role), message, width)
                 {
@@ -164,6 +166,71 @@ impl HistoryCell for RespondingCell<'_> {
             RespondingCellContent::Working(detail) => compact_message_lines(detail, 1),
         }
     }
+}
+
+fn bash_completion_lines(
+    role: &str,
+    message: &str,
+    max_lines: usize,
+) -> Option<Vec<Line<'static>>> {
+    if !matches!(role, "Tool Result" | "Tool Error") {
+        return None;
+    }
+
+    let mut lines = message.lines();
+    let first = lines.next()?.trim();
+    let normalized = first.strip_prefix("bash: ").unwrap_or(first);
+    let (success, exit_code) = if normalized == "bash finished with exit code 0"
+        || normalized == "finished with exit code 0"
+    {
+        (true, Some(0))
+    } else {
+        let code = normalized
+            .strip_prefix("bash failed with exit code ")
+            .or_else(|| normalized.strip_prefix("failed with exit code "))
+            .and_then(|value| value.parse::<i32>().ok())?;
+        (false, Some(code))
+    };
+
+    let icon_style = if success {
+        Style::default()
+            .fg(STATUS_SUCCESS)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(STATUS_ERROR)
+            .add_modifier(Modifier::BOLD)
+    };
+    let mut status = Line::from(vec![
+        Span::styled(if success { "✓" } else { "✗" }, icon_style),
+        Span::raw(" bash"),
+    ]);
+    if let Some(code) = exit_code.filter(|code| *code != 0) {
+        status.push_span(Span::styled(
+            format!(" · exit {code}"),
+            Style::default().fg(TEXT_SECONDARY),
+        ));
+    }
+
+    let body_budget = max_lines.saturating_sub(1);
+    let mut rendered = vec![status];
+    if body_budget == 0 {
+        return Some(rendered);
+    }
+
+    rendered.extend(
+        lines
+            .map(str::trim_end)
+            .filter(|line| !line.is_empty())
+            .take(body_budget)
+            .map(|line| {
+                Line::from(Span::styled(
+                    format!("  {line}"),
+                    Style::default().fg(TEXT_SECONDARY),
+                ))
+            }),
+    );
+    Some(rendered)
 }
 
 fn lightweight_stream_lines(rendered: &[Line<'static>], max_lines: usize) -> Vec<Line<'static>> {


### PR DESCRIPTION
## Summary

- Hide stale successful bash tool results while live thinking or live activity is visible.
- Render bash completion fallbacks as compact status lines such as `✓ bash` or `✗ bash · exit N`.
- Add active-turn render regressions for thinking plus bash success and compact bash completion status.
- Record the TUI behavior change in a dated journal.

## Motivation

The active turn renderer could show live thinking and then append the previous
successful bash result as a fallback message. That made the bottom of the
transcript look stuck on `bash finished with exit code 0` even though the model
was actively thinking.

## Related Issue

None.

## Testing

- `cargo test --locked active_turn_cell_hides_successful_bash_result_while_thinking`
- `cargo test --locked active_turn_cell_renders_bash_completion_as_status_line`
- `cargo test --locked tui::render::cells::tests`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
