### PR TITLE
chore: bump version to 0.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10849,7 +10849,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rara"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -10933,7 +10933,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -10942,7 +10942,7 @@ dependencies = [
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "async-trait",
  "libc",
@@ -10957,7 +10957,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -10968,7 +10968,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -10981,7 +10981,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -10989,7 +10989,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "ignore",
@@ -11000,7 +11000,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11010,7 +11010,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "rmcp 2.2.0",
@@ -11020,7 +11020,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -11038,14 +11038,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "fs2",
@@ -11060,7 +11060,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -11070,7 +11070,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11083,7 +11083,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11094,7 +11094,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "serde",
@@ -11103,7 +11103,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11116,11 +11116,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.6"
+version = "0.0.7"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11129,7 +11129,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

- bump the workspace package version from `0.0.6` to `0.0.7`
- refresh workspace package entries in `Cargo.lock`

## Motivation

Prepare the repository for the `v0.0.7` release. The release workflow requires the Cargo package version to match the tag version before any tag is created or release workflow is dispatched.

## Related Issue

None.

## Testing

```bash
cargo fmt --all
cargo metadata --locked --no-deps --format-version 1
cargo check --offline
cargo check --locked
export VERSION=0.0.7; cargo metadata --no-deps --format-version 1 | python3 -c 'import json,os,sys; data=json.load(sys.stdin); pkg=next(p for p in data["packages"] if p["name"]=="rara"); actual=pkg["version"]; expected=os.environ["VERSION"]; print(f"rara package version: {actual} (expected {expected})"); sys.exit(0 if actual == expected else 1)'
git diff --check
```

Pre-commit hook also ran:

```bash
cargo clippy
```

## Release Notes

This PR only prepares the version bump. Do not create or push `v0.0.7` until this PR is merged and the tag points at the merged commit with Cargo version `0.0.7`.
