### PR TITLE
feat: add Harbor ATIF trajectory export

### DIFF
--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -183,7 +183,10 @@ Each trial should end with one of:
 - For single-task smoke runs, filter the dataset with `--task
   terminal-bench/<task-name>` and inspect `/logs/agent/rara-exec.jsonl`,
   `/logs/agent/rara-exec.status`, and verifier output when reward is `0.0`.
-- Confirm the Harbor run receives an ATIF-compatible trajectory artifact.
+- Confirm the Harbor run receives an ATIF-compatible `agent/trajectory.json`
+  artifact. The adapter writes this file by converting `rara exec --json`
+  events into Harbor's ATIF model and keeps `/logs/agent/rara-exec.jsonl` as
+  the raw event stream.
 - Confirm failures include enough trajectory data to reproduce the final
   decision.
 - Confirm headless configuration can select provider/model/API key without TUI
@@ -212,3 +215,4 @@ Each trial should end with one of:
 
 - `docs/journal/2026-07-05-rara-exec-headless.md`
 - `docs/journal/2026-07-05-harbor-rara-agent-adapter.md`
+- `docs/journal/2026-07-11-harbor-atif-trajectory.md`

--- a/docs/journal/2026-07-11-harbor-atif-trajectory.md
+++ b/docs/journal/2026-07-11-harbor-atif-trajectory.md
@@ -1,0 +1,46 @@
+# 2026-07-11 · Harbor ATIF trajectory
+
+## Summary
+
+RARA's Harbor adapter now declares ATIF support and writes
+`agent/trajectory.json` for Terminal-Bench runs. The adapter still preserves
+the raw `rara exec --json` stream as `/logs/agent/rara-exec.jsonl`, but Harbor
+can now upload and view a normalized trajectory artifact.
+
+## Scope
+
+- Converts RARA `thread.started`, `turn.completed`, `turn.failed`, and
+  `item.completed` JSONL events into Harbor's ATIF `Trajectory` model.
+- Records the benchmark instruction as the user step.
+- Emits assistant messages, reasoning, tool calls, tool progress, tool
+  results, system status, and failure messages as trajectory steps or
+  observations.
+- Links tool observations back to the RARA item id for the originating tool
+  call when possible.
+- Propagates final token counts from the RARA turn completion event into
+  Harbor agent context metrics.
+
+## Key Decisions
+
+- The adapter owns ATIF conversion because Harbor owns the artifact contract,
+  while `rara exec` remains responsible for the stable RARA JSONL event stream.
+- Tool result events do not currently carry an explicit call id, so the adapter
+  associates them with the most recent unmatched tool call of the same name.
+  The raw JSONL remains available for debugging if this heuristic is ambiguous.
+- The trajectory uses Harbor's current `ATIF-v1.7` model instead of a
+  RARA-local JSON schema.
+
+## Validation
+
+```bash
+HARBOR_SITE_PACKAGES=$(find /Users/hawkingrei/.local/share/uv/tools/harbor/lib -path '*/site-packages' -type d | head -1)
+PYTHONPATH="${HARBOR_SITE_PACKAGES}:tools/harbor:." python -m unittest tools.harbor.test_rara_agent
+cargo fmt
+git diff --check
+```
+
+## Follow-Ups
+
+- A future `rara exec` event revision can include explicit tool call ids on
+  tool result and progress events to remove the adapter-side name-matching
+  heuristic.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -49,7 +49,7 @@ Active backlog only. Keep this file small and current.
 - [x] Add a dynamic Harbor adapter that loads with
       `--agent rara_agent:RaraAgent` and invokes `rara exec --json` inside the
       benchmark task workspace.
-- [ ] Convert RARA JSONL events into full ATIF-compatible trajectory logs for
+- [x] Convert RARA JSONL events into full ATIF-compatible trajectory logs for
       Harbor result artifacts. See `docs/features/terminal-bench-evaluation.md`.
 
 ## Agent / Subagent

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -324,11 +324,12 @@ class RaraAgent(BaseInstalledAgent):
         if trajectory.final_metrics:
             metrics = trajectory.final_metrics
             context.cost_usd = metrics.total_cost_usd
-            context.n_input_tokens = metrics.total_prompt_tokens or context.n_input_tokens
-            context.n_output_tokens = (
-                metrics.total_completion_tokens or context.n_output_tokens
-            )
-            context.n_cache_tokens = metrics.total_cached_tokens or 0
+            if metrics.total_prompt_tokens is not None:
+                context.n_input_tokens = metrics.total_prompt_tokens
+            if metrics.total_completion_tokens is not None:
+                context.n_output_tokens = metrics.total_completion_tokens
+            if metrics.total_cached_tokens is not None:
+                context.n_cache_tokens = metrics.total_cached_tokens
 
     @staticmethod
     def _completed_with_mock_backend(events: list[dict[str, Any]]) -> bool:
@@ -403,8 +404,8 @@ def convert_rara_events_to_trajectory(
     pending_model_input: int | None = None
     pending_reasoning: list[str] = []
     pending_tool_calls: list[tuple[str, str]] = []
-    total_input_tokens = 0
-    total_output_tokens = 0
+    total_input_tokens: int | None = None
+    total_output_tokens: int | None = None
     final_message: str | None = None
     failure_message: str | None = None
 
@@ -436,8 +437,12 @@ def convert_rara_events_to_trajectory(
         if event_type == "turn.completed":
             usage = event.get("usage") or {}
             if isinstance(usage, dict):
-                total_input_tokens = _int_value(usage.get("input_tokens")) or 0
-                total_output_tokens = _int_value(usage.get("output_tokens")) or 0
+                total_input_tokens = _add_optional_int(
+                    total_input_tokens, _int_value(usage.get("input_tokens"))
+                )
+                total_output_tokens = _add_optional_int(
+                    total_output_tokens, _int_value(usage.get("output_tokens"))
+                )
             final_message = _string_value(event.get("final_message"))
             if final_message and not _has_agent_message_step(steps, final_message):
                 append_step(
@@ -592,8 +597,8 @@ def convert_rara_events_to_trajectory(
         ),
         steps=steps,
         final_metrics=FinalMetrics(
-            total_prompt_tokens=total_input_tokens or None,
-            total_completion_tokens=total_output_tokens or None,
+            total_prompt_tokens=total_input_tokens,
+            total_completion_tokens=total_output_tokens,
             total_cached_tokens=None,
             total_cost_usd=None,
             total_steps=len(steps),
@@ -608,6 +613,12 @@ def _string_value(value: Any) -> str | None:
 
 def _int_value(value: Any) -> int | None:
     return value if isinstance(value, int) else None
+
+
+def _add_optional_int(total: int | None, value: int | None) -> int | None:
+    if value is None:
+        return total
+    return (total or 0) + value
 
 
 def _take_joined(parts: list[str]) -> str | None:
@@ -626,7 +637,7 @@ def _last_matching_tool_call(pending: list[tuple[str, str]], name: str) -> str |
     for call_id, pending_name in reversed(pending):
         if pending_name == name:
             return call_id
-    return pending[-1][0] if pending else None
+    return None
 
 
 def _pop_matching_tool_call(pending: list[tuple[str, str]], name: str) -> str | None:
@@ -635,10 +646,7 @@ def _pop_matching_tool_call(pending: list[tuple[str, str]], name: str) -> str | 
         if pending_name == name:
             del pending[index]
             return call_id
-    if not pending:
-        return None
-    call_id, _ = pending.pop()
-    return call_id
+    return None
 
 
 def _append_observation(
@@ -664,6 +672,7 @@ def _append_observation(
 
 def _attach_metrics_to_latest_agent_step(steps: list[Step], metrics: Metrics) -> None:
     for step in reversed(steps):
-        if step.source == "agent" and step.metrics is None:
-            step.metrics = metrics
+        if step.source == "agent":
+            if step.metrics is None:
+                step.metrics = metrics
             return

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -18,7 +18,18 @@ from typing import Any
 from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
 from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
+from harbor.models.trajectories import (
+    Agent,
+    FinalMetrics,
+    Metrics,
+    Observation,
+    ObservationResult,
+    Step,
+    ToolCall,
+    Trajectory,
+)
 from harbor.models.trial.paths import EnvironmentPaths
+from harbor.utils.trajectory_utils import format_trajectory_json
 
 
 DEFAULT_REMOTE_BINARY = PurePosixPath("/installed-agent/rara")
@@ -27,6 +38,7 @@ DEFAULT_JSONL_PATH = EnvironmentPaths.agent_dir / "rara-exec.jsonl"
 DEFAULT_EXIT_STATUS_PATH = EnvironmentPaths.agent_dir / "rara-exec.status"
 DEFAULT_INSTRUCTION_PATH = EnvironmentPaths.agent_dir / "instruction.txt"
 DEFAULT_LAST_MESSAGE_PATH = EnvironmentPaths.agent_dir / "last-message.txt"
+DEFAULT_TRAJECTORY_PATH = EnvironmentPaths.agent_dir / "trajectory.json"
 DEFAULT_BENCHMARK_CWD = "/app"
 CA_CERTIFICATE_BUNDLE = PurePosixPath("/etc/ssl/certs/ca-certificates.crt")
 PROVIDER_API_KEY_ENVS = {
@@ -43,7 +55,7 @@ PROVIDER_INFERENCE_ORDER = ("deepseek", "kimi", "gemini", "openrouter", "codex")
 class RaraAgent(BaseInstalledAgent):
     """Run RARA as a Harbor installed agent using the headless exec surface."""
 
-    SUPPORTS_ATIF = False
+    SUPPORTS_ATIF = True
     SUPPORTS_WINDOWS = False
 
     def __init__(
@@ -145,6 +157,7 @@ class RaraAgent(BaseInstalledAgent):
         stdout = result.stdout or ""
         events = parse_rara_jsonl(stdout)
         self._populate_context(context, events)
+        self._write_trajectory(context, instruction=benchmark_instruction, events=events)
         if self._completed_with_mock_backend(events):
             raise RuntimeError(
                 "RARA completed with the mock backend. Pass provider/model credentials "
@@ -280,7 +293,42 @@ class RaraAgent(BaseInstalledAgent):
             "failure": failure,
             "jsonl_path": DEFAULT_JSONL_PATH.as_posix(),
             "last_message_path": DEFAULT_LAST_MESSAGE_PATH.as_posix(),
+            "trajectory_path": DEFAULT_TRAJECTORY_PATH.as_posix(),
         }
+
+    def _write_trajectory(
+        self,
+        context: AgentContext,
+        *,
+        instruction: str,
+        events: list[dict[str, Any]],
+    ) -> None:
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction=instruction,
+            agent_version=self.version() or "unknown",
+            default_model_name=self.model,
+        )
+        if trajectory is None:
+            return
+
+        trajectory_path = self.logs_dir / "trajectory.json"
+        try:
+            trajectory_path.write_text(
+                format_trajectory_json(trajectory.to_json_dict()), encoding="utf-8"
+            )
+        except OSError as exc:
+            self.logger.debug(f"Failed to write RARA trajectory file: {exc}")
+            return
+
+        if trajectory.final_metrics:
+            metrics = trajectory.final_metrics
+            context.cost_usd = metrics.total_cost_usd
+            context.n_input_tokens = metrics.total_prompt_tokens or context.n_input_tokens
+            context.n_output_tokens = (
+                metrics.total_completion_tokens or context.n_output_tokens
+            )
+            context.n_cache_tokens = metrics.total_cached_tokens or 0
 
     @staticmethod
     def _completed_with_mock_backend(events: list[dict[str, Any]]) -> bool:
@@ -332,3 +380,290 @@ def parse_rara_jsonl(output: str) -> list[dict[str, Any]]:
         if isinstance(payload, dict) and isinstance(payload.get("type"), str):
             events.append(payload)
     return events
+
+
+def convert_rara_events_to_trajectory(
+    events: list[dict[str, Any]],
+    *,
+    instruction: str,
+    agent_version: str = "unknown",
+    default_model_name: str | None = None,
+) -> Trajectory | None:
+    """Convert RARA exec JSONL events into Harbor's ATIF trajectory model."""
+    if not events and not instruction.strip():
+        return None
+
+    session_id = "unknown"
+    run_id: str | None = None
+    task_id: str | None = None
+    event_counts: dict[str, int] = {}
+    steps: list[Step] = []
+    next_step_id = 1
+    last_model_name = default_model_name
+    pending_model_input: int | None = None
+    pending_reasoning: list[str] = []
+    pending_tool_calls: list[tuple[str, str]] = []
+    total_input_tokens = 0
+    total_output_tokens = 0
+    final_message: str | None = None
+    failure_message: str | None = None
+
+    def append_step(**kwargs: Any) -> Step:
+        nonlocal next_step_id
+        step = Step(step_id=next_step_id, **kwargs)
+        steps.append(step)
+        next_step_id += 1
+        return step
+
+    if instruction.strip():
+        append_step(source="user", message=instruction)
+
+    for event in events:
+        event_type = event.get("type")
+        if isinstance(event_type, str):
+            event_counts[event_type] = event_counts.get(event_type, 0) + 1
+
+        timestamp = _string_value(event.get("timestamp"))
+
+        if event_type == "thread.started":
+            metadata = event.get("metadata") or {}
+            if isinstance(metadata, dict):
+                session_id = _string_value(metadata.get("session_id")) or session_id
+                run_id = _string_value(metadata.get("run_id"))
+                task_id = _string_value(metadata.get("task_id"))
+            continue
+
+        if event_type == "turn.completed":
+            usage = event.get("usage") or {}
+            if isinstance(usage, dict):
+                total_input_tokens = _int_value(usage.get("input_tokens")) or 0
+                total_output_tokens = _int_value(usage.get("output_tokens")) or 0
+            final_message = _string_value(event.get("final_message"))
+            if final_message and not _has_agent_message_step(steps, final_message):
+                append_step(
+                    source="agent",
+                    timestamp=timestamp,
+                    model_name=last_model_name,
+                    message=final_message,
+                )
+            continue
+
+        if event_type == "turn.failed":
+            error = event.get("error") or {}
+            if isinstance(error, dict):
+                failure_message = _string_value(error.get("message"))
+            if failure_message:
+                append_step(
+                    source="system",
+                    timestamp=timestamp,
+                    message=f"RARA exec failed: {failure_message}",
+                )
+            continue
+
+        if event_type != "item.completed":
+            continue
+
+        item = event.get("item") or {}
+        if not isinstance(item, dict):
+            continue
+        item_id = _string_value(item.get("id")) or f"item_{next_step_id}"
+        item_type = item.get("type")
+
+        if item_type == "reasoning":
+            text = _string_value(item.get("text"))
+            if text:
+                pending_reasoning.append(text)
+            continue
+
+        if item_type == "agent_message":
+            text = _string_value(item.get("text"))
+            if text:
+                append_step(
+                    source="agent",
+                    timestamp=timestamp,
+                    model_name=last_model_name,
+                    message=text,
+                    reasoning_content=_take_joined(pending_reasoning),
+                )
+            continue
+
+        if item_type == "tool_call":
+            name = _string_value(item.get("name")) or "tool"
+            arguments = item.get("input")
+            if not isinstance(arguments, dict):
+                arguments = {"input": arguments}
+            pending_tool_calls.append((item_id, name))
+            append_step(
+                source="agent",
+                timestamp=timestamp,
+                model_name=last_model_name,
+                message=f"Call tool `{name}`.",
+                reasoning_content=_take_joined(pending_reasoning),
+                tool_calls=[
+                    ToolCall(
+                        tool_call_id=item_id,
+                        function_name=name,
+                        arguments=arguments,
+                    )
+                ],
+            )
+            continue
+
+        if item_type == "tool_result":
+            name = _string_value(item.get("name")) or "tool"
+            content = _string_value(item.get("content")) or ""
+            is_error = bool(item.get("is_error"))
+            call_id = _pop_matching_tool_call(pending_tool_calls, name)
+            _append_observation(
+                steps,
+                source_call_id=call_id,
+                content=content,
+                extra={"tool_name": name, "is_error": is_error},
+            )
+            continue
+
+        if item_type == "tool_progress":
+            name = _string_value(item.get("name")) or "tool"
+            stream = _string_value(item.get("stream"))
+            chunk = _string_value(item.get("chunk")) or ""
+            call_id = _last_matching_tool_call(pending_tool_calls, name)
+            _append_observation(
+                steps,
+                source_call_id=call_id,
+                content=chunk,
+                extra={"tool_name": name, "stream": stream, "progress": True},
+            )
+            continue
+
+        if item_type == "model_request":
+            last_model_name = _string_value(item.get("model")) or last_model_name
+            pending_model_input = _int_value(item.get("input_tokens"))
+            continue
+
+        if item_type == "model_response":
+            last_model_name = _string_value(item.get("model")) or last_model_name
+            output_tokens = _int_value(item.get("output_tokens"))
+            _attach_metrics_to_latest_agent_step(
+                steps,
+                Metrics(
+                    prompt_tokens=pending_model_input,
+                    completion_tokens=output_tokens,
+                    extra={"finish_reason": _string_value(item.get("finish_reason"))},
+                ),
+            )
+            pending_model_input = None
+            continue
+
+        if item_type == "status":
+            message = _string_value(item.get("message"))
+            if message:
+                append_step(source="system", timestamp=timestamp, message=message)
+            continue
+
+        if item_type == "error":
+            message = _string_value(item.get("message"))
+            if message:
+                append_step(
+                    source="system",
+                    timestamp=timestamp,
+                    message=message,
+                    extra={"recoverable": bool(item.get("recoverable"))},
+                )
+            continue
+
+    if not steps:
+        return None
+
+    final_extra = {
+        "event_counts": event_counts,
+        "run_id": run_id,
+        "task_id": task_id,
+        "final_message": final_message,
+        "failure": failure_message,
+    }
+
+    return Trajectory(
+        schema_version="ATIF-v1.7",
+        session_id=session_id,
+        agent=Agent(
+            name="rara",
+            version=agent_version,
+            model_name=last_model_name,
+        ),
+        steps=steps,
+        final_metrics=FinalMetrics(
+            total_prompt_tokens=total_input_tokens or None,
+            total_completion_tokens=total_output_tokens or None,
+            total_cached_tokens=None,
+            total_cost_usd=None,
+            total_steps=len(steps),
+            extra={k: v for k, v in final_extra.items() if v is not None},
+        ),
+    )
+
+
+def _string_value(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _int_value(value: Any) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def _take_joined(parts: list[str]) -> str | None:
+    if not parts:
+        return None
+    joined = "\n".join(parts)
+    parts.clear()
+    return joined
+
+
+def _has_agent_message_step(steps: list[Step], message: str) -> bool:
+    return any(step.source == "agent" and step.message == message for step in steps)
+
+
+def _last_matching_tool_call(pending: list[tuple[str, str]], name: str) -> str | None:
+    for call_id, pending_name in reversed(pending):
+        if pending_name == name:
+            return call_id
+    return pending[-1][0] if pending else None
+
+
+def _pop_matching_tool_call(pending: list[tuple[str, str]], name: str) -> str | None:
+    for index in range(len(pending) - 1, -1, -1):
+        call_id, pending_name = pending[index]
+        if pending_name == name:
+            del pending[index]
+            return call_id
+    if not pending:
+        return None
+    call_id, _ = pending.pop()
+    return call_id
+
+
+def _append_observation(
+    steps: list[Step],
+    *,
+    source_call_id: str | None,
+    content: str,
+    extra: dict[str, Any],
+) -> None:
+    result = ObservationResult(
+        source_call_id=source_call_id,
+        content=content,
+        extra={k: v for k, v in extra.items() if v is not None},
+    )
+    for step in reversed(steps):
+        if step.source == "agent":
+            if step.observation is None:
+                step.observation = Observation(results=[result])
+            else:
+                step.observation.results.append(result)
+            return
+
+
+def _attach_metrics_to_latest_agent_step(steps: list[Step], metrics: Metrics) -> None:
+    for step in reversed(steps):
+        if step.source == "agent" and step.metrics is None:
+            step.metrics = metrics
+            return

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -9,7 +9,12 @@ from uuid import UUID
 
 from harbor.models.agent.context import AgentContext
 
-from rara_agent import RaraAgent, build_benchmark_instruction, parse_rara_jsonl
+from rara_agent import (
+    RaraAgent,
+    build_benchmark_instruction,
+    convert_rara_events_to_trajectory,
+    parse_rara_jsonl,
+)
 
 
 class FakeExecResult:
@@ -62,7 +67,110 @@ class FakeRunEnvironment:
         )
 
 
+class FakeTrajectoryEnvironment(FakeRunEnvironment):
+    async def exec(
+        self,
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> FakeExecResult:
+        self.exec_cwd = cwd
+        self.exec_env = dict(env or {})
+        events = [
+            {
+                "type": "thread.started",
+                "metadata": {
+                    "session_id": "session-1",
+                    "run_id": "run-1",
+                    "task_id": "task-1",
+                },
+                "timestamp": "2026-07-11T00:00:00Z",
+            },
+            {"type": "turn.started", "timestamp": "2026-07-11T00:00:01Z"},
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_0",
+                    "type": "model_request",
+                    "model": "gemini-2.5-flash",
+                    "input_tokens": 11,
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_1",
+                    "type": "reasoning",
+                    "text": "Need to inspect files.",
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_2",
+                    "type": "tool_call",
+                    "name": "bash",
+                    "input": {"command": "ls"},
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_3",
+                    "type": "tool_progress",
+                    "name": "bash",
+                    "stream": "stdout",
+                    "chunk": "solution.sparql\n",
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_4",
+                    "type": "tool_result",
+                    "name": "bash",
+                    "content": "done",
+                    "is_error": False,
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_5",
+                    "type": "agent_message",
+                    "text": "Created /app/solution.sparql.",
+                },
+            },
+            {
+                "type": "item.completed",
+                "item": {
+                    "id": "item_6",
+                    "type": "model_response",
+                    "model": "gemini-2.5-flash",
+                    "output_tokens": 7,
+                    "finish_reason": "stop",
+                },
+            },
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 13, "output_tokens": 9},
+                "final_message": "Created /app/solution.sparql.",
+                "timestamp": "2026-07-11T00:00:02Z",
+            },
+        ]
+        return FakeExecResult(0, stdout="\n".join(json_line(event) for event in events))
+
+
+def json_line(value: dict[str, object]) -> str:
+    import json
+
+    return json.dumps(value)
+
+
 class RaraAgentTests(unittest.TestCase):
+    def test_agent_declares_atif_support(self) -> None:
+        self.assertTrue(RaraAgent.SUPPORTS_ATIF)
+
     def test_parse_rara_jsonl_ignores_non_json_lines(self) -> None:
         output = "\n".join(
             [
@@ -96,6 +204,7 @@ class RaraAgentTests(unittest.TestCase):
         self.assertEqual(context.n_output_tokens, 7)
         self.assertEqual(context.metadata["final_message"], "done")
         self.assertEqual(context.metadata["event_counts"]["turn.completed"], 1)
+        self.assertEqual(context.metadata["trajectory_path"], "/logs/agent/trajectory.json")
 
     def test_populate_context_preserves_zero_token_counts(self) -> None:
         context = AgentContext()
@@ -187,6 +296,55 @@ class RaraAgentTests(unittest.TestCase):
         self.assertEqual(environment.exec_env["RARA_LOCAL_EMBEDDINGS"], "off")
         self.assertEqual(environment.exec_env["RARA_HOME"], "/logs/agent/rara-home")
         self.assertEqual(environment.exec_cwd, "/app")
+
+    def test_run_writes_atif_trajectory(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            context = AgentContext()
+            environment = FakeTrajectoryEnvironment()
+
+            asyncio.run(agent.run("Create /app/solution.sparql.", environment, context))  # type: ignore[arg-type]
+
+            trajectory = Path(temp, "trajectory.json")
+            data = trajectory.read_text(encoding="utf-8")
+
+        self.assertIn('"schema_version": "ATIF-v1.7"', data)
+        self.assertIn('"session_id": "session-1"', data)
+        self.assertIn('"name": "rara"', data)
+        self.assertIn('"function_name": "bash"', data)
+        self.assertIn('"source_call_id": "item_2"', data)
+        self.assertEqual(context.n_input_tokens, 13)
+        self.assertEqual(context.n_output_tokens, 9)
+
+    def test_convert_rara_events_to_trajectory_links_tool_observations(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"thread.started","metadata":{"session_id":"s"},"timestamp":"2026-07-11T00:00:00Z"}',
+                    '{"type":"item.completed","item":{"id":"call_1","type":"tool_call","name":"bash","input":{"command":"true"}}}',
+                    '{"type":"item.completed","item":{"id":"result_1","type":"tool_result","name":"bash","content":"ok","is_error":false}}',
+                    '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2},"final_message":"done","timestamp":"2026-07-11T00:00:01Z"}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Run a command.",
+            agent_version="test",
+            default_model_name="mock",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        tool_step = next(step for step in trajectory.steps if step.tool_calls)
+        self.assertEqual(tool_step.tool_calls[0].tool_call_id, "call_1")
+        self.assertIsNotNone(tool_step.observation)
+        assert tool_step.observation is not None
+        self.assertEqual(tool_step.observation.results[0].source_call_id, "call_1")
+        self.assertEqual(tool_step.observation.results[0].content, "ok")
+        self.assertEqual(trajectory.final_metrics.total_prompt_tokens, 5)
+        self.assertEqual(trajectory.final_metrics.total_completion_tokens, 2)
 
     def test_run_maps_inferred_provider_api_key_to_rara_api_key(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -346,6 +346,88 @@ class RaraAgentTests(unittest.TestCase):
         self.assertEqual(trajectory.final_metrics.total_prompt_tokens, 5)
         self.assertEqual(trajectory.final_metrics.total_completion_tokens, 2)
 
+    def test_write_trajectory_preserves_zero_token_context_metrics(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            context = AgentContext()
+            context.n_input_tokens = 9
+            context.n_output_tokens = 9
+            events = parse_rara_jsonl(
+                '{"type":"turn.completed","usage":{"input_tokens":0,"output_tokens":0},"final_message":"done"}'
+            )
+
+            agent._write_trajectory(context, instruction="Finish.", events=events)
+
+        self.assertEqual(context.n_input_tokens, 0)
+        self.assertEqual(context.n_output_tokens, 0)
+
+    def test_convert_rara_events_to_trajectory_accumulates_turn_usage(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2},"final_message":"first"}',
+                    '{"type":"turn.completed","usage":{"input_tokens":7,"output_tokens":3},"final_message":"second"}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Run multiple turns.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        self.assertEqual(trajectory.final_metrics.total_prompt_tokens, 12)
+        self.assertEqual(trajectory.final_metrics.total_completion_tokens, 5)
+
+    def test_unmatched_tool_result_does_not_borrow_other_tool_call_id(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"item.completed","item":{"id":"call_1","type":"tool_call","name":"read_file","input":{"path":"/app/a"}}}',
+                    '{"type":"item.completed","item":{"id":"result_1","type":"tool_result","name":"bash","content":"ok","is_error":false}}',
+                    '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1},"final_message":"done"}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Run one tool.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        tool_step = next(step for step in trajectory.steps if step.tool_calls)
+        self.assertIsNotNone(tool_step.observation)
+        assert tool_step.observation is not None
+        self.assertIsNone(tool_step.observation.results[0].source_call_id)
+
+    def test_model_response_does_not_attach_metrics_to_older_agent_step(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"item.completed","item":{"id":"msg_1","type":"agent_message","text":"first"}}',
+                    '{"type":"item.completed","item":{"id":"resp_1","type":"model_response","model":"mock","output_tokens":1,"finish_reason":"stop"}}',
+                    '{"type":"item.completed","item":{"id":"msg_2","type":"agent_message","text":"second"}}',
+                    '{"type":"item.completed","item":{"id":"resp_2","type":"model_response","model":"mock","output_tokens":2,"finish_reason":"stop"}}',
+                    '{"type":"item.completed","item":{"id":"resp_3","type":"model_response","model":"mock","output_tokens":3,"finish_reason":"stop"}}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Check metrics.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        agent_steps = [step for step in trajectory.steps if step.source == "agent"]
+        self.assertEqual(agent_steps[0].metrics.completion_tokens, 1)
+        self.assertEqual(agent_steps[1].metrics.completion_tokens, 2)
+
     def test_run_maps_inferred_provider_api_key_to_rara_api_key(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
             agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")


### PR DESCRIPTION
## Summary

- Enable ATIF support for the Harbor RARA adapter.
- Convert `rara exec --json` events into Harbor `agent/trajectory.json` artifacts.
- Preserve raw `/logs/agent/rara-exec.jsonl` output and update the Terminal-Bench TODO/spec/journal.

## Purpose

Terminal-Bench runs should produce a normalized trajectory artifact that Harbor can upload and view, while keeping RARA's JSONL stream as the runtime-owned raw event log.

## Related issue

- None

## Testing

```bash
HARBOR_SITE_PACKAGES=$(find /Users/hawkingrei/.local/share/uv/tools/harbor/lib -path '*/site-packages' -type d | head -1)
PYTHONPATH="${HARBOR_SITE_PACKAGES}:tools/harbor:." python -m unittest tools.harbor.test_rara_agent
cargo fmt
git diff --check
```
