### PR TITLE
fix(tools): disable local embeddings for Harbor

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -22,9 +22,10 @@ pub use self::mcp::{
 };
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{
-    ConfigManager, ContextFileSearchPolicy, OpenAiEndpointKind, OpenAiEndpointProfile,
-    ProviderConfigState, RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig, TuiThemeConfig,
-    ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for, workspace_data_dir_for_home,
+    ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy, OpenAiEndpointKind,
+    OpenAiEndpointProfile, ProviderConfigState, RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig,
+    TuiThemeConfig, ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for,
+    workspace_data_dir_for_home,
 };
 pub use self::provider_surface::{
     ConfigValueSource, EffectiveProviderSurface, ResolvedProviderValue,

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -91,8 +91,8 @@ impl ContextFileSearchPolicy {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum LocalEmbeddingPolicy {
-    #[default]
     Off,
+    #[default]
     Auto,
 }
 
@@ -356,6 +356,14 @@ impl RaraConfig {
     where
         F: FnMut(&str) -> Option<String>,
     {
+        if let Some(value) = read_env("RARA_LOCAL_EMBEDDINGS") {
+            self.local_embeddings = match value.trim().to_ascii_lowercase().as_str() {
+                "off" | "false" | "0" | "no" => LocalEmbeddingPolicy::Off,
+                "auto" | "on" | "true" | "1" | "yes" => LocalEmbeddingPolicy::Auto,
+                _ => self.local_embeddings,
+            };
+        }
+
         if self.has_api_key()
             || self.effective_openai_endpoint_kind() != Some(OpenAiEndpointKind::Kimi)
         {
@@ -1178,26 +1186,38 @@ mod tests {
     }
 
     #[test]
-    fn local_embeddings_default_off_and_omitted() {
+    fn local_embeddings_default_auto_and_omitted() {
         let config = RaraConfig::default();
 
-        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
 
         let json = serde_json::to_string(&config).expect("serialize config");
         assert!(!json.contains("local_embeddings"));
     }
 
     #[test]
-    fn local_embeddings_can_enable_auto_sidecar_policy() {
+    fn local_embeddings_can_disable_sidecar_policy() {
         let config: RaraConfig = serde_json::from_str(
             r#"{
                 "provider": "deepseek",
-                "local_embeddings": "auto"
+                "local_embeddings": "off"
             }"#,
         )
         .expect("deserialize config");
 
-        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
+    }
+
+    #[test]
+    fn local_embeddings_can_be_disabled_by_environment_for_benchmarks() {
+        let mut config = RaraConfig::default();
+
+        config.apply_provider_environment_defaults_from(|key| match key {
+            "RARA_LOCAL_EMBEDDINGS" => Some("off".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
     }
 
     #[test]

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -87,6 +87,21 @@ impl ContextFileSearchPolicy {
     }
 }
 
+/// Controls whether RARA may start the bundled local embedding sidecar.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalEmbeddingPolicy {
+    #[default]
+    Off,
+    Auto,
+}
+
+impl LocalEmbeddingPolicy {
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProviderConfigState {
     #[serde(
@@ -293,6 +308,8 @@ pub struct RaraConfig {
     pub memory_consolidation: MemoryConsolidationConfig,
     #[serde(default, skip_serializing_if = "ContextFileSearchPolicy::is_default")]
     pub context_file_search: ContextFileSearchPolicy,
+    #[serde(default, skip_serializing_if = "LocalEmbeddingPolicy::is_default")]
+    pub local_embeddings: LocalEmbeddingPolicy,
     #[serde(default, skip_serializing_if = "TuiConfig::is_default")]
     pub tui: TuiConfig,
 }
@@ -1062,8 +1079,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        ConfigManager, ContextFileSearchPolicy, OpenAiEndpointKind, OpenAiEndpointProfile,
-        ProviderConfigState, RaraConfig, workspace_data_dir_for_home,
+        ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy, OpenAiEndpointKind,
+        OpenAiEndpointProfile, ProviderConfigState, RaraConfig, workspace_data_dir_for_home,
     };
     use crate::defaults::{
         DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL,
@@ -1158,6 +1175,29 @@ mod tests {
         .expect("deserialize config");
 
         assert_eq!(config.context_file_search, ContextFileSearchPolicy::Off);
+    }
+
+    #[test]
+    fn local_embeddings_default_off_and_omitted() {
+        let config = RaraConfig::default();
+
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
+
+        let json = serde_json::to_string(&config).expect("serialize config");
+        assert!(!json.contains("local_embeddings"));
+    }
+
+    #[test]
+    fn local_embeddings_can_enable_auto_sidecar_policy() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "deepseek",
+                "local_embeddings": "auto"
+            }"#,
+        )
+        .expect("deserialize config");
+
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
     }
 
     #[test]

--- a/docs/features/local-embedding-runtimes.md
+++ b/docs/features/local-embedding-runtimes.md
@@ -144,20 +144,24 @@ warning for hard failures.
 
 ### Configuration Policy
 
-Local embeddings are opt-in. The default config keeps the bundled sidecar off
-and routes embedding calls through the current `LlmBackend` implementation.
-This avoids unexpected Python environment setup, model downloads, or sidecar
-startup in ordinary CLI, TUI, ACP, and benchmark runs.
+Local embeddings default to `auto` so ordinary CLI, TUI, ACP, and memory
+workflows keep the provider-aware sidecar behavior. This preserves the normal
+local-first memory path.
 
-Users can enable sidecar routing with:
+Benchmark adapters can disable sidecar routing for faster startup by setting:
 
-```json
-{"local_embeddings":"auto"}
+```text
+RARA_LOCAL_EMBEDDINGS=off
 ```
 
 `auto` preserves the provider-aware routing policy: providers with a usable
 embedding surface can keep using the current backend, while local or
 embedding-limited chat providers may use the bundled local model server.
+
+`off` always routes embedding calls through the current `LlmBackend`
+implementation. The Harbor Terminal-Bench adapter uses this mode so benchmark
+runs do not create a Python environment, download embedding models, or start
+the local model server before solving the task.
 
 ### Startup Bootstrap And Reuse
 

--- a/docs/features/local-embedding-runtimes.md
+++ b/docs/features/local-embedding-runtimes.md
@@ -142,6 +142,23 @@ If the sidecar is not ready or startup reports an error, RARA falls back to the
 configured provider's existing embedding implementation and surfaces a bootstrap
 warning for hard failures.
 
+### Configuration Policy
+
+Local embeddings are opt-in. The default config keeps the bundled sidecar off
+and routes embedding calls through the current `LlmBackend` implementation.
+This avoids unexpected Python environment setup, model downloads, or sidecar
+startup in ordinary CLI, TUI, ACP, and benchmark runs.
+
+Users can enable sidecar routing with:
+
+```json
+{"local_embeddings":"auto"}
+```
+
+`auto` preserves the provider-aware routing policy: providers with a usable
+embedding surface can keep using the current backend, while local or
+embedding-limited chat providers may use the bundled local model server.
+
 ### Startup Bootstrap And Reuse
 
 RARA owns the model server lifecycle. A normal `rara` startup should:

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -57,7 +57,9 @@ Recommended components:
   --agent rara_agent:RaraAgent --agent-kwarg
   binary_path=$PWD/target/release/rara`. The adapter defaults to `/app` as the
   benchmark cwd and preserves the `rara exec` exit code while teeing JSONL
-  output into `/logs/agent/rara-exec.jsonl`.
+  output into `/logs/agent/rara-exec.jsonl`. It also sets
+  `RARA_LOCAL_EMBEDDINGS=off` so benchmark startup does not prepare the bundled
+  local embedding sidecar.
 - `rara eval terminal-bench` may be added later as a convenience wrapper, but
   the first integration target is Harbor compatibility.
 - Stable workspace setup contract:

--- a/docs/journal/2026-07-05-harbor-rara-agent-adapter.md
+++ b/docs/journal/2026-07-05-harbor-rara-agent-adapter.md
@@ -19,6 +19,8 @@ The adapter lives at `tools/harbor/rara_agent.py` and exposes
   not treat a failed agent run as a successful zero-reward verifier run.
 - Validates the uploaded binary during agent setup and reports host/container
   architecture mismatches before the task runs.
+- Sets `RARA_LOCAL_EMBEDDINGS=off` for benchmark runs so RARA does not prepare
+  the bundled local embedding sidecar before solving the task.
 - Parses RARA JSONL output into Harbor `AgentContext` usage and metadata.
 - Preserves parsed context metadata even when `rara exec` exits non-zero.
 

--- a/docs/journal/2026-07-06-local-embedding-opt-in.md
+++ b/docs/journal/2026-07-06-local-embedding-opt-in.md
@@ -1,25 +1,29 @@
-# Local Embedding Opt-In Default
+# Benchmark Local Embedding Override
 
 ## Summary
 
-Local embedding sidecar startup is now opt-in. The default config keeps local
-embeddings off and uses the current `LlmBackend` embedding path, avoiding
-unexpected Python setup, model downloads, or model-server startup during normal
-CLI, TUI, ACP, and benchmark runs.
+Local embedding sidecar startup remains enabled by default through the existing
+provider-aware `auto` policy. Terminal-Bench runs disable local embeddings
+through the Harbor adapter environment so benchmark startup does not create a
+Python environment, download embedding models, or start the model server before
+the task begins.
 
 ## Scope
 
-- Added `local_embeddings` config with `off` as the default and `auto` as the
-  explicit sidecar policy.
-- Changed runtime embedding routing so `off` always reuses the current backend.
-- Preserved the existing provider-aware local sidecar routing when
-  `local_embeddings` is set to `auto`.
+- Added `local_embeddings` config with `auto` as the default and `off` as the
+  explicit disable policy.
+- Added `RARA_LOCAL_EMBEDDINGS=off` environment override for benchmark and
+  automation entrypoints.
+- Updated the Harbor adapter to pass `RARA_LOCAL_EMBEDDINGS=off` while keeping
+  ordinary RARA startup behavior unchanged.
 
 ## Validation
 
 ```bash
 cargo test -p rara-config local_embeddings -- --nocapture
 cargo test embedding_route_ -- --nocapture
+HARBOR_SITE_PACKAGES=$(find "$(uv tool dir)/harbor/lib" -path '*/site-packages' -type d | head -1)
+PYTHONPATH="${HARBOR_SITE_PACKAGES}:tools/harbor:." python -m unittest tools.harbor.test_rara_agent
 cargo fmt
 git diff --check
 ```

--- a/docs/journal/2026-07-06-local-embedding-opt-in.md
+++ b/docs/journal/2026-07-06-local-embedding-opt-in.md
@@ -1,0 +1,25 @@
+# Local Embedding Opt-In Default
+
+## Summary
+
+Local embedding sidecar startup is now opt-in. The default config keeps local
+embeddings off and uses the current `LlmBackend` embedding path, avoiding
+unexpected Python setup, model downloads, or model-server startup during normal
+CLI, TUI, ACP, and benchmark runs.
+
+## Scope
+
+- Added `local_embeddings` config with `off` as the default and `auto` as the
+  explicit sidecar policy.
+- Changed runtime embedding routing so `off` always reuses the current backend.
+- Preserved the existing provider-aware local sidecar routing when
+  `local_embeddings` is set to `auto`.
+
+## Validation
+
+```bash
+cargo test -p rara-config local_embeddings -- --nocapture
+cargo test embedding_route_ -- --nocapture
+cargo fmt
+git diff --check
+```

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -685,9 +685,23 @@ mod tests {
     }
 
     #[test]
-    fn embedding_route_disables_local_sidecar_by_default() {
+    fn embedding_route_prefers_local_sidecar_by_default() {
         let deepseek = RaraConfig {
             provider: "deepseek".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            embedding_route_for_config(&deepseek),
+            EmbeddingRoute::LocalModelServer
+        );
+        assert!(config_requires_local_embedding_sidecar(&deepseek));
+    }
+
+    #[test]
+    fn embedding_route_disables_local_sidecar_when_policy_is_off() {
+        let deepseek = RaraConfig {
+            provider: "deepseek".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Off,
             ..Default::default()
         };
         assert_eq!(
@@ -701,7 +715,6 @@ mod tests {
     fn embedding_route_prefers_local_sidecar_when_auto_policy_is_enabled() {
         let deepseek = RaraConfig {
             provider: "deepseek".to_string(),
-            local_embeddings: LocalEmbeddingPolicy::Auto,
             ..Default::default()
         };
         assert_eq!(

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -10,7 +10,8 @@ use self::tooling::{create_full_tool_manager, load_skill_manager, vector_db_uri_
 use crate::agent::Agent;
 use crate::config::{
     DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, DEFAULT_GEMINI_BASE_URL, DEFAULT_GEMINI_MODEL,
-    OpenAiEndpointKind, REASONING_SUMMARY_NONE, RaraConfig, ensure_rara_home_dir,
+    LocalEmbeddingPolicy, OpenAiEndpointKind, REASONING_SUMMARY_NONE, RaraConfig,
+    ensure_rara_home_dir,
 };
 use crate::embedding::EmbeddingOverrideBackend;
 use crate::google_oauth::GoogleOAuthManager;
@@ -267,6 +268,9 @@ enum EmbeddingRoute {
 }
 
 fn embedding_route_for_config(config: &RaraConfig) -> EmbeddingRoute {
+    if config.local_embeddings == LocalEmbeddingPolicy::Off {
+        return EmbeddingRoute::CurrentLlmBackend;
+    }
     match config.provider.as_str() {
         "codex" | "mock" => EmbeddingRoute::CurrentLlmBackend,
         provider if RaraConfig::is_openai_compatible_family(provider) => {
@@ -536,10 +540,13 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        EmbeddingRoute, build_backend_with_progress, embedding_route_for_config,
-        initialize_rara_context, ollama_thinking_enabled, vector_db_uri_for_workspace,
+        EmbeddingRoute, build_backend_with_progress, config_requires_local_embedding_sidecar,
+        embedding_route_for_config, initialize_rara_context, ollama_thinking_enabled,
+        vector_db_uri_for_workspace,
     };
-    use crate::config::{DEFAULT_REASONING_SUMMARY, REASONING_SUMMARY_NONE, RaraConfig};
+    use crate::config::{
+        DEFAULT_REASONING_SUMMARY, LocalEmbeddingPolicy, REASONING_SUMMARY_NONE, RaraConfig,
+    };
     use crate::workspace::WorkspaceMemory;
 
     #[test]
@@ -678,9 +685,23 @@ mod tests {
     }
 
     #[test]
-    fn embedding_route_prefers_local_sidecar_for_unsupported_or_local_chat_providers() {
+    fn embedding_route_disables_local_sidecar_by_default() {
         let deepseek = RaraConfig {
             provider: "deepseek".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            embedding_route_for_config(&deepseek),
+            EmbeddingRoute::CurrentLlmBackend
+        );
+        assert!(!config_requires_local_embedding_sidecar(&deepseek));
+    }
+
+    #[test]
+    fn embedding_route_prefers_local_sidecar_when_auto_policy_is_enabled() {
+        let deepseek = RaraConfig {
+            provider: "deepseek".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Auto,
             ..Default::default()
         };
         assert_eq!(
@@ -690,6 +711,7 @@ mod tests {
 
         let local = RaraConfig {
             provider: "local".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Auto,
             ..Default::default()
         };
         assert_eq!(
@@ -699,6 +721,7 @@ mod tests {
 
         let gemini_code_assist = RaraConfig {
             provider: "gemini-code-assist".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Auto,
             ..Default::default()
         };
         assert_eq!(

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -107,7 +107,11 @@ class RaraAgent(BaseInstalledAgent):
             DEFAULT_INSTRUCTION_PATH.as_posix(),
         )
 
-        env = {**self.extra_env, "RARA_HOME": self.rara_home.as_posix()}
+        env = {
+            **self.extra_env,
+            "RARA_HOME": self.rara_home.as_posix(),
+            "RARA_LOCAL_EMBEDDINGS": "off",
+        }
         command = self._build_exec_command()
         result = await environment.exec(command=command, cwd=self.cwd, env=env)
 

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -38,6 +38,27 @@ class FakeInstallEnvironment:
         return FakeExecResult(0)
 
 
+class FakeRunEnvironment:
+    def __init__(self) -> None:
+        self.uploads: list[tuple[Path, str]] = []
+        self.exec_env: dict[str, str] | None = None
+
+    async def upload_file(self, source: Path, destination: str) -> None:
+        self.uploads.append((source, destination))
+
+    async def exec(
+        self,
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> FakeExecResult:
+        self.exec_env = dict(env or {})
+        return FakeExecResult(
+            0,
+            stdout='{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1},"final_message":"done"}\n',
+        )
+
+
 class RaraAgentTests(unittest.TestCase):
     def test_parse_rara_jsonl_ignores_non_json_lines(self) -> None:
         output = "\n".join(
@@ -117,6 +138,17 @@ class RaraAgentTests(unittest.TestCase):
         agent = RaraAgent(logs_dir=Path("/tmp/logs"), binary_path="/tmp/rara")
 
         self.assertEqual(agent.cwd, "/app")
+
+    def test_run_disables_local_embeddings_for_benchmark(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            context = AgentContext()
+            environment = FakeRunEnvironment()
+
+            asyncio.run(agent.run("solve task", environment, context))  # type: ignore[arg-type]
+
+        self.assertEqual(environment.exec_env["RARA_LOCAL_EMBEDDINGS"], "off")
+        self.assertEqual(environment.exec_env["RARA_HOME"], "/logs/agent/rara-home")
 
     def test_binary_path_is_resolved(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:


### PR DESCRIPTION
## Summary

- keep local embeddings enabled by default with the existing `auto` policy
- add `RARA_LOCAL_EMBEDDINGS=off` for benchmark/automation overrides
- make the Harbor Terminal-Bench adapter pass that override so benchmark startup skips the local embedding sidecar

## Motivation

Terminal-Bench/Harbor runs should not pay Python environment setup, embedding
model download, or sidecar startup costs before solving a task. Ordinary RARA
usage should keep the default local-first memory behavior.

## Related Issue

None.

## Testing

- `cargo test -p rara-config local_embeddings -- --nocapture`
- `cargo test embedding_route_ -- --nocapture`
- `PYTHONPATH="${HARBOR_SITE_PACKAGES}:tools/harbor:." python -m unittest tools.harbor.test_rara_agent`
- `cargo fmt`
- `git diff --check`

