### PR TITLE
fix(agent): add shell capability fallbacks

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -442,7 +442,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "For repository review or architecture analysis, inspect the workspace proactively with tools before asking follow-up questions.",
                     "For repository review, avoid repeating the same discovery tool call with the same arguments unless the workspace changed.",
                     "When a dedicated search or file-discovery tool is unavailable or unsuitable and you need to search through a shell, first check 'rg' with 'command -v rg'. When it is available, prefer 'rg' for text search and 'rg --files' for file discovery because it is faster than grep/find. Otherwise use an equivalent available tool such as grep or find.",
-                    "Before relying on an external shell command that may not be installed, check its availability with 'command -v <command>' or use a dedicated tool that provides the capability. If it is unavailable, use an equivalent available or POSIX tool when practical; do not assume it can be installed or use package-manager installation as a fallback unless the user explicitly requests that environment change.",
+                    "Before relying on an external shell command that may not be installed, check its availability with 'command -v command_name' or use a dedicated tool that provides the capability. If it is unavailable, use an equivalent available or POSIX tool when practical; do not assume it can be installed or use package-manager installation as a fallback unless the user explicitly requests that environment change.",
                     "Prefer source directories and key project files over build artifacts or cache directories when inspecting a repository.",
                     "Never print raw provider-specific tool markup such as DSML tags. When a tool is needed, call the provided tool directly.",
                 ],
@@ -1335,6 +1335,7 @@ mod tests {
                 .text
                 .contains("Before relying on an external shell command that may not be installed")
         );
+        assert!(effective.text.contains("command -v command_name"));
         assert!(effective.text.contains(
             "do not assume it can be installed or use package-manager installation as a fallback"
         ));

--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -441,7 +441,8 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "Do not ask the user to paste local file contents or name local files when tools can read them directly.",
                     "For repository review or architecture analysis, inspect the workspace proactively with tools before asking follow-up questions.",
                     "For repository review, avoid repeating the same discovery tool call with the same arguments unless the workspace changed.",
-                    "When a dedicated search or file-discovery tool is unavailable or unsuitable and you need to search through a shell, prefer 'rg' for text search and 'rg --files' for file discovery because it is faster than grep/find. If 'rg' is unavailable, fall back to other tools.",
+                    "When a dedicated search or file-discovery tool is unavailable or unsuitable and you need to search through a shell, first check 'rg' with 'command -v rg'. When it is available, prefer 'rg' for text search and 'rg --files' for file discovery because it is faster than grep/find. Otherwise use an equivalent available tool such as grep or find.",
+                    "Before relying on an external shell command that may not be installed, check its availability with 'command -v <command>' or use a dedicated tool that provides the capability. If it is unavailable, use an equivalent available or POSIX tool when practical; do not assume it can be installed or use package-manager installation as a fallback unless the user explicitly requests that environment change.",
                     "Prefer source directories and key project files over build artifacts or cache directories when inspecting a repository.",
                     "Never print raw provider-specific tool markup such as DSML tags. When a tool is needed, call the provided tool directly.",
                 ],
@@ -1309,6 +1310,34 @@ mod tests {
                 .text
                 .contains("Do not immediately repeat the exact same call")
         );
+    }
+
+    #[test]
+    fn default_prompt_checks_command_availability_before_shell_fallbacks() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace =
+            WorkspaceMemory::from_paths(temp.path().to_path_buf(), temp.path().join(".rara"));
+
+        let effective = build_effective_prompt(
+            &workspace,
+            &PromptRuntimeConfig::default(),
+            PromptMode::Execute,
+        );
+
+        assert!(effective.section_keys.contains(&"workspace_behavior"));
+        assert!(
+            effective
+                .text
+                .contains("first check 'rg' with 'command -v rg'")
+        );
+        assert!(
+            effective
+                .text
+                .contains("Before relying on an external shell command that may not be installed")
+        );
+        assert!(effective.text.contains(
+            "do not assume it can be installed or use package-manager installation as a fallback"
+        ));
     }
 
     #[test]

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -80,6 +80,13 @@ for simple answers, use concise bullets for longer reports, use language-tagged 
 for multi-line code or commands, prefer `path:line` code references, avoid large tables unless they
 improve comparison, and avoid emojis unless explicitly requested.
 
+Shell capability guidance keeps the runtime portable across constrained environments. When a
+dedicated tool is unavailable or unsuitable, the agent checks an optional shell command before
+depending on it (for example, `command -v rg`), prefers `rg` only when present, and otherwise uses
+an equivalent available or POSIX tool. Missing commands are not an implicit package-installation
+request: the default prompt must not infer a package manager or install a dependency unless the
+user explicitly requests an environment change.
+
 Git conflict guidance is intentionally conservative. It tells the model to inspect the current git
 state and conflicted file, preserve complementary changes instead of blindly choosing one side, use
 structured edits where practical, scan for remaining conflict markers, and run the narrowest relevant

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -152,13 +152,16 @@ Important tool requirements:
 The default prompt may describe general terminal-agent discipline:
 
 - inspect before editing;
-- prefer `rg` for search;
+- prefer `rg` for search only after checking it is available, then fall back to an equivalent
+  available or POSIX tool;
 - use patch/file tools instead of shell redirection for edits;
 - run focused verification;
 - summarize unresolved failures.
 
 The default prompt must not contain benchmark task answers, benchmark-specific
 oracle behavior, or hidden test assumptions.
+It must not treat missing commands as an implicit request to identify a package manager and install
+dependencies; such an environment change requires explicit user instruction.
 
 ### Result Contract
 

--- a/docs/journal/2026-07-13-shell-capability-fallback-guidance.md
+++ b/docs/journal/2026-07-13-shell-capability-fallback-guidance.md
@@ -1,0 +1,27 @@
+# Shell Capability Fallback Guidance
+
+## Summary
+
+The default prompt now requires command availability checks before relying on optional shell
+utilities. It keeps `rg` as the preferred shell search utility when available and directs the
+agent to use an equivalent available or POSIX fallback otherwise.
+
+## Background
+
+TerminalBench runs inside task-provided containers. A failed task showed that an agent can stop
+after assuming a utility such as `python3` exists. Preinstalling tools in the benchmark adapter
+would mutate the task environment and weaken the evaluation contract.
+
+## Key Decisions
+
+- Check optional commands with `command -v <command>` before depending on them.
+- Prefer dedicated tools when they provide the required capability.
+- Use available or POSIX fallbacks when practical.
+- Do not infer a package manager or install missing dependencies unless the user explicitly asks
+  for that environment change.
+
+## Validation
+
+- `cargo test -p rara-instructions default_prompt_checks_command_availability_before_shell_fallbacks`
+- `cargo fmt --check`
+- `cargo check`


### PR DESCRIPTION
## Summary

- Check `rg` availability before selecting it for shell search or file discovery.
- Require availability checks for optional external commands and use dedicated or POSIX fallbacks.
- Explicitly forbid inferring package installation from a missing command.

## Purpose

TerminalBench tasks run in constrained task-provided containers. The agent should recover from a
missing optional command without mutating the benchmark environment or stopping prematurely.

## Related Issue

None.

## Testing

- `cargo fmt --all --check`
- `cargo test -p rara-instructions default_prompt_checks_command_availability_before_shell_fallbacks -- --nocapture`
- `cargo check -p rara-instructions`
- `git diff --check`
