### PR TITLE
fix(ci): attach release assets and deb packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
            local memory, and pluggable LLM backends.
           EOF
           sed -i 's/^          //' "${package_root}/DEBIAN/control"
-          dpkg-deb --build --root-owner-group "${package_root}" "dist/rara-${VERSION}-${TARGET}.deb"
+          dpkg-deb --build --root-owner-group "${package_root}" "dist/rara_${VERSION}_${deb_arch}.deb"
 
       - name: Package windows archive
         if: ${{ runner.os == 'Windows' }}
@@ -295,7 +295,7 @@ jobs:
           name: rara-${{ matrix.target }}
           path: |
             dist/rara-${{ needs.tag-check.outputs.version }}-${{ matrix.target }}.${{ matrix.archive }}
-            dist/rara-${{ needs.tag-check.outputs.version }}-${{ matrix.target }}.deb
+            dist/*.deb
           if-no-files-found: error
 
   release:
@@ -338,7 +338,7 @@ jobs:
 
           (
             cd dist/release
-            shasum -a 256 rara-"${VERSION}"-* > checksums.txt
+            shasum -a 256 * > checksums.txt
             while read -r checksum filename; do
               printf "%s  %s\n" "${checksum}" "${filename}" > "${filename}.sha256"
             done < checksums.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,45 @@ jobs:
           chmod +x "${dist_dir}/rara"
           tar -C "${dist_dir}" -czf "dist/rara-${VERSION}-${TARGET}.tar.gz" rara
 
+      - name: Package Debian package
+        if: ${{ runner.os == 'Linux' && contains(matrix.target, 'linux-musl') }}
+        shell: bash
+        env:
+          VERSION: ${{ needs.tag-check.outputs.version }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+
+          case "${TARGET}" in
+            x86_64-unknown-linux-musl)
+              deb_arch="amd64"
+              ;;
+            aarch64-unknown-linux-musl)
+              deb_arch="arm64"
+              ;;
+            *)
+              echo "Unsupported Debian package target: ${TARGET}" >&2
+              exit 1
+              ;;
+          esac
+
+          package_root="dist/deb/${TARGET}"
+          install -Dm755 "target/${TARGET}/release/rara" "${package_root}/usr/bin/rara"
+          mkdir -p "${package_root}/DEBIAN"
+          cat > "${package_root}/DEBIAN/control" <<EOF
+          Package: rara
+          Version: ${VERSION}
+          Architecture: ${deb_arch}
+          Maintainer: linkerdog <noreply@linkerdog.com>
+          Section: utils
+          Priority: optional
+          Description: Local-first coding agent runtime
+           RARA is a local-first coding agent runtime with terminal chat, tools,
+           local memory, and pluggable LLM backends.
+          EOF
+          sed -i 's/^          //' "${package_root}/DEBIAN/control"
+          dpkg-deb --build --root-owner-group "${package_root}" "dist/rara-${VERSION}-${TARGET}.deb"
+
       - name: Package windows archive
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
@@ -254,7 +293,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: rara-${{ matrix.target }}
-          path: dist/rara-${{ needs.tag-check.outputs.version }}-${{ matrix.target }}.${{ matrix.archive }}
+          path: |
+            dist/rara-${{ needs.tag-check.outputs.version }}-${{ matrix.target }}.${{ matrix.archive }}
+            dist/rara-${{ needs.tag-check.outputs.version }}-${{ matrix.target }}.deb
           if-no-files-found: error
 
   release:
@@ -284,13 +325,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist/release
-          find dist/artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -print0 \
+          find dist/artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.deb" \) -print0 \
             | xargs -0 -I{} cp "{}" dist/release/
 
-          expected=6
-          actual="$(find dist/release -type f \( -name "*.tar.gz" -o -name "*.zip" \) | wc -l | tr -d ' ')"
+          expected=8
+          actual="$(find dist/release -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.deb" \) | wc -l | tr -d ' ')"
           [[ "${actual}" == "${expected}" ]] || {
-            echo "Expected ${expected} release archives, found ${actual}." >&2
+            echo "Expected ${expected} release binary assets, found ${actual}." >&2
             find dist/release -maxdepth 1 -type f -print >&2
             exit 1
           }
@@ -302,6 +343,7 @@ jobs:
               printf "%s  %s\n" "${checksum}" "${filename}" > "${filename}.sha256"
             done < checksums.txt
           )
+          find dist/release -maxdepth 1 -type f | sort
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -310,8 +352,32 @@ jobs:
           tag_name: ${{ needs.tag-check.outputs.tag }}
           generate_release_notes: true
           prerelease: ${{ needs.tag-check.outputs.prerelease }}
-          files: |
-            dist/release/rara-${{ needs.tag-check.outputs.version }}-*.tar.gz
-            dist/release/rara-${{ needs.tag-check.outputs.version }}-*.zip
-            dist/release/rara-${{ needs.tag-check.outputs.version }}-*.sha256
-            dist/release/checksums.txt
+
+      - name: Upload GitHub Release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.tag-check.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mapfile -t assets < <(find dist/release -maxdepth 1 -type f | sort)
+          [[ "${#assets[@]}" -gt 0 ]] || {
+            echo "No release assets staged for upload." >&2
+            exit 1
+          }
+          gh release upload "${TAG}" "${assets[@]}" --clobber
+
+      - name: Verify GitHub Release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.tag-check.outputs.tag }}
+        run: |
+          set -euo pipefail
+          expected=17
+          actual="$(gh release view "${TAG}" --json assets --jq '.assets | length')"
+          [[ "${actual}" == "${expected}" ]] || {
+            echo "Expected ${expected} assets on release ${TAG}, found ${actual}." >&2
+            gh release view "${TAG}" --json assets --jq '.assets[].name' >&2
+            exit 1
+          }

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -62,7 +62,7 @@ Each build produces one executable archive:
 
 - Unix: `rara-${VERSION}-${TARGET}.tar.gz`
 - Windows: `rara-${VERSION}-${TARGET}.zip`
-- Debian package for Linux targets: `rara-${VERSION}-${TARGET}.deb`
+- Debian package for Linux targets: `rara_${VERSION}_${DEB_ARCH}.deb`
 
 Each release should also publish checksum files:
 
@@ -77,6 +77,11 @@ Archives contain only the executable at the archive root:
 Debian packages install the executable to:
 
 - `/usr/bin/rara`
+
+Debian package architecture names follow Debian conventions:
+
+- `amd64` for `x86_64-unknown-linux-musl`
+- `arm64` for `aarch64-unknown-linux-musl`
 
 ## GitHub Release Contract
 

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -48,8 +48,8 @@ Initial release targets:
 | --- | --- | --- |
 | `aarch64-apple-darwin` | `macos-14` | `.tar.gz` |
 | `x86_64-apple-darwin` | `macos-13` | `.tar.gz` |
-| `x86_64-unknown-linux-musl` | `ubuntu-latest` | `.tar.gz` |
-| `aarch64-unknown-linux-musl` | `ubuntu-latest` with `cross` | `.tar.gz` |
+| `x86_64-unknown-linux-musl` | `ubuntu-latest` | `.tar.gz`, `.deb` |
+| `aarch64-unknown-linux-musl` | `ubuntu-latest` with `cross` | `.tar.gz`, `.deb` |
 | `x86_64-pc-windows-msvc` | `windows-latest` | `.zip` |
 | `aarch64-pc-windows-msvc` | `windows-latest` | `.zip` |
 
@@ -62,6 +62,7 @@ Each build produces one executable archive:
 
 - Unix: `rara-${VERSION}-${TARGET}.tar.gz`
 - Windows: `rara-${VERSION}-${TARGET}.zip`
+- Debian package for Linux targets: `rara-${VERSION}-${TARGET}.deb`
 
 Each release should also publish checksum files:
 
@@ -72,6 +73,10 @@ Archives contain only the executable at the archive root:
 
 - `rara`
 - `rara.exe`
+
+Debian packages install the executable to:
+
+- `/usr/bin/rara`
 
 ## GitHub Release Contract
 
@@ -110,9 +115,11 @@ depend on a runner-provided `sqlite3.lib`.
 - pinned Rust toolchain discovery from `rust-toolchain.toml`;
 - target matrix release builds;
 - deterministic binary archives;
+- Debian packages for Linux `amd64` and `arm64` targets;
 - runnable archive smoke tests on native runner/target pairs;
 - checksum generation;
-- GitHub Release asset publishing.
+- GitHub Release creation through the release action, followed by explicit
+  `gh release upload --clobber` asset publishing and verification.
 
 It intentionally does not publish Homebrew or npm packages yet.
 

--- a/docs/journal/2026-07-06-release-assets-deb.md
+++ b/docs/journal/2026-07-06-release-assets-deb.md
@@ -1,0 +1,23 @@
+# Release Assets And Debian Packages
+
+## Summary
+
+The release workflow now stages Debian packages for Linux targets and performs
+an explicit GitHub Release asset upload after the release is created. This
+prevents a tag release from existing without binary assets attached.
+
+## Scope
+
+- Package `.deb` files for `x86_64-unknown-linux-musl` and
+  `aarch64-unknown-linux-musl`.
+- Include `.deb` files in the release checksum set.
+- Upload staged release files with `gh release upload --clobber` after
+  `softprops/action-gh-release` creates or updates the release.
+- Verify the final GitHub Release asset count.
+
+## Validation
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'
+git diff --check
+```

--- a/docs/journal/2026-07-06-release-assets-deb.md
+++ b/docs/journal/2026-07-06-release-assets-deb.md
@@ -9,7 +9,7 @@ prevents a tag release from existing without binary assets attached.
 ## Scope
 
 - Package `.deb` files for `x86_64-unknown-linux-musl` and
-  `aarch64-unknown-linux-musl`.
+  `aarch64-unknown-linux-musl` using Debian archive names.
 - Include `.deb` files in the release checksum set.
 - Upload staged release files with `gh release upload --clobber` after
   `softprops/action-gh-release` creates or updates the release.

--- a/docs/journal/2026-07-06-release-assets-deb.md
+++ b/docs/journal/2026-07-06-release-assets-deb.md
@@ -2,9 +2,10 @@
 
 ## Summary
 
-The release workflow now stages Debian packages for Linux targets and performs
-an explicit GitHub Release asset upload after the release is created. This
-prevents a tag release from existing without binary assets attached.
+The `.github/workflows/release.yml` release workflow now stages Debian packages
+for Linux targets and performs an explicit GitHub Release asset upload after the
+release is created. This prevents a tag release from existing without binary
+assets attached.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

- add Debian package generation for Linux release targets
- stage `.deb` files alongside release archives and checksums
- create the GitHub Release first, then upload all staged assets with `gh release upload --clobber`
- verify the final release asset count so tag releases cannot silently miss binaries

## Purpose

The current release workflow can create a GitHub Release without attached binary assets. This makes the asset upload explicit and adds Debian packages for Linux `amd64` and `arm64` consumers.

## Related Issue

None.

## Testing

- `cargo fmt`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'`
- `git diff --check`
