### PR TITLE
feat(plugins): surface plugin skill summaries

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -936,6 +936,8 @@ fn render_available_skills_section(skills: &[PromptSkillSummary]) -> Option<Stri
          listed in the current skill listing or explicitly typed by the user — do not guess or invent \
          skill names from memory or training data. When a listed skill matches the user's request, \
          invoking it is a blocking first step before task-specific analysis or implementation. \
+         If a listed skill has `disable_model_invocation: true`, treat it as visible metadata only \
+         and do not invoke it with the `skill` tool. \
          Do not mention that a skill applies unless you actually invoke it, and if the skill body \
          is already injected in the current turn, follow it instead of invoking it again.\n\n\
          How to invoke:\n\
@@ -1397,6 +1399,7 @@ mod tests {
                 .text
                 .contains("invoking it is a blocking first step before task-specific analysis")
         );
+        assert!(effective.text.contains("disable_model_invocation: true"));
         assert!(
             effective
                 .text

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -26,6 +26,7 @@ This spec covers:
 - Synchronous `PreToolUse` command-hook blocking in the agent tool execution
   path.
 - `SessionEnd` command hooks on final agent-loop completion.
+- Prompt-visible summaries for plugin `skills/<name>/SKILL.md` directories.
 - Timeout enforcement per hook (default 60s, configurable).
 - Integration with RARA's existing `HookRuntime` so plugin hooks fire on the
   same lifecycle events as built-in hooks.
@@ -232,6 +233,16 @@ rara plugin remove clawmem
 Installation copies/clones the plugin to `~/.rara/plugins/<name>/`. For git
 URLs, a shallow clone is performed and kept for future updates.
 
+### Skill Extension Summaries
+
+Runtime bootstrap discovers `skills/<name>/SKILL.md` directories from loaded
+plugins and appends compact summaries to the agent's available-skill listing.
+Plugin skill names are exposed as `plugin_name:skill_name`, use
+`scope: "plugin"`, and set `disable_model_invocation: true` until plugin skill
+invocation is routed through the shared skill registry. This makes plugin skill
+availability visible to the model and control surfaces without implying that
+the existing `skill` tool can invoke those bodies yet.
+
 ## Contracts
 
 ### Crate API
@@ -272,6 +283,7 @@ scope for now.
 | `{ "continue": false }` blocks command hook execution | `cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture` |
 | `SessionEnd` receives final assistant payload | `cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture` |
 | `SessionEnd` marks cancelled model turns as interrupts | `cargo test agent::tests::plugin_hooks::plugin_session_end_marks_cancelled_model_turn_as_interrupt -- --nocapture` |
+| Plugin skills are prompt-visible summaries | `cargo test plugin_middleware::tests::registers_project_plugin_skill_summaries -- --nocapture` and `cargo test agent::tests::plugin_hooks::plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |
 | `discover_plugins` skips non-directories | unit test |
@@ -326,6 +338,10 @@ Implemented in the first merged slice:
   `is_interrupt: false`. Cancelled model turns fire `SessionEnd` with
   `is_interrupt: true` before returning the cancellation error. Approval waits
   and other resumable pauses do not fire `SessionEnd`.
+- Plugin `skills/<name>/SKILL.md` directories are exposed as prompt-visible
+  summaries with namespaced `plugin_name:skill_name` names and plugin scope.
+  They are marked `disable_model_invocation: true` because the `skill` tool
+  still reads from the local `SkillManager`, not from plugin extension roots.
 
 Next implementation slices:
 
@@ -335,7 +351,9 @@ Next implementation slices:
 2. Add git-source install support on top of the existing local-directory
    `rara plugin install/list/remove` commands.
 3. Feed plugin `.mcp.json`, commands, skills, and agents into the same
-   structured extension-source registries used by native RARA features.
+   structured extension-source registries used by native RARA features. Skills
+   already have prompt-visible summaries; invocation and reload integration
+   remain open.
 
 ## Open Risks
 

--- a/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
+++ b/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
@@ -50,9 +50,15 @@ non-TUI surfaces without the same runtime behavior.
   cancellation error returns to the caller. Other runtime errors keep the
   existing error and recovery behavior so recoverable continuation paths do not
   run cleanup early.
+- Plugin `skills/<name>/SKILL.md` directories are now discovered during runtime
+  plugin registration and appended to the agent's available-skill summaries as
+  `plugin_name:skill_name` entries with `scope: "plugin"`.
+- Plugin skill summaries set `disable_model_invocation: true`; this records
+  availability without pretending the existing `skill` tool can invoke plugin
+  skill bodies before the shared extension registry is wired through.
 - This slice does not change non-tool lifecycle dispatch beyond `SessionEnd`,
   full structured hook output observability, or plugin extension registry
-  ingestion.
+  invocation/reload ingestion.
 
 ## Validation
 
@@ -70,6 +76,8 @@ git diff --check
 cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture
 cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture
 cargo test agent::tests::plugin_hooks::plugin_session_end_marks_cancelled_model_turn_as_interrupt -- --nocapture
+cargo test plugin_middleware::tests::registers_project_plugin_skill_summaries -- --nocapture
+cargo test agent::tests::plugin_hooks::plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet -- --nocapture
 cargo test plugin_middleware::tests -- --nocapture
 ```
 
@@ -77,5 +85,5 @@ cargo test plugin_middleware::tests -- --nocapture
 
 - Implement non-tool lifecycle dispatch beyond `SessionEnd` and hook output
   observability.
-- Feed plugin `.mcp.json`, commands, skills, and agents into structured
-  extension registries.
+- Feed plugin `.mcp.json`, commands, skill invocation/reload, and agents into
+  structured extension registries.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -142,6 +142,7 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin explicit plugin directory config persistence.
 - [x] Claude plugin matcher evaluation for tool hooks.
 - [x] Claude plugin `SessionEnd` command hook dispatch.
+- [x] Claude plugin skill directory prompt summaries.
 - [ ] Claude plugin lifecycle parity: non-tool lifecycle dispatch beyond `SessionEnd` and output observability.
-- [ ] Claude plugin extension registries for `.mcp.json`, commands, skills, and agents.
+- [ ] Claude plugin extension registries for `.mcp.json`, commands, skill invocation/reload, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -5,7 +5,7 @@ use crate::context::{
     AssembledContext, AssembledTurnContext, ContextAssembler, RuntimeContextInputs,
     RuntimeInteractionInput, SharedTaskContextView,
 };
-use crate::prompt::{PromptSource, PromptSourceKind};
+use crate::prompt::{PromptSkillSummary, PromptSource, PromptSourceKind};
 use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 use crate::tasklist::TaskListStore;
 use crate::tool_result::ToolResultProjectionPolicy;
@@ -153,6 +153,21 @@ impl Agent {
         skill_source_registry: std::sync::Arc<SkillSourceRegistry>,
     ) {
         self.skill_source_registry = Some(skill_source_registry);
+    }
+
+    pub(crate) fn add_plugin_skill_summaries(
+        &mut self,
+        summaries: &[crate::plugin_middleware::PluginSkillSummary],
+    ) {
+        self.prompt_config
+            .available_skills
+            .extend(summaries.iter().map(|summary| PromptSkillSummary {
+                name: summary.name.clone(),
+                title: summary.title.clone(),
+                description: summary.description.clone(),
+                scope: "plugin".to_string(),
+                disable_model_invocation: true,
+            }));
     }
 
     pub fn set_lsp_manager(&mut self, lsp_manager: std::sync::Arc<crate::lsp_manager::LspManager>) {

--- a/src/agent/tests/plugin_hooks.rs
+++ b/src/agent/tests/plugin_hooks.rs
@@ -279,6 +279,31 @@ async fn plugin_session_end_marks_cancelled_model_turn_as_interrupt() {
     );
 }
 
+#[test]
+fn plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet() {
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        Arc::new(SequencedBackend::new(Vec::new())),
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+
+    agent.add_plugin_skill_summaries(&[crate::plugin_middleware::PluginSkillSummary {
+        name: "skillful:reviewer".to_string(),
+        title: Some("reviewer".to_string()),
+        description: "Inspect plugin-provided behavior.".to_string(),
+        path: std::path::PathBuf::from("/tmp/plugin/skills/reviewer/SKILL.md"),
+    }]);
+
+    assert_eq!(agent.prompt_config().available_skills.len(), 1);
+    let summary = &agent.prompt_config().available_skills[0];
+    assert_eq!(summary.name, "skillful:reviewer");
+    assert_eq!(summary.scope, "plugin");
+    assert!(summary.disable_model_invocation);
+}
+
 fn write_blocking_plugin(workspace_root: &std::path::Path) {
     let root = workspace_root.join(".rara").join("plugins").join("blocker");
     fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -1,10 +1,11 @@
-//! Bridge between `rara-plugins` and RARA's `HookRuntime`.
+//! Bridge between `rara-plugins` and RARA's runtime registries.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use rara_plugins::{
-    HookEvent, HookInput, PluginDiscoverySource, PluginSource, RegisteredHook,
+    HookEvent, HookInput, Plugin, PluginDiscoverySource, PluginSource, RegisteredHook,
     discover_plugins_from_sources, execute_command_hook,
 };
 use serde_json::Value;
@@ -17,12 +18,21 @@ use crate::runtime_control::HookLifecycle;
 pub(crate) struct PluginHookRuntime {
     session_id: String,
     hooks: Vec<RegisteredHook>,
+    skill_summaries: Vec<PluginSkillSummary>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PluginHookBlock {
     pub plugin_name: String,
     pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PluginSkillSummary {
+    pub name: String,
+    pub title: Option<String>,
+    pub description: String,
+    pub path: PathBuf,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -35,13 +45,25 @@ struct HookInputFields {
 }
 
 impl PluginHookRuntime {
-    fn new(session_id: String, hooks: Vec<RegisteredHook>) -> Self {
-        Self { session_id, hooks }
+    fn new(
+        session_id: String,
+        hooks: Vec<RegisteredHook>,
+        skill_summaries: Vec<PluginSkillSummary>,
+    ) -> Self {
+        Self {
+            session_id,
+            hooks,
+            skill_summaries,
+        }
     }
 
     #[cfg(test)]
     fn hook_count(&self) -> usize {
         self.hooks.len()
+    }
+
+    pub(crate) fn skill_summaries(&self) -> &[PluginSkillSummary] {
+        &self.skill_summaries
     }
 
     pub(crate) async fn run_pre_tool_use(
@@ -228,7 +250,50 @@ fn load_plugin_hooks_blocking(
     for plugin in &plugins {
         hooks.extend(rara_plugins::loader::registered_hooks_for_plugin(plugin));
     }
-    PluginHookRuntime::new(session_id.to_string(), hooks)
+    let skill_summaries = plugin_skill_summaries(&plugins);
+    PluginHookRuntime::new(session_id.to_string(), hooks, skill_summaries)
+}
+
+fn plugin_skill_summaries(plugins: &[Plugin]) -> Vec<PluginSkillSummary> {
+    let mut summaries = Vec::new();
+    for plugin in plugins {
+        let skills_dir = plugin.root.join("skills");
+        let Ok(entries) = fs::read_dir(&skills_dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let skill_md = path.join("SKILL.md");
+            if !skill_md.is_file() {
+                continue;
+            }
+            let Some(skill_name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let content = fs::read_to_string(&skill_md).unwrap_or_default();
+            summaries.push(PluginSkillSummary {
+                name: format!("{}:{skill_name}", plugin.name),
+                title: Some(skill_name.to_string()),
+                description: extract_plugin_skill_description(&content),
+                path: skill_md,
+            });
+        }
+    }
+    summaries.sort_by(|left, right| left.name.cmp(&right.name));
+    summaries
+}
+
+fn extract_plugin_skill_description(content: &str) -> String {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with('#') && trimmed != "---" {
+            return trimmed.to_string();
+        }
+    }
+    "No description provided.".to_string()
 }
 
 fn register_plugin_hooks_blocking(
@@ -473,6 +538,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn registers_project_plugin_skill_summaries() {
+        let dir = tempdir().expect("tempdir");
+        let rara_home = dir.path().join("home").join(".rara");
+        let workspace_root = dir.path().join("workspace");
+        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+        let plugin_root = project_plugins_dir.join("skillful");
+        write_test_plugin(&plugin_root, "skillful", "echo project");
+        fs::create_dir_all(plugin_root.join("skills").join("reviewer")).expect("skill dir");
+        fs::write(
+            plugin_root.join("skills").join("reviewer").join("SKILL.md"),
+            "# Reviewer\nInspect plugin-provided behavior.",
+        )
+        .expect("skill");
+
+        let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
+        let registered =
+            register_plugin_hooks(&runtime, Some(rara_home), &workspace_root, &[], "session-1")
+                .await;
+
+        assert_eq!(
+            registered.skill_summaries(),
+            &[PluginSkillSummary {
+                name: "skillful:reviewer".to_string(),
+                title: Some("reviewer".to_string()),
+                description: "Inspect plugin-provided behavior.".to_string(),
+                path: plugin_root.join("skills").join("reviewer").join("SKILL.md"),
+            }]
+        );
+    }
+
+    #[tokio::test]
     async fn plugin_callbacks_do_not_retain_hook_runtime_strong_reference() {
         let dir = tempdir().expect("tempdir");
         let rara_home = dir.path().join("home").join(".rara");
@@ -564,6 +660,7 @@ mod tests {
                 plugin_name: "control".to_string(),
                 plugin_root,
             }],
+            Vec::new(),
         );
 
         let block = plugin_hooks

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -287,13 +287,37 @@ fn plugin_skill_summaries(plugins: &[Plugin]) -> Vec<PluginSkillSummary> {
 }
 
 fn extract_plugin_skill_description(content: &str) -> String {
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if !trimmed.is_empty() && !trimmed.starts_with('#') && trimmed != "---" {
-            return trimmed.to_string();
+    let body = strip_leading_frontmatter(content);
+    for section in body.split("\n#") {
+        for line in section.lines() {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                return trimmed.to_string();
+            }
         }
     }
     "No description provided.".to_string()
+}
+
+fn strip_leading_frontmatter(content: &str) -> &str {
+    if !content
+        .lines()
+        .next()
+        .is_some_and(|line| line.trim() == "---")
+    {
+        return content;
+    }
+    let mut offset = 0usize;
+    for (index, line) in content.split_inclusive('\n').enumerate() {
+        offset += line.len();
+        if index == 0 {
+            continue;
+        }
+        if line.trim() == "---" {
+            return &content[offset..];
+        }
+    }
+    content
 }
 
 fn register_plugin_hooks_blocking(
@@ -565,6 +589,16 @@ mod tests {
                 description: "Inspect plugin-provided behavior.".to_string(),
                 path: plugin_root.join("skills").join("reviewer").join("SKILL.md"),
             }]
+        );
+    }
+
+    #[test]
+    fn plugin_skill_description_uses_first_markdown_body_section() {
+        let content = "---\nname: reviewer\ndescription: metadata\n---\n# Reviewer\nInspect plugin-provided behavior.\n\n## Details\nMore.";
+
+        assert_eq!(
+            extract_plugin_skill_description(content),
+            "Inspect plugin-provided behavior."
         );
     }
 

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -156,6 +156,9 @@ impl RuntimeBootstrap {
             &parts.0.session_id,
         )
         .await;
+        parts
+            .0
+            .add_plugin_skill_summaries(plugin_hook_runtime.skill_summaries());
         parts.0.set_plugin_hook_runtime(plugin_hook_runtime);
         parts
     }


### PR DESCRIPTION
## Summary

- discover plugin `skills/<name>/SKILL.md` directories during runtime plugin registration
- expose plugin skills as prompt-visible summaries using `plugin_name:skill_name` and `scope: "plugin"`
- mark plugin skill summaries as `disable_model_invocation: true` until plugin skill invocation is wired through the shared registry
- update the skill prompt guidance so disabled skill summaries are treated as metadata only
- update the plugin runtime spec, journal, and TODO list for this slice

## Motivation

This starts the plugin extension registry work after hook lifecycle parity. It keeps plugin extension handling in runtime bootstrap while avoiding a false contract that the existing `skill` tool can invoke plugin-provided skill bodies.

## Related Issues

None.

## Testing

```bash
cargo test plugin_middleware::tests::registers_project_plugin_skill_summaries -- --nocapture
cargo test agent::tests::plugin_hooks::plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet -- --nocapture
cargo test plugin_middleware::tests -- --nocapture
cargo test -p rara-instructions build_system_prompt_includes_skill_usage_guidance_without_listing -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
cargo fmt --check
git diff --check
```

Note: local test linking still emits the existing `ld: __eh_frame section too large` warning.
