### PR TITLE
chore: update Codex Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1998,8 +1998,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2017,8 +2017,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2044,12 +2044,13 @@ dependencies = [
  "tracing",
  "tungstenite",
  "url",
+ "uuid",
 ]
 
 [[package]]
 name = "codex-async-utils"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -2057,8 +2058,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2070,13 +2071,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 
 [[package]]
 name = "codex-config"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2120,8 +2121,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2131,24 +2132,27 @@ dependencies = [
  "serde_json",
  "shlex 1.3.0",
  "starlark",
+ "tempfile",
  "thiserror 2.0.19",
+ "tokio",
 ]
 
 [[package]]
 name = "codex-extension-items"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
  "ts-rs",
 ]
 
 [[package]]
 name = "codex-features"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2160,8 +2164,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2173,8 +2177,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2198,8 +2202,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -2224,8 +2228,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "keyring",
  "tracing",
@@ -2233,8 +2237,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2248,6 +2252,7 @@ dependencies = [
  "codex-secrets",
  "codex-terminal-detection",
  "codex-utils-template",
+ "http 1.4.2",
  "once_cell",
  "os_info",
  "rand 0.9.4",
@@ -2266,8 +2271,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -2278,8 +2283,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -2297,8 +2302,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2332,8 +2337,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2363,8 +2368,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2402,8 +2407,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "age",
  "anyhow",
@@ -2421,16 +2426,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "dirs",
  "dunce",
@@ -2441,8 +2446,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "lru 0.16.4",
  "sha1",
@@ -2451,8 +2456,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2460,8 +2465,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2473,8 +2478,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2482,8 +2487,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2492,8 +2497,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -2507,16 +2512,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "rustls 0.23.41",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "regex-lite",
  "serde",
@@ -2525,13 +2530,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.144.6"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
+version = "0.145.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -2560,7 +2565,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6776,7 +6781,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -10290,7 +10295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -10309,7 +10314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -10480,7 +10485,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -10518,7 +10523,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -14894,7 +14899,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,10 +40,10 @@ tempfile = "3.17"
 ignore = "0.4.26"
 nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
 rmcp = { version = "2.0", features = ["client", "transport-child-process"] }
-codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
-codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
+codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
 rara-instructions = { path = "crates/instructions" }
 
 [package]


### PR DESCRIPTION
## Summary

- Update Codex Rust git dependencies from `rust-v0.144.6` to `rust-v0.145.0`.
- Refresh `Cargo.lock` for the Codex git dependency set only.

## Purpose

Keep RARA aligned with the latest stable Codex Rust dependency tag available from `openai/codex`.

## Related Issues

None.

## Testing

- `cargo fmt`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `git diff --check`
