### PR TITLE
fix(ci): use friendly release asset names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,23 +119,28 @@ jobs:
         include:
           - runner: macos-14
             target: aarch64-apple-darwin
+            asset_name: macos-aarch64
             archive: tar.gz
             smoke: true
           - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
+            asset_name: linux-x86_64
             archive: tar.gz
             smoke: true
           - runner: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
+            asset_name: linux-aarch64
             archive: tar.gz
             build_with: cross
             smoke: false
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+            asset_name: windows-x86_64
             archive: zip
             smoke: true
           - runner: windows-latest
             target: aarch64-pc-windows-msvc
+            asset_name: windows-aarch64
             archive: zip
             smoke: false
     steps:
@@ -211,6 +216,7 @@ jobs:
         if: ${{ runner.os != 'Windows' }}
         shell: bash
         env:
+          ASSET_NAME: ${{ matrix.asset_name }}
           VERSION: ${{ needs.tag-check.outputs.version }}
           TARGET: ${{ matrix.target }}
         run: |
@@ -219,7 +225,7 @@ jobs:
           mkdir -p "${dist_dir}"
           cp "target/${TARGET}/release/rara" "${dist_dir}/rara"
           chmod +x "${dist_dir}/rara"
-          tar -C "${dist_dir}" -czf "dist/rara-${VERSION}-${TARGET}.tar.gz" rara
+          tar -C "${dist_dir}" -czf "dist/rara-${VERSION}-${ASSET_NAME}.tar.gz" rara
 
       - name: Package Debian package
         if: ${{ runner.os == 'Linux' && contains(matrix.target, 'unknown-linux') }}
@@ -264,37 +270,40 @@ jobs:
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
         env:
+          ASSET_NAME: ${{ matrix.asset_name }}
           VERSION: ${{ needs.tag-check.outputs.version }}
           TARGET: ${{ matrix.target }}
         run: |
           $distDir = "dist/$env:TARGET"
           New-Item -ItemType Directory -Force -Path $distDir | Out-Null
           Copy-Item "target/$env:TARGET/release/rara.exe" "$distDir/rara.exe"
-          Compress-Archive -Path "$distDir/rara.exe" -DestinationPath "dist/rara-$env:VERSION-$env:TARGET.zip" -Force
+          Compress-Archive -Path "$distDir/rara.exe" -DestinationPath "dist/rara-$env:VERSION-$env:ASSET_NAME.zip" -Force
 
       - name: Smoke test unix archive
         if: ${{ runner.os != 'Windows' && matrix.smoke }}
         shell: bash
         env:
+          ASSET_NAME: ${{ matrix.asset_name }}
           VERSION: ${{ needs.tag-check.outputs.version }}
           TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
           smoke_dir="dist/smoke-${TARGET}"
           mkdir -p "${smoke_dir}"
-          tar -C "${smoke_dir}" -xzf "dist/rara-${VERSION}-${TARGET}.tar.gz"
+          tar -C "${smoke_dir}" -xzf "dist/rara-${VERSION}-${ASSET_NAME}.tar.gz"
           "${smoke_dir}/rara" --version
 
       - name: Smoke test windows archive
         if: ${{ runner.os == 'Windows' && matrix.smoke }}
         shell: pwsh
         env:
+          ASSET_NAME: ${{ matrix.asset_name }}
           VERSION: ${{ needs.tag-check.outputs.version }}
           TARGET: ${{ matrix.target }}
         run: |
           $smokeDir = "dist/smoke-$env:TARGET"
           New-Item -ItemType Directory -Force -Path $smokeDir | Out-Null
-          Expand-Archive -Path "dist/rara-$env:VERSION-$env:TARGET.zip" -DestinationPath $smokeDir -Force
+          Expand-Archive -Path "dist/rara-$env:VERSION-$env:ASSET_NAME.zip" -DestinationPath $smokeDir -Force
           & "$smokeDir/rara.exe" --version
 
       - name: Upload release archive
@@ -302,7 +311,7 @@ jobs:
         with:
           name: rara-${{ matrix.target }}
           path: |
-            dist/rara-${{ needs.tag-check.outputs.version }}-${{ matrix.target }}.${{ matrix.archive }}
+            dist/rara-${{ needs.tag-check.outputs.version }}-${{ matrix.asset_name }}.${{ matrix.archive }}
             dist/*.deb
           if-no-files-found: error
 

--- a/docs/features/release-distribution.md
+++ b/docs/features/release-distribution.md
@@ -57,10 +57,13 @@ or linker behavior makes a target unreliable.
 
 ## Artifact Contract
 
-Each build produces one executable archive:
+Each build produces one executable archive using user-facing platform names:
 
-- Unix: `rara-${VERSION}-${TARGET}.tar.gz`
-- Windows: `rara-${VERSION}-${TARGET}.zip`
+- macOS: `rara-${VERSION}-macos-aarch64.tar.gz`
+- Linux: `rara-${VERSION}-linux-x86_64.tar.gz`
+- Linux: `rara-${VERSION}-linux-aarch64.tar.gz`
+- Windows: `rara-${VERSION}-windows-x86_64.zip`
+- Windows: `rara-${VERSION}-windows-aarch64.zip`
 - Debian package for Linux targets: `rara_${VERSION}_${DEB_ARCH}.deb`
 
 The current target matrix produces seven binary release assets: five target
@@ -70,6 +73,9 @@ Each release should also publish checksum files:
 
 - `rara-${VERSION}-${TARGET}.sha256`
 - `checksums.txt`
+
+Build jobs still use Rust target triples internally. Release archive names avoid
+the Rust `unknown` vendor component so they are easier for users to identify.
 
 Archives contain only the executable at the archive root:
 

--- a/docs/journal/2026-07-06-release-assets-deb.md
+++ b/docs/journal/2026-07-06-release-assets-deb.md
@@ -72,3 +72,15 @@ ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "
 bash -lc 'RELEASE_BINARY_ASSET_COUNT=7; expected=$((RELEASE_BINARY_ASSET_COUNT * 2 + 1)); test "$expected" = 15; echo "$expected"'
 git diff --check
 ```
+
+## User-Facing Archive Names
+
+Release archives now use user-facing platform labels instead of full Rust target
+triples. The build matrix still compiles with triples such as
+`x86_64-unknown-linux-gnu`, but the uploaded archives are named:
+
+- `rara-${VERSION}-macos-aarch64.tar.gz`
+- `rara-${VERSION}-linux-x86_64.tar.gz`
+- `rara-${VERSION}-linux-aarch64.tar.gz`
+- `rara-${VERSION}-windows-x86_64.zip`
+- `rara-${VERSION}-windows-aarch64.zip`


### PR DESCRIPTION
## Summary

- use user-facing platform labels for GitHub Release archive names
- keep Rust target triples for build matrix and compiler target selection
- document the release asset naming contract

## Purpose

The Linux Rust target triples include the `unknown` vendor component, for example `x86_64-unknown-linux-gnu`. That is correct for builds, but it is noisy in downloadable release assets.

This PR changes only the release archive filenames to friendlier labels such as:

- `rara-${VERSION}-linux-x86_64.tar.gz`
- `rara-${VERSION}-linux-aarch64.tar.gz`

Debian package names and internal build targets are unchanged.

## Related Issue

None.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts ".github/workflows/release.yml ok"'`
- `git diff --check`
