### PR TITLE
fix(agent): honor full access classifier bypass

### DIFF
--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -144,6 +144,13 @@ The adapter discards unmatched calls at `turn.completed` and `turn.failed`
 boundaries. A call without a result belongs only to its originating turn and
 must not affect same-name associations in a later turn.
 
+For externally isolated Harbor task containers, the adapter invokes `rara exec`
+with explicit `--full-access`. This bypasses interactive bash approval and the
+auto-permission classifier so task-required container setup is not rejected as
+an out-of-workspace host operation. The outer Harbor task container remains the
+isolation boundary; ordinary TUI and `rara exec` invocations retain their normal
+permission policy unless the caller explicitly selects full access.
+
 ### Tool Contract
 
 The same file and shell tools used in ordinary sessions must be available in the
@@ -168,6 +175,8 @@ The default prompt may describe general terminal-agent discipline:
   available or POSIX tool;
 - use patch/file tools instead of shell redirection for edits;
 - run focused verification;
+- verify PATH requirements from a fresh non-interactive process rather than a
+  shell with a command-local PATH override;
 - summarize unresolved failures.
 
 The default prompt must not contain benchmark task answers, benchmark-specific
@@ -234,4 +243,5 @@ Each trial should end with one of:
 
 - `docs/journal/2026-07-05-rara-exec-headless.md`
 - `docs/journal/2026-07-05-harbor-rara-agent-adapter.md`
+- `docs/journal/2026-07-14-harbor-full-access-path-validation.md`
 - `docs/journal/2026-07-11-harbor-atif-trajectory.md`

--- a/docs/journal/2026-07-14-harbor-full-access-path-validation.md
+++ b/docs/journal/2026-07-14-harbor-full-access-path-validation.md
@@ -1,0 +1,45 @@
+# Harbor Full-Access PATH Validation
+
+## Summary
+
+Harbor's explicit `rara exec --full-access` mode now bypasses the
+auto-permission classifier as well as interactive bash approval. Benchmark
+guidance also requires PATH-dependent work to be checked from a fresh
+non-interactive process.
+
+## Background
+
+The `terminal-bench/sqlite-with-gcov` run compiled SQLite with gcov support,
+but did not score because the verifier could not resolve `sqlite3` on PATH.
+The agent's attempt to create `/usr/local/bin/sqlite3` was denied by the
+auto-permission classifier despite the adapter selecting full access. It then
+mistook a command-local PATH export and shell startup-file update for verifier
+visibility.
+
+## Scope
+
+- Skip the auto-permission classifier when the caller explicitly selects full
+  access.
+- Keep the classifier and approval policy unchanged for normal sessions.
+- Add generic benchmark guidance and adapter coverage for non-interactive PATH
+  validation.
+
+## Key Decisions
+
+- Full access is valid only when selected explicitly by the caller; for Harbor,
+  the task container is the external isolation boundary.
+- The guidance is task-agnostic. It does not name a benchmark command or encode
+  verifier behavior beyond the general distinction between shell-local and
+  fresh-process environment state.
+
+## Validation
+
+- `cargo test --locked agent::tests::planning::full_access_mode_bypasses_auto_permission_classifier_denials -- --nocapture`
+- `PYTHONPATH=$PWD/tools/harbor /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -m unittest tools.harbor.test_rara_agent`
+- `cargo fmt --check`
+- `cargo check --locked`
+
+## Follow-Ups
+
+- Re-run `terminal-bench/sqlite-with-gcov` and record the Harbor verifier
+  artifact in the Terminal-Bench observed-results journal.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1462,9 +1462,11 @@ impl Agent {
             // ── Auto-permission classifier safety net ────────────────────────────
             // Safety net: for dangerous tools (bash, web_*, pty), run the LLM
             // classifier to detect suspicious commands the static rules missed.
+            // Explicit full access delegates that boundary to the caller's
+            // external isolation and therefore bypasses this local gate.
             const CLASSIFIABLE_TOOLS: &[&str] =
                 &["bash", "pty", "web_search", "web_fetch", "mcp_tool_search"];
-            if CLASSIFIABLE_TOOLS.contains(&tool_name.as_str()) {
+            if !self.full_access_mode && CLASSIFIABLE_TOOLS.contains(&tool_name.as_str()) {
                 let classifier_input = tool_input.clone();
                 let request = crate::classifier::AutoPermissionRequest {
                     tool_name: tool_name.clone(),

--- a/src/agent/tests/planning.rs
+++ b/src/agent/tests/planning.rs
@@ -1063,6 +1063,64 @@ async fn full_access_mode_auto_allows_escalated_sandbox_request() {
 }
 
 #[tokio::test]
+async fn full_access_mode_bypasses_auto_permission_classifier_denials() {
+    let backend = Arc::new(
+        SequencedBackend::new(vec![
+            LlmResponse {
+                content: vec![ContentBlock::ToolUse {
+                    id: "tool-system-path".to_string(),
+                    name: "bash".to_string(),
+                    input: json!({
+                        "command": "ln -sf /app/tool /usr/local/bin/tool",
+                        "sandbox_permissions": "require_escalated"
+                    }),
+                }],
+                stop_reason: Some("tool_use".to_string()),
+                usage: Some(TokenUsage::default()),
+            },
+            LlmResponse {
+                content: vec![ContentBlock::Text {
+                    text: "done".to_string(),
+                }],
+                stop_reason: Some("end_turn".to_string()),
+                usage: Some(TokenUsage::default()),
+            },
+        ])
+        .with_classifier_response(
+            r#"{"decision":"deny","reason":"outside workspace","matched_rule":"workspace"}"#,
+        ),
+    );
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(StubBashTool));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.set_full_access_mode(true);
+
+    agent
+        .query_with_mode(
+            "install the command in the externally isolated container".to_string(),
+            super::super::AgentOutputMode::Silent,
+        )
+        .await
+        .expect("full access should execute the command");
+
+    assert_eq!(backend.classifier_call_count(), 0);
+    assert!(backend.observed_messages()[1].iter().any(|message| {
+        message.role == "user"
+            && message
+                .content
+                .to_string()
+                .contains("finished with exit code 0")
+    }));
+}
+
+#[tokio::test]
 async fn approved_prefix_auto_allows_matching_escalated_request() {
     let backend = Arc::new(SequencedBackend::new(vec![
         LlmResponse {

--- a/src/agent/tests/support.rs
+++ b/src/agent/tests/support.rs
@@ -145,7 +145,10 @@ impl LlmBackend for SequencedBackend {
 
     async fn classify(&self, instructions: &str, messages: &[Message]) -> Result<String> {
         self.classifier_calls.fetch_add(1, Ordering::Relaxed);
-        let response = self.classifier_responses.lock().expect("lock").pop();
+        let response = {
+            let mut responses = self.classifier_responses.lock().expect("lock");
+            (!responses.is_empty()).then(|| responses.remove(0))
+        };
         match response {
             Some(response) => Ok(response),
             None => self.summarize(messages, instructions).await,

--- a/src/agent/tests/support.rs
+++ b/src/agent/tests/support.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -45,6 +48,8 @@ pub(super) struct SequencedBackend {
     observed_messages: Mutex<Vec<Vec<Message>>>,
     observed_tools: Mutex<Vec<Vec<String>>>,
     model_label: Mutex<Option<String>>,
+    classifier_responses: Mutex<Vec<String>>,
+    classifier_calls: AtomicUsize,
 }
 
 impl SequencedBackend {
@@ -54,12 +59,26 @@ impl SequencedBackend {
             observed_messages: Mutex::new(Vec::new()),
             observed_tools: Mutex::new(Vec::new()),
             model_label: Mutex::new(None),
+            classifier_responses: Mutex::new(Vec::new()),
+            classifier_calls: AtomicUsize::new(0),
         }
     }
 
     pub(super) fn with_model_label(self, model_label: impl Into<String>) -> Self {
         *self.model_label.lock().expect("lock") = Some(model_label.into());
         self
+    }
+
+    pub(super) fn with_classifier_response(self, response: impl Into<String>) -> Self {
+        self.classifier_responses
+            .lock()
+            .expect("lock")
+            .push(response.into());
+        self
+    }
+
+    pub(super) fn classifier_call_count(&self) -> usize {
+        self.classifier_calls.load(Ordering::Relaxed)
     }
 
     pub(super) fn observed_tools(&self) -> Vec<Vec<String>> {
@@ -122,5 +141,14 @@ impl LlmBackend for SequencedBackend {
 
     async fn summarize(&self, _messages: &[Message], _instruction: &str) -> Result<String> {
         Ok("summary".to_string())
+    }
+
+    async fn classify(&self, instructions: &str, messages: &[Message]) -> Result<String> {
+        self.classifier_calls.fetch_add(1, Ordering::Relaxed);
+        let response = self.classifier_responses.lock().expect("lock").pop();
+        match response {
+            Some(response) => Ok(response),
+            None => self.summarize(messages, instructions).await,
+        }
     }
 }

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -359,6 +359,7 @@ heredocs, sed, awk, perl, or ad-hoc scripts to edit files when a direct edit \
 tool can do the job.
 Use shell commands for process execution and focused validation commands.
 Treat task constraints as validation requirements. If the task says only certain edits are allowed, files must not be edited, output must match an exact format, or substitutions must come from an allowed list, verify those constraints directly before finishing.
+When a task requires a command to be available in PATH, verify it in a fresh non-interactive process without a command-local PATH export. Updating shell startup files alone does not prove that the verifier can resolve the command.
 When running shell commands, request escalated sandbox permissions; Harbor already isolates this task inside its container.
 Do not finish with only an explanation. Finish only after the requested artifacts exist, or report the exact blocker if you cannot create them.
 

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -585,6 +585,8 @@ class RaraAgentTests(unittest.TestCase):
         self.assertIn("Use shell commands for process execution", uploaded_instruction)
         self.assertIn("Treat task constraints as validation requirements", uploaded_instruction)
         self.assertIn("substitutions must come from an allowed list", uploaded_instruction)
+        self.assertIn("fresh non-interactive process", uploaded_instruction)
+        self.assertIn("shell startup files alone does not prove", uploaded_instruction)
         self.assertIn("request escalated sandbox permissions", uploaded_instruction)
         self.assertIn("/app/solution.sparql", uploaded_instruction)
         self.assertIn("Do not finish with only an explanation", uploaded_instruction)


### PR DESCRIPTION
## Summary

- make explicit `rara exec --full-access` bypass the auto-permission classifier
- add generic Harbor guidance for verifying PATH-dependent commands from a fresh non-interactive process
- add focused Rust and Harbor adapter regression coverage

## Why

`terminal-bench/sqlite-with-gcov` built SQLite successfully but scored zero because the verifier could not resolve `sqlite3` on PATH. The agent's required `/usr/local/bin` setup was rejected by the classifier even though Harbor had explicitly selected full access inside an isolated task container. A shell-local PATH export then produced a false successful validation.

## Impact

The classifier remains active for normal TUI and headless runs. It is bypassed only when the caller explicitly selects `--full-access`; Harbor's task container remains the isolation boundary.

## Testing

- `cargo fmt --all --check`
- `cargo test --locked agent::tests::planning::full_access_mode_bypasses_auto_permission_classifier_denials -- --nocapture`
- `PYTHONPATH=$PWD/tools/harbor /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -m unittest tools.harbor.test_rara_agent`
- `cargo check --locked`
- pre-commit `cargo clippy --locked --all-targets --no-deps -- -D warnings`
