### PR TITLE
feat(plugins): move runtime hooks into bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,14 @@ The current product direction is to make local inference a first-class path inst
 - The agent loop should continue to depend on a stable backend trait instead of model-specific code paths.
 - Local models should plug into the same `LlmBackend` contract used by hosted providers.
 - TUI interaction should converge toward one unified prompt surface instead of growing separate setup-only flows for common actions.
+- Runtime-changing features such as plugins, hooks, MCP servers, skills,
+  commands, agents, and extension registries belong to runtime/app-server
+  assembly. TUI is a presentation consumer: it may pass explicit runtime
+  options and render runtime status, but it must not own plugin discovery,
+  hook registration, or extension registry ingestion.
+- Runtime handles used by agent execution must be session-scoped. Do not route
+  mutable runtime behavior through process-global strong references when ACP,
+  Wire, headless, or app-server surfaces may host more than one session.
 - Prefer smaller modules over long files; as a rule of thumb, avoid letting a single source file grow beyond roughly 1000 lines unless there is a strong reason not to split it.
 - If an implementation would push a source file toward or past that limit, proactively split the file instead of continuing to accumulate new logic in place.
 - Non-trivial behavior changes should add or update focused tests when practical.

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -285,8 +285,10 @@ Implemented in the first merged slice:
   plugins, and user plugins with the same plugin name. Relative explicit plugin
   directories are normalized to absolute paths during CLI startup, and duplicate
   normalized directories are scanned only once. Runtime bootstrap creates and
-  starts the hook runtime, then registers plugin command hooks before handing an
-  agent to the surface consumer.
+  starts a session-scoped hook runtime, registers plugin command hooks, and
+  attaches that hook runtime to the agent before handing the agent to the
+  surface consumer. Presentation surfaces must not route plugin behavior
+  through TUI-owned state or process-global strong references.
 - `hooks/hooks.json` matcher groups are preserved on registered hook handlers.
   Tool hook matchers are evaluated before command execution. Empty matchers and
   `*` match all tools; exact tool names are matched case-insensitively; Claude

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -261,30 +261,32 @@ Implemented in the first merged slice:
 - `.claude-plugin/plugin.json` and `hooks/hooks.json` are parsed.
 - Command hooks can be executed with stdin JSON, timeout handling, exit-code
   reporting, and stdout parsing.
-- A middleware bridge exists in `src/plugin_middleware.rs` and is used by the
-  TUI runtime rebuild path for workspace plugin hook registration.
+- A middleware bridge exists in `src/plugin_middleware.rs` and is owned by
+  runtime bootstrap assembly rather than by any presentation surface.
 - The discovery API can scan a single directory with source metadata or scan
   multiple ordered sources with name-based de-duplication. Later sources in the
   ordered list override earlier sources, so callers own their precedence policy.
 - Workspace plugin CLI uses the project source for
   `<workspace>/.rara/plugins`.
-- TUI runtime hook registration combines `~/.rara/plugins` as the user source
-  and `<workspace>/.rara/plugins` as the project source through the ordered
+- Runtime hook registration combines `~/.rara/plugins` as the user source and
+  `<workspace>/.rara/plugins` as the project source through the ordered
   discovery API. Project plugins override user plugins with the same plugin
-  name.
+  name. The same bootstrap path is used by TUI, ask, print, headless exec,
+  ACP, and Wire surfaces; those surfaces pass runtime options and then render or
+  translate the resulting event stream.
 - User plugin home resolution happens on the blocking registration worker. If
   user plugin home cannot be resolved, project plugin registration still runs.
-- TUI and `resume` startup accept plugin directories from persisted
-  `plugin_dirs` config and repeated `--plugin-dir <path>` global CLI flags.
+- TUI, `resume`, ask, print, headless exec, ACP, and Wire startup accept plugin
+  directories from persisted `plugin_dirs` config and repeated
+  `--plugin-dir <path>` global CLI flags.
   Configured directories are appended before CLI directories, and both are
   passed into plugin hook registration as the final explicit source tier. CLI
   plugin directories therefore override configured explicit directories, project
   plugins, and user plugins with the same plugin name. Relative explicit plugin
   directories are normalized to absolute paths during CLI startup, and duplicate
-  normalized directories are scanned only once. Supplying any explicit plugin
-  directories triggers the TUI runtime rebuild path on startup so the hook
-  runtime is created and plugin hooks are registered even when local embedding
-  startup is disabled.
+  normalized directories are scanned only once. Runtime bootstrap creates and
+  starts the hook runtime, then registers plugin command hooks before handing an
+  agent to the surface consumer.
 - `hooks/hooks.json` matcher groups are preserved on registered hook handlers.
   Tool hook matchers are evaluated before command execution. Empty matchers and
   `*` match all tools; exact tool names are matched case-insensitively; Claude
@@ -293,13 +295,11 @@ Implemented in the first merged slice:
 
 Next implementation slices:
 
-1. Extend plugin source composition beyond the TUI rebuild path to headless,
-   ACP, and Wire runtime startup.
-2. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd`
+1. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd`
    mapping, blocking hook results, and hook output observability.
-3. Add git-source install support on top of the existing local-directory
+2. Add git-source install support on top of the existing local-directory
    `rara plugin install/list/remove` commands.
-4. Feed plugin `.mcp.json`, commands, skills, and agents into the same
+3. Feed plugin `.mcp.json`, commands, skills, and agents into the same
    structured extension-source registries used by native RARA features.
 
 ## Open Risks
@@ -323,3 +323,4 @@ Next implementation slices:
 - `docs/journal/2026-07-19-plugin-source-discovery.md`
 - `docs/journal/2026-07-20-plugin-dir-config.md`
 - `docs/journal/2026-07-20-plugin-hook-matchers.md`
+- `docs/journal/2026-07-20-plugin-runtime-bootstrap.md`

--- a/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
+++ b/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
@@ -1,0 +1,55 @@
+# Plugin Runtime Bootstrap Ownership
+
+## Summary
+
+Plugin hook registration now belongs to runtime bootstrap assembly instead of
+the TUI rebuild completion path. TUI, ask, print, headless exec, ACP, and Wire
+surfaces pass plugin directory options into the same bootstrap path and receive
+an already configured runtime.
+
+## Background
+
+The app-server architecture treats TUI as a presentation consumer over the
+runtime event bus. Plugin hooks change runtime behavior, so registering them in
+TUI task completion made plugin execution a display-layer side effect and left
+non-TUI surfaces without the same runtime behavior.
+
+## Scope
+
+- Added `RuntimeBootstrapOptions` with explicit plugin directories.
+- Created and started `HookRuntime` during runtime bootstrap.
+- Registered plugin command hooks while converting `RuntimeBootstrap` into an
+  agent/runtime handle set.
+- Routed TUI rebuild, TUI startup, ask, print, headless exec, ACP, and Wire
+  through the same plugin-aware bootstrap options.
+- Removed plugin hook registration from TUI rebuild completion.
+
+## Key Decisions
+
+- Plugin discovery source composition remains `user -> project -> explicit`.
+- Presentation surfaces may supply runtime options, but they do not own plugin
+  scanning or hook registration.
+- This slice does not change `SessionEnd`, blocking hook behavior, hook output
+  observability, or plugin extension registry ingestion.
+- The existing global hook-output bridge remains a compatibility path. Removing
+  it requires a separate runtime ownership refactor.
+
+## Validation
+
+```bash
+cargo test runtime_context::tests::runtime_bootstrap_options_preserve_plugin_dirs -- --nocapture
+cargo test plugin_middleware::tests::plugin_discovery_sources_order_user_project_then_cli -- --nocapture
+cargo test app_cli::tests::effective_plugin_dirs_put_cli_dirs_after_config_dirs_and_deduplicates -- --nocapture
+cargo test app_cli::tests::clap_parses_explicit_plugin_dirs_as_global_args -- --nocapture
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
+cargo fmt --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Implement `SessionEnd`, blocking hook results, and hook output observability.
+- Feed plugin `.mcp.json`, commands, skills, and agents into structured
+  extension registries.
+- Replace the global hook-output bridge with per-runtime ownership.

--- a/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
+++ b/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
@@ -18,6 +18,9 @@ non-TUI surfaces without the same runtime behavior.
 
 - Added `RuntimeBootstrapOptions` with explicit plugin directories.
 - Created and started `HookRuntime` during runtime bootstrap.
+- Attached the hook runtime to each agent so hook output, tool input mutation,
+  and memory-query hooks use the session-owned runtime instead of a process
+  global.
 - Registered plugin command hooks while converting `RuntimeBootstrap` into an
   agent/runtime handle set.
 - Routed TUI rebuild, TUI startup, ask, print, headless exec, ACP, and Wire
@@ -29,16 +32,19 @@ non-TUI surfaces without the same runtime behavior.
 - Plugin discovery source composition remains `user -> project -> explicit`.
 - Presentation surfaces may supply runtime options, but they do not own plugin
   scanning or hook registration.
+- Agent execution uses a session-scoped hook runtime. The process-global hook
+  runtime bridge was removed so runtime behavior cannot silently pin or route
+  through the first initialized ACP session.
 - This slice does not change `SessionEnd`, blocking hook behavior, hook output
   observability, or plugin extension registry ingestion.
-- The existing global hook-output bridge remains a compatibility path. Removing
-  it requires a separate runtime ownership refactor.
 
 ## Validation
 
 ```bash
 cargo test runtime_context::tests::runtime_bootstrap_options_preserve_plugin_dirs -- --nocapture
+cargo test hook_runtime::tests::start_does_not_capture_runtime_event_bus_arc -- --nocapture
 cargo test plugin_middleware::tests::plugin_discovery_sources_order_user_project_then_cli -- --nocapture
+cargo test plugin_middleware::tests::plugin_callbacks_do_not_retain_hook_runtime_strong_reference -- --nocapture
 cargo test app_cli::tests::effective_plugin_dirs_put_cli_dirs_after_config_dirs_and_deduplicates -- --nocapture
 cargo test app_cli::tests::clap_parses_explicit_plugin_dirs_as_global_args -- --nocapture
 cargo check --locked --workspace --all-targets
@@ -52,4 +58,3 @@ git diff --check
 - Implement `SessionEnd`, blocking hook results, and hook output observability.
 - Feed plugin `.mcp.json`, commands, skills, and agents into structured
   extension registries.
-- Replace the global hook-output bridge with per-runtime ownership.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -137,7 +137,7 @@ Active backlog only. Keep this file small and current.
 
 - [x] Claude plugin discovery source metadata and ordered de-duplication.
 - [x] Claude plugin TUI runtime startup across user and project plugin directories.
-- [ ] Claude plugin runtime startup parity for headless, ACP, and Wire surfaces.
+- [x] Claude plugin runtime startup parity for headless, ACP, and Wire surfaces.
 - [x] Claude plugin explicit plugin directory CLI surface for TUI sessions.
 - [x] Claude plugin explicit plugin directory config persistence.
 - [x] Claude plugin matcher evaluation for tool hooks.

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -47,13 +47,15 @@ struct AcpSession {
 /// ACP adapter state. Every ACP session owns an independent RARA runtime.
 pub struct RaraAcpAgent {
     config: RaraConfig,
+    plugin_dirs: Vec<PathBuf>,
     sessions: RwLock<HashMap<String, Arc<AcpSession>>>,
 }
 
 impl RaraAcpAgent {
-    pub fn new(config: RaraConfig) -> Self {
+    pub fn new(config: RaraConfig, plugin_dirs: Vec<PathBuf>) -> Self {
         Self {
             config,
+            plugin_dirs,
             sessions: RwLock::new(HashMap::new()),
         }
     }
@@ -154,16 +156,30 @@ impl RaraAcpAgent {
     }
 
     async fn ensure_runtime(&self, session: &AcpSession) -> Result<AcpSessionRuntime, String> {
-        let bootstrap = crate::runtime_context::initialize_rara_context_for_workspace(
+        let bootstrap = crate::runtime_context::initialize_rara_context_for_workspace_with_options(
             &self.config,
             Some(&session.cwd),
             None,
+            crate::runtime_context::RuntimeBootstrapOptions::with_plugin_dirs(
+                self.plugin_dirs.clone(),
+            ),
         )
         .await
         .map_err(|err| err.to_string())?;
         let event_bus = bootstrap.event_bus.clone();
-        let (agent, _, _, _, _, mcp_manager, prompt_registry, skill_registry, hook_registry, _) =
-            bootstrap.into_parts();
+        let (
+            agent,
+            _,
+            _,
+            _,
+            _,
+            mcp_manager,
+            prompt_registry,
+            skill_registry,
+            hook_registry,
+            _hook_runtime,
+            _,
+        ) = bootstrap.into_parts_with_runtime_extensions().await;
         Ok(AcpSessionRuntime {
             agent,
             event_bus: event_bus.clone(),
@@ -431,7 +447,7 @@ mod tests {
 
     #[tokio::test]
     async fn sessions_keep_distinct_requested_workspaces() {
-        let agent = RaraAcpAgent::new(RaraConfig::default());
+        let agent = RaraAcpAgent::new(RaraConfig::default(), Vec::new());
         let first = SessionId::from("first");
         let second = SessionId::from("second");
         agent.sessions.write().expect("session registry").insert(

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -26,6 +26,7 @@ use crate::context::{
     AgentTurnTraceView, FileSearchCandidateProvider, RetrievalCandidate, RetrievedMemoryCandidate,
 };
 use crate::control_tokens::scrub_internal_control_tokens;
+use crate::hook_runtime::HookRuntime;
 use crate::hooks::HookDefinition;
 use crate::hooks::HookParseStatus;
 use crate::hooks::HookRegistry;
@@ -300,6 +301,7 @@ pub struct Agent {
     pub compact_state: CompactState,
     pub hook_registry: Option<Arc<crate::hooks::HookRegistry>>,
     pub hook_sandbox: Option<HookSandbox>,
+    hook_runtime: Option<Arc<HookRuntime>>,
     pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
     pub file_search_candidates: Vec<RetrievalCandidate>,
     pub mcp_resource_candidates: Vec<RetrievalCandidate>,
@@ -326,9 +328,11 @@ impl Agent {
         &mut self,
         registry: Arc<crate::hooks::HookRegistry>,
         sandbox: HookSandbox,
+        runtime: Arc<HookRuntime>,
     ) {
         self.hook_registry = Some(registry);
         self.hook_sandbox = Some(sandbox);
+        self.hook_runtime = Some(runtime);
     }
 
     /// Accumulate subagent (auxiliary model) cache statistics.
@@ -470,6 +474,7 @@ impl Agent {
             compact_state: CompactState::default(),
             hook_registry: None,
             hook_sandbox: None,
+            hook_runtime: None,
             retrieved_memory_candidates: Vec::new(),
             file_search_candidates: Vec::new(),
             mcp_resource_candidates: Vec::new(),
@@ -887,8 +892,10 @@ impl Agent {
                         name: name.clone(),
                         input: input.clone(),
                     });
-                    let modified_input =
-                        crate::hook_runtime::global_modify_tool_input(name.as_str(), input.clone());
+                    let modified_input = match self.hook_runtime.as_ref() {
+                        Some(runtime) => runtime.modify_tool_input(name.as_str(), input.clone()),
+                        None => input.clone(),
+                    };
                     report(AgentEvent::ToolUse {
                         name: name.clone(),
                         input: modified_input.clone(),
@@ -1010,7 +1017,7 @@ impl Agent {
             self.ensure_active_plan_step();
             // Inject hook outputs as system messages before the model turn
             self.hook_output_candidates.clear();
-            if let Some(hr) = crate::hook_runtime::get_global_hook_runtime() {
+            if let Some(hr) = self.hook_runtime.as_ref() {
                 let outputs = hr.blocking_drain_outputs();
                 self.hook_output_candidates = outputs
                     .iter()

--- a/src/agent/tests/stop_hooks.rs
+++ b/src/agent/tests/stop_hooks.rs
@@ -54,6 +54,9 @@ async fn stop_hook_blocks_completion_and_returns_feedback_to_the_model() {
             workspace_root: temp.path().to_path_buf(),
             ..HookSandbox::default()
         },
+        Arc::new(crate::hook_runtime::HookRuntime::new(Arc::new(
+            crate::runtime_event_bus::RuntimeEventBus::new(4),
+        ))),
     );
 
     let mut events = Vec::new();

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -200,12 +200,12 @@ pub(crate) async fn run_cli() -> Result<()> {
     let oauth_manager = OAuthManager::new()?;
 
     match command.unwrap_or(Commands::Tui) {
-        Commands::Acp => run_acp_command(&config).await?,
+        Commands::Acp => run_acp_command(&config, plugin_dirs).await?,
         Commands::Connect(args) => run_connect_command(&config, args)?,
         Commands::Models(cmd) => run_models_command(&config, cmd)?,
         Commands::Plugin(cmd) => run_plugin_command(cmd)?,
-        Commands::Ask { prompt } => run_ask_command(&config, prompt).await?,
-        Commands::Exec(args) => run_exec_command(&config, args).await?,
+        Commands::Ask { prompt } => run_ask_command(&config, prompt, plugin_dirs).await?,
+        Commands::Exec(args) => run_exec_command(&config, args, plugin_dirs).await?,
         Commands::Fork { thread_id } => thread_cli::run_fork_command(&thread_id)?,
         Commands::Distill { thread_id } => run_distill_command(&config, &thread_id).await?,
         Commands::Thread { thread_id } => thread_cli::run_thread_command(&thread_id)?,
@@ -234,8 +234,8 @@ pub(crate) async fn run_cli() -> Result<()> {
             .await?
         }
         Commands::Logout => run_logout_command(&mut config, &config_manager, &oauth_manager)?,
-        Commands::Print { prompt } => run_print_command(&config, prompt).await?,
-        Commands::Wire { prompt } => run_wire_command(&config, prompt).await?,
+        Commands::Print { prompt } => run_print_command(&config, prompt, plugin_dirs).await?,
+        Commands::Wire { prompt } => run_wire_command(&config, prompt, plugin_dirs).await?,
         Commands::Tui => {
             run_tui_command(
                 &config,
@@ -314,39 +314,69 @@ fn normalize_path_components(path: PathBuf) -> PathBuf {
     normalized
 }
 
-async fn run_acp_command(config: &RaraConfig) -> Result<()> {
-    let acp_agent = RaraAcpAgent::new(config.clone());
+async fn run_acp_command(config: &RaraConfig, plugin_dirs: Vec<PathBuf>) -> Result<()> {
+    let acp_agent = RaraAcpAgent::new(config.clone(), plugin_dirs);
     acp_agent
         .run_acp_stdio()
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
-async fn run_ask_command(config: &RaraConfig, prompt: String) -> Result<()> {
-    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+async fn run_ask_command(
+    config: &RaraConfig,
+    prompt: String,
+    plugin_dirs: Vec<PathBuf>,
+) -> Result<()> {
+    let bootstrap = runtime_context::initialize_rara_context_for_workspace_with_options(
+        config,
+        None,
+        None,
+        runtime_context::RuntimeBootstrapOptions::with_plugin_dirs(plugin_dirs),
+    )
+    .await?;
     emit_bootstrap_warnings(&bootstrap.warnings);
-    let mut agent = bootstrap.into_agent();
+    let mut agent = bootstrap.into_agent().await;
     agent.query(prompt).await
 }
 
-async fn run_print_command(config: &RaraConfig, prompt: String) -> Result<()> {
-    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+async fn run_print_command(
+    config: &RaraConfig,
+    prompt: String,
+    plugin_dirs: Vec<PathBuf>,
+) -> Result<()> {
+    let bootstrap = runtime_context::initialize_rara_context_for_workspace_with_options(
+        config,
+        None,
+        None,
+        runtime_context::RuntimeBootstrapOptions::with_plugin_dirs(plugin_dirs),
+    )
+    .await?;
     emit_bootstrap_warnings(&bootstrap.warnings);
     let event_bus = bootstrap.event_bus.clone();
-    let agent = bootstrap.into_agent();
+    let agent = bootstrap.into_agent().await;
     let consumer = PrintConsumer::new(agent, event_bus, prompt);
     consumer.run().await
 }
 
-async fn run_exec_command(config: &RaraConfig, args: ExecArgs) -> Result<()> {
+async fn run_exec_command(
+    config: &RaraConfig,
+    args: ExecArgs,
+    plugin_dirs: Vec<PathBuf>,
+) -> Result<()> {
     let startup_complete = install_exec_panic_hook(&args);
     if let Some(cwd) = args.cwd.as_deref() {
         std::env::set_current_dir(cwd)
             .map_err(|err| anyhow::anyhow!("failed to switch cwd to {}: {err}", cwd.display()))?;
     }
-    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+    let bootstrap = runtime_context::initialize_rara_context_for_workspace_with_options(
+        config,
+        None,
+        None,
+        runtime_context::RuntimeBootstrapOptions::with_plugin_dirs(plugin_dirs),
+    )
+    .await?;
     emit_bootstrap_warnings(&bootstrap.warnings);
-    let mut agent = bootstrap.into_agent();
+    let mut agent = bootstrap.into_agent().await;
     if args.full_access {
         agent.set_full_access_mode(true);
     }
@@ -388,11 +418,21 @@ fn install_exec_panic_hook(args: &ExecArgs) -> Option<Arc<AtomicBool>> {
     Some(startup_complete)
 }
 
-async fn run_wire_command(config: &RaraConfig, prompt: String) -> Result<()> {
-    let bootstrap = runtime_context::initialize_rara_context(config, None).await?;
+async fn run_wire_command(
+    config: &RaraConfig,
+    prompt: String,
+    plugin_dirs: Vec<PathBuf>,
+) -> Result<()> {
+    let bootstrap = runtime_context::initialize_rara_context_for_workspace_with_options(
+        config,
+        None,
+        None,
+        runtime_context::RuntimeBootstrapOptions::with_plugin_dirs(plugin_dirs),
+    )
+    .await?;
     emit_bootstrap_warnings(&bootstrap.warnings);
     let event_bus = bootstrap.event_bus.clone();
-    let agent = bootstrap.into_agent();
+    let agent = bootstrap.into_agent().await;
     let consumer = WireConsumer::new(agent, event_bus, prompt);
     consumer.run().await
 }
@@ -426,15 +466,22 @@ async fn run_tui_command(
     let initialize_local_embeddings =
         should_initialize_local_embeddings_on_tui_startup(config).await?;
     let bootstrap = if initialize_local_embeddings {
-        runtime_context::initialize_rara_context_with_local_embedding_bootstrap(
+        runtime_context::initialize_rara_context_with_options_and_local_embedding_bootstrap(
             config,
             None,
             None,
             runtime_context::LocalEmbeddingBootstrap::InspectOnly,
+            runtime_context::RuntimeBootstrapOptions::with_plugin_dirs(plugin_dirs.clone()),
         )
         .await?
     } else {
-        runtime_context::initialize_rara_context(config, None).await?
+        runtime_context::initialize_rara_context_for_workspace_with_options(
+            config,
+            None,
+            None,
+            runtime_context::RuntimeBootstrapOptions::with_plugin_dirs(plugin_dirs.clone()),
+        )
+        .await?
     };
     emit_bootstrap_warnings(&bootstrap.warnings);
     let event_bus = bootstrap.event_bus.clone();
@@ -448,8 +495,9 @@ async fn run_tui_command(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
+        hook_runtime,
         lsp_manager,
-    ) = bootstrap.into_parts();
+    ) = bootstrap.into_parts_with_runtime_extensions().await;
     let resumed_thread_id = crate::tui::run_tui(
         agent,
         goal_handle,
@@ -462,6 +510,7 @@ async fn run_tui_command(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
+        hook_runtime,
         lsp_manager,
         initialize_local_embeddings,
         plugin_dirs,

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -10,8 +10,6 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
-use serde_json::Value;
-
 use crate::agent::AgentEvent;
 use crate::runtime_control::HookLifecycle;
 use crate::runtime_event_bus::RuntimeEventBus;
@@ -118,10 +116,9 @@ impl HookRuntime {
             return None;
         }
         let hooks = Arc::clone(&self.hooks);
-        let bus = self.bus.clone();
+        let mut rx = self.bus.subscribe();
 
         let handle = tokio::task::spawn(async move {
-            let mut rx = bus.subscribe();
             loop {
                 match rx.recv().await {
                     Ok(event) => {
@@ -171,34 +168,6 @@ fn lifecycle_for_event(event: &AgentEvent) -> Option<HookLifecycle> {
 
 fn lifecycle_matches(lifecycle: &HookLifecycle, event: &AgentEvent) -> bool {
     lifecycle_for_event(event).as_ref() == Some(lifecycle)
-}
-
-// ---------------------------------------------------------------------------
-// Global hook runtime — avoids threading Arc<HookRuntime> through every
-// Agent constructor. Set once by the builder, read by the agent loop.
-// ---------------------------------------------------------------------------
-
-static GLOBAL_HOOK_RUNTIME: std::sync::OnceLock<Arc<HookRuntime>> = std::sync::OnceLock::new();
-
-pub(crate) fn set_global_hook_runtime(hr: Arc<HookRuntime>) {
-    let _ = GLOBAL_HOOK_RUNTIME.set(hr);
-}
-
-pub(crate) fn get_global_hook_runtime() -> Option<&'static Arc<HookRuntime>> {
-    GLOBAL_HOOK_RUNTIME.get()
-}
-
-pub(crate) fn global_modify_tool_input(tool_name: &str, input: Value) -> Value {
-    match GLOBAL_HOOK_RUNTIME.get() {
-        Some(hr) => hr.modify_tool_input(tool_name, input),
-        None => input,
-    }
-}
-
-pub(crate) fn global_dispatch_memory_query(query: &str) {
-    if let Some(hr) = GLOBAL_HOOK_RUNTIME.get() {
-        hr.dispatch_memory_query(query);
-    }
 }
 
 #[cfg(test)]
@@ -268,6 +237,18 @@ mod tests {
             Box::new(|_| {}),
         );
         assert_eq!(runtime.hook_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn start_does_not_capture_runtime_event_bus_arc() {
+        let bus = Arc::new(RuntimeEventBus::new(4));
+        let runtime = HookRuntime::new(bus.clone());
+        let before = Arc::strong_count(&bus);
+
+        let handle = runtime.start().expect("start hook runtime");
+
+        assert_eq!(Arc::strong_count(&bus), before);
+        handle.abort();
     }
 
     #[test]

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -110,11 +110,14 @@ fn register_plugin_hooks_blocking(
             let lifecycle = hook_event_to_lifecycle(rh.event);
 
             let plugin_name_for_callback = plugin_name.clone();
-            let runtime_for_output = runtime.clone();
+            let runtime_for_output = Arc::downgrade(runtime);
             let callback = Box::new(move |event: &AgentEvent| {
                 if !hook_matches_agent_event(&hook, event) {
                     return;
                 }
+                let Some(runtime_for_output) = runtime_for_output.upgrade() else {
+                    return;
+                };
                 let hook_event_name = match agent_event_to_hook_event(event) {
                     Some(e) => e.as_str().to_string(),
                     None => return,
@@ -282,6 +285,25 @@ mod tests {
 
         assert_eq!(registered, 2);
         assert_eq!(runtime.hook_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn plugin_callbacks_do_not_retain_hook_runtime_strong_reference() {
+        let dir = tempdir().expect("tempdir");
+        let rara_home = dir.path().join("home").join(".rara");
+        let workspace_root = dir.path().join("workspace");
+        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+        write_test_plugin(
+            &project_plugins_dir.join("project-only"),
+            "project-only",
+            "echo project-only",
+        );
+
+        let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
+        register_plugin_hooks(&runtime, Some(rara_home), &workspace_root, &[], "session-1").await;
+
+        assert_eq!(runtime.hook_count(), 1);
+        assert_eq!(Arc::strong_count(&runtime), 1);
     }
 
     #[test]

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -110,6 +110,7 @@ impl RuntimeBootstrap {
                 workspace_root: hook_workspace_root,
                 ..crate::hooks::HookSandbox::default()
             },
+            self.hook_runtime.clone(),
         );
         (
             agent,
@@ -295,7 +296,6 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
 
     let event_bus = Arc::new(RuntimeEventBus::new(256));
     let hook_runtime = Arc::new(HookRuntime::new(event_bus.clone()));
-    crate::hook_runtime::set_global_hook_runtime(hook_runtime.clone());
     hook_runtime.start();
     let prompt_source_registry = Arc::new(PromptSourceRegistry::new(event_bus.clone()));
     let skill_source_registry = Arc::new(SkillSourceRegistry::new(event_bus.clone()));
@@ -345,6 +345,7 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
         sandbox_network_access.clone(),
         goal_handle.clone(),
         mcp_tool_cache.clone(),
+        hook_runtime.clone(),
         lsp_manager.clone(),
         agent_definitions.clone(),
     );

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -1,6 +1,6 @@
 mod tooling;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, atomic::AtomicBool};
 
 use anyhow::{Context, Result, bail};
@@ -17,6 +17,7 @@ use crate::config::{
 use crate::embedding::EmbeddingOverrideBackend;
 use crate::google_oauth::GoogleOAuthManager;
 use crate::hook_registry::HookRegistry;
+use crate::hook_runtime::HookRuntime;
 use crate::llm::{
     BedrockBackend, CodexBackend, EmbeddingBackend, GeminiBackend, LlmBackend, LlmEmbeddingBackend,
     MockLlm, OllamaBackend, OpenAiCompatibleBackend, fetch_model_context_window,
@@ -54,17 +55,20 @@ pub(crate) struct RuntimeBootstrap {
     pub prompt_source_registry: Arc<PromptSourceRegistry>,
     pub skill_source_registry: Arc<SkillSourceRegistry>,
     pub hook_registry: Arc<HookRegistry>,
+    pub hook_runtime: Arc<HookRuntime>,
     command_hook_registry: Arc<crate::hooks::HookRegistry>,
     pub goal_handle: GoalHandle,
     pub mcp_tool_cache: McpToolCache,
     pub mcp_manager: Arc<McpConnectionManager>,
     pub lsp_manager: Arc<LspManager>,
     pub agent_definitions: AgentDefinitionCache,
+    plugin_dirs: Vec<PathBuf>,
+    rara_home: Option<PathBuf>,
 }
 
 impl RuntimeBootstrap {
-    pub(crate) fn into_agent(self) -> Agent {
-        let (agent, _, _, _, _, _, _, _, _, _) = self.into_parts();
+    pub(crate) async fn into_agent(self) -> Agent {
+        let (agent, _, _, _, _, _, _, _, _, _, _) = self.into_parts_with_runtime_extensions().await;
         agent
     }
 
@@ -83,6 +87,7 @@ impl RuntimeBootstrap {
         Arc<PromptSourceRegistry>,
         Arc<SkillSourceRegistry>,
         Arc<HookRegistry>,
+        Arc<HookRuntime>,
         Arc<LspManager>,
     ) {
         let hook_workspace_root = self.workspace.root.clone();
@@ -116,8 +121,52 @@ impl RuntimeBootstrap {
             self.prompt_source_registry,
             self.skill_source_registry,
             self.hook_registry,
+            self.hook_runtime,
             self.lsp_manager,
         )
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub(crate) async fn into_parts_with_runtime_extensions(
+        self,
+    ) -> (
+        Agent,
+        Vec<String>,
+        Arc<AtomicBool>,
+        GoalHandle,
+        McpToolCache,
+        Arc<McpConnectionManager>,
+        Arc<PromptSourceRegistry>,
+        Arc<SkillSourceRegistry>,
+        Arc<HookRegistry>,
+        Arc<HookRuntime>,
+        Arc<LspManager>,
+    ) {
+        let workspace_root = self.workspace.root.clone();
+        let plugin_dirs = self.plugin_dirs.clone();
+        let rara_home = self.rara_home.clone();
+        let hook_runtime = self.hook_runtime.clone();
+        let parts = self.into_parts();
+        crate::plugin_middleware::register_plugin_hooks(
+            &hook_runtime,
+            rara_home,
+            &workspace_root,
+            &plugin_dirs,
+            &parts.0.session_id,
+        )
+        .await;
+        parts
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct RuntimeBootstrapOptions {
+    pub plugin_dirs: Vec<PathBuf>,
+}
+
+impl RuntimeBootstrapOptions {
+    pub(crate) fn with_plugin_dirs(plugin_dirs: Vec<PathBuf>) -> Self {
+        Self { plugin_dirs }
     }
 }
 
@@ -143,6 +192,22 @@ pub(crate) async fn initialize_rara_context_for_workspace(
     .await
 }
 
+pub(crate) async fn initialize_rara_context_for_workspace_with_options(
+    config: &RaraConfig,
+    workspace_root: Option<&Path>,
+    progress: Option<LocalProgressReporter>,
+    options: RuntimeBootstrapOptions,
+) -> Result<RuntimeBootstrap> {
+    initialize_rara_context_with_options_and_local_embedding_bootstrap(
+        config,
+        workspace_root,
+        progress,
+        LocalEmbeddingBootstrap::Prepare,
+        options,
+    )
+    .await
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LocalEmbeddingBootstrap {
     Prepare,
@@ -154,6 +219,23 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     workspace_root: Option<&Path>,
     progress: Option<LocalProgressReporter>,
     local_embedding_bootstrap: LocalEmbeddingBootstrap,
+) -> Result<RuntimeBootstrap> {
+    initialize_rara_context_with_options_and_local_embedding_bootstrap(
+        config,
+        workspace_root,
+        progress,
+        local_embedding_bootstrap,
+        RuntimeBootstrapOptions::default(),
+    )
+    .await
+}
+
+pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_bootstrap(
+    config: &RaraConfig,
+    workspace_root: Option<&Path>,
+    progress: Option<LocalProgressReporter>,
+    local_embedding_bootstrap: LocalEmbeddingBootstrap,
+    options: RuntimeBootstrapOptions,
 ) -> Result<RuntimeBootstrap> {
     let embedding_progress = progress.clone();
     let chat_backend = build_backend_with_progress(config, progress).await?;
@@ -212,6 +294,9 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     ));
 
     let event_bus = Arc::new(RuntimeEventBus::new(256));
+    let hook_runtime = Arc::new(HookRuntime::new(event_bus.clone()));
+    crate::hook_runtime::set_global_hook_runtime(hook_runtime.clone());
+    hook_runtime.start();
     let prompt_source_registry = Arc::new(PromptSourceRegistry::new(event_bus.clone()));
     let skill_source_registry = Arc::new(SkillSourceRegistry::new(event_bus.clone()));
     let hook_registry = Arc::new(HookRegistry::new(event_bus.clone()));
@@ -221,8 +306,9 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
     let lsp_manager = Arc::new(LspManager::new(workspace.root.clone()));
 
     let config_manager = crate::config::ConfigManager::new()?;
+    let rara_home = ensure_rara_home_dir()?;
     let mcp_registry = config_manager
-        .load_mcp_registry_for_project(&ensure_rara_home_dir()?)
+        .load_mcp_registry_for_project(&rara_home)
         .unwrap_or_else(|_| crate::config::McpRegistry::empty());
     let mcp_registry = Arc::new(mcp_registry);
 
@@ -280,12 +366,15 @@ pub(crate) async fn initialize_rara_context_with_local_embedding_bootstrap(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
+        hook_runtime,
         command_hook_registry,
         goal_handle,
         mcp_tool_cache,
         mcp_manager,
         lsp_manager,
         agent_definitions,
+        plugin_dirs: options.plugin_dirs,
+        rara_home: Some(rara_home),
     })
 }
 
@@ -565,12 +654,14 @@ fn ollama_thinking_enabled(config: &RaraConfig) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use tempfile::tempdir;
 
     use super::{
-        EmbeddingRoute, build_backend_with_progress, config_requires_local_embedding_sidecar,
-        embedding_route_for_config, initialize_rara_context, ollama_thinking_enabled,
-        vector_db_uri_for_workspace,
+        EmbeddingRoute, RuntimeBootstrapOptions, build_backend_with_progress,
+        config_requires_local_embedding_sidecar, embedding_route_for_config,
+        initialize_rara_context, ollama_thinking_enabled, vector_db_uri_for_workspace,
     };
     use crate::config::{
         DEFAULT_REASONING_SUMMARY, LocalEmbeddingPolicy, REASONING_SUMMARY_NONE, RaraConfig,
@@ -737,6 +828,16 @@ mod tests {
             EmbeddingRoute::CurrentLlmBackend
         );
         assert!(!config_requires_local_embedding_sidecar(&deepseek));
+    }
+
+    #[test]
+    fn runtime_bootstrap_options_preserve_plugin_dirs() {
+        let plugin_dirs = vec![
+            PathBuf::from("/tmp/rara-plugin-a"),
+            PathBuf::from("plugins-b"),
+        ];
+        let options = RuntimeBootstrapOptions::with_plugin_dirs(plugin_dirs.clone());
+        assert_eq!(options.plugin_dirs, plugin_dirs);
     }
 
     #[test]

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -15,6 +15,7 @@ use rara_tools::planning::{EnterPlanModeTool, ExitPlanModeTool};
 use rara_tools::search::{GlobTool, GrepTool};
 use rara_tools::tool::ToolManager;
 
+use crate::hook_runtime::HookRuntime;
 use crate::llm::{EmbeddingBackend, LlmBackend};
 use crate::lsp_manager::LspManager;
 use crate::mcp_tool_cache::McpToolCache;
@@ -64,6 +65,7 @@ pub(super) fn create_full_tool_manager(
     sandbox_network_access: Arc<AtomicBool>,
     goal_handle: GoalHandle,
     mcp_tool_cache: McpToolCache,
+    hook_runtime: Arc<HookRuntime>,
     lsp_manager: Arc<LspManager>,
     agent_definitions: AgentDefinitionCache,
 ) -> ToolManager {
@@ -134,7 +136,9 @@ pub(super) fn create_full_tool_manager(
     tm.register(Box::new(SearchMemoryTool {
         rara_home: workspace.rara_dir.clone(),
         vdb: Some(vdb.clone()),
-        hook_callback: Some(Arc::new(crate::hook_runtime::global_dispatch_memory_query)),
+        hook_callback: Some(Arc::new(move |query| {
+            hook_runtime.dispatch_memory_query(query);
+        })),
     }));
     tm.register(Box::new(LspDiagnosticsTool::new(lsp_manager)));
     tm.register(Box::new(McpToolSearch::new(mcp_tool_cache)));

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -53,6 +53,7 @@ pub async fn run_tui(
     prompt_source_registry: Arc<PromptSourceRegistry>,
     skill_source_registry: Arc<SkillSourceRegistry>,
     hook_registry: Arc<crate::hook_registry::HookRegistry>,
+    hook_runtime: Arc<crate::hook_runtime::HookRuntime>,
     lsp_manager: Arc<LspManager>,
     initialize_local_embeddings: bool,
     explicit_plugin_dirs: Vec<PathBuf>,
@@ -69,6 +70,7 @@ pub async fn run_tui(
     app.prompt_source_registry = Some(prompt_source_registry);
     app.skill_source_registry = Some(skill_source_registry);
     app.hook_registry = Some(hook_registry);
+    app.hook_runtime = Some(hook_runtime);
     app.explicit_plugin_dirs = explicit_plugin_dirs;
     app.lsp_manager = Some(lsp_manager);
     app.memory_handler = Some(Arc::new(

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -582,6 +582,7 @@ fn start_automatic_plan_implementation_task(app: &mut TuiApp, agent: Agent) {
 pub(super) fn start_rebuild_task(app: &mut TuiApp) {
     let (sender, receiver) = mpsc::unbounded_channel();
     let config = app.config.clone();
+    let plugin_dirs = app.explicit_plugin_dirs.clone();
     let provider = config.provider.clone();
     let model = config.model.clone().unwrap_or_else(|| "-".to_string());
     app.bottom_pane.notice = Some(format!("Rebuilding backend for {provider} / {model}."));
@@ -599,7 +600,7 @@ pub(super) fn start_rebuild_task(app: &mut TuiApp) {
                 message,
             });
         });
-        let result = rebuild_agent_with_progress(&config, Some(progress)).await;
+        let result = rebuild_agent_with_progress(&config, Some(progress), plugin_dirs).await;
         TaskCompletion::Rebuild { result }
     });
 

--- a/src/tui/runtime/tasks/builder.rs
+++ b/src/tui/runtime/tasks/builder.rs
@@ -5,8 +5,15 @@ use crate::tui::state::RebuildSuccess;
 pub(super) async fn rebuild_agent_with_progress(
     config: &crate::config::RaraConfig,
     progress: Option<crate::local_backend::LocalProgressReporter>,
+    plugin_dirs: Vec<std::path::PathBuf>,
 ) -> anyhow::Result<RebuildSuccess> {
-    let bootstrap = crate::runtime_context::initialize_rara_context(config, progress).await?;
+    let bootstrap = crate::runtime_context::initialize_rara_context_for_workspace_with_options(
+        config,
+        None,
+        progress,
+        crate::runtime_context::RuntimeBootstrapOptions::with_plugin_dirs(plugin_dirs),
+    )
+    .await?;
     // `inspect_local_model_server_status` uses a `reqwest::blocking` client, which spins up and
     // drops its own Tokio runtime; dropping a runtime inside the async context would panic, so run
     // it on a blocking thread where that is allowed.
@@ -16,11 +23,6 @@ pub(super) async fn rebuild_agent_with_progress(
     })
     .await?;
     let event_bus = bootstrap.event_bus.clone();
-
-    // Start the hook runtime — registers command-type hooks found in `.claude/hooks/`
-    let hook_runtime = Arc::new(crate::hook_runtime::HookRuntime::new(event_bus.clone()));
-    crate::hook_runtime::set_global_hook_runtime(hook_runtime.clone());
-    hook_runtime.start();
 
     let (
         agent,
@@ -32,8 +34,9 @@ pub(super) async fn rebuild_agent_with_progress(
         prompt_source_registry,
         skill_source_registry,
         hook_registry,
+        hook_runtime,
         lsp_manager,
-    ) = bootstrap.into_parts();
+    ) = bootstrap.into_parts_with_runtime_extensions().await;
     let memory_handler = Arc::new(crate::protocol_sources::MemoryControlHandler::with_store(
         event_bus,
         agent.memory_store.clone(),

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -289,18 +289,6 @@ pub(crate) async fn finish_running_task_if_ready(
                 app.memory_handler = Some(rebuilt.memory_handler);
                 app.hook_registry = Some(rebuilt.hook_registry);
                 app.hook_runtime = Some(rebuilt.hook_runtime.clone());
-                if let (Ok(workspace_root), Some(hr)) =
-                    (std::env::current_dir(), app.hook_runtime.as_ref())
-                {
-                    crate::plugin_middleware::register_plugin_hooks(
-                        hr,
-                        None,
-                        &workspace_root,
-                        &app.explicit_plugin_dirs,
-                        &agent.session_id,
-                    )
-                    .await;
-                }
                 app.local_model_server = rebuilt.local_model_server;
                 app.config_manager.save(&app.config)?;
                 let is_bootstrap = app.setup_status.is_none();


### PR DESCRIPTION
## Summary

- move Claude plugin hook registration out of TUI rebuild completion and into runtime bootstrap assembly
- pass plugin directory options through TUI, ask, print, headless exec, ACP, and Wire startup
- update the plugin runtime spec, TODO, and journal to record app-server/runtime ownership

## Purpose

Plugin hooks change runtime behavior, so they should be assembled by the runtime rather than by the TUI presentation path. This keeps TUI as a display consumer and gives non-TUI surfaces the same plugin hook behavior.

## Related Issues

None.

## Testing

```bash
cargo test runtime_context::tests::runtime_bootstrap_options_preserve_plugin_dirs -- --nocapture
cargo test plugin_middleware::tests::plugin_discovery_sources_order_user_project_then_cli -- --nocapture
cargo test app_cli::tests::effective_plugin_dirs_put_cli_dirs_after_config_dirs_and_deduplicates -- --nocapture
cargo test app_cli::tests::clap_parses_explicit_plugin_dirs_as_global_args -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
cargo fmt --check
git diff --check
```
