### PR TITLE
feat(plugins): evaluate hook matchers

### DIFF
--- a/crates/rara-plugins/src/loader.rs
+++ b/crates/rara-plugins/src/loader.rs
@@ -165,24 +165,37 @@ fn parse_hooks_json(path: &Path) -> Result<Vec<HookHandler>, String> {
 
     let mut handlers = Vec::new();
     for group in parsed.Stop {
-        handlers.extend(group.hooks);
+        handlers.extend(hooks_with_group_matcher(group));
     }
     for group in parsed.PostToolUse {
-        handlers.extend(group.hooks);
+        handlers.extend(hooks_with_group_matcher(group));
     }
     for group in parsed.PreToolUse {
-        handlers.extend(group.hooks);
+        handlers.extend(hooks_with_group_matcher(group));
     }
     for group in parsed.UserPromptSubmit {
-        handlers.extend(group.hooks);
+        handlers.extend(hooks_with_group_matcher(group));
     }
     for group in parsed.SessionStart {
-        handlers.extend(group.hooks);
+        handlers.extend(hooks_with_group_matcher(group));
     }
     for group in parsed.SessionEnd {
-        handlers.extend(group.hooks);
+        handlers.extend(hooks_with_group_matcher(group));
     }
     Ok(handlers)
+}
+
+fn hooks_with_group_matcher(group: MatcherGroup) -> Vec<HookHandler> {
+    group
+        .hooks
+        .into_iter()
+        .map(|mut hook| {
+            if hook.matcher.is_none() {
+                hook.matcher = group.matcher.clone();
+            }
+            hook
+        })
+        .collect()
 }
 
 /// Produce all registered hooks for a plugin, binding each handler to its event.
@@ -198,7 +211,7 @@ pub fn registered_hooks_for_plugin(plugin: &Plugin) -> Vec<RegisteredHook> {
     };
 
     for group in parsed.Stop {
-        for h in group.hooks {
+        for h in hooks_with_group_matcher(group) {
             registered.push(RegisteredHook {
                 event: HookEvent::Stop,
                 handler: h,
@@ -208,7 +221,7 @@ pub fn registered_hooks_for_plugin(plugin: &Plugin) -> Vec<RegisteredHook> {
         }
     }
     for group in parsed.PostToolUse {
-        for h in group.hooks {
+        for h in hooks_with_group_matcher(group) {
             registered.push(RegisteredHook {
                 event: HookEvent::PostToolUse,
                 handler: h,
@@ -218,7 +231,7 @@ pub fn registered_hooks_for_plugin(plugin: &Plugin) -> Vec<RegisteredHook> {
         }
     }
     for group in parsed.PreToolUse {
-        for h in group.hooks {
+        for h in hooks_with_group_matcher(group) {
             registered.push(RegisteredHook {
                 event: HookEvent::PreToolUse,
                 handler: h,
@@ -228,7 +241,7 @@ pub fn registered_hooks_for_plugin(plugin: &Plugin) -> Vec<RegisteredHook> {
         }
     }
     for group in parsed.UserPromptSubmit {
-        for h in group.hooks {
+        for h in hooks_with_group_matcher(group) {
             registered.push(RegisteredHook {
                 event: HookEvent::UserPromptSubmit,
                 handler: h,
@@ -238,7 +251,7 @@ pub fn registered_hooks_for_plugin(plugin: &Plugin) -> Vec<RegisteredHook> {
         }
     }
     for group in parsed.SessionStart {
-        for h in group.hooks {
+        for h in hooks_with_group_matcher(group) {
             registered.push(RegisteredHook {
                 event: HookEvent::SessionStart,
                 handler: h,
@@ -248,7 +261,7 @@ pub fn registered_hooks_for_plugin(plugin: &Plugin) -> Vec<RegisteredHook> {
         }
     }
     for group in parsed.SessionEnd {
-        for h in group.hooks {
+        for h in hooks_with_group_matcher(group) {
             registered.push(RegisteredHook {
                 event: HookEvent::SessionEnd,
                 handler: h,
@@ -306,6 +319,44 @@ mod tests {
         assert_eq!(registered.len(), 1);
         assert_eq!(registered[0].event, HookEvent::Stop);
         assert_eq!(registered[0].handler.command, "echo ok");
+        assert_eq!(registered[0].handler.matcher.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn registered_hooks_inherit_group_matcher_unless_handler_overrides() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join(".claude-plugin")).unwrap();
+        fs::write(
+            dir.path().join(".claude-plugin").join("plugin.json"),
+            json!({
+                "name": "matcher-plugin",
+                "description": "matcher plugin"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("hooks")).unwrap();
+        fs::write(
+            dir.path().join("hooks").join("hooks.json"),
+            json!({
+                "PreToolUse": [{
+                    "matcher": "Bash(*)",
+                    "hooks": [
+                        {"type": "command", "command": "echo inherited"},
+                        {"type": "command", "command": "echo override", "matcher": "Write|Edit"}
+                    ]
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let plugin = load_plugin(dir.path()).unwrap();
+        let registered = registered_hooks_for_plugin(&plugin);
+
+        assert_eq!(registered.len(), 2);
+        assert_eq!(registered[0].handler.matcher.as_deref(), Some("Bash(*)"));
+        assert_eq!(registered[1].handler.matcher.as_deref(), Some("Write|Edit"));
     }
 
     #[test]

--- a/crates/rara-plugins/src/loader.rs
+++ b/crates/rara-plugins/src/loader.rs
@@ -185,17 +185,15 @@ fn parse_hooks_json(path: &Path) -> Result<Vec<HookHandler>, String> {
     Ok(handlers)
 }
 
-fn hooks_with_group_matcher(group: MatcherGroup) -> Vec<HookHandler> {
-    group
-        .hooks
-        .into_iter()
-        .map(|mut hook| {
+fn hooks_with_group_matcher(mut group: MatcherGroup) -> Vec<HookHandler> {
+    if let Some(matcher) = group.matcher {
+        for hook in &mut group.hooks {
             if hook.matcher.is_none() {
-                hook.matcher = group.matcher.clone();
+                hook.matcher = Some(matcher.clone());
             }
-            hook
-        })
-        .collect()
+        }
+    }
+    group.hooks
 }
 
 /// Produce all registered hooks for a plugin, binding each handler to its event.

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -285,13 +285,18 @@ Implemented in the first merged slice:
   directories triggers the TUI runtime rebuild path on startup so the hook
   runtime is created and plugin hooks are registered even when local embedding
   startup is disabled.
+- `hooks/hooks.json` matcher groups are preserved on registered hook handlers.
+  Tool hook matchers are evaluated before command execution. Empty matchers and
+  `*` match all tools; exact tool names are matched case-insensitively; Claude
+  Code-style tool patterns such as `Bash(*)` match by the tool name before the
+  parenthesized input pattern; alternatives can be separated with `|` or `,`.
 
 Next implementation slices:
 
 1. Extend plugin source composition beyond the TUI rebuild path to headless,
    ACP, and Wire runtime startup.
-2. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd` mapping,
-   matcher evaluation, blocking hook results, and hook output observability.
+2. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd`
+   mapping, blocking hook results, and hook output observability.
 3. Add git-source install support on top of the existing local-directory
    `rara plugin install/list/remove` commands.
 4. Feed plugin `.mcp.json`, commands, skills, and agents into the same
@@ -302,8 +307,10 @@ Next implementation slices:
 - Hook scripts may `require` Node modules that aren't installed in the user's
   environment. RARA cannot manage Node dependencies. Plugin `README.md` must
   document runtime requirements.
-- Matcher pattern evaluation (`Bash(*)`, `Write|Edit`) is deferred. All hooks
-  currently fire for all tool calls within their event.
+- Full matcher pattern evaluation is not complete yet. Current matcher
+  evaluation matches the tool name only. Parenthesized input
+  subpatterns such as `Bash(git status*)` are treated as tool-name matchers for
+  `Bash`; input-level glob evaluation remains deferred.
 - `prompt`-type hooks require prompt assembly integration that is not yet
   designed.
 - No sandboxing of hook processes. A malicious plugin hook script has full user
@@ -315,3 +322,4 @@ Next implementation slices:
 - `docs/journal/2026-05-12-main-sync-development-plan.md`
 - `docs/journal/2026-07-19-plugin-source-discovery.md`
 - `docs/journal/2026-07-20-plugin-dir-config.md`
+- `docs/journal/2026-07-20-plugin-hook-matchers.md`

--- a/docs/journal/2026-07-20-plugin-hook-matchers.md
+++ b/docs/journal/2026-07-20-plugin-hook-matchers.md
@@ -1,0 +1,41 @@
+# Plugin Hook Matchers
+
+## Summary
+
+RARA now evaluates Claude plugin tool hook matchers before executing command
+hooks for `PreToolUse` and `PostToolUse` events.
+
+## Background
+
+The plugin loader already parsed `hooks/hooks.json`, but matcher groups were not
+preserved on the registered hook handlers and plugin middleware executed every
+tool hook for every tool event. This was enough for early registration tests but
+too broad for real Claude plugin compatibility.
+
+## Scope
+
+- Preserved group-level `matcher` values on hook handlers.
+- Kept handler-level `matcher` values as the more specific override.
+- Evaluated tool-name matchers before spawning plugin command hooks.
+- Supported empty matcher and `*` as match-all, case-insensitive exact tool
+  names, Claude-style `ToolName(...)` patterns by tool name, and `|` or `,`
+  alternatives.
+- Kept input-level glob evaluation, blocking hook results, `SessionEnd`, and
+  output observability out of this slice.
+
+## Validation
+
+```bash
+cargo test -p rara-plugins registered_hooks_inherit_group_matcher_unless_handler_overrides -- --nocapture
+cargo test plugin_middleware::tests::hook_matcher_filters_tool_events_by_tool_name -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
+cargo fmt --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Add input-level matcher evaluation if RARA needs Claude's full tool-input
+  glob semantics.
+- Implement `SessionEnd`, blocking hook results, and hook output observability.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -140,6 +140,7 @@ Active backlog only. Keep this file small and current.
 - [ ] Claude plugin runtime startup parity for headless, ACP, and Wire surfaces.
 - [x] Claude plugin explicit plugin directory CLI surface for TUI sessions.
 - [x] Claude plugin explicit plugin directory config persistence.
-- [ ] Claude plugin lifecycle parity: `SessionEnd`, matcher evaluation, blocking results, and output observability.
+- [x] Claude plugin matcher evaluation for tool hooks.
+- [ ] Claude plugin lifecycle parity: `SessionEnd`, blocking results, and output observability.
 - [ ] Claude plugin extension registries for `.mcp.json`, commands, skills, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -184,7 +184,7 @@ fn hook_matches_agent_event(hook: &rara_plugins::HookHandler, event: &AgentEvent
 }
 
 fn tool_name_matches(matcher: &str, tool_name: &str) -> bool {
-    let tool_name = tool_name.trim().to_ascii_lowercase();
+    let tool_name = tool_name.trim();
     matcher
         .split(['|', ','])
         .map(str::trim)
@@ -194,9 +194,8 @@ fn tool_name_matches(matcher: &str, tool_name: &str) -> bool {
                 .split_once('(')
                 .map(|(name, _)| name)
                 .unwrap_or(part)
-                .trim()
-                .to_ascii_lowercase();
-            tool_pattern == "*" || tool_pattern == tool_name
+                .trim();
+            tool_pattern == "*" || tool_pattern.eq_ignore_ascii_case(tool_name)
         })
 }
 

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -112,6 +112,9 @@ fn register_plugin_hooks_blocking(
             let plugin_name_for_callback = plugin_name.clone();
             let runtime_for_output = runtime.clone();
             let callback = Box::new(move |event: &AgentEvent| {
+                if !hook_matches_agent_event(&hook, event) {
+                    return;
+                }
                 let hook_event_name = match agent_event_to_hook_event(event) {
                     Some(e) => e.as_str().to_string(),
                     None => return,
@@ -164,6 +167,37 @@ fn extract_tool_name(event: &AgentEvent) -> Option<String> {
         AgentEvent::ToolResult { name, .. } => Some(name.clone()),
         _ => None,
     }
+}
+
+fn hook_matches_agent_event(hook: &rara_plugins::HookHandler, event: &AgentEvent) -> bool {
+    let Some(matcher) = hook.matcher.as_deref() else {
+        return true;
+    };
+    let matcher = matcher.trim();
+    if matcher.is_empty() || matcher == "*" {
+        return true;
+    }
+    let Some(tool_name) = extract_tool_name(event) else {
+        return true;
+    };
+    tool_name_matches(matcher, &tool_name)
+}
+
+fn tool_name_matches(matcher: &str, tool_name: &str) -> bool {
+    let tool_name = tool_name.trim().to_ascii_lowercase();
+    matcher
+        .split(['|', ','])
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .any(|part| {
+            let tool_pattern = part
+                .split_once('(')
+                .map(|(name, _)| name)
+                .unwrap_or(part)
+                .trim()
+                .to_ascii_lowercase();
+            tool_pattern == "*" || tool_pattern == tool_name
+        })
 }
 
 #[cfg(test)]
@@ -249,6 +283,37 @@ mod tests {
 
         assert_eq!(registered, 2);
         assert_eq!(runtime.hook_count(), 2);
+    }
+
+    #[test]
+    fn hook_matcher_filters_tool_events_by_tool_name() {
+        let bash_hook = rara_plugins::HookHandler {
+            r#type: "command".to_string(),
+            command: "echo bash".to_string(),
+            timeout: 1,
+            matcher: Some("Bash(*)".to_string()),
+            once: false,
+        };
+        let edit_hook = rara_plugins::HookHandler {
+            r#type: "command".to_string(),
+            command: "echo edit".to_string(),
+            timeout: 1,
+            matcher: Some("Write|Edit".to_string()),
+            once: false,
+        };
+        let bash_event = AgentEvent::ToolUse {
+            name: "bash".to_string(),
+            input: serde_json::json!({}),
+        };
+        let edit_event = AgentEvent::ToolUse {
+            name: "Edit".to_string(),
+            input: serde_json::json!({}),
+        };
+
+        assert!(hook_matches_agent_event(&bash_hook, &bash_event));
+        assert!(!hook_matches_agent_event(&bash_hook, &edit_event));
+        assert!(hook_matches_agent_event(&edit_hook, &edit_event));
+        assert!(!hook_matches_agent_event(&edit_hook, &bash_event));
     }
 
     fn write_test_plugin(root: &Path, name: &str, command: &str) {


### PR DESCRIPTION
## Summary

- preserve `hooks/hooks.json` group matchers on registered plugin hooks
- evaluate tool hook matchers before spawning plugin command hooks
- document the matcher slice and keep `SessionEnd`, blocking results, and output observability as follow-ups

## Purpose

This advances Claude plugin lifecycle parity without mixing in broader hook execution semantics. Tool hooks now avoid running for unrelated tools while keeping input-level glob matching deferred.

## Related Issues

None.

## Testing

```bash
cargo test -p rara-plugins registered_hooks_inherit_group_matcher_unless_handler_overrides -- --nocapture
cargo test -p rara-plugins loads_plugin_from_directory -- --nocapture
cargo test plugin_middleware::tests::hook_matcher_filters_tool_events_by_tool_name -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
cargo fmt --check
git diff --check
```
