### PR TITLE
chore: bump release version to 0.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10832,7 +10832,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rara"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -10915,7 +10915,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -10924,7 +10924,7 @@ dependencies = [
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "async-trait",
  "libc",
@@ -10939,7 +10939,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -10963,7 +10963,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -10971,7 +10971,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "ignore",
@@ -10982,7 +10982,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -10992,7 +10992,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "rmcp 2.1.0",
@@ -11002,7 +11002,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -11020,14 +11020,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "fs2",
@@ -11042,7 +11042,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "serde",
  "serde_json",
@@ -11052,7 +11052,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11065,7 +11065,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11076,7 +11076,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -11085,7 +11085,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11098,11 +11098,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.1"
+version = "0.0.3"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11111,7 +11111,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.1"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ rara-instructions = { path = "crates/instructions" }
 
 [package]
 name = "rara"
-version = "0.0.3"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 rara-persistence = { path = "crates/rara-persistence" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.3"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -47,7 +47,7 @@ rara-instructions = { path = "crates/instructions" }
 
 [package]
 name = "rara"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2024"
 
 [dependencies]

--- a/crates/rara-plugins/Cargo.toml
+++ b/crates/rara-plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rara-plugins"
-version = "0.0.1"
+version = "0.0.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "Claude Code plugin loader and command hook executor for RARA"

--- a/crates/rara-plugins/Cargo.toml
+++ b/crates/rara-plugins/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rara-plugins"
-version = "0.0.3"
-edition = "2024"
-license = "Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Claude Code plugin loader and command hook executor for RARA"
 
 [dependencies]


### PR DESCRIPTION
## Summary

- bump the RARA workspace and binary package version to `0.0.3`
- sync `Cargo.lock` workspace package versions
- update `rara-plugins` to the same release version

## Purpose

The release workflow validates that the tag version matches the Cargo package version. Publishing `v0.0.3` requires the package metadata to report `0.0.3`.

## Related Issue

None.

## Testing

- `cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])'`
- `cargo fmt`
- `git diff --check origin/main...HEAD`
