### PR TITLE
feat(plugins): register plugin commands

### DIFF
--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -277,6 +277,21 @@ duplicate server name fails registry assembly with both source paths, matching
 the base MCP registry contract. Stdio plugin MCP servers receive `cwd` set to
 the plugin root when the existing MCP runtime later connects them.
 
+### Command Extension Registry
+
+Runtime bootstrap discovers plugin `commands/**/*.md` files from loaded
+plugins and attaches compact summaries to the session plugin runtime. Plugin
+command names are exposed as `plugin_name:command_name`, with nested command
+paths preserved as `/` separators. The command description comes from leading
+frontmatter `description` when present, otherwise from the first non-heading
+body line.
+
+Plugin command summaries are runtime-owned metadata only. TUI and protocol
+surfaces may render the command count or future command details from the
+runtime snapshot, but plugin commands are not routed through the TUI local
+slash-command parser and are not executable until a shared command invocation
+contract exists.
+
 ## Contracts
 
 ### Crate API
@@ -323,6 +338,7 @@ scope for now.
 | Plugin `.mcp.json` registers into the shared MCP registry | `cargo test plugin_middleware::tests::appends_plugin_mcp_configs_with_plugin_source_metadata -- --nocapture` |
 | Plugin MCP file and relative cwd handling | `cargo test plugin_middleware::tests::plugin_mcp_configs_skip_mcp_json_directories -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_resolve_relative_cwd_from_plugin_root -- --nocapture` |
 | Plugin MCP parse and duplicate-name failures surface | `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_duplicate_server_names -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_invalid_json -- --nocapture` |
+| Plugin command markdown files register as runtime summaries | `cargo test plugin_middleware::tests::registers_project_plugin_command_summaries -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |
 | `discover_plugins` skips non-directories | unit test |
@@ -392,16 +408,20 @@ Implemented in the first merged slice:
   summaries with namespaced `plugin_name:skill_name` names and plugin scope.
   They are marked `disable_model_invocation: true` because the `skill` tool
   still reads from the local `SkillManager`, not from plugin extension roots.
+- Plugin `commands/**/*.md` files are exposed as runtime-owned command
+  summaries with namespaced `plugin_name:command_name` names. `/status`
+  displays the loaded command count from the runtime snapshot. Invocation is
+  intentionally deferred until a shared command execution contract exists.
 - `rara plugin install <source>` accepts both local plugin directories and git
   sources. Git sources are cloned with `git clone --depth 1` into a temporary
   checkout before the existing plugin validation and workspace copy path runs.
 
 Next implementation slices:
 
-1. Feed plugin `.mcp.json`, commands, skills, and agents into the same
-   structured extension-source registries used by native RARA features. Skills
-   already have prompt-visible summaries; invocation and reload integration
-   remain open.
+1. Feed plugin skill invocation/reload and agents into the same structured
+   extension-source registries used by native RARA features. Skills already
+   have prompt-visible summaries; invocation and reload integration remain
+   open.
 
 ## Open Risks
 
@@ -427,3 +447,4 @@ Next implementation slices:
 - `docs/journal/2026-07-20-plugin-hook-matchers.md`
 - `docs/journal/2026-07-20-plugin-runtime-bootstrap.md`
 - `docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md`
+- `docs/journal/2026-07-22-plugin-command-registry.md`

--- a/docs/journal/2026-07-22-plugin-command-registry.md
+++ b/docs/journal/2026-07-22-plugin-command-registry.md
@@ -1,0 +1,32 @@
+# Plugin Command Registry
+
+## Summary
+
+Plugin `commands/**/*.md` files now load into the session plugin runtime as
+compact command summaries. The summaries are owned by runtime bootstrap and are
+attached to the agent alongside plugin hooks and plugin skill summaries, so
+presentation surfaces can report loaded command metadata without scanning
+plugin directories themselves.
+
+## Key Decisions
+
+- Plugin command names are namespaced as `plugin_name:command_name`.
+- Nested command files preserve their relative directory path with `/`
+  separators, for example `plugin:git/review`.
+- Command descriptions come from leading frontmatter `description` when
+  present, otherwise from the first non-heading markdown body line.
+- Plugin command summaries are not routed through the TUI local slash-command
+  parser yet. Invocation remains deferred until RARA has a shared command
+  execution contract outside the TUI presentation layer.
+- `/status` displays the loaded plugin command count from the runtime snapshot.
+
+## Validation
+
+- `cargo test plugin_middleware::tests::registers_project_plugin_command_summaries -- --nocapture`
+- `cargo test tui::status_display::tests::overview_status_reports_agent_extension_details -- --nocapture`
+
+## Follow-Ups
+
+- Route plugin skill invocation/reload through a shared runtime registry.
+- Register plugin agent definitions through the runtime-owned agent registry.
+- Continue control-plane readiness work for plugin-provided extension sources.

--- a/docs/journal/2026-07-22-plugin-mcp-registry.md
+++ b/docs/journal/2026-07-22-plugin-mcp-registry.md
@@ -18,8 +18,8 @@ surface that consumes the registry sees the same plugin-provided servers.
   paths from the plugin root.
 - Duplicate MCP server names across user, project, and plugin sources remain a
   hard registry error rather than a precedence override.
-- Commands, real skill invocation/reload, and plugin agent definitions remain
-  separate extension-registry follow-ups.
+- Real skill invocation/reload and plugin agent definitions remain separate
+  extension-registry follow-ups.
 
 ## Validation
 
@@ -30,7 +30,7 @@ surface that consumes the registry sees the same plugin-provided servers.
 
 ## Follow-Ups
 
-- Register plugin commands, skill invocation/reload, and plugin agents through
-  their shared runtime registries.
+- Register plugin skill invocation/reload and plugin agents through their
+  shared runtime registries.
 - Continue control-plane readiness work for new plugin-provided extension
   sources.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -146,5 +146,6 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin non-tool command hook dispatch for `SessionStart` and `UserPromptSubmit`.
 - [x] Claude plugin lifecycle parity: structured hook output observability.
 - [x] Claude plugin `.mcp.json` extension registry integration.
-- [ ] Claude plugin extension registries for commands, skill invocation/reload, and agents.
+- [x] Claude plugin command extension registry summaries.
+- [ ] Claude plugin extension registries for skill invocation/reload and agents.
 - [ ] Control-plane readiness for new features

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -345,6 +345,12 @@ impl Agent {
         self.plugin_hook_runtime = Some(runtime);
     }
 
+    pub(crate) fn plugin_command_count(&self) -> usize {
+        self.plugin_hook_runtime
+            .as_ref()
+            .map_or(0, |runtime| runtime.command_summaries().len())
+    }
+
     /// Accumulate subagent (auxiliary model) cache statistics.
     /// Called by consolidation and other subagent completion
     /// handlers to split cache reporting between main and aux models.

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -23,6 +23,7 @@ pub(crate) struct PluginHookRuntime {
     session_id: String,
     hooks: Vec<RegisteredHook>,
     skill_summaries: Vec<PluginSkillSummary>,
+    command_summaries: Vec<PluginCommandSummary>,
     hook_runtime: Option<Weak<HookRuntime>>,
 }
 
@@ -34,6 +35,14 @@ pub(crate) struct PluginHookBlock {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PluginSkillSummary {
+    pub name: String,
+    pub title: Option<String>,
+    pub description: String,
+    pub path: PathBuf,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PluginCommandSummary {
     pub name: String,
     pub title: Option<String>,
     pub description: String,
@@ -55,12 +64,14 @@ impl PluginHookRuntime {
         session_id: String,
         hooks: Vec<RegisteredHook>,
         skill_summaries: Vec<PluginSkillSummary>,
+        command_summaries: Vec<PluginCommandSummary>,
         hook_runtime: Option<Arc<HookRuntime>>,
     ) -> Self {
         Self {
             session_id,
             hooks,
             skill_summaries,
+            command_summaries,
             hook_runtime: hook_runtime.map(|runtime| Arc::downgrade(&runtime)),
         }
     }
@@ -72,6 +83,10 @@ impl PluginHookRuntime {
 
     pub(crate) fn skill_summaries(&self) -> &[PluginSkillSummary] {
         &self.skill_summaries
+    }
+
+    pub(crate) fn command_summaries(&self) -> &[PluginCommandSummary] {
+        &self.command_summaries
     }
 
     pub(crate) async fn run_pre_tool_use(
@@ -329,7 +344,14 @@ fn load_plugin_hooks_blocking(
         hooks.extend(rara_plugins::loader::registered_hooks_for_plugin(plugin));
     }
     let skill_summaries = plugin_skill_summaries(&plugins);
-    PluginHookRuntime::new(session_id.to_string(), hooks, skill_summaries, runtime)
+    let command_summaries = plugin_command_summaries(&plugins);
+    PluginHookRuntime::new(
+        session_id.to_string(),
+        hooks,
+        skill_summaries,
+        command_summaries,
+        runtime,
+    )
 }
 
 fn append_plugin_mcp_configs_from_plugins(
@@ -403,6 +425,108 @@ fn plugin_skill_summaries(plugins: &[Plugin]) -> Vec<PluginSkillSummary> {
     }
     summaries.sort_by(|left, right| left.name.cmp(&right.name));
     summaries
+}
+
+fn plugin_command_summaries(plugins: &[Plugin]) -> Vec<PluginCommandSummary> {
+    let mut summaries = Vec::new();
+    for plugin in plugins {
+        let commands_dir = plugin.root.join("commands");
+        let mut command_paths = Vec::new();
+        collect_markdown_files(&commands_dir, &mut command_paths);
+        for path in command_paths {
+            let Some(local_name) = local_plugin_command_name(&commands_dir, &path) else {
+                continue;
+            };
+            let content = fs::read_to_string(&path).unwrap_or_default();
+            summaries.push(PluginCommandSummary {
+                name: format!("{}:{local_name}", plugin.name),
+                title: Some(local_name),
+                description: extract_plugin_command_description(&content),
+                path,
+            });
+        }
+    }
+    summaries.sort_by(|left, right| left.name.cmp(&right.name));
+    summaries
+}
+
+fn collect_markdown_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_markdown_files(&path, out);
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+            out.push(path);
+        }
+    }
+}
+
+fn local_plugin_command_name(commands_dir: &Path, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(commands_dir).ok()?;
+    let mut parts = Vec::new();
+    for component in relative.components() {
+        let std::path::Component::Normal(raw) = component else {
+            return None;
+        };
+        let mut part = raw.to_str()?.to_string();
+        if part.ends_with(".md") {
+            part.truncate(part.len() - ".md".len());
+        }
+        if part.is_empty() {
+            return None;
+        }
+        parts.push(part);
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("/"))
+    }
+}
+
+fn extract_plugin_command_description(content: &str) -> String {
+    extract_leading_frontmatter_field(content, "description")
+        .unwrap_or_else(|| extract_plugin_skill_description(content))
+}
+
+fn extract_leading_frontmatter_field(content: &str, key: &str) -> Option<String> {
+    let mut lines = content.lines();
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            break;
+        }
+        let Some((field, value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        if field.trim() != key {
+            continue;
+        }
+        let value = trim_yaml_scalar(value);
+        if !value.is_empty() {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn trim_yaml_scalar(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.len() >= 2 {
+        let bytes = trimmed.as_bytes();
+        if (bytes[0] == b'"' && bytes[trimmed.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[trimmed.len() - 1] == b'\'')
+        {
+            return trimmed[1..trimmed.len() - 1].to_string();
+        }
+    }
+    trimmed.to_string()
 }
 
 fn extract_plugin_skill_description(content: &str) -> String {
@@ -717,6 +841,50 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn registers_project_plugin_command_summaries() {
+        let dir = tempdir().expect("tempdir");
+        let rara_home = dir.path().join("home").join(".rara");
+        let workspace_root = dir.path().join("workspace");
+        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+        let plugin_root = project_plugins_dir.join("commands");
+        write_test_plugin(&plugin_root, "commands", "echo project");
+        fs::create_dir_all(plugin_root.join("commands").join("git")).expect("commands dir");
+        fs::write(
+            plugin_root.join("commands").join("git").join("review.md"),
+            "---\ndescription: Review the current diff.\n---\n# Review\nBody text.",
+        )
+        .expect("command");
+        fs::write(
+            plugin_root.join("commands").join("explain.md"),
+            "# Explain\nExplain selected code.",
+        )
+        .expect("command");
+
+        let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
+        let registered =
+            register_plugin_hooks(&runtime, Some(rara_home), &workspace_root, &[], "session-1")
+                .await;
+
+        assert_eq!(
+            registered.command_summaries(),
+            &[
+                PluginCommandSummary {
+                    name: "commands:explain".to_string(),
+                    title: Some("explain".to_string()),
+                    description: "Explain selected code.".to_string(),
+                    path: plugin_root.join("commands").join("explain.md"),
+                },
+                PluginCommandSummary {
+                    name: "commands:git/review".to_string(),
+                    title: Some("git/review".to_string()),
+                    description: "Review the current diff.".to_string(),
+                    path: plugin_root.join("commands").join("git").join("review.md"),
+                },
+            ]
+        );
+    }
+
     #[test]
     fn appends_plugin_mcp_configs_with_plugin_source_metadata() {
         let dir = tempdir().expect("tempdir");
@@ -963,6 +1131,7 @@ mod tests {
                 plugin_root,
             }],
             Vec::new(),
+            Vec::new(),
             None,
         );
 
@@ -996,6 +1165,7 @@ mod tests {
                 plugin_name: "observer".to_string(),
                 plugin_root,
             }],
+            Vec::new(),
             Vec::new(),
             Some(hook_runtime.clone()),
         );

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -203,6 +203,7 @@ impl TuiApp {
                     .collect()
             },
             extension_hook_count: ext_counts.0.max(runtime_hook_count),
+            extension_command_count: agent.plugin_command_count(),
             extension_agent_count: ext_counts.1,
             extension_agent_status_lines: ext_counts.2,
         };

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -293,6 +293,7 @@ pub struct RuntimeSnapshot {
     pub extension_skill_count: usize,
     pub extension_skill_scopes: Vec<String>,
     pub extension_hook_count: usize,
+    pub extension_command_count: usize,
     pub extension_agent_count: usize,
     pub extension_agent_status_lines: Vec<String>,
 }

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -114,6 +114,12 @@ fn render_overview_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
     );
     kv(
         lines,
+        "commands",
+        &snap.extension_command_count.to_string(),
+        Color::DarkGray,
+    );
+    kv(
+        lines,
         "agents",
         &snap.extension_agent_count.to_string(),
         Color::DarkGray,
@@ -525,6 +531,7 @@ mod tests {
         })
         .expect("app");
         app.snapshot = RuntimeSnapshot {
+            extension_command_count: 2,
             extension_agent_count: 1,
             extension_agent_status_lines: vec![
                 "  code-reviewer  .rara/agents/code-reviewer.md  ok  (disabled)".to_string(),
@@ -539,6 +546,8 @@ mod tests {
             .join("\n");
 
         assert!(rendered.contains("agents"));
+        assert!(rendered.contains("commands"));
+        assert!(rendered.contains("2"));
         assert!(rendered.contains("code-reviewer"));
         assert!(rendered.contains(".rara/agents/code-reviewer.md"));
     }


### PR DESCRIPTION
## Summary

- discover plugin `commands/**/*.md` files into runtime-owned command summaries
- expose plugin command counts through the agent runtime snapshot and `/status`
- update plugin runtime spec, journal notes, and TODO status for the completed command registry slice

## Purpose

This keeps plugin command metadata in the app/runtime layer instead of the TUI local slash-command parser. Plugin commands are visible as registered extension metadata, but invocation remains deferred until RARA has a shared command execution contract.

## Related Issues

- None

## Testing

- `cargo test plugin_middleware::tests::registers_project_plugin_command_summaries -- --nocapture`
- `cargo test tui::status_display::tests::overview_status_reports_agent_extension_details -- --nocapture`
- `cargo fmt --check`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
