### PR TITLE
feat(plugins): install plugins from git sources

### DIFF
--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -244,8 +244,13 @@ rara plugin list
 rara plugin remove clawmem
 ```
 
-Installation copies/clones the plugin to `~/.rara/plugins/<name>/`. For git
-URLs, a shallow clone is performed and kept for future updates.
+Installation copies the plugin into the current workspace's
+`.rara/plugins/<name>/` directory. Local directory sources are copied directly.
+Git sources (`https://`, `ssh://`, `git://`, `file://`, and `git@...`) are
+shallow-cloned to a temporary checkout, validated as Claude Code plugin
+directories, copied under the plugin name from `.claude-plugin/plugin.json`,
+and then removed from the temporary checkout location. Existing plugins require
+`--force` to replace.
 
 ### Skill Extension Summaries
 
@@ -366,12 +371,13 @@ Implemented in the first merged slice:
   summaries with namespaced `plugin_name:skill_name` names and plugin scope.
   They are marked `disable_model_invocation: true` because the `skill` tool
   still reads from the local `SkillManager`, not from plugin extension roots.
+- `rara plugin install <source>` accepts both local plugin directories and git
+  sources. Git sources are cloned with `git clone --depth 1` into a temporary
+  checkout before the existing plugin validation and workspace copy path runs.
 
 Next implementation slices:
 
-1. Add git-source install support on top of the existing local-directory
-   `rara plugin install/list/remove` commands.
-2. Feed plugin `.mcp.json`, commands, skills, and agents into the same
+1. Feed plugin `.mcp.json`, commands, skills, and agents into the same
    structured extension-source registries used by native RARA features. Skills
    already have prompt-visible summaries; invocation and reload integration
    remain open.

--- a/docs/journal/2026-06-14-plugin-cli.md
+++ b/docs/journal/2026-06-14-plugin-cli.md
@@ -13,7 +13,14 @@ under the plugin name from `.claude-plugin/plugin.json`. Existing plugins requir
 `--force` to replace. `remove` validates names before deleting so callers cannot
 escape the workspace plugin directory.
 
+Git sources are now accepted by the same install command. Sources beginning
+with `https://`, `ssh://`, `git://`, `file://`, or `git@` are cloned with
+`git clone --depth 1` into a temporary checkout, validated with the same
+`rara-plugins` loader path, copied into the workspace plugin directory, and
+then removed from the temporary checkout location. The installed plugin name
+still comes from `.claude-plugin/plugin.json`, not from the repository URL.
+
 Verification:
 
 - `cargo test app_cli -- --nocapture`
-
+- `cargo test plugin_cli -- --nocapture`

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -1099,7 +1099,7 @@ mod tests {
             .expect("parse plugin install");
         match cli.command.expect("command") {
             Commands::Plugin(PluginCommands::Install(args)) => {
-                assert_eq!(args.source, std::path::PathBuf::from("../my-plugin"));
+                assert_eq!(args.source, "../my-plugin");
                 assert!(args.force);
             }
             other => panic!("unexpected command: {other:?}"),

--- a/src/plugin_cli.rs
+++ b/src/plugin_cli.rs
@@ -1,12 +1,14 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 
 #[derive(Debug, clap::Args)]
 pub(crate) struct PluginInstallArgs {
-    /// Local plugin directory to install into .rara/plugins
-    pub(crate) source: PathBuf,
+    /// Local plugin directory or git URL to install into .rara/plugins
+    pub(crate) source: String,
 
     /// Replace an existing installed plugin with the same name
     #[arg(long)]
@@ -21,7 +23,7 @@ pub(crate) struct PluginRemoveArgs {
 
 #[derive(Debug, clap::Subcommand)]
 pub(crate) enum PluginCommands {
-    /// Install a local Claude Code plugin directory
+    /// Install a local Claude Code plugin directory or git source
     Install(PluginInstallArgs),
     /// List plugins installed in this workspace
     List,
@@ -82,23 +84,18 @@ fn list_plugins_for_workspace(workspace_root: &Path) -> Vec<rara_plugins::Plugin
 
 fn install_plugin_for_workspace(
     workspace_root: &Path,
-    source: &Path,
+    source: &str,
     force: bool,
 ) -> Result<String> {
-    let source = source
-        .canonicalize()
-        .with_context(|| format!("failed to resolve plugin source {}", source.display()))?;
-    if !source.is_dir() {
-        bail!("plugin source must be a directory: {}", source.display());
-    }
+    let source = resolve_install_source(source)?;
     let plugin = rara_plugins::load_plugin_with_source(
-        &source,
-        rara_plugins::PluginSource::Cli(source.clone()),
+        source.path(),
+        rara_plugins::PluginSource::Cli(source.path().to_path_buf()),
     )
     .with_context(|| {
         format!(
             "plugin source {} must contain .claude-plugin/plugin.json",
-            source.display()
+            source.path().display()
         )
     })?;
     let name = safe_plugin_name(&plugin.name)?;
@@ -109,7 +106,7 @@ fn install_plugin_for_workspace(
         let target_canonical = target
             .canonicalize()
             .with_context(|| format!("failed to resolve plugin target {}", target.display()))?;
-        if target_canonical == source {
+        if target_canonical == source.path() {
             bail!("plugin {name} is already installed at {}", target.display());
         }
         if !force {
@@ -125,8 +122,98 @@ fn install_plugin_for_workspace(
             plugins_dir.display()
         )
     })?;
-    copy_dir_recursive(&source, &target)?;
+    copy_dir_recursive(source.path(), &target)?;
     Ok(name)
+}
+
+struct ResolvedPluginSource {
+    path: PathBuf,
+    temp_root: Option<PathBuf>,
+}
+
+impl ResolvedPluginSource {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ResolvedPluginSource {
+    fn drop(&mut self) {
+        if let Some(temp_root) = self.temp_root.take()
+            && let Err(err) = fs::remove_dir_all(&temp_root)
+        {
+            log::warn!(
+                "failed to remove temporary plugin checkout {}: {err}",
+                temp_root.display()
+            );
+        }
+    }
+}
+
+fn resolve_install_source(source: &str) -> Result<ResolvedPluginSource> {
+    if is_git_source(source) {
+        return clone_git_plugin_source(source);
+    }
+    let path = PathBuf::from(source)
+        .canonicalize()
+        .with_context(|| format!("failed to resolve plugin source {source}"))?;
+    if !path.is_dir() {
+        bail!("plugin source must be a directory: {}", path.display());
+    }
+    Ok(ResolvedPluginSource {
+        path,
+        temp_root: None,
+    })
+}
+
+fn is_git_source(source: &str) -> bool {
+    source.starts_with("http://")
+        || source.starts_with("https://")
+        || source.starts_with("ssh://")
+        || source.starts_with("git://")
+        || source.starts_with("file://")
+        || source.starts_with("git@")
+}
+
+fn clone_git_plugin_source(source: &str) -> Result<ResolvedPluginSource> {
+    let temp_root = unique_plugin_checkout_dir();
+    let checkout = temp_root.join("checkout");
+    fs::create_dir_all(&temp_root).with_context(|| {
+        format!(
+            "failed to create temporary plugin checkout directory {}",
+            temp_root.display()
+        )
+    })?;
+    let output = Command::new("git")
+        .arg("clone")
+        .arg("--depth")
+        .arg("1")
+        .arg(source)
+        .arg(&checkout)
+        .output()
+        .with_context(|| format!("failed to run git clone for plugin source {source}"))?;
+    if !output.status.success() {
+        let _ = fs::remove_dir_all(&temp_root);
+        bail!(
+            "failed to clone plugin source {source}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(ResolvedPluginSource {
+        path: checkout,
+        temp_root: Some(temp_root),
+    })
+}
+
+fn unique_plugin_checkout_dir() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    std::env::temp_dir().join(format!(
+        "rara-plugin-install-{}-{nanos}",
+        std::process::id()
+    ))
 }
 
 fn remove_plugin_for_workspace(workspace_root: &Path, name: &str) -> Result<()> {
@@ -199,7 +286,8 @@ mod tests {
         write_test_plugin(&source, "test-plugin");
 
         let name =
-            install_plugin_for_workspace(workspace.path(), &source, false).expect("install plugin");
+            install_plugin_for_workspace(workspace.path(), &source.display().to_string(), false)
+                .expect("install plugin");
         assert_eq!(name, "test-plugin");
         assert!(
             workspace
@@ -224,11 +312,51 @@ mod tests {
         let source = source_parent.path().join("source-plugin");
         write_test_plugin(&source, "test-plugin");
 
-        install_plugin_for_workspace(workspace.path(), &source, false).expect("first install");
-        let err = install_plugin_for_workspace(workspace.path(), &source, false).unwrap_err();
+        install_plugin_for_workspace(workspace.path(), &source.display().to_string(), false)
+            .expect("first install");
+        let err =
+            install_plugin_for_workspace(workspace.path(), &source.display().to_string(), false)
+                .unwrap_err();
         assert!(format!("{err}").contains("--force"));
 
-        install_plugin_for_workspace(workspace.path(), &source, true).expect("force install");
+        install_plugin_for_workspace(workspace.path(), &source.display().to_string(), true)
+            .expect("force install");
+    }
+
+    #[test]
+    fn plugin_install_accepts_git_file_url_source() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let repo = tempfile::tempdir().expect("repo");
+        write_test_plugin(repo.path(), "git-plugin");
+        run_git(repo.path(), &["init"]);
+        run_git(repo.path(), &["add", "."]);
+        run_git(
+            repo.path(),
+            &[
+                "-c",
+                "user.name=RARA Test",
+                "-c",
+                "user.email=rara@example.test",
+                "commit",
+                "-m",
+                "add plugin",
+            ],
+        );
+        let source = format!("file://{}", repo.path().display());
+
+        let name = install_plugin_for_workspace(workspace.path(), &source, false)
+            .expect("install git plugin");
+
+        assert_eq!(name, "git-plugin");
+        assert!(
+            workspace
+                .path()
+                .join(".rara/plugins/git-plugin/.claude-plugin/plugin.json")
+                .exists()
+        );
+        let plugins = list_plugins_for_workspace(workspace.path());
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(plugins[0].name, "git-plugin");
     }
 
     #[test]
@@ -262,5 +390,19 @@ mod tests {
             .to_string(),
         )
         .expect("hooks json");
+    }
+
+    fn run_git(cwd: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/src/plugin_cli.rs
+++ b/src/plugin_cli.rs
@@ -139,14 +139,18 @@ impl ResolvedPluginSource {
 
 impl Drop for ResolvedPluginSource {
     fn drop(&mut self) {
-        if let Some(temp_root) = self.temp_root.take()
-            && let Err(err) = fs::remove_dir_all(&temp_root)
-        {
-            log::warn!(
-                "failed to remove temporary plugin checkout {}: {err}",
-                temp_root.display()
-            );
+        if let Some(temp_root) = self.temp_root.take() {
+            remove_temp_plugin_checkout(&temp_root);
         }
+    }
+}
+
+fn remove_temp_plugin_checkout(temp_root: &Path) {
+    if let Err(err) = fs::remove_dir_all(temp_root) {
+        log::warn!(
+            "failed to remove temporary plugin checkout {}: {err}",
+            temp_root.display()
+        );
     }
 }
 
@@ -184,25 +188,25 @@ fn clone_git_plugin_source(source: &str) -> Result<ResolvedPluginSource> {
             temp_root.display()
         )
     })?;
+    let source_guard = ResolvedPluginSource {
+        path: checkout,
+        temp_root: Some(temp_root),
+    };
     let output = Command::new("git")
         .arg("clone")
         .arg("--depth")
         .arg("1")
         .arg(source)
-        .arg(&checkout)
+        .arg(source_guard.path())
         .output()
         .with_context(|| format!("failed to run git clone for plugin source {source}"))?;
     if !output.status.success() {
-        let _ = fs::remove_dir_all(&temp_root);
         bail!(
             "failed to clone plugin source {source}: {}",
             String::from_utf8_lossy(&output.stderr).trim()
         );
     }
-    Ok(ResolvedPluginSource {
-        path: checkout,
-        temp_root: Some(temp_root),
-    })
+    Ok(source_guard)
 }
 
 fn unique_plugin_checkout_dir() -> PathBuf {


### PR DESCRIPTION
## Summary

- Allow `rara plugin install <source>` to accept git sources in addition to local plugin directories.
- Clone git sources with `git clone --depth 1` into a temporary checkout, then reuse the existing plugin validation and workspace copy path.
- Keep the installed plugin name sourced from `.claude-plugin/plugin.json`, not from the repository URL.

## Motivation

The plugin runtime spec already documents git-source installation as part of the intended plugin CLI surface. This closes that small install gap without adding marketplace browsing, update management, or extension registry loading.

## Related Issues

None.

## Testing

```bash
cargo test plugin_cli -- --nocapture
cargo test app_cli::tests::clap_parses_plugin_install -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings
cargo fmt --check
git diff --check
```
