### PR TITLE
chore: update Codex dependencies to 0.143.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,8 +1965,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1984,14 +1984,15 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "codex-client",
+ "codex-http-client",
  "codex-protocol",
  "codex-utils-rustls-provider",
  "eventsource-stream",
@@ -2012,34 +2013,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-app-server-protocol"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
-dependencies = [
- "anyhow",
- "clap",
- "codex-experimental-api-macros",
- "codex-protocol",
- "codex-shell-command",
- "codex-utils-absolute-path",
- "codex-utils-path-uri",
- "inventory",
- "rmcp 1.8.0",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "serde_with",
- "strum_macros 0.28.0",
- "thiserror 2.0.18",
- "tracing",
- "ts-rs",
- "uuid",
-]
-
-[[package]]
 name = "codex-async-utils"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -2047,45 +2023,29 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
- "bytes",
- "codex-utils-rustls-provider",
+ "codex-http-client",
  "eventsource-stream",
  "futures",
  "http 1.4.2",
- "opentelemetry",
  "rand 0.9.4",
- "reqwest 0.12.28",
- "rustls 0.23.41",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "system-configuration",
- "thiserror 2.0.18",
  "tokio",
- "tracing",
- "tracing-opentelemetry",
- "windows-sys 0.52.0",
- "zstd",
 ]
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 
 [[package]]
 name = "codex-config"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "codex-app-server-protocol",
  "codex-execpolicy",
  "codex-features",
  "codex-file-system",
@@ -2105,6 +2065,7 @@ dependencies = [
  "libc",
  "multimap",
  "prost",
+ "regex-lite",
  "schemars 0.8.22",
  "serde",
  "serde_ignored",
@@ -2125,8 +2086,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "anyhow",
  "clap",
@@ -2140,19 +2101,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-experimental-api-macros"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "codex-features"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2164,8 +2115,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2177,8 +2128,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2201,9 +2152,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-http-client"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
+dependencies = [
+ "bytes",
+ "codex-utils-rustls-provider",
+ "futures",
+ "http 1.4.2",
+ "opentelemetry",
+ "reqwest 0.12.28",
+ "rustls 0.23.41",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "windows-sys 0.52.0",
+ "zstd",
+]
+
+[[package]]
 name = "codex-keyring-store"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "keyring",
  "tracing",
@@ -2211,15 +2188,14 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "codex-agent-identity",
- "codex-app-server-protocol",
- "codex-client",
  "codex-config",
+ "codex-http-client",
  "codex-keyring-store",
  "codex-model-provider-info",
  "codex-otel",
@@ -2245,11 +2221,10 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "codex-api",
- "codex-app-server-protocol",
  "codex-protocol",
  "http 1.4.2",
  "schemars 0.8.22",
@@ -2258,11 +2233,10 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "chrono",
- "codex-app-server-protocol",
  "codex-collaboration-mode-templates",
  "codex-login",
  "codex-otel",
@@ -2277,8 +2251,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2296,6 +2270,7 @@ dependencies = [
  "rama-tcp",
  "rama-tls-rustls",
  "rama-unix",
+ "rand 0.9.4",
  "rustls-native-certs",
  "schannel",
  "security-framework 3.7.0",
@@ -2311,12 +2286,11 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "chrono",
  "codex-api",
- "codex-app-server-protocol",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-string",
@@ -2343,8 +2317,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2361,7 +2335,7 @@ dependencies = [
  "icu_locale_core",
  "icu_provider",
  "landlock",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "reqwest 0.12.28",
  "schemars 0.8.22",
  "seccompiler",
@@ -2381,8 +2355,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "age",
  "anyhow",
@@ -2399,37 +2373,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-shell-command"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
-dependencies = [
- "base64 0.22.1",
- "codex-protocol",
- "codex-utils-absolute-path",
- "libc",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "shlex 1.3.0",
- "tree-sitter",
- "tree-sitter-bash",
- "url",
- "which 8.0.4",
-]
-
-[[package]]
 name = "codex-terminal-detection"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "dirs",
  "dunce",
@@ -2440,8 +2394,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "lru 0.16.4",
  "sha1",
@@ -2450,8 +2404,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2459,8 +2413,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2472,8 +2426,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2481,8 +2435,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2491,8 +2445,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -2506,16 +2460,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "rustls 0.23.41",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 dependencies = [
  "regex-lite",
  "serde",
@@ -2524,8 +2478,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.142.5"
-source = "git+https://github.com/openai/codex?tag=rust-v0.142.5#26de83050b20f7e0ee211b9739e52ae00ce8032a"
+version = "0.143.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.143.0#c4d748f586a84a3ed5b6aceb82e9a1db4abb1cda"
 
 [[package]]
 name = "color_quant"
@@ -3028,7 +2982,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "walkdir",
- "which 7.0.3",
+ "which",
 ]
 
 [[package]]
@@ -6674,7 +6628,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -10125,7 +10079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -10144,7 +10098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10274,21 +10228,21 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -10315,7 +10269,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10353,7 +10307,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -11013,7 +10967,7 @@ name = "rara-mcp-client"
 version = "0.0.7"
 dependencies = [
  "anyhow",
- "rmcp 2.2.0",
+ "rmcp",
  "serde_json",
  "tokio",
 ]
@@ -11556,28 +11510,6 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "chrono",
- "futures",
- "pastey",
- "pin-project-lite",
- "rmcp-macros 1.8.0",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "rmcp"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
@@ -11589,7 +11521,7 @@ dependencies = [
  "pastey",
  "pin-project-lite",
  "process-wrap",
- "rmcp-macros 2.2.0",
+ "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -11598,19 +11530,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "rmcp-macros"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -12856,12 +12775,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
 
 [[package]]
-name = "streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
-
-[[package]]
 name = "strong_hash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13853,36 +13766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
-dependencies = [
- "cc",
- "regex",
- "regex-syntax",
- "serde_json",
- "streaming-iterator",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-bash"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-language"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
-
-[[package]]
 name = "triomphe"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14619,15 +14502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "8.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14670,7 +14544,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ tempfile = "3.17"
 ignore = "0.4.26"
 nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
 rmcp = { version = "2.0", features = ["client", "transport-child-process"] }
-codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.142.5" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.142.5" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.142.5" }
+codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.143.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.143.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.143.0" }
 rara-instructions = { path = "crates/instructions" }
 
 [package]


### PR DESCRIPTION
## Summary

- update OpenAI Codex git dependencies from `rust-v0.142.5` to `rust-v0.143.0`
- refresh `Cargo.lock` for the Codex dependency graph

## Motivation

Keep RARA on the latest stable Codex Rust dependency tag. The latest stable upstream tag was confirmed from `openai/codex` as `rust-v0.143.0`.

## Related Issue

None.

## Testing

```bash
cargo check --locked
cargo fmt --all
cargo test --locked app_cli::tests
git diff --check
```

Pre-commit hook also ran:

```bash
cargo clippy
```
