### PR TITLE
chore: bump version to 0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10803,7 +10803,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rara"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -10887,7 +10887,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -10896,7 +10896,7 @@ dependencies = [
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "async-trait",
  "libc",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -10922,7 +10922,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -10935,7 +10935,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -10943,7 +10943,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "ignore",
@@ -10954,7 +10954,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -10964,7 +10964,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -10974,7 +10974,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -10992,14 +10992,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "fs2",
@@ -11014,7 +11014,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -11024,7 +11024,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11037,7 +11037,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11048,7 +11048,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "serde",
@@ -11057,7 +11057,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11070,11 +11070,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.7"
+version = "0.0.8"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11083,7 +11083,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

- Bump the workspace package version from `0.0.7` to `0.0.8`.
- Refresh `Cargo.lock` so all workspace packages resolve to `0.0.8`.

## Motivation

Prepare the repository for the next RARA release after `v0.0.7`.

## Related Issues

None.

## Testing

- `cargo metadata --locked --no-deps --format-version 1`
- `VERSION=0.0.8 cargo metadata --no-deps --format-version 1 | python3 ...`
- `cargo fmt --all`
- `git diff --check`
- pre-commit: `cargo clippy`
