### PR TITLE
fix(exec): surface startup panics in JSONL

### DIFF
--- a/docs/journal/2026-07-07-exec-startup-panic-jsonl.md
+++ b/docs/journal/2026-07-07-exec-startup-panic-jsonl.md
@@ -1,0 +1,29 @@
+# Exec Startup Panic JSONL
+
+## Summary
+
+Added a headless `rara exec --json` panic hook for initialization failures that
+occur before the normal exec event processor starts.
+
+## Background
+
+A Harbor Terminal-Bench smoke run reached `rara-exec.status=101` with an empty
+`rara-exec.jsonl`. That means RARA panicked before emitting `thread.started`,
+so the benchmark adapter could only report a missing task artifact after
+verification.
+
+## Changes
+
+- `rara exec --json` now installs a narrow panic hook before cwd switching and
+  runtime bootstrap.
+- Startup panics emit `thread.started`, `turn.started`, and `turn.failed`
+  JSONL events with the harness `run_id` and `task_id`.
+- The hook is gated by a per-run startup-complete flag, so panics after the
+  normal exec event processor starts do not inject duplicate startup events.
+- The hook still calls the default panic hook, preserving stderr and backtrace
+  output for `/logs/agent/rara-exec.stderr`.
+
+## Validation
+
+- `cargo test exec_consumer::tests::startup_failure_events_preserve_harness_metadata`
+- `cargo fmt`

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
@@ -294,6 +295,7 @@ async fn run_print_command(config: &RaraConfig, prompt: String) -> Result<()> {
 }
 
 async fn run_exec_command(config: &RaraConfig, args: ExecArgs) -> Result<()> {
+    let startup_complete = install_exec_panic_hook(&args);
     if let Some(cwd) = args.cwd.as_deref() {
         std::env::set_current_dir(cwd)
             .map_err(|err| anyhow::anyhow!("failed to switch cwd to {}: {err}", cwd.display()))?;
@@ -311,7 +313,32 @@ async fn run_exec_command(config: &RaraConfig, args: ExecArgs) -> Result<()> {
             task_id: args.task_id,
         },
     );
+    if let Some(startup_complete) = startup_complete {
+        startup_complete.store(true, Ordering::Release);
+    }
     consumer.run().await
+}
+
+fn install_exec_panic_hook(args: &ExecArgs) -> Option<Arc<AtomicBool>> {
+    if !args.json {
+        return None;
+    }
+    let startup_complete = Arc::new(AtomicBool::new(false));
+    let startup_complete_for_hook = startup_complete.clone();
+    let run_id = args.run_id.clone();
+    let task_id = args.task_id.clone();
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        if !startup_complete_for_hook.load(Ordering::Acquire) {
+            crate::exec_consumer::emit_exec_startup_failure_jsonl(
+                run_id.clone(),
+                task_id.clone(),
+                format!("rara exec panicked during startup: {info}"),
+            );
+        }
+        default_hook(info);
+    }));
+    Some(startup_complete)
 }
 
 async fn run_wire_command(config: &RaraConfig, prompt: String) -> Result<()> {

--- a/src/exec_consumer.rs
+++ b/src/exec_consumer.rs
@@ -87,6 +87,40 @@ impl ExecConsumer {
     }
 }
 
+pub fn emit_exec_startup_failure_jsonl(
+    run_id: Option<String>,
+    task_id: Option<String>,
+    message: String,
+) {
+    for event in exec_startup_failure_events(run_id, task_id, message) {
+        let _ = emit_jsonl(&event);
+    }
+}
+
+pub fn exec_startup_failure_events(
+    run_id: Option<String>,
+    task_id: Option<String>,
+    message: String,
+) -> Vec<ExecEvent> {
+    vec![
+        ExecEvent::ThreadStarted {
+            metadata: ExecRunMetadata {
+                session_id: "startup".to_string(),
+                run_id,
+                task_id,
+            },
+            timestamp: timestamp_now(),
+        },
+        ExecEvent::TurnStarted {
+            timestamp: timestamp_now(),
+        },
+        ExecEvent::TurnFailed {
+            error: ExecError { message },
+            timestamp: timestamp_now(),
+        },
+    ]
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExecRunMetadata {
     pub session_id: String,
@@ -504,6 +538,32 @@ mod tests {
 
         assert_eq!(processor.usage.input_tokens, 13);
         assert_eq!(processor.usage.output_tokens, 7);
+    }
+
+    #[test]
+    fn startup_failure_events_preserve_harness_metadata() {
+        let events = exec_startup_failure_events(
+            Some("run-1".to_string()),
+            Some("task-1".to_string()),
+            "rara exec panicked during startup".to_string(),
+        );
+
+        assert_eq!(events.len(), 3);
+        match &events[0] {
+            ExecEvent::ThreadStarted { metadata, .. } => {
+                assert_eq!(metadata.session_id, "startup");
+                assert_eq!(metadata.run_id.as_deref(), Some("run-1"));
+                assert_eq!(metadata.task_id.as_deref(), Some("task-1"));
+            }
+            other => panic!("unexpected first event: {other:?}"),
+        }
+        assert!(matches!(events[1], ExecEvent::TurnStarted { .. }));
+        match &events[2] {
+            ExecEvent::TurnFailed { error, .. } => {
+                assert_eq!(error.message, "rara exec panicked during startup");
+            }
+            other => panic!("unexpected third event: {other:?}"),
+        }
     }
 
     fn test_metadata() -> ExecRunMetadata {


### PR DESCRIPTION
## Summary

- Install a narrow panic hook for `rara exec --json`.
- Emit startup `thread.started`, `turn.started`, and `turn.failed` JSONL events when exec panics before normal runtime bootstrap completes.
- Preserve harness `run_id` and `task_id` in those startup failure events.
- Add a focused regression test and journal checkpoint.

## Purpose

Harbor Terminal-Bench reported `rara-exec.status=101` with an empty JSONL stream. That means RARA panicked before the normal exec event processor started, leaving the adapter unable to attribute the failure. This change makes startup panics visible to the harness while keeping the default panic stderr/backtrace behavior intact.

## Related Issue

None.

## Testing

```bash
cargo test exec_consumer::tests::startup_failure_events_preserve_harness_metadata
HARBOR_SITE_PACKAGES=$(find "$(uv tool dir)/harbor/lib" -path '*/site-packages' -type d | head -1)
PYTHONPATH="${HARBOR_SITE_PACKAGES}:tools/harbor:." python -m unittest tools.harbor.test_rara_agent
python -m py_compile tools/harbor/rara_agent.py tools/harbor/test_rara_agent.py
cargo fmt
git diff --check
```

Note: the focused Rust test emitted a macOS linker compact-unwind warning unrelated to this change.

