### PR TITLE
feat(plugins): add explicit plugin dirs for TUI

### DIFF
--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -277,7 +277,10 @@ Implemented in the first merged slice:
 - TUI and `resume` startup accept repeated `--plugin-dir <path>` global CLI
   flags and pass those directories into plugin hook registration as the final
   source tier. CLI plugin directories override project and user plugins with the
-  same plugin name.
+  same plugin name. Relative CLI plugin directories are normalized to absolute
+  paths during CLI startup. Supplying explicit plugin directories triggers the
+  TUI runtime rebuild path on startup so the hook runtime is created and plugin
+  hooks are registered even when local embedding startup is disabled.
 
 Next implementation slices:
 

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -71,7 +71,7 @@ RARA will scan:
 |---|---|---|
 | `~/.rara/plugins/<name>/` | User | per-user plugins |
 | `<workspace>/.rara/plugins/<name>/` | Project | per-project plugins |
-| `--plugin-dir <path>` | CLI | manual override |
+| `--plugin-dir <path>` | CLI | manual override for TUI sessions |
 
 A valid plugin directory contains:
 
@@ -274,15 +274,16 @@ Implemented in the first merged slice:
   name.
 - User plugin home resolution happens on the blocking registration worker. If
   user plugin home cannot be resolved, project plugin registration still runs.
-- The middleware API accepts explicit CLI plugin directories as the final source
-  tier, but the user-facing CLI flag for passing those directories remains a
-  follow-up.
+- TUI and `resume` startup accept repeated `--plugin-dir <path>` global CLI
+  flags and pass those directories into plugin hook registration as the final
+  source tier. CLI plugin directories override project and user plugins with the
+  same plugin name.
 
 Next implementation slices:
 
 1. Extend plugin source composition beyond the TUI rebuild path to headless,
    ACP, and Wire runtime startup.
-2. Add a user-facing CLI/config path for explicit plugin directories.
+2. Add config persistence for explicit plugin directories.
 3. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd` mapping,
    matcher evaluation, blocking hook results, and hook output observability.
 4. Add git-source install support on top of the existing local-directory

--- a/docs/journal/2026-07-19-plugin-explicit-dirs.md
+++ b/docs/journal/2026-07-19-plugin-explicit-dirs.md
@@ -16,9 +16,13 @@ directory testing dependent on code-level call sites.
 ## Scope
 
 - Added a global `--plugin-dir DIR` CLI flag.
-- Preserved the parsed directories through TUI and `resume` startup.
+- Normalized parsed directories to absolute paths during CLI startup.
+- Preserved the normalized directories through TUI and `resume` startup.
 - Stored explicit plugin directories on `TuiApp` so runtime rebuild hook
   registration can pass them into `register_plugin_hooks`.
+- Triggered the TUI runtime rebuild path when explicit plugin directories are
+  supplied so plugin hook registration runs even when local embedding startup is
+  disabled.
 - Kept headless, ACP, and Wire runtime startup out of scope because those
   surfaces still need plugin hook execution ownership work.
 
@@ -27,6 +31,7 @@ directory testing dependent on code-level call sites.
 ```bash
 cargo test app_cli::tests::clap_parses_explicit_plugin_dirs_as_global_args -- --nocapture
 cargo test app_cli::tests::clap_parses_explicit_plugin_dirs_after_tui_command -- --nocapture
+cargo test app_cli::tests::normalize_plugin_dirs_returns_absolute_paths -- --nocapture
 cargo test tui::state::tests::new_starts_without_explicit_plugin_dirs -- --nocapture
 cargo test plugin_middleware::tests::plugin_discovery_sources_order_user_project_then_cli -- --nocapture
 cargo check --locked --workspace --all-targets

--- a/docs/journal/2026-07-19-plugin-explicit-dirs.md
+++ b/docs/journal/2026-07-19-plugin-explicit-dirs.md
@@ -1,0 +1,41 @@
+# Plugin Explicit Directories
+
+## Summary
+
+RARA now accepts repeated `--plugin-dir <path>` global CLI flags for TUI and
+`resume` sessions. These directories are passed into the TUI runtime and used as
+the final Claude plugin discovery source tier during hook registration.
+
+## Background
+
+The previous plugin runtime source work added user and project plugin discovery
+plus a middleware parameter for explicit plugin directories, but there was no
+user-facing CLI path that filled that parameter. This left manual plugin
+directory testing dependent on code-level call sites.
+
+## Scope
+
+- Added a global `--plugin-dir DIR` CLI flag.
+- Preserved the parsed directories through TUI and `resume` startup.
+- Stored explicit plugin directories on `TuiApp` so runtime rebuild hook
+  registration can pass them into `register_plugin_hooks`.
+- Kept headless, ACP, and Wire runtime startup out of scope because those
+  surfaces still need plugin hook execution ownership work.
+
+## Validation
+
+```bash
+cargo test app_cli::tests::clap_parses_explicit_plugin_dirs_as_global_args -- --nocapture
+cargo test app_cli::tests::clap_parses_explicit_plugin_dirs_after_tui_command -- --nocapture
+cargo test tui::state::tests::new_starts_without_explicit_plugin_dirs -- --nocapture
+cargo test plugin_middleware::tests::plugin_discovery_sources_order_user_project_then_cli -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo fmt --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Add config persistence for explicit plugin directories.
+- Extend plugin runtime startup beyond TUI once headless, ACP, and Wire define
+  their hook runtime execution boundary.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -138,7 +138,8 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin discovery source metadata and ordered de-duplication.
 - [x] Claude plugin TUI runtime startup across user and project plugin directories.
 - [ ] Claude plugin runtime startup parity for headless, ACP, and Wire surfaces.
-- [ ] Claude plugin explicit plugin directory CLI/config surface.
+- [x] Claude plugin explicit plugin directory CLI surface for TUI sessions.
+- [ ] Claude plugin explicit plugin directory config persistence.
 - [ ] Claude plugin lifecycle parity: `SessionEnd`, matcher evaluation, blocking results, and output observability.
 - [ ] Claude plugin extension registries for `.mcp.json`, commands, skills, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -190,7 +190,7 @@ enum Commands {
 
 pub(crate) async fn run_cli() -> Result<()> {
     let cli = Cli::parse();
-    let plugin_dirs = cli.plugin_dirs.clone();
+    let plugin_dirs = normalize_plugin_dirs(&cli.plugin_dirs)?;
     let config_manager = ConfigManager::new()?;
     let mut config = config_manager.load()?;
     let command = apply_cli_overrides(&mut config, cli);
@@ -266,6 +266,21 @@ fn apply_cli_overrides(config: &mut RaraConfig, cli: Cli) -> Option<Commands> {
         config.set_revision(Some(revision));
     }
     cli.command
+}
+
+fn normalize_plugin_dirs(plugin_dirs: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    plugin_dirs
+        .iter()
+        .map(|path| normalize_plugin_dir(path))
+        .collect()
+}
+
+fn normalize_plugin_dir(path: &Path) -> Result<PathBuf> {
+    match path.canonicalize() {
+        Ok(path) => Ok(path),
+        Err(_) if path.is_absolute() => Ok(path.to_path_buf()),
+        Err(_) => Ok(std::env::current_dir()?.join(path)),
+    }
 }
 
 async fn run_acp_command(config: &RaraConfig) -> Result<()> {
@@ -745,6 +760,22 @@ mod tests {
 
         assert_eq!(cli.plugin_dirs, vec![PathBuf::from("plugins-a")]);
         assert!(matches!(cli.command, Some(Commands::Tui)));
+    }
+
+    #[test]
+    fn normalize_plugin_dirs_returns_absolute_paths() {
+        let cwd = std::env::current_dir().expect("cwd");
+        let normalized = normalize_plugin_dirs(&[
+            PathBuf::from("."),
+            PathBuf::from("missing-plugin-dir"),
+            cwd.join("missing-absolute-plugin-dir"),
+        ])
+        .expect("normalize plugin dirs");
+
+        assert_eq!(normalized[0], cwd.canonicalize().expect("canonical cwd"));
+        assert_eq!(normalized[1], cwd.join("missing-plugin-dir"));
+        assert_eq!(normalized[2], cwd.join("missing-absolute-plugin-dir"));
+        assert!(normalized.iter().all(|path| path.is_absolute()));
     }
 
     #[test]

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -42,6 +42,10 @@ pub(crate) struct Cli {
 
     #[arg(long, global = true)]
     revision: Option<String>,
+
+    /// Additional Claude plugin directory to scan during TUI startup.
+    #[arg(long = "plugin-dir", value_name = "DIR", global = true)]
+    plugin_dirs: Vec<PathBuf>,
 }
 
 /// Register a model provider.
@@ -186,6 +190,7 @@ enum Commands {
 
 pub(crate) async fn run_cli() -> Result<()> {
     let cli = Cli::parse();
+    let plugin_dirs = cli.plugin_dirs.clone();
     let config_manager = ConfigManager::new()?;
     let mut config = config_manager.load()?;
     let command = apply_cli_overrides(&mut config, cli);
@@ -210,6 +215,7 @@ pub(crate) async fn run_cli() -> Result<()> {
                 oauth_manager,
                 startup_resume_target_for_command(&Commands::Resume { thread_id, last })
                     .expect("resume command should always map to a startup target"),
+                plugin_dirs,
             )
             .await?
         }
@@ -235,6 +241,7 @@ pub(crate) async fn run_cli() -> Result<()> {
                 oauth_manager,
                 startup_resume_target_for_command(&Commands::Tui)
                     .expect("tui command should always map to a startup target"),
+                plugin_dirs,
             )
             .await?
         }
@@ -368,6 +375,7 @@ async fn run_tui_command(
     config: &RaraConfig,
     oauth_manager: OAuthManager,
     startup_resume: StartupResumeTarget,
+    plugin_dirs: Vec<PathBuf>,
 ) -> Result<()> {
     let initialize_local_embeddings =
         should_initialize_local_embeddings_on_tui_startup(config).await?;
@@ -410,6 +418,7 @@ async fn run_tui_command(
         hook_registry,
         lsp_manager,
         initialize_local_embeddings,
+        plugin_dirs,
     )
     .await?;
     if let Some(thread_id) = resumed_thread_id {
@@ -708,6 +717,34 @@ mod tests {
             Commands::Ask { prompt } => assert_eq!(prompt, "hello"),
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn clap_parses_explicit_plugin_dirs_as_global_args() {
+        let cli = Cli::try_parse_from([
+            "rara",
+            "--plugin-dir",
+            "plugins-a",
+            "--plugin-dir",
+            "plugins-b",
+            "tui",
+        ])
+        .expect("parse plugin dirs");
+
+        assert_eq!(
+            cli.plugin_dirs,
+            vec![PathBuf::from("plugins-a"), PathBuf::from("plugins-b")]
+        );
+        assert!(matches!(cli.command, Some(Commands::Tui)));
+    }
+
+    #[test]
+    fn clap_parses_explicit_plugin_dirs_after_tui_command() {
+        let cli = Cli::try_parse_from(["rara", "tui", "--plugin-dir", "plugins-a"])
+            .expect("parse plugin dir after tui command");
+
+        assert_eq!(cli.plugin_dirs, vec![PathBuf::from("plugins-a")]);
+        assert!(matches!(cli.command, Some(Commands::Tui)));
     }
 
     #[test]

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
@@ -54,6 +55,7 @@ pub async fn run_tui(
     hook_registry: Arc<crate::hook_registry::HookRegistry>,
     lsp_manager: Arc<LspManager>,
     initialize_local_embeddings: bool,
+    explicit_plugin_dirs: Vec<PathBuf>,
 ) -> anyhow::Result<Option<String>> {
     enable_raw_mode()?;
     let initial_size = terminal_size()?;
@@ -67,6 +69,7 @@ pub async fn run_tui(
     app.prompt_source_registry = Some(prompt_source_registry);
     app.skill_source_registry = Some(skill_source_registry);
     app.hook_registry = Some(hook_registry);
+    app.explicit_plugin_dirs = explicit_plugin_dirs;
     app.lsp_manager = Some(lsp_manager);
     app.memory_handler = Some(Arc::new(
         crate::protocol_sources::MemoryControlHandler::with_store(

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -115,9 +115,16 @@ pub async fn run_tui(
 
     maintainer.sync_snapshot();
     maintainer.start_repo_context_detection();
-    if initialize_local_embeddings {
+    if should_start_initial_rebuild(
+        initialize_local_embeddings,
+        &maintainer.app().explicit_plugin_dirs,
+    ) {
         let (app, _) = maintainer.split_mut();
-        app.push_entry("Runtime", "Initializing local embedding model.");
+        if initialize_local_embeddings {
+            app.push_entry("Runtime", "Initializing local embedding model.");
+        } else {
+            app.push_entry("Runtime", "Loading explicit plugin directories.");
+        }
         super::runtime::start_rebuild_task(app);
     }
 
@@ -219,4 +226,28 @@ pub async fn run_tui(
                 .then(|| maintainer.app().snapshot.session_id.clone())
         });
     Ok(session_id)
+}
+
+fn should_start_initial_rebuild(
+    initialize_local_embeddings: bool,
+    explicit_plugin_dirs: &[PathBuf],
+) -> bool {
+    initialize_local_embeddings || !explicit_plugin_dirs.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::should_start_initial_rebuild;
+
+    #[test]
+    fn initial_rebuild_starts_for_embeddings_or_explicit_plugin_dirs() {
+        assert!(should_start_initial_rebuild(true, &[]));
+        assert!(should_start_initial_rebuild(
+            false,
+            &[PathBuf::from("/plugins")]
+        ));
+        assert!(!should_start_initial_rebuild(false, &[]));
+    }
 }

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -296,7 +296,7 @@ pub(crate) async fn finish_running_task_if_ready(
                         hr,
                         None,
                         &workspace_root,
-                        &[],
+                        &app.explicit_plugin_dirs,
                         &agent.session_id,
                     )
                     .await;

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -302,6 +302,7 @@ impl TuiApp {
             skill_source_registry: None,
             hook_registry: None,
             hook_runtime: None,
+            explicit_plugin_dirs: Vec::new(),
             memory_handler: None,
             provider_connection_status: std::collections::HashMap::new(),
             repo_context_task: None,

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -428,6 +428,17 @@ fn new_does_not_detect_repo_context_synchronously() {
 }
 
 #[test]
+fn new_starts_without_explicit_plugin_dirs() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let app = TuiApp::new(cm).expect("app");
+
+    assert!(app.explicit_plugin_dirs.is_empty());
+}
+
+#[test]
 fn push_entry_keeps_manual_transcript_scroll_position() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -761,6 +761,7 @@ pub struct TuiApp {
     pub skill_source_registry: Option<Arc<SkillSourceRegistry>>,
     pub hook_registry: Option<Arc<HookRegistry>>,
     pub hook_runtime: Option<Arc<crate::hook_runtime::HookRuntime>>,
+    pub explicit_plugin_dirs: Vec<PathBuf>,
     pub memory_handler: Option<Arc<MemoryControlHandler>>,
     pub provider_connection_status: std::collections::HashMap<ProviderFamily, bool>,
     pub repo_context_task: Option<JoinHandle<(Option<String>, Option<String>)>>,


### PR DESCRIPTION
## Summary

- add a repeated global `--plugin-dir DIR` flag for TUI and `resume` sessions
- pass explicit plugin directories through TUI startup into plugin hook registration
- document the implemented CLI slice and keep config/headless follow-ups explicit

## Purpose

This completes the user-facing CLI half of explicit Claude plugin directory
support after the source-aware discovery and TUI runtime source work. Manual
plugin directories now participate as the final source tier for TUI sessions,
so they override project and user plugins with the same plugin name.

## Related Issues

None.

## Testing

```bash
cargo test app_cli::tests::clap_parses_explicit_plugin_dirs -- --nocapture
cargo test tui::state::tests::new_starts_without_explicit_plugin_dirs -- --nocapture
cargo test plugin_middleware::tests::plugin_discovery_sources_order_user_project_then_cli -- --nocapture
cargo check --locked --workspace --all-targets
cargo fmt --check
git diff --check
```
