### PR TITLE
feat(hooks): gate completion with Stop hooks

### DIFF
--- a/docs/features/hooks-plugin-lifecycle.md
+++ b/docs/features/hooks-plugin-lifecycle.md
@@ -13,6 +13,7 @@ observable model context without bypassing safety or retrieval boundaries.
 - Hook output flow into model context and `/context` observability.
 - MemoryQuery hook dispatch from the `search_memory` tool.
 - Plugin hook registration and execution boundaries.
+- Claude Code-compatible project `Stop` command hooks that can gate completion.
 
 ## Non-Goals
 
@@ -20,6 +21,7 @@ observable model context without bypassing safety or retrieval boundaries.
 - Unbounded hook output injection.
 - Hook execution that bypasses sandbox, approval, timeout, or provenance rules.
 - Replacing file-based prompt hooks.
+- Reading benchmark verifier files, hidden tests, or external evaluation metadata.
 
 ## Architecture
 
@@ -51,6 +53,28 @@ entered the model context directly.
 - Hook output must be bounded by the hook runtime and drained once.
 - Drained hook output is next-turn context. It must not be reselected by memory
   retrieval after direct injection.
+
+Project settings may declare a Claude Code-compatible command Stop hook in
+`.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [{
+      "hooks": [{
+        "type": "command",
+        "command": "./scripts/verify-completion.sh",
+        "timeout": 30
+      }]
+    }]
+  }
+}
+```
+
+RARA currently supports the `hooks.Stop` command-handler subset. The command
+runs in the workspace and receives JSON on stdin containing `session_id`,
+`cwd`, `hook_event_name`, `stop_hook_active`, and `last_assistant_message`.
+It may only rely on files and commands available in that workspace.
 - `MemoryQuery` hooks fire before `search_memory` runs and receive the raw query
   text through a lifecycle callback.
 - Plugin hooks are registered during runtime rebuild/startup before the runtime
@@ -59,6 +83,15 @@ entered the model context directly.
   failure is not allowed.
 - Hook output candidates use `source_type=hook_output`, `scope=turn`, and a
   session-scoped source reference.
+- A Stop command returning exit code `2` blocks completion and its stderr is
+  supplied to the next model turn as a system message. Exit code `0` may instead
+  print JSON `{ "decision": "block", "reason": "..." }`, or
+  `hookSpecificOutput.additionalContext`, to continue with feedback.
+- Other non-zero exits and hook timeouts are visible as status warnings but do
+  not block completion, matching Claude Code's exit-code semantics.
+- RARA allows at most eight consecutive Stop-hook continuations before it
+  completes the turn, preventing an unsatisfiable hook from consuming the
+  entire agent budget.
 
 ## Validation Matrix
 
@@ -66,6 +99,8 @@ entered the model context directly.
 - Agent context tests cover hook-output candidate shape and non-selectability.
 - Tooling checks cover that `search_memory` is registered with a MemoryQuery
   callback.
+- Stop-hook tests cover Claude settings discovery, exit-code blocking, JSON
+  blocking output, and model-visible continuation feedback.
 - Workspace validation should run `cargo check --locked --workspace
   --all-targets` and `cargo clippy --locked --workspace --all-targets --
   -D warnings`.
@@ -76,7 +111,10 @@ entered the model context directly.
 - Hook output is injected directly before the next model turn; later work may
   route prompt-type hooks through the retrieval budget if a stronger selection
   policy is needed.
+- Only the `Stop` command-handler subset is compatible today; matcher, HTTP,
+  prompt, and agent hook types need separate contracts before they are enabled.
 
 ## Source Journals
 
 - `docs/journal/2026-07-04-hooks-context-lifecycle.md`
+- `docs/journal/2026-07-12-claude-stop-hooks.md`

--- a/docs/features/verify-skill.md
+++ b/docs/features/verify-skill.md
@@ -21,7 +21,7 @@ RARA should adopt that shape before considering a runtime-level verifier tool.
 ## Non-Goals
 
 - Adding a built-in `verify` runtime tool.
-- Adding a stop-condition hook that blocks final answers.
+- Replacing lifecycle hooks with verifier skills.
 - Replacing unit tests, type checks, format checks, or CI.
 - Automatically installing browser, tmux, API, or recorder dependencies.
 - Treating verifier skills as permission to mutate files or external systems.
@@ -84,7 +84,8 @@ The expected flow is:
 6. Agent reports the verdict and evidence.
 
 The first implementation should remain advisory. The runtime should not force every task through
-`verify`, because RARA does not yet have a stop-condition verifier hook or a complete todo runtime.
+`verify`, because project Stop hooks and verifier skills serve different purposes: the former
+mechanically gate completion while the latter guide the agent's evidence-gathering workflow.
 
 ### 4) Report Format
 

--- a/docs/journal/2026-07-12-claude-stop-hooks.md
+++ b/docs/journal/2026-07-12-claude-stop-hooks.md
@@ -1,0 +1,35 @@
+# Claude-Compatible Stop Hooks Checkpoint
+
+## What Changed
+
+RARA now discovers project `hooks.Stop` command handlers from
+`.claude/settings.json` and executes them when the agent would otherwise finish
+without tool calls. A handler receives JSON context on stdin and runs in the
+workspace. Exit code `2`, or Claude-style JSON `{ "decision": "block" }`,
+keeps the agent loop alive and feeds the failure reason back into the next model
+turn.
+
+## Why
+
+Completion requirements must be enforced through visible project contracts,
+not by reading a benchmark's private verifier. This follows Claude Code's Stop
+hook model: projects can require a check before completion while the agent gets
+the failed check's diagnostic and can repair its work.
+
+## Safety And Compatibility
+
+The initial implementation supports only command handlers under `hooks.Stop`.
+Handlers run in the workspace, have an optional per-hook timeout, and receive
+only session and workspace context. RARA treats exit code `2` as a blocking
+result; other non-zero exits and timeouts are warnings, which preserves Claude
+Code's distinction between enforcement failures and hook execution failures.
+
+To avoid endless retries, RARA mirrors Claude Code's bounded continuation
+behavior and allows at most eight consecutive Stop-hook blocks before ending
+the turn with a visible error event.
+
+## Follow-Up
+
+Expand the compatibility surface deliberately: matcher-aware tool hooks,
+structured command output beyond the Stop subset, and non-command handlers need
+separate security and timeout contracts.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -175,7 +175,21 @@ struct StopHookSpecificOutput {
 }
 
 fn message_text(message: &Message) -> Option<String> {
-    message.content.as_str().map(ToString::to_string)
+    match &message.content {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(blocks) => {
+            let text = blocks
+                .iter()
+                .filter_map(|block| {
+                    block
+                        .as_str()
+                        .or_else(|| block.get("text").and_then(Value::as_str))
+                })
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
+        }
+        _ => None,
+    }
 }
 
 fn stop_hook_block_reason(outcome: &HookOutcome) -> Option<String> {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -29,7 +29,7 @@ use crate::control_tokens::scrub_internal_control_tokens;
 use crate::hooks::HookDefinition;
 use crate::hooks::HookParseStatus;
 use crate::hooks::HookRegistry;
-use crate::hooks::{HookSandbox, run_sandboxed_hook};
+use crate::hooks::{HookOutcome, HookSandbox, run_sandboxed_hook};
 #[cfg(test)]
 use crate::llm::LlmEmbeddingBackend;
 use crate::llm::{
@@ -57,6 +57,7 @@ use crate::workspace::WorkspaceMemory;
 
 const MAX_RUNTIME_ERROR_RECOVERY_ATTEMPTS: usize = 1;
 const MAX_PLAN_EXIT_REPAIR_ATTEMPTS: usize = 1;
+const MAX_STOP_HOOK_CONTINUATIONS: usize = 8;
 
 pub use self::compact::{CompactBoundaryMetadata, CompactState, latest_compact_boundary_metadata};
 pub use self::planning::{
@@ -151,6 +152,71 @@ struct ToolCall {
     id: String,
     name: String,
     input: Value,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StopHookBlock {
+    hook_id: String,
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct StopHookOutput {
+    decision: Option<String>,
+    reason: Option<String>,
+    #[serde(rename = "hookSpecificOutput")]
+    hook_specific_output: Option<StopHookSpecificOutput>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StopHookSpecificOutput {
+    #[serde(rename = "additionalContext")]
+    additional_context: Option<String>,
+}
+
+fn message_text(message: &Message) -> Option<String> {
+    message.content.as_str().map(ToString::to_string)
+}
+
+fn stop_hook_block_reason(outcome: &HookOutcome) -> Option<String> {
+    if outcome.exit_code == Some(2) {
+        return Some(non_empty_hook_message(&outcome.stderr));
+    }
+    if outcome.exit_code != Some(0) {
+        return None;
+    }
+    let output: StopHookOutput = serde_json::from_str(&outcome.stdout).ok()?;
+    if output.decision.as_deref() == Some("block") {
+        return Some(
+            output
+                .reason
+                .filter(|reason| !reason.trim().is_empty())
+                .unwrap_or_else(|| "Stop hook blocked completion.".to_string()),
+        );
+    }
+    output
+        .hook_specific_output
+        .and_then(|output| output.additional_context)
+        .filter(|context| !context.trim().is_empty())
+}
+
+fn non_empty_hook_message(message: &str) -> String {
+    let message = message.trim();
+    if message.is_empty() {
+        "Stop hook exited with code 2.".to_string()
+    } else {
+        message.to_string()
+    }
+}
+
+fn stop_hook_feedback(block: &StopHookBlock) -> Message {
+    Message {
+        role: "system".to_string(),
+        content: Value::String(format!(
+            "Stop hook {} blocked completion: {}\nResolve the reported condition before finishing.",
+            block.hook_id, block.reason
+        )),
+    }
 }
 
 #[derive(Debug)]
@@ -876,6 +942,7 @@ impl Agent {
         F: FnMut(AgentEvent) + Send,
     {
         let mut plan_exit_repair_attempts = 0usize;
+        let mut stop_hook_continuations = 0usize;
         loop {
             if let Some(max) = self.max_turns
                 && *agentic_turns >= max
@@ -998,6 +1065,10 @@ impl Agent {
                 self.checkpoint_session()?;
                 break;
             }
+            let last_assistant_message = turn_output
+                .assistant_message
+                .as_ref()
+                .and_then(message_text);
             let assistant_message_recorded = turn_output.assistant_message.is_some();
             if let Some(message) = turn_output.assistant_message.take() {
                 self.push_history_message(message);
@@ -1077,6 +1148,44 @@ impl Agent {
                     self.checkpoint_session()?;
                     continue;
                 }
+                if let Some(block) = self.run_stop_hooks(
+                    last_assistant_message.as_deref(),
+                    stop_hook_continuations > 0,
+                    report,
+                ) {
+                    if stop_hook_continuations < MAX_STOP_HOOK_CONTINUATIONS {
+                        stop_hook_continuations += 1;
+                        *agentic_turns += 1;
+                        report(AgentEvent::AgentError {
+                            message: format!(
+                                "Stop hook {} blocked completion: {}",
+                                block.hook_id, block.reason
+                            ),
+                            recoverable: true,
+                        });
+                        report(AgentEvent::Status(
+                            "Stop hook blocked completion. Continuing with hook feedback."
+                                .to_string(),
+                        ));
+                        self.record_agent_turn_trace(
+                            &turn_output,
+                            *agentic_turns,
+                            Some("continued"),
+                            Some("stop_hook_blocked"),
+                            assistant_message_recorded,
+                        );
+                        self.push_history_message(stop_hook_feedback(&block));
+                        self.checkpoint_session()?;
+                        continue;
+                    }
+                    report(AgentEvent::AgentError {
+                        message: format!(
+                            "Stop hook {} continued to block after {MAX_STOP_HOOK_CONTINUATIONS} attempts; allowing completion.",
+                            block.hook_id
+                        ),
+                        recoverable: false,
+                    });
+                }
                 self.record_agent_turn_trace(
                     &turn_output,
                     *agentic_turns,
@@ -1107,6 +1216,60 @@ impl Agent {
             self.extend_history_for_next_turn(tool_results, report, *agentic_turns)?;
         }
         Ok(())
+    }
+
+    fn run_stop_hooks<F>(
+        &self,
+        last_assistant_message: Option<&str>,
+        stop_hook_active: bool,
+        report: &mut F,
+    ) -> Option<StopHookBlock>
+    where
+        F: FnMut(AgentEvent) + Send,
+    {
+        let (Some(registry), Some(sandbox)) = (&self.hook_registry, &self.hook_sandbox) else {
+            return None;
+        };
+        let input = json!({
+            "session_id": self.session_id,
+            "cwd": sandbox.workspace_root,
+            "hook_event_name": "Stop",
+            "stop_hook_active": stop_hook_active,
+            "last_assistant_message": last_assistant_message.unwrap_or_default(),
+        })
+        .to_string();
+
+        for hook in registry.executable_hooks_for_phase(HookLifecycle::Stop) {
+            match run_sandboxed_hook(hook, sandbox, &input) {
+                Ok(outcome) => {
+                    if outcome.timed_out {
+                        report(AgentEvent::Status(format!(
+                            "Stop hook {} timed out; allowing completion.",
+                            hook.id
+                        )));
+                        continue;
+                    }
+                    if let Some(reason) = stop_hook_block_reason(&outcome) {
+                        return Some(StopHookBlock {
+                            hook_id: hook.id.clone(),
+                            reason,
+                        });
+                    }
+                    if outcome.exit_code.is_some_and(|code| code != 0) {
+                        report(AgentEvent::Status(format!(
+                            "Stop hook {} exited unsuccessfully; allowing completion: {}",
+                            hook.id,
+                            outcome.stderr.trim()
+                        )));
+                    }
+                }
+                Err(error) => report(AgentEvent::Status(format!(
+                    "Stop hook {} failed; allowing completion: {error}",
+                    hook.id
+                ))),
+            }
+        }
+        None
     }
 
     fn record_agent_turn_trace(
@@ -1346,7 +1509,7 @@ impl Agent {
             }
             // PreToolUse hook: run registered hooks that can allow/block.
             if let (Some(registry), Some(sandbox)) = (&self.hook_registry, &self.hook_sandbox) {
-                let hooks = registry.hooks_for_phase(HookLifecycle::PreToolUse);
+                let hooks = registry.executable_hooks_for_phase(HookLifecycle::PreToolUse);
                 let mut blocked = false;
                 if !hooks.is_empty() {
                     let input = serde_json::json!({

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -3,4 +3,5 @@ mod context_view;
 mod dup_detection;
 mod microcompact;
 mod planning;
+mod stop_hooks;
 mod support;

--- a/src/agent/tests/stop_hooks.rs
+++ b/src/agent/tests/stop_hooks.rs
@@ -23,7 +23,7 @@ async fn stop_hook_blocks_completion_and_returns_feedback_to_the_model() {
                 "Stop": [{
                     "hooks": [{
                         "type": "command",
-                        "command": "cat > .stop-hook-input.json; if [ -e .stop-hook-ran ]; then exit 0; fi; touch .stop-hook-ran; echo 'Run the visible completion check.' >&2; exit 2"
+                        "command": "if [ -e .stop-hook-ran ]; then exit 0; fi; cat > .stop-hook-input.json; touch .stop-hook-ran; echo 'Run the visible completion check.' >&2; exit 2"
                     }]
                 }]
             }

--- a/src/agent/tests/stop_hooks.rs
+++ b/src/agent/tests/stop_hooks.rs
@@ -23,7 +23,7 @@ async fn stop_hook_blocks_completion_and_returns_feedback_to_the_model() {
                 "Stop": [{
                     "hooks": [{
                         "type": "command",
-                        "command": "if [ -e .stop-hook-ran ]; then exit 0; fi; touch .stop-hook-ran; echo 'Run the visible completion check.' >&2; exit 2"
+                        "command": "cat > .stop-hook-input.json; if [ -e .stop-hook-ran ]; then exit 0; fi; touch .stop-hook-ran; echo 'Run the visible completion check.' >&2; exit 2"
                     }]
                 }]
             }
@@ -78,6 +78,14 @@ async fn stop_hook_blocks_completion_and_returns_feedback_to_the_model() {
                 .as_str()
                 .is_some_and(|content| content.contains("Stop hook"))
     }));
+    let hook_input: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(temp.path().join(".stop-hook-input.json")).expect("hook input"),
+    )
+    .expect("valid hook input");
+    assert_eq!(
+        hook_input["last_assistant_message"],
+        serde_json::Value::String("first completion".to_string())
+    );
 }
 
 fn response(text: &str) -> LlmResponse {
@@ -102,5 +110,22 @@ fn stop_hook_json_block_reason_is_returned_to_the_agent() {
     assert_eq!(
         super::super::stop_hook_block_reason(&outcome),
         Some("Run the completion check.".to_string())
+    );
+}
+
+#[test]
+fn message_text_extracts_text_blocks_from_structured_assistant_content() {
+    let message = crate::agent::Message {
+        role: "assistant".to_string(),
+        content: json!([
+            {"type": "text", "text": "first "},
+            {"type": "tool_use", "name": "read_file"},
+            {"type": "text", "text": "last"}
+        ]),
+    };
+
+    assert_eq!(
+        super::super::message_text(&message),
+        Some("first last".to_string())
     );
 }

--- a/src/agent/tests/stop_hooks.rs
+++ b/src/agent/tests/stop_hooks.rs
@@ -1,0 +1,106 @@
+use std::fs;
+use std::sync::Arc;
+
+use rara_memory::vectordb::VectorDB;
+use rara_tools::tool::ToolManager;
+use serde_json::json;
+
+use super::support::{SequencedBackend, test_runtime_storage};
+use crate::agent::{Agent, AgentEvent, AgentOutputMode};
+use crate::hooks::HookOutcome;
+use crate::hooks::{HookRegistry, HookSandbox};
+use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
+
+#[tokio::test]
+async fn stop_hook_blocks_completion_and_returns_feedback_to_the_model() {
+    let (temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let claude_dir = temp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).expect("mkdir");
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{
+            "hooks": {
+                "Stop": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": "if [ -e .stop-hook-ran ]; then exit 0; fi; touch .stop-hook-ran; echo 'Run the visible completion check.' >&2; exit 2"
+                    }]
+                }]
+            }
+        }"#,
+    )
+    .expect("settings");
+    let mut registry = HookRegistry::new();
+    registry.discover_repo_hooks(temp.path());
+
+    let backend = Arc::new(SequencedBackend::new(vec![
+        response("first completion"),
+        response("verified completion"),
+    ]));
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.history.push(crate::agent::Message {
+        role: "user".to_string(),
+        content: json!("complete the task"),
+    });
+    agent.set_hook_context(
+        Arc::new(registry),
+        HookSandbox {
+            workspace_root: temp.path().to_path_buf(),
+            ..HookSandbox::default()
+        },
+    );
+
+    let mut events = Vec::new();
+    agent
+        .run_agent_loop_with_limit(
+            AgentOutputMode::Silent,
+            &mut |event| events.push(event),
+            &mut 0,
+        )
+        .await
+        .expect("agent loop");
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AgentEvent::AgentError { message, recoverable: true }
+            if message.contains("Run the visible completion check.")
+    )));
+    assert!(backend.observed_messages()[1].iter().any(|message| {
+        message.role == "system"
+            && message
+                .content
+                .as_str()
+                .is_some_and(|content| content.contains("Stop hook"))
+    }));
+}
+
+fn response(text: &str) -> LlmResponse {
+    LlmResponse {
+        content: vec![ContentBlock::Text {
+            text: text.to_string(),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: Some(TokenUsage::default()),
+    }
+}
+
+#[test]
+fn stop_hook_json_block_reason_is_returned_to_the_agent() {
+    let outcome = HookOutcome {
+        stdout: r#"{"decision":"block","reason":"Run the completion check."}"#.to_string(),
+        stderr: String::new(),
+        exit_code: Some(0),
+        timed_out: false,
+    };
+
+    assert_eq!(
+        super::super::stop_hook_block_reason(&outcome),
+        Some("Run the completion check.".to_string())
+    );
+}

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 /// Hook phases aligned with Claude Code's lifecycle events.
 use rara_instructions::HookLifecycle;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// A discovered and normalised hook declaration.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -27,6 +27,9 @@ pub struct HookDefinition {
     pub parse_status: HookParseStatus,
     /// Hook body / handler content.
     pub body: String,
+    /// Per-hook timeout from Claude-compatible settings, if configured.
+    #[serde(skip_serializing)]
+    pub timeout: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -38,7 +41,6 @@ pub enum HookParseStatus {
 }
 
 /// Discovers hook candidates and stores their normalised definitions.
-/// Execution is currently disabled — this is discovery-only.
 pub struct HookRegistry {
     pub hooks: BTreeMap<String, HookDefinition>,
     pub load_warnings: Vec<String>,
@@ -100,6 +102,7 @@ impl HookRegistry {
                             phase,
                             parse_status: HookParseStatus::ParseError,
                             body: format!("read error: {err}"),
+                            timeout: None,
                         },
                     );
                     continue;
@@ -120,6 +123,7 @@ impl HookRegistry {
                     phase,
                     parse_status,
                     body,
+                    timeout: None,
                 },
             );
         }
@@ -131,6 +135,74 @@ impl HookRegistry {
     pub fn discover_repo_hooks(&mut self, repo_root: &Path) {
         let hooks_dir = repo_root.join(".claude").join("hooks");
         self.discover_from_dir(&hooks_dir);
+        self.discover_claude_settings_hooks(repo_root);
+    }
+
+    /// Discover the Claude Code project-settings subset that RARA executes.
+    ///
+    /// Version one supports `hooks.Stop` command handlers. The handler runs at
+    /// the completion boundary, so it needs no matcher and can return a
+    /// blocking decision before the agent reports success.
+    fn discover_claude_settings_hooks(&mut self, repo_root: &Path) {
+        let path = repo_root.join(".claude").join("settings.json");
+        if !path.exists() {
+            return;
+        }
+        let contents = match fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(err) => {
+                self.load_warnings
+                    .push(format!("hook settings {}: {err}", path.display()));
+                return;
+            }
+        };
+        let settings: ClaudeHookSettings = match serde_json::from_str(&contents) {
+            Ok(settings) => settings,
+            Err(err) => {
+                self.load_warnings
+                    .push(format!("hook settings {}: {err}", path.display()));
+                return;
+            }
+        };
+        let Some(groups) = settings.hooks.get("Stop") else {
+            return;
+        };
+
+        for (group_index, group) in groups.iter().enumerate() {
+            for (handler_index, handler) in group.hooks.iter().enumerate() {
+                if handler.handler_type != "command" {
+                    self.load_warnings.push(format!(
+                        "hook settings {}: Stop handler {group_index}:{handler_index} has unsupported type {:?}",
+                        path.display(),
+                        handler.handler_type
+                    ));
+                    continue;
+                }
+                let Some(command) = handler
+                    .command
+                    .as_deref()
+                    .filter(|command| !command.trim().is_empty())
+                else {
+                    self.load_warnings.push(format!(
+                        "hook settings {}: Stop command handler {group_index}:{handler_index} is missing command",
+                        path.display()
+                    ));
+                    continue;
+                };
+                self.hooks.insert(
+                    format!("hook-settings-stop-{group_index}-{handler_index}"),
+                    HookDefinition {
+                        id: format!("hook-settings-stop-{group_index}-{handler_index}"),
+                        source_path: ".claude/settings.json".to_string(),
+                        phase: HookLifecycle::Stop,
+                        parse_status: HookParseStatus::Ok,
+                        body: command.to_string(),
+                        timeout: handler.timeout.map(Duration::from_secs),
+                    },
+                );
+            }
+        }
+        self.refresh_active_phases();
     }
 
     fn refresh_active_phases(&mut self) {
@@ -153,6 +225,34 @@ impl HookRegistry {
             .filter(|h| h.parse_status == HookParseStatus::Ok && h.phase == phase)
             .collect()
     }
+
+    /// Return command hooks loaded from Claude-compatible project settings.
+    pub fn executable_hooks_for_phase(&self, phase: HookLifecycle) -> Vec<&HookDefinition> {
+        self.hooks_for_phase(phase)
+            .into_iter()
+            .filter(|hook| hook.source_path == ".claude/settings.json")
+            .collect()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeHookSettings {
+    #[serde(default)]
+    hooks: BTreeMap<String, Vec<ClaudeHookMatcher>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeHookMatcher {
+    #[serde(default)]
+    hooks: Vec<ClaudeHookHandler>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeHookHandler {
+    #[serde(rename = "type")]
+    handler_type: String,
+    command: Option<String>,
+    timeout: Option<u64>,
 }
 
 fn phase_ordinal(phase: HookLifecycle) -> u8 {
@@ -231,6 +331,37 @@ mod tests {
         assert_eq!(hook.parse_status, HookParseStatus::ParseError);
         assert!(registry.active_phases.is_empty());
     }
+
+    #[test]
+    fn discovers_claude_settings_stop_command_hook() {
+        let dir = tempdir().expect("tempdir");
+        let claude_dir = dir.path().join(".claude");
+        fs::create_dir_all(&claude_dir).expect("mkdir");
+        fs::write(
+            claude_dir.join("settings.json"),
+            r#"{
+                "hooks": {
+                    "Stop": [{
+                        "hooks": [{
+                            "type": "command",
+                            "command": "./check-completion.sh",
+                            "timeout": 5
+                        }]
+                    }]
+                }
+            }"#,
+        )
+        .expect("settings");
+
+        let mut registry = HookRegistry::new();
+        registry.discover_repo_hooks(dir.path());
+
+        let hooks = registry.hooks_for_phase(HookLifecycle::Stop);
+        assert_eq!(hooks.len(), 1);
+        assert_eq!(hooks[0].body, "./check-completion.sh");
+        assert_eq!(hooks[0].timeout, Some(Duration::from_secs(5)));
+        assert_eq!(hooks[0].source_path, ".claude/settings.json");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -256,6 +387,7 @@ impl Default for HookSandbox {
 
 /// Outcome of a hook execution.
 pub struct HookOutcome {
+    pub stdout: String,
     pub stderr: String,
     pub exit_code: Option<i32>,
     pub timed_out: bool,
@@ -299,6 +431,7 @@ pub fn run_sandboxed_hook(
     }
     // stdin is dropped here — closes the pipe so the hook sees EOF.
 
+    let timeout = hook.timeout.unwrap_or(sandbox.timeout);
     let start = Instant::now();
     let output: std::process::Output;
 
@@ -316,11 +449,12 @@ pub fn run_sandboxed_hook(
                 break;
             }
             None => {
-                if start.elapsed() >= sandbox.timeout {
+                if start.elapsed() >= timeout {
                     let _ = child.kill();
                     let _ = child.wait();
                     return Ok(HookOutcome {
-                        stderr: format!("hook {} timed out after {:?}", hook.id, sandbox.timeout),
+                        stdout: String::new(),
+                        stderr: format!("hook {} timed out after {timeout:?}", hook.id),
                         exit_code: None,
                         timed_out: true,
                     });
@@ -331,6 +465,7 @@ pub fn run_sandboxed_hook(
     }
 
     Ok(HookOutcome {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         exit_code: output.status.code(),
         timed_out: false,

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -53,6 +53,7 @@ pub(crate) struct RuntimeBootstrap {
     pub prompt_source_registry: Arc<PromptSourceRegistry>,
     pub skill_source_registry: Arc<SkillSourceRegistry>,
     pub hook_registry: Arc<HookRegistry>,
+    command_hook_registry: Arc<crate::hooks::HookRegistry>,
     pub goal_handle: GoalHandle,
     pub mcp_tool_cache: McpToolCache,
     pub mcp_manager: Arc<McpConnectionManager>,
@@ -83,6 +84,7 @@ impl RuntimeBootstrap {
         Arc<HookRegistry>,
         Arc<LspManager>,
     ) {
+        let hook_workspace_root = self.workspace.root.clone();
         let mut agent = Agent::new_with_embedding_backend_and_agent_definitions(
             self.tool_manager,
             self.backend,
@@ -97,8 +99,11 @@ impl RuntimeBootstrap {
         agent.set_skill_source_registry(self.skill_source_registry.clone());
         agent.set_lsp_manager(self.lsp_manager.clone());
         agent.set_hook_context(
-            Arc::new(crate::hooks::HookRegistry::new()),
-            crate::hooks::HookSandbox::default(),
+            self.command_hook_registry,
+            crate::hooks::HookSandbox {
+                workspace_root: hook_workspace_root,
+                ..crate::hooks::HookSandbox::default()
+            },
         );
         (
             agent,
@@ -214,11 +219,14 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     prompt_config.hook_prompt_entries = file_hooks
         .hooks
         .values()
+        .filter(|hook| hook.source_path != ".claude/settings.json")
         .map(|h| rara_instructions::HookPromptEntry {
             phase: h.phase,
             body: format!("## {}\n\n{}", h.phase.as_str(), h.body),
         })
         .collect();
+    let file_hook_warnings = file_hooks.load_warnings.clone();
+    let command_hook_registry = Arc::new(file_hooks);
     let agent_definitions = AgentDefinitionCache::load(workspace.root.clone());
     let tool_manager = create_full_tool_manager(
         backend.clone(),
@@ -238,6 +246,7 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     );
     let mut warnings = prompt_config.warnings.clone();
     warnings.extend(embedding_warnings);
+    warnings.extend(file_hook_warnings);
 
     Ok(RuntimeBootstrap {
         backend,
@@ -253,6 +262,7 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
+        command_hook_registry,
         goal_handle,
         mcp_tool_cache,
         mcp_manager,


### PR DESCRIPTION
## Summary

- add a Claude Code-compatible `.claude/settings.json` `hooks.Stop` command-hook subset
- block agent completion on exit code `2` or JSON `decision: "block"`, then feed diagnostics into the next model turn
- document the compatibility boundary, non-cheating workspace-only contract, and focused regression coverage

## Why

Projects need a mechanical, visible completion gate without reading benchmark verifiers or adding harness-specific task logic. Stop hooks let a project validate its own workspace state and return actionable feedback to the agent.

## Testing

- `cargo test --bin rara hooks::tests`
- `cargo test --bin rara agent::tests::stop_hooks`
- `cargo test --bin rara app_cli::tests`
- `cargo clippy --bin rara --no-deps -- -D warnings`
- `cargo fmt --all --check`

## Related Issue

None.
