### PR TITLE
fix(ci): repair release matrix builds

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,7 +1,6 @@
 name: release-build
 
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -29,10 +28,6 @@ jobs:
         include:
           - runner: macos-14
             target: aarch64-apple-darwin
-            archive: tar.gz
-            smoke: true
-          - runner: macos-13
-            target: x86_64-apple-darwin
             archive: tar.gz
             smoke: true
           - runner: ubuntu-22.04

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,205 @@
+name: release-build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+  VERSION: 0.0.0-ci
+
+jobs:
+  build:
+    name: build-${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            target: aarch64-apple-darwin
+            archive: tar.gz
+            smoke: true
+          - runner: macos-13
+            target: x86_64-apple-darwin
+            archive: tar.gz
+            smoke: true
+          - runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+            smoke: true
+          - runner: ubuntu-22.04
+            target: aarch64-unknown-linux-gnu
+            archive: tar.gz
+            build_with: cross
+            smoke: false
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: zip
+            smoke: true
+          - runner: windows-latest
+            target: aarch64-pc-windows-msvc
+            archive: zip
+            smoke: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Read pinned Rust toolchain
+        id: rust-toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          channel="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/{print $2; exit}' rust-toolchain.toml)"
+          [[ -n "${channel}" ]] || {
+            echo "Failed to read Rust toolchain channel from rust-toolchain.toml." >&2
+            exit 1
+          }
+          echo "channel=${channel}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
+          targets: ${{ matrix.target }}
+
+      - name: Install protoc on Linux
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev pkg-config protobuf-compiler
+
+      - name: Install protoc on macOS
+        if: ${{ runner.os == 'macOS' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew install protobuf
+
+      - name: Install protoc on Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: choco install protoc --no-progress
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Install cross
+        if: ${{ matrix.build_with == 'cross' }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build
+        if: ${{ matrix.build_with != 'cross' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --locked --release --target "${{ matrix.target }}" --bin rara
+
+      - name: Cross build
+        if: ${{ matrix.build_with == 'cross' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cross build --locked --release --target "${{ matrix.target }}" --bin rara
+
+      - name: Package unix archive
+        if: ${{ runner.os != 'Windows' }}
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          dist_dir="dist/${TARGET}"
+          mkdir -p "${dist_dir}"
+          cp "target/${TARGET}/release/rara" "${dist_dir}/rara"
+          chmod +x "${dist_dir}/rara"
+          tar -C "${dist_dir}" -czf "dist/rara-${VERSION}-${TARGET}.tar.gz" rara
+
+      - name: Package Debian package
+        if: ${{ runner.os == 'Linux' && contains(matrix.target, 'unknown-linux') }}
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+
+          case "${TARGET}" in
+            x86_64-unknown-linux-gnu)
+              deb_arch="amd64"
+              ;;
+            aarch64-unknown-linux-gnu)
+              deb_arch="arm64"
+              ;;
+            *)
+              echo "Unsupported Debian package target: ${TARGET}" >&2
+              exit 1
+              ;;
+          esac
+
+          package_root="dist/deb/${TARGET}"
+          install -Dm755 "target/${TARGET}/release/rara" "${package_root}/usr/bin/rara"
+          mkdir -p "${package_root}/DEBIAN"
+          cat > "${package_root}/DEBIAN/control" <<EOF
+          Package: rara
+          Version: ${VERSION}
+          Architecture: ${deb_arch}
+          Maintainer: linkerdog <noreply@linkerdog.com>
+          Section: utils
+          Priority: optional
+          Description: Local-first coding agent runtime
+           RARA is a local-first coding agent runtime with terminal chat, tools,
+           local memory, and pluggable LLM backends.
+          EOF
+          sed -i 's/^          //' "${package_root}/DEBIAN/control"
+          dpkg-deb --build --root-owner-group "${package_root}" "dist/rara_${VERSION}_${deb_arch}.deb"
+
+      - name: Package windows archive
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          $distDir = "dist/$env:TARGET"
+          New-Item -ItemType Directory -Force -Path $distDir | Out-Null
+          Copy-Item "target/$env:TARGET/release/rara.exe" "$distDir/rara.exe"
+          Compress-Archive -Path "$distDir/rara.exe" -DestinationPath "dist/rara-$env:VERSION-$env:TARGET.zip" -Force
+
+      - name: Smoke test unix archive
+        if: ${{ runner.os != 'Windows' && matrix.smoke }}
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          smoke_dir="dist/smoke-${TARGET}"
+          mkdir -p "${smoke_dir}"
+          tar -C "${smoke_dir}" -xzf "dist/rara-${VERSION}-${TARGET}.tar.gz"
+          "${smoke_dir}/rara" --version
+
+      - name: Smoke test windows archive
+        if: ${{ runner.os == 'Windows' && matrix.smoke }}
+        shell: pwsh
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          $smokeDir = "dist/smoke-$env:TARGET"
+          New-Item -ItemType Directory -Force -Path $smokeDir | Out-Null
+          Expand-Archive -Path "dist/rara-$env:VERSION-$env:TARGET.zip" -DestinationPath $smokeDir -Force
+          & "$smokeDir/rara.exe" --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,12 +122,12 @@ jobs:
             target: x86_64-apple-darwin
             archive: tar.gz
             smoke: true
-          - runner: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+          - runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
             archive: tar.gz
             smoke: true
-          - runner: ubuntu-latest
-            target: aarch64-unknown-linux-musl
+          - runner: ubuntu-22.04
+            target: aarch64-unknown-linux-gnu
             archive: tar.gz
             build_with: cross
             smoke: false
@@ -163,21 +163,30 @@ jobs:
           toolchain: ${{ steps.rust-toolchain.outputs.channel }}
           targets: ${{ matrix.target }}
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@v3
+      - name: Install protoc on Linux
+        if: ${{ runner.os == 'Linux' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update -y
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y libssl-dev pkg-config protobuf-compiler
+
+      - name: Install protoc on macOS
+        if: ${{ runner.os == 'macOS' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew install protobuf
+
+      - name: Install protoc on Windows
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: choco install protoc --no-progress
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-
-      - name: Install musl tools
-        if: ${{ runner.os == 'Linux' && contains(matrix.target, 'musl') && matrix.build_with != 'cross' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo apt-get update -y
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y musl-tools
 
       - name: Install cross
         if: ${{ matrix.build_with == 'cross' }}
@@ -214,7 +223,7 @@ jobs:
           tar -C "${dist_dir}" -czf "dist/rara-${VERSION}-${TARGET}.tar.gz" rara
 
       - name: Package Debian package
-        if: ${{ runner.os == 'Linux' && contains(matrix.target, 'linux-musl') }}
+        if: ${{ runner.os == 'Linux' && contains(matrix.target, 'unknown-linux') }}
         shell: bash
         env:
           VERSION: ${{ needs.tag-check.outputs.version }}
@@ -223,10 +232,10 @@ jobs:
           set -euo pipefail
 
           case "${TARGET}" in
-            x86_64-unknown-linux-musl)
+            x86_64-unknown-linux-gnu)
               deb_arch="amd64"
               ;;
-            aarch64-unknown-linux-musl)
+            aarch64-unknown-linux-gnu)
               deb_arch="arm64"
               ;;
             *)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,6 @@ jobs:
             target: aarch64-apple-darwin
             archive: tar.gz
             smoke: true
-          - runner: macos-13
-            target: x86_64-apple-darwin
-            archive: tar.gz
-            smoke: true
           - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             archive: tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9316,6 +9316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9323,6 +9332,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -10863,6 +10873,7 @@ dependencies = [
  "nix 0.31.3",
  "nom 8.0.0",
  "open",
+ "openssl",
  "owo-colors",
  "portable-pty",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,9 @@ ethnum = "1.5.3"
 tempfile = "3.17"
 insta = "1.43"
 
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
+
 [patch.crates-io]
 tokio-tungstenite = { git = "https://github.com/openai-oss-forks/tokio-tungstenite", rev = "132f5b39c862e3a970f731d709608b3e6276d5f6" }
 tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,7 @@
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
-    "apt-get update && apt-get install --assume-yes make perl protobuf-compiler",
+    "apt-get update && apt-get install --assume-yes ca-certificates curl make perl unzip",
+    "curl --fail --location --output /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v25.3/protoc-25.3-linux-x86_64.zip",
+    "unzip -o /tmp/protoc.zip -d /usr/local",
+    "chmod +x /usr/local/bin/protoc",
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "apt-get update && apt-get install --assume-yes make perl protobuf-compiler",
+]

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -48,8 +48,8 @@ Initial release targets:
 | --- | --- | --- |
 | `aarch64-apple-darwin` | `macos-14` | `.tar.gz` |
 | `x86_64-apple-darwin` | `macos-13` | `.tar.gz` |
-| `x86_64-unknown-linux-musl` | `ubuntu-latest` | `.tar.gz`, `.deb` |
-| `aarch64-unknown-linux-musl` | `ubuntu-latest` with `cross` | `.tar.gz`, `.deb` |
+| `x86_64-unknown-linux-gnu` | `ubuntu-22.04` | `.tar.gz`, `.deb` |
+| `aarch64-unknown-linux-gnu` | `ubuntu-22.04` with `cross` | `.tar.gz`, `.deb` |
 | `x86_64-pc-windows-msvc` | `windows-latest` | `.zip` |
 | `aarch64-pc-windows-msvc` | `windows-latest` | `.zip` |
 
@@ -80,8 +80,8 @@ Debian packages install the executable to:
 
 Debian package architecture names follow Debian conventions:
 
-- `amd64` for `x86_64-unknown-linux-musl`
-- `arm64` for `aarch64-unknown-linux-musl`
+- `amd64` for `x86_64-unknown-linux-gnu`
+- `arm64` for `aarch64-unknown-linux-gnu`
 
 ## GitHub Release Contract
 
@@ -103,6 +103,8 @@ jobs should not run unless the release assets exist.
 Pull-request CI includes:
 
 - Linux build, fmt, clippy, and test jobs on `ubuntu-latest`;
+- release matrix build coverage for the archive/package target set without
+  publishing assets;
 
 Post-merge CI additionally includes a Windows build gate on `windows-latest`
 using the pinned Rust toolchain and `cargo build --locked`.
@@ -112,7 +114,12 @@ release workflow still owns Windows archive packaging and native smoke tests.
 SQLite is built through `rusqlite`'s bundled feature so Windows builds do not
 depend on a runner-provided `sqlite3.lib`.
 
-`.github/workflows/release.yml` implements the first release slice:
+`.github/workflows/release-build.yml` validates the release matrix before
+merge. It builds and packages the same platform targets as the release workflow,
+including Linux Debian packages, and runs native archive smoke tests. It does
+not create GitHub Releases or upload release assets.
+
+`.github/workflows/release.yml` implements the tag-driven release slice:
 
 - tag validation for `vX.Y.Z`, `vX.Y.Z-alpha(.N)`, and `vX.Y.Z-beta(.N)`;
 - explicit tag checkout for both tag push and manual dispatch releases;

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -47,7 +47,6 @@ Initial release targets:
 | Target | Runner | Archive |
 | --- | --- | --- |
 | `aarch64-apple-darwin` | `macos-14` | `.tar.gz` |
-| `x86_64-apple-darwin` | `macos-13` | `.tar.gz` |
 | `x86_64-unknown-linux-gnu` | `ubuntu-22.04` | `.tar.gz`, `.deb` |
 | `aarch64-unknown-linux-gnu` | `ubuntu-22.04` with `cross` | `.tar.gz`, `.deb` |
 | `x86_64-pc-windows-msvc` | `windows-latest` | `.zip` |
@@ -102,9 +101,7 @@ jobs should not run unless the release assets exist.
 
 Pull-request CI includes:
 
-- Linux build, fmt, clippy, and test jobs on `ubuntu-latest`;
-- release matrix build coverage for the archive/package target set without
-  publishing assets;
+- Linux build, fmt, clippy, and test jobs on `ubuntu-latest`.
 
 Post-merge CI additionally includes a Windows build gate on `windows-latest`
 using the pinned Rust toolchain and `cargo build --locked`.
@@ -114,10 +111,11 @@ release workflow still owns Windows archive packaging and native smoke tests.
 SQLite is built through `rusqlite`'s bundled feature so Windows builds do not
 depend on a runner-provided `sqlite3.lib`.
 
-`.github/workflows/release-build.yml` validates the release matrix before
-merge. It builds and packages the same platform targets as the release workflow,
-including Linux Debian packages, and runs native archive smoke tests. It does
-not create GitHub Releases or upload release assets.
+`.github/workflows/release-build.yml` validates the release matrix after merge
+on `main`. It builds and packages the same platform targets as the release
+workflow, including Linux Debian packages, and runs native archive smoke tests.
+It does not run on pull requests, create GitHub Releases, or upload release
+assets.
 
 `.github/workflows/release.yml` implements the tag-driven release slice:
 

--- a/docs/journal/2026-07-06-release-assets-deb.md
+++ b/docs/journal/2026-07-06-release-assets-deb.md
@@ -30,13 +30,18 @@ covered before merge:
 The follow-up keeps the published Linux binaries on GNU targets
 (`x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`) built on
 `ubuntu-22.04`, installs `protoc` through runner package managers, uses vendored
-OpenSSL for the aarch64 Linux target, and adds a pull-request `release-build`
-workflow that builds, packages, and smoke-tests the same target matrix without
-publishing release assets. The `aarch64-unknown-linux-gnu` cross image now also
-installs the minimal build tools needed by vendored OpenSSL and a fixed upstream
-`protoc` version for protobuf-backed build scripts. The fixed `protoc` install
-is required because the cross image's Ubuntu xenial package repository provides
-`protoc` 2.6.1, which does not support `--experimental_allow_proto3_optional`.
+OpenSSL for the aarch64 Linux target, and drops `x86_64-apple-darwin` from the
+release matrix because the current release scope does not require `macos-13`.
+The `aarch64-unknown-linux-gnu` cross image now also installs the minimal build
+tools needed by vendored OpenSSL and a fixed upstream `protoc` version for
+protobuf-backed build scripts. The fixed `protoc` install is required because
+the cross image's Ubuntu xenial package repository provides `protoc` 2.6.1,
+which does not support `--experimental_allow_proto3_optional`.
+
+The pull-request `release-build` trigger was removed after the validated targets
+passed so normal pull-request CI does not run release packaging. The
+`release-build` workflow remains as a post-merge `main` check to build, package,
+and smoke-test the release target matrix without publishing assets.
 
 ## Validation
 

--- a/docs/journal/2026-07-06-release-assets-deb.md
+++ b/docs/journal/2026-07-06-release-assets-deb.md
@@ -33,8 +33,10 @@ The follow-up keeps the published Linux binaries on GNU targets
 OpenSSL for the aarch64 Linux target, and adds a pull-request `release-build`
 workflow that builds, packages, and smoke-tests the same target matrix without
 publishing release assets. The `aarch64-unknown-linux-gnu` cross image now also
-installs the minimal build tools needed by vendored OpenSSL and protobuf-backed
-build scripts.
+installs the minimal build tools needed by vendored OpenSSL and a fixed upstream
+`protoc` version for protobuf-backed build scripts. The fixed `protoc` install
+is required because the cross image's Ubuntu xenial package repository provides
+`protoc` 2.6.1, which does not support `--experimental_allow_proto3_optional`.
 
 ## Validation
 

--- a/docs/journal/2026-07-06-release-assets-deb.md
+++ b/docs/journal/2026-07-06-release-assets-deb.md
@@ -9,16 +9,38 @@ assets attached.
 
 ## Scope
 
-- Package `.deb` files for `x86_64-unknown-linux-musl` and
-  `aarch64-unknown-linux-musl` using Debian archive names.
+- Package `.deb` files for Linux release targets using Debian archive names.
 - Include `.deb` files in the release checksum set.
 - Upload staged release files with `gh release upload --clobber` after
   `softprops/action-gh-release` creates or updates the release.
 - Verify the final GitHub Release asset count.
 
+## Release Matrix Follow-up
+
+The first `v0.0.3` release run exposed target-specific failures that were not
+covered before merge:
+
+- macOS failed while installing `protoc` through an unauthenticated setup action
+  that hit the GitHub API rate limit.
+- Linux musl builds failed in `openssl-sys` because the current dependency graph
+  expects target OpenSSL metadata that is not available in the musl runners.
+- Windows builds failed because local model server process handling imported
+  Unix-only `nix` modules.
+
+The follow-up keeps the published Linux binaries on GNU targets
+(`x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`) built on
+`ubuntu-22.04`, installs `protoc` through runner package managers, uses vendored
+OpenSSL for the aarch64 Linux target, and adds a pull-request `release-build`
+workflow that builds, packages, and smoke-tests the same target matrix without
+publishing release assets. The `aarch64-unknown-linux-gnu` cross image now also
+installs the minimal build tools needed by vendored OpenSSL and protobuf-backed
+build scripts.
+
 ## Validation
 
 ```bash
-ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'
+ruby -e 'require "yaml"; [".github/workflows/release.yml", ".github/workflows/release-build.yml"].each { |p| YAML.load_file(p); puts "#{p} ok" }'
+cargo metadata --locked --format-version 1 --filter-platform aarch64-unknown-linux-gnu
+cargo check --locked --bin rara
 git diff --check
 ```

--- a/src/local_model_server/backend.rs
+++ b/src/local_model_server/backend.rs
@@ -113,10 +113,7 @@ impl Drop for LocalModelServerEmbeddingBackend {
     fn drop(&mut self) {
         let runtime_dir = self.rara_home.join("runtime").join("model-server");
         if let Ok(Some(metadata)) = read_server_metadata(&metadata_path(&runtime_dir)) {
-            let _ = nix::sys::signal::kill(
-                Pid::from_raw(metadata.pid as i32),
-                nix::sys::signal::Signal::SIGTERM,
-            );
+            terminate_process(metadata.pid);
         }
     }
 }

--- a/src/local_model_server/mod.rs
+++ b/src/local_model_server/mod.rs
@@ -12,7 +12,6 @@ use fs2::FileExt;
 use hf_hub::api::Progress as HfProgress;
 use hf_hub::api::sync::ApiBuilder;
 use hf_hub::{Cache, Repo, RepoType};
-use nix::unistd::Pid;
 use rara_persistence::redaction::{redact_secrets, sanitize_url_for_display};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src/local_model_server/util.rs
+++ b/src/local_model_server/util.rs
@@ -314,10 +314,83 @@ pub(crate) fn set_private_file_permissions(_path: &Path) -> Result<()> {
 
 /// Check whether a process identified by `pid` has exited.
 /// Returns `true` if the pid is no longer running (or never existed).
+#[cfg(unix)]
 pub(crate) fn process_exited(pid: u32) -> bool {
     use nix::sys::signal::kill;
     use nix::unistd::Pid;
     // Signal 0 (null signal) — does not actually send a signal, only
     // checks whether the process exists and we have permission.
     kill(Pid::from_raw(pid as i32), None).is_err()
+}
+
+/// Check whether a process identified by `pid` has exited.
+/// Returns `true` if the pid is no longer running (or never existed).
+#[cfg(windows)]
+pub(crate) fn process_exited(pid: u32) -> bool {
+    let pid_text = pid.to_string();
+    let filter = format!("PID eq {pid}");
+    match Command::new("tasklist")
+        .args(["/FI", filter.as_str(), "/NH"])
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            !stdout.lines().any(|line| {
+                line.split_whitespace()
+                    .nth(1)
+                    .is_some_and(|value| value == pid_text)
+            })
+        }
+        Ok(output) => {
+            log::warn!(
+                "failed to inspect Windows process {pid}: tasklist exited with {}",
+                output.status
+            );
+            false
+        }
+        Err(err) => {
+            log::warn!("failed to inspect Windows process {pid}: {err}");
+            false
+        }
+    }
+}
+
+/// Check whether a process identified by `pid` has exited.
+/// Returns `true` if the pid is no longer running (or never existed).
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn process_exited(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(unix)]
+pub(crate) fn terminate_process(pid: u32) {
+    use nix::sys::signal::{Signal, kill};
+    use nix::unistd::Pid;
+
+    if let Err(err) = kill(Pid::from_raw(pid as i32), Signal::SIGTERM) {
+        log::warn!("failed to terminate local model server process {pid}: {err}");
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn terminate_process(pid: u32) {
+    match Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T"])
+        .status()
+    {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            log::warn!(
+                "failed to terminate local model server process {pid}: taskkill exited with {status}"
+            );
+        }
+        Err(err) => {
+            log::warn!("failed to terminate local model server process {pid}: {err}");
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+pub(crate) fn terminate_process(pid: u32) {
+    log::warn!("cannot terminate local model server process {pid}: unsupported platform");
 }

--- a/src/tui/clipboard.rs
+++ b/src/tui/clipboard.rs
@@ -24,6 +24,9 @@ fn write_osc52(text: &str) -> io::Result<()> {
 }
 
 fn try_native_clipboard(text: &str) {
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    let _ = text;
+
     #[cfg(target_os = "macos")]
     {
         let _ = pipe_to_command("pbcopy", &[], text);


### PR DESCRIPTION
## Summary

- repair the tag release matrix by avoiding unauthenticated protoc setup, switching Linux release artifacts to GNU targets, and packaging `.deb` files from those targets
- keep release packaging coverage in the `release-build` workflow, triggered only after merge on `main`
- drop `x86_64-apple-darwin`/`macos-13` from the release matrix and keep Windows process handling compiling on Windows targets

## Purpose

The `v0.0.3` release run exposed failures that were only visible after tagging: protoc installation rate limits on macOS, OpenSSL target resolution failures on Linux, and Unix-only process handling in Windows builds.

This PR fixes those release paths while keeping pull-request CI focused on the normal fmt, build, clippy, and test gates. Release packaging is validated after merge through the `release-build` workflow on `main`, without publishing release assets.

## Related Issue

None.

## Testing

- `ruby -e 'require "yaml"; [".github/workflows/release.yml", ".github/workflows/release-build.yml"].each { |p| YAML.load_file(p); puts "#{p} ok" }'`
- `cargo metadata --locked --format-version 1 --filter-platform aarch64-unknown-linux-gnu`
- `cargo check --locked --bin rara`
- `cargo clippy --locked --bin rara -- -D warnings`
- `git diff --check`
- GitHub Actions release-build evidence on this PR before removing the PR trigger:
  - `build-aarch64-apple-darwin`
  - `build-x86_64-unknown-linux-gnu`
  - `build-aarch64-unknown-linux-gnu`
  - `build-x86_64-pc-windows-msvc`
  - `build-aarch64-pc-windows-msvc`

## Notes

Local macOS validation of `cargo check --target x86_64-pc-windows-msvc --bin rara` reached dependency C build setup and then stopped because the host does not have the MSVC C toolchain and headers. The `release-build` workflow runs Windows builds on `windows-latest`.
