### PR TITLE
chore: prepare v0.0.5 release

### DIFF
--- a/.agents/skills/release-rara/SKILL.md
+++ b/.agents/skills/release-rara/SKILL.md
@@ -55,6 +55,7 @@ Run this before creating or pushing a release tag:
 
 ```bash
 VERSION=X.Y.Z
+export VERSION
 cargo metadata --no-deps --format-version 1 \
   | python3 -c 'import json,os,sys; data=json.load(sys.stdin); pkg=next(p for p in data["packages"] if p["name"]=="rara"); actual=pkg["version"]; expected=os.environ["VERSION"]; print(actual); sys.exit(0 if actual == expected else 1)'
 ```

--- a/.agents/skills/release-rara/SKILL.md
+++ b/.agents/skills/release-rara/SKILL.md
@@ -57,7 +57,7 @@ Run this before creating or pushing a release tag:
 VERSION=X.Y.Z
 export VERSION
 cargo metadata --no-deps --format-version 1 \
-  | python3 -c 'import json,os,sys; data=json.load(sys.stdin); pkg=next(p for p in data["packages"] if p["name"]=="rara"); actual=pkg["version"]; expected=os.environ["VERSION"]; print(actual); sys.exit(0 if actual == expected else 1)'
+  | python3 -c 'import json,os,sys; data=json.load(sys.stdin); pkg=next(p for p in data["packages"] if p["name"]=="rara"); actual=pkg["version"]; expected=os.environ["VERSION"]; print(f"rara package version: {actual} (expected {expected})"); sys.exit(0 if actual == expected else 1)'
 ```
 
 If this exits non-zero, fix `Cargo.toml` before continuing.

--- a/.agents/skills/release-rara/SKILL.md
+++ b/.agents/skills/release-rara/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: release-rara
+description: Use when preparing, validating, tagging, or troubleshooting a RARA release. Enforces the release order that prevents tag versions from diverging from the Cargo package version.
+---
+
+# Release RARA
+
+Use this skill for every RARA release request, including version bumps,
+release-candidate checks, tag creation, workflow dispatch, and release failure
+triage.
+
+## Non-Negotiable Rule
+
+Never create, push, or dispatch a release tag until the Cargo package version
+matches the target tag version.
+
+For tag `vX.Y.Z`, `[workspace.package].version` in `Cargo.toml` must be
+`X.Y.Z`. For prerelease tag `vX.Y.Z-alpha.N` or `vX.Y.Z-beta.N`, the Cargo
+version must be `X.Y.Z-alpha.N` or `X.Y.Z-beta.N`.
+
+If the release workflow reports:
+
+```text
+Tag version X.Y.Z does not match Cargo package version A.B.C.
+```
+
+stop the release. Do not rerun the release workflow until a normal commit bumps
+the Cargo version to `X.Y.Z` and that commit is the one being tagged.
+
+## Release Preparation Checklist
+
+1. Confirm the requested tag and version.
+   - Tag format: `vX.Y.Z`, `vX.Y.Z-alpha.N`, or `vX.Y.Z-beta.N`.
+   - Version is the tag without the leading `v`.
+2. Start from an up-to-date `main`.
+   - Check the worktree is clean before editing.
+   - Pull `main` before preparing the version bump.
+3. Update the Cargo version before tagging.
+   - Edit `[workspace.package].version` in `Cargo.toml`.
+   - Update `Cargo.lock` by running `cargo metadata --locked` first to detect
+     whether the lock is already consistent; if it is stale, run a normal Cargo
+     command that refreshes the lockfile.
+4. Verify the exact package version.
+   - Use the `rara` package by name, not the first metadata package.
+5. Commit the version bump.
+   - Commit title format follows RARA rules, for example:
+     `chore: bump version to X.Y.Z`
+6. Push the version bump and wait for required CI.
+7. Create and push the tag from the version-bump commit.
+8. Watch the release workflow until assets are published and verified.
+
+## Required Version Check
+
+Run this before creating or pushing a release tag:
+
+```bash
+VERSION=X.Y.Z
+cargo metadata --no-deps --format-version 1 \
+  | python3 -c 'import json,os,sys; data=json.load(sys.stdin); pkg=next(p for p in data["packages"] if p["name"]=="rara"); actual=pkg["version"]; expected=os.environ["VERSION"]; print(actual); sys.exit(0 if actual == expected else 1)'
+```
+
+If this exits non-zero, fix `Cargo.toml` before continuing.
+
+## Tag Commands
+
+Only after the required version check passes:
+
+```bash
+TAG=vX.Y.Z
+git tag -a "${TAG}" -m "Release ${TAG}"
+git push origin "${TAG}"
+```
+
+For a manual workflow dispatch, the tag must already exist and point to the
+commit with the matching Cargo version.
+
+## Existing Bad Tag Recovery
+
+If a tag already exists on the wrong commit:
+
+1. Do not force-push or delete the tag without explicit user approval.
+2. Create a normal version-bump commit on `main`.
+3. Explain that the existing tag points at the wrong versioned commit.
+4. Ask whether to create a new patch tag or to move the existing tag.
+
+Prefer a new patch tag when the bad tag may already have been observed by
+GitHub Actions, package consumers, or release automation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,11 @@ jobs:
         run: |
           set -euo pipefail
           cargo_version="$(cargo metadata --no-deps --format-version 1 \
-            | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+            | python3 -c 'import json,sys; data=json.load(sys.stdin); print(next(p for p in data["packages"] if p["name"] == "rara")["version"])')"
           [[ "${cargo_version}" == "${VERSION}" ]] || {
-            echo "Tag version ${VERSION} does not match Cargo package version ${cargo_version}." >&2
+            echo "::error title=Release version mismatch::Tag version ${VERSION} does not match Cargo package version ${cargo_version}." >&2
+            echo "Before creating or dispatching a release tag, commit a Cargo.toml version bump so the rara package version equals ${VERSION}." >&2
+            echo "Then create the tag from that version-bump commit." >&2
             exit 1
           }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,8 @@ guides instead of expanding this charter with long procedural detail:
   `docs/journal/`.
 - `rara-docs-spec`: write or review canonical feature specs under
   `docs/features/`.
+- `release-rara`: prepare, validate, tag, or troubleshoot RARA releases without
+  tag/package version drift.
 - `project-github-titles`: write RARA commit and PR titles using the allowed
   project title format.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10842,7 +10842,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rara"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -10926,7 +10926,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -10935,7 +10935,7 @@ dependencies = [
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "libc",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -10961,7 +10961,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -10974,7 +10974,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -10982,7 +10982,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "ignore",
@@ -10993,7 +10993,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11003,7 +11003,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "rmcp 2.1.0",
@@ -11013,7 +11013,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -11031,14 +11031,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "fs2",
@@ -11053,7 +11053,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -11063,7 +11063,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11076,7 +11076,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11087,7 +11087,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "serde",
@@ -11096,7 +11096,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11109,11 +11109,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.3"
+version = "0.0.5"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11122,7 +11122,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.5"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/docs/journal/2026-07-06-release-skill.md
+++ b/docs/journal/2026-07-06-release-skill.md
@@ -1,0 +1,29 @@
+# Release Skill
+
+## Summary
+
+Added a repo-local `release-rara` skill so future releases follow a fixed
+agent-assisted checklist before tags are created or workflow dispatches run.
+
+## Background
+
+The release workflow correctly rejects a tag when the tag version does not match
+the Cargo package version. That guard prevents publishing mismatched binaries,
+but the failure still happens late if a tag is created before the version bump.
+
+## Scope
+
+- Added `.agents/skills/release-rara/SKILL.md`.
+- Registered the skill in `AGENTS.md`.
+- Tightened the release workflow's Cargo version lookup to select the `rara`
+  package by name.
+- Expanded the release workflow mismatch error with the required recovery
+  sequence.
+
+## Validation
+
+```bash
+cargo fmt
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts ".github/workflows/release.yml ok"'
+git diff --check
+```


### PR DESCRIPTION
## Summary

- add a repo-local `release-rara` skill for agent-assisted RARA releases
- improve release workflow version mismatch diagnostics and read the `rara` package version by package name
- bump the workspace package version and lockfile entries to `0.0.5` for the planned `v0.0.5` release

## Purpose

The release workflow correctly rejects tags when the tag version does not match the Cargo package version, but that failure happens late if the tag is created first. This PR adds a release checklist skill so future agent-assisted releases bump and verify the Cargo version before creating or dispatching a release tag.

It also prepares the repository for `v0.0.5`, so the eventual `v0.0.5` tag can point at a commit whose `rara` package version already matches `0.0.5`.

## Related Issue

None.

## Testing

- `cargo metadata --locked --no-deps --format-version 1 | env VERSION=0.0.5 python3 -c 'import json,os,sys; data=json.load(sys.stdin); pkg=next(p for p in data["packages"] if p["name"]=="rara"); actual=pkg["version"]; expected=os.environ["VERSION"]; print(actual); sys.exit(0 if actual == expected else 1)'`
- `ruby -e 'require "yaml"; [".github/workflows/release.yml", ".github/workflows/release-build.yml", ".agents/skills/release-rara/SKILL.md"].each { |p| YAML.load_file(p); puts "#{p} ok" }'`
- `cargo fmt`
- `git diff --check HEAD~2..HEAD`

## Release Note

After this PR merges, create `v0.0.5` from the merge commit, not from an older commit.
