### PR TITLE
feat(acp): isolate session workspaces

### DIFF
--- a/crates/rara-tools/src/tool.rs
+++ b/crates/rara-tools/src/tool.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
@@ -36,6 +37,7 @@ pub enum ToolProgressEvent {
 pub struct ToolCallContext {
     cancellation: Option<Arc<AtomicBool>>,
     session_id: Option<String>,
+    workspace_root: Option<PathBuf>,
 }
 
 impl ToolCallContext {
@@ -49,8 +51,17 @@ impl ToolCallContext {
         self
     }
 
+    pub fn with_workspace_root(mut self, workspace_root: impl Into<PathBuf>) -> Self {
+        self.workspace_root = Some(workspace_root.into());
+        self
+    }
+
     pub fn session_id(&self) -> Option<&str> {
         self.session_id.as_deref()
+    }
+
+    pub fn workspace_root(&self) -> Option<&Path> {
+        self.workspace_root.as_deref()
     }
 
     pub fn is_cancelled(&self) -> bool {
@@ -194,5 +205,15 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(names, vec!["alpha_tool", "zeta_tool"]);
+    }
+
+    #[test]
+    fn call_context_retains_workspace_root() {
+        let context = ToolCallContext::default().with_workspace_root("/tmp/rara-workspace");
+
+        assert_eq!(
+            context.workspace_root(),
+            Some(Path::new("/tmp/rara-workspace"))
+        );
     }
 }

--- a/docs/features/support-acp-integration.md
+++ b/docs/features/support-acp-integration.md
@@ -85,6 +85,19 @@ Clients must not send raw keys such as `Esc` or rely on TUI overlay behavior.
 Queued follow-ups preserve input order. Cancellation and interruption are
 separate control requests and must not be implied by a follow-up.
 
+### Session And Workspace Isolation
+
+Each ACP `session/new` creates a session-scoped RARA runtime lazily on its
+first prompt. The requested absolute `cwd` is the workspace root for that
+runtime: its history, workspace memory, session data, hooks, and default Bash
+and PTY working directories are isolated from every other ACP session.
+
+An ACP host process may serve several workspaces concurrently. Adapters must
+therefore pass the workspace explicitly and must never change the process cwd
+to implement session switching. `CancelNotification.session_id` targets only
+the matching runtime, and emitted cancellation events retain that ACP session
+id in their control-plane provenance.
+
 ### Output Events
 
 ACP-facing output should be derived from structured runtime events, not parsed
@@ -104,6 +117,14 @@ The support skill should document at least these event families:
 
 Plain text streaming is a presentation layer. The source of truth is the
 runtime-control event stream.
+
+ACP v1 has native session updates for assistant text and thinking, tool calls
+and updates, and complete plan snapshots. RARA translates those families to
+their native ACP representations. Approval requests and decisions, todo
+updates, warnings, errors, cancellation, and completion remain structured
+`RuntimeControlEvent` values with ACP provenance because ACP v1 has no native
+`SessionUpdate` variant for them. Clients that require those signals must
+subscribe to the RARA control-plane stream rather than infer them from text.
 
 ### Source Registration
 
@@ -143,6 +164,8 @@ approval and permission system used by the local TUI.
   and context specs rather than redefining incompatible contracts.
 - ACP client examples use semantic runtime intents, not TUI key events.
 - Output examples are event-based and do not require scraping rendered text.
+- Multiple ACP sessions with different `cwd` values preserve separate runtime
+  state and cancellation targets.
 - Source registration examples include provenance and lifetime metadata.
 - Changes to runtime-control request or event shapes update the support skill
   in the same PR.

--- a/docs/journal/2026-07-14-acp-session-workspace-foundation.md
+++ b/docs/journal/2026-07-14-acp-session-workspace-foundation.md
@@ -12,6 +12,10 @@ session workspace when the model does not provide an explicit working directory.
   sessions for different workspaces concurrently.
 - Route cancellation through the session registry and include the ACP session
   ID in runtime-control provenance.
+- Give each session a shared atomic cancellation token so a cancellation request
+  interrupts an active prompt without waiting for its runtime mutex. The session
+  registry uses a synchronous `RwLock` because map operations never span an
+  await point.
 - Translate assistant text, reasoning, tool lifecycle and streams, and plan
   snapshots through ACP-native session updates instead of formatting them as
   transcript text.
@@ -30,5 +34,6 @@ cargo test -q runtime_event_bus::tests::adapter_events_keep_their_acp_provenance
 cargo test -q acp::tests::sessions_keep_distinct_requested_workspaces
 cargo test -q acp::tests::plan_events_translate_to_native_acp_updates
 cargo test -q acp::tests::cancellation_envelope_targets_the_notified_session
+cargo test -q acp::tests::cancellation_token_is_shared_without_waiting_for_runtime
 git diff --check
 ```

--- a/docs/journal/2026-07-14-acp-session-workspace-foundation.md
+++ b/docs/journal/2026-07-14-acp-session-workspace-foundation.md
@@ -1,0 +1,34 @@
+# ACP Session Workspace Foundation
+
+## Summary
+
+ACP sessions now retain their requested workspace directory and initialize an
+independent RARA runtime on the first prompt. Bash and PTY calls inherit that
+session workspace when the model does not provide an explicit working directory.
+
+## Key Decisions
+
+- Do not mutate the process cwd for ACP sessions; a single ACP process may host
+  sessions for different workspaces concurrently.
+- Route cancellation through the session registry and include the ACP session
+  ID in runtime-control provenance.
+- Translate assistant text, reasoning, tool lifecycle and streams, and plan
+  snapshots through ACP-native session updates instead of formatting them as
+  transcript text.
+- Preserve approval, todo, warning/error, cancellation, and completion as
+  structured runtime-control events with ACP provenance. ACP v1 has no native
+  `SessionUpdate` representation for those event families.
+
+## Validation
+
+```bash
+cargo fmt --all --check
+cargo check -q
+cargo test -q -p rara-tools tool::tests::call_context_retains_workspace_root
+cargo test -q runtime_control::tests::agent_plan_and_approval_events_preserve_structured_fields
+cargo test -q runtime_event_bus::tests::adapter_events_keep_their_acp_provenance
+cargo test -q acp::tests::sessions_keep_distinct_requested_workspaces
+cargo test -q acp::tests::plan_events_translate_to_native_acp_updates
+cargo test -q acp::tests::cancellation_envelope_targets_the_notified_session
+git diff --check
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -120,15 +120,15 @@ Active backlog only. Keep this file small and current.
 
 ## ACP Compatibility
 
-- [ ] Replace the single ACP `active_agent` with session-scoped runtime state;
+- [x] Replace the single ACP `active_agent` with session-scoped runtime state;
       bind each `session/new` ID to its own history and requested workspace cwd.
-- [ ] Route ACP cancellation by `CancelNotification.session_id` and retain the
+- [x] Route ACP cancellation by `CancelNotification.session_id` and retain the
       session ID in control-plane provenance so one client cannot interrupt
       another session.
-- [ ] Map ACP output from structured runtime events rather than presentation
+- [x] Map ACP output from structured runtime events rather than presentation
       text: include thinking, tool lifecycle and streams, approvals, plans,
       todos, warnings, errors, cancellation, and completion.
-- [ ] Add focused ACP regressions for multi-session isolation, cwd propagation,
+- [x] Add focused ACP regressions for multi-session isolation, cwd propagation,
       session-targeted cancellation, and structured event translation.
 
 ## Long-term

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -2,7 +2,8 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
 
 use agent_client_protocol::{
     Agent as AcpRoleAgent, Client, ConnectionTo, Dispatch, Responder, Result as AcpResult,
@@ -40,19 +41,20 @@ struct AcpSessionRuntime {
 struct AcpSession {
     cwd: PathBuf,
     runtime: tokio::sync::Mutex<Option<AcpSessionRuntime>>,
+    cancellation_token: Arc<AtomicBool>,
 }
 
 /// ACP adapter state. Every ACP session owns an independent RARA runtime.
 pub struct RaraAcpAgent {
     config: RaraConfig,
-    sessions: tokio::sync::RwLock<HashMap<String, Arc<AcpSession>>>,
+    sessions: RwLock<HashMap<String, Arc<AcpSession>>>,
 }
 
 impl RaraAcpAgent {
     pub fn new(config: RaraConfig) -> Self {
         Self {
             config,
-            sessions: tokio::sync::RwLock::new(HashMap::new()),
+            sessions: RwLock::new(HashMap::new()),
         }
     }
 
@@ -87,13 +89,20 @@ impl RaraAcpAgent {
                         let this = this.clone();
                         async move {
                             let session_id = SessionId::from(uuid::Uuid::new_v4().to_string());
-                            this.sessions.write().await.insert(
-                                session_id.to_string(),
-                                Arc::new(AcpSession {
-                                    cwd: req.cwd,
-                                    runtime: tokio::sync::Mutex::new(None),
-                                }),
-                            );
+                            this.sessions
+                                .write()
+                                .unwrap_or_else(|error| {
+                                    log::warn!("ACP session registry was poisoned: {error}");
+                                    error.into_inner()
+                                })
+                                .insert(
+                                    session_id.to_string(),
+                                    Arc::new(AcpSession {
+                                        cwd: req.cwd,
+                                        runtime: tokio::sync::Mutex::new(None),
+                                        cancellation_token: Arc::new(AtomicBool::new(false)),
+                                    }),
+                                );
                             responder.respond(NewSessionResponse::new(session_id))
                         }
                     }
@@ -133,10 +142,13 @@ impl RaraAcpAgent {
             .await
     }
 
-    async fn session(&self, session_id: &SessionId) -> Option<Arc<AcpSession>> {
+    fn session(&self, session_id: &SessionId) -> Option<Arc<AcpSession>> {
         self.sessions
             .read()
-            .await
+            .unwrap_or_else(|error| {
+                log::warn!("ACP session registry was poisoned: {error}");
+                error.into_inner()
+            })
             .get(&session_id.to_string())
             .cloned()
     }
@@ -164,27 +176,32 @@ impl RaraAcpAgent {
     }
 
     async fn cancel_session(&self, session_id: SessionId) {
-        let Some(session) = self.session(&session_id).await else {
+        let Some(session) = self.session(&session_id) else {
             return;
         };
-        let mut runtime = session.runtime.lock().await;
-        let Some(runtime) = runtime.as_mut() else {
-            return;
-        };
-        let envelope = cancel_envelope(session_id.clone());
-        if let Err(err) = crate::control_plane::dispatch(
-            envelope,
-            &runtime.mcp_manager,
-            &runtime.prompt_registry,
-            &runtime.skill_registry,
-            &runtime.memory_handler,
-            &runtime.hook_registry,
-            Some(&mut runtime.agent),
-            |_| {},
-        )
-        .await
+        session.cancellation_token.store(true, Ordering::SeqCst);
+
+        if let Ok(mut runtime) = session.runtime.try_lock()
+            && let Some(runtime) = runtime.as_mut()
         {
-            log::warn!("ACP cancellation failed for session {session_id}: {err}");
+            let event_bus = runtime.event_bus.clone();
+            let envelope = cancel_envelope(session_id.clone());
+            if let Err(err) = crate::control_plane::dispatch(
+                envelope,
+                &runtime.mcp_manager,
+                &runtime.prompt_registry,
+                &runtime.skill_registry,
+                &runtime.memory_handler,
+                &runtime.hook_registry,
+                Some(&mut runtime.agent),
+                move |event| {
+                    event_bus.publish_control_event(event);
+                },
+            )
+            .await
+            {
+                log::warn!("ACP cancellation failed for session {session_id}: {err}");
+            }
         }
     }
 
@@ -199,10 +216,11 @@ impl RaraAcpAgent {
             responder.respond(PromptResponse::new(StopReason::EndTurn))?;
             return Ok(());
         }
-        let Some(session) = self.session(&req.session_id).await else {
+        let Some(session) = self.session(&req.session_id) else {
             responder.respond(PromptResponse::new(StopReason::EndTurn))?;
             return Ok(());
         };
+        session.cancellation_token.store(false, Ordering::SeqCst);
         let mut runtime = session.runtime.lock().await;
         if runtime.is_none() {
             match self.ensure_runtime(&session).await {
@@ -215,6 +233,9 @@ impl RaraAcpAgent {
             }
         }
         let runtime = runtime.as_mut().expect("runtime initialized");
+        runtime
+            .agent
+            .set_cancellation_token(Some(session.cancellation_token.clone()));
         let provenance = RuntimeProvenance::protocol(
             RuntimeControllerKind::Acp,
             "acp",
@@ -413,27 +434,29 @@ mod tests {
         let agent = RaraAcpAgent::new(RaraConfig::default());
         let first = SessionId::from("first");
         let second = SessionId::from("second");
-        agent.sessions.write().await.insert(
+        agent.sessions.write().expect("session registry").insert(
             first.to_string(),
             Arc::new(AcpSession {
                 cwd: PathBuf::from("/tmp/rara-acp-first"),
                 runtime: tokio::sync::Mutex::new(None),
+                cancellation_token: Arc::new(AtomicBool::new(false)),
             }),
         );
-        agent.sessions.write().await.insert(
+        agent.sessions.write().expect("session registry").insert(
             second.to_string(),
             Arc::new(AcpSession {
                 cwd: PathBuf::from("/tmp/rara-acp-second"),
                 runtime: tokio::sync::Mutex::new(None),
+                cancellation_token: Arc::new(AtomicBool::new(false)),
             }),
         );
 
         assert_eq!(
-            agent.session(&first).await.expect("first session").cwd,
+            agent.session(&first).expect("first session").cwd,
             PathBuf::from("/tmp/rara-acp-first")
         );
         assert_eq!(
-            agent.session(&second).await.expect("second session").cwd,
+            agent.session(&second).expect("second session").cwd,
             PathBuf::from("/tmp/rara-acp-second")
         );
     }
@@ -465,5 +488,19 @@ mod tests {
                 crate::runtime_control::SessionControlRequest::CancelCurrentTurn
             )
         ));
+    }
+
+    #[test]
+    fn cancellation_token_is_shared_without_waiting_for_runtime() {
+        let session = AcpSession {
+            cwd: PathBuf::from("/tmp/rara-acp-cancel"),
+            runtime: tokio::sync::Mutex::new(None),
+            cancellation_token: Arc::new(AtomicBool::new(false)),
+        };
+
+        let _runtime_guard = session.runtime.try_lock().expect("runtime lock");
+        session.cancellation_token.store(true, Ordering::SeqCst);
+
+        assert!(session.cancellation_token.load(Ordering::SeqCst));
     }
 }

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -1,82 +1,63 @@
-//! ACP (Agent Client Protocol) integration for RARA.
-//!
-//! Implements an ACP-compliant agent with a full tool-calling loop.
-//! The agent accepts stdio transports per the ACP spec.
+//! ACP (Agent Client Protocol) adapter with workspace-scoped session runtimes.
 
+use std::collections::{HashMap, VecDeque};
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use agent_client_protocol::{
     Agent as AcpRoleAgent, Client, ConnectionTo, Dispatch, Responder, Result as AcpResult,
     schema::v1::{
         AgentCapabilities, AuthenticateRequest, AuthenticateResponse, CancelNotification,
         ContentBlock as AcpContentBlock, ContentChunk, InitializeRequest, InitializeResponse,
-        NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, SessionId,
-        SessionNotification, SessionUpdate, StopReason, TextContent,
+        NewSessionRequest, NewSessionResponse, Plan, PlanEntry, PlanEntryPriority, PlanEntryStatus,
+        PromptRequest, PromptResponse, SessionId, SessionNotification, SessionUpdate, StopReason,
+        TextContent, ToolCall, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
     },
 };
-use rara_tools::tool::{ToolManager, ToolProgressEvent};
-use serde_json::Value;
 use tokio::io::{stdin, stdout};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-use crate::agent::{Agent, Message};
+use crate::agent::Agent;
+use crate::config::RaraConfig;
 use crate::hook_registry::HookRegistry;
-use crate::llm::{ContentBlock, LlmBackend, LlmStreamEvent};
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::protocol_sources::{MemoryControlHandler, PromptSourceRegistry, SkillSourceRegistry};
 use crate::runtime_control::{
-    RuntimeControlEnvelope, RuntimeControlRequest, RuntimeControllerKind,
+    RuntimeControlEnvelope, RuntimeControlRequest, RuntimeControllerKind, RuntimeProvenance,
 };
 use crate::runtime_event_bus::RuntimeEventBus;
 
-/// ACP agent state shared across request handlers.
+struct AcpSessionRuntime {
+    agent: Agent,
+    event_bus: Arc<RuntimeEventBus>,
+    mcp_manager: Arc<McpConnectionManager>,
+    prompt_registry: Arc<PromptSourceRegistry>,
+    skill_registry: Arc<SkillSourceRegistry>,
+    hook_registry: Arc<HookRegistry>,
+    memory_handler: Arc<MemoryControlHandler>,
+}
+
+struct AcpSession {
+    cwd: PathBuf,
+    runtime: tokio::sync::Mutex<Option<AcpSessionRuntime>>,
+}
+
+/// ACP adapter state. Every ACP session owns an independent RARA runtime.
 pub struct RaraAcpAgent {
-    pub llm_backend: Arc<dyn LlmBackend>,
-    pub tool_manager: Arc<ToolManager>,
-    pub event_bus: Arc<RuntimeEventBus>,
-    pub mcp_manager: Arc<McpConnectionManager>,
-    pub prompt_registry: Arc<PromptSourceRegistry>,
-    pub skill_registry: Arc<SkillSourceRegistry>,
-    pub hook_registry: Arc<HookRegistry>,
-    pub memory_handler: Arc<MemoryControlHandler>,
-    /// active agent (one per ACP session for now)
-    active_agent: tokio::sync::Mutex<Option<Agent>>,
+    config: RaraConfig,
+    sessions: tokio::sync::RwLock<HashMap<String, Arc<AcpSession>>>,
 }
 
 impl RaraAcpAgent {
-    #[allow(clippy::too_many_arguments)]
-    // ACP session wiring owns the runtime dependencies explicitly; grouping
-    // them would duplicate RuntimeContext without reducing call-site risk.
-    pub fn new(
-        llm_backend: Arc<dyn LlmBackend>,
-        tool_manager: Arc<ToolManager>,
-        event_bus: Arc<RuntimeEventBus>,
-        mcp_manager: Arc<McpConnectionManager>,
-        prompt_registry: Arc<PromptSourceRegistry>,
-        skill_registry: Arc<SkillSourceRegistry>,
-        hook_registry: Arc<HookRegistry>,
-        memory_handler: Arc<MemoryControlHandler>,
-    ) -> Self {
+    pub fn new(config: RaraConfig) -> Self {
         Self {
-            llm_backend,
-            tool_manager,
-            event_bus,
-            mcp_manager,
-            prompt_registry,
-            skill_registry,
-            hook_registry,
-            memory_handler,
-            active_agent: tokio::sync::Mutex::new(None),
+            config,
+            sessions: tokio::sync::RwLock::new(HashMap::new()),
         }
     }
 
-    /// Run the ACP agent on stdio using the ACP builder API.
     pub async fn run_acp_stdio(self) -> AcpResult<()> {
-        let llm = self.llm_backend.clone();
-        let tools = self.tool_manager.clone();
         let this = Arc::new(self);
-
         let transport =
             agent_client_protocol::ByteStreams::new(stdout().compat_write(), stdin().compat());
 
@@ -98,22 +79,33 @@ impl RaraAcpAgent {
                 agent_client_protocol::on_receive_request!(),
             )
             .on_receive_request(
-                async move |_req: NewSessionRequest, responder, _cx| {
-                    let session_id = SessionId::from(uuid::Uuid::new_v4().to_string());
-                    responder.respond(NewSessionResponse::new(session_id))
+                {
+                    let this = this.clone();
+                    move |req: NewSessionRequest,
+                          responder: Responder<NewSessionResponse>,
+                          _cx: ConnectionTo<Client>| {
+                        let this = this.clone();
+                        async move {
+                            let session_id = SessionId::from(uuid::Uuid::new_v4().to_string());
+                            this.sessions.write().await.insert(
+                                session_id.to_string(),
+                                Arc::new(AcpSession {
+                                    cwd: req.cwd,
+                                    runtime: tokio::sync::Mutex::new(None),
+                                }),
+                            );
+                            responder.respond(NewSessionResponse::new(session_id))
+                        }
+                    }
                 },
                 agent_client_protocol::on_receive_request!(),
             )
             .on_receive_request(
                 {
                     let this = this.clone();
-                    let llm = llm.clone();
-                    let tools = tools.clone();
                     move |req: PromptRequest, responder, cx: ConnectionTo<Client>| {
                         let this = this.clone();
-                        let llm = llm.clone();
-                        let tools = tools.clone();
-                        async move { this.handle_prompt(req, responder, cx, llm, tools).await }
+                        async move { this.handle_prompt(req, responder, cx).await }
                     }
                 },
                 agent_client_protocol::on_receive_request!(),
@@ -121,40 +113,8 @@ impl RaraAcpAgent {
             .on_receive_notification(
                 {
                     let this = this.clone();
-                    async move |_notif: CancelNotification, _cx: ConnectionTo<Client>| {
-                        eprintln!("[acp] cancel notification received");
-
-                        let provenance = crate::runtime_control::RuntimeProvenance::protocol(
-                            crate::runtime_control::RuntimeControllerKind::Acp,
-                            "acp",
-                            None, // We might not have session_id here if it's broad?
-                            // Actually ACP CancelNotification has session_id.
-                            None,
-                        );
-                        let request = crate::runtime_control::RuntimeControlRequest::Session(
-                            crate::runtime_control::SessionControlRequest::CancelCurrentTurn,
-                        );
-                        let envelope = crate::runtime_control::RuntimeControlEnvelope {
-                            request_id: uuid::Uuid::new_v4().to_string(),
-                            provenance,
-                            request,
-                        };
-
-                        let mut active_agent = this.active_agent.lock().await;
-                        let agent = active_agent.as_mut();
-
-                        let _ = crate::control_plane::dispatch(
-                            envelope,
-                            &this.mcp_manager,
-                            &this.prompt_registry,
-                            &this.skill_registry,
-                            &this.memory_handler,
-                            &this.hook_registry,
-                            agent,
-                            |_| {},
-                        )
-                        .await;
-
+                    async move |notification: CancelNotification, _cx: ConnectionTo<Client>| {
+                        this.cancel_session(notification.session_id).await;
                         Ok(())
                     }
                 },
@@ -173,173 +133,337 @@ impl RaraAcpAgent {
             .await
     }
 
-    /// Handle a prompt request with a full tool-calling agent loop.
+    async fn session(&self, session_id: &SessionId) -> Option<Arc<AcpSession>> {
+        self.sessions
+            .read()
+            .await
+            .get(&session_id.to_string())
+            .cloned()
+    }
+
+    async fn ensure_runtime(&self, session: &AcpSession) -> Result<AcpSessionRuntime, String> {
+        let bootstrap = crate::runtime_context::initialize_rara_context_for_workspace(
+            &self.config,
+            Some(&session.cwd),
+            None,
+        )
+        .await
+        .map_err(|err| err.to_string())?;
+        let event_bus = bootstrap.event_bus.clone();
+        let (agent, _, _, _, _, mcp_manager, prompt_registry, skill_registry, hook_registry, _) =
+            bootstrap.into_parts();
+        Ok(AcpSessionRuntime {
+            agent,
+            event_bus: event_bus.clone(),
+            mcp_manager,
+            prompt_registry,
+            skill_registry,
+            hook_registry,
+            memory_handler: Arc::new(MemoryControlHandler::new(event_bus)),
+        })
+    }
+
+    async fn cancel_session(&self, session_id: SessionId) {
+        let Some(session) = self.session(&session_id).await else {
+            return;
+        };
+        let mut runtime = session.runtime.lock().await;
+        let Some(runtime) = runtime.as_mut() else {
+            return;
+        };
+        let envelope = cancel_envelope(session_id.clone());
+        if let Err(err) = crate::control_plane::dispatch(
+            envelope,
+            &runtime.mcp_manager,
+            &runtime.prompt_registry,
+            &runtime.skill_registry,
+            &runtime.memory_handler,
+            &runtime.hook_registry,
+            Some(&mut runtime.agent),
+            |_| {},
+        )
+        .await
+        {
+            log::warn!("ACP cancellation failed for session {session_id}: {err}");
+        }
+    }
+
     async fn handle_prompt(
         &self,
         req: PromptRequest,
         responder: Responder<PromptResponse>,
         cx: ConnectionTo<Client>,
-        _llm: Arc<dyn LlmBackend>,
-        _tool_manager: Arc<ToolManager>,
     ) -> AcpResult<()> {
-        let session_id = req.session_id.to_string();
-        let prompt_text = extract_prompt_text(&req.prompt);
-
-        if prompt_text.trim().is_empty() {
+        let prompt = extract_prompt_text(&req.prompt);
+        if prompt.trim().is_empty() {
             responder.respond(PromptResponse::new(StopReason::EndTurn))?;
             return Ok(());
         }
-
-        let cancel_token = Arc::new(AtomicBool::new(false));
-
-        // Create or get the agent for this session.
-        let mut active_agent = self.active_agent.lock().await;
-        if active_agent.is_none() {
-            let bootstrap = match crate::runtime_context::initialize_rara_context(
-                &crate::config::ConfigManager::new()
-                    .and_then(|m| m.load())
-                    .unwrap_or_default(),
-                None,
-            )
-            .await
-            {
-                Ok(b) => b,
-                Err(_e) => {
-                    let _ = responder.respond(PromptResponse::new(StopReason::EndTurn));
+        let Some(session) = self.session(&req.session_id).await else {
+            responder.respond(PromptResponse::new(StopReason::EndTurn))?;
+            return Ok(());
+        };
+        let mut runtime = session.runtime.lock().await;
+        if runtime.is_none() {
+            match self.ensure_runtime(&session).await {
+                Ok(created) => *runtime = Some(created),
+                Err(err) => {
+                    log::warn!("ACP session initialization failed: {err}");
+                    responder.respond(PromptResponse::new(StopReason::EndTurn))?;
                     return Ok(());
                 }
-            };
-            *active_agent = Some(bootstrap.into_agent());
+            }
         }
-
-        let agent = active_agent.as_mut().unwrap();
-        agent.set_cancellation_token(Some(cancel_token.clone()));
-
-        // Create the control envelope.
-        let provenance = crate::runtime_control::RuntimeProvenance::protocol(
-            crate::runtime_control::RuntimeControllerKind::Acp,
+        let runtime = runtime.as_mut().expect("runtime initialized");
+        let provenance = RuntimeProvenance::protocol(
+            RuntimeControllerKind::Acp,
             "acp",
-            Some(session_id.clone()),
+            Some(req.session_id.to_string()),
             None,
         );
-        let request = crate::runtime_control::RuntimeControlRequest::Input(
-            crate::runtime_control::InputControlRequest::SubmitUserPrompt {
-                prompt: prompt_text,
-            },
-        );
-        let envelope = crate::runtime_control::RuntimeControlEnvelope {
+        let envelope = RuntimeControlEnvelope {
             request_id: uuid::Uuid::new_v4().to_string(),
-            provenance,
-            request,
+            provenance: provenance.clone(),
+            request: RuntimeControlRequest::Input(
+                crate::runtime_control::InputControlRequest::SubmitUserPrompt { prompt },
+            ),
         };
-
-        // Wire up the event reporter to send ACP notifications.
-        let cx_for_report = cx.clone();
-        let sid_for_report = req.session_id.clone();
-        let bus = self.event_bus.clone();
-
-        let mut on_event = move |control_event: crate::runtime_control::RuntimeControlEvent| {
-            // Forward to RuntimeEventBus for other subscribers.
-            let _ = bus.send_with_provenance(
-                match &control_event.event {
-                    crate::runtime_control::RuntimeEvent::Session(
-                        crate::runtime_control::SessionEvent::Status { message },
-                    ) => crate::agent::AgentEvent::Status(message.clone()),
-                    crate::runtime_control::RuntimeEvent::Session(_) => {
-                        return;
-                    }
-                    crate::runtime_control::RuntimeEvent::Assistant(ae) => match ae {
-                        crate::runtime_control::AssistantEvent::TextDelta(text) => {
-                            crate::agent::AgentEvent::AssistantDelta(text.clone())
-                        }
-                        crate::runtime_control::AssistantEvent::ThinkingDelta(text) => {
-                            crate::agent::AgentEvent::AssistantThinkingDelta(text.clone())
-                        }
-                        _ => return,
-                    },
-                    crate::runtime_control::RuntimeEvent::Tool(te) => match te {
-                        crate::runtime_control::ToolEvent::Use { name, input, .. } => {
-                            crate::agent::AgentEvent::ToolUse {
-                                name: name.clone(),
-                                input: input.clone(),
-                            }
-                        }
-                        crate::runtime_control::ToolEvent::Result {
-                            name,
-                            content,
-                            is_error,
-                        } => crate::agent::AgentEvent::ToolResult {
-                            name: name.clone(),
-                            content: content.clone(),
-                            is_error: *is_error,
-                        },
-                        _ => return,
-                    },
-                    _ => return,
-                },
-                control_event.provenance.clone(),
-            );
-
-            // Translate to ACP SessionNotification.
-            match control_event.event {
+        let session_id = req.session_id.clone();
+        let event_bus = runtime.event_bus.clone();
+        let mut tool_ids = HashMap::<String, VecDeque<String>>::new();
+        let mut sequence = 0_u64;
+        let mut report = move |event: crate::runtime_control::RuntimeControlEvent| {
+            sequence += 1;
+            let event_id = format!("acp-{sequence:016x}");
+            let _ = event_bus.publish_control_event(event.clone());
+            match event.event {
                 crate::runtime_control::RuntimeEvent::Assistant(
                     crate::runtime_control::AssistantEvent::TextDelta(text),
                 ) => {
-                    let chunk = ContentChunk::new(AcpContentBlock::Text(TextContent::new(text)));
-                    let _ = cx_for_report.send_notification(SessionNotification::new(
-                        sid_for_report.clone(),
-                        SessionUpdate::AgentMessageChunk(chunk),
-                    ));
+                    send_update(
+                        &cx,
+                        &session_id,
+                        SessionUpdate::AgentMessageChunk(ContentChunk::new(AcpContentBlock::Text(
+                            TextContent::new(text),
+                        ))),
+                    );
+                }
+                crate::runtime_control::RuntimeEvent::Assistant(
+                    crate::runtime_control::AssistantEvent::ThinkingDelta(text),
+                ) => {
+                    send_update(
+                        &cx,
+                        &session_id,
+                        SessionUpdate::AgentThoughtChunk(ContentChunk::new(AcpContentBlock::Text(
+                            TextContent::new(text),
+                        ))),
+                    );
                 }
                 crate::runtime_control::RuntimeEvent::Tool(
-                    crate::runtime_control::ToolEvent::Result { name, content, .. },
+                    crate::runtime_control::ToolEvent::Use { name, input },
                 ) => {
-                    let label = format!("\n[Tool result: {name}]\n{}\n", content);
-                    let chunk = ContentChunk::new(AcpContentBlock::Text(TextContent::new(label)));
-                    let _ = cx_for_report.send_notification(SessionNotification::new(
-                        sid_for_report.clone(),
-                        SessionUpdate::AgentMessageChunk(chunk),
-                    ));
+                    let id = format!("{event_id}-{name}");
+                    tool_ids
+                        .entry(name.clone())
+                        .or_default()
+                        .push_back(id.clone());
+                    send_update(
+                        &cx,
+                        &session_id,
+                        SessionUpdate::ToolCall(ToolCall::new(id, name).raw_input(input)),
+                    );
+                }
+                crate::runtime_control::RuntimeEvent::Tool(
+                    crate::runtime_control::ToolEvent::Result {
+                        name,
+                        content,
+                        is_error,
+                    },
+                ) => {
+                    if let Some(id) = tool_ids.get_mut(&name).and_then(VecDeque::pop_front) {
+                        let status = if is_error {
+                            ToolCallStatus::Failed
+                        } else {
+                            ToolCallStatus::Completed
+                        };
+                        send_update(
+                            &cx,
+                            &session_id,
+                            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                                id,
+                                ToolCallUpdateFields::new().status(status).raw_output(
+                                    serde_json::json!({
+                                        "content": content,
+                                        "is_error": is_error,
+                                    }),
+                                ),
+                            )),
+                        );
+                    }
+                }
+                crate::runtime_control::RuntimeEvent::Tool(
+                    crate::runtime_control::ToolEvent::Progress {
+                        name,
+                        stream,
+                        chunk,
+                    },
+                ) => {
+                    if let Some(id) = tool_ids.get(&name).and_then(|ids| ids.front()) {
+                        send_update(
+                            &cx,
+                            &session_id,
+                            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                                id.clone(),
+                                ToolCallUpdateFields::new().raw_output(serde_json::json!({
+                                    "stream": stream,
+                                    "chunk": chunk,
+                                })),
+                            )),
+                        );
+                    }
+                }
+                crate::runtime_control::RuntimeEvent::Plan(
+                    crate::runtime_control::PlanEvent::Updated { steps, .. },
+                ) => {
+                    send_update(&cx, &session_id, acp_plan_update(steps));
                 }
                 _ => {}
             }
         };
-
-        // Dispatch via control plane.
         let result = crate::control_plane::dispatch(
             envelope,
-            &self.mcp_manager,
-            &self.prompt_registry,
-            &self.skill_registry,
-            &self.memory_handler,
-            &self.hook_registry,
-            Some(agent),
-            &mut on_event,
+            &runtime.mcp_manager,
+            &runtime.prompt_registry,
+            &runtime.skill_registry,
+            &runtime.memory_handler,
+            &runtime.hook_registry,
+            Some(&mut runtime.agent),
+            &mut report,
         )
         .await;
-
-        let stop_reason = match result {
+        responder.respond(PromptResponse::new(match result {
             Ok(()) => StopReason::EndTurn,
-            Err(e) if e.contains("cancelled") => StopReason::Cancelled,
-            Err(_) => StopReason::EndTurn, // ACP StopReason doesn't have Error, using EndTurn as fallback
-        };
-
-        responder.respond(PromptResponse::new(stop_reason))?;
+            Err(err) if err.contains("cancelled") => StopReason::Cancelled,
+            Err(err) => {
+                log::warn!("ACP prompt failed: {err}");
+                StopReason::EndTurn
+            }
+        }))?;
         Ok(())
     }
 }
 
-/// Extract plain text from ACP content blocks.
+fn cancel_envelope(session_id: SessionId) -> RuntimeControlEnvelope {
+    RuntimeControlEnvelope {
+        request_id: uuid::Uuid::new_v4().to_string(),
+        provenance: RuntimeProvenance::protocol(
+            RuntimeControllerKind::Acp,
+            "acp",
+            Some(session_id.to_string()),
+            None,
+        ),
+        request: RuntimeControlRequest::Session(
+            crate::runtime_control::SessionControlRequest::CancelCurrentTurn,
+        ),
+    }
+}
+
+fn acp_plan_update(steps: Vec<crate::runtime_control::PlanStepEvent>) -> SessionUpdate {
+    let entries = steps
+        .into_iter()
+        .map(|step| {
+            let status = match step.status {
+                crate::runtime_control::PlanStepStatusEvent::Pending => PlanEntryStatus::Pending,
+                crate::runtime_control::PlanStepStatusEvent::InProgress => {
+                    PlanEntryStatus::InProgress
+                }
+                crate::runtime_control::PlanStepStatusEvent::Completed => {
+                    PlanEntryStatus::Completed
+                }
+            };
+            PlanEntry::new(step.step, PlanEntryPriority::Medium, status)
+        })
+        .collect();
+    SessionUpdate::Plan(Plan::new(entries))
+}
+
+fn send_update(cx: &ConnectionTo<Client>, session_id: &SessionId, update: SessionUpdate) {
+    if let Err(err) = cx.send_notification(SessionNotification::new(session_id.clone(), update)) {
+        log::warn!("ACP session update delivery failed: {err}");
+    }
+}
+
 fn extract_prompt_text(prompt: &[AcpContentBlock]) -> String {
     prompt
         .iter()
-        .filter_map(|block| {
-            if let AcpContentBlock::Text(text) = block {
-                Some(text.text.as_str())
-            } else {
-                None
-            }
+        .filter_map(|block| match block {
+            AcpContentBlock::Text(text) => Some(text.text.as_str()),
+            _ => None,
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn sessions_keep_distinct_requested_workspaces() {
+        let agent = RaraAcpAgent::new(RaraConfig::default());
+        let first = SessionId::from("first");
+        let second = SessionId::from("second");
+        agent.sessions.write().await.insert(
+            first.to_string(),
+            Arc::new(AcpSession {
+                cwd: PathBuf::from("/tmp/rara-acp-first"),
+                runtime: tokio::sync::Mutex::new(None),
+            }),
+        );
+        agent.sessions.write().await.insert(
+            second.to_string(),
+            Arc::new(AcpSession {
+                cwd: PathBuf::from("/tmp/rara-acp-second"),
+                runtime: tokio::sync::Mutex::new(None),
+            }),
+        );
+
+        assert_eq!(
+            agent.session(&first).await.expect("first session").cwd,
+            PathBuf::from("/tmp/rara-acp-first")
+        );
+        assert_eq!(
+            agent.session(&second).await.expect("second session").cwd,
+            PathBuf::from("/tmp/rara-acp-second")
+        );
+    }
+
+    #[test]
+    fn plan_events_translate_to_native_acp_updates() {
+        let update = acp_plan_update(vec![crate::runtime_control::PlanStepEvent {
+            step: "verify cancellation".to_string(),
+            status: crate::runtime_control::PlanStepStatusEvent::Completed,
+        }]);
+
+        assert!(matches!(
+            update,
+            SessionUpdate::Plan(Plan { entries, .. })
+                if entries.len() == 1
+                && entries[0].content == "verify cancellation"
+                && entries[0].status == PlanEntryStatus::Completed
+        ));
+    }
+
+    #[test]
+    fn cancellation_envelope_targets_the_notified_session() {
+        let envelope = cancel_envelope(SessionId::from("second"));
+
+        assert_eq!(envelope.provenance.session_id.as_deref(), Some("second"));
+        assert!(matches!(
+            envelope.request,
+            RuntimeControlRequest::Session(
+                crate::runtime_control::SessionControlRequest::CancelCurrentTurn
+            )
+        ));
+    }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -123,6 +123,21 @@ pub enum AgentEvent {
         message: String,
     },
     TodoUpdated(TodoState),
+    /// The execution plan changed and should be rendered as a complete snapshot.
+    PlanUpdated {
+        steps: Vec<PlanStep>,
+        explanation: Option<String>,
+    },
+    /// A structured approval is required before the agent can continue.
+    ApprovalRequested {
+        approval_id: String,
+        kind: String,
+    },
+    /// A structured approval decision was applied.
+    ApprovalAnswered {
+        approval_id: String,
+        approved: bool,
+    },
     /// Agent loop started a new run.
     AgentStart,
     /// Agent loop stopped normally (e.g. turn complete, user interruption).
@@ -839,7 +854,13 @@ impl Agent {
                         if matches!(self.execution_mode, AgentExecutionMode::Plan) {
                             malformed_proposed_plan |=
                                 planning::has_unclosed_proposed_plan_block(&clean_text);
-                            plan_updated |= self.capture_plan_from_text(&clean_text)?;
+                            if self.capture_plan_from_text(&clean_text)? {
+                                plan_updated = true;
+                                report(AgentEvent::PlanUpdated {
+                                    steps: self.current_plan.clone(),
+                                    explanation: self.plan_explanation.clone(),
+                                });
+                            }
                         }
                         if matches!(output_mode, AgentOutputMode::Terminal) {
                             println!("Agent: {}", clean_text);
@@ -856,6 +877,10 @@ impl Agent {
                         self.current_plan = steps;
                         self.plan_explanation = explanation;
                         plan_updated = true;
+                        report(AgentEvent::PlanUpdated {
+                            steps: self.current_plan.clone(),
+                            explanation: self.plan_explanation.clone(),
+                        });
                     }
                     sanitized_content.push(ContentBlock::ToolUse {
                         id: id.clone(),
@@ -1399,6 +1424,13 @@ impl Agent {
                     continue;
                 }
                 self.pending_plan_exit_tool_id = Some(tool_id);
+                report(AgentEvent::ApprovalRequested {
+                    approval_id: self
+                        .pending_plan_exit_tool_id
+                        .clone()
+                        .expect("plan approval id was just assigned"),
+                    kind: "plan".to_string(),
+                });
                 report(AgentEvent::Status(
                     "Plan ready for approval. Waiting for a structured user decision.".to_string(),
                 ));
@@ -1451,6 +1483,10 @@ impl Agent {
                     self.pending_approval = Some(PendingApproval {
                         tool_use_id: tool_id.clone(),
                         request: request.to_owned(),
+                    });
+                    report(AgentEvent::ApprovalRequested {
+                        approval_id: tool_id.clone(),
+                        kind: "shell".to_string(),
                     });
                     report(AgentEvent::Status(
                         "Bash approval required. Waiting for a structured user decision."
@@ -1683,7 +1719,9 @@ Rules:
     }
 
     fn tool_call_context(&self) -> ToolCallContext {
-        let context = ToolCallContext::default().with_session_id(self.session_id.clone());
+        let context = ToolCallContext::default()
+            .with_session_id(self.session_id.clone())
+            .with_workspace_root(self.workspace.root.clone());
         match self.cancellation_token.as_ref() {
             Some(token) => context.with_cancellation(token.clone()),
             None => context,

--- a/src/agent/planning.rs
+++ b/src/agent/planning.rs
@@ -270,6 +270,10 @@ impl Agent {
         self.pending_approval = None;
         self.pending_user_input = None;
         self.completed_approval = None;
+        report(AgentEvent::ApprovalAnswered {
+            approval_id: pending.tool_use_id.clone(),
+            approved: !matches!(selection, BashApprovalDecision::Suggestion),
+        });
 
         match selection {
             BashApprovalDecision::Once => {
@@ -507,6 +511,13 @@ impl Agent {
         self.pending_approval = None;
         let pending_plan_exit_tool_id = self.pending_plan_exit_tool_id.take();
 
+        if let Some(approval_id) = pending_plan_exit_tool_id.as_ref() {
+            report(AgentEvent::ApprovalAnswered {
+                approval_id: approval_id.clone(),
+                approved: !continue_planning,
+            });
+        }
+
         if continue_planning {
             self.execution_mode = AgentExecutionMode::Plan;
             report(AgentEvent::Status(
@@ -550,6 +561,11 @@ impl Agent {
             );
             self.checkpoint_session()?;
         }
+
+        report(AgentEvent::PlanUpdated {
+            steps: self.current_plan.clone(),
+            explanation: self.plan_explanation.clone(),
+        });
 
         self.run_agent_loop(output_mode, &mut report).await
     }

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -262,20 +262,7 @@ fn apply_cli_overrides(config: &mut RaraConfig, cli: Cli) -> Option<Commands> {
 }
 
 async fn run_acp_command(config: &RaraConfig) -> Result<()> {
-    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
-    emit_bootstrap_warnings(&bootstrap.warnings);
-    let acp_agent = RaraAcpAgent::new(
-        bootstrap.backend.clone(),
-        Arc::new(bootstrap.tool_manager),
-        bootstrap.event_bus.clone(),
-        bootstrap.mcp_manager.clone(),
-        bootstrap.prompt_source_registry.clone(),
-        bootstrap.skill_source_registry.clone(),
-        bootstrap.hook_registry.clone(),
-        Arc::new(crate::protocol_sources::MemoryControlHandler::new(
-            bootstrap.event_bus.clone(),
-        )),
-    );
+    let acp_agent = RaraAcpAgent::new(config.clone());
     acp_agent
         .run_acp_stdio()
         .await
@@ -387,6 +374,7 @@ async fn run_tui_command(
     let bootstrap = if initialize_local_embeddings {
         runtime_context::initialize_rara_context_with_local_embedding_bootstrap(
             config,
+            None,
             None,
             runtime_context::LocalEmbeddingBootstrap::InspectOnly,
         )

--- a/src/control_plane.rs
+++ b/src/control_plane.rs
@@ -13,7 +13,9 @@ use crate::agent::Agent;
 use crate::hook_registry::HookRegistry;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::protocol_sources::{MemoryControlHandler, PromptSourceRegistry, SkillSourceRegistry};
-use crate::runtime_control::{RuntimeControlEnvelope, RuntimeControlEvent, RuntimeControlRequest};
+use crate::runtime_control::{
+    RuntimeControlEnvelope, RuntimeControlEvent, RuntimeControlRequest, RuntimeEvent, SessionEvent,
+};
 
 /// Dispatch a structured control-plane request and stream resulting events
 /// to the provided callback.
@@ -66,10 +68,30 @@ where
         }
         RuntimeControlRequest::Session(session_request) => {
             if let Some(agent) = agent {
-                agent
+                let result = agent
                     .handle_session_control(session_request)
                     .await
-                    .map_err(|err| err.to_string())
+                    .map_err(|err| err.to_string());
+                if result.is_ok() {
+                    let event = match session_request {
+                        crate::runtime_control::SessionControlRequest::CancelCurrentTurn => {
+                            Some(SessionEvent::TurnCancelled)
+                        }
+                        crate::runtime_control::SessionControlRequest::InterruptCurrentTurn => {
+                            Some(SessionEvent::TurnInterrupted)
+                        }
+                        _ => None,
+                    };
+                    if let Some(event) = event {
+                        on_event(RuntimeControlEvent {
+                            event_id: uuid::Uuid::new_v4().to_string(),
+                            provenance: envelope.provenance.clone(),
+                            sequence: 0,
+                            event: RuntimeEvent::Session(event),
+                        });
+                    }
+                }
+                result
             } else {
                 Err("no active session available for session control".to_string())
             }
@@ -93,10 +115,21 @@ where
                     on_event(control_event);
                 };
 
-                agent
+                report(crate::agent::AgentEvent::AgentStart);
+                let result = agent
                     .handle_input_control(input_request, &mut report)
                     .await
-                    .map_err(|err| err.to_string())
+                    .map_err(|err| err.to_string());
+                match &result {
+                    Ok(()) => report(crate::agent::AgentEvent::AgentStop {
+                        reason: "turn complete".to_string(),
+                    }),
+                    Err(err) => report(crate::agent::AgentEvent::AgentError {
+                        message: err.clone(),
+                        recoverable: false,
+                    }),
+                }
+                result
             } else {
                 Err("no active session available for input control".to_string())
             }

--- a/src/exec_consumer.rs
+++ b/src/exec_consumer.rs
@@ -297,6 +297,9 @@ impl ExecJsonlProcessor {
         match event {
             AgentEvent::AgentStart => Ok(()),
             AgentEvent::AgentStop { .. } => Ok(()),
+            AgentEvent::PlanUpdated { .. }
+            | AgentEvent::ApprovalRequested { .. }
+            | AgentEvent::ApprovalAnswered { .. } => Ok(()),
             AgentEvent::AssistantText(text) => {
                 self.final_message
                     .get_or_insert_with(String::new)

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -162,6 +162,9 @@ fn lifecycle_for_event(event: &AgentEvent) -> Option<HookLifecycle> {
         | AgentEvent::McpStatusUpdated(_)
         | AgentEvent::McpStatusLoadFailed { .. }
         | AgentEvent::TodoUpdated(_)
+        | AgentEvent::PlanUpdated { .. }
+        | AgentEvent::ApprovalRequested { .. }
+        | AgentEvent::ApprovalAnswered { .. }
         | AgentEvent::AgentError { .. } => None,
     }
 }

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -1,5 +1,6 @@
 mod tooling;
 
+use std::path::Path;
 use std::sync::{Arc, atomic::AtomicBool};
 
 use anyhow::{Context, Result, bail};
@@ -124,8 +125,18 @@ pub(crate) async fn initialize_rara_context(
     config: &RaraConfig,
     progress: Option<LocalProgressReporter>,
 ) -> Result<RuntimeBootstrap> {
+    initialize_rara_context_for_workspace(config, None, progress).await
+}
+
+/// Build a runtime for an explicit workspace without mutating the process cwd.
+pub(crate) async fn initialize_rara_context_for_workspace(
+    config: &RaraConfig,
+    workspace_root: Option<&Path>,
+    progress: Option<LocalProgressReporter>,
+) -> Result<RuntimeBootstrap> {
     initialize_rara_context_with_local_embedding_bootstrap(
         config,
+        workspace_root,
         progress,
         LocalEmbeddingBootstrap::Prepare,
     )
@@ -140,6 +151,7 @@ pub(crate) enum LocalEmbeddingBootstrap {
 
 pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     config: &RaraConfig,
+    workspace_root: Option<&Path>,
     progress: Option<LocalProgressReporter>,
     local_embedding_bootstrap: LocalEmbeddingBootstrap,
 ) -> Result<RuntimeBootstrap> {
@@ -156,9 +168,17 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     )
     .await?;
 
-    let workspace = Arc::new(WorkspaceMemory::new()?);
+    let workspace = match workspace_root {
+        Some(root) => Arc::new(WorkspaceMemory::from_paths(
+            root.to_path_buf(),
+            rara_config::workspace_data_dir_for(root)?,
+        )),
+        None => Arc::new(WorkspaceMemory::new()?),
+    };
     let vdb = Arc::new(VectorDB::new(&vector_db_uri_for_workspace(&workspace)));
-    let session_manager = Arc::new(SessionManager::new()?);
+    let session_manager = Arc::new(SessionManager::new_for_rara_dir(
+        workspace.rara_dir.clone(),
+    )?);
     let shell_env = capture_shell_environment_snapshot().await;
     let sandbox_manager = Arc::new(SandboxManager::new_with_command_path(
         shell_env.env.get("PATH").cloned(),
@@ -213,9 +233,7 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
 
     // Discover file-based hooks and inject into prompt config
     let mut file_hooks = crate::hooks::HookRegistry::new();
-    if let Ok(cwd) = std::env::current_dir() {
-        file_hooks.discover_repo_hooks(&cwd);
-    }
+    file_hooks.discover_repo_hooks(&workspace.root);
     prompt_config.hook_prompt_entries = file_hooks
         .hooks
         .values()

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -11,7 +11,7 @@ use rara_tools::tool::ToolOutputStream;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::agent::{AgentEvent, BashApprovalDecision};
+use crate::agent::{AgentEvent, BashApprovalDecision, PlanStep, PlanStepStatus};
 use crate::context::{ContextObservabilityView, RetrievalOrchestrationView};
 use crate::mcp_status::{McpConnectionState, McpStatusSnapshot};
 use crate::session_promotion::SessionShardPromotionOutcome;
@@ -188,9 +188,41 @@ pub enum ApprovalEvent {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum PlanEvent {
-    Updated,
+    Updated {
+        steps: Vec<PlanStepEvent>,
+        explanation: Option<String>,
+    },
     Approved,
     Continued,
+}
+
+#[allow(dead_code)] // ACP protocol type — reserved for future lifecycle events
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlanStepEvent {
+    pub step: String,
+    pub status: PlanStepStatusEvent,
+}
+
+#[allow(dead_code)] // ACP protocol type — reserved for future lifecycle events
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanStepStatusEvent {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+impl From<PlanStep> for PlanStepEvent {
+    fn from(step: PlanStep) -> Self {
+        Self {
+            step: step.step,
+            status: match step.status {
+                PlanStepStatus::Pending => PlanStepStatusEvent::Pending,
+                PlanStepStatus::InProgress => PlanStepStatusEvent::InProgress,
+                PlanStepStatus::Completed => PlanStepStatusEvent::Completed,
+            },
+        }
+    }
 }
 
 #[allow(dead_code)] // ACP protocol type — reserved for future lifecycle events
@@ -380,6 +412,20 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
             RuntimeEvent::Mcp(McpEvent::StatusLoadFailed { message })
         }
         AgentEvent::TodoUpdated(state) => RuntimeEvent::Todo(TodoEvent::Updated { state }),
+        AgentEvent::PlanUpdated { steps, explanation } => RuntimeEvent::Plan(PlanEvent::Updated {
+            steps: steps.into_iter().map(PlanStepEvent::from).collect(),
+            explanation,
+        }),
+        AgentEvent::ApprovalRequested { approval_id, kind } => {
+            RuntimeEvent::Approval(ApprovalEvent::Requested { approval_id, kind })
+        }
+        AgentEvent::ApprovalAnswered {
+            approval_id,
+            approved,
+        } => RuntimeEvent::Approval(ApprovalEvent::Answered {
+            approval_id,
+            approved,
+        }),
         AgentEvent::AgentStart => RuntimeEvent::Session(SessionEvent::TurnStarted),
         AgentEvent::AgentStop { reason } => RuntimeEvent::Session(SessionEvent::TurnFinished {
             reason: Some(reason),
@@ -447,6 +493,35 @@ mod tests {
                 chunk: "error\n".to_string(),
             })
         );
+    }
+
+    #[test]
+    fn agent_plan_and_approval_events_preserve_structured_fields() {
+        let plan = agent_event_to_runtime_event(AgentEvent::PlanUpdated {
+            steps: vec![PlanStep {
+                step: "inspect ACP adapter".to_string(),
+                status: PlanStepStatus::InProgress,
+            }],
+            explanation: Some("verify event mapping".to_string()),
+        });
+        assert!(matches!(
+            plan,
+            RuntimeEvent::Plan(PlanEvent::Updated { steps, explanation })
+                if steps == vec![PlanStepEvent {
+                    step: "inspect ACP adapter".to_string(),
+                    status: PlanStepStatusEvent::InProgress,
+                }]
+                && explanation.as_deref() == Some("verify event mapping")
+        ));
+
+        assert!(matches!(
+            agent_event_to_runtime_event(AgentEvent::ApprovalRequested {
+                approval_id: "tool-1".to_string(),
+                kind: "shell".to_string(),
+            }),
+            RuntimeEvent::Approval(ApprovalEvent::Requested { approval_id, kind })
+                if approval_id == "tool-1" && kind == "shell"
+        ));
     }
 
     #[test]

--- a/src/runtime_event_bus.rs
+++ b/src/runtime_event_bus.rs
@@ -102,6 +102,16 @@ impl RuntimeEventBus {
         };
         self.control_sender.send(control_event).unwrap_or(0)
     }
+
+    /// Publish an adapter-produced event without changing its provenance or
+    /// sequence. Protocol adapters use this after `control_plane::dispatch`
+    /// has already wrapped an agent event for the originating session.
+    pub fn publish_control_event(&self, event: RuntimeControlEvent) -> usize {
+        if self.control_sender.receiver_count() == 0 {
+            return 0;
+        }
+        self.control_sender.send(event).unwrap_or(0)
+    }
 }
 
 #[cfg(test)]
@@ -206,5 +216,28 @@ mod tests {
         let event = control.try_recv().expect("control event");
         assert_eq!(event.sequence, 1);
         assert_eq!(event.event_id, "evt-0000000000000001");
+    }
+
+    #[test]
+    fn adapter_events_keep_their_acp_provenance() {
+        let bus = RuntimeEventBus::new(8);
+        let mut control = bus.subscribe_control();
+        let event = RuntimeControlEvent {
+            event_id: "acp-1".to_string(),
+            provenance: RuntimeProvenance::protocol(
+                crate::runtime_control::RuntimeControllerKind::Acp,
+                "acp",
+                Some("session-1".to_string()),
+                None,
+            ),
+            sequence: 7,
+            event: RuntimeEvent::Session(crate::runtime_control::SessionEvent::TurnCancelled),
+        };
+
+        assert_eq!(bus.publish_control_event(event), 1);
+        let received = control.try_recv().expect("control event");
+        assert_eq!(received.event_id, "acp-1");
+        assert_eq!(received.sequence, 7);
+        assert_eq!(received.provenance.session_id.as_deref(), Some("session-1"));
     }
 }

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -518,7 +518,20 @@ impl Tool for BashTool {
         report: &mut (dyn FnMut(ToolProgressEvent) + Send),
     ) -> Result<Value, ToolError> {
         let request = BashCommandInput::from_value(i)?;
-        let cwd = request.working_dir()?;
+        let cwd = request
+            .cwd
+            .as_deref()
+            .filter(|cwd| !cwd.trim().is_empty())
+            .map_or_else(
+                || {
+                    context
+                        .workspace_root()
+                        .map(|cwd| cwd.display().to_string())
+                        .map(Ok)
+                        .unwrap_or_else(|| request.working_dir())
+                },
+                |cwd| Ok(cwd.to_string()),
+            )?;
         let allow_net = self.sandbox_network_access.load(Ordering::Relaxed) || request.allow_net;
         let wrapped = if let Some(command) = request.command.as_deref() {
             if request.sandbox_permissions == BashSandboxPermissions::RequireEscalated {
@@ -597,11 +610,7 @@ impl Tool for BashTool {
                     .filter(|v| !v.trim().is_empty())
                     .map(String::from),
                 args: request.args.clone(),
-                cwd: request
-                    .cwd
-                    .as_ref()
-                    .filter(|d| !d.trim().is_empty())
-                    .cloned(),
+                cwd: Some(cwd.clone()),
                 sandboxed: wrapped.sandboxed,
                 sandbox_backend: wrapped.sandbox_backend.clone(),
                 network_access: wrapped.network_access,

--- a/src/tools/pty.rs
+++ b/src/tools/pty.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use portable_pty::{Child, CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use rara_tool_macros::tool_spec;
-use rara_tools::tool::{Tool, ToolError};
+use rara_tools::tool::{Tool, ToolCallContext, ToolError, ToolProgressEvent};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
@@ -602,8 +602,30 @@ impl PtyCommandInput {
 #[async_trait]
 impl Tool for PtyStartTool {
     async fn call(&self, input: Value) -> Result<Value, ToolError> {
+        self.call_with_context_events(input, ToolCallContext::default(), &mut |_| {})
+            .await
+    }
+
+    async fn call_with_context_events(
+        &self,
+        input: Value,
+        context: ToolCallContext,
+        _report: &mut (dyn FnMut(ToolProgressEvent) + Send),
+    ) -> Result<Value, ToolError> {
         let request = PtyCommandInput::from_value(input)?;
-        let cwd = request.working_dir();
+        let cwd = request
+            .cwd
+            .as_deref()
+            .filter(|cwd| !cwd.trim().is_empty())
+            .map_or_else(
+                || {
+                    context
+                        .workspace_root()
+                        .map(|cwd| cwd.display().to_string())
+                        .unwrap_or_else(|| request.working_dir())
+                },
+                str::to_string,
+            );
         let allow_net = self.sandbox_network_access.load(Ordering::Relaxed) || request.allow_net;
         let (command, wrapped) =
             if let Some(cmd) = request.command.as_deref().filter(|v| !v.trim().is_empty()) {

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -348,6 +348,9 @@ pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
             role: "Todo",
             message: format_todo_update(&state),
         }),
+        AgentEvent::PlanUpdated { .. }
+        | AgentEvent::ApprovalRequested { .. }
+        | AgentEvent::ApprovalAnswered { .. } => None,
         AgentEvent::McpStatusUpdated(_) => None,
         AgentEvent::McpStatusLoadFailed { .. } => None,
         AgentEvent::AgentStart => None,


### PR DESCRIPTION
## Summary

- replace the singleton ACP agent with a session-scoped runtime registry
- bind each ACP session to its requested workspace without mutating process cwd
- route session-targeted cancellation and preserve ACP provenance on control-plane events
- translate text, thinking, tool lifecycle/streams, and plans to native ACP v1 updates
- retain approval, todo, warning/error, cancellation, and completion as structured control-plane events where ACP v1 has no native update type

## Motivation

The previous ACP adapter reused one active agent and ignored `session/new` workspace isolation. That allowed sessions to share state and made cancellation provenance ambiguous. This change establishes safe multi-workspace behavior in one ACP process.

## Compatibility

ACP v1 does not define native `SessionUpdate` variants for approval, todo, warning/error, cancellation, or completion. Clients that require those families should consume RARA's structured control-plane stream; the adapter preserves the originating ACP session ID there.

## Related issue

None.

## Validation

- `cargo fmt --all --check`
- `cargo check -q`
- focused workspace, multi-session, cancellation/provenance, plan translation, and control-event regression tests
