### PR TITLE
fix(tools): preserve Harbor tool observation links

### DIFF
--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -466,10 +466,16 @@ fn command_exists(program: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn command_search_path_dirs(command_path: Option<&std::ffi::OsStr>) -> Vec<PathBuf> {
-    let home_dir = env::var_os("HOME")
+fn command_search_home_dir() -> Option<PathBuf> {
+    env::var_os("HOME")
         .map(PathBuf::from)
-        .and_then(|path| fs::canonicalize(&path).ok().or(Some(path)));
+        .and_then(|path| fs::canonicalize(&path).ok().or(Some(path)))
+}
+
+fn command_search_path_dirs(
+    command_path: Option<&std::ffi::OsStr>,
+    home_dir: Option<&Path>,
+) -> Vec<PathBuf> {
     command_path
         .map(OsString::from)
         .or_else(|| env::var_os("PATH"))
@@ -486,7 +492,7 @@ fn command_search_path_dirs(command_path: Option<&std::ffi::OsStr>) -> Vec<PathB
                 if path_contains_control_chars(&dir) {
                     continue;
                 }
-                if is_broad_command_search_dir(&dir, home_dir.as_deref()) {
+                if is_broad_command_search_dir(&dir, home_dir) {
                     continue;
                 }
                 if !dirs.iter().any(|existing| existing == &dir) {
@@ -503,17 +509,22 @@ fn is_broad_command_search_dir(dir: &Path, home_dir: Option<&Path>) -> bool {
 }
 
 fn command_search_install_roots(command_path: Option<&std::ffi::OsStr>) -> Vec<PathBuf> {
+    let home_dir = command_search_home_dir();
+    command_search_install_roots_for_home(command_path, home_dir.as_deref())
+}
+
+fn command_search_install_roots_for_home(
+    command_path: Option<&std::ffi::OsStr>,
+    home_dir: Option<&Path>,
+) -> Vec<PathBuf> {
     let mut roots = Vec::new();
-    let home_dir = env::var_os("HOME")
-        .map(PathBuf::from)
-        .and_then(|path| fs::canonicalize(&path).ok().or(Some(path)));
-    for dir in command_search_path_dirs(command_path) {
+    for dir in command_search_path_dirs(command_path, home_dir) {
         let root = if matches!(
             dir.file_name().and_then(|name| name.to_str()),
             Some("bin" | "sbin")
         ) {
             let parent = dir.parent().unwrap_or(dir.as_path());
-            if parent == Path::new("/") || home_dir.as_deref() == Some(parent) {
+            if parent == Path::new("/") || home_dir == Some(parent) {
                 dir.clone()
             } else {
                 parent.to_path_buf()

--- a/crates/sandbox/src/tests.rs
+++ b/crates/sandbox/src/tests.rs
@@ -6,8 +6,8 @@ use tempfile::tempdir;
 
 use super::{
     DEFAULT_SHELL, MACOS_SANDBOX_EXEC, SandboxBackend, SandboxManager, cleanup_profiles_older_than,
-    cleanup_stale_profiles, command_search_install_roots, sandbox_profile_string_literal,
-    sanitize_shell_program, shell_command_flag, shell_program,
+    cleanup_stale_profiles, command_search_install_roots, command_search_install_roots_for_home,
+    sandbox_profile_string_literal, sanitize_shell_program, shell_command_flag, shell_program,
 };
 
 fn manager(os: &str, backend: SandboxBackend) -> SandboxManager {
@@ -523,16 +523,7 @@ fn home_bin_path_stays_narrow() {
     std::fs::create_dir_all(&home_bin).expect("home bin dir");
     let home = std::fs::canonicalize(&home).expect("canonical home");
     let home_bin = home.join("bin");
-    let original_home = std::env::var_os("HOME");
-    set_env_var("HOME", &home);
-
-    let roots = command_search_install_roots(Some(home_bin.as_os_str()));
-
-    if let Some(home) = original_home {
-        set_env_var("HOME", home);
-    } else {
-        remove_env_var("HOME");
-    }
+    let roots = command_search_install_roots_for_home(Some(home_bin.as_os_str()), Some(&home));
 
     assert_eq!(roots, vec![home_bin]);
 }
@@ -548,18 +539,9 @@ fn command_search_install_roots_rejects_broad_path_entries() {
     let home = std::fs::canonicalize(&home).expect("canonical home");
     let tool_root = std::fs::canonicalize(&tool_root).expect("canonical tool root");
     let tool_bin = tool_root.join("bin");
-    let original_home = std::env::var_os("HOME");
-    set_env_var("HOME", &home);
-
     let path = env::join_paths([PathBuf::from("/"), home.clone(), tool_bin.clone()])
         .expect("build test PATH");
-    let roots = command_search_install_roots(Some(path.as_os_str()));
-
-    if let Some(home) = original_home {
-        set_env_var("HOME", home);
-    } else {
-        remove_env_var("HOME");
-    }
+    let roots = command_search_install_roots_for_home(Some(path.as_os_str()), Some(&home));
 
     assert_eq!(roots, vec![tool_root]);
 }

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -140,6 +140,10 @@ observation `source_call_id` belongs to a tool call on the same step. A future
 event revision may carry the provider tool-call id on progress and result events
 to remove this compatibility association.
 
+The adapter discards unmatched calls at `turn.completed` and `turn.failed`
+boundaries. A call without a result belongs only to its originating turn and
+must not affect same-name associations in a later turn.
+
 ### Tool Contract
 
 The same file and shell tools used in ordinary sessions must be available in the
@@ -197,6 +201,8 @@ Each trial should end with one of:
   the raw event stream.
 - Confirm multiple same-name tool calls in one model response keep each
   progress/result observation on the matching tool-call step.
+- Confirm an incomplete tool call cannot affect same-name result association in
+  the next completed or failed turn.
 - Confirm failures include enough trajectory data to reproduce the final
   decision.
 - Confirm headless configuration can select provider/model/API key without TUI

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -132,6 +132,14 @@ status items, model usage items, and final failure reasons. Later revisions can
 add richer command exit metadata and file-change grouping without requiring a
 benchmark-specific runtime.
 
+For the current headless runtime, tool calls from one model response execute in
+emission order. The Harbor adapter therefore associates same-name progress and
+result events with the earliest unmatched call of that name, and attaches the
+observation to that call's ATIF step. This preserves ATIF's requirement that an
+observation `source_call_id` belongs to a tool call on the same step. A future
+event revision may carry the provider tool-call id on progress and result events
+to remove this compatibility association.
+
 ### Tool Contract
 
 The same file and shell tools used in ordinary sessions must be available in the
@@ -187,6 +195,8 @@ Each trial should end with one of:
   artifact. The adapter writes this file by converting `rara exec --json`
   events into Harbor's ATIF model and keeps `/logs/agent/rara-exec.jsonl` as
   the raw event stream.
+- Confirm multiple same-name tool calls in one model response keep each
+  progress/result observation on the matching tool-call step.
 - Confirm failures include enough trajectory data to reproduce the final
   decision.
 - Confirm headless configuration can select provider/model/API key without TUI

--- a/docs/journal/2026-04-29-sandbox-path-roots.md
+++ b/docs/journal/2026-04-29-sandbox-path-roots.md
@@ -24,3 +24,7 @@
 - The first snapshot slice captures `PATH` only. This mirrors the Codex and
   Claude direction of reusing user shell initialization while avoiding a full
   shell-state import before RARA has a richer environment policy.
+- Command-root classification now receives the resolved home directory as an
+  explicit internal input. This preserves the runtime environment behavior and
+  lets path-root tests avoid mutating process-wide `HOME` while running in
+  parallel.

--- a/docs/journal/2026-07-11-harbor-atif-trajectory.md
+++ b/docs/journal/2026-07-11-harbor-atif-trajectory.md
@@ -30,6 +30,8 @@ can now upload and view a normalized trajectory artifact.
   observation to that call's ATIF step. This keeps `source_call_id` valid for
   multiple same-name calls in one model response. The raw JSONL remains
   available for debugging if an external event producer breaks that ordering.
+- Unmatched calls are discarded at completed and failed turn boundaries so an
+  interrupted call cannot alter same-name result association in a later turn.
 - The trajectory uses Harbor's current `ATIF-v1.7` model instead of a
   RARA-local JSON schema.
 

--- a/docs/journal/2026-07-11-harbor-atif-trajectory.md
+++ b/docs/journal/2026-07-11-harbor-atif-trajectory.md
@@ -24,9 +24,12 @@ can now upload and view a normalized trajectory artifact.
 
 - The adapter owns ATIF conversion because Harbor owns the artifact contract,
   while `rara exec` remains responsible for the stable RARA JSONL event stream.
-- Tool result events do not currently carry an explicit call id, so the adapter
-  associates them with the most recent unmatched tool call of the same name.
-  The raw JSONL remains available for debugging if this heuristic is ambiguous.
+- Tool result events do not currently carry an explicit call id. Because RARA
+  executes tool calls in emission order, the adapter associates same-name
+  progress and results with the earliest unmatched call, then appends the
+  observation to that call's ATIF step. This keeps `source_call_id` valid for
+  multiple same-name calls in one model response. The raw JSONL remains
+  available for debugging if an external event producer breaks that ordering.
 - The trajectory uses Harbor's current `ATIF-v1.7` model instead of a
   RARA-local JSON schema.
 
@@ -42,5 +45,5 @@ git diff --check
 ## Follow-Ups
 
 - A future `rara exec` event revision can include explicit tool call ids on
-  tool result and progress events to remove the adapter-side name-matching
-  heuristic.
+  tool result and progress events to remove the adapter-side ordering
+  association.

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -452,6 +452,7 @@ def convert_rara_events_to_trajectory(
                     model_name=last_model_name,
                     message=final_message,
                 )
+            pending_tool_calls.clear()
             continue
 
         if event_type == "turn.failed":
@@ -464,6 +465,7 @@ def convert_rara_events_to_trajectory(
                     timestamp=timestamp,
                     message=f"RARA exec failed: {failure_message}",
                 )
+            pending_tool_calls.clear()
             continue
 
         if event_type != "item.completed":

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -404,6 +404,7 @@ def convert_rara_events_to_trajectory(
     pending_model_input: int | None = None
     pending_reasoning: list[str] = []
     pending_tool_calls: list[tuple[str, str]] = []
+    tool_call_steps: dict[str, Step] = {}
     total_input_tokens: int | None = None
     total_output_tokens: int | None = None
     final_message: str | None = None
@@ -498,7 +499,7 @@ def convert_rara_events_to_trajectory(
             if not isinstance(arguments, dict):
                 arguments = {"input": arguments}
             pending_tool_calls.append((item_id, name))
-            append_step(
+            tool_call_steps[item_id] = append_step(
                 source="agent",
                 timestamp=timestamp,
                 model_name=last_model_name,
@@ -521,6 +522,7 @@ def convert_rara_events_to_trajectory(
             call_id = _pop_matching_tool_call(pending_tool_calls, name)
             _append_observation(
                 steps,
+                tool_call_steps=tool_call_steps,
                 source_call_id=call_id,
                 content=content,
                 extra={"tool_name": name, "is_error": is_error},
@@ -531,9 +533,10 @@ def convert_rara_events_to_trajectory(
             name = _string_value(item.get("name")) or "tool"
             stream = _string_value(item.get("stream"))
             chunk = _string_value(item.get("chunk")) or ""
-            call_id = _last_matching_tool_call(pending_tool_calls, name)
+            call_id = _first_matching_tool_call(pending_tool_calls, name)
             _append_observation(
                 steps,
+                tool_call_steps=tool_call_steps,
                 source_call_id=call_id,
                 content=chunk,
                 extra={"tool_name": name, "stream": stream, "progress": True},
@@ -633,16 +636,15 @@ def _has_agent_message_step(steps: list[Step], message: str) -> bool:
     return any(step.source == "agent" and step.message == message for step in steps)
 
 
-def _last_matching_tool_call(pending: list[tuple[str, str]], name: str) -> str | None:
-    for call_id, pending_name in reversed(pending):
+def _first_matching_tool_call(pending: list[tuple[str, str]], name: str) -> str | None:
+    for call_id, pending_name in pending:
         if pending_name == name:
             return call_id
     return None
 
 
 def _pop_matching_tool_call(pending: list[tuple[str, str]], name: str) -> str | None:
-    for index in range(len(pending) - 1, -1, -1):
-        call_id, pending_name = pending[index]
+    for index, (call_id, pending_name) in enumerate(pending):
         if pending_name == name:
             del pending[index]
             return call_id
@@ -652,6 +654,7 @@ def _pop_matching_tool_call(pending: list[tuple[str, str]], name: str) -> str | 
 def _append_observation(
     steps: list[Step],
     *,
+    tool_call_steps: dict[str, Step],
     source_call_id: str | None,
     content: str,
     extra: dict[str, Any],
@@ -661,13 +664,15 @@ def _append_observation(
         content=content,
         extra={k: v for k, v in extra.items() if v is not None},
     )
-    for step in reversed(steps):
-        if step.source == "agent":
-            if step.observation is None:
-                step.observation = Observation(results=[result])
-            else:
-                step.observation.results.append(result)
-            return
+    step = tool_call_steps.get(source_call_id) if source_call_id else None
+    if step is None:
+        step = next((step for step in reversed(steps) if step.source == "agent"), None)
+    if step is None:
+        return
+    if step.observation is None:
+        step.observation = Observation(results=[result])
+    else:
+        step.observation.results.append(result)
 
 
 def _attach_metrics_to_latest_agent_step(steps: list[Step], metrics: Metrics) -> None:

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -385,6 +385,45 @@ class RaraAgentTests(unittest.TestCase):
             ],
         )
 
+    def test_convert_rara_events_to_trajectory_drops_orphaned_calls_at_turn_boundaries(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"item.completed","item":{"id":"completed_orphan","type":"tool_call","name":"read_file","input":{"path":"/app/orphan-after-completion"}}}',
+                    '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1},"final_message":"first"}',
+                    '{"type":"item.completed","item":{"id":"after_completion","type":"tool_call","name":"read_file","input":{"path":"/app/after-completion"}}}',
+                    '{"type":"item.completed","item":{"id":"result_after_completion","type":"tool_result","name":"read_file","content":"after completion","is_error":false}}',
+                    '{"type":"item.completed","item":{"id":"failed_orphan","type":"tool_call","name":"read_file","input":{"path":"/app/orphan-after-failure"}}}',
+                    '{"type":"turn.failed","error":{"message":"interrupted"}}',
+                    '{"type":"item.completed","item":{"id":"after_failure","type":"tool_call","name":"read_file","input":{"path":"/app/after-failure"}}}',
+                    '{"type":"item.completed","item":{"id":"result_after_failure","type":"tool_result","name":"read_file","content":"after failure","is_error":false}}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Read the files.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        tool_steps = {
+            step.tool_calls[0].tool_call_id: step
+            for step in trajectory.steps
+            if step.tool_calls
+        }
+        self.assertIsNone(tool_steps["completed_orphan"].observation)
+        self.assertEqual(
+            tool_steps["after_completion"].observation.results[0].source_call_id,
+            "after_completion",
+        )
+        self.assertIsNone(tool_steps["failed_orphan"].observation)
+        self.assertEqual(
+            tool_steps["after_failure"].observation.results[0].source_call_id,
+            "after_failure",
+        )
+
     def test_write_trajectory_preserves_zero_token_context_metrics(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
             agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -346,6 +346,45 @@ class RaraAgentTests(unittest.TestCase):
         self.assertEqual(trajectory.final_metrics.total_prompt_tokens, 5)
         self.assertEqual(trajectory.final_metrics.total_completion_tokens, 2)
 
+    def test_convert_rara_events_to_trajectory_keeps_same_name_results_with_calls(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"item.completed","item":{"id":"call_1","type":"tool_call","name":"read_file","input":{"path":"/app/main.tex"}}}',
+                    '{"type":"item.completed","item":{"id":"call_2","type":"tool_call","name":"read_file","input":{"path":"/app/input.tex"}}}',
+                    '{"type":"item.completed","item":{"id":"call_3","type":"tool_call","name":"read_file","input":{"path":"/app/synonyms.txt"}}}',
+                    '{"type":"item.completed","item":{"id":"progress_1","type":"tool_progress","name":"read_file","stream":"stdout","chunk":"main progress"}}',
+                    '{"type":"item.completed","item":{"id":"result_1","type":"tool_result","name":"read_file","content":"main result","is_error":false}}',
+                    '{"type":"item.completed","item":{"id":"result_2","type":"tool_result","name":"read_file","content":"input result","is_error":false}}',
+                    '{"type":"item.completed","item":{"id":"result_3","type":"tool_result","name":"read_file","content":"synonyms result","is_error":false}}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Read the input files.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        tool_steps = [step for step in trajectory.steps if step.tool_calls]
+        self.assertEqual(
+            [step.tool_calls[0].tool_call_id for step in tool_steps],
+            ["call_1", "call_2", "call_3"],
+        )
+        self.assertEqual(
+            [
+                [(result.source_call_id, result.content) for result in step.observation.results]
+                for step in tool_steps
+            ],
+            [
+                [("call_1", "main progress"), ("call_1", "main result")],
+                [("call_2", "input result")],
+                [("call_3", "synonyms result")],
+            ],
+        )
+
     def test_write_trajectory_preserves_zero_token_context_metrics(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
             agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")


### PR DESCRIPTION
## Summary

- Associate Harbor ATIF observations with the exact RARA tool-call step.
- Match same-name progress and result events in RARA's sequential execution order.
- Add a regression test for three same-name `read_file` calls and document the compatibility contract.

## Purpose

Harbor rejected a Terminal-Bench trajectory when a result for `item_114` was attached to the step containing `item_115`. ATIF requires each observation `source_call_id` to be present in the same step's tool calls.

## Related issue

- None.

## Testing

```text
PYTHONPATH=tools/harbor:. /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -m unittest tools.harbor.test_rara_agent
# 25 tests passed

PYTHONPATH=tools/harbor:. /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -c '<convert the failing job JSONL>'
# validated 844 ATIF steps

git diff --check
```
