### PR TITLE
chore: bump version to 0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10842,7 +10842,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rara"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -10926,7 +10926,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -10935,7 +10935,7 @@ dependencies = [
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "async-trait",
  "libc",
@@ -10950,7 +10950,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -10961,7 +10961,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -10974,7 +10974,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -10982,7 +10982,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "ignore",
@@ -10993,7 +10993,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11003,7 +11003,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "rmcp 2.1.0",
@@ -11013,7 +11013,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -11031,14 +11031,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "fs2",
@@ -11053,7 +11053,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -11063,7 +11063,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11076,7 +11076,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11087,7 +11087,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "serde",
@@ -11096,7 +11096,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11109,11 +11109,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.5"
+version = "0.0.6"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11122,7 +11122,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

- Bump the workspace package version from `0.0.5` to `0.0.6`.
- Refresh `Cargo.lock` so all local RARA workspace crates resolve to `0.0.6`.

## Purpose

Prepare the repository for the `v0.0.6` release. The release workflow requires the Cargo package version to match the release tag before the tag is created.

## Related Issue

None.

## Testing

```bash
cargo metadata --locked --no-deps --format-version 1
VERSION=0.0.6 cargo metadata --no-deps --format-version 1 | python3 -c 'import json,os,sys; data=json.load(sys.stdin); pkg=next(p for p in data["packages"] if p["name"]=="rara"); actual=pkg["version"]; expected=os.environ["VERSION"]; print(f"rara package version: {actual} (expected {expected})"); sys.exit(0 if actual == expected else 1)'
cargo fmt
```

