### PR TITLE
fix(tools): enforce Terminal-Bench artifacts

### DIFF
--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -56,10 +56,13 @@ Recommended components:
   `PYTHONPATH=$PWD/tools/harbor harbor run -d terminal-bench/terminal-bench-2
   --agent rara_agent:RaraAgent --agent-kwarg
   binary_path=$PWD/target/release/rara`. The adapter defaults to `/app` as the
-  benchmark cwd and preserves the `rara exec` exit code while teeing JSONL
-  output into `/logs/agent/rara-exec.jsonl`. It also sets
+  benchmark cwd, passes that cwd explicitly to `rara exec`, and preserves the
+  `rara exec` exit code while teeing JSONL output into
+  `/logs/agent/rara-exec.jsonl`. It also sets
   `RARA_LOCAL_EMBEDDINGS=off` so benchmark startup does not prepare the bundled
-  local embedding sidecar.
+  local embedding sidecar. The adapter wraps task text with generic
+  non-interactive benchmark guidance so RARA treats named output files as
+  required artifacts rather than optional final-answer prose.
 - `rara eval terminal-bench` may be added later as a convenience wrapper, but
   the first integration target is Harbor compatibility.
 - Stable workspace setup contract:
@@ -102,6 +105,12 @@ RARA owns the generic headless agent execution and event stream.
 The adapter must not require interactive TUI-only features. Any configuration
 that is currently only exposed through `/model`, `/auth`, or overlays must also
 have a headless path.
+
+The adapter may add generic harness guidance around the raw task instruction.
+That guidance can require non-interactive operation, exact creation of
+task-named output files, focused validation, and blocker reporting. It must not
+embed task-specific solutions, hidden verifier knowledge, or benchmark oracle
+content.
 
 ### Headless Execution Contract
 

--- a/docs/journal/2026-07-07-harbor-benchmark-artifacts.md
+++ b/docs/journal/2026-07-07-harbor-benchmark-artifacts.md
@@ -1,0 +1,24 @@
+# Harbor Benchmark Artifact Guidance
+
+## Summary
+
+Tightened the Harbor adapter contract after a Terminal-Bench
+`sparql-university` smoke run exited successfully but did not create the
+required `/app/solution.sparql` artifact.
+
+## Changes
+
+- Wrapped Harbor task instructions with generic non-interactive benchmark
+  guidance.
+- Made named output files explicit required artifacts in that guidance.
+- Passed the benchmark workspace to `rara exec` through both Harbor's command
+  cwd and RARA's own `--cwd` option.
+- Kept the guidance task-agnostic: it does not include benchmark answers,
+  hidden verifier behavior, or task-specific shortcuts.
+
+## Validation
+
+- `python -m unittest tools.harbor.test_rara_agent`
+- `python -m py_compile tools/harbor/rara_agent.py tools/harbor/test_rara_agent.py`
+- `cargo fmt`
+

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -27,6 +27,7 @@ DEFAULT_JSONL_PATH = EnvironmentPaths.agent_dir / "rara-exec.jsonl"
 DEFAULT_EXIT_STATUS_PATH = EnvironmentPaths.agent_dir / "rara-exec.status"
 DEFAULT_INSTRUCTION_PATH = EnvironmentPaths.agent_dir / "instruction.txt"
 DEFAULT_LAST_MESSAGE_PATH = EnvironmentPaths.agent_dir / "last-message.txt"
+DEFAULT_BENCHMARK_CWD = "/app"
 
 
 class RaraAgent(BaseInstalledAgent):
@@ -40,7 +41,7 @@ class RaraAgent(BaseInstalledAgent):
         *args: Any,
         binary_path: str | None = None,
         remote_binary: str | None = None,
-        cwd: str = "/app",
+        cwd: str = DEFAULT_BENCHMARK_CWD,
         rara_home: str | None = None,
         **kwargs: Any,
     ) -> None:
@@ -101,7 +102,9 @@ class RaraAgent(BaseInstalledAgent):
     ) -> None:
         instruction_path = self.logs_dir / "instruction.txt"
         instruction_path.parent.mkdir(parents=True, exist_ok=True)
-        instruction_path.write_text(instruction, encoding="utf-8")
+        cwd = self.effective_cwd()
+        benchmark_instruction = build_benchmark_instruction(instruction, cwd)
+        instruction_path.write_text(benchmark_instruction, encoding="utf-8")
         await environment.upload_file(
             instruction_path,
             DEFAULT_INSTRUCTION_PATH.as_posix(),
@@ -113,7 +116,7 @@ class RaraAgent(BaseInstalledAgent):
             "RARA_LOCAL_EMBEDDINGS": "off",
         }
         command = self._build_exec_command()
-        result = await environment.exec(command=command, cwd=self.cwd, env=env)
+        result = await environment.exec(command=command, cwd=cwd, env=env)
 
         stdout = result.stdout or ""
         events = parse_rara_jsonl(stdout)
@@ -123,6 +126,7 @@ class RaraAgent(BaseInstalledAgent):
 
     def _build_exec_command(self) -> str:
         binary = shlex.quote(self.remote_binary.as_posix())
+        cwd = shlex.quote(self.effective_cwd())
         jsonl_path = shlex.quote(DEFAULT_JSONL_PATH.as_posix())
         status_path = shlex.quote(DEFAULT_EXIT_STATUS_PATH.as_posix())
         instruction_path = shlex.quote(DEFAULT_INSTRUCTION_PATH.as_posix())
@@ -133,7 +137,7 @@ class RaraAgent(BaseInstalledAgent):
             f"mkdir -p {shlex.quote(EnvironmentPaths.agent_dir.as_posix())} "
             f"{shlex.quote(self.rara_home.as_posix())} || exit $?; "
             "{ "
-            f"{binary} exec --json --run-id {run_id} --task-id {task_id} "
+            f"{binary} exec --json --cwd {cwd} --run-id {run_id} --task-id {task_id} "
             f"--output-last-message {last_message_path} - "
             f"< {instruction_path}; "
             f"printf '%s\\n' \"$?\" > {status_path}; "
@@ -180,6 +184,24 @@ class RaraAgent(BaseInstalledAgent):
             "jsonl_path": DEFAULT_JSONL_PATH.as_posix(),
             "last_message_path": DEFAULT_LAST_MESSAGE_PATH.as_posix(),
         }
+
+    def effective_cwd(self) -> str:
+        return self.cwd or DEFAULT_BENCHMARK_CWD
+
+
+def build_benchmark_instruction(instruction: str, cwd: str) -> str:
+    """Wrap Harbor task text with generic non-interactive benchmark guidance."""
+    return f"""You are running inside a non-interactive Terminal-Bench task container.
+
+Work only in the benchmark workspace: {cwd}.
+Read the task carefully and create every file path that the task asks for exactly as specified.
+If the task names an absolute output path under the workspace, write that artifact before you finish.
+Use available shell and file tools to inspect inputs, edit files, and run focused validation commands.
+Do not finish with only an explanation. Finish only after the requested artifacts exist, or report the exact blocker if you cannot create them.
+
+Task instructions:
+{instruction.strip()}
+"""
 
 
 def parse_rara_jsonl(output: str) -> list[dict[str, Any]]:

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 from harbor.models.agent.context import AgentContext
 
-from rara_agent import RaraAgent, parse_rara_jsonl
+from rara_agent import RaraAgent, build_benchmark_instruction, parse_rara_jsonl
 
 
 class FakeExecResult:
@@ -42,6 +42,7 @@ class FakeRunEnvironment:
     def __init__(self) -> None:
         self.uploads: list[tuple[Path, str]] = []
         self.exec_env: dict[str, str] | None = None
+        self.exec_cwd: str | None = None
 
     async def upload_file(self, source: Path, destination: str) -> None:
         self.uploads.append((source, destination))
@@ -52,6 +53,7 @@ class FakeRunEnvironment:
         cwd: str | None = None,
         env: dict[str, str] | None = None,
     ) -> FakeExecResult:
+        self.exec_cwd = cwd
         self.exec_env = dict(env or {})
         return FakeExecResult(
             0,
@@ -123,6 +125,7 @@ class RaraAgentTests(unittest.TestCase):
         command = agent._build_exec_command()
 
         self.assertIn("/opt/rara exec --json", command)
+        self.assertIn("--cwd /app", command)
         self.assertIn("--run-id 00000000000000000000000000000123", command)
         self.assertIn("--task-id trial-agent", command)
         self.assertIn("--output-last-message /logs/agent/last-message.txt", command)
@@ -139,6 +142,21 @@ class RaraAgentTests(unittest.TestCase):
 
         self.assertEqual(agent.cwd, "/app")
 
+    def test_empty_cwd_falls_back_to_terminal_bench_workdir(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara", cwd="")
+            context = AgentContext()
+            environment = FakeRunEnvironment()
+
+            asyncio.run(agent.run("Create /app/output.txt.", environment, context))  # type: ignore[arg-type]
+
+            uploaded_instruction = environment.uploads[0][0].read_text(encoding="utf-8")
+
+        self.assertEqual(agent.effective_cwd(), "/app")
+        self.assertEqual(environment.exec_cwd, "/app")
+        self.assertIn("--cwd /app", agent._build_exec_command())
+        self.assertIn("Work only in the benchmark workspace: /app", uploaded_instruction)
+
     def test_run_disables_local_embeddings_for_benchmark(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
             agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
@@ -149,6 +167,36 @@ class RaraAgentTests(unittest.TestCase):
 
         self.assertEqual(environment.exec_env["RARA_LOCAL_EMBEDDINGS"], "off")
         self.assertEqual(environment.exec_env["RARA_HOME"], "/logs/agent/rara-home")
+        self.assertEqual(environment.exec_cwd, "/app")
+
+    def test_run_wraps_instruction_with_benchmark_artifact_guidance(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            context = AgentContext()
+            environment = FakeRunEnvironment()
+
+            asyncio.run(
+                agent.run(
+                    "Save your query in `/app/solution.sparql`.",
+                    environment,
+                    context,
+                )
+            )  # type: ignore[arg-type]
+
+            uploaded_instruction = environment.uploads[0][0].read_text(encoding="utf-8")
+
+        self.assertIn("non-interactive Terminal-Bench task container", uploaded_instruction)
+        self.assertIn("Work only in the benchmark workspace: /app", uploaded_instruction)
+        self.assertIn("create every file path that the task asks for", uploaded_instruction)
+        self.assertIn("/app/solution.sparql", uploaded_instruction)
+        self.assertIn("Do not finish with only an explanation", uploaded_instruction)
+
+    def test_build_benchmark_instruction_preserves_task_text(self) -> None:
+        instruction = "\nCreate /app/solution.sparql.\n"
+
+        wrapped = build_benchmark_instruction(instruction, "/app")
+
+        self.assertTrue(wrapped.endswith("Create /app/solution.sparql.\n"))
 
     def test_binary_path_is_resolved(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:


### PR DESCRIPTION
## Summary

- Wrap Harbor task instructions with generic non-interactive benchmark guidance.
- Pass the benchmark workspace explicitly to `rara exec --cwd`.
- Add adapter regression tests for artifact guidance, cwd propagation, and preserved task text.
- Update the Terminal-Bench spec and journal checkpoint.

## Purpose

Terminal-Bench can return reward `0.0` when an agent exits successfully but does not create the task-requested artifact, such as `/app/solution.sparql` for `sparql-university`. The adapter should make RARA treat named output paths as required benchmark artifacts rather than optional final-answer prose.

## Related Issue

None.

## Testing

```bash
HARBOR_SITE_PACKAGES=$(find "$(uv tool dir)/harbor/lib" -path '*/site-packages' -type d | head -1)
PYTHONPATH="${HARBOR_SITE_PACKAGES}:tools/harbor:." python -m unittest tools.harbor.test_rara_agent
python -m py_compile tools/harbor/rara_agent.py tools/harbor/test_rara_agent.py
git diff --check
cargo fmt
```

