### PR TITLE
fix(ci): correct release asset counts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
+  RELEASE_BINARY_ASSET_COUNT: "7"
 
 jobs:
   tag-check:
@@ -335,7 +336,7 @@ jobs:
           find dist/artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.deb" \) -print0 \
             | xargs -0 -I{} cp "{}" dist/release/
 
-          expected=8
+          expected="${RELEASE_BINARY_ASSET_COUNT}"
           actual="$(find dist/release -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.deb" \) | wc -l | tr -d ' ')"
           [[ "${actual}" == "${expected}" ]] || {
             echo "Expected ${expected} release binary assets, found ${actual}." >&2
@@ -381,7 +382,7 @@ jobs:
           TAG: ${{ needs.tag-check.outputs.tag }}
         run: |
           set -euo pipefail
-          expected=17
+          expected=$((RELEASE_BINARY_ASSET_COUNT * 2 + 1))
           actual="$(gh release view "${TAG}" --json assets --jq '.assets | length')"
           [[ "${actual}" == "${expected}" ]] || {
             echo "Expected ${expected} assets on release ${TAG}, found ${actual}." >&2

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -63,6 +63,9 @@ Each build produces one executable archive:
 - Windows: `rara-${VERSION}-${TARGET}.zip`
 - Debian package for Linux targets: `rara_${VERSION}_${DEB_ARCH}.deb`
 
+The current target matrix produces seven binary release assets: five target
+archives and two Linux Debian packages.
+
 Each release should also publish checksum files:
 
 - `rara-${VERSION}-${TARGET}.sha256`

--- a/docs/journal/2026-07-06-release-assets-deb.md
+++ b/docs/journal/2026-07-06-release-assets-deb.md
@@ -51,3 +51,24 @@ cargo metadata --locked --format-version 1 --filter-platform aarch64-unknown-lin
 cargo check --locked --bin rara
 git diff --check
 ```
+
+## v0.0.5 Release Count Fix
+
+The first `v0.0.5` release run built every matrix target successfully, but the
+`github-release` job failed while staging checksums because the release workflow
+still expected eight binary assets. After `x86_64-apple-darwin` was removed from
+the release matrix, the release produces seven binary assets: five target
+archives and two Linux Debian packages.
+
+The workflow now stores the expected binary asset count in
+`RELEASE_BINARY_ASSET_COUNT` and derives the final GitHub Release asset count as
+`binary_count * 2 + 1`, covering each binary asset, each `.sha256` file, and
+`checksums.txt`.
+
+Validation:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts ".github/workflows/release.yml ok"'
+bash -lc 'RELEASE_BINARY_ASSET_COUNT=7; expected=$((RELEASE_BINARY_ASSET_COUNT * 2 + 1)); test "$expected" = 15; echo "$expected"'
+git diff --check
+```


### PR DESCRIPTION
## Summary

- update the release workflow binary asset count from 8 to 7 after dropping `x86_64-apple-darwin`
- derive the final GitHub Release asset count from the binary asset count
- document the current seven binary release assets and the `v0.0.5` failure root cause

## Purpose

The `v0.0.5` release run built all matrix targets successfully, but `github-release` failed during `Stage checksums` because the workflow still expected eight binary assets. The current matrix produces seven binary assets: five archives and two Linux Debian packages.

The final GitHub Release should contain 15 assets: seven binaries, seven `.sha256` files, and `checksums.txt`.

## Related Issue

None.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts ".github/workflows/release.yml ok"'`
- `bash -lc 'RELEASE_BINARY_ASSET_COUNT=7; expected=$((RELEASE_BINARY_ASSET_COUNT * 2 + 1)); test "$expected" = 15; echo "$expected"'`
- `cargo fmt`
- `git diff --check`

## Release Recovery

After this PR merges, rerun the release workflow with `workflow_dispatch` for existing tag `v0.0.5`. The tag already points at the correct `0.0.5` commit.
