### PR TITLE
fix(tools): pass Harbor provider credentials

### DIFF
--- a/docs/journal/2026-07-09-harbor-provider-env.md
+++ b/docs/journal/2026-07-09-harbor-provider-env.md
@@ -1,0 +1,66 @@
+# Harbor Provider Environment
+
+**Date**: 2026-07-09
+**Context**: Terminal-Bench runs through the Harbor RARA adapter.
+**Result**: The adapter now prepares container CA certificates and forwards provider credentials without putting API keys in the command line.
+
+---
+
+## Summary
+
+The Harbor adapter failed in two stages when running `terminal-bench/sparql-university`:
+
+- RARA could panic during startup inside the task container because `reqwest` could not load system CA certificates.
+- After CA setup was fixed, RARA could still complete through the mock backend when the benchmark container did not receive a real provider configuration, leaving `/app/solution.sparql` missing.
+
+The adapter now installs or refreshes CA certificates during agent setup, before validating the uploaded RARA binary. It also supports provider/model/base URL kwargs and maps a selected provider API key from the Harbor host process environment into `RARA_API_KEY` for the container execution environment.
+
+## Background
+
+Harbor runs the uploaded RARA binary inside a task container with its own filesystem and environment. The adapter intentionally sets a fresh `RARA_HOME` under `/logs/agent/rara-home`, so host-local RARA config files are not automatically available in the benchmark container.
+
+That isolation is useful for reproducible trials, but it means provider credentials must be forwarded explicitly. Without credentials or provider selection, RARA can use the mock backend and produce a successful-looking final message without writing the benchmark artifact.
+
+## Scope
+
+Changed:
+
+- `tools/harbor/rara_agent.py`
+  - installs `ca-certificates` for common Linux package managers when the bundle is missing;
+  - accepts `provider`, `model`, `base_url`, and `api_key_env` kwargs;
+  - infers a provider from supported host API key environment variables when no provider kwarg is set;
+  - forwards the API key through `RARA_API_KEY` in the environment, not through command-line flags;
+  - fails the agent phase if a completed turn still reports `Mock Response:`.
+- `tools/harbor/test_rara_agent.py`
+  - covers CA setup ordering;
+  - covers provider flag construction without command-line API key exposure;
+  - covers host environment API key forwarding;
+  - covers mock backend completion rejection.
+
+Not changed:
+
+- RARA core provider configuration semantics.
+- Terminal-Bench task definitions.
+- Host RARA config file upload behavior.
+
+## Key Decisions
+
+- Keep API keys out of the generated shell command so Harbor job logs do not capture secrets.
+- Prefer explicit `--agent-kwarg provider=...` and `--agent-kwarg model=...`, while still allowing provider inference from host environment variables for local runs.
+- Fail early on mock backend completion so the job reports the real setup issue before verifier output collapses into missing artifact assertions.
+
+## Validation
+
+```bash
+PYTHONPATH=$PWD/tools/harbor /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -m unittest tools.harbor.test_rara_agent
+git diff --check
+```
+
+Manual log inspection used:
+
+- `jobs/2026-07-08__20-45-55/sparql-university__w3PTeRy/agent/rara-exec.jsonl`
+- `jobs/2026-07-09__11-04-40/sparql-university__CnKTBtr/agent/rara-exec.jsonl`
+
+## Follow-Ups
+
+- Run a full Harbor Terminal-Bench job with a rotated provider key and verify that `/app/solution.sparql` is created before the verifier starts.

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -28,6 +28,16 @@ DEFAULT_EXIT_STATUS_PATH = EnvironmentPaths.agent_dir / "rara-exec.status"
 DEFAULT_INSTRUCTION_PATH = EnvironmentPaths.agent_dir / "instruction.txt"
 DEFAULT_LAST_MESSAGE_PATH = EnvironmentPaths.agent_dir / "last-message.txt"
 DEFAULT_BENCHMARK_CWD = "/app"
+CA_CERTIFICATE_BUNDLE = PurePosixPath("/etc/ssl/certs/ca-certificates.crt")
+PROVIDER_API_KEY_ENVS = {
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "gemini": ("GEMINI_API_KEY",),
+    "kimi": ("KIMI_API_KEY", "MOONSHOT_API_KEY"),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "codex": ("CODEX_API_KEY", "OPENAI_API_KEY"),
+    "openai-compatible": ("RARA_API_KEY", "OPENAI_API_KEY"),
+}
+PROVIDER_INFERENCE_ORDER = ("deepseek", "kimi", "gemini", "openrouter", "codex")
 
 
 class RaraAgent(BaseInstalledAgent):
@@ -43,6 +53,10 @@ class RaraAgent(BaseInstalledAgent):
         remote_binary: str | None = None,
         cwd: str = DEFAULT_BENCHMARK_CWD,
         rara_home: str | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        base_url: str | None = None,
+        api_key_env: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -52,6 +66,10 @@ class RaraAgent(BaseInstalledAgent):
         self.remote_binary = PurePosixPath(remote_binary or DEFAULT_REMOTE_BINARY)
         self.cwd = cwd
         self.rara_home = PurePosixPath(rara_home or DEFAULT_RARA_HOME)
+        self.provider = provider
+        self.model = model
+        self.base_url = base_url
+        self.api_key_env = api_key_env
 
     @staticmethod
     def name() -> str:
@@ -77,6 +95,11 @@ class RaraAgent(BaseInstalledAgent):
         await self.exec_as_root(
             environment,
             command=f"chmod 0755 {shlex.quote(self.remote_binary.as_posix())}",
+        )
+        await self.exec_as_root(
+            environment,
+            command=self._ca_certificate_install_command(),
+            timeout_sec=180,
         )
         validation = await environment.exec(
             command=f"{shlex.quote(self.remote_binary.as_posix())} --version",
@@ -111,6 +134,7 @@ class RaraAgent(BaseInstalledAgent):
         )
 
         env = {
+            **self._provider_env(),
             **self.extra_env,
             "RARA_HOME": self.rara_home.as_posix(),
             "RARA_LOCAL_EMBEDDINGS": "off",
@@ -121,6 +145,13 @@ class RaraAgent(BaseInstalledAgent):
         stdout = result.stdout or ""
         events = parse_rara_jsonl(stdout)
         self._populate_context(context, events)
+        if self._completed_with_mock_backend(events):
+            raise RuntimeError(
+                "RARA completed with the mock backend. Pass provider/model credentials "
+                "to the Harbor adapter, for example "
+                "--agent-kwarg provider=gemini --agent-kwarg model=gemini-2.5-flash, "
+                "or expose a supported provider API key in the Harbor process environment."
+            )
         if result.return_code != 0:
             raise self._classify_exec_error(command, result)
 
@@ -133,11 +164,13 @@ class RaraAgent(BaseInstalledAgent):
         last_message_path = shlex.quote(DEFAULT_LAST_MESSAGE_PATH.as_posix())
         run_id = shlex.quote(self.context_id.hex if self.context_id else "harbor")
         task_id = shlex.quote(self.session_id or "harbor-task")
+        global_flags = self._build_rara_global_flags()
+        binary_invocation = f"{binary} {global_flags}".rstrip()
         return (
             f"mkdir -p {shlex.quote(EnvironmentPaths.agent_dir.as_posix())} "
             f"{shlex.quote(self.rara_home.as_posix())} || exit $?; "
             "{ "
-            f"{binary} exec --json --cwd {cwd} --run-id {run_id} --task-id {task_id} "
+            f"{binary_invocation} exec --json --cwd {cwd} --run-id {run_id} --task-id {task_id} "
             f"--output-last-message {last_message_path} - "
             f"< {instruction_path}; "
             f"printf '%s\\n' \"$?\" > {status_path}; "
@@ -145,6 +178,69 @@ class RaraAgent(BaseInstalledAgent):
             f"status=$(cat {status_path} 2>/dev/null || printf '1'); "
             'exit "$status"'
         )
+
+    @staticmethod
+    def _ca_certificate_install_command() -> str:
+        bundle = shlex.quote(CA_CERTIFICATE_BUNDLE.as_posix())
+        return (
+            f"if [ -s {bundle} ]; then exit 0; fi; "
+            "if command -v apt-get >/dev/null 2>&1; then "
+            "export DEBIAN_FRONTEND=noninteractive; "
+            "apt-get update && "
+            "apt-get install -y --no-install-recommends ca-certificates && "
+            "update-ca-certificates; "
+            "elif command -v apk >/dev/null 2>&1; then "
+            "apk add --no-cache ca-certificates && "
+            "update-ca-certificates; "
+            "elif command -v dnf >/dev/null 2>&1; then "
+            "dnf install -y ca-certificates && "
+            "(update-ca-trust extract || true); "
+            "elif command -v yum >/dev/null 2>&1; then "
+            "yum install -y ca-certificates && "
+            "(update-ca-trust extract || true); "
+            "else "
+            "echo 'RARA requires CA certificates, but no supported package manager was found.' >&2; "
+            "exit 1; "
+            "fi"
+        )
+
+    def _build_rara_global_flags(self) -> str:
+        flags: list[str] = []
+        provider = self.effective_provider()
+        if provider:
+            flags.extend(["--provider", shlex.quote(provider)])
+        if self.base_url:
+            flags.extend(["--base-url", shlex.quote(self.base_url)])
+        if self.model:
+            flags.extend(["--model", shlex.quote(self.model)])
+        return " ".join(flags)
+
+    def _provider_env(self) -> dict[str, str]:
+        api_key = self._api_key_from_host_env()
+        if api_key is None:
+            return {}
+        return {"RARA_API_KEY": api_key}
+
+    def _api_key_from_host_env(self) -> str | None:
+        names: tuple[str, ...]
+        if self.api_key_env:
+            names = (self.api_key_env,)
+        else:
+            provider = self.effective_provider()
+            names = PROVIDER_API_KEY_ENVS.get(provider or "", ())
+        for name in names:
+            value = os.environ.get(name)
+            if value and value.strip():
+                return value
+        return None
+
+    def effective_provider(self) -> str | None:
+        if self.provider:
+            return self.provider
+        for provider in PROVIDER_INFERENCE_ORDER:
+            if any(os.environ.get(name, "").strip() for name in PROVIDER_API_KEY_ENVS[provider]):
+                return provider
+        return None
 
     @staticmethod
     def _populate_context(context: AgentContext, events: list[dict[str, Any]]) -> None:
@@ -184,6 +280,16 @@ class RaraAgent(BaseInstalledAgent):
             "jsonl_path": DEFAULT_JSONL_PATH.as_posix(),
             "last_message_path": DEFAULT_LAST_MESSAGE_PATH.as_posix(),
         }
+
+    @staticmethod
+    def _completed_with_mock_backend(events: list[dict[str, Any]]) -> bool:
+        for event in events:
+            if event.get("type") != "turn.completed":
+                continue
+            final_message = event.get("final_message")
+            if isinstance(final_message, str) and final_message.startswith("Mock Response:"):
+                return True
+        return False
 
     def effective_cwd(self) -> str:
         return self.cwd or DEFAULT_BENCHMARK_CWD

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -4,6 +4,7 @@ import asyncio
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 from uuid import UUID
 
 from harbor.models.agent.context import AgentContext
@@ -122,7 +123,8 @@ class RaraAgentTests(unittest.TestCase):
         agent.context_id = UUID("00000000-0000-0000-0000-000000000123")
         agent.session_id = "trial-agent"
 
-        command = agent._build_exec_command()
+        with patch.dict("os.environ", {}, clear=True):
+            command = agent._build_exec_command()
 
         self.assertIn("/opt/rara exec --json", command)
         self.assertIn("--cwd /app", command)
@@ -136,6 +138,23 @@ class RaraAgentTests(unittest.TestCase):
         self.assertIn('exit "$status"', command)
         self.assertNotIn("2>&1", command)
         self.assertIn("| tee /logs/agent/rara-exec.jsonl", command)
+
+    def test_build_exec_command_includes_provider_flags_without_api_key(self) -> None:
+        agent = RaraAgent(
+            logs_dir=Path("/tmp/logs"),
+            binary_path="/tmp/rara",
+            remote_binary="/opt/rara",
+            provider="gemini",
+            model="gemini-2.5-flash",
+        )
+
+        command = agent._build_exec_command()
+
+        self.assertIn(
+            "/opt/rara --provider gemini --model gemini-2.5-flash exec --json",
+            command,
+        )
+        self.assertNotIn("--api-key", command)
 
     def test_default_cwd_matches_terminal_bench_workdir(self) -> None:
         agent = RaraAgent(logs_dir=Path("/tmp/logs"), binary_path="/tmp/rara")
@@ -168,6 +187,57 @@ class RaraAgentTests(unittest.TestCase):
         self.assertEqual(environment.exec_env["RARA_LOCAL_EMBEDDINGS"], "off")
         self.assertEqual(environment.exec_env["RARA_HOME"], "/logs/agent/rara-home")
         self.assertEqual(environment.exec_cwd, "/app")
+
+    def test_run_maps_inferred_provider_api_key_to_rara_api_key(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            context = AgentContext()
+            environment = FakeRunEnvironment()
+
+            with patch.dict("os.environ", {"GEMINI_API_KEY": "secret"}, clear=True):
+                asyncio.run(agent.run("solve task", environment, context))  # type: ignore[arg-type]
+                self.assertEqual(agent.effective_provider(), "gemini")
+                self.assertIn("--provider gemini", agent._build_exec_command())
+
+        self.assertEqual(environment.exec_env["RARA_API_KEY"], "secret")
+
+    def test_run_prefers_explicit_extra_env_over_inferred_provider_key(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(
+                logs_dir=Path(temp),
+                binary_path="/tmp/rara",
+                extra_env={"RARA_API_KEY": "explicit"},
+            )
+            context = AgentContext()
+            environment = FakeRunEnvironment()
+
+            with patch.dict("os.environ", {"GEMINI_API_KEY": "inferred"}, clear=True):
+                asyncio.run(agent.run("solve task", environment, context))  # type: ignore[arg-type]
+
+        self.assertEqual(environment.exec_env["RARA_API_KEY"], "explicit")
+
+    def test_run_rejects_mock_backend_completion(self) -> None:
+        class FakeMockRunEnvironment(FakeRunEnvironment):
+            async def exec(
+                self,
+                command: str,
+                cwd: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> FakeExecResult:
+                self.exec_cwd = cwd
+                self.exec_env = dict(env or {})
+                return FakeExecResult(
+                    0,
+                    stdout='{"type":"turn.completed","final_message":"Mock Response: solve task"}\n',
+                )
+
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            context = AgentContext()
+            environment = FakeMockRunEnvironment()
+
+            with self.assertRaisesRegex(RuntimeError, "mock backend"):
+                asyncio.run(agent.run("solve task", environment, context))  # type: ignore[arg-type]
 
     def test_run_wraps_instruction_with_benchmark_artifact_guidance(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
@@ -219,6 +289,50 @@ class RaraAgentTests(unittest.TestCase):
                 asyncio.run(agent.install(environment))  # type: ignore[arg-type]
 
         self.assertIn("/installed-agent/rara --version", environment.commands)
+
+    def test_install_ensures_ca_certificates_before_validation(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            binary_path = Path(temp) / "rara"
+            binary_path.touch()
+            agent = RaraAgent(logs_dir=Path("/tmp/logs"), binary_path=str(binary_path))
+            environment = FakeInstallEnvironment()
+
+            with self.assertRaisesRegex(RuntimeError, "Linux binary"):
+                asyncio.run(agent.install(environment))  # type: ignore[arg-type]
+
+        ca_command_index = next(
+            index
+            for index, command in enumerate(environment.commands)
+            if "ca-certificates" in command
+        )
+        validation_index = next(
+            index
+            for index, command in enumerate(environment.commands)
+            if command.endswith("--version")
+        )
+        self.assertLess(ca_command_index, validation_index)
+
+    def test_ca_certificate_install_command_supports_common_images(self) -> None:
+        command = RaraAgent._ca_certificate_install_command()
+
+        self.assertIn("/etc/ssl/certs/ca-certificates.crt", command)
+        self.assertIn(
+            "apt-get update && "
+            "apt-get install -y --no-install-recommends ca-certificates && "
+            "update-ca-certificates",
+            command,
+        )
+        self.assertIn(
+            "apk add --no-cache ca-certificates && update-ca-certificates", command
+        )
+        self.assertIn(
+            "dnf install -y ca-certificates && (update-ca-trust extract || true)",
+            command,
+        )
+        self.assertIn(
+            "yum install -y ca-certificates && (update-ca-trust extract || true)",
+            command,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- install CA certificates during Harbor agent setup before validating the uploaded RARA binary
- pass Harbor provider/model/base URL settings into `rara exec`
- forward provider API keys through `RARA_API_KEY` instead of command-line flags
- fail early when a Harbor run completes with the mock backend
- record the checkpoint in a dated journal

## Motivation

Terminal-Bench containers can lack a CA bundle during the agent phase, causing `reqwest::Client::new()` to panic before RARA can start a real turn. After that was fixed, isolated benchmark containers could still run RARA with the mock backend when provider credentials were not forwarded, producing a successful-looking final message without creating `/app/solution.sparql`.

## Related Issue

None.

## Testing

```bash
PYTHONPATH=$PWD/tools/harbor /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -m unittest tools.harbor.test_rara_agent
git diff --check
```
