### PR TITLE
feat(plugins): register plugin MCP configs

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::defaults::{
 };
 pub use self::mcp::{
     McpRegistry, McpServerConfig, McpServerScope, McpServerSource, McpServerTransport,
-    SourcedMcpServerConfig,
+    SourcedMcpServerConfig, load_mcp_servers_from_json_path,
 };
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{

--- a/crates/config/src/mcp.rs
+++ b/crates/config/src/mcp.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum McpServerScope {
     Project,
+    Plugin,
     Local,
     User,
     Enterprise,
@@ -19,6 +20,7 @@ impl McpServerScope {
     pub fn label(self) -> &'static str {
         match self {
             Self::Project => "project",
+            Self::Plugin => "plugin",
             Self::Local => "local",
             Self::User => "user",
             Self::Enterprise => "enterprise",
@@ -45,7 +47,7 @@ impl McpRegistry {
         }
     }
 
-    fn insert_source(
+    pub fn insert_source(
         &mut self,
         source: McpServerSource,
         servers: BTreeMap<String, McpServerConfig>,
@@ -152,12 +154,21 @@ pub fn load_mcp_registry(user_config_toml: &Path, project_root: &Path) -> Result
         &mut registry,
         &project_config,
         McpServerScope::Project,
-        |content| {
-            serde_json::from_str::<ProjectMcpConfig>(content).map(|config| config.mcp_servers)
-        },
+        parse_mcp_servers_json,
     )?;
 
     Ok(registry)
+}
+
+pub fn load_mcp_servers_from_json_path(path: &Path) -> Result<BTreeMap<String, McpServerConfig>> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    parse_mcp_servers_json(&content).with_context(|| format!("parse {}", path.display()))
+}
+
+fn parse_mcp_servers_json(
+    content: &str,
+) -> std::result::Result<BTreeMap<String, McpServerConfig>, serde_json::Error> {
+    serde_json::from_str::<ProjectMcpConfig>(content).map(|config| config.mcp_servers)
 }
 
 fn append_servers_from_path<E>(

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -321,6 +321,7 @@ scope for now.
 | Lifecycle hook stdout/stderr publishes a structured control event | `cargo test plugin_middleware::tests::lifecycle_hook_output_is_published_as_structured_control_event -- --nocapture` and `cargo test runtime_control::tests::hook_command_output_uses_structured_wire_shape -- --nocapture` |
 | Plugin skills are prompt-visible summaries | `cargo test plugin_middleware::tests::registers_project_plugin_skill_summaries -- --nocapture` and `cargo test agent::tests::plugin_hooks::plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet -- --nocapture` |
 | Plugin `.mcp.json` registers into the shared MCP registry | `cargo test plugin_middleware::tests::appends_plugin_mcp_configs_with_plugin_source_metadata -- --nocapture` |
+| Plugin MCP file and relative cwd handling | `cargo test plugin_middleware::tests::plugin_mcp_configs_skip_mcp_json_directories -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_resolve_relative_cwd_from_plugin_root -- --nocapture` |
 | Plugin MCP parse and duplicate-name failures surface | `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_duplicate_server_names -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_invalid_json -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -44,8 +44,9 @@ This spec covers:
   reasoning into the agent loop and require per-turn prompt assembly changes.
 - No `http`-type hook execution (external webhook POST).
 - No `agent`-type hook execution (sub-agent spawn for evaluation).
-- No MCP server lifecycle management (start, stop, reconnect). The MCP config
-  from `.mcp.json` is parsed but not yet launched.
+- No plugin-owned MCP lifecycle manager. Plugin `.mcp.json` files are registered
+  into RARA's shared MCP registry; connection, refresh, status, and tool-cache
+  behavior remain owned by the existing MCP runtime path.
 - No configSchema-driven UI forms or CLI prompt flows.
 - No plugin marketplace browsing from within RARA (just `install` from known
   sources).
@@ -262,6 +263,20 @@ invocation is routed through the shared skill registry. This makes plugin skill
 availability visible to the model and control surfaces without implying that
 the existing `skill` tool can invoke those bodies yet.
 
+### MCP Extension Registry
+
+Runtime bootstrap registers plugin `.mcp.json` files into the same source-aware
+`McpRegistry` used by user `config.toml` and workspace `.mcp.json` files.
+Plugin MCP entries use `scope: "plugin"` and keep the source path at the plugin
+`.mcp.json` file so `/mcp`, runtime-control events, ACP, Wire, and future
+app-server clients can display provenance without parsing plugin directories
+themselves.
+
+Plugin MCP server names do not override user or workspace MCP servers. A
+duplicate server name fails registry assembly with both source paths, matching
+the base MCP registry contract. Stdio plugin MCP servers receive `cwd` set to
+the plugin root when the existing MCP runtime later connects them.
+
 ## Contracts
 
 ### Crate API
@@ -305,6 +320,8 @@ scope for now.
 | `SessionStart` and `UserPromptSubmit` fire from agent queries | `cargo test agent::tests::plugin_hooks::plugin_non_tool_lifecycle_hooks_run_from_agent_query -- --nocapture` |
 | Lifecycle hook stdout/stderr publishes a structured control event | `cargo test plugin_middleware::tests::lifecycle_hook_output_is_published_as_structured_control_event -- --nocapture` and `cargo test runtime_control::tests::hook_command_output_uses_structured_wire_shape -- --nocapture` |
 | Plugin skills are prompt-visible summaries | `cargo test plugin_middleware::tests::registers_project_plugin_skill_summaries -- --nocapture` and `cargo test agent::tests::plugin_hooks::plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet -- --nocapture` |
+| Plugin `.mcp.json` registers into the shared MCP registry | `cargo test plugin_middleware::tests::appends_plugin_mcp_configs_with_plugin_source_metadata -- --nocapture` |
+| Plugin MCP parse and duplicate-name failures surface | `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_duplicate_server_names -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_invalid_json -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |
 | `discover_plugins` skips non-directories | unit test |
@@ -338,6 +355,9 @@ Implemented in the first merged slice:
 - TUI, `resume`, ask, print, headless exec, ACP, and Wire startup accept plugin
   directories from persisted `plugin_dirs` config and repeated
   `--plugin-dir <path>` global CLI flags.
+- Plugin `.mcp.json` definitions are converted into the shared MCP registry
+  with `plugin` scope, plugin-root `cwd` for stdio servers, and duplicate-name
+  conflict handling shared with user and project MCP sources.
   Configured directories are appended before CLI directories, and both are
   passed into plugin hook registration as the final explicit source tier. CLI
   plugin directories therefore override configured explicit directories, project

--- a/docs/features/mcp-runtime.md
+++ b/docs/features/mcp-runtime.md
@@ -34,6 +34,7 @@ RARA tracks MCP definitions with explicit scope provenance:
 
 - `user`: `~/.rara/config.toml`;
 - `project`: `<workspace>/.mcp.json`;
+- `plugin`: `<plugin-root>/.mcp.json` from loaded Claude Code plugins;
 - `local`: reserved for machine-local project settings;
 - `enterprise`: reserved for managed policy;
 - `builtin`: reserved for RARA-provided MCP surfaces.
@@ -189,6 +190,12 @@ large dynamic surfaces should be searched or referenced, not eagerly appended.
 - Source scope and path are preserved for every server.
 - Registry parsing is independent from TUI rendering and future connection
   startup.
+- Plugin MCP server definitions enter the same registry after user and project
+  config loading. Their source path is the plugin `.mcp.json` file, their scope
+  is `plugin`, and duplicate server names across user, project, and plugin
+  sources fail loudly instead of overriding.
+- Plugin stdio MCP servers run relative to the plugin root when they are
+  connected by the existing MCP refresh/tool-cache path.
 - `/mcp` renders the registry-derived status grouped by scope and source path.
 - `/mcp` must report parse/conflict failures instead of silently ignoring broken
   config.

--- a/docs/journal/2026-07-22-plugin-mcp-registry.md
+++ b/docs/journal/2026-07-22-plugin-mcp-registry.md
@@ -14,6 +14,8 @@ surface that consumes the registry sees the same plugin-provided servers.
 - The source path for each plugin MCP server is the plugin `.mcp.json` file.
 - Plugin stdio MCP servers receive `cwd` set to the plugin root so relative
   plugin launcher commands resolve from the installed plugin directory.
+- Plugin stdio MCP servers with explicit relative `cwd` values resolve those
+  paths from the plugin root.
 - Duplicate MCP server names across user, project, and plugin sources remain a
   hard registry error rather than a precedence override.
 - Commands, real skill invocation/reload, and plugin agent definitions remain
@@ -22,6 +24,8 @@ surface that consumes the registry sees the same plugin-provided servers.
 ## Validation
 
 - `cargo test plugin_middleware::tests::appends_plugin_mcp_configs_with_plugin_source_metadata -- --nocapture`
+- `cargo test plugin_middleware::tests::plugin_mcp_configs_resolve_relative_cwd_from_plugin_root -- --nocapture`
+- `cargo test plugin_middleware::tests::plugin_mcp_configs_skip_mcp_json_directories -- --nocapture`
 - `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_duplicate_server_names -- --nocapture`
 
 ## Follow-Ups

--- a/docs/journal/2026-07-22-plugin-mcp-registry.md
+++ b/docs/journal/2026-07-22-plugin-mcp-registry.md
@@ -1,0 +1,32 @@
+# Plugin MCP Registry
+
+## Summary
+
+Plugin `.mcp.json` files now feed RARA's shared MCP registry instead of staying
+as parsed plugin metadata. Runtime bootstrap combines user, project, and plugin
+MCP definitions before constructing the MCP connection manager, so every
+surface that consumes the registry sees the same plugin-provided servers.
+
+## Key Decisions
+
+- Plugin MCP entries use the existing `McpRegistry` boundary and a dedicated
+  `plugin` source scope.
+- The source path for each plugin MCP server is the plugin `.mcp.json` file.
+- Plugin stdio MCP servers receive `cwd` set to the plugin root so relative
+  plugin launcher commands resolve from the installed plugin directory.
+- Duplicate MCP server names across user, project, and plugin sources remain a
+  hard registry error rather than a precedence override.
+- Commands, real skill invocation/reload, and plugin agent definitions remain
+  separate extension-registry follow-ups.
+
+## Validation
+
+- `cargo test plugin_middleware::tests::appends_plugin_mcp_configs_with_plugin_source_metadata -- --nocapture`
+- `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_duplicate_server_names -- --nocapture`
+
+## Follow-Ups
+
+- Register plugin commands, skill invocation/reload, and plugin agents through
+  their shared runtime registries.
+- Continue control-plane readiness work for new plugin-provided extension
+  sources.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -145,5 +145,6 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin skill directory prompt summaries.
 - [x] Claude plugin non-tool command hook dispatch for `SessionStart` and `UserPromptSubmit`.
 - [x] Claude plugin lifecycle parity: structured hook output observability.
-- [ ] Claude plugin extension registries for `.mcp.json`, commands, skill invocation/reload, and agents.
+- [x] Claude plugin `.mcp.json` extension registry integration.
+- [ ] Claude plugin extension registries for commands, skill invocation/reload, and agents.
 - [ ] Control-plane readiness for new features

--- a/src/mcp_status.rs
+++ b/src/mcp_status.rs
@@ -173,6 +173,7 @@ fn transport_display(config: &McpServerConfig) -> (McpTransportKind, String) {
 fn scope_heading(scope: McpServerScope) -> &'static str {
     match scope {
         McpServerScope::Project => "Project",
+        McpServerScope::Plugin => "Plugin",
         McpServerScope::Local => "Local",
         McpServerScope::User => "User",
         McpServerScope::Enterprise => "Enterprise",

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -11,6 +11,10 @@ use rara_plugins::{
 use serde_json::Value;
 
 use crate::agent::AgentEvent;
+use crate::config::{
+    McpRegistry, McpServerConfig, McpServerScope, McpServerSource, McpServerTransport,
+    load_mcp_servers_from_json_path,
+};
 use crate::hook_runtime::HookRuntime;
 use crate::runtime_control::{HookEvent as RuntimeHookEvent, HookLifecycle};
 
@@ -273,6 +277,17 @@ pub(crate) async fn register_plugin_hooks(
     }
 }
 
+pub(crate) fn append_plugin_mcp_configs(
+    registry: &mut McpRegistry,
+    rara_home: Option<&Path>,
+    workspace_root: &Path,
+    explicit_plugin_dirs: &[PathBuf],
+) -> anyhow::Result<()> {
+    let sources = plugin_discovery_sources(rara_home, workspace_root, explicit_plugin_dirs);
+    let plugins = discover_plugins_from_sources(&sources);
+    append_plugin_mcp_configs_from_plugins(registry, &plugins)
+}
+
 fn plugin_discovery_sources(
     rara_home: Option<&Path>,
     workspace_root: &Path,
@@ -315,6 +330,42 @@ fn load_plugin_hooks_blocking(
     }
     let skill_summaries = plugin_skill_summaries(&plugins);
     PluginHookRuntime::new(session_id.to_string(), hooks, skill_summaries, runtime)
+}
+
+fn append_plugin_mcp_configs_from_plugins(
+    registry: &mut McpRegistry,
+    plugins: &[Plugin],
+) -> anyhow::Result<()> {
+    for plugin in plugins {
+        let mcp_path = plugin.root.join(".mcp.json");
+        if !mcp_path.exists() {
+            continue;
+        }
+        let mut servers = load_mcp_servers_from_json_path(&mcp_path)?;
+        apply_plugin_mcp_defaults(&mut servers, &plugin.root);
+        registry.insert_source(
+            McpServerSource {
+                scope: McpServerScope::Plugin,
+                path: mcp_path,
+            },
+            servers,
+        )?;
+    }
+    Ok(())
+}
+
+fn apply_plugin_mcp_defaults(
+    servers: &mut std::collections::BTreeMap<String, McpServerConfig>,
+    plugin_root: &Path,
+) {
+    for server in servers.values_mut() {
+        match &mut server.transport {
+            McpServerTransport::Stdio { cwd, .. } if cwd.is_none() => {
+                *cwd = Some(plugin_root.to_path_buf());
+            }
+            McpServerTransport::Stdio { .. } | McpServerTransport::StreamableHttp { .. } => {}
+        }
+    }
 }
 
 fn plugin_skill_summaries(plugins: &[Plugin]) -> Vec<PluginSkillSummary> {
@@ -662,6 +713,96 @@ mod tests {
     }
 
     #[test]
+    fn appends_plugin_mcp_configs_with_plugin_source_metadata() {
+        let dir = tempdir().expect("tempdir");
+        let workspace_root = dir.path().join("workspace");
+        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+        let plugin_root = project_plugins_dir.join("mcp-plugin");
+        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+        write_test_plugin_mcp_config(&plugin_root, "docs", "docs-server", &["--stdio"]);
+
+        let mut registry = McpRegistry::empty();
+        append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
+            .expect("append plugin mcp config");
+
+        let server = registry.servers.get("docs").expect("docs server");
+        assert_eq!(server.source.scope, McpServerScope::Plugin);
+        assert_eq!(server.source.path, plugin_root.join(".mcp.json"));
+        assert_eq!(
+            server.config.transport,
+            McpServerTransport::Stdio {
+                command: "docs-server".to_string(),
+                args: vec!["--stdio".to_string()],
+                env: None,
+                cwd: Some(plugin_root),
+            }
+        );
+    }
+
+    #[test]
+    fn plugin_mcp_configs_fail_on_duplicate_server_names() {
+        let dir = tempdir().expect("tempdir");
+        let workspace_root = dir.path().join("workspace");
+        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+        let plugin_root = project_plugins_dir.join("mcp-plugin");
+        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+        write_test_plugin_mcp_config(&plugin_root, "docs", "docs-server", &[]);
+
+        let mut registry = McpRegistry::empty();
+        registry
+            .insert_source(
+                McpServerSource {
+                    scope: McpServerScope::Project,
+                    path: workspace_root.join(".mcp.json"),
+                },
+                std::collections::BTreeMap::from([(
+                    "docs".to_string(),
+                    McpServerConfig {
+                        transport: McpServerTransport::Stdio {
+                            command: "project-docs".to_string(),
+                            args: Vec::new(),
+                            env: None,
+                            cwd: None,
+                        },
+                        enabled: true,
+                        required: false,
+                        supports_parallel_tool_calls: false,
+                        startup_timeout_sec: None,
+                        tool_timeout_sec: None,
+                        enabled_tools: None,
+                        disabled_tools: None,
+                    },
+                )]),
+            )
+            .expect("insert project source");
+
+        let err = append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
+            .expect_err("duplicate server should fail");
+
+        let message = err.to_string();
+        assert!(message.contains("MCP server `docs` is defined in both project"));
+        assert!(message.contains("plugin"));
+    }
+
+    #[test]
+    fn plugin_mcp_configs_fail_on_invalid_json() {
+        let dir = tempdir().expect("tempdir");
+        let workspace_root = dir.path().join("workspace");
+        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+        let plugin_root = project_plugins_dir.join("mcp-plugin");
+        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+        fs::write(plugin_root.join(".mcp.json"), "{invalid json").expect("mcp json");
+
+        let mut registry = McpRegistry::empty();
+        let err = append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
+            .expect_err("invalid plugin mcp json should fail");
+
+        let message = err.to_string();
+        assert!(message.contains("parse"));
+        assert!(message.contains(".mcp.json"));
+    }
+
+    #[test]
     fn plugin_skill_description_uses_first_markdown_body_section() {
         let content = "---\nname: reviewer\ndescription: metadata\n---\n# Reviewer\nInspect plugin-provided behavior.\n\n## Details\nMore.";
 
@@ -848,5 +989,21 @@ mod tests {
             .to_string(),
         )
         .expect("hooks json");
+    }
+
+    fn write_test_plugin_mcp_config(root: &Path, name: &str, command: &str, args: &[&str]) {
+        fs::write(
+            root.join(".mcp.json"),
+            json!({
+                "mcpServers": {
+                    name: {
+                        "command": command,
+                        "args": args
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("mcp json");
     }
 }

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -338,7 +338,7 @@ fn append_plugin_mcp_configs_from_plugins(
 ) -> anyhow::Result<()> {
     for plugin in plugins {
         let mcp_path = plugin.root.join(".mcp.json");
-        if !mcp_path.exists() {
+        if !mcp_path.is_file() {
             continue;
         }
         let mut servers = load_mcp_servers_from_json_path(&mcp_path)?;
@@ -360,10 +360,15 @@ fn apply_plugin_mcp_defaults(
 ) {
     for server in servers.values_mut() {
         match &mut server.transport {
-            McpServerTransport::Stdio { cwd, .. } if cwd.is_none() => {
-                *cwd = Some(plugin_root.to_path_buf());
+            McpServerTransport::Stdio { cwd, .. } => {
+                let resolved = match cwd.take() {
+                    Some(path) if path.is_absolute() => path,
+                    Some(path) => plugin_root.join(path),
+                    None => plugin_root.to_path_buf(),
+                };
+                *cwd = Some(resolved);
             }
-            McpServerTransport::Stdio { .. } | McpServerTransport::StreamableHttp { .. } => {}
+            McpServerTransport::StreamableHttp { .. } => {}
         }
     }
 }
@@ -737,6 +742,59 @@ mod tests {
                 cwd: Some(plugin_root),
             }
         );
+    }
+
+    #[test]
+    fn plugin_mcp_configs_resolve_relative_cwd_from_plugin_root() {
+        let dir = tempdir().expect("tempdir");
+        let workspace_root = dir.path().join("workspace");
+        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+        let plugin_root = project_plugins_dir.join("mcp-plugin");
+        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+        fs::write(
+            plugin_root.join(".mcp.json"),
+            json!({
+                "mcpServers": {
+                    "docs": {
+                        "command": "docs-server",
+                        "cwd": "server"
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("mcp json");
+
+        let mut registry = McpRegistry::empty();
+        append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
+            .expect("append plugin mcp config");
+
+        let server = registry.servers.get("docs").expect("docs server");
+        assert_eq!(
+            server.config.transport,
+            McpServerTransport::Stdio {
+                command: "docs-server".to_string(),
+                args: Vec::new(),
+                env: None,
+                cwd: Some(plugin_root.join("server")),
+            }
+        );
+    }
+
+    #[test]
+    fn plugin_mcp_configs_skip_mcp_json_directories() {
+        let dir = tempdir().expect("tempdir");
+        let workspace_root = dir.path().join("workspace");
+        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+        let plugin_root = project_plugins_dir.join("mcp-plugin");
+        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+        fs::create_dir_all(plugin_root.join(".mcp.json")).expect("mcp json dir");
+
+        let mut registry = McpRegistry::empty();
+        append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
+            .expect("directory should be skipped");
+
+        assert!(registry.servers.is_empty());
     }
 
     #[test]

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -311,9 +311,15 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
 
     let config_manager = crate::config::ConfigManager::new()?;
     let rara_home = ensure_rara_home_dir()?;
-    let mcp_registry = config_manager
-        .load_mcp_registry_for_project(&rara_home)
+    let mut mcp_registry = config_manager
+        .load_mcp_registry_for_project(&workspace.root)
         .unwrap_or_else(|_| crate::config::McpRegistry::empty());
+    crate::plugin_middleware::append_plugin_mcp_configs(
+        &mut mcp_registry,
+        Some(&rara_home),
+        &workspace.root,
+        &options.plugin_dirs,
+    )?;
     let mcp_registry = Arc::new(mcp_registry);
 
     let mcp_manager = Arc::new(McpConnectionManager::new(


### PR DESCRIPTION
## Summary

- Register Claude plugin `.mcp.json` files into RARA's shared MCP registry with `plugin` source provenance.
- Reuse the existing MCP JSON parser so plugin MCP configs support the same server shape as workspace `.mcp.json`.
- Set plugin stdio MCP server `cwd` to the plugin root by default and fail loudly on duplicate server names or invalid plugin MCP JSON.
- Update MCP/plugin specs, journal, and TODO state.

## Purpose

This closes the `.mcp.json` slice of the Claude plugin extension-registry backlog without adding a plugin-owned MCP lifecycle manager. Runtime/bootstrap owns registry assembly; TUI and protocol surfaces continue to consume the shared MCP status/control path.

## Related Issues

None.

## Testing

- `cargo test plugin_middleware::tests::plugin_mcp_configs -- --nocapture`
- `cargo test plugin_middleware::tests::appends_plugin_mcp_configs_with_plugin_source_metadata -- --nocapture`
- `cargo check --locked --workspace --all-targets`
- `cargo fmt --check`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `git diff --check`
