### PR TITLE
feat(plugins): persist explicit plugin dirs

### DIFF
--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -310,6 +310,8 @@ pub struct RaraConfig {
     pub context_file_search: ContextFileSearchPolicy,
     #[serde(default, skip_serializing_if = "LocalEmbeddingPolicy::is_default")]
     pub local_embeddings: LocalEmbeddingPolicy,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub plugin_dirs: Vec<PathBuf>,
     #[serde(default, skip_serializing_if = "TuiConfig::is_default")]
     pub tui: TuiConfig,
 }
@@ -1082,6 +1084,7 @@ fn stable_path_hash(root: &Path) -> u64 {
 mod tests {
     use std::collections::BTreeMap;
     use std::fs;
+    use std::path::PathBuf;
 
     use secrecy::ExposeSecret;
     use tempfile::tempdir;
@@ -1225,6 +1228,32 @@ mod tests {
         });
 
         assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
+    }
+
+    #[test]
+    fn plugin_dirs_default_empty_and_omitted() {
+        let config = RaraConfig::default();
+
+        assert!(config.plugin_dirs.is_empty());
+
+        let json = serde_json::to_string(&config).expect("serialize config");
+        assert!(!json.contains("plugin_dirs"));
+    }
+
+    #[test]
+    fn plugin_dirs_can_be_loaded_from_config() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "deepseek",
+                "plugin_dirs": ["plugins-a", "/tmp/plugins-b"]
+            }"#,
+        )
+        .expect("deserialize config");
+
+        assert_eq!(
+            config.plugin_dirs,
+            vec![PathBuf::from("plugins-a"), PathBuf::from("/tmp/plugins-b")]
+        );
     }
 
     #[test]

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -280,10 +280,11 @@ Implemented in the first merged slice:
   passed into plugin hook registration as the final explicit source tier. CLI
   plugin directories therefore override configured explicit directories, project
   plugins, and user plugins with the same plugin name. Relative explicit plugin
-  directories are normalized to absolute paths during CLI startup. Supplying any
-  explicit plugin directories triggers the TUI runtime rebuild path on startup
-  so the hook runtime is created and plugin hooks are registered even when local
-  embedding startup is disabled.
+  directories are normalized to absolute paths during CLI startup, and duplicate
+  normalized directories are scanned only once. Supplying any explicit plugin
+  directories triggers the TUI runtime rebuild path on startup so the hook
+  runtime is created and plugin hooks are registered even when local embedding
+  startup is disabled.
 
 Next implementation slices:
 

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -274,24 +274,26 @@ Implemented in the first merged slice:
   name.
 - User plugin home resolution happens on the blocking registration worker. If
   user plugin home cannot be resolved, project plugin registration still runs.
-- TUI and `resume` startup accept repeated `--plugin-dir <path>` global CLI
-  flags and pass those directories into plugin hook registration as the final
-  source tier. CLI plugin directories override project and user plugins with the
-  same plugin name. Relative CLI plugin directories are normalized to absolute
-  paths during CLI startup. Supplying explicit plugin directories triggers the
-  TUI runtime rebuild path on startup so the hook runtime is created and plugin
-  hooks are registered even when local embedding startup is disabled.
+- TUI and `resume` startup accept plugin directories from persisted
+  `plugin_dirs` config and repeated `--plugin-dir <path>` global CLI flags.
+  Configured directories are appended before CLI directories, and both are
+  passed into plugin hook registration as the final explicit source tier. CLI
+  plugin directories therefore override configured explicit directories, project
+  plugins, and user plugins with the same plugin name. Relative explicit plugin
+  directories are normalized to absolute paths during CLI startup. Supplying any
+  explicit plugin directories triggers the TUI runtime rebuild path on startup
+  so the hook runtime is created and plugin hooks are registered even when local
+  embedding startup is disabled.
 
 Next implementation slices:
 
 1. Extend plugin source composition beyond the TUI rebuild path to headless,
    ACP, and Wire runtime startup.
-2. Add config persistence for explicit plugin directories.
-3. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd` mapping,
+2. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd` mapping,
    matcher evaluation, blocking hook results, and hook output observability.
-4. Add git-source install support on top of the existing local-directory
+3. Add git-source install support on top of the existing local-directory
    `rara plugin install/list/remove` commands.
-5. Feed plugin `.mcp.json`, commands, skills, and agents into the same
+4. Feed plugin `.mcp.json`, commands, skills, and agents into the same
    structured extension-source registries used by native RARA features.
 
 ## Open Risks
@@ -311,3 +313,4 @@ Next implementation slices:
 - `docs/journal/2026-05-12-claude-plugin-runtime.md`
 - `docs/journal/2026-05-12-main-sync-development-plan.md`
 - `docs/journal/2026-07-19-plugin-source-discovery.md`
+- `docs/journal/2026-07-20-plugin-dir-config.md`

--- a/docs/journal/2026-07-20-plugin-dir-config.md
+++ b/docs/journal/2026-07-20-plugin-dir-config.md
@@ -1,0 +1,40 @@
+# Plugin Directory Config
+
+## Summary
+
+RARA now persists explicit Claude plugin directories in `plugin_dirs` config and
+uses them for TUI and `resume` plugin hook registration.
+
+## Background
+
+The previous plugin explicit-directory slice added repeated `--plugin-dir DIR`
+CLI flags, but those directories only lived for the current process. Users who
+always load the same local plugin directory still needed to pass the CLI flag on
+every TUI or `resume` startup.
+
+## Scope
+
+- Added `RaraConfig.plugin_dirs: Vec<PathBuf>` with an empty default that is
+  omitted from serialized config.
+- Loaded configured plugin directories from `plugin_dirs`.
+- Merged configured plugin directories before CLI plugin directories so CLI
+  inputs remain the most explicit override within the explicit source tier.
+- Reused the existing absolute-path normalization and TUI startup rebuild path.
+
+## Validation
+
+```bash
+cargo test -p rara-config plugin_dirs -- --nocapture
+cargo test app_cli::tests::effective_plugin_dirs_put_cli_dirs_after_config_dirs -- --nocapture
+cargo test app_cli::tests::normalize_plugin_dirs_returns_absolute_paths -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo fmt --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Extend plugin source composition beyond TUI once headless, ACP, and Wire have
+  a clear hook runtime execution boundary.
+- Implement lifecycle parity for `SessionEnd`, matcher evaluation, blocking
+  hook results, and hook output observability.

--- a/docs/journal/2026-07-20-plugin-dir-config.md
+++ b/docs/journal/2026-07-20-plugin-dir-config.md
@@ -19,13 +19,15 @@ every TUI or `resume` startup.
 - Loaded configured plugin directories from `plugin_dirs`.
 - Merged configured plugin directories before CLI plugin directories so CLI
   inputs remain the most explicit override within the explicit source tier.
+- Deduplicated normalized explicit plugin directories while preserving the
+  effective scan order.
 - Reused the existing absolute-path normalization and TUI startup rebuild path.
 
 ## Validation
 
 ```bash
 cargo test -p rara-config plugin_dirs -- --nocapture
-cargo test app_cli::tests::effective_plugin_dirs_put_cli_dirs_after_config_dirs -- --nocapture
+cargo test app_cli::tests::effective_plugin_dirs_put_cli_dirs_after_config_dirs_and_deduplicates -- --nocapture
 cargo test app_cli::tests::normalize_plugin_dirs_returns_absolute_paths -- --nocapture
 cargo check --locked --workspace --all-targets
 cargo fmt --check

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -139,7 +139,7 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin TUI runtime startup across user and project plugin directories.
 - [ ] Claude plugin runtime startup parity for headless, ACP, and Wire surfaces.
 - [x] Claude plugin explicit plugin directory CLI surface for TUI sessions.
-- [ ] Claude plugin explicit plugin directory config persistence.
+- [x] Claude plugin explicit plugin directory config persistence.
 - [ ] Claude plugin lifecycle parity: `SessionEnd`, matcher evaluation, blocking results, and output observability.
 - [ ] Claude plugin extension registries for `.mcp.json`, commands, skills, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -279,15 +279,39 @@ fn normalize_plugin_dirs(plugin_dirs: &[PathBuf]) -> Result<Vec<PathBuf>> {
 fn effective_plugin_dirs(config: &RaraConfig, cli_plugin_dirs: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut plugin_dirs = config.plugin_dirs.clone();
     plugin_dirs.extend_from_slice(cli_plugin_dirs);
-    normalize_plugin_dirs(&plugin_dirs)
+    let normalized = normalize_plugin_dirs(&plugin_dirs)?;
+    let mut seen = std::collections::HashSet::new();
+    Ok(normalized
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .collect())
 }
 
 fn normalize_plugin_dir(path: &Path) -> Result<PathBuf> {
-    match path.canonicalize() {
-        Ok(path) => Ok(path),
-        Err(_) if path.is_absolute() => Ok(path.to_path_buf()),
-        Err(_) => Ok(std::env::current_dir()?.join(path)),
+    let path = match path.canonicalize() {
+        Ok(path) => path,
+        Err(_) if path.is_absolute() => path.to_path_buf(),
+        Err(_) => std::env::current_dir()?.join(path),
+    };
+    Ok(normalize_path_components(path))
+}
+
+fn normalize_path_components(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
     }
+    normalized
 }
 
 async fn run_acp_command(config: &RaraConfig) -> Result<()> {
@@ -786,13 +810,24 @@ mod tests {
     }
 
     #[test]
-    fn effective_plugin_dirs_put_cli_dirs_after_config_dirs() {
+    fn effective_plugin_dirs_put_cli_dirs_after_config_dirs_and_deduplicates() {
         let cwd = std::env::current_dir().expect("cwd");
-        let mut config = RaraConfig::default();
-        config.plugin_dirs = vec![PathBuf::from("config-plugins")];
+        let config = RaraConfig {
+            plugin_dirs: vec![
+                PathBuf::from("config-plugins"),
+                PathBuf::from("./config-plugins"),
+            ],
+            ..Default::default()
+        };
 
-        let normalized = effective_plugin_dirs(&config, &[PathBuf::from("cli-plugins")])
-            .expect("effective plugin dirs");
+        let normalized = effective_plugin_dirs(
+            &config,
+            &[
+                PathBuf::from("cli-plugins"),
+                PathBuf::from("config-plugins"),
+            ],
+        )
+        .expect("effective plugin dirs");
 
         assert_eq!(
             normalized,

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -190,10 +190,11 @@ enum Commands {
 
 pub(crate) async fn run_cli() -> Result<()> {
     let cli = Cli::parse();
-    let plugin_dirs = normalize_plugin_dirs(&cli.plugin_dirs)?;
+    let cli_plugin_dirs = cli.plugin_dirs.clone();
     let config_manager = ConfigManager::new()?;
     let mut config = config_manager.load()?;
     let command = apply_cli_overrides(&mut config, cli);
+    let plugin_dirs = effective_plugin_dirs(&config, &cli_plugin_dirs)?;
     config.apply_provider_environment_defaults();
 
     let oauth_manager = OAuthManager::new()?;
@@ -273,6 +274,12 @@ fn normalize_plugin_dirs(plugin_dirs: &[PathBuf]) -> Result<Vec<PathBuf>> {
         .iter()
         .map(|path| normalize_plugin_dir(path))
         .collect()
+}
+
+fn effective_plugin_dirs(config: &RaraConfig, cli_plugin_dirs: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut plugin_dirs = config.plugin_dirs.clone();
+    plugin_dirs.extend_from_slice(cli_plugin_dirs);
+    normalize_plugin_dirs(&plugin_dirs)
 }
 
 fn normalize_plugin_dir(path: &Path) -> Result<PathBuf> {
@@ -776,6 +783,21 @@ mod tests {
         assert_eq!(normalized[1], cwd.join("missing-plugin-dir"));
         assert_eq!(normalized[2], cwd.join("missing-absolute-plugin-dir"));
         assert!(normalized.iter().all(|path| path.is_absolute()));
+    }
+
+    #[test]
+    fn effective_plugin_dirs_put_cli_dirs_after_config_dirs() {
+        let cwd = std::env::current_dir().expect("cwd");
+        let mut config = RaraConfig::default();
+        config.plugin_dirs = vec![PathBuf::from("config-plugins")];
+
+        let normalized = effective_plugin_dirs(&config, &[PathBuf::from("cli-plugins")])
+            .expect("effective plugin dirs");
+
+        assert_eq!(
+            normalized,
+            vec![cwd.join("config-plugins"), cwd.join("cli-plugins")]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add persisted `plugin_dirs` config for explicit Claude plugin directories
- merge configured plugin dirs before CLI `--plugin-dir` inputs for TUI and `resume`
- update the plugin runtime spec, journal, and TODO state

## Purpose

This completes the config-persistence half of explicit plugin directory support.
Users can now keep stable local plugin directories in config while preserving
CLI flags as the most explicit override within the explicit source tier.

## Related Issues

None.

## Testing

```bash
cargo test -p rara-config plugin_dirs -- --nocapture
cargo test app_cli::tests:: -- --nocapture
cargo check --locked --workspace --all-targets
cargo fmt --check
git diff --check
```
