### PR TITLE
chore: bump Codex and RARA versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,8 +1996,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2015,8 +2015,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2046,8 +2046,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -2055,8 +2055,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2068,13 +2068,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 
 [[package]]
 name = "codex-config"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2118,8 +2118,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "clap",
@@ -2134,8 +2134,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -2145,8 +2145,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2158,8 +2158,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2171,8 +2171,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2196,8 +2196,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -2222,8 +2222,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "keyring",
  "tracing",
@@ -2231,8 +2231,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2264,8 +2264,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -2276,8 +2276,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -2295,8 +2295,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2330,8 +2330,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2361,8 +2361,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2400,8 +2400,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "age",
  "anyhow",
@@ -2419,16 +2419,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "dirs",
  "dunce",
@@ -2439,8 +2439,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "lru 0.16.4",
  "sha1",
@@ -2449,8 +2449,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2458,8 +2458,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2471,8 +2471,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2480,8 +2480,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2490,8 +2490,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -2505,16 +2505,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "rustls 0.23.41",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "regex-lite",
  "serde",
@@ -2523,13 +2523,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.144.3"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.3#78ad6e6bfd1d3b6a209acd3ef82172a96b25179c"
+version = "0.144.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.4#8c68d4c87dc54d38861f5114e920c3de2efa5876"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -2558,7 +2558,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6774,7 +6774,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -10288,7 +10288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -10307,7 +10307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -10478,7 +10478,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10516,7 +10516,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -11012,7 +11012,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rara"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -11097,7 +11097,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -11106,7 +11106,7 @@ dependencies = [
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "async-trait",
  "libc",
@@ -11121,7 +11121,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -11132,7 +11132,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -11145,7 +11145,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -11153,7 +11153,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "ignore",
@@ -11164,7 +11164,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11174,7 +11174,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -11184,7 +11184,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -11202,14 +11202,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "fs2",
@@ -11224,7 +11224,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "serde",
  "serde_json",
@@ -11234,7 +11234,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11247,7 +11247,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11258,7 +11258,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "serde",
@@ -11267,7 +11267,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11280,11 +11280,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.12"
+version = "0.0.13"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11293,7 +11293,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -14881,7 +14881,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 license = "Apache-2.0"
 
@@ -40,10 +40,10 @@ tempfile = "3.17"
 ignore = "0.4.26"
 nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
 rmcp = { version = "2.0", features = ["client", "transport-child-process"] }
-codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.144.3" }
-codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.3" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.144.3" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.144.3" }
+codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.144.4" }
 rara-instructions = { path = "crates/instructions" }
 
 [package]

--- a/docs/journal/2026-07-15-codex-144-4-dependency-bump.md
+++ b/docs/journal/2026-07-15-codex-144-4-dependency-bump.md
@@ -1,0 +1,25 @@
+# Codex 0.144.4 Dependency Bump
+
+## Summary
+
+RARA now pins its direct Codex git dependencies to the latest stable Rust
+release tag, `rust-v0.144.4`. The available `0.145.0` tags remain pre-release
+alphas and are intentionally excluded.
+
+The updated crates are:
+
+- `codex-execpolicy`
+- `codex-http-client`
+- `codex-login`
+- `codex-models-manager`
+
+## Scope
+
+This is a patch-level update from `0.144.3`. The dependency lockfile records
+the complete resolved Codex graph at the selected release tag.
+
+## Validation
+
+- `cargo metadata --locked --no-deps --format-version 1`
+- `cargo fmt --check`
+- `cargo check`

--- a/docs/journal/2026-07-15-rara-0-0-13-version-bump.md
+++ b/docs/journal/2026-07-15-rara-0-0-13-version-bump.md
@@ -1,0 +1,19 @@
+# RARA 0.0.13 Version Bump
+
+## Summary
+
+RARA's workspace package version is now `0.0.13`, the next patch release after
+`0.0.12`.
+
+## Scope
+
+The Cargo workspace manifest and lockfile carry the release version. This
+change prepares the package version for a later release tag; it does not create
+or push a tag.
+
+## Validation
+
+- `cargo metadata --locked --no-deps --format-version 1`
+- package version check for `rara` at `0.0.13`
+- `cargo fmt --check`
+- `cargo check`


### PR DESCRIPTION
## Summary

- Update the direct Codex git dependencies from `rust-v0.144.3` to the latest stable `rust-v0.144.4` release.
- Refresh the locked Codex dependency graph at commit `8c68d4c87dc54d38861f5114e920c3de2efa5876`.
- Bump the RARA workspace package version from `0.0.12` to `0.0.13`.
- Record both maintenance checkpoints in the engineering journal.

## Why

The previous Codex pin is one stable patch release behind. Updating it keeps RARA's direct authentication, HTTP, model-management, and exec-policy integrations aligned with the current stable Codex Rust release while avoiding the available `0.145.0` alpha tags.

## Impact

All workspace packages now report version `0.0.13`. This PR prepares the version bump only; it does not create or push a release tag.

## Related issue

None.

## Testing

- `cargo check`
- `cargo test -p rara`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo metadata --locked --no-deps --format-version 1`
- package version check: `rara 0.0.13`
- `git diff --check`
