### PR TITLE
chore: upgrade codex dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,7 +1510,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1996,8 +1996,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2015,8 +2015,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2046,8 +2046,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -2055,8 +2055,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2068,13 +2068,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 
 [[package]]
 name = "codex-config"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2118,8 +2118,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "anyhow",
  "clap",
@@ -2134,8 +2134,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -2145,8 +2145,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2158,8 +2158,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2171,8 +2171,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2196,8 +2196,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -2222,8 +2222,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "keyring",
  "tracing",
@@ -2231,8 +2231,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2264,8 +2264,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -2276,8 +2276,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -2295,8 +2295,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2330,8 +2330,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2361,8 +2361,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2400,8 +2400,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "age",
  "anyhow",
@@ -2419,16 +2419,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "dirs",
  "dunce",
@@ -2439,8 +2439,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "lru 0.16.4",
  "sha1",
@@ -2449,8 +2449,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2458,8 +2458,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2471,8 +2471,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2480,8 +2480,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2490,8 +2490,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -2505,16 +2505,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "rustls 0.23.41",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "regex-lite",
  "serde",
@@ -2523,13 +2523,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.144.1"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.1#44918ea10c0f99151c6710411b4322c2f5c96bea"
+version = "0.144.3"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -2558,7 +2558,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6774,7 +6774,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -10288,7 +10288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -10307,7 +10307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10478,7 +10478,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10516,7 +10516,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -14881,7 +14881,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ tempfile = "3.17"
 ignore = "0.4.26"
 nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
 rmcp = { version = "2.0", features = ["client", "transport-child-process"] }
-codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.144.1" }
+codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.144.3" }
+codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.3" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.144.3" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.144.3" }
 rara-instructions = { path = "crates/instructions" }
 
 [package]

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -234,4 +234,5 @@ Each trial should end with one of:
 
 - `docs/journal/2026-07-05-rara-exec-headless.md`
 - `docs/journal/2026-07-05-harbor-rara-agent-adapter.md`
+- `docs/journal/2026-07-14-terminal-bench-results.md`
 - `docs/journal/2026-07-11-harbor-atif-trajectory.md`

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -234,5 +234,5 @@ Each trial should end with one of:
 
 - `docs/journal/2026-07-05-rara-exec-headless.md`
 - `docs/journal/2026-07-05-harbor-rara-agent-adapter.md`
-- `docs/journal/2026-07-14-terminal-bench-results.md`
 - `docs/journal/2026-07-11-harbor-atif-trajectory.md`
+- `docs/journal/2026-07-14-terminal-bench-results.md`

--- a/docs/journal/2026-07-14-codex-144-3-dependency-bump.md
+++ b/docs/journal/2026-07-14-codex-144-3-dependency-bump.md
@@ -1,0 +1,33 @@
+# Codex 0.144.3 Dependency Bump
+
+## Summary
+
+RARA now pins its direct Codex git dependencies to the latest stable Rust
+release tag, `rust-v0.144.3`. The `0.145.0` tags available at the time of this
+change are pre-release alphas and remain out of scope.
+
+The updated crates are:
+
+- `codex-execpolicy`
+- `codex-http-client`
+- `codex-login`
+- `codex-models-manager`
+
+Cargo resolved the Codex dependency graph at commit
+`78ad6e6bfd1d3b6a209acd3ef82172a96b25179c`.
+
+## Scope
+
+This is a compatible patch-level update from `0.144.1`. RARA retains the
+existing explicit `HttpClientFactory` supplied to `ModelsManager::list_models`,
+which was required by the previous `0.144.1` upgrade.
+
+## Validation
+
+```bash
+cargo metadata --locked --no-deps --format-version 1
+cargo fmt --check
+cargo check
+```
+
+All commands completed successfully.

--- a/docs/journal/2026-07-14-terminal-bench-results.md
+++ b/docs/journal/2026-07-14-terminal-bench-results.md
@@ -1,0 +1,47 @@
+# Terminal-Bench Observed Results
+
+## Summary
+
+This journal is the evidence-backed record of observed Terminal-Bench task
+outcomes for RARA's Harbor adapter. A task is confirmed as passed only when the
+Harbor verifier reports reward `1.0`; a successful RARA process exit alone is
+not sufficient.
+
+## Results
+
+| Task | Outcome | Evidence | Notes |
+| --- | --- | --- | --- |
+| `terminal-bench/regex-log` | Passed | Harbor verifier reward `1.0` | The run recorded RARA exit status `0` and an authoritative verifier success. |
+| `terminal-bench/overfull-hbox` | Failed | Final task artifact violated an edit constraint | The agent removed the LaTeX warnings, but also changed `an` to `a` when only synonym substitutions were allowed. The task therefore did not pass validation. |
+| `terminal-bench/sparql-university` | Passed (artifact pending) | User-reported successful benchmark run | Earlier attempts were inconclusive because of CA and provider setup failures. Record the Harbor verifier artifact for this successful rerun when its job path is available. |
+
+## Recording Rules
+
+- Report verifier reward separately from RARA's exit status and final message.
+- Use `Passed` for a confirmed official verifier reward of `1.0`; append
+  `(artifact pending)` when the successful outcome is reported before its
+  Harbor verifier artifact is available in the repository.
+- Use `Failed` when the verifier rejects an otherwise completed task artifact.
+- Use `Inconclusive` for adapter, provider, credential, environment, or harness
+  failures that prevent a valid task attempt.
+- Record the Harbor run command, dataset revision, RARA revision, provider,
+  model, and links to JSONL and verifier artifacts for every future result.
+
+## Evidence
+
+- `docs/journal/2026-07-09-harbor-provider-env.md` records the `regex-log`
+  verifier reward and the earlier inconclusive `sparql-university` setup attempts.
+- The successful `sparql-university` outcome was reported during the
+  2026-07-14 evaluation checkpoint; its Harbor job path and verifier reward
+  have not yet been added to this repository.
+- `docs/journal/2026-07-09-headless-constraint-validation.md` records the
+  `overfull-hbox` constraint violation.
+
+## Follow-Ups
+
+- Re-run `overfull-hbox` with the current full-access and constraint-validation
+  guidance, then append the authoritative verifier result.
+- Use `regex-log` as the first smoke-regression task before adding a more
+  constraint-heavy task to the smoke subset.
+- Add the successful `sparql-university` Harbor job path and verifier artifact
+  to this record.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -118,6 +118,19 @@ Active backlog only. Keep this file small and current.
 
 - [ ] Explicit embedding controls: enable/disable, provider override (low priority)
 
+## ACP Compatibility
+
+- [ ] Replace the single ACP `active_agent` with session-scoped runtime state;
+      bind each `session/new` ID to its own history and requested workspace cwd.
+- [ ] Route ACP cancellation by `CancelNotification.session_id` and retain the
+      session ID in control-plane provenance so one client cannot interrupt
+      another session.
+- [ ] Map ACP output from structured runtime events rather than presentation
+      text: include thinking, tool lifecycle and streams, approvals, plans,
+      todos, warnings, errors, cancellation, and completion.
+- [ ] Add focused ACP regressions for multi-session isolation, cwd propagation,
+      session-targeted cancellation, and structured event translation.
+
 ## Long-term
 
 - [ ] Claude plugin runtime integration


### PR DESCRIPTION
## Summary

- update the direct Codex git dependencies from `rust-v0.144.1` to the latest stable `rust-v0.144.3` tag;
- refresh the locked Codex dependency graph at commit `78ad6e6bfd1d3b6a209acd3ef82172a96b25179c`;
- record ACP compatibility follow-ups for session isolation, cancellation routing, workspace propagation, structured event translation, and focused regressions.

## Purpose

Keep RARA aligned with the latest stable Codex Rust release while documenting ACP work that remains independent of this dependency update. The available `0.145.0` tags are alpha releases and are intentionally excluded.

## Related Issues

None.

## Testing

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --check`
- `cargo check --locked`
- `git diff --check`
