### PR TITLE
feat(plugins): publish hook output events

### DIFF
--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -217,9 +217,10 @@ the agent query path instead of through the async event-bus callback.
 `SessionStart` fires once for each `Agent` instance before the first submitted
 prompt is compacted or appended to history. `UserPromptSubmit` fires once for
 each `query_with_mode_and_events` call and receives the submitted prompt in the
-`prompt` field. These lifecycle hooks are fire-and-log only for now: failures
-are logged and do not block the turn, and stdout is not injected into model
-context until the structured hook-output surface is designed.
+`prompt` field. These lifecycle hooks do not block the turn. Their command
+stdout, stderr, exit code, timeout state, and success state are published as
+structured `RuntimeEvent::Hook(command_output)` control-plane events and are not
+injected into model context.
 
 `SessionEnd` command hooks are not registered through the async event-bus
 callback because there is no ordinary tool event to translate. The agent loop
@@ -231,7 +232,8 @@ when a final assistant message is available. Normal completion sends
 `is_interrupt: false`; model-turn cancellation sends `is_interrupt: true`
 before returning the cancellation error to the caller. `SessionEnd` hook
 failures are logged and do not block completion; stdout observability is
-reserved for a later structured output surface.
+published through the same structured hook command-output event used by other
+non-blocking lifecycle hooks.
 
 ### Installation
 
@@ -296,6 +298,7 @@ scope for now.
 | `SessionEnd` receives final assistant payload | `cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture` |
 | `SessionEnd` marks cancelled model turns as interrupts | `cargo test agent::tests::plugin_hooks::plugin_session_end_marks_cancelled_model_turn_as_interrupt -- --nocapture` |
 | `SessionStart` and `UserPromptSubmit` fire from agent queries | `cargo test agent::tests::plugin_hooks::plugin_non_tool_lifecycle_hooks_run_from_agent_query -- --nocapture` |
+| Lifecycle hook stdout/stderr publishes a structured control event | `cargo test plugin_middleware::tests::lifecycle_hook_output_is_published_as_structured_control_event -- --nocapture` and `cargo test runtime_control::tests::hook_command_output_uses_structured_wire_shape -- --nocapture` |
 | Plugin skills are prompt-visible summaries | `cargo test plugin_middleware::tests::registers_project_plugin_skill_summaries -- --nocapture` and `cargo test agent::tests::plugin_hooks::plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |
@@ -354,8 +357,11 @@ Implemented in the first merged slice:
 - `SessionStart` and `UserPromptSubmit` command hooks execute directly from
   agent queries. `SessionStart` runs once per agent instance. `UserPromptSubmit`
   runs once per submitted query and includes the submitted prompt. Both
-  lifecycle hooks are non-blocking and log failures without injecting stdout
-  into model context yet.
+  lifecycle hooks are non-blocking.
+- Non-blocking lifecycle hook stdout, stderr, exit code, timeout state, and
+  success state are published as `RuntimeEvent::Hook(command_output)` events on
+  the session control bus. These events are structured observability only and do
+  not feed model context.
 - Plugin `skills/<name>/SKILL.md` directories are exposed as prompt-visible
   summaries with namespaced `plugin_name:skill_name` names and plugin scope.
   They are marked `disable_model_invocation: true` because the `skill` tool
@@ -363,11 +369,9 @@ Implemented in the first merged slice:
 
 Next implementation slices:
 
-1. Fix remaining lifecycle parity gaps before broad user-facing rollout:
-   structured hook output observability for lifecycle hooks.
-2. Add git-source install support on top of the existing local-directory
+1. Add git-source install support on top of the existing local-directory
    `rara plugin install/list/remove` commands.
-3. Feed plugin `.mcp.json`, commands, skills, and agents into the same
+2. Feed plugin `.mcp.json`, commands, skills, and agents into the same
    structured extension-source registries used by native RARA features. Skills
    already have prompt-visible summaries; invocation and reload integration
    remain open.

--- a/docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md
+++ b/docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md
@@ -47,7 +47,25 @@ git diff --check
 
 ## Follow-Ups
 
-- Add structured observability for non-blocking lifecycle hook stdout and
-  stderr.
 - Feed plugin `.mcp.json`, commands, skill invocation/reload, and agents into
   structured extension registries.
+
+## Structured Output Observability
+
+RARA now publishes non-blocking lifecycle hook command output as structured
+control-plane events. `SessionStart`, `UserPromptSubmit`, and `SessionEnd`
+command hooks emit `RuntimeEvent::Hook(command_output)` when they produce
+stdout, stderr, or a failed execution result.
+
+The event includes plugin name, hook event name, stdout, stderr, exit code,
+timeout state, and success state. This keeps lifecycle hook output observable to
+app-server/control-plane subscribers without injecting that output into model
+context or changing hook blocking semantics.
+
+## Additional Validation
+
+```bash
+cargo test plugin_middleware::tests::lifecycle_hook_output_is_published_as_structured_control_event -- --nocapture
+cargo test runtime_control::tests::hook_command_output_uses_structured_wire_shape -- --nocapture
+cargo check --locked --workspace --all-targets
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -144,6 +144,6 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin `SessionEnd` command hook dispatch.
 - [x] Claude plugin skill directory prompt summaries.
 - [x] Claude plugin non-tool command hook dispatch for `SessionStart` and `UserPromptSubmit`.
-- [ ] Claude plugin lifecycle parity: structured hook output observability.
+- [x] Claude plugin lifecycle parity: structured hook output observability.
 - [ ] Claude plugin extension registries for `.mcp.json`, commands, skill invocation/reload, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 
 use crate::agent::AgentEvent;
-use crate::runtime_control::HookLifecycle;
+use crate::runtime_control::{HookEvent, HookLifecycle, RuntimeEvent};
 use crate::runtime_event_bus::RuntimeEventBus;
 
 /// A registered in-process hook combining a lifecycle trigger and a callback.
@@ -50,6 +50,12 @@ impl HookRuntime {
         if let Ok(mut guard) = self.outputs.lock() {
             guard.push(text);
         }
+    }
+
+    /// Publish structured plugin hook command output to control-plane
+    /// subscribers without injecting it into model context.
+    pub fn publish_plugin_hook_output(&self, event: HookEvent) -> usize {
+        self.bus.publish_control(RuntimeEvent::Hook(event))
     }
 
     /// Drain outputs synchronously (for use in non-async contexts).

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -2,7 +2,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use rara_plugins::{
     HookEvent, HookInput, Plugin, PluginDiscoverySource, PluginSource, RegisteredHook,
@@ -12,13 +12,14 @@ use serde_json::Value;
 
 use crate::agent::AgentEvent;
 use crate::hook_runtime::HookRuntime;
-use crate::runtime_control::HookLifecycle;
+use crate::runtime_control::{HookEvent as RuntimeHookEvent, HookLifecycle};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PluginHookRuntime {
     session_id: String,
     hooks: Vec<RegisteredHook>,
     skill_summaries: Vec<PluginSkillSummary>,
+    hook_runtime: Option<Weak<HookRuntime>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -50,11 +51,13 @@ impl PluginHookRuntime {
         session_id: String,
         hooks: Vec<RegisteredHook>,
         skill_summaries: Vec<PluginSkillSummary>,
+        hook_runtime: Option<Arc<HookRuntime>>,
     ) -> Self {
         Self {
             session_id,
             hooks,
             skill_summaries,
+            hook_runtime: hook_runtime.map(|runtime| Arc::downgrade(&runtime)),
         }
     }
 
@@ -117,6 +120,7 @@ impl PluginHookRuntime {
                 },
             );
             let result = execute_command_hook(&hook.handler, &hook.plugin_root, input).await;
+            self.publish_hook_output(hook, HookEvent::SessionEnd, &result);
             if !result.ok {
                 log::warn!(
                     "plugin hook {} failed: {} / {}",
@@ -148,6 +152,7 @@ impl PluginHookRuntime {
         for hook in self.matching_hooks(event, None) {
             let input = self.hook_input(event, hook, fields.clone());
             let result = execute_command_hook(&hook.handler, &hook.plugin_root, input).await;
+            self.publish_hook_output(hook, event, &result);
             if !result.ok {
                 log::warn!(
                     "plugin hook {} failed: {} / {}",
@@ -157,6 +162,29 @@ impl PluginHookRuntime {
                 );
             }
         }
+    }
+
+    fn publish_hook_output(
+        &self,
+        hook: &RegisteredHook,
+        event: HookEvent,
+        result: &rara_plugins::HookExecutionResult,
+    ) {
+        if result.stdout.trim().is_empty() && result.stderr.trim().is_empty() && result.ok {
+            return;
+        }
+        let Some(runtime) = self.hook_runtime.as_ref().and_then(Weak::upgrade) else {
+            return;
+        };
+        runtime.publish_plugin_hook_output(RuntimeHookEvent::CommandOutput {
+            plugin_name: hook.plugin_name.clone(),
+            hook_event: event.as_str().to_string(),
+            stdout: result.stdout.clone(),
+            stderr: result.stderr.clone(),
+            exit_code: result.exit_code,
+            timed_out: result.timed_out,
+            ok: result.ok,
+        });
     }
 
     fn matching_hooks(
@@ -230,7 +258,8 @@ pub(crate) async fn register_plugin_hooks(
             &workspace_root,
             &explicit_plugin_dirs,
         );
-        let plugin_runtime = load_plugin_hooks_blocking(sources, &session_id);
+        let plugin_runtime =
+            load_plugin_hooks_blocking(sources, &session_id, Some(runtime.clone()));
         register_plugin_hooks_blocking(&runtime, &plugin_runtime);
         plugin_runtime
     })
@@ -277,6 +306,7 @@ fn plugin_discovery_sources(
 fn load_plugin_hooks_blocking(
     sources: Vec<PluginDiscoverySource>,
     session_id: &str,
+    runtime: Option<Arc<HookRuntime>>,
 ) -> PluginHookRuntime {
     let plugins = discover_plugins_from_sources(&sources);
     let mut hooks = Vec::new();
@@ -284,7 +314,7 @@ fn load_plugin_hooks_blocking(
         hooks.extend(rara_plugins::loader::registered_hooks_for_plugin(plugin));
     }
     let skill_summaries = plugin_skill_summaries(&plugins);
-    PluginHookRuntime::new(session_id.to_string(), hooks, skill_summaries)
+    PluginHookRuntime::new(session_id.to_string(), hooks, skill_summaries, runtime)
 }
 
 fn plugin_skill_summaries(plugins: &[Plugin]) -> Vec<PluginSkillSummary> {
@@ -734,6 +764,7 @@ mod tests {
                 plugin_root,
             }],
             Vec::new(),
+            None,
         );
 
         let block = plugin_hooks
@@ -741,6 +772,52 @@ mod tests {
             .await;
 
         assert_eq!(block, None);
+        assert!(hook_runtime.blocking_drain_outputs().is_empty());
+    }
+
+    #[tokio::test]
+    async fn lifecycle_hook_output_is_published_as_structured_control_event() {
+        let bus = Arc::new(RuntimeEventBus::new(8));
+        let mut events = bus.subscribe_control();
+        let hook_runtime = Arc::new(HookRuntime::new(bus));
+        let dir = tempdir().expect("tempdir");
+        let plugin_root = dir.path().join("plugin");
+        fs::create_dir_all(&plugin_root).expect("plugin root");
+        let plugin_hooks = PluginHookRuntime::new(
+            "session-1".to_string(),
+            vec![rara_plugins::RegisteredHook {
+                event: HookEvent::SessionStart,
+                handler: rara_plugins::HookHandler {
+                    r#type: "command".to_string(),
+                    command: "cat >/dev/null; echo visible; echo warn >&2".to_string(),
+                    timeout: 1,
+                    matcher: None,
+                    once: false,
+                },
+                plugin_name: "observer".to_string(),
+                plugin_root,
+            }],
+            Vec::new(),
+            Some(hook_runtime.clone()),
+        );
+
+        plugin_hooks.run_session_start().await;
+
+        let event = events.try_recv().expect("hook output event");
+        assert_eq!(
+            event.event,
+            crate::runtime_control::RuntimeEvent::Hook(
+                crate::runtime_control::HookEvent::CommandOutput {
+                    plugin_name: "observer".to_string(),
+                    hook_event: "SessionStart".to_string(),
+                    stdout: "visible\n".to_string(),
+                    stderr: "warn\n".to_string(),
+                    exit_code: Some(0),
+                    timed_out: false,
+                    ok: true,
+                }
+            )
+        );
         assert!(hook_runtime.blocking_drain_outputs().is_empty());
     }
 

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -337,6 +337,15 @@ pub enum HookEvent {
         hook_id: String,
         reason: String,
     },
+    CommandOutput {
+        plugin_name: String,
+        hook_event: String,
+        stdout: String,
+        stderr: String,
+        exit_code: Option<i32>,
+        timed_out: bool,
+        ok: bool,
+    },
 }
 
 #[allow(dead_code)] // ACP protocol type — reserved for future lifecycle events
@@ -617,6 +626,39 @@ mod tests {
                     "type": "follow_up_queued",
                     "payload": {
                         "queue_len": 3
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn hook_command_output_uses_structured_wire_shape() {
+        let value = serde_json::to_value(RuntimeEvent::Hook(HookEvent::CommandOutput {
+            plugin_name: "observer".to_string(),
+            hook_event: "SessionStart".to_string(),
+            stdout: "visible\n".to_string(),
+            stderr: "warn\n".to_string(),
+            exit_code: Some(0),
+            timed_out: false,
+            ok: true,
+        }))
+        .unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "type": "hook",
+                "payload": {
+                    "type": "command_output",
+                    "payload": {
+                        "plugin_name": "observer",
+                        "hook_event": "SessionStart",
+                        "stdout": "visible\n",
+                        "stderr": "warn\n",
+                        "exit_code": 0,
+                        "timed_out": false,
+                        "ok": true
                     }
                 }
             })


### PR DESCRIPTION
## Summary

- Publish non-blocking plugin lifecycle hook command output as structured `RuntimeEvent::Hook(command_output)` events.
- Include plugin name, hook event name, stdout, stderr, exit code, timeout state, and success state in the control-plane payload.
- Keep lifecycle hook output out of model context while preserving existing non-blocking semantics.

## Motivation

`SessionStart`, `UserPromptSubmit`, and `SessionEnd` hooks were intentionally fire-and-log after PR #733. The remaining lifecycle parity gap was structured observability for stdout/stderr without injecting that output into the model prompt.

## Implementation Notes

- `HookRuntime` now exposes a narrow publisher for plugin hook output events.
- `PluginHookRuntime` stores a weak reference to the session hook runtime, so observability does not reintroduce a strong-reference lifecycle cycle.
- Lifecycle hooks publish output only when stdout/stderr is present or execution failed.

## Related Issues

None.

## Testing

```bash
cargo test plugin_middleware::tests::lifecycle_hook_output_is_published_as_structured_control_event -- --nocapture
cargo test runtime_control::tests::hook_command_output_uses_structured_wire_shape -- --nocapture
cargo test plugin_middleware::tests -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
cargo fmt --check
git diff --check
```
