### PR TITLE
feat(plugins): run session end hooks

### DIFF
--- a/crates/rara-plugins/src/exec.rs
+++ b/crates/rara-plugins/src/exec.rs
@@ -25,6 +25,8 @@ pub struct HookInput {
     pub tool_name: Option<String>,
     pub tool_input: Option<Value>,
     pub tool_response: Option<Value>,
+    pub last_assistant_message: Option<String>,
+    pub is_interrupt: Option<bool>,
 }
 
 /// Result of executing a command hook.
@@ -155,6 +157,8 @@ mod tests {
                 tool_name: None,
                 tool_input: None,
                 tool_response: None,
+                last_assistant_message: None,
+                is_interrupt: None,
             },
         )
         .await;
@@ -181,6 +185,8 @@ mod tests {
                 tool_name: None,
                 tool_input: None,
                 tool_response: None,
+                last_assistant_message: None,
+                is_interrupt: None,
             },
         )
         .await;
@@ -207,6 +213,8 @@ mod tests {
                 tool_name: None,
                 tool_input: None,
                 tool_response: None,
+                last_assistant_message: None,
+                is_interrupt: None,
             },
         )
         .await;

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -25,6 +25,7 @@ This spec covers:
   read exit code and stdout JSON (`{ continue: bool }`).
 - Synchronous `PreToolUse` command-hook blocking in the agent tool execution
   path.
+- `SessionEnd` command hooks on final agent-loop completion.
 - Timeout enforcement per hook (default 60s, configurable).
 - Integration with RARA's existing `HookRuntime` so plugin hooks fire on the
   same lifecycle events as built-in hooks.
@@ -182,7 +183,9 @@ wait_with_timeout(timeout_secs)
   "plugin_root": "/path/to/plugin",
   "tool_name": "Bash",        // only for tool events
   "tool_input": { "command": "git status" },
-  "tool_response": null       // reserved for PostToolUse
+  "tool_response": null,      // reserved for PostToolUse
+  "last_assistant_message": null,
+  "is_interrupt": null
 }
 ```
 
@@ -204,6 +207,17 @@ Non-blocking plugin events continue to register with `HookRuntime` and inject
 stdout into the model context before a later model turn. `PreToolUse` is not
 also registered through the async event-bus callback, so command hooks are not
 run twice.
+
+`SessionEnd` command hooks are not registered through the async event-bus
+callback because there is no ordinary tool event to translate. The agent loop
+executes them directly when the loop reaches a terminal completion or hard stop
+such as max-turn or token-budget exhaustion. Waiting states such as shell
+approval or plan-exit approval do not fire `SessionEnd` because the session is
+paused rather than complete. The hook input includes `last_assistant_message`
+when a final assistant message is available and `is_interrupt: false` for this
+non-interrupt path. `SessionEnd` hook failures are logged and do not block
+completion; stdout observability is reserved for a later structured output
+surface.
 
 ### Installation
 
@@ -255,6 +269,7 @@ scope for now.
 | Invalid JSON produces load_warnings | unit test |
 | `execute_command_hook` with working command | integration test (echo return code) |
 | `{ "continue": false }` blocks command hook execution | `cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture` |
+| `SessionEnd` receives final assistant payload | `cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |
 | `discover_plugins` skips non-directories | unit test |
@@ -303,12 +318,17 @@ Implemented in the first merged slice:
   `*` match all tools; exact tool names are matched case-insensitively; Claude
   Code-style tool patterns such as `Bash(*)` match by the tool name before the
   parenthesized input pattern; alternatives can be separated with `|` or `,`.
+- `SessionEnd` command hooks execute once when the agent loop reaches final
+  completion or a hard stop. They receive `hook_event: "SessionEnd"`, empty
+  tool fields, the best available `last_assistant_message`, and
+  `is_interrupt: false`. Approval waits and other resumable pauses do not fire
+  `SessionEnd`.
 
 Next implementation slices:
 
 1. Fix remaining lifecycle parity gaps before broad user-facing rollout:
-   `SessionEnd` mapping, structured hook output observability, and non-tool
-   lifecycle dispatch.
+   structured hook output observability and non-tool lifecycle dispatch beyond
+   `SessionEnd`.
 2. Add git-source install support on top of the existing local-directory
    `rara plugin install/list/remove` commands.
 3. Feed plugin `.mcp.json`, commands, skills, and agents into the same

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -214,10 +214,11 @@ executes them directly when the loop reaches a terminal completion or hard stop
 such as max-turn or token-budget exhaustion. Waiting states such as shell
 approval or plan-exit approval do not fire `SessionEnd` because the session is
 paused rather than complete. The hook input includes `last_assistant_message`
-when a final assistant message is available and `is_interrupt: false` for this
-non-interrupt path. `SessionEnd` hook failures are logged and do not block
-completion; stdout observability is reserved for a later structured output
-surface.
+when a final assistant message is available. Normal completion sends
+`is_interrupt: false`; model-turn cancellation sends `is_interrupt: true`
+before returning the cancellation error to the caller. `SessionEnd` hook
+failures are logged and do not block completion; stdout observability is
+reserved for a later structured output surface.
 
 ### Installation
 
@@ -270,6 +271,7 @@ scope for now.
 | `execute_command_hook` with working command | integration test (echo return code) |
 | `{ "continue": false }` blocks command hook execution | `cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture` |
 | `SessionEnd` receives final assistant payload | `cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture` |
+| `SessionEnd` marks cancelled model turns as interrupts | `cargo test agent::tests::plugin_hooks::plugin_session_end_marks_cancelled_model_turn_as_interrupt -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |
 | `discover_plugins` skips non-directories | unit test |
@@ -321,8 +323,9 @@ Implemented in the first merged slice:
 - `SessionEnd` command hooks execute once when the agent loop reaches final
   completion or a hard stop. They receive `hook_event: "SessionEnd"`, empty
   tool fields, the best available `last_assistant_message`, and
-  `is_interrupt: false`. Approval waits and other resumable pauses do not fire
-  `SessionEnd`.
+  `is_interrupt: false`. Cancelled model turns fire `SessionEnd` with
+  `is_interrupt: true` before returning the cancellation error. Approval waits
+  and other resumable pauses do not fire `SessionEnd`.
 
 Next implementation slices:
 

--- a/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
+++ b/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
@@ -46,6 +46,10 @@ non-TUI surfaces without the same runtime behavior.
 - `SessionEnd` payloads include empty tool fields, the best available
   `last_assistant_message`, and `is_interrupt: false`. Approval waits remain
   resumable pauses and do not fire `SessionEnd`.
+- Cancelled model turns fire `SessionEnd` with `is_interrupt: true` before the
+  cancellation error returns to the caller. Other runtime errors keep the
+  existing error and recovery behavior so recoverable continuation paths do not
+  run cleanup early.
 - This slice does not change non-tool lifecycle dispatch beyond `SessionEnd`,
   full structured hook output observability, or plugin extension registry
   ingestion.
@@ -65,6 +69,7 @@ cargo fmt --check
 git diff --check
 cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture
 cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture
+cargo test agent::tests::plugin_hooks::plugin_session_end_marks_cancelled_model_turn_as_interrupt -- --nocapture
 cargo test plugin_middleware::tests -- --nocapture
 ```
 

--- a/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
+++ b/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
@@ -39,8 +39,16 @@ non-TUI surfaces without the same runtime behavior.
   execution path at the agent tool boundary. `continue:false`, non-zero exits,
   and timeouts return an error tool result to the model and prevent the tool
   from running.
-- This slice does not change `SessionEnd`, non-tool lifecycle dispatch, full
-  structured hook output observability, or plugin extension registry ingestion.
+- Plugin `SessionEnd` command hooks run once when the agent loop reaches final
+  completion or a hard stop such as max-turn or token-budget exhaustion. The
+  agent invokes them directly instead of registering them through the async
+  event-bus callback because there is no ordinary tool event to translate.
+- `SessionEnd` payloads include empty tool fields, the best available
+  `last_assistant_message`, and `is_interrupt: false`. Approval waits remain
+  resumable pauses and do not fire `SessionEnd`.
+- This slice does not change non-tool lifecycle dispatch beyond `SessionEnd`,
+  full structured hook output observability, or plugin extension registry
+  ingestion.
 
 ## Validation
 
@@ -56,12 +64,13 @@ cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
 cargo fmt --check
 git diff --check
 cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture
+cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture
 cargo test plugin_middleware::tests -- --nocapture
 ```
 
 ## Follow-Ups
 
-- Implement `SessionEnd`, non-tool lifecycle dispatch, and hook output
+- Implement non-tool lifecycle dispatch beyond `SessionEnd` and hook output
   observability.
 - Feed plugin `.mcp.json`, commands, skills, and agents into structured
   extension registries.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -141,6 +141,7 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin explicit plugin directory CLI surface for TUI sessions.
 - [x] Claude plugin explicit plugin directory config persistence.
 - [x] Claude plugin matcher evaluation for tool hooks.
-- [ ] Claude plugin lifecycle parity: `SessionEnd`, non-tool lifecycle dispatch, and output observability.
+- [x] Claude plugin `SessionEnd` command hook dispatch.
+- [ ] Claude plugin lifecycle parity: non-tool lifecycle dispatch beyond `SessionEnd` and output observability.
 - [ ] Claude plugin extension registries for `.mcp.json`, commands, skills, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1047,7 +1047,15 @@ impl Agent {
                     });
                 }
             }
-            let mut turn_output = self.run_model_turn(output_mode, report).await?;
+            let mut turn_output = match self.run_model_turn(output_mode, report).await {
+                Ok(turn_output) => turn_output,
+                Err(err) if is_interrupt_error(&err) => {
+                    self.run_session_end_plugin_hooks(self.latest_assistant_message_text(), true)
+                        .await;
+                    return Err(err);
+                }
+                Err(err) => return Err(err),
+            };
             self.record_agent_turn_trace(&turn_output, *agentic_turns, None, None, false);
             self.last_query_plan_updated = turn_output.plan_updated;
             if !turn_output.tool_calls.is_empty() {
@@ -1281,13 +1289,23 @@ impl Agent {
             self.advance_plan_step();
             self.extend_history_for_next_turn(tool_results, report, *agentic_turns)?;
         }
-        if should_run_session_end_hooks && let Some(plugin_hooks) = self.plugin_hook_runtime.clone()
-        {
-            plugin_hooks
-                .run_session_end(session_end_last_assistant_message.as_deref())
+        if should_run_session_end_hooks {
+            self.run_session_end_plugin_hooks(session_end_last_assistant_message, false)
                 .await;
         }
         Ok(())
+    }
+
+    async fn run_session_end_plugin_hooks(
+        &self,
+        last_assistant_message: Option<String>,
+        is_interrupt: bool,
+    ) {
+        if let Some(plugin_hooks) = self.plugin_hook_runtime.clone() {
+            plugin_hooks
+                .run_session_end(last_assistant_message.as_deref(), is_interrupt)
+                .await;
+        }
     }
 
     fn latest_assistant_message_text(&self) -> Option<String> {
@@ -1886,6 +1904,18 @@ fn recoverable_runtime_error_kind(err: &anyhow::Error) -> Option<&'static str> {
     } else {
         None
     }
+}
+
+fn is_interrupt_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io_err| io_err.kind() == std::io::ErrorKind::Interrupted)
+            || cause
+                .to_string()
+                .to_ascii_lowercase()
+                .contains("cancelled by user")
+    })
 }
 
 fn recoverable_runtime_error_message(kind: &str, err: &anyhow::Error) -> Message {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -999,6 +999,8 @@ impl Agent {
     {
         let mut plan_exit_repair_attempts = 0usize;
         let mut stop_hook_continuations = 0usize;
+        let mut session_end_last_assistant_message: Option<String> = None;
+        let mut should_run_session_end_hooks = false;
         loop {
             if let Some(max) = self.max_turns
                 && *agentic_turns >= max
@@ -1009,6 +1011,8 @@ impl Agent {
                 report(AgentEvent::Status(format!(
                     "Agent reached max-turns limit ({max})",
                 )));
+                session_end_last_assistant_message = self.latest_assistant_message_text();
+                should_run_session_end_hooks = true;
                 break;
             }
             if let Some(budget) = self.token_budget
@@ -1022,6 +1026,8 @@ impl Agent {
                     "Agent reached token budget ({}/{budget})",
                     self.total_model_tokens()
                 )));
+                session_end_last_assistant_message = self.latest_assistant_message_text();
+                should_run_session_end_hooks = true;
                 break;
             }
             self.ensure_active_plan_step();
@@ -1119,6 +1125,8 @@ impl Agent {
                     false,
                 );
                 self.checkpoint_session()?;
+                session_end_last_assistant_message = self.latest_assistant_message_text();
+                should_run_session_end_hooks = true;
                 break;
             }
             let last_assistant_message = turn_output
@@ -1250,6 +1258,8 @@ impl Agent {
                     assistant_message_recorded,
                 );
                 self.complete_active_plan_step();
+                session_end_last_assistant_message = last_assistant_message;
+                should_run_session_end_hooks = true;
                 break;
             }
             *agentic_turns += 1;
@@ -1271,7 +1281,21 @@ impl Agent {
             self.advance_plan_step();
             self.extend_history_for_next_turn(tool_results, report, *agentic_turns)?;
         }
+        if should_run_session_end_hooks && let Some(plugin_hooks) = self.plugin_hook_runtime.clone()
+        {
+            plugin_hooks
+                .run_session_end(session_end_last_assistant_message.as_deref())
+                .await;
+        }
         Ok(())
+    }
+
+    fn latest_assistant_message_text(&self) -> Option<String> {
+        self.history
+            .iter()
+            .rev()
+            .find(|message| message.role == "assistant")
+            .and_then(message_text)
     }
 
     fn run_stop_hooks<F>(

--- a/src/agent/tests/plugin_hooks.rs
+++ b/src/agent/tests/plugin_hooks.rs
@@ -14,7 +14,32 @@ use serde_json::{Value, json};
 use super::support::{SequencedBackend, test_runtime_storage};
 use crate::agent::{Agent, AgentEvent, AgentOutputMode};
 use crate::hooks::{HookRegistry, HookSandbox};
-use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
+use crate::llm::{ContentBlock, LlmBackend, LlmResponse, TokenUsage};
+
+struct CancelledBackend;
+
+#[async_trait]
+impl LlmBackend for CancelledBackend {
+    async fn ask(
+        &self,
+        _messages: &[crate::agent::Message],
+        _tools: &[Value],
+    ) -> Result<LlmResponse> {
+        anyhow::bail!("cancelled by user")
+    }
+
+    async fn embed(&self, _text: &str) -> Result<Vec<f32>> {
+        Ok(vec![0.0; 8])
+    }
+
+    async fn summarize(
+        &self,
+        _messages: &[crate::agent::Message],
+        _instruction: &str,
+    ) -> Result<String> {
+        Ok("summary".to_string())
+    }
+}
 
 struct CountingTool {
     calls: Arc<AtomicUsize>,
@@ -181,6 +206,73 @@ async fn plugin_session_end_runs_once_with_last_assistant_message() {
         serde_json::Value::String("final answer".to_string())
     );
     assert_eq!(hook_input["is_interrupt"], serde_json::Value::Bool(false));
+    assert_eq!(
+        fs::read_to_string(plugin_root.join("session-end-count")).expect("count"),
+        "x"
+    );
+}
+
+#[tokio::test]
+async fn plugin_session_end_marks_cancelled_model_turn_as_interrupt() {
+    let (temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    write_session_end_plugin(temp.path());
+
+    let hook_runtime = Arc::new(crate::hook_runtime::HookRuntime::new(Arc::new(
+        crate::runtime_event_bus::RuntimeEventBus::new(4),
+    )));
+    let plugin_hooks = crate::plugin_middleware::register_plugin_hooks(
+        &hook_runtime,
+        None,
+        temp.path(),
+        &[],
+        "session-1",
+    )
+    .await;
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        Arc::new(CancelledBackend),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.history.push(crate::agent::Message {
+        role: "user".to_string(),
+        content: json!("complete"),
+    });
+    agent.set_hook_context(
+        Arc::new(HookRegistry::new()),
+        HookSandbox {
+            workspace_root: temp.path().to_path_buf(),
+            ..HookSandbox::default()
+        },
+        hook_runtime,
+    );
+    agent.set_plugin_hook_runtime(plugin_hooks);
+
+    let error = agent
+        .run_agent_loop_with_limit(AgentOutputMode::Silent, &mut |_| {}, &mut 0)
+        .await
+        .expect_err("agent loop should return cancellation");
+
+    assert!(error.to_string().contains("cancelled by user"));
+    let plugin_root = temp
+        .path()
+        .join(".rara")
+        .join("plugins")
+        .join("session-end");
+    let hook_input: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(plugin_root.join("session-end-input.json")).expect("hook input"),
+    )
+    .expect("valid hook input");
+    assert_eq!(
+        hook_input["hook_event"],
+        serde_json::Value::String("SessionEnd".to_string())
+    );
+    assert_eq!(hook_input["is_interrupt"], serde_json::Value::Bool(true));
+    assert_eq!(
+        hook_input["last_assistant_message"],
+        serde_json::Value::Null
+    );
     assert_eq!(
         fs::read_to_string(plugin_root.join("session-end-count")).expect("count"),
         "x"

--- a/src/agent/tests/plugin_hooks.rs
+++ b/src/agent/tests/plugin_hooks.rs
@@ -111,6 +111,82 @@ async fn plugin_pre_tool_use_continue_false_blocks_tool_execution() {
     }));
 }
 
+#[tokio::test]
+async fn plugin_session_end_runs_once_with_last_assistant_message() {
+    let (temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    write_session_end_plugin(temp.path());
+
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::Text {
+            text: "final answer".to_string(),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+    let hook_runtime = Arc::new(crate::hook_runtime::HookRuntime::new(Arc::new(
+        crate::runtime_event_bus::RuntimeEventBus::new(4),
+    )));
+    let plugin_hooks = crate::plugin_middleware::register_plugin_hooks(
+        &hook_runtime,
+        None,
+        temp.path(),
+        &[],
+        "session-1",
+    )
+    .await;
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.history.push(crate::agent::Message {
+        role: "user".to_string(),
+        content: json!("complete"),
+    });
+    agent.set_hook_context(
+        Arc::new(HookRegistry::new()),
+        HookSandbox {
+            workspace_root: temp.path().to_path_buf(),
+            ..HookSandbox::default()
+        },
+        hook_runtime,
+    );
+    agent.set_plugin_hook_runtime(plugin_hooks);
+
+    agent
+        .run_agent_loop_with_limit(AgentOutputMode::Silent, &mut |_| {}, &mut 0)
+        .await
+        .expect("agent loop");
+
+    let plugin_root = temp
+        .path()
+        .join(".rara")
+        .join("plugins")
+        .join("session-end");
+    let hook_input: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(plugin_root.join("session-end-input.json")).expect("hook input"),
+    )
+    .expect("valid hook input");
+    assert_eq!(
+        hook_input["hook_event"],
+        serde_json::Value::String("SessionEnd".to_string())
+    );
+    assert_eq!(hook_input["tool_name"], serde_json::Value::Null);
+    assert_eq!(hook_input["tool_input"], serde_json::Value::Null);
+    assert_eq!(hook_input["tool_response"], serde_json::Value::Null);
+    assert_eq!(
+        hook_input["last_assistant_message"],
+        serde_json::Value::String("final answer".to_string())
+    );
+    assert_eq!(hook_input["is_interrupt"], serde_json::Value::Bool(false));
+    assert_eq!(
+        fs::read_to_string(plugin_root.join("session-end-count")).expect("count"),
+        "x"
+    );
+}
+
 fn write_blocking_plugin(workspace_root: &std::path::Path) {
     let root = workspace_root.join(".rara").join("plugins").join("blocker");
     fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");
@@ -133,6 +209,39 @@ fn write_blocking_plugin(workspace_root: &std::path::Path) {
                 "hooks": [{
                     "type": "command",
                     "command": "cat > hook-input.json; echo '{\"continue\":false,\"reason\":\"blocked by policy\"}'",
+                    "timeout": 5
+                }]
+            }]
+        })
+        .to_string(),
+    )
+    .expect("hooks json");
+}
+
+fn write_session_end_plugin(workspace_root: &std::path::Path) {
+    let root = workspace_root
+        .join(".rara")
+        .join("plugins")
+        .join("session-end");
+    fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");
+    fs::write(
+        root.join(".claude-plugin").join("plugin.json"),
+        json!({
+            "name": "session-end",
+            "version": "1.0.0",
+            "description": "test session end"
+        })
+        .to_string(),
+    )
+    .expect("plugin json");
+    fs::create_dir_all(root.join("hooks")).expect("hooks dir");
+    fs::write(
+        root.join("hooks").join("hooks.json"),
+        json!({
+            "SessionEnd": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": "cat > \"$CLAUDE_PLUGIN_ROOT/session-end-input.json\"; printf x >> \"$CLAUDE_PLUGIN_ROOT/session-end-count\"",
                     "timeout": 5
                 }]
             }]

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -25,6 +25,15 @@ pub(crate) struct PluginHookBlock {
     pub message: String,
 }
 
+#[derive(Clone, Debug, Default)]
+struct HookInputFields {
+    tool_name: Option<String>,
+    tool_input: Option<Value>,
+    tool_response: Option<Value>,
+    last_assistant_message: Option<String>,
+    is_interrupt: Option<bool>,
+}
+
 impl PluginHookRuntime {
     fn new(session_id: String, hooks: Vec<RegisteredHook>) -> Self {
         Self { session_id, hooks }
@@ -40,13 +49,15 @@ impl PluginHookRuntime {
         tool_name: &str,
         tool_input: &Value,
     ) -> Option<PluginHookBlock> {
-        for hook in self.matching_hooks(HookEvent::PreToolUse, tool_name) {
+        for hook in self.matching_hooks(HookEvent::PreToolUse, Some(tool_name)) {
             let input = self.hook_input(
                 HookEvent::PreToolUse,
                 hook,
-                Some(tool_name.to_string()),
-                Some(tool_input.clone()),
-                None,
+                HookInputFields {
+                    tool_name: Some(tool_name.to_string()),
+                    tool_input: Some(tool_input.clone()),
+                    ..HookInputFields::default()
+                },
             );
             let result = execute_command_hook(&hook.handler, &hook.plugin_root, input).await;
             if !result.ok {
@@ -67,15 +78,38 @@ impl PluginHookRuntime {
         None
     }
 
+    pub(crate) async fn run_session_end(&self, last_assistant_message: Option<&str>) {
+        for hook in self.matching_hooks(HookEvent::SessionEnd, None) {
+            let input = self.hook_input(
+                HookEvent::SessionEnd,
+                hook,
+                HookInputFields {
+                    last_assistant_message: last_assistant_message.map(ToString::to_string),
+                    is_interrupt: Some(false),
+                    ..HookInputFields::default()
+                },
+            );
+            let result = execute_command_hook(&hook.handler, &hook.plugin_root, input).await;
+            if !result.ok {
+                eprintln!(
+                    "plugin hook {} failed: {} / {}",
+                    hook.plugin_name,
+                    result.exit_code.unwrap_or(-1),
+                    result.stderr
+                );
+            }
+        }
+    }
+
     fn matching_hooks(
         &self,
         event: HookEvent,
-        tool_name: &str,
+        tool_name: Option<&str>,
     ) -> impl Iterator<Item = &RegisteredHook> {
         self.hooks.iter().filter(move |hook| {
             hook.event == event
                 && is_command_hook(&hook.handler)
-                && hook_handler_matches_tool(&hook.handler, Some(tool_name))
+                && hook_handler_matches_tool(&hook.handler, tool_name)
         })
     }
 
@@ -83,18 +117,18 @@ impl PluginHookRuntime {
         &self,
         event: HookEvent,
         hook: &RegisteredHook,
-        tool_name: Option<String>,
-        tool_input: Option<Value>,
-        tool_response: Option<Value>,
+        fields: HookInputFields,
     ) -> HookInput {
         HookInput {
             session_id: self.session_id.clone(),
             transcript_path: None,
             hook_event: event.as_str().to_string(),
             plugin_root: hook.plugin_root.to_string_lossy().to_string(),
-            tool_name,
-            tool_input,
-            tool_response,
+            tool_name: fields.tool_name,
+            tool_input: fields.tool_input,
+            tool_response: fields.tool_response,
+            last_assistant_message: fields.last_assistant_message,
+            is_interrupt: fields.is_interrupt,
         }
     }
 }
@@ -200,7 +234,9 @@ fn register_plugin_hooks_blocking(
     let mut registered = 0usize;
 
     for rh in &plugin_runtime.hooks {
-        if rh.event == HookEvent::PreToolUse || !is_command_hook(&rh.handler) {
+        if matches!(rh.event, HookEvent::PreToolUse | HookEvent::SessionEnd)
+            || !is_command_hook(&rh.handler)
+        {
             continue;
         }
         let hook = rh.handler.clone();
@@ -231,6 +267,8 @@ fn register_plugin_hooks_blocking(
                 tool_name: extract_tool_name(event),
                 tool_input: extract_tool_input(event),
                 tool_response: extract_tool_response(event),
+                last_assistant_message: None,
+                is_interrupt: None,
             };
 
             let h = hook.clone();

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -78,14 +78,18 @@ impl PluginHookRuntime {
         None
     }
 
-    pub(crate) async fn run_session_end(&self, last_assistant_message: Option<&str>) {
+    pub(crate) async fn run_session_end(
+        &self,
+        last_assistant_message: Option<&str>,
+        is_interrupt: bool,
+    ) {
         for hook in self.matching_hooks(HookEvent::SessionEnd, None) {
             let input = self.hook_input(
                 HookEvent::SessionEnd,
                 hook,
                 HookInputFields {
                     last_assistant_message: last_assistant_message.map(ToString::to_string),
-                    is_interrupt: Some(false),
+                    is_interrupt: Some(is_interrupt),
                     ..HookInputFields::default()
                 },
             );


### PR DESCRIPTION
## Summary

- run Claude plugin `SessionEnd` command hooks from the agent loop when the loop reaches final completion or a hard stop
- extend plugin hook input payloads with `last_assistant_message` and `is_interrupt`
- add focused agent coverage for `SessionEnd` payload shape and single execution
- update the Claude plugin runtime spec, journal, and TODO list for the completed slice

## Motivation

This continues the Claude plugin runtime parity work after `PreToolUse` blocking hooks. `SessionEnd` is a runtime lifecycle behavior, so it is dispatched by the app-server runtime path instead of any TUI display state.

## Related Issues

None.

## Testing

```bash
cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture
cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture
cargo test plugin_middleware::tests -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
cargo fmt --check
git diff --check
```

Note: local test linking still emits the existing `ld: __eh_frame section too large` warning.
