### PR TITLE
feat(plugins): register user and project plugin sources

### DIFF
--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -266,19 +266,26 @@ Implemented in the first merged slice:
 - The discovery API can scan a single directory with source metadata or scan
   multiple ordered sources with name-based de-duplication. Later sources in the
   ordered list override earlier sources, so callers own their precedence policy.
-- Workspace plugin CLI and runtime hook registration currently use the project
-  source for `<workspace>/.rara/plugins`.
+- Workspace plugin CLI uses the project source for
+  `<workspace>/.rara/plugins`.
+- TUI runtime hook registration combines `~/.rara/plugins` as the user source
+  and `<workspace>/.rara/plugins` as the project source through the ordered
+  discovery API. Project plugins override user plugins with the same plugin
+  name.
+- The middleware API accepts explicit CLI plugin directories as the final source
+  tier, but the user-facing CLI flag for passing those directories remains a
+  follow-up.
 
 Next implementation slices:
 
-1. Extend runtime startup beyond the TUI rebuild path and combine user,
-   project, and explicit CLI plugin directories through the ordered discovery
-   API.
-2. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd` mapping,
+1. Extend plugin source composition beyond the TUI rebuild path to headless,
+   ACP, and Wire runtime startup.
+2. Add a user-facing CLI/config path for explicit plugin directories.
+3. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd` mapping,
    matcher evaluation, blocking hook results, and hook output observability.
-3. Add git-source install support on top of the existing local-directory
+4. Add git-source install support on top of the existing local-directory
    `rara plugin install/list/remove` commands.
-4. Feed plugin `.mcp.json`, commands, skills, and agents into the same
+5. Feed plugin `.mcp.json`, commands, skills, and agents into the same
    structured extension-source registries used by native RARA features.
 
 ## Open Risks

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -272,6 +272,8 @@ Implemented in the first merged slice:
   and `<workspace>/.rara/plugins` as the project source through the ordered
   discovery API. Project plugins override user plugins with the same plugin
   name.
+- User plugin home resolution happens on the blocking registration worker. If
+  user plugin home cannot be resolved, project plugin registration still runs.
 - The middleware API accepts explicit CLI plugin directories as the final source
   tier, but the user-facing CLI flag for passing those directories remains a
   follow-up.

--- a/docs/journal/2026-07-19-plugin-runtime-sources.md
+++ b/docs/journal/2026-07-19-plugin-runtime-sources.md
@@ -20,6 +20,8 @@ use that contract instead of rebuilding a one-directory scan path.
   - explicit plugin directories as the final CLI source tier for future callers.
 - Updated TUI runtime rebuild to call plugin hook registration with RARA home
   and the workspace root.
+- RARA home resolution runs on the blocking registration worker. If home
+  resolution fails, project and explicit plugin sources are still discovered.
 - Preserved the current behavior of not creating project-local `.rara` during
   plugin discovery. Missing plugin directories simply discover zero plugins.
 - Added focused middleware tests for source ordering and project-over-user

--- a/docs/journal/2026-07-19-plugin-runtime-sources.md
+++ b/docs/journal/2026-07-19-plugin-runtime-sources.md
@@ -1,0 +1,46 @@
+# Plugin Runtime Sources
+
+## Summary
+
+TUI runtime hook registration now discovers Claude plugins from both the user
+plugin directory and the project plugin directory through the ordered
+source-aware discovery API.
+
+## Background
+
+The previous plugin runtime path registered hooks from only the workspace
+plugin directory. After source-aware discovery landed, runtime startup needed to
+use that contract instead of rebuilding a one-directory scan path.
+
+## Scope
+
+- Added middleware source construction for:
+  - `~/.rara/plugins` as the user plugin source;
+  - `<workspace>/.rara/plugins` as the project plugin source;
+  - explicit plugin directories as the final CLI source tier for future callers.
+- Updated TUI runtime rebuild to call plugin hook registration with RARA home
+  and the workspace root.
+- Preserved the current behavior of not creating project-local `.rara` during
+  plugin discovery. Missing plugin directories simply discover zero plugins.
+- Added focused middleware tests for source ordering and project-over-user
+  de-duplication.
+
+## Key Decisions
+
+- Source precedence is `user -> project -> explicit CLI`, with later sources
+  overriding earlier sources by plugin name.
+- This slice only wires the TUI runtime rebuild path. Headless, ACP, and Wire
+  startup parity remains separate work.
+- This slice does not add matcher evaluation, blocking hook behavior,
+  `SessionEnd` dispatch, or plugin extension registry ingestion.
+
+## Validation
+
+```bash
+cargo test plugin_middleware -- --nocapture
+cargo test -p rara-plugins -- --nocapture
+cargo test plugin_ -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo fmt --check
+git diff --check
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -136,7 +136,9 @@ Active backlog only. Keep this file small and current.
 ## Long-term
 
 - [x] Claude plugin discovery source metadata and ordered de-duplication.
-- [ ] Claude plugin runtime startup across user, project, and explicit CLI plugin directories.
+- [x] Claude plugin TUI runtime startup across user and project plugin directories.
+- [ ] Claude plugin runtime startup parity for headless, ACP, and Wire surfaces.
+- [ ] Claude plugin explicit plugin directory CLI/config surface.
 - [ ] Claude plugin lifecycle parity: `SessionEnd`, matcher evaluation, blocking results, and output observability.
 - [ ] Claude plugin extension registries for `.mcp.json`, commands, skills, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -4,7 +4,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rara_plugins::{
-    HookEvent, HookInput, PluginSource, discover_plugins_from_source, execute_command_hook,
+    HookEvent, HookInput, PluginDiscoverySource, PluginSource, discover_plugins_from_sources,
+    execute_command_hook,
 };
 
 use crate::agent::AgentEvent;
@@ -33,14 +34,16 @@ fn hook_event_to_lifecycle(event: HookEvent) -> HookLifecycle {
 
 pub async fn register_plugin_hooks(
     runtime: &Arc<HookRuntime>,
-    project_plugins_dir: &Path,
+    rara_home: &Path,
+    workspace_root: &Path,
+    explicit_plugin_dirs: &[PathBuf],
     session_id: &str,
 ) -> usize {
     let runtime = runtime.clone();
-    let project_plugins_dir = project_plugins_dir.to_path_buf();
+    let sources = plugin_discovery_sources(rara_home, workspace_root, explicit_plugin_dirs);
     let session_id = session_id.to_string();
     match tokio::task::spawn_blocking(move || {
-        register_plugin_hooks_blocking(&runtime, &project_plugins_dir, &session_id)
+        register_plugin_hooks_blocking(&runtime, sources, &session_id)
     })
     .await
     {
@@ -52,15 +55,41 @@ pub async fn register_plugin_hooks(
     }
 }
 
+fn plugin_discovery_sources(
+    rara_home: &Path,
+    workspace_root: &Path,
+    explicit_plugin_dirs: &[PathBuf],
+) -> Vec<PluginDiscoverySource> {
+    let user_plugins_dir = rara_home.join("plugins");
+    let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+    let mut sources = vec![
+        PluginDiscoverySource {
+            plugins_dir: user_plugins_dir.clone(),
+            source: PluginSource::User(user_plugins_dir),
+        },
+        PluginDiscoverySource {
+            plugins_dir: project_plugins_dir.clone(),
+            source: PluginSource::Project(project_plugins_dir),
+        },
+    ];
+    sources.extend(
+        explicit_plugin_dirs
+            .iter()
+            .cloned()
+            .map(|plugins_dir| PluginDiscoverySource {
+                plugins_dir: plugins_dir.clone(),
+                source: PluginSource::Cli(plugins_dir),
+            }),
+    );
+    sources
+}
+
 fn register_plugin_hooks_blocking(
     runtime: &Arc<HookRuntime>,
-    project_plugins_dir: &Path,
+    sources: Vec<PluginDiscoverySource>,
     session_id: &str,
 ) -> usize {
-    let plugins = discover_plugins_from_source(
-        project_plugins_dir,
-        PluginSource::Project(project_plugins_dir.to_path_buf()),
-    );
+    let plugins = discover_plugins_from_sources(&sources);
     let mut registered = 0usize;
 
     for plugin in &plugins {
@@ -126,5 +155,97 @@ fn extract_tool_name(event: &AgentEvent) -> Option<String> {
         AgentEvent::ToolUse { name, .. } => Some(name.clone()),
         AgentEvent::ToolResult { name, .. } => Some(name.clone()),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::runtime_event_bus::RuntimeEventBus;
+
+    #[test]
+    fn plugin_discovery_sources_order_user_project_then_cli() {
+        let dir = tempdir().expect("tempdir");
+        let rara_home = dir.path().join("home").join(".rara");
+        let workspace_root = dir.path().join("workspace");
+        let explicit_plugins_dir = dir.path().join("explicit-plugins");
+
+        let sources = plugin_discovery_sources(
+            &rara_home,
+            &workspace_root,
+            std::slice::from_ref(&explicit_plugins_dir),
+        );
+
+        assert_eq!(sources.len(), 3);
+        assert_eq!(sources[0].source.label(), "user");
+        assert_eq!(sources[0].plugins_dir, rara_home.join("plugins"));
+        assert_eq!(sources[1].source.label(), "project");
+        assert_eq!(
+            sources[1].plugins_dir,
+            workspace_root.join(".rara").join("plugins")
+        );
+        assert_eq!(sources[2].source.label(), "cli");
+        assert_eq!(sources[2].plugins_dir, explicit_plugins_dir);
+    }
+
+    #[tokio::test]
+    async fn registers_user_and_project_plugins_with_project_precedence() {
+        let dir = tempdir().expect("tempdir");
+        let rara_home = dir.path().join("home").join(".rara");
+        let workspace_root = dir.path().join("workspace");
+        let user_plugins_dir = rara_home.join("plugins");
+        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+        write_test_plugin(&user_plugins_dir.join("shared"), "shared", "echo user");
+        write_test_plugin(
+            &project_plugins_dir.join("shared"),
+            "shared",
+            "echo project",
+        );
+        write_test_plugin(
+            &project_plugins_dir.join("project-only"),
+            "project-only",
+            "echo project-only",
+        );
+
+        let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
+        let registered =
+            register_plugin_hooks(&runtime, &rara_home, &workspace_root, &[], "session-1").await;
+
+        assert_eq!(registered, 2);
+        assert_eq!(runtime.hook_count(), 2);
+    }
+
+    fn write_test_plugin(root: &Path, name: &str, command: &str) {
+        fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");
+        fs::write(
+            root.join(".claude-plugin").join("plugin.json"),
+            json!({
+                "name": name,
+                "version": "1.0.0",
+                "description": "test plugin"
+            })
+            .to_string(),
+        )
+        .expect("plugin json");
+        fs::create_dir_all(root.join("hooks")).expect("hooks dir");
+        fs::write(
+            root.join("hooks").join("hooks.json"),
+            json!({
+                "Stop": [{
+                    "hooks": [{
+                        "type": "command",
+                        "command": command,
+                        "timeout": 1
+                    }]
+                }]
+            })
+            .to_string(),
+        )
+        .expect("hooks json");
     }
 }

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -34,15 +34,22 @@ fn hook_event_to_lifecycle(event: HookEvent) -> HookLifecycle {
 
 pub async fn register_plugin_hooks(
     runtime: &Arc<HookRuntime>,
-    rara_home: &Path,
+    rara_home: Option<PathBuf>,
     workspace_root: &Path,
     explicit_plugin_dirs: &[PathBuf],
     session_id: &str,
 ) -> usize {
     let runtime = runtime.clone();
-    let sources = plugin_discovery_sources(rara_home, workspace_root, explicit_plugin_dirs);
+    let workspace_root = workspace_root.to_path_buf();
+    let explicit_plugin_dirs = explicit_plugin_dirs.to_vec();
     let session_id = session_id.to_string();
     match tokio::task::spawn_blocking(move || {
+        let resolved_rara_home = rara_home.or_else(|| crate::config::ensure_rara_home_dir().ok());
+        let sources = plugin_discovery_sources(
+            resolved_rara_home.as_deref(),
+            &workspace_root,
+            &explicit_plugin_dirs,
+        );
         register_plugin_hooks_blocking(&runtime, sources, &session_id)
     })
     .await
@@ -56,22 +63,23 @@ pub async fn register_plugin_hooks(
 }
 
 fn plugin_discovery_sources(
-    rara_home: &Path,
+    rara_home: Option<&Path>,
     workspace_root: &Path,
     explicit_plugin_dirs: &[PathBuf],
 ) -> Vec<PluginDiscoverySource> {
-    let user_plugins_dir = rara_home.join("plugins");
     let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-    let mut sources = vec![
-        PluginDiscoverySource {
+    let mut sources = Vec::new();
+    if let Some(rara_home) = rara_home {
+        let user_plugins_dir = rara_home.join("plugins");
+        sources.push(PluginDiscoverySource {
             plugins_dir: user_plugins_dir.clone(),
             source: PluginSource::User(user_plugins_dir),
-        },
-        PluginDiscoverySource {
-            plugins_dir: project_plugins_dir.clone(),
-            source: PluginSource::Project(project_plugins_dir),
-        },
-    ];
+        });
+    }
+    sources.push(PluginDiscoverySource {
+        plugins_dir: project_plugins_dir.clone(),
+        source: PluginSource::Project(project_plugins_dir),
+    });
     sources.extend(
         explicit_plugin_dirs
             .iter()
@@ -176,7 +184,7 @@ mod tests {
         let explicit_plugins_dir = dir.path().join("explicit-plugins");
 
         let sources = plugin_discovery_sources(
-            &rara_home,
+            Some(&rara_home),
             &workspace_root,
             std::slice::from_ref(&explicit_plugins_dir),
         );
@@ -191,6 +199,28 @@ mod tests {
         );
         assert_eq!(sources[2].source.label(), "cli");
         assert_eq!(sources[2].plugins_dir, explicit_plugins_dir);
+    }
+
+    #[test]
+    fn plugin_discovery_sources_keep_project_when_user_home_is_unavailable() {
+        let dir = tempdir().expect("tempdir");
+        let workspace_root = dir.path().join("workspace");
+        let explicit_plugins_dir = dir.path().join("explicit-plugins");
+
+        let sources = plugin_discovery_sources(
+            None,
+            &workspace_root,
+            std::slice::from_ref(&explicit_plugins_dir),
+        );
+
+        assert_eq!(sources.len(), 2);
+        assert_eq!(sources[0].source.label(), "project");
+        assert_eq!(
+            sources[0].plugins_dir,
+            workspace_root.join(".rara").join("plugins")
+        );
+        assert_eq!(sources[1].source.label(), "cli");
+        assert_eq!(sources[1].plugins_dir, explicit_plugins_dir);
     }
 
     #[tokio::test]
@@ -214,7 +244,8 @@ mod tests {
 
         let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
         let registered =
-            register_plugin_hooks(&runtime, &rara_home, &workspace_root, &[], "session-1").await;
+            register_plugin_hooks(&runtime, Some(rara_home), &workspace_root, &[], "session-1")
+                .await;
 
         assert_eq!(registered, 2);
         assert_eq!(runtime.hook_count(), 2);

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -291,11 +291,10 @@ pub(crate) async fn finish_running_task_if_ready(
                 app.hook_runtime = Some(rebuilt.hook_runtime.clone());
                 if let (Ok(workspace_root), Some(hr)) =
                     (std::env::current_dir(), app.hook_runtime.as_ref())
-                    && let Ok(rara_home) = crate::config::ensure_rara_home_dir()
                 {
                     crate::plugin_middleware::register_plugin_hooks(
                         hr,
-                        &rara_home,
+                        None,
                         &workspace_root,
                         &[],
                         &agent.session_id,

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -291,16 +291,16 @@ pub(crate) async fn finish_running_task_if_ready(
                 app.hook_runtime = Some(rebuilt.hook_runtime.clone());
                 if let (Ok(workspace_root), Some(hr)) =
                     (std::env::current_dir(), app.hook_runtime.as_ref())
+                    && let Ok(rara_home) = crate::config::ensure_rara_home_dir()
                 {
-                    let plugins_dir = workspace_root.join(".rara").join("plugins");
-                    if plugins_dir.is_dir() {
-                        crate::plugin_middleware::register_plugin_hooks(
-                            hr,
-                            &plugins_dir,
-                            &agent.session_id,
-                        )
-                        .await;
-                    }
+                    crate::plugin_middleware::register_plugin_hooks(
+                        hr,
+                        &rara_home,
+                        &workspace_root,
+                        &[],
+                        &agent.session_id,
+                    )
+                    .await;
                 }
                 app.local_model_server = rebuilt.local_model_server;
                 app.config_manager.save(&app.config)?;


### PR DESCRIPTION
## Summary

- Register TUI runtime plugin hooks from both `~/.rara/plugins` and `<workspace>/.rara/plugins`.
- Use ordered source-aware discovery so project plugins override user plugins with the same plugin name.
- Keep explicit plugin directories as the final middleware source tier for future CLI/config callers.
- Update the Claude plugin runtime spec, journal, and TODO list with the completed TUI source-composition slice and remaining follow-ups.

## Purpose

This builds on source-aware plugin discovery by wiring it into runtime startup for the TUI rebuild path. It keeps the slice narrow: no new hook lifecycle semantics, matcher evaluation, blocking hook behavior, or extension registry ingestion are added here.

## Related Issues

None.

## Testing

```bash
cargo test plugin_middleware -- --nocapture
cargo test -p rara-plugins -- --nocapture
cargo test plugin_ -- --nocapture
cargo check --locked --workspace --all-targets
cargo fmt --check
git diff --check
```
