### PR TITLE
fix(tools): allow Harbor headless shell commands

### DIFF
--- a/.github/workflows/harbor-adapter.yml
+++ b/.github/workflows/harbor-adapter.yml
@@ -1,0 +1,49 @@
+name: harbor-adapter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  harbor-adapter:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install Harbor
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "harbor==0.17.1"
+
+      - name: Run Harbor adapter tests
+        run: PYTHONPATH=$PWD/tools/harbor python -m unittest tools.harbor.test_rara_agent
+
+  exec-cli:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-05-02
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run exec CLI tests
+        run: cargo test --locked app_cli::tests

--- a/docs/journal/2026-07-09-harbor-headless-full-access.md
+++ b/docs/journal/2026-07-09-harbor-headless-full-access.md
@@ -1,0 +1,63 @@
+# Harbor Headless Full Access
+
+**Date**: 2026-07-09
+**Context**: Terminal-Bench runs through `rara exec` and the Harbor adapter.
+**Result**: Harbor now runs headless RARA with explicit full-access shell mode inside the task container.
+
+---
+
+## Summary
+
+`terminal-bench/overfull-hbox` exposed a headless execution gap after provider credentials were fixed. The model correctly tried to compile `main.tex` with `pdflatex`, but the bash tool first attempted sandboxed execution. The task container did not have `bubblewrap`, so sandboxed bash failed with:
+
+```text
+sandboxed command execution is unsupported on platform linux (sandbox unavailable: install bubblewrap/bwrap)
+```
+
+The model then requested escalated shell permissions. In headless Harbor execution there is no interactive approval surface, so RARA stopped with:
+
+```text
+headless exec completed without a final assistant message
+```
+
+## Scope
+
+Changed:
+
+- `rara exec` accepts `--full-access`.
+- `run_exec_command` sets `Agent.full_access_mode` when the flag is present.
+- The Harbor adapter passes `--full-access` by default because Terminal-Bench already isolates the run inside a task container.
+- The Harbor benchmark instruction tells the model to request escalated sandbox permissions for shell commands, so missing `bwrap` does not force a failed first sandbox attempt.
+- Harbor adapter tests now assert that generated `rara exec` commands include `--full-access`.
+- CI now has a focused `harbor-adapter` workflow for the Python adapter tests and `app_cli::tests`.
+
+Not changed:
+
+- TUI permission defaults.
+- Non-Harbor `rara exec` behavior unless callers opt into `--full-access`.
+- The bash tool sandbox implementation.
+
+## Key Decisions
+
+- Keep the permission expansion explicit at the `rara exec` CLI boundary instead of inferring from environment variables.
+- Apply full access in the Harbor adapter because benchmark containers are already the isolation boundary and many Terminal-Bench tasks require shell commands for validation.
+
+## Validation
+
+Failure log inspected:
+
+- `jobs/2026-07-09__13-32-01/result.json`
+- `jobs/2026-07-09__13-32-01/overfull-hbox__NELn3Jb/agent/rara-exec.jsonl`
+- `jobs/2026-07-09__13-32-01/overfull-hbox__NELn3Jb/exception.txt`
+
+Commands:
+
+```bash
+PYTHONPATH=$PWD/tools/harbor /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -m unittest tools.harbor.test_rara_agent
+cargo test --locked app_cli::tests
+git diff --check
+```
+
+## Follow-Ups
+
+- Re-run `terminal-bench/overfull-hbox` after the fix lands to confirm that `pdflatex` runs inside the task container without an approval pause.

--- a/docs/journal/2026-07-09-harbor-provider-env.md
+++ b/docs/journal/2026-07-09-harbor-provider-env.md
@@ -61,6 +61,15 @@ Manual log inspection used:
 - `jobs/2026-07-08__20-45-55/sparql-university__w3PTeRy/agent/rara-exec.jsonl`
 - `jobs/2026-07-09__11-04-40/sparql-university__CnKTBtr/agent/rara-exec.jsonl`
 
+Full Terminal-Bench validation used a different task from `terminal-bench/terminal-bench-2`:
+
+- `jobs/2026-07-09__11-22-44/regex-log__duKe4R5/config.json`
+- `jobs/2026-07-09__11-22-44/regex-log__duKe4R5/agent/rara-exec.status`
+- `jobs/2026-07-09__11-22-44/regex-log__duKe4R5/result.json`
+- `jobs/2026-07-09__11-22-44/regex-log__duKe4R5/verifier/reward.txt`
+
+The `terminal-bench/regex-log` run exited with RARA status `0` and verifier reward `1.0`.
+
 ## Follow-Ups
 
-- Run a full Harbor Terminal-Bench job with a rotated provider key and verify that `/app/solution.sparql` is created before the verifier starts.
+- None for this checkpoint.

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -111,6 +111,10 @@ struct ExecArgs {
     #[arg(long = "task-id", value_name = "ID")]
     task_id: Option<String>,
 
+    /// Run headless automation with full shell access inside the selected workspace/container.
+    #[arg(long = "full-access", default_value_t = false)]
+    full_access: bool,
+
     /// Initial instructions. If omitted, or if `-` is used, read from stdin.
     #[arg(value_name = "PROMPT")]
     prompt: Option<String>,
@@ -302,7 +306,10 @@ async fn run_exec_command(config: &RaraConfig, args: ExecArgs) -> Result<()> {
     }
     let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
     emit_bootstrap_warnings(&bootstrap.warnings);
-    let agent = bootstrap.into_agent();
+    let mut agent = bootstrap.into_agent();
+    if args.full_access {
+        agent.set_full_access_mode(true);
+    }
     let consumer = crate::exec_consumer::ExecConsumer::new(
         agent,
         crate::exec_consumer::ExecRunOptions {
@@ -729,6 +736,7 @@ mod tests {
             "task-1",
             "--output-last-message",
             "final.txt",
+            "--full-access",
             "-",
         ])
         .expect("parse exec");
@@ -739,6 +747,7 @@ mod tests {
                 assert_eq!(args.run_id.as_deref(), Some("run-1"));
                 assert_eq!(args.task_id.as_deref(), Some("task-1"));
                 assert_eq!(args.output_last_message, Some(PathBuf::from("final.txt")));
+                assert!(args.full_access);
                 assert_eq!(args.prompt.as_deref(), Some("-"));
             }
             other => panic!("unexpected command: {other:?}"),
@@ -823,6 +832,7 @@ mod tests {
                 output_last_message: None,
                 run_id: None,
                 task_id: None,
+                full_access: false,
                 prompt: Some("hello".to_string()),
             }))
             .is_none()

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -170,7 +170,8 @@ class RaraAgent(BaseInstalledAgent):
             f"mkdir -p {shlex.quote(EnvironmentPaths.agent_dir.as_posix())} "
             f"{shlex.quote(self.rara_home.as_posix())} || exit $?; "
             "{ "
-            f"{binary_invocation} exec --json --cwd {cwd} --run-id {run_id} --task-id {task_id} "
+            f"{binary_invocation} exec --json --full-access --cwd {cwd} "
+            f"--run-id {run_id} --task-id {task_id} "
             f"--output-last-message {last_message_path} - "
             f"< {instruction_path}; "
             f"printf '%s\\n' \"$?\" > {status_path}; "
@@ -303,6 +304,7 @@ Work only in the benchmark workspace: {cwd}.
 Read the task carefully and create every file path that the task asks for exactly as specified.
 If the task names an absolute output path under the workspace, write that artifact before you finish.
 Use available shell and file tools to inspect inputs, edit files, and run focused validation commands.
+When running shell commands, request escalated sandbox permissions; Harbor already isolates this task inside its container.
 Do not finish with only an explanation. Finish only after the requested artifacts exist, or report the exact blocker if you cannot create them.
 
 Task instructions:

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -126,13 +126,13 @@ class RaraAgentTests(unittest.TestCase):
         with patch.dict("os.environ", {}, clear=True):
             command = agent._build_exec_command()
 
-        self.assertIn("/opt/rara exec --json", command)
+        self.assertIn("/opt/rara exec --json --full-access", command)
         self.assertIn("--cwd /app", command)
         self.assertIn("--run-id 00000000000000000000000000000123", command)
         self.assertIn("--task-id trial-agent", command)
         self.assertIn("--output-last-message /logs/agent/last-message.txt", command)
         self.assertIn("< /logs/agent/instruction.txt", command)
-        self.assertIn("{ /opt/rara exec --json", command)
+        self.assertIn("{ /opt/rara exec --json --full-access", command)
         self.assertIn("printf '%s\\n' \"$?\" > /logs/agent/rara-exec.status", command)
         self.assertIn("status=$(cat /logs/agent/rara-exec.status", command)
         self.assertIn('exit "$status"', command)
@@ -151,7 +151,7 @@ class RaraAgentTests(unittest.TestCase):
         command = agent._build_exec_command()
 
         self.assertIn(
-            "/opt/rara --provider gemini --model gemini-2.5-flash exec --json",
+            "/opt/rara --provider gemini --model gemini-2.5-flash exec --json --full-access",
             command,
         )
         self.assertNotIn("--api-key", command)
@@ -258,6 +258,7 @@ class RaraAgentTests(unittest.TestCase):
         self.assertIn("non-interactive Terminal-Bench task container", uploaded_instruction)
         self.assertIn("Work only in the benchmark workspace: /app", uploaded_instruction)
         self.assertIn("create every file path that the task asks for", uploaded_instruction)
+        self.assertIn("request escalated sandbox permissions", uploaded_instruction)
         self.assertIn("/app/solution.sparql", uploaded_instruction)
         self.assertIn("Do not finish with only an explanation", uploaded_instruction)
 


### PR DESCRIPTION
## Summary

- add `rara exec --full-access` for headless automation
- run the Harbor Terminal-Bench adapter with full access inside the task container
- instruct Harbor benchmark runs to request escalated shell sandbox permissions
- add a focused `harbor-adapter` GitHub Actions workflow
- record the `terminal-bench/overfull-hbox` failure mode in a journal

## Motivation

`terminal-bench/overfull-hbox` needs shell validation through `pdflatex`. The task container did not have `bubblewrap`, so sandboxed bash failed. The model then requested escalated permissions, but headless Harbor has no approval surface, causing `headless exec completed without a final assistant message`.

## Related Issue

Follow-up to #681.

## Testing

```bash
PYTHONPATH=$PWD/tools/harbor /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -m unittest tools.harbor.test_rara_agent
cargo test --locked app_cli::tests
cargo fmt --all
git diff --check
```

Pre-commit hook also ran:

```bash
cargo fmt
cargo clippy
```
