### PR TITLE
chore: bump version to 0.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11012,7 +11012,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rara"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -11097,7 +11097,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -11106,7 +11106,7 @@ dependencies = [
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "async-trait",
  "libc",
@@ -11121,7 +11121,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -11132,7 +11132,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -11145,7 +11145,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -11153,7 +11153,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "ignore",
@@ -11164,7 +11164,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11174,7 +11174,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -11184,7 +11184,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -11202,14 +11202,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "fs2",
@@ -11224,7 +11224,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -11234,7 +11234,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11247,7 +11247,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11258,7 +11258,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "serde",
@@ -11267,7 +11267,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11280,11 +11280,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.9"
+version = "0.0.11"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11293,7 +11293,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.9"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.9"
+version = "0.0.11"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

- Bump the workspace package version from `0.0.9` to `0.0.11`.
- Refresh every workspace package record in `Cargo.lock` to `0.0.11`.

## Purpose

Prepare the repository for the `v0.0.11` release while keeping the Cargo package
version and lockfile records aligned before a release tag is created.

## Related Issue

None.

## Testing

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check -p rara`
- `cargo metadata --no-deps --format-version 1` package-version check for `rara == 0.0.11`
- `cargo fmt --all`
- `git diff --check`

## Release Follow-Up

After this PR merges and required CI passes, create and push `v0.0.11` from the
version-bump commit to trigger the release workflow.
