### PR TITLE
chore(memory): default local embeddings off

### DIFF
--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -1209,7 +1209,7 @@ mod tests {
     }
 
     #[test]
-    fn local_embeddings_can_be_enabled_by_environment() {
+    fn local_embeddings_can_be_enabled_and_disabled_by_environment() {
         let mut config = RaraConfig::default();
 
         config.apply_provider_environment_defaults_from(|key| match key {
@@ -1218,6 +1218,13 @@ mod tests {
         });
 
         assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
+
+        config.apply_provider_environment_defaults_from(|key| match key {
+            "RARA_LOCAL_EMBEDDINGS" => Some("off".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
     }
 
     #[test]

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -91,8 +91,8 @@ impl ContextFileSearchPolicy {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum LocalEmbeddingPolicy {
-    Off,
     #[default]
+    Off,
     Auto,
 }
 
@@ -1186,38 +1186,38 @@ mod tests {
     }
 
     #[test]
-    fn local_embeddings_default_auto_and_omitted() {
+    fn local_embeddings_default_off_and_omitted() {
         let config = RaraConfig::default();
 
-        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
 
         let json = serde_json::to_string(&config).expect("serialize config");
         assert!(!json.contains("local_embeddings"));
     }
 
     #[test]
-    fn local_embeddings_can_disable_sidecar_policy() {
+    fn local_embeddings_can_enable_sidecar_policy() {
         let config: RaraConfig = serde_json::from_str(
             r#"{
                 "provider": "deepseek",
-                "local_embeddings": "off"
+                "local_embeddings": "auto"
             }"#,
         )
         .expect("deserialize config");
 
-        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
     }
 
     #[test]
-    fn local_embeddings_can_be_disabled_by_environment_for_benchmarks() {
+    fn local_embeddings_can_be_enabled_by_environment() {
         let mut config = RaraConfig::default();
 
         config.apply_provider_environment_defaults_from(|key| match key {
-            "RARA_LOCAL_EMBEDDINGS" => Some("off".to_string()),
+            "RARA_LOCAL_EMBEDDINGS" => Some("on".to_string()),
             _ => None,
         });
 
-        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
     }
 
     #[test]

--- a/docs/features/embedding-provider-decoupling.md
+++ b/docs/features/embedding-provider-decoupling.md
@@ -21,8 +21,8 @@ to plug in the local embedding sidecar introduced by
   vector tools through that standalone backend.
 - Allow runtime bootstrap to choose between provider-native embeddings and the
   local model-server sidecar independently of the chat backend.
-- Define the durable routing policy as sidecar-first unless a provider has an
-  explicit native-embedding capability entry.
+- Keep the bundled local model-server sidecar as an explicit opt-in enhancement
+  instead of starting it during ordinary runtime bootstrap by default.
 - Preserve the existing `LlmBackend::embed` implementations as a compatibility
   shim for provider wrappers and tests in this slice.
 
@@ -131,13 +131,19 @@ vector indexing/search is a separate dependency.
   `EmbeddingInputKind::Document`.
 - Runtime bootstrap must build one embedding backend per process runtime and
   pass it through to the main agent and sub-agents.
+- `local_embeddings` defaults to `off`, so ordinary startup must not prepare,
+  download, or start the bundled local embedding sidecar.
+- `local_embeddings = "auto"` and `RARA_LOCAL_EMBEDDINGS=auto|on|true|1|yes`
+  explicitly opt in to the provider-aware local sidecar routing matrix.
 - Provider-native embeddings must be enabled only through an explicit capability
   entry or equivalent allowlist, not by assuming that all providers in one chat
   family expose usable embedding models.
 - Providers with known missing native embeddings, including `deepseek` and
-  `kimi`, must route to the local sidecar.
-- Unknown providers must default to the local sidecar until RARA validates and
-  records a native embedding capability for that provider surface.
+  `kimi`, must route to the local sidecar when local embeddings are explicitly
+  enabled.
+- Unknown providers must default to the local sidecar only when local embeddings
+  are explicitly enabled and until RARA validates and records a native embedding
+  capability for that provider surface.
 - The local sidecar client must not rely on ambient proxy configuration for
   loopback embedding calls.
 - `MemoryStore` may keep a chat-backend reference for distillation, but its
@@ -159,10 +165,14 @@ vector indexing/search is a separate dependency.
 
 - Provider-native embeddings are still exposed through the legacy
   `LlmBackend::embed` compatibility path in this slice.
-- The local sidecar path is now the default recovery route for providers that
-  cannot produce useful embeddings themselves.
-- The intended steady-state policy is `sidecar-first` with a small explicit
-  native-embedding allowlist. Broad provider-family inference is transitional.
+- The local sidecar path is available as an explicit opt-in recovery route for
+  providers that cannot produce useful embeddings themselves.
+- Local memory remains in scope. Disabling bundled sidecar startup by default
+  does not remove memory storage, retrieval orchestration, LanceDB integration,
+  or the standalone `EmbeddingBackend` boundary.
+- The intended steady-state policy is conservative startup with explicit
+  embedding enablement and a small native-embedding allowlist. Broad
+  provider-family inference is transitional.
 - Retrieval paths that depend on a query vector still degrade to "no vector
   candidates" when the configured embedding backend is unavailable; broader
   keyword-only fallback remains follow-up work.

--- a/docs/journal/2026-07-06-local-embedding-opt-in.md
+++ b/docs/journal/2026-07-06-local-embedding-opt-in.md
@@ -2,11 +2,16 @@
 
 ## Summary
 
-Local embedding sidecar startup remains enabled by default through the existing
-provider-aware `auto` policy. Terminal-Bench runs disable local embeddings
-through the Harbor adapter environment so benchmark startup does not create a
-Python environment, download embedding models, or start the model server before
-the task begins.
+This checkpoint introduced the initial local embedding sidecar policy before
+the later default-off change. At the time, local embedding sidecar startup
+remained enabled by default through the provider-aware `auto` policy, while
+Terminal-Bench runs disabled local embeddings through the Harbor adapter
+environment so benchmark startup did not create a Python environment, download
+embedding models, or start the model server before the task began.
+
+See `docs/journal/2026-07-19-local-embedding-default-off.md` for the follow-up
+that made bundled local embedding startup default-off while preserving explicit
+opt-in.
 
 ## Scope
 

--- a/docs/journal/2026-07-19-local-embedding-default-off.md
+++ b/docs/journal/2026-07-19-local-embedding-default-off.md
@@ -1,0 +1,45 @@
+# Local Embedding Default Off
+
+## Summary
+
+Bundled local embedding sidecar startup now defaults to off. RARA still keeps
+local memory, retrieval orchestration, LanceDB-backed vector storage, and the
+standalone `EmbeddingBackend` boundary, but ordinary startup no longer prepares
+or starts the local model-server sidecar unless the user explicitly opts in.
+
+## Background
+
+The previous `auto` default made providers without native embeddings route to
+the bundled sidecar during startup. That improved retrieval quality for those
+providers, but it also meant ordinary RARA startup could create a Python
+environment, download embedding models, or start a sidecar before the user had
+asked for that local embedding runtime.
+
+The desired boundary is conservative startup without removing local memory.
+External memory providers can integrate with RARA, but they are not replacements
+for RARA's local memory path.
+
+## Scope
+
+- Made `LocalEmbeddingPolicy::Off` the default config value.
+- Preserved `LocalEmbeddingPolicy::Auto` as an explicit opt-in policy.
+- Preserved the existing `RARA_LOCAL_EMBEDDINGS=auto|on|true|1|yes` override as
+  an opt-in path.
+- Updated embedding route tests so default startup reuses the current backend
+  and explicit `auto` keeps the existing local sidecar route matrix.
+
+## Validation
+
+```bash
+cargo test -p rara-config local_embeddings -- --nocapture
+cargo test embedding_route_ -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo fmt --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Add explicit provider override controls if RARA needs user-facing selection
+  between provider-native embeddings and the local sidecar beyond `off` and
+  `auto`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -116,7 +116,9 @@ Active backlog only. Keep this file small and current.
 
 ## Configuration
 
-- [ ] Explicit embedding controls: enable/disable, provider override (low priority)
+- [x] Default bundled local embedding sidecar startup to off while preserving
+      explicit `local_embeddings = "auto"` opt-in.
+- [ ] Explicit embedding provider override beyond `off` / `auto` (low priority)
 
 ## ACP Compatibility
 

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -713,16 +713,16 @@ mod tests {
     }
 
     #[test]
-    fn embedding_route_prefers_local_sidecar_by_default() {
+    fn embedding_route_keeps_local_sidecar_off_by_default() {
         let deepseek = RaraConfig {
             provider: "deepseek".to_string(),
             ..Default::default()
         };
         assert_eq!(
             embedding_route_for_config(&deepseek),
-            EmbeddingRoute::LocalModelServer
+            EmbeddingRoute::CurrentLlmBackend
         );
-        assert!(config_requires_local_embedding_sidecar(&deepseek));
+        assert!(!config_requires_local_embedding_sidecar(&deepseek));
     }
 
     #[test]
@@ -743,6 +743,7 @@ mod tests {
     fn embedding_route_prefers_local_sidecar_when_auto_policy_is_enabled() {
         let deepseek = RaraConfig {
             provider: "deepseek".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Auto,
             ..Default::default()
         };
         assert_eq!(

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -776,6 +776,7 @@ mod tests {
     fn embedding_route_reuses_provider_embedding_for_supported_openai_like_surfaces() {
         let codex = RaraConfig {
             provider: "codex".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Auto,
             ..Default::default()
         };
         assert_eq!(
@@ -785,6 +786,7 @@ mod tests {
 
         let openai_compatible = RaraConfig {
             provider: "openai-compatible".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Auto,
             ..Default::default()
         };
         assert_eq!(
@@ -794,6 +796,7 @@ mod tests {
 
         let mock = RaraConfig {
             provider: "mock".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Auto,
             ..Default::default()
         };
         assert_eq!(


### PR DESCRIPTION
## Summary

- Default `local_embeddings` to `off` so ordinary startup does not prepare or start the bundled local embedding sidecar.
- Keep `local_embeddings = "auto"` and `RARA_LOCAL_EMBEDDINGS=auto|on|true|1|yes` as explicit opt-in paths for the existing provider-aware sidecar route.
- Update the embedding provider spec, implementation journal, and active TODO list to clarify that local memory remains in scope.

## Purpose

Bundled local embeddings are useful, but they should not create a Python environment, download models, or start a sidecar during normal startup unless explicitly requested. This keeps startup conservative while preserving RARA's local memory and retrieval boundaries.

## Related Issues

None.

## Testing

```bash
cargo test -p rara-config local_embeddings -- --nocapture
cargo test embedding_route_ -- --nocapture
cargo check --locked --workspace --all-targets
cargo fmt --check
git diff --check
```
