### PR TITLE
feat(plugins): block tools from plugin hooks

### DIFF
--- a/crates/rara-plugins/src/exec.rs
+++ b/crates/rara-plugins/src/exec.rs
@@ -8,6 +8,7 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use serde::Serialize;
+use serde_json::Value;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tokio::time::timeout;
@@ -22,7 +23,8 @@ pub struct HookInput {
     pub hook_event: String,
     pub plugin_root: String,
     pub tool_name: Option<String>,
-    pub tool_input: Option<String>,
+    pub tool_input: Option<Value>,
+    pub tool_response: Option<Value>,
 }
 
 /// Result of executing a command hook.
@@ -152,6 +154,7 @@ mod tests {
                 plugin_root: "/tmp".to_string(),
                 tool_name: None,
                 tool_input: None,
+                tool_response: None,
             },
         )
         .await;
@@ -177,6 +180,7 @@ mod tests {
                 plugin_root: "/tmp".to_string(),
                 tool_name: None,
                 tool_input: None,
+                tool_response: None,
             },
         )
         .await;
@@ -202,6 +206,7 @@ mod tests {
                 plugin_root: "/tmp".to_string(),
                 tool_name: None,
                 tool_input: None,
+                tool_response: None,
             },
         )
         .await;

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -23,6 +23,8 @@ This spec covers:
   SessionEnd).
 - Execution of `command`-type hooks: spawn a shell process, feed JSON on stdin,
   read exit code and stdout JSON (`{ continue: bool }`).
+- Synchronous `PreToolUse` command-hook blocking in the agent tool execution
+  path.
 - Timeout enforcement per hook (default 60s, configurable).
 - Integration with RARA's existing `HookRuntime` so plugin hooks fire on the
   same lifecycle events as built-in hooks.
@@ -178,27 +180,30 @@ wait_with_timeout(timeout_secs)
   "transcript_path": "/path/to/session.jsonl",
   "hook_event": "Stop",
   "plugin_root": "/path/to/plugin",
-  "tool_name": "Bash",        // only for PreToolUse/PostToolUse
-  "tool_input": "..."         // only for PreToolUse/PostToolUse
+  "tool_name": "Bash",        // only for tool events
+  "tool_input": { "command": "git status" },
+  "tool_response": null       // reserved for PostToolUse
 }
 ```
 
 ### Integration With Existing Hook Runtime
 
-RARA's `HookRuntime` already maps `AgentEvent` → `HookLifecycle` and runs a
-dispatch loop. Plugin hooks are added as an additional source:
+Plugin discovery and registration are owned by runtime bootstrap. The resulting
+plugin hook set is session-scoped and attached to the agent alongside the
+session-owned `HookRuntime`.
 
-```rust
-// In hook_runtime.rs or a new integration point:
-let plugin_hooks = PluginLoader::load_all();
-for hook in plugin_hooks {
-    runtime.register(hook.event, hook);
-}
-```
+`PreToolUse` command hooks are executed synchronously at the tool execution
+boundary. A hook result with `continue:false`, a non-zero exit, or a timeout
+returns an error `tool_result` to the model and the tool is not executed. The
+blocking message is selected from stdout JSON `stopReason`, `reason`, or
+`systemMessage`, then stderr, plain stdout, then a generic fallback. `PreToolUse`
+stdout is treated as control output for the blocking decision and is not
+injected into later model context.
 
-When the hook runtime dispatches a lifecycle event, it iterates registered
-hooks and calls `PluginRuntime::execute_hook()` for each `HandlerType::Command`
-hook.
+Non-blocking plugin events continue to register with `HookRuntime` and inject
+stdout into the model context before a later model turn. `PreToolUse` is not
+also registered through the async event-bus callback, so command hooks are not
+run twice.
 
 ### Installation
 
@@ -237,7 +242,9 @@ pub fn remove_plugin(name: &str, target_dir: &Path) -> Result<()>;
 ```
 
 Unknown fields are ignored. Unknown event keys are ignored with a warning.
-Matchers are parsed but not evaluated in the first slice (matching is deferred).
+Tool matchers are evaluated by tool name, including simple `A|B`, `A,B`, and
+`Tool(...)` forms. Full Claude Code input-pattern matching remains out of
+scope for now.
 
 ## Validation Matrix
 
@@ -247,7 +254,7 @@ Matchers are parsed but not evaluated in the first slice (matching is deferred).
 | Missing `.claude-plugin/` returns None | unit test |
 | Invalid JSON produces load_warnings | unit test |
 | `execute_command_hook` with working command | integration test (echo return code) |
-| `{ "continue": false }` blocks | integration test |
+| `{ "continue": false }` blocks command hook execution | `cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |
 | `discover_plugins` skips non-directories | unit test |
@@ -261,6 +268,8 @@ Implemented in the first merged slice:
 - `.claude-plugin/plugin.json` and `hooks/hooks.json` are parsed.
 - Command hooks can be executed with stdin JSON, timeout handling, exit-code
   reporting, and stdout parsing.
+- `PreToolUse` command hooks run synchronously before tool execution. Blocking
+  results return an error tool result to the model and skip the tool call.
 - A middleware bridge exists in `src/plugin_middleware.rs` and is owned by
   runtime bootstrap assembly rather than by any presentation surface.
 - The discovery API can scan a single directory with source metadata or scan
@@ -297,8 +306,9 @@ Implemented in the first merged slice:
 
 Next implementation slices:
 
-1. Fix lifecycle parity gaps before broad user-facing rollout: `SessionEnd`
-   mapping, blocking hook results, and hook output observability.
+1. Fix remaining lifecycle parity gaps before broad user-facing rollout:
+   `SessionEnd` mapping, structured hook output observability, and non-tool
+   lifecycle dispatch.
 2. Add git-source install support on top of the existing local-directory
    `rara plugin install/list/remove` commands.
 3. Feed plugin `.mcp.json`, commands, skills, and agents into the same
@@ -322,6 +332,7 @@ Next implementation slices:
 
 - `docs/journal/2026-05-12-claude-plugin-runtime.md`
 - `docs/journal/2026-05-12-main-sync-development-plan.md`
+- `docs/journal/2026-07-20-plugin-runtime-bootstrap.md`
 - `docs/journal/2026-07-19-plugin-source-discovery.md`
 - `docs/journal/2026-07-20-plugin-dir-config.md`
 - `docs/journal/2026-07-20-plugin-hook-matchers.md`

--- a/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
+++ b/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
@@ -35,8 +35,12 @@ non-TUI surfaces without the same runtime behavior.
 - Agent execution uses a session-scoped hook runtime. The process-global hook
   runtime bridge was removed so runtime behavior cannot silently pin or route
   through the first initialized ACP session.
-- This slice does not change `SessionEnd`, blocking hook behavior, hook output
-  observability, or plugin extension registry ingestion.
+- Plugin `PreToolUse` command hooks now also have a session-scoped synchronous
+  execution path at the agent tool boundary. `continue:false`, non-zero exits,
+  and timeouts return an error tool result to the model and prevent the tool
+  from running.
+- This slice does not change `SessionEnd`, non-tool lifecycle dispatch, full
+  structured hook output observability, or plugin extension registry ingestion.
 
 ## Validation
 
@@ -51,10 +55,13 @@ cargo check --locked --workspace --all-targets
 cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
 cargo fmt --check
 git diff --check
+cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture
+cargo test plugin_middleware::tests -- --nocapture
 ```
 
 ## Follow-Ups
 
-- Implement `SessionEnd`, blocking hook results, and hook output observability.
+- Implement `SessionEnd`, non-tool lifecycle dispatch, and hook output
+  observability.
 - Feed plugin `.mcp.json`, commands, skills, and agents into structured
   extension registries.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -141,6 +141,6 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin explicit plugin directory CLI surface for TUI sessions.
 - [x] Claude plugin explicit plugin directory config persistence.
 - [x] Claude plugin matcher evaluation for tool hooks.
-- [ ] Claude plugin lifecycle parity: `SessionEnd`, blocking results, and output observability.
+- [ ] Claude plugin lifecycle parity: `SessionEnd`, non-tool lifecycle dispatch, and output observability.
 - [ ] Claude plugin extension registries for `.mcp.json`, commands, skills, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -302,6 +302,7 @@ pub struct Agent {
     pub hook_registry: Option<Arc<crate::hooks::HookRegistry>>,
     pub hook_sandbox: Option<HookSandbox>,
     hook_runtime: Option<Arc<HookRuntime>>,
+    plugin_hook_runtime: Option<Arc<crate::plugin_middleware::PluginHookRuntime>>,
     pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
     pub file_search_candidates: Vec<RetrievalCandidate>,
     pub mcp_resource_candidates: Vec<RetrievalCandidate>,
@@ -333,6 +334,14 @@ impl Agent {
         self.hook_registry = Some(registry);
         self.hook_sandbox = Some(sandbox);
         self.hook_runtime = Some(runtime);
+    }
+
+    /// Configure Claude plugin hooks loaded for this runtime session.
+    pub(crate) fn set_plugin_hook_runtime(
+        &mut self,
+        runtime: Arc<crate::plugin_middleware::PluginHookRuntime>,
+    ) {
+        self.plugin_hook_runtime = Some(runtime);
     }
 
     /// Accumulate subagent (auxiliary model) cache statistics.
@@ -475,6 +484,7 @@ impl Agent {
             hook_registry: None,
             hook_sandbox: None,
             hook_runtime: None,
+            plugin_hook_runtime: None,
             retrieved_memory_candidates: Vec::new(),
             file_search_candidates: Vec::new(),
             mcp_resource_candidates: Vec::new(),
@@ -1599,6 +1609,21 @@ impl Agent {
                 if blocked {
                     continue;
                 }
+            }
+            if let Some(plugin_hooks) = self.plugin_hook_runtime.clone()
+                && let Some(block) = plugin_hooks.run_pre_tool_use(&tool_name, &tool_input).await
+            {
+                let error_text = format!(
+                    "Error: tool {} blocked by plugin hook {}: {}",
+                    tool_name, block.plugin_name, block.message
+                );
+                report(AgentEvent::ToolResult {
+                    name: tool_name.clone(),
+                    content: error_text.clone(),
+                    is_error: true,
+                });
+                tool_results.push(tool_result_message(&tool_id, error_text, true));
+                continue;
             }
             if let Some(tool) = self.tool_manager.get_tool(&tool_name) {
                 self.inspection_progress

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -3,5 +3,6 @@ mod context_view;
 mod dup_detection;
 mod microcompact;
 mod planning;
+mod plugin_hooks;
 mod stop_hooks;
 mod support;

--- a/src/agent/tests/plugin_hooks.rs
+++ b/src/agent/tests/plugin_hooks.rs
@@ -1,0 +1,143 @@
+use std::fs;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use rara_memory::vectordb::VectorDB;
+use rara_tool_macros::tool_spec;
+use rara_tools::tool::{Tool, ToolError, ToolManager};
+use serde_json::{Value, json};
+
+use super::support::{SequencedBackend, test_runtime_storage};
+use crate::agent::{Agent, AgentEvent, AgentOutputMode};
+use crate::hooks::{HookRegistry, HookSandbox};
+use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
+
+struct CountingTool {
+    calls: Arc<AtomicUsize>,
+}
+
+#[tool_spec(
+    name = "stub_tool",
+    description = "Return a simple structured result",
+    input_schema = { "type": "object" }
+)]
+#[async_trait]
+impl Tool for CountingTool {
+    async fn call(&self, _input: Value) -> Result<Value, ToolError> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(json!({ "status": "ok" }))
+    }
+}
+
+#[tokio::test]
+async fn plugin_pre_tool_use_continue_false_blocks_tool_execution() {
+    let (temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    write_blocking_plugin(temp.path());
+
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "tool-1".to_string(),
+                name: "stub_tool".to_string(),
+                input: json!({ "path": "src/lib.rs" }),
+            }],
+            stop_reason: Some("tool_use".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "blocked".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mut tool_manager = ToolManager::new();
+    tool_manager.register(Box::new(CountingTool {
+        calls: calls.clone(),
+    }));
+    let hook_runtime = Arc::new(crate::hook_runtime::HookRuntime::new(Arc::new(
+        crate::runtime_event_bus::RuntimeEventBus::new(4),
+    )));
+    let plugin_hooks = crate::plugin_middleware::register_plugin_hooks(
+        &hook_runtime,
+        None,
+        temp.path(),
+        &[],
+        "session-1",
+    )
+    .await;
+    let mut agent = Agent::new(
+        tool_manager,
+        backend.clone(),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.set_hook_context(
+        Arc::new(HookRegistry::new()),
+        HookSandbox {
+            workspace_root: temp.path().to_path_buf(),
+            ..HookSandbox::default()
+        },
+        hook_runtime,
+    );
+    agent.set_plugin_hook_runtime(plugin_hooks);
+    let mut events = Vec::new();
+
+    agent
+        .query_with_mode_and_events("run tool".to_string(), AgentOutputMode::Silent, |event| {
+            events.push(event)
+        })
+        .await
+        .expect("query");
+
+    assert_eq!(calls.load(Ordering::Relaxed), 0);
+    assert!(events.iter().any(|event| matches!(
+        event,
+        AgentEvent::ToolResult {
+            name,
+            content,
+            is_error: true
+        } if name == "stub_tool" && content.contains("blocked by policy")
+    )));
+    assert!(backend.observed_messages()[1].iter().any(|message| {
+        message.role == "user" && message.content.to_string().contains("blocked by policy")
+    }));
+}
+
+fn write_blocking_plugin(workspace_root: &std::path::Path) {
+    let root = workspace_root.join(".rara").join("plugins").join("blocker");
+    fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");
+    fs::write(
+        root.join(".claude-plugin").join("plugin.json"),
+        json!({
+            "name": "blocker",
+            "version": "1.0.0",
+            "description": "test blocker"
+        })
+        .to_string(),
+    )
+    .expect("plugin json");
+    fs::create_dir_all(root.join("hooks")).expect("hooks dir");
+    fs::write(
+        root.join("hooks").join("hooks.json"),
+        json!({
+            "PreToolUse": [{
+                "matcher": "stub_tool",
+                "hooks": [{
+                    "type": "command",
+                    "command": "cat > hook-input.json; echo '{\"continue\":false,\"reason\":\"blocked by policy\"}'",
+                    "timeout": 5
+                }]
+            }]
+        })
+        .to_string(),
+    )
+    .expect("hooks json");
+}

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -4,13 +4,100 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rara_plugins::{
-    HookEvent, HookInput, PluginDiscoverySource, PluginSource, discover_plugins_from_sources,
-    execute_command_hook,
+    HookEvent, HookInput, PluginDiscoverySource, PluginSource, RegisteredHook,
+    discover_plugins_from_sources, execute_command_hook,
 };
+use serde_json::Value;
 
 use crate::agent::AgentEvent;
 use crate::hook_runtime::HookRuntime;
 use crate::runtime_control::HookLifecycle;
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PluginHookRuntime {
+    session_id: String,
+    hooks: Vec<RegisteredHook>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PluginHookBlock {
+    pub plugin_name: String,
+    pub message: String,
+}
+
+impl PluginHookRuntime {
+    fn new(session_id: String, hooks: Vec<RegisteredHook>) -> Self {
+        Self { session_id, hooks }
+    }
+
+    #[cfg(test)]
+    fn hook_count(&self) -> usize {
+        self.hooks.len()
+    }
+
+    pub(crate) async fn run_pre_tool_use(
+        &self,
+        tool_name: &str,
+        tool_input: &Value,
+    ) -> Option<PluginHookBlock> {
+        for hook in self.matching_hooks(HookEvent::PreToolUse, tool_name) {
+            let input = self.hook_input(
+                HookEvent::PreToolUse,
+                hook,
+                Some(tool_name.to_string()),
+                Some(tool_input.clone()),
+                None,
+            );
+            let result = execute_command_hook(&hook.handler, &hook.plugin_root, input).await;
+            if !result.ok {
+                if !result.stderr.trim().is_empty() {
+                    eprintln!(
+                        "plugin hook {} failed: {} / {}",
+                        hook.plugin_name,
+                        result.exit_code.unwrap_or(-1),
+                        result.stderr
+                    );
+                }
+                return Some(PluginHookBlock {
+                    plugin_name: hook.plugin_name.clone(),
+                    message: plugin_hook_block_message(&result.stdout, &result.stderr),
+                });
+            }
+        }
+        None
+    }
+
+    fn matching_hooks(
+        &self,
+        event: HookEvent,
+        tool_name: &str,
+    ) -> impl Iterator<Item = &RegisteredHook> {
+        self.hooks.iter().filter(move |hook| {
+            hook.event == event
+                && is_command_hook(&hook.handler)
+                && hook_handler_matches_tool(&hook.handler, Some(tool_name))
+        })
+    }
+
+    fn hook_input(
+        &self,
+        event: HookEvent,
+        hook: &RegisteredHook,
+        tool_name: Option<String>,
+        tool_input: Option<Value>,
+        tool_response: Option<Value>,
+    ) -> HookInput {
+        HookInput {
+            session_id: self.session_id.clone(),
+            transcript_path: None,
+            hook_event: event.as_str().to_string(),
+            plugin_root: hook.plugin_root.to_string_lossy().to_string(),
+            tool_name,
+            tool_input,
+            tool_response,
+        }
+    }
+}
 
 fn agent_event_to_hook_event(event: &AgentEvent) -> Option<HookEvent> {
     match event {
@@ -32,13 +119,13 @@ fn hook_event_to_lifecycle(event: HookEvent) -> HookLifecycle {
     }
 }
 
-pub async fn register_plugin_hooks(
+pub(crate) async fn register_plugin_hooks(
     runtime: &Arc<HookRuntime>,
     rara_home: Option<PathBuf>,
     workspace_root: &Path,
     explicit_plugin_dirs: &[PathBuf],
     session_id: &str,
-) -> usize {
+) -> Arc<PluginHookRuntime> {
     let runtime = runtime.clone();
     let workspace_root = workspace_root.to_path_buf();
     let explicit_plugin_dirs = explicit_plugin_dirs.to_vec();
@@ -50,14 +137,16 @@ pub async fn register_plugin_hooks(
             &workspace_root,
             &explicit_plugin_dirs,
         );
-        register_plugin_hooks_blocking(&runtime, sources, &session_id)
+        let plugin_runtime = load_plugin_hooks_blocking(sources, &session_id);
+        register_plugin_hooks_blocking(&runtime, &plugin_runtime);
+        plugin_runtime
     })
     .await
     {
-        Ok(count) => count,
+        Ok(plugin_runtime) => Arc::new(plugin_runtime),
         Err(err) => {
             eprintln!("plugin hook registration task failed: {err}");
-            0
+            Arc::new(PluginHookRuntime::default())
         }
     }
 }
@@ -92,76 +181,91 @@ fn plugin_discovery_sources(
     sources
 }
 
-fn register_plugin_hooks_blocking(
-    runtime: &Arc<HookRuntime>,
+fn load_plugin_hooks_blocking(
     sources: Vec<PluginDiscoverySource>,
     session_id: &str,
-) -> usize {
+) -> PluginHookRuntime {
     let plugins = discover_plugins_from_sources(&sources);
+    let mut hooks = Vec::new();
+    for plugin in &plugins {
+        hooks.extend(rara_plugins::loader::registered_hooks_for_plugin(plugin));
+    }
+    PluginHookRuntime::new(session_id.to_string(), hooks)
+}
+
+fn register_plugin_hooks_blocking(
+    runtime: &Arc<HookRuntime>,
+    plugin_runtime: &PluginHookRuntime,
+) -> usize {
     let mut registered = 0usize;
 
-    for plugin in &plugins {
-        let registered_hooks = rara_plugins::loader::registered_hooks_for_plugin(plugin);
-        for rh in &registered_hooks {
-            let hook = rh.handler.clone();
-            let plugin_name = rh.plugin_name.clone();
-            let plugin_root = rh.plugin_root.clone();
-            let session_id = session_id.to_string();
-            let lifecycle = hook_event_to_lifecycle(rh.event);
-
-            let plugin_name_for_callback = plugin_name.clone();
-            let runtime_for_output = Arc::downgrade(runtime);
-            let callback = Box::new(move |event: &AgentEvent| {
-                if !hook_matches_agent_event(&hook, event) {
-                    return;
-                }
-                let Some(runtime_for_output) = runtime_for_output.upgrade() else {
-                    return;
-                };
-                let hook_event_name = match agent_event_to_hook_event(event) {
-                    Some(e) => e.as_str().to_string(),
-                    None => return,
-                };
-
-                let input = HookInput {
-                    session_id: session_id.clone(),
-                    transcript_path: None,
-                    hook_event: hook_event_name,
-                    plugin_root: plugin_root.to_string_lossy().to_string(),
-                    tool_name: extract_tool_name(event),
-                    tool_input: None,
-                };
-
-                let h = hook.clone();
-                let pr = plugin_root.clone();
-                let pn = plugin_name_for_callback.clone();
-                let r = runtime_for_output.clone();
-                tokio::task::spawn(async move {
-                    let result = execute_command_hook(&h, &pr, input).await;
-                    if !result.ok {
-                        eprintln!(
-                            "plugin hook {pn} failed: {} / {}",
-                            result.exit_code.unwrap_or(-1),
-                            result.stderr
-                        );
-                    }
-                    if !result.stdout.trim().is_empty() {
-                        r.push_output(result.stdout);
-                    }
-                });
-            });
-
-            runtime.register(
-                format!("{}-{}", plugin_name, rh.event.as_str()),
-                lifecycle,
-                callback,
-            );
-
-            registered += 1;
+    for rh in &plugin_runtime.hooks {
+        if rh.event == HookEvent::PreToolUse || !is_command_hook(&rh.handler) {
+            continue;
         }
+        let hook = rh.handler.clone();
+        let plugin_name = rh.plugin_name.clone();
+        let plugin_root = rh.plugin_root.clone();
+        let session_id = plugin_runtime.session_id.clone();
+        let lifecycle = hook_event_to_lifecycle(rh.event);
+
+        let plugin_name_for_callback = plugin_name.clone();
+        let runtime_for_output = Arc::downgrade(runtime);
+        let callback = Box::new(move |event: &AgentEvent| {
+            if !hook_matches_agent_event(&hook, event) {
+                return;
+            }
+            let Some(runtime_for_output) = runtime_for_output.upgrade() else {
+                return;
+            };
+            let hook_event_name = match agent_event_to_hook_event(event) {
+                Some(e) => e.as_str().to_string(),
+                None => return,
+            };
+
+            let input = HookInput {
+                session_id: session_id.clone(),
+                transcript_path: None,
+                hook_event: hook_event_name,
+                plugin_root: plugin_root.to_string_lossy().to_string(),
+                tool_name: extract_tool_name(event),
+                tool_input: extract_tool_input(event),
+                tool_response: extract_tool_response(event),
+            };
+
+            let h = hook.clone();
+            let pr = plugin_root.clone();
+            let pn = plugin_name_for_callback.clone();
+            let r = runtime_for_output.clone();
+            tokio::task::spawn(async move {
+                let result = execute_command_hook(&h, &pr, input).await;
+                if !result.ok {
+                    eprintln!(
+                        "plugin hook {pn} failed: {} / {}",
+                        result.exit_code.unwrap_or(-1),
+                        result.stderr
+                    );
+                }
+                if !result.stdout.trim().is_empty() {
+                    r.push_output(result.stdout);
+                }
+            });
+        });
+
+        runtime.register(
+            format!("{}-{}", plugin_name, rh.event.as_str()),
+            lifecycle,
+            callback,
+        );
+
+        registered += 1;
     }
 
     registered
+}
+
+fn is_command_hook(hook: &rara_plugins::HookHandler) -> bool {
+    hook.r#type.is_empty() || hook.r#type == "command"
 }
 
 fn extract_tool_name(event: &AgentEvent) -> Option<String> {
@@ -172,7 +276,27 @@ fn extract_tool_name(event: &AgentEvent) -> Option<String> {
     }
 }
 
+fn extract_tool_input(event: &AgentEvent) -> Option<Value> {
+    match event {
+        AgentEvent::ToolUse { input, .. } => Some(input.clone()),
+        _ => None,
+    }
+}
+
+fn extract_tool_response(event: &AgentEvent) -> Option<Value> {
+    match event {
+        AgentEvent::ToolResult { content, .. } => {
+            Some(serde_json::from_str(content).unwrap_or_else(|_| Value::String(content.clone())))
+        }
+        _ => None,
+    }
+}
+
 fn hook_matches_agent_event(hook: &rara_plugins::HookHandler, event: &AgentEvent) -> bool {
+    hook_handler_matches_tool(hook, extract_tool_name(event).as_deref())
+}
+
+fn hook_handler_matches_tool(hook: &rara_plugins::HookHandler, tool_name: Option<&str>) -> bool {
     let Some(matcher) = hook.matcher.as_deref() else {
         return true;
     };
@@ -180,10 +304,10 @@ fn hook_matches_agent_event(hook: &rara_plugins::HookHandler, event: &AgentEvent
     if matcher.is_empty() || matcher == "*" {
         return true;
     }
-    let Some(tool_name) = extract_tool_name(event) else {
+    let Some(tool_name) = tool_name else {
         return true;
     };
-    tool_name_matches(matcher, &tool_name)
+    tool_name_matches(matcher, tool_name)
 }
 
 fn tool_name_matches(matcher: &str, tool_name: &str) -> bool {
@@ -200,6 +324,25 @@ fn tool_name_matches(matcher: &str, tool_name: &str) -> bool {
                 .trim();
             tool_pattern == "*" || tool_pattern.eq_ignore_ascii_case(tool_name)
         })
+}
+
+fn plugin_hook_block_message(stdout: &str, stderr: &str) -> String {
+    if let Ok(parsed) = serde_json::from_str::<Value>(stdout) {
+        for key in ["stopReason", "reason", "systemMessage"] {
+            if let Some(message) = parsed.get(key).and_then(Value::as_str)
+                && !message.trim().is_empty()
+            {
+                return message.trim().to_string();
+            }
+        }
+    }
+    if !stderr.trim().is_empty() {
+        return stderr.trim().to_string();
+    }
+    if !stdout.trim().is_empty() {
+        return stdout.trim().to_string();
+    }
+    "blocked by plugin hook".to_string()
 }
 
 #[cfg(test)]
@@ -283,7 +426,7 @@ mod tests {
             register_plugin_hooks(&runtime, Some(rara_home), &workspace_root, &[], "session-1")
                 .await;
 
-        assert_eq!(registered, 2);
+        assert_eq!(registered.hook_count(), 2);
         assert_eq!(runtime.hook_count(), 2);
     }
 
@@ -335,6 +478,58 @@ mod tests {
         assert!(!hook_matches_agent_event(&bash_hook, &edit_event));
         assert!(hook_matches_agent_event(&edit_hook, &edit_event));
         assert!(!hook_matches_agent_event(&edit_hook, &bash_event));
+    }
+
+    #[test]
+    fn extracts_tool_result_content_for_post_tool_use_hooks() {
+        let event = AgentEvent::ToolResult {
+            name: "stub_tool".to_string(),
+            content: json!({ "status": "ok" }).to_string(),
+            is_error: false,
+        };
+
+        assert_eq!(
+            extract_tool_response(&event),
+            Some(json!({ "status": "ok" }))
+        );
+    }
+
+    #[test]
+    fn plugin_hook_block_message_falls_back_to_plain_stdout() {
+        assert_eq!(
+            plugin_hook_block_message("plain stdout failure", ""),
+            "plain stdout failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_control_stdout_is_not_buffered_as_context() {
+        let hook_runtime = HookRuntime::new(Arc::new(RuntimeEventBus::new(4)));
+        let dir = tempdir().expect("tempdir");
+        let plugin_root = dir.path().join("plugin");
+        fs::create_dir_all(&plugin_root).expect("plugin root");
+        let plugin_hooks = PluginHookRuntime::new(
+            "session-1".to_string(),
+            vec![rara_plugins::RegisteredHook {
+                event: HookEvent::PreToolUse,
+                handler: rara_plugins::HookHandler {
+                    r#type: "command".to_string(),
+                    command: "echo '{\"continue\":true}'".to_string(),
+                    timeout: 1,
+                    matcher: Some("stub_tool".to_string()),
+                    once: false,
+                },
+                plugin_name: "control".to_string(),
+                plugin_root,
+            }],
+        );
+
+        let block = plugin_hooks
+            .run_pre_tool_use("stub_tool", &json!({ "path": "src/lib.rs" }))
+            .await;
+
+        assert_eq!(block, None);
+        assert!(hook_runtime.blocking_drain_outputs().is_empty());
     }
 
     fn write_test_plugin(root: &Path, name: &str, command: &str) {

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -147,8 +147,8 @@ impl RuntimeBootstrap {
         let plugin_dirs = self.plugin_dirs.clone();
         let rara_home = self.rara_home.clone();
         let hook_runtime = self.hook_runtime.clone();
-        let parts = self.into_parts();
-        crate::plugin_middleware::register_plugin_hooks(
+        let mut parts = self.into_parts();
+        let plugin_hook_runtime = crate::plugin_middleware::register_plugin_hooks(
             &hook_runtime,
             rara_home,
             &workspace_root,
@@ -156,6 +156,7 @@ impl RuntimeBootstrap {
             &parts.0.session_id,
         )
         .await;
+        parts.0.set_plugin_hook_runtime(plugin_hook_runtime);
         parts
     }
 }


### PR DESCRIPTION
## Summary

- add a session-scoped plugin hook runtime that can run matching `PreToolUse` command hooks synchronously
- block tool execution when a plugin hook returns `continue:false`, exits non-zero, or times out
- pass structured `tool_input` into plugin hook stdin and cover the behavior with an agent regression test
- update the Claude plugin runtime spec, journal, and TODO to reflect the remaining lifecycle gaps

## Purpose

PR #729 moved plugin hook registration into runtime bootstrap. This follow-up closes the next runtime gap: plugin hooks that need to affect tool execution must return a decision at the agent/tool boundary instead of only emitting async output through the event bus.

## Related Issues

None.

## Testing

```bash
cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture
cargo test plugin_middleware::tests -- --nocapture
cargo check --locked --workspace --all-targets
cargo fmt --check
git diff --check
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
```

Note: focused test binaries still emit the existing macOS linker warning about `__eh_frame section too large`.
