### PR TITLE
chore: record terminal-bench results

### DIFF
--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -234,4 +234,5 @@ Each trial should end with one of:
 
 - `docs/journal/2026-07-05-rara-exec-headless.md`
 - `docs/journal/2026-07-05-harbor-rara-agent-adapter.md`
+- `docs/journal/2026-07-14-terminal-bench-results.md`
 - `docs/journal/2026-07-11-harbor-atif-trajectory.md`

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -234,5 +234,5 @@ Each trial should end with one of:
 
 - `docs/journal/2026-07-05-rara-exec-headless.md`
 - `docs/journal/2026-07-05-harbor-rara-agent-adapter.md`
-- `docs/journal/2026-07-14-terminal-bench-results.md`
 - `docs/journal/2026-07-11-harbor-atif-trajectory.md`
+- `docs/journal/2026-07-14-terminal-bench-results.md`

--- a/docs/journal/2026-07-14-terminal-bench-results.md
+++ b/docs/journal/2026-07-14-terminal-bench-results.md
@@ -1,0 +1,47 @@
+# Terminal-Bench Observed Results
+
+## Summary
+
+This journal is the evidence-backed record of observed Terminal-Bench task
+outcomes for RARA's Harbor adapter. A task is confirmed as passed only when the
+Harbor verifier reports reward `1.0`; a successful RARA process exit alone is
+not sufficient.
+
+## Results
+
+| Task | Outcome | Evidence | Notes |
+| --- | --- | --- | --- |
+| `terminal-bench/regex-log` | Passed | Harbor verifier reward `1.0` | The run recorded RARA exit status `0` and an authoritative verifier success. |
+| `terminal-bench/overfull-hbox` | Failed | Final task artifact violated an edit constraint | The agent removed the LaTeX warnings, but also changed `an` to `a` when only synonym substitutions were allowed. The task therefore did not pass validation. |
+| `terminal-bench/sparql-university` | Passed (artifact pending) | User-reported successful benchmark run | Earlier attempts were inconclusive because of CA and provider setup failures. Record the Harbor verifier artifact for this successful rerun when its job path is available. |
+
+## Recording Rules
+
+- Report verifier reward separately from RARA's exit status and final message.
+- Use `Passed` for a confirmed official verifier reward of `1.0`; append
+  `(artifact pending)` when the successful outcome is reported before its
+  Harbor verifier artifact is available in the repository.
+- Use `Failed` when the verifier rejects an otherwise completed task artifact.
+- Use `Inconclusive` for adapter, provider, credential, environment, or harness
+  failures that prevent a valid task attempt.
+- Record the Harbor run command, dataset revision, RARA revision, provider,
+  model, and links to JSONL and verifier artifacts for every future result.
+
+## Evidence
+
+- `docs/journal/2026-07-09-harbor-provider-env.md` records the `regex-log`
+  verifier reward and the earlier inconclusive `sparql-university` setup attempts.
+- The successful `sparql-university` outcome was reported during the
+  2026-07-14 evaluation checkpoint; its Harbor job path and verifier reward
+  have not yet been added to this repository.
+- `docs/journal/2026-07-09-headless-constraint-validation.md` records the
+  `overfull-hbox` constraint violation.
+
+## Follow-Ups
+
+- Re-run `overfull-hbox` with the current full-access and constraint-validation
+  guidance, then append the authoritative verifier result.
+- Use `regex-log` as the first smoke-regression task before adding a more
+  constraint-heavy task to the smoke subset.
+- Add the successful `sparql-university` Harbor job path and verifier artifact
+  to this record.


### PR DESCRIPTION
## Summary

- add an evidence-backed Terminal-Bench outcome ledger
- record the current `regex-log`, `overfull-hbox`, and `sparql-university` results
- link the ledger from the Terminal-Bench evaluation specification

## Why

Terminal-Bench agent exit status is not equivalent to official verifier success.
The ledger keeps successful, failed, and inconclusive runs distinct and records
the evidence required for future comparisons.

## Impact

Documentation only. No runtime, API, or benchmark behavior changes.

The `sparql-university` success is marked artifact-pending until its Harbor job
path and verifier output are added.

## Testing

- `git diff --check`
