### PR TITLE
feat: add Harbor RARA agent adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .rara/
 .idea/
 data/lancedb
+jobs/
 .DS_Store
 .tmp-pr-*
 .tmp-pr*.md

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -55,7 +55,9 @@ Recommended components:
   The first local integration ships as a dynamic Harbor import-path adapter:
   `PYTHONPATH=$PWD/tools/harbor harbor run -d terminal-bench/terminal-bench-2
   --agent rara_agent:RaraAgent --agent-kwarg
-  binary_path=$PWD/target/release/rara`.
+  binary_path=$PWD/target/release/rara`. The adapter defaults to `/app` as the
+  benchmark cwd and preserves the `rara exec` exit code while teeing JSONL
+  output into `/logs/agent/rara-exec.jsonl`.
 - `rara eval terminal-bench` may be added later as a convenience wrapper, but
   the first integration target is Harbor compatibility.
 - Stable workspace setup contract:
@@ -164,7 +166,12 @@ Each trial should end with one of:
 - Run Harbor's Terminal-Bench tutorial command with a RARA installed agent and
   record the exact `harbor run` invocation.
 - For local dynamic-adapter smoke runs, build `target/release/rara` first and
-  pass it through `--agent-kwarg binary_path=$PWD/target/release/rara`.
+  pass it through `--agent-kwarg binary_path=$PWD/target/release/rara`. The
+  binary must be executable inside the benchmark environment; Linux Docker
+  tasks require a Linux RARA binary, not a macOS host build.
+- For single-task smoke runs, filter the dataset with `--task
+  terminal-bench/<task-name>` and inspect `/logs/agent/rara-exec.jsonl`,
+  `/logs/agent/rara-exec.status`, and verifier output when reward is `0.0`.
 - Confirm the Harbor run receives an ATIF-compatible trajectory artifact.
 - Confirm failures include enough trajectory data to reproduce the final
   decision.

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -52,6 +52,10 @@ Recommended components:
   `--output-last-message`.
 - A Harbor installed-agent adapter that invokes `rara exec` for the task and
   converts RARA's structured output into ATIF-compatible trajectory artifacts.
+  The first local integration ships as a dynamic Harbor import-path adapter:
+  `PYTHONPATH=$PWD/tools/harbor harbor run -d terminal-bench/terminal-bench-2
+  --agent rara_agent:RaraAgent --agent-kwarg
+  binary_path=$PWD/target/release/rara`.
 - `rara eval terminal-bench` may be added later as a convenience wrapper, but
   the first integration target is Harbor compatibility.
 - Stable workspace setup contract:
@@ -159,6 +163,8 @@ Each trial should end with one of:
 - Run a small smoke subset locally through the adapter.
 - Run Harbor's Terminal-Bench tutorial command with a RARA installed agent and
   record the exact `harbor run` invocation.
+- For local dynamic-adapter smoke runs, build `target/release/rara` first and
+  pass it through `--agent-kwarg binary_path=$PWD/target/release/rara`.
 - Confirm the Harbor run receives an ATIF-compatible trajectory artifact.
 - Confirm failures include enough trajectory data to reproduce the final
   decision.
@@ -187,3 +193,4 @@ Each trial should end with one of:
 ## Source Journals
 
 - `docs/journal/2026-07-05-rara-exec-headless.md`
+- `docs/journal/2026-07-05-harbor-rara-agent-adapter.md`

--- a/docs/journal/2026-07-05-harbor-rara-agent-adapter.md
+++ b/docs/journal/2026-07-05-harbor-rara-agent-adapter.md
@@ -1,0 +1,42 @@
+# Harbor RARA Agent Adapter
+
+## Summary
+
+Added a repo-local Harbor adapter that can be dynamically loaded through
+Harbor's `--agent module.path:ClassName` import-path support.
+
+The adapter lives at `tools/harbor/rara_agent.py` and exposes
+`rara_agent:RaraAgent`.
+
+## Scope
+
+- Uploads a locally built RARA binary into the benchmark container.
+- Invokes `rara exec --json` with Harbor trial metadata and stdin-provided task
+  instructions.
+- Writes `rara-exec.jsonl` and the final assistant message under
+  `/logs/agent`.
+- Parses RARA JSONL output into Harbor `AgentContext` usage and metadata.
+- Preserves parsed context metadata even when `rara exec` exits non-zero.
+
+## Usage
+
+```bash
+cargo build --release
+PYTHONPATH=$PWD/tools/harbor harbor run -d terminal-bench/terminal-bench-2 \
+  --agent rara_agent:RaraAgent \
+  --agent-kwarg binary_path=$PWD/target/release/rara
+```
+
+## Validation
+
+```bash
+PYTHONPATH=/Users/hawkingrei/.local/share/uv/tools/harbor/lib/python3.13/site-packages:tools/harbor:. \
+  python -m unittest tools.harbor.test_rara_agent
+python -m py_compile tools/harbor/rara_agent.py tools/harbor/test_rara_agent.py
+```
+
+## Follow-Ups
+
+- Convert RARA JSONL events into full ATIF-compatible trajectory artifacts.
+- Run a Harbor Terminal-Bench smoke task with the dynamic adapter and record the
+  exact command and resulting artifact paths.

--- a/docs/journal/2026-07-05-harbor-rara-agent-adapter.md
+++ b/docs/journal/2026-07-05-harbor-rara-agent-adapter.md
@@ -15,6 +15,10 @@ The adapter lives at `tools/harbor/rara_agent.py` and exposes
   instructions.
 - Writes `rara-exec.jsonl` and the final assistant message under
   `/logs/agent`.
+- Preserves the `rara exec` exit code while teeing JSONL output, so Harbor does
+  not treat a failed agent run as a successful zero-reward verifier run.
+- Validates the uploaded binary during agent setup and reports host/container
+  architecture mismatches before the task runs.
 - Parses RARA JSONL output into Harbor `AgentContext` usage and metadata.
 - Preserves parsed context metadata even when `rara exec` exits non-zero.
 
@@ -27,6 +31,19 @@ PYTHONPATH=$PWD/tools/harbor harbor run -d terminal-bench/terminal-bench-2 \
   --agent-kwarg binary_path=$PWD/target/release/rara
 ```
 
+When Harbor uses Linux Docker containers, `binary_path` must point to a Linux
+RARA binary. A macOS `target/release/rara` build will fail setup with an
+`Exec format error`.
+
+For a single-task smoke run:
+
+```bash
+PYTHONPATH=$PWD/tools/harbor harbor run -d terminal-bench/terminal-bench-2 \
+  --task terminal-bench/sparql-university \
+  --agent rara_agent:RaraAgent \
+  --agent-kwarg binary_path=$PWD/target/release/rara
+```
+
 ## Validation
 
 ```bash
@@ -34,6 +51,16 @@ HARBOR_SITE_PACKAGES=$(find "$(uv tool dir)/harbor/lib" -path '*/site-packages' 
 PYTHONPATH="${HARBOR_SITE_PACKAGES}:tools/harbor:." python -m unittest tools.harbor.test_rara_agent
 python -m py_compile tools/harbor/rara_agent.py tools/harbor/test_rara_agent.py
 ```
+
+The single-task smoke run `terminal-bench/sparql-university` confirmed that
+`cwd=/app` is required for Docker execution and that verifier reward `0.0` can
+mean the agent produced no task artifact. The adapter now defaults to `/app` and
+preserves `rara exec` failures through the JSONL tee pipeline.
+
+A follow-up smoke run exposed a host/container binary mismatch: the local
+`target/release/rara` was a macOS arm64 binary while the task ran in a Linux
+container. The adapter now probes `rara --version` after upload and fails setup
+with an actionable Linux-binary diagnostic.
 
 ## Follow-Ups
 

--- a/docs/journal/2026-07-05-harbor-rara-agent-adapter.md
+++ b/docs/journal/2026-07-05-harbor-rara-agent-adapter.md
@@ -30,8 +30,8 @@ PYTHONPATH=$PWD/tools/harbor harbor run -d terminal-bench/terminal-bench-2 \
 ## Validation
 
 ```bash
-PYTHONPATH=/Users/hawkingrei/.local/share/uv/tools/harbor/lib/python3.13/site-packages:tools/harbor:. \
-  python -m unittest tools.harbor.test_rara_agent
+HARBOR_SITE_PACKAGES=$(find "$(uv tool dir)/harbor/lib" -path '*/site-packages' -type d | head -1)
+PYTHONPATH="${HARBOR_SITE_PACKAGES}:tools/harbor:." python -m unittest tools.harbor.test_rara_agent
 python -m py_compile tools/harbor/rara_agent.py tools/harbor/test_rara_agent.py
 ```
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -46,10 +46,11 @@ Active backlog only. Keep this file small and current.
 
 ## Benchmark / Evaluation
 
-- [ ] Add Harbor-compatible Terminal-Bench integration. Build the Harbor
-      installed-agent adapter on top of `rara exec --json`, run inside the
-      benchmark task workspace, and write ATIF-compatible trajectory logs. See
-      `docs/features/terminal-bench-evaluation.md`.
+- [x] Add a dynamic Harbor adapter that loads with
+      `--agent rara_agent:RaraAgent` and invokes `rara exec --json` inside the
+      benchmark task workspace.
+- [ ] Convert RARA JSONL events into full ATIF-compatible trajectory logs for
+      Harbor result artifacts. See `docs/features/terminal-bench-evaluation.md`.
 
 ## Agent / Subagent
 

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -1,0 +1,169 @@
+"""Harbor adapter for running RARA through ``rara exec``.
+
+Load dynamically with:
+
+    PYTHONPATH=$PWD/tools/harbor harbor run -d terminal-bench/terminal-bench-2 \
+      --agent rara_agent:RaraAgent \
+      --agent-kwarg binary_path=$PWD/target/release/rara
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+from harbor.models.trial.paths import EnvironmentPaths
+
+
+DEFAULT_REMOTE_BINARY = PurePosixPath("/installed-agent/rara")
+DEFAULT_RARA_HOME = PurePosixPath("/logs/agent/rara-home")
+DEFAULT_JSONL_PATH = EnvironmentPaths.agent_dir / "rara-exec.jsonl"
+DEFAULT_INSTRUCTION_PATH = EnvironmentPaths.agent_dir / "instruction.txt"
+DEFAULT_LAST_MESSAGE_PATH = EnvironmentPaths.agent_dir / "last-message.txt"
+
+
+class RaraAgent(BaseInstalledAgent):
+    """Run RARA as a Harbor installed agent using the headless exec surface."""
+
+    SUPPORTS_ATIF = False
+    SUPPORTS_WINDOWS = False
+
+    def __init__(
+        self,
+        *args: Any,
+        binary_path: str | None = None,
+        remote_binary: str | None = None,
+        cwd: str = ".",
+        rara_home: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.binary_path = Path(
+            binary_path or os.environ.get("RARA_HARBOR_BINARY", "target/release/rara")
+        ).expanduser()
+        self.remote_binary = PurePosixPath(remote_binary or DEFAULT_REMOTE_BINARY)
+        self.cwd = cwd
+        self.rara_home = PurePosixPath(rara_home or DEFAULT_RARA_HOME)
+
+    @staticmethod
+    def name() -> str:
+        return "rara"
+
+    def version(self) -> str | None:
+        return self._version
+
+    def get_version_command(self) -> str | None:
+        return f"{shlex.quote(self.remote_binary.as_posix())} --version"
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        if not self.binary_path.is_file():
+            raise FileNotFoundError(
+                "RARA binary not found. Build it first or pass "
+                f"--agent-kwarg binary_path=/path/to/rara. Looked at: {self.binary_path}"
+            )
+
+        await environment.upload_file(
+            self.binary_path,
+            self.remote_binary.as_posix(),
+        )
+        await self.exec_as_root(
+            environment,
+            command=f"chmod 0755 {shlex.quote(self.remote_binary.as_posix())}",
+        )
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        instruction_path = self.logs_dir / "instruction.txt"
+        instruction_path.parent.mkdir(parents=True, exist_ok=True)
+        instruction_path.write_text(instruction)
+        await environment.upload_file(
+            instruction_path,
+            DEFAULT_INSTRUCTION_PATH.as_posix(),
+        )
+
+        env = {**self.extra_env, "RARA_HOME": self.rara_home.as_posix()}
+        command = self._build_exec_command()
+        result = await environment.exec(command=command, cwd=self.cwd, env=env)
+
+        stdout = result.stdout or ""
+        events = parse_rara_jsonl(stdout)
+        self._populate_context(context, events)
+        if result.return_code != 0:
+            raise self._classify_exec_error(command, result)
+
+    def _build_exec_command(self) -> str:
+        binary = shlex.quote(self.remote_binary.as_posix())
+        jsonl_path = shlex.quote(DEFAULT_JSONL_PATH.as_posix())
+        instruction_path = shlex.quote(DEFAULT_INSTRUCTION_PATH.as_posix())
+        last_message_path = shlex.quote(DEFAULT_LAST_MESSAGE_PATH.as_posix())
+        run_id = shlex.quote(self.context_id.hex if self.context_id else "harbor")
+        task_id = shlex.quote(self.session_id or "harbor-task")
+        return (
+            f"mkdir -p {shlex.quote(EnvironmentPaths.agent_dir.as_posix())} "
+            f"{shlex.quote(self.rara_home.as_posix())}\n"
+            f"{binary} exec --json --run-id {run_id} --task-id {task_id} "
+            f"--output-last-message {last_message_path} - "
+            f"< {instruction_path} 2>&1 | tee {jsonl_path}"
+        )
+
+    @staticmethod
+    def _populate_context(context: AgentContext, events: list[dict[str, Any]]) -> None:
+        final_message: str | None = None
+        failure: str | None = None
+        input_tokens = 0
+        output_tokens = 0
+        event_counts: dict[str, int] = {}
+
+        for event in events:
+            event_type = event.get("type")
+            if isinstance(event_type, str):
+                event_counts[event_type] = event_counts.get(event_type, 0) + 1
+            if event_type == "turn.completed":
+                usage = event.get("usage") or {}
+                input_tokens = int(usage.get("input_tokens") or input_tokens)
+                output_tokens = int(usage.get("output_tokens") or output_tokens)
+                if isinstance(event.get("final_message"), str):
+                    final_message = event["final_message"]
+            elif event_type == "turn.failed":
+                error = event.get("error") or {}
+                if isinstance(error.get("message"), str):
+                    failure = error["message"]
+
+        context.n_input_tokens = input_tokens
+        context.n_output_tokens = output_tokens
+        context.metadata = {
+            "adapter": "rara-harbor",
+            "event_count": len(events),
+            "event_counts": event_counts,
+            "final_message": final_message,
+            "failure": failure,
+            "jsonl_path": DEFAULT_JSONL_PATH.as_posix(),
+            "last_message_path": DEFAULT_LAST_MESSAGE_PATH.as_posix(),
+        }
+
+
+def parse_rara_jsonl(output: str) -> list[dict[str, Any]]:
+    """Extract RARA JSONL events from mixed stdout/stderr output."""
+    events: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and isinstance(payload.get("type"), str):
+            events.append(payload)
+    return events

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -46,7 +46,7 @@ class RaraAgent(BaseInstalledAgent):
         super().__init__(*args, **kwargs)
         self.binary_path = Path(
             binary_path or os.environ.get("RARA_HARBOR_BINARY", "target/release/rara")
-        ).expanduser()
+        ).expanduser().resolve()
         self.remote_binary = PurePosixPath(remote_binary or DEFAULT_REMOTE_BINARY)
         self.cwd = cwd
         self.rara_home = PurePosixPath(rara_home or DEFAULT_RARA_HOME)
@@ -86,7 +86,7 @@ class RaraAgent(BaseInstalledAgent):
     ) -> None:
         instruction_path = self.logs_dir / "instruction.txt"
         instruction_path.parent.mkdir(parents=True, exist_ok=True)
-        instruction_path.write_text(instruction)
+        instruction_path.write_text(instruction, encoding="utf-8")
         await environment.upload_file(
             instruction_path,
             DEFAULT_INSTRUCTION_PATH.as_posix(),
@@ -111,10 +111,10 @@ class RaraAgent(BaseInstalledAgent):
         task_id = shlex.quote(self.session_id or "harbor-task")
         return (
             f"mkdir -p {shlex.quote(EnvironmentPaths.agent_dir.as_posix())} "
-            f"{shlex.quote(self.rara_home.as_posix())}\n"
+            f"{shlex.quote(self.rara_home.as_posix())} && "
             f"{binary} exec --json --run-id {run_id} --task-id {task_id} "
             f"--output-last-message {last_message_path} - "
-            f"< {instruction_path} 2>&1 | tee {jsonl_path}"
+            f"< {instruction_path} | tee {jsonl_path}"
         )
 
     @staticmethod
@@ -131,8 +131,12 @@ class RaraAgent(BaseInstalledAgent):
                 event_counts[event_type] = event_counts.get(event_type, 0) + 1
             if event_type == "turn.completed":
                 usage = event.get("usage") or {}
-                input_tokens = int(usage.get("input_tokens") or input_tokens)
-                output_tokens = int(usage.get("output_tokens") or output_tokens)
+                u_input = usage.get("input_tokens")
+                if u_input is not None:
+                    input_tokens = int(u_input)
+                u_output = usage.get("output_tokens")
+                if u_output is not None:
+                    output_tokens = int(u_output)
                 if isinstance(event.get("final_message"), str):
                     final_message = event["final_message"]
             elif event_type == "turn.failed":

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -24,6 +24,7 @@ from harbor.models.trial.paths import EnvironmentPaths
 DEFAULT_REMOTE_BINARY = PurePosixPath("/installed-agent/rara")
 DEFAULT_RARA_HOME = PurePosixPath("/logs/agent/rara-home")
 DEFAULT_JSONL_PATH = EnvironmentPaths.agent_dir / "rara-exec.jsonl"
+DEFAULT_EXIT_STATUS_PATH = EnvironmentPaths.agent_dir / "rara-exec.status"
 DEFAULT_INSTRUCTION_PATH = EnvironmentPaths.agent_dir / "instruction.txt"
 DEFAULT_LAST_MESSAGE_PATH = EnvironmentPaths.agent_dir / "last-message.txt"
 
@@ -39,7 +40,7 @@ class RaraAgent(BaseInstalledAgent):
         *args: Any,
         binary_path: str | None = None,
         remote_binary: str | None = None,
-        cwd: str = ".",
+        cwd: str = "/app",
         rara_home: str | None = None,
         **kwargs: Any,
     ) -> None:
@@ -76,6 +77,20 @@ class RaraAgent(BaseInstalledAgent):
             environment,
             command=f"chmod 0755 {shlex.quote(self.remote_binary.as_posix())}",
         )
+        validation = await environment.exec(
+            command=f"{shlex.quote(self.remote_binary.as_posix())} --version",
+            user="root",
+            timeout_sec=30,
+        )
+        if validation.return_code != 0:
+            output = validation.stderr or validation.stdout or "no output"
+            raise RuntimeError(
+                "Uploaded RARA binary cannot run inside the Harbor environment. "
+                "For Docker-backed Terminal-Bench runs, pass a Linux binary via "
+                "--agent-kwarg binary_path=/path/to/linux/rara. "
+                f"Host binary: {self.binary_path}. "
+                f"Remote error: {output.strip()}"
+            )
 
     @with_prompt_template
     async def run(
@@ -105,16 +120,22 @@ class RaraAgent(BaseInstalledAgent):
     def _build_exec_command(self) -> str:
         binary = shlex.quote(self.remote_binary.as_posix())
         jsonl_path = shlex.quote(DEFAULT_JSONL_PATH.as_posix())
+        status_path = shlex.quote(DEFAULT_EXIT_STATUS_PATH.as_posix())
         instruction_path = shlex.quote(DEFAULT_INSTRUCTION_PATH.as_posix())
         last_message_path = shlex.quote(DEFAULT_LAST_MESSAGE_PATH.as_posix())
         run_id = shlex.quote(self.context_id.hex if self.context_id else "harbor")
         task_id = shlex.quote(self.session_id or "harbor-task")
         return (
             f"mkdir -p {shlex.quote(EnvironmentPaths.agent_dir.as_posix())} "
-            f"{shlex.quote(self.rara_home.as_posix())} && "
+            f"{shlex.quote(self.rara_home.as_posix())} || exit $?; "
+            "{ "
             f"{binary} exec --json --run-id {run_id} --task-id {task_id} "
             f"--output-last-message {last_message_path} - "
-            f"< {instruction_path} | tee {jsonl_path}"
+            f"< {instruction_path}; "
+            f"printf '%s\\n' \"$?\" > {status_path}; "
+            f"}} | tee {jsonl_path}; "
+            f"status=$(cat {status_path} 2>/dev/null || printf '1'); "
+            'exit "$status"'
         )
 
     @staticmethod

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tempfile
 import unittest
 from pathlib import Path
 from uuid import UUID
@@ -22,7 +23,9 @@ class RaraAgentTests(unittest.TestCase):
 
         events = parse_rara_jsonl(output)
 
-        self.assertEqual([event["type"] for event in events], ["thread.started", "turn.completed"])
+        self.assertEqual(
+            [event["type"] for event in events], ["thread.started", "turn.completed"]
+        )
 
     def test_populate_context_reads_usage_and_final_message(self) -> None:
         context = AgentContext()
@@ -42,6 +45,22 @@ class RaraAgentTests(unittest.TestCase):
         self.assertEqual(context.metadata["final_message"], "done")
         self.assertEqual(context.metadata["event_counts"]["turn.completed"], 1)
 
+    def test_populate_context_preserves_zero_token_counts(self) -> None:
+        context = AgentContext()
+        context.n_input_tokens = 9
+        context.n_output_tokens = 9
+        events = [
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            },
+        ]
+
+        RaraAgent._populate_context(context, events)
+
+        self.assertEqual(context.n_input_tokens, 0)
+        self.assertEqual(context.n_output_tokens, 0)
+
     def test_build_exec_command_uses_context_and_session_ids(self) -> None:
         agent = RaraAgent(
             logs_dir=Path("/tmp/logs"),
@@ -59,7 +78,19 @@ class RaraAgentTests(unittest.TestCase):
         self.assertIn("--task-id trial-agent", command)
         self.assertIn("--output-last-message /logs/agent/last-message.txt", command)
         self.assertIn("< /logs/agent/instruction.txt", command)
+        self.assertIn(" && /opt/rara exec --json", command)
+        self.assertNotIn("2>&1", command)
         self.assertIn("| tee /logs/agent/rara-exec.jsonl", command)
+
+    def test_binary_path_is_resolved(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            binary_path = Path(temp) / "rara"
+            binary_path.touch()
+            relative_path = binary_path.relative_to(Path.cwd())
+
+            agent = RaraAgent(logs_dir=Path("/tmp/logs"), binary_path=str(relative_path))
+
+        self.assertTrue(agent.binary_path.is_absolute())
 
 
 if __name__ == "__main__":

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from uuid import UUID
+
+from harbor.models.agent.context import AgentContext
+
+from rara_agent import RaraAgent, parse_rara_jsonl
+
+
+class RaraAgentTests(unittest.TestCase):
+    def test_parse_rara_jsonl_ignores_non_json_lines(self) -> None:
+        output = "\n".join(
+            [
+                "warning: setup detail",
+                '{"type":"thread.started","metadata":{"session_id":"s"},"timestamp":"t"}',
+                "not json",
+                '{"type":"turn.completed","usage":{"input_tokens":3,"output_tokens":2},"final_message":"done","timestamp":"t"}',
+            ]
+        )
+
+        events = parse_rara_jsonl(output)
+
+        self.assertEqual([event["type"] for event in events], ["thread.started", "turn.completed"])
+
+    def test_populate_context_reads_usage_and_final_message(self) -> None:
+        context = AgentContext()
+        events = [
+            {"type": "thread.started"},
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 13, "output_tokens": 7},
+                "final_message": "done",
+            },
+        ]
+
+        RaraAgent._populate_context(context, events)
+
+        self.assertEqual(context.n_input_tokens, 13)
+        self.assertEqual(context.n_output_tokens, 7)
+        self.assertEqual(context.metadata["final_message"], "done")
+        self.assertEqual(context.metadata["event_counts"]["turn.completed"], 1)
+
+    def test_build_exec_command_uses_context_and_session_ids(self) -> None:
+        agent = RaraAgent(
+            logs_dir=Path("/tmp/logs"),
+            binary_path="/tmp/rara",
+            remote_binary="/opt/rara",
+            rara_home="/tmp/rara-home",
+        )
+        agent.context_id = UUID("00000000-0000-0000-0000-000000000123")
+        agent.session_id = "trial-agent"
+
+        command = agent._build_exec_command()
+
+        self.assertIn("/opt/rara exec --json", command)
+        self.assertIn("--run-id 00000000000000000000000000000123", command)
+        self.assertIn("--task-id trial-agent", command)
+        self.assertIn("--output-last-message /logs/agent/last-message.txt", command)
+        self.assertIn("< /logs/agent/instruction.txt", command)
+        self.assertIn("| tee /logs/agent/rara-exec.jsonl", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import tempfile
 import unittest
 from pathlib import Path
@@ -8,6 +9,33 @@ from uuid import UUID
 from harbor.models.agent.context import AgentContext
 
 from rara_agent import RaraAgent, parse_rara_jsonl
+
+
+class FakeExecResult:
+    def __init__(
+        self, return_code: int, stdout: str | None = "", stderr: str | None = ""
+    ) -> None:
+        self.return_code = return_code
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class FakeInstallEnvironment:
+    def __init__(self) -> None:
+        self.uploads: list[tuple[Path, str]] = []
+        self.commands: list[str] = []
+
+    async def upload_file(self, source: Path, destination: str) -> None:
+        self.uploads.append((source, destination))
+
+    async def exec(self, command: str, **_: object) -> FakeExecResult:
+        self.commands.append(command)
+        if command.endswith("--version"):
+            return FakeExecResult(
+                126,
+                stdout="cannot execute binary file: Exec format error",
+            )
+        return FakeExecResult(0)
 
 
 class RaraAgentTests(unittest.TestCase):
@@ -78,9 +106,17 @@ class RaraAgentTests(unittest.TestCase):
         self.assertIn("--task-id trial-agent", command)
         self.assertIn("--output-last-message /logs/agent/last-message.txt", command)
         self.assertIn("< /logs/agent/instruction.txt", command)
-        self.assertIn(" && /opt/rara exec --json", command)
+        self.assertIn("{ /opt/rara exec --json", command)
+        self.assertIn("printf '%s\\n' \"$?\" > /logs/agent/rara-exec.status", command)
+        self.assertIn("status=$(cat /logs/agent/rara-exec.status", command)
+        self.assertIn('exit "$status"', command)
         self.assertNotIn("2>&1", command)
         self.assertIn("| tee /logs/agent/rara-exec.jsonl", command)
+
+    def test_default_cwd_matches_terminal_bench_workdir(self) -> None:
+        agent = RaraAgent(logs_dir=Path("/tmp/logs"), binary_path="/tmp/rara")
+
+        self.assertEqual(agent.cwd, "/app")
 
     def test_binary_path_is_resolved(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
@@ -91,6 +127,18 @@ class RaraAgentTests(unittest.TestCase):
             agent = RaraAgent(logs_dir=Path("/tmp/logs"), binary_path=str(relative_path))
 
         self.assertTrue(agent.binary_path.is_absolute())
+
+    def test_install_reports_remote_binary_validation_failure(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            binary_path = Path(temp) / "rara"
+            binary_path.touch()
+            agent = RaraAgent(logs_dir=Path("/tmp/logs"), binary_path=str(binary_path))
+            environment = FakeInstallEnvironment()
+
+            with self.assertRaisesRegex(RuntimeError, "Linux binary"):
+                asyncio.run(agent.install(environment))  # type: ignore[arg-type]
+
+        self.assertIn("/installed-agent/rara --version", environment.commands)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add a repo-local Harbor dynamic import adapter at `tools/harbor/rara_agent.py`.
- Run RARA through `rara exec --json` inside Harbor task containers and populate Harbor `AgentContext` metadata.
- Document the dynamic adapter command and split the remaining ATIF trajectory conversion follow-up.

## Motivation

Harbor does not treat `--agent ./target/release/rara` as an executable path. It expects an installed agent name, an ACP registry shorthand, or a Python import path. This PR adds the import-path adapter so RARA can be loaded without patching Harbor.

## Usage

```bash
cargo build --release
PYTHONPATH=$PWD/tools/harbor harbor run -d terminal-bench/terminal-bench-2 \
  --agent rara_agent:RaraAgent \
  --agent-kwarg binary_path=$PWD/target/release/rara
```

## Related Issues

None.

## Testing

```bash
PYTHONPATH=/Users/hawkingrei/.local/share/uv/tools/harbor/lib/python3.13/site-packages:tools/harbor:. \
  python -m unittest tools.harbor.test_rara_agent
python -m py_compile tools/harbor/rara_agent.py tools/harbor/test_rara_agent.py
git diff --check
```
