### PR TITLE
chore: bump version to 0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10831,7 +10831,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rara"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -10916,7 +10916,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -10925,7 +10925,7 @@ dependencies = [
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "libc",
@@ -10940,7 +10940,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -10951,7 +10951,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -10964,7 +10964,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -10972,7 +10972,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "ignore",
@@ -10983,7 +10983,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -10993,7 +10993,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -11003,7 +11003,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -11021,14 +11021,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "fs2",
@@ -11043,7 +11043,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -11053,7 +11053,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11066,7 +11066,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11077,7 +11077,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "serde",
@@ -11086,7 +11086,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11099,11 +11099,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.8"
+version = "0.0.9"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11112,7 +11112,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

- Bump the workspace package version from `0.0.8` to `0.0.9`.
- Synchronize `Cargo.lock` entries for the local RARA workspace crates.

## Purpose

Prepare the repository for the `v0.0.9` release so the release tag and Cargo package version will match.

## Related issue

- None

## Testing

- `cargo fmt`
- `cargo fmt --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `VERSION=0.0.9 cargo metadata --no-deps --format-version 1` with exact `rara` package version check
- `git diff --check`
