### PR TITLE
feat(plugins): dispatch non-tool lifecycle hooks

### DIFF
--- a/crates/rara-plugins/src/exec.rs
+++ b/crates/rara-plugins/src/exec.rs
@@ -83,6 +83,7 @@ pub async fn execute_command_hook(
         let json = match serde_json::to_string(&input) {
             Ok(json) => json,
             Err(e) => {
+                let _ = child.start_kill();
                 return HookExecutionResult {
                     exit_code: Some(-1),
                     stdout: String::new(),
@@ -93,6 +94,7 @@ pub async fn execute_command_hook(
             }
         };
         if let Err(e) = stdin.write_all(json.as_bytes()).await {
+            let _ = child.start_kill();
             return HookExecutionResult {
                 exit_code: Some(-1),
                 stdout: String::new(),

--- a/crates/rara-plugins/src/exec.rs
+++ b/crates/rara-plugins/src/exec.rs
@@ -27,6 +27,7 @@ pub struct HookInput {
     pub tool_response: Option<Value>,
     pub last_assistant_message: Option<String>,
     pub is_interrupt: Option<bool>,
+    pub prompt: Option<String>,
 }
 
 /// Result of executing a command hook.
@@ -79,8 +80,27 @@ pub async fn execute_command_hook(
 
     // Write JSON input to stdin
     if let Some(mut stdin) = child.stdin.take() {
-        let json = serde_json::to_string(&input).unwrap_or_default();
-        let _ = stdin.write_all(json.as_bytes()).await;
+        let json = match serde_json::to_string(&input) {
+            Ok(json) => json,
+            Err(e) => {
+                return HookExecutionResult {
+                    exit_code: Some(-1),
+                    stdout: String::new(),
+                    stderr: format!("failed to encode hook input: {e}"),
+                    timed_out: false,
+                    ok: false,
+                };
+            }
+        };
+        if let Err(e) = stdin.write_all(json.as_bytes()).await {
+            return HookExecutionResult {
+                exit_code: Some(-1),
+                stdout: String::new(),
+                stderr: format!("failed to write hook input: {e}"),
+                timed_out: false,
+                ok: false,
+            };
+        }
         // Close stdin
         drop(stdin);
     }
@@ -159,6 +179,7 @@ mod tests {
                 tool_response: None,
                 last_assistant_message: None,
                 is_interrupt: None,
+                prompt: None,
             },
         )
         .await;
@@ -187,6 +208,7 @@ mod tests {
                 tool_response: None,
                 last_assistant_message: None,
                 is_interrupt: None,
+                prompt: None,
             },
         )
         .await;
@@ -215,6 +237,7 @@ mod tests {
                 tool_response: None,
                 last_assistant_message: None,
                 is_interrupt: None,
+                prompt: None,
             },
         )
         .await;

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -25,6 +25,8 @@ This spec covers:
   read exit code and stdout JSON (`{ continue: bool }`).
 - Synchronous `PreToolUse` command-hook blocking in the agent tool execution
   path.
+- Direct `SessionStart` and `UserPromptSubmit` command hooks from the agent
+  query path.
 - `SessionEnd` command hooks on final agent-loop completion.
 - Prompt-visible summaries for plugin `skills/<name>/SKILL.md` directories.
 - Timeout enforcement per hook (default 60s, configurable).
@@ -186,7 +188,8 @@ wait_with_timeout(timeout_secs)
   "tool_input": { "command": "git status" },
   "tool_response": null,      // reserved for PostToolUse
   "last_assistant_message": null,
-  "is_interrupt": null
+  "is_interrupt": null,
+  "prompt": null              // only populated for UserPromptSubmit
 }
 ```
 
@@ -208,6 +211,15 @@ Non-blocking plugin events continue to register with `HookRuntime` and inject
 stdout into the model context before a later model turn. `PreToolUse` is not
 also registered through the async event-bus callback, so command hooks are not
 run twice.
+
+`SessionStart` and `UserPromptSubmit` command hooks are executed directly by
+the agent query path instead of through the async event-bus callback.
+`SessionStart` fires once for each `Agent` instance before the first submitted
+prompt is compacted or appended to history. `UserPromptSubmit` fires once for
+each `query_with_mode_and_events` call and receives the submitted prompt in the
+`prompt` field. These lifecycle hooks are fire-and-log only for now: failures
+are logged and do not block the turn, and stdout is not injected into model
+context until the structured hook-output surface is designed.
 
 `SessionEnd` command hooks are not registered through the async event-bus
 callback because there is no ordinary tool event to translate. The agent loop
@@ -283,6 +295,7 @@ scope for now.
 | `{ "continue": false }` blocks command hook execution | `cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture` |
 | `SessionEnd` receives final assistant payload | `cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture` |
 | `SessionEnd` marks cancelled model turns as interrupts | `cargo test agent::tests::plugin_hooks::plugin_session_end_marks_cancelled_model_turn_as_interrupt -- --nocapture` |
+| `SessionStart` and `UserPromptSubmit` fire from agent queries | `cargo test agent::tests::plugin_hooks::plugin_non_tool_lifecycle_hooks_run_from_agent_query -- --nocapture` |
 | Plugin skills are prompt-visible summaries | `cargo test plugin_middleware::tests::registers_project_plugin_skill_summaries -- --nocapture` and `cargo test agent::tests::plugin_hooks::plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |
@@ -338,6 +351,11 @@ Implemented in the first merged slice:
   `is_interrupt: false`. Cancelled model turns fire `SessionEnd` with
   `is_interrupt: true` before returning the cancellation error. Approval waits
   and other resumable pauses do not fire `SessionEnd`.
+- `SessionStart` and `UserPromptSubmit` command hooks execute directly from
+  agent queries. `SessionStart` runs once per agent instance. `UserPromptSubmit`
+  runs once per submitted query and includes the submitted prompt. Both
+  lifecycle hooks are non-blocking and log failures without injecting stdout
+  into model context yet.
 - Plugin `skills/<name>/SKILL.md` directories are exposed as prompt-visible
   summaries with namespaced `plugin_name:skill_name` names and plugin scope.
   They are marked `disable_model_invocation: true` because the `skill` tool
@@ -346,8 +364,7 @@ Implemented in the first merged slice:
 Next implementation slices:
 
 1. Fix remaining lifecycle parity gaps before broad user-facing rollout:
-   structured hook output observability and non-tool lifecycle dispatch beyond
-   `SessionEnd`.
+   structured hook output observability for lifecycle hooks.
 2. Add git-source install support on top of the existing local-directory
    `rara plugin install/list/remove` commands.
 3. Feed plugin `.mcp.json`, commands, skills, and agents into the same
@@ -378,3 +395,4 @@ Next implementation slices:
 - `docs/journal/2026-07-20-plugin-dir-config.md`
 - `docs/journal/2026-07-20-plugin-hook-matchers.md`
 - `docs/journal/2026-07-20-plugin-runtime-bootstrap.md`
+- `docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md`

--- a/docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md
+++ b/docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md
@@ -1,0 +1,53 @@
+# Plugin Non-Tool Lifecycle Hooks
+
+## Summary
+
+RARA now dispatches plugin command hooks for `SessionStart` and
+`UserPromptSubmit` from the agent query path. This extends plugin lifecycle
+coverage beyond tool hooks and `SessionEnd` while keeping execution ownership in
+the app-server runtime rather than the TUI.
+
+## Scope
+
+- Added direct plugin hook runtime entry points for `SessionStart` and
+  `UserPromptSubmit`.
+- Fired `SessionStart` once per `Agent` instance before the first query mutates
+  conversation history.
+- Fired `UserPromptSubmit` once per submitted query with the prompt included in
+  hook stdin JSON.
+- Extended command-hook input with an optional `prompt` field.
+- Added an agent-level regression that proves `SessionStart` runs once and
+  `UserPromptSubmit` runs once per query.
+
+## Key Decisions
+
+- Non-tool lifecycle hooks are invoked directly by the agent instead of routed
+  through the async event-bus callback. The callback path only receives
+  concrete runtime events that can be translated from tool or stop activity.
+- `SessionStart` is an agent-session lifecycle event, not a process lifecycle
+  event. A resumed or rebuilt runtime receives a new agent instance and may fire
+  it again.
+- `UserPromptSubmit` receives the exact submitted prompt before compaction and
+  history repair run for that turn.
+- These hooks are currently fire-and-log only. A hook failure does not block the
+  user turn, and hook stdout is not injected into model context until a
+  structured hook-output surface is introduced.
+
+## Validation
+
+```bash
+cargo test agent::tests::plugin_hooks::plugin_non_tool_lifecycle_hooks_run_from_agent_query -- --nocapture
+cargo test plugin_middleware::tests -- --nocapture
+cargo test -p rara-plugins
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
+cargo fmt --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Add structured observability for non-blocking lifecycle hook stdout and
+  stderr.
+- Feed plugin `.mcp.json`, commands, skill invocation/reload, and agents into
+  structured extension registries.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -143,6 +143,7 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin matcher evaluation for tool hooks.
 - [x] Claude plugin `SessionEnd` command hook dispatch.
 - [x] Claude plugin skill directory prompt summaries.
-- [ ] Claude plugin lifecycle parity: non-tool lifecycle dispatch beyond `SessionEnd` and output observability.
+- [x] Claude plugin non-tool command hook dispatch for `SessionStart` and `UserPromptSubmit`.
+- [ ] Claude plugin lifecycle parity: structured hook output observability.
 - [ ] Claude plugin extension registries for `.mcp.json`, commands, skill invocation/reload, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1316,8 +1316,8 @@ impl Agent {
         if self.plugin_session_start_hooks_ran {
             return;
         }
-        self.plugin_session_start_hooks_ran = true;
         if let Some(plugin_hooks) = self.plugin_hook_runtime.clone() {
+            self.plugin_session_start_hooks_ran = true;
             plugin_hooks.run_session_start().await;
         }
     }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -303,6 +303,7 @@ pub struct Agent {
     pub hook_sandbox: Option<HookSandbox>,
     hook_runtime: Option<Arc<HookRuntime>>,
     plugin_hook_runtime: Option<Arc<crate::plugin_middleware::PluginHookRuntime>>,
+    plugin_session_start_hooks_ran: bool,
     pub retrieved_memory_candidates: Vec<RetrievedMemoryCandidate>,
     pub file_search_candidates: Vec<RetrievalCandidate>,
     pub mcp_resource_candidates: Vec<RetrievalCandidate>,
@@ -485,6 +486,7 @@ impl Agent {
             hook_sandbox: None,
             hook_runtime: None,
             plugin_hook_runtime: None,
+            plugin_session_start_hooks_ran: false,
             retrieved_memory_candidates: Vec::new(),
             file_search_candidates: Vec::new(),
             mcp_resource_candidates: Vec::new(),
@@ -540,6 +542,8 @@ impl Agent {
         self.inspection_progress = InspectionProgress::default();
         self.last_query_plan_updated = false;
         self.pending_plan_exit_tool_id = None;
+        self.run_plugin_session_start_hooks_once().await;
+        self.run_user_prompt_submit_plugin_hooks(&prompt).await;
         self.compact_if_needed_with_reporter(&mut report).await?;
         let repaired_history = repair_tool_result_history(&self.history);
         if repaired_history != self.history {
@@ -1305,6 +1309,22 @@ impl Agent {
             plugin_hooks
                 .run_session_end(last_assistant_message.as_deref(), is_interrupt)
                 .await;
+        }
+    }
+
+    async fn run_plugin_session_start_hooks_once(&mut self) {
+        if self.plugin_session_start_hooks_ran {
+            return;
+        }
+        self.plugin_session_start_hooks_ran = true;
+        if let Some(plugin_hooks) = self.plugin_hook_runtime.clone() {
+            plugin_hooks.run_session_start().await;
+        }
+    }
+
+    async fn run_user_prompt_submit_plugin_hooks(&self, prompt: &str) {
+        if let Some(plugin_hooks) = self.plugin_hook_runtime.clone() {
+            plugin_hooks.run_user_prompt_submit(prompt).await;
         }
     }
 

--- a/src/agent/tests/plugin_hooks.rs
+++ b/src/agent/tests/plugin_hooks.rs
@@ -396,6 +396,75 @@ async fn plugin_non_tool_lifecycle_hooks_run_from_agent_query() {
     assert_eq!(prompt_submit_input["tool_name"], serde_json::Value::Null);
 }
 
+#[tokio::test]
+async fn plugin_session_start_waits_until_plugin_runtime_is_attached() {
+    let (temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    write_non_tool_lifecycle_plugin(temp.path());
+
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "first answer".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "second answer".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+    let hook_runtime = Arc::new(crate::hook_runtime::HookRuntime::new(Arc::new(
+        crate::runtime_event_bus::RuntimeEventBus::new(4),
+    )));
+    let plugin_hooks = crate::plugin_middleware::register_plugin_hooks(
+        &hook_runtime,
+        None,
+        temp.path(),
+        &[],
+        "session-1",
+    )
+    .await;
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.set_hook_context(
+        Arc::new(HookRegistry::new()),
+        HookSandbox {
+            workspace_root: temp.path().to_path_buf(),
+            ..HookSandbox::default()
+        },
+        hook_runtime,
+    );
+
+    agent
+        .query_with_mode_and_events("first prompt".to_string(), AgentOutputMode::Silent, |_| {})
+        .await
+        .expect("first query");
+    agent.set_plugin_hook_runtime(plugin_hooks);
+    agent
+        .query_with_mode_and_events("second prompt".to_string(), AgentOutputMode::Silent, |_| {})
+        .await
+        .expect("second query");
+
+    let plugin_root = temp.path().join(".rara").join("plugins").join("lifecycle");
+    assert_eq!(
+        fs::read_to_string(plugin_root.join("session-start-count")).expect("session count"),
+        "x"
+    );
+    assert_eq!(
+        fs::read_to_string(plugin_root.join("prompt-submit-count")).expect("prompt count"),
+        "x"
+    );
+}
+
 fn write_blocking_plugin(workspace_root: &std::path::Path) {
     let root = workspace_root.join(".rara").join("plugins").join("blocker");
     fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");

--- a/src/agent/tests/plugin_hooks.rs
+++ b/src/agent/tests/plugin_hooks.rs
@@ -304,6 +304,98 @@ fn plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet() {
     assert!(summary.disable_model_invocation);
 }
 
+#[tokio::test]
+async fn plugin_non_tool_lifecycle_hooks_run_from_agent_query() {
+    let (temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    write_non_tool_lifecycle_plugin(temp.path());
+
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "first answer".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "second answer".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        },
+    ]));
+    let hook_runtime = Arc::new(crate::hook_runtime::HookRuntime::new(Arc::new(
+        crate::runtime_event_bus::RuntimeEventBus::new(4),
+    )));
+    let plugin_hooks = crate::plugin_middleware::register_plugin_hooks(
+        &hook_runtime,
+        None,
+        temp.path(),
+        &[],
+        "session-1",
+    )
+    .await;
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend,
+        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
+        session_manager,
+        workspace,
+    );
+    agent.set_hook_context(
+        Arc::new(HookRegistry::new()),
+        HookSandbox {
+            workspace_root: temp.path().to_path_buf(),
+            ..HookSandbox::default()
+        },
+        hook_runtime,
+    );
+    agent.set_plugin_hook_runtime(plugin_hooks);
+
+    agent
+        .query_with_mode_and_events("first prompt".to_string(), AgentOutputMode::Silent, |_| {})
+        .await
+        .expect("first query");
+    agent
+        .query_with_mode_and_events("second prompt".to_string(), AgentOutputMode::Silent, |_| {})
+        .await
+        .expect("second query");
+
+    let plugin_root = temp.path().join(".rara").join("plugins").join("lifecycle");
+    assert_eq!(
+        fs::read_to_string(plugin_root.join("session-start-count")).expect("session count"),
+        "x"
+    );
+    assert_eq!(
+        fs::read_to_string(plugin_root.join("prompt-submit-count")).expect("prompt count"),
+        "xx"
+    );
+    let session_start_input: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(plugin_root.join("session-start-input.json")).expect("session input"),
+    )
+    .expect("valid session input");
+    assert_eq!(
+        session_start_input["hook_event"],
+        serde_json::Value::String("SessionStart".to_string())
+    );
+    assert_eq!(session_start_input["prompt"], serde_json::Value::Null);
+
+    let prompt_submit_input: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(plugin_root.join("prompt-submit-input.json")).expect("prompt input"),
+    )
+    .expect("valid prompt input");
+    assert_eq!(
+        prompt_submit_input["hook_event"],
+        serde_json::Value::String("UserPromptSubmit".to_string())
+    );
+    assert_eq!(
+        prompt_submit_input["prompt"],
+        serde_json::Value::String("second prompt".to_string())
+    );
+    assert_eq!(prompt_submit_input["tool_name"], serde_json::Value::Null);
+}
+
 fn write_blocking_plugin(workspace_root: &std::path::Path) {
     let root = workspace_root.join(".rara").join("plugins").join("blocker");
     fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");
@@ -326,6 +418,46 @@ fn write_blocking_plugin(workspace_root: &std::path::Path) {
                 "hooks": [{
                     "type": "command",
                     "command": "cat > hook-input.json; echo '{\"continue\":false,\"reason\":\"blocked by policy\"}'",
+                    "timeout": 5
+                }]
+            }]
+        })
+        .to_string(),
+    )
+    .expect("hooks json");
+}
+
+fn write_non_tool_lifecycle_plugin(workspace_root: &std::path::Path) {
+    let root = workspace_root
+        .join(".rara")
+        .join("plugins")
+        .join("lifecycle");
+    fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");
+    fs::write(
+        root.join(".claude-plugin").join("plugin.json"),
+        json!({
+            "name": "lifecycle",
+            "version": "1.0.0",
+            "description": "test lifecycle hooks"
+        })
+        .to_string(),
+    )
+    .expect("plugin json");
+    fs::create_dir_all(root.join("hooks")).expect("hooks dir");
+    fs::write(
+        root.join("hooks").join("hooks.json"),
+        json!({
+            "SessionStart": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": "cat > \"$CLAUDE_PLUGIN_ROOT/session-start-input.json\"; printf x >> \"$CLAUDE_PLUGIN_ROOT/session-start-count\"",
+                    "timeout": 5
+                }]
+            }],
+            "UserPromptSubmit": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": "cat > \"$CLAUDE_PLUGIN_ROOT/prompt-submit-input.json\"; printf x >> \"$CLAUDE_PLUGIN_ROOT/prompt-submit-count\"",
                     "timeout": 5
                 }]
             }]

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -42,6 +42,7 @@ struct HookInputFields {
     tool_response: Option<Value>,
     last_assistant_message: Option<String>,
     is_interrupt: Option<bool>,
+    prompt: Option<String>,
 }
 
 impl PluginHookRuntime {
@@ -84,7 +85,7 @@ impl PluginHookRuntime {
             let result = execute_command_hook(&hook.handler, &hook.plugin_root, input).await;
             if !result.ok {
                 if !result.stderr.trim().is_empty() {
-                    eprintln!(
+                    log::warn!(
                         "plugin hook {} failed: {} / {}",
                         hook.plugin_name,
                         result.exit_code.unwrap_or(-1),
@@ -117,7 +118,38 @@ impl PluginHookRuntime {
             );
             let result = execute_command_hook(&hook.handler, &hook.plugin_root, input).await;
             if !result.ok {
-                eprintln!(
+                log::warn!(
+                    "plugin hook {} failed: {} / {}",
+                    hook.plugin_name,
+                    result.exit_code.unwrap_or(-1),
+                    result.stderr
+                );
+            }
+        }
+    }
+
+    pub(crate) async fn run_session_start(&self) {
+        self.run_unblocked_lifecycle(HookEvent::SessionStart, HookInputFields::default())
+            .await;
+    }
+
+    pub(crate) async fn run_user_prompt_submit(&self, prompt: &str) {
+        self.run_unblocked_lifecycle(
+            HookEvent::UserPromptSubmit,
+            HookInputFields {
+                prompt: Some(prompt.to_string()),
+                ..HookInputFields::default()
+            },
+        )
+        .await;
+    }
+
+    async fn run_unblocked_lifecycle(&self, event: HookEvent, fields: HookInputFields) {
+        for hook in self.matching_hooks(event, None) {
+            let input = self.hook_input(event, hook, fields.clone());
+            let result = execute_command_hook(&hook.handler, &hook.plugin_root, input).await;
+            if !result.ok {
+                log::warn!(
                     "plugin hook {} failed: {} / {}",
                     hook.plugin_name,
                     result.exit_code.unwrap_or(-1),
@@ -155,6 +187,7 @@ impl PluginHookRuntime {
             tool_response: fields.tool_response,
             last_assistant_message: fields.last_assistant_message,
             is_interrupt: fields.is_interrupt,
+            prompt: fields.prompt,
         }
     }
 }
@@ -205,7 +238,7 @@ pub(crate) async fn register_plugin_hooks(
     {
         Ok(plugin_runtime) => Arc::new(plugin_runtime),
         Err(err) => {
-            eprintln!("plugin hook registration task failed: {err}");
+            log::warn!("plugin hook registration task failed: {err}");
             Arc::new(PluginHookRuntime::default())
         }
     }
@@ -327,8 +360,13 @@ fn register_plugin_hooks_blocking(
     let mut registered = 0usize;
 
     for rh in &plugin_runtime.hooks {
-        if matches!(rh.event, HookEvent::PreToolUse | HookEvent::SessionEnd)
-            || !is_command_hook(&rh.handler)
+        if matches!(
+            rh.event,
+            HookEvent::PreToolUse
+                | HookEvent::SessionStart
+                | HookEvent::UserPromptSubmit
+                | HookEvent::SessionEnd
+        ) || !is_command_hook(&rh.handler)
         {
             continue;
         }
@@ -362,6 +400,7 @@ fn register_plugin_hooks_blocking(
                 tool_response: extract_tool_response(event),
                 last_assistant_message: None,
                 is_interrupt: None,
+                prompt: None,
             };
 
             let h = hook.clone();
@@ -371,7 +410,7 @@ fn register_plugin_hooks_blocking(
             tokio::task::spawn(async move {
                 let result = execute_command_hook(&h, &pr, input).await;
                 if !result.ok {
-                    eprintln!(
+                    log::warn!(
                         "plugin hook {pn} failed: {} / {}",
                         result.exit_code.unwrap_or(-1),
                         result.stderr

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -725,7 +725,7 @@ mod tests {
                 event: HookEvent::PreToolUse,
                 handler: rara_plugins::HookHandler {
                     r#type: "command".to_string(),
-                    command: "echo '{\"continue\":true}'".to_string(),
+                    command: "cat >/dev/null; echo '{\"continue\":true}'".to_string(),
                     timeout: 1,
                     matcher: Some("stub_tool".to_string()),
                     once: false,


### PR DESCRIPTION
## Summary

- Dispatch plugin `SessionStart` command hooks once per agent session.
- Dispatch plugin `UserPromptSubmit` command hooks once per submitted query with the submitted prompt in hook stdin JSON.
- Document the lifecycle boundary and keep structured hook output observability as the remaining follow-up.

## Motivation

RARA already supports plugin `PreToolUse` and `SessionEnd` command hooks through runtime-owned plugin middleware. The next parity gap is non-tool lifecycle dispatch that belongs in the app-server agent runtime rather than the TUI presentation layer.

## Implementation Notes

- `SessionStart` and `UserPromptSubmit` are invoked directly from the agent query path instead of through the async event-bus callback.
- These hooks are currently fire-and-log only: failures are reported with `log::warn!`, do not block the turn, and stdout is not injected into model context yet.
- `HookInput` now includes an optional `prompt` field for `UserPromptSubmit`.

## Related Issues

None.

## Testing

```bash
cargo test agent::tests::plugin_hooks::plugin_non_tool_lifecycle_hooks_run_from_agent_query -- --nocapture
cargo test plugin_middleware::tests -- --nocapture
cargo test -p rara-plugins
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
cargo fmt --check
git diff --check
```
