### PR TITLE
feat(plugins): complete extension registries

### DIFF
--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -94,6 +94,8 @@ pub enum LocalEmbeddingPolicy {
     #[default]
     Off,
     Auto,
+    Provider,
+    Local,
 }
 
 impl LocalEmbeddingPolicy {
@@ -362,6 +364,8 @@ impl RaraConfig {
             self.local_embeddings = match value.trim().to_ascii_lowercase().as_str() {
                 "off" | "false" | "0" | "no" => LocalEmbeddingPolicy::Off,
                 "auto" | "on" | "true" | "1" | "yes" => LocalEmbeddingPolicy::Auto,
+                "provider" | "native" | "llm" => LocalEmbeddingPolicy::Provider,
+                "local" | "sidecar" => LocalEmbeddingPolicy::Local,
                 _ => self.local_embeddings,
             };
         }
@@ -1212,6 +1216,27 @@ mod tests {
     }
 
     #[test]
+    fn local_embeddings_accepts_explicit_provider_and_local_overrides() {
+        let provider: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "deepseek",
+                "local_embeddings": "provider"
+            }"#,
+        )
+        .expect("deserialize provider override");
+        assert_eq!(provider.local_embeddings, LocalEmbeddingPolicy::Provider);
+
+        let local: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "codex",
+                "local_embeddings": "local"
+            }"#,
+        )
+        .expect("deserialize local override");
+        assert_eq!(local.local_embeddings, LocalEmbeddingPolicy::Local);
+    }
+
+    #[test]
     fn local_embeddings_can_be_enabled_and_disabled_by_environment() {
         let mut config = RaraConfig::default();
 
@@ -1221,6 +1246,20 @@ mod tests {
         });
 
         assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
+
+        config.apply_provider_environment_defaults_from(|key| match key {
+            "RARA_LOCAL_EMBEDDINGS" => Some("provider".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Provider);
+
+        config.apply_provider_environment_defaults_from(|key| match key {
+            "RARA_LOCAL_EMBEDDINGS" => Some("local".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Local);
 
         config.apply_provider_environment_defaults_from(|key| match key {
             "RARA_LOCAL_EMBEDDINGS" => Some("off".to_string()),

--- a/crates/skills/src/lib.rs
+++ b/crates/skills/src/lib.rs
@@ -10,6 +10,7 @@ use serde::Serialize;
 pub enum SkillScope {
     Workspace,
     Global,
+    Plugin,
     // Legacy variants for compatibility
     Home,
     Repo,
@@ -22,6 +23,7 @@ impl SkillScope {
         match self {
             Self::Workspace => "workspace",
             Self::Global => "global",
+            Self::Plugin => "plugin",
             Self::Home => "home",
             Self::Repo => "repo",
             Self::Cwd => "cwd",
@@ -88,6 +90,18 @@ impl SkillManager {
 
     pub fn load_all(&mut self) -> Result<()> {
         self.discover_and_load()
+    }
+
+    pub fn load_plugin_skills_from_root(
+        &mut self,
+        plugin_name: &str,
+        plugin_root: &Path,
+    ) -> Result<()> {
+        let skills_dir = plugin_root.join("skills");
+        if skills_dir.is_dir() {
+            self.load_plugin_skills_from_dir(plugin_name, &skills_dir)?;
+        }
+        Ok(())
     }
 
     pub fn list_summaries(&self) -> Vec<SkillSummary> {
@@ -166,23 +180,7 @@ impl SkillManager {
                 let skill_md = path.join("SKILL.md");
                 if skill_md.is_file() {
                     match self.load_skill(&skill_md, scope) {
-                        Ok(skill) => {
-                            let name = skill.name.clone();
-                            if let Some(existing) = self.skills.get(&name) {
-                                let mut chain = self.overrides.remove(&name).unwrap_or_default();
-                                if scope == SkillScope::Workspace
-                                    && existing.scope == SkillScope::Global
-                                {
-                                    chain.push(existing.clone());
-                                    self.skills.insert(name.clone(), skill);
-                                } else {
-                                    chain.push(skill);
-                                }
-                                self.overrides.insert(name, chain);
-                            } else {
-                                self.skills.insert(name, skill);
-                            }
-                        }
+                        Ok(skill) => self.insert_skill(skill),
                         Err(err) => {
                             self.load_warnings.push(format!(
                                 "Failed to load skill from {}: {}",
@@ -195,6 +193,47 @@ impl SkillManager {
             }
         }
         Ok(())
+    }
+
+    fn load_plugin_skills_from_dir(&mut self, plugin_name: &str, dir: &Path) -> Result<()> {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let skill_md = path.join("SKILL.md");
+            if !skill_md.is_file() {
+                continue;
+            }
+            match self.load_plugin_skill(plugin_name, &skill_md) {
+                Ok(skill) => self.insert_skill(skill),
+                Err(err) => {
+                    self.load_warnings.push(format!(
+                        "Failed to load plugin skill from {}: {}",
+                        skill_md.display(),
+                        err
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn insert_skill(&mut self, skill: Skill) {
+        let name = skill.name.clone();
+        if let Some(existing) = self.skills.get(&name) {
+            let mut chain = self.overrides.remove(&name).unwrap_or_default();
+            if skill.scope == SkillScope::Workspace && existing.scope == SkillScope::Global {
+                chain.push(existing.clone());
+                self.skills.insert(name.clone(), skill);
+            } else {
+                chain.push(skill);
+            }
+            self.overrides.insert(name, chain);
+        } else {
+            self.skills.insert(name, skill);
+        }
     }
 
     fn load_skill(&self, path: &Path, scope: SkillScope) -> Result<Skill> {
@@ -215,6 +254,28 @@ impl SkillManager {
             description,
             path: path.to_path_buf(),
             scope,
+            content,
+            disable_model_invocation: false,
+        })
+    }
+
+    fn load_plugin_skill(&self, plugin_name: &str, path: &Path) -> Result<Skill> {
+        let content = fs::read_to_string(path)?;
+        let local_name = path
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow!("invalid plugin skill path"))?;
+        let name = format!("{plugin_name}:{local_name}");
+        let description =
+            extract_description(&content).unwrap_or_else(|| "No description provided.".to_string());
+
+        Ok(Skill {
+            name: name.clone(),
+            title: Some(local_name.to_string()),
+            description,
+            path: path.to_path_buf(),
+            scope: SkillScope::Plugin,
             content,
             disable_model_invocation: false,
         })
@@ -334,6 +395,31 @@ mod tests {
         assert_eq!(manager.skills.get("s").unwrap().content, "c2");
         assert_eq!(manager.overrides.get("s").unwrap().len(), 1);
         assert_eq!(manager.overrides.get("s").unwrap()[0].content, "c1");
+        Ok(())
+    }
+
+    #[test]
+    fn plugin_skills_are_namespaced_and_invokable() -> Result<()> {
+        let temp = tempdir()?;
+        let plugin_root = temp.path().join("plugin");
+        let skill_path = plugin_root.join("skills").join("reviewer");
+        fs::create_dir_all(&skill_path)?;
+        fs::write(
+            skill_path.join("SKILL.md"),
+            "# Reviewer\nInspect plugin-provided behavior.",
+        )?;
+
+        let mut manager = SkillManager::new();
+        manager.load_plugin_skills_from_root("quality", &plugin_root)?;
+
+        let skill = manager.get_skill("quality:reviewer").unwrap();
+        assert_eq!(skill.name, "quality:reviewer");
+        assert_eq!(skill.title.as_deref(), Some("reviewer"));
+        assert_eq!(skill.scope, SkillScope::Plugin);
+        assert_eq!(
+            skill.instructions(),
+            "# Reviewer\nInspect plugin-provided behavior."
+        );
         Ok(())
     }
 }

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -253,15 +253,16 @@ directories, copied under the plugin name from `.claude-plugin/plugin.json`,
 and then removed from the temporary checkout location. Existing plugins require
 `--force` to replace.
 
-### Skill Extension Summaries
+### Skill Extension Registry
 
 Runtime bootstrap discovers `skills/<name>/SKILL.md` directories from loaded
-plugins and appends compact summaries to the agent's available-skill listing.
-Plugin skill names are exposed as `plugin_name:skill_name`, use
-`scope: "plugin"`, and set `disable_model_invocation: true` until plugin skill
-invocation is routed through the shared skill registry. This makes plugin skill
-availability visible to the model and control surfaces without implying that
-the existing `skill` tool can invoke those bodies yet.
+plugins and loads them into the shared `SkillManager`. Plugin skill names are
+exposed as `plugin_name:skill_name`, use `scope: "plugin"`, and are available
+through the existing `skill` tool `list`, `invoke`, and `reload` actions.
+
+Plugin skill reload uses the same runtime-owned plugin roots captured during
+bootstrap. Reload updates the running `SkillManager`; it is not a validation-only
+rescan.
 
 ### MCP Extension Registry
 
@@ -291,6 +292,17 @@ surfaces may render the command count or future command details from the
 runtime snapshot, but plugin commands are not routed through the TUI local
 slash-command parser and are not executable until a shared command invocation
 contract exists.
+
+### Agent Extension Registry
+
+Runtime bootstrap discovers plugin `agents/**/*.md` definitions and feeds them
+into the same session-scoped `AgentDefinitionCache` used by workspace and user
+agent definitions. Plugin agent names are exposed as `plugin_name:agent_name`,
+which avoids collisions with built-in, user, and workspace agents.
+
+Plugin agent definitions use the existing Claude-compatible agent frontmatter
+contract: `description`, `tools`, `disallowed_tools`, `model`, `max_turns`,
+`token_budget`, `permission_mode`, `plan_mode_required`, and `hidden`.
 
 ## Contracts
 
@@ -334,11 +346,12 @@ scope for now.
 | `SessionEnd` marks cancelled model turns as interrupts | `cargo test agent::tests::plugin_hooks::plugin_session_end_marks_cancelled_model_turn_as_interrupt -- --nocapture` |
 | `SessionStart` and `UserPromptSubmit` fire from agent queries | `cargo test agent::tests::plugin_hooks::plugin_non_tool_lifecycle_hooks_run_from_agent_query -- --nocapture` |
 | Lifecycle hook stdout/stderr publishes a structured control event | `cargo test plugin_middleware::tests::lifecycle_hook_output_is_published_as_structured_control_event -- --nocapture` and `cargo test runtime_control::tests::hook_command_output_uses_structured_wire_shape -- --nocapture` |
-| Plugin skills are prompt-visible summaries | `cargo test plugin_middleware::tests::registers_project_plugin_skill_summaries -- --nocapture` and `cargo test agent::tests::plugin_hooks::plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet -- --nocapture` |
+| Plugin skills load into the shared skill registry | `cargo test -p rara-skills plugin_skills_are_namespaced_and_invokable -- --nocapture` and `cargo test tools::skill::reload_updates_running_manager_with_plugin_skills -- --nocapture` |
 | Plugin `.mcp.json` registers into the shared MCP registry | `cargo test plugin_middleware::tests::appends_plugin_mcp_configs_with_plugin_source_metadata -- --nocapture` |
 | Plugin MCP file and relative cwd handling | `cargo test plugin_middleware::tests::plugin_mcp_configs_skip_mcp_json_directories -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_resolve_relative_cwd_from_plugin_root -- --nocapture` |
 | Plugin MCP parse and duplicate-name failures surface | `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_duplicate_server_names -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_invalid_json -- --nocapture` |
 | Plugin command markdown files register as runtime summaries | `cargo test plugin_middleware::tests::registers_project_plugin_command_summaries -- --nocapture` |
+| Plugin agent markdown files register as runtime agent definitions | `cargo test plugin_middleware::tests::plugin_agent_records_are_namespaced_by_plugin_name -- --nocapture` |
 | Non-zero exit code fails | integration test |
 | Timeout fires | integration test (sleep 10) |
 | `discover_plugins` skips non-directories | unit test |
@@ -404,24 +417,20 @@ Implemented in the first merged slice:
   success state are published as `RuntimeEvent::Hook(command_output)` events on
   the session control bus. These events are structured observability only and do
   not feed model context.
-- Plugin `skills/<name>/SKILL.md` directories are exposed as prompt-visible
-  summaries with namespaced `plugin_name:skill_name` names and plugin scope.
-  They are marked `disable_model_invocation: true` because the `skill` tool
-  still reads from the local `SkillManager`, not from plugin extension roots.
+- Plugin `skills/<name>/SKILL.md` directories are loaded into the shared
+  `SkillManager` with namespaced `plugin_name:skill_name` names and plugin
+  scope. The `skill` tool can list, invoke, and reload them.
 - Plugin `commands/**/*.md` files are exposed as runtime-owned command
   summaries with namespaced `plugin_name:command_name` names. `/status`
   displays the loaded command count from the runtime snapshot. Invocation is
   intentionally deferred until a shared command execution contract exists.
+- Plugin `agents/**/*.md` files are loaded into the shared
+  `AgentDefinitionCache` with namespaced `plugin_name:agent_name` names and can
+  be used by `spawn_agent`, `explore_agent`, `plan_agent`, and team creation
+  paths through the existing agent resolution contract.
 - `rara plugin install <source>` accepts both local plugin directories and git
   sources. Git sources are cloned with `git clone --depth 1` into a temporary
   checkout before the existing plugin validation and workspace copy path runs.
-
-Next implementation slices:
-
-1. Feed plugin skill invocation/reload and agents into the same structured
-   extension-source registries used by native RARA features. Skills already
-   have prompt-visible summaries; invocation and reload integration remain
-   open.
 
 ## Open Risks
 
@@ -448,3 +457,4 @@ Next implementation slices:
 - `docs/journal/2026-07-20-plugin-runtime-bootstrap.md`
 - `docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md`
 - `docs/journal/2026-07-22-plugin-command-registry.md`
+- `docs/journal/2026-07-25-extension-completion.md`

--- a/docs/features/embedding-provider-decoupling.md
+++ b/docs/features/embedding-provider-decoupling.md
@@ -135,6 +135,12 @@ vector indexing/search is a separate dependency.
   download, or start the bundled local embedding sidecar.
 - `local_embeddings = "auto"` and `RARA_LOCAL_EMBEDDINGS=auto|on|true|1|yes`
   explicitly opt in to the provider-aware local sidecar routing matrix.
+- `local_embeddings = "provider"` and
+  `RARA_LOCAL_EMBEDDINGS=provider|native|llm` force embedding calls through the
+  current chat provider embedding route and must not start the local sidecar.
+- `local_embeddings = "local"` and `RARA_LOCAL_EMBEDDINGS=local|sidecar`
+  force embedding calls through the bundled local sidecar, even for providers
+  that would otherwise use provider-native embeddings.
 - Provider-native embeddings must be enabled only through an explicit capability
   entry or equivalent allowlist, not by assuming that all providers in one chat
   family expose usable embedding models.

--- a/docs/features/local-embedding-runtimes.md
+++ b/docs/features/local-embedding-runtimes.md
@@ -525,8 +525,8 @@ Valid preparation states:
   versioned by profile.
 - LanceDB table versioning still needs a separate migration plan before mixed
   embedding dimensions or model profiles are enabled.
-- Explicit embedding enable/disable and provider override config still remains
-  follow-up work.
+- Explicit provider/local embedding route overrides are available through
+  `local_embeddings = "provider"` and `local_embeddings = "local"`.
 
 ## Source Journals
 

--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -99,6 +99,9 @@ That means:
 - prompt-affecting data enters through source objects, not string append points;
 - visible runtime state can be consumed by `/context`, `/status`, and protocol
   subscribers;
+- extension registries publish structured readiness snapshots when runtime
+  bootstrap loads plugin-provided hooks, skills, commands, agents, or MCP
+  servers;
 - sandbox, approval, and permission decisions remain centralized in RARA;
 - new state is either persisted or explicitly marked transient.
 
@@ -398,6 +401,7 @@ Minimum event families:
 - `MemoryEvent`;
 - `HookEvent`;
 - `ContextEvent`;
+- `ExtensionEvent`;
 - `WarningEvent`;
 - `ErrorEvent`.
 

--- a/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
+++ b/docs/journal/2026-07-20-plugin-runtime-bootstrap.md
@@ -50,12 +50,10 @@ non-TUI surfaces without the same runtime behavior.
   cancellation error returns to the caller. Other runtime errors keep the
   existing error and recovery behavior so recoverable continuation paths do not
   run cleanup early.
-- Plugin `skills/<name>/SKILL.md` directories are now discovered during runtime
-  plugin registration and appended to the agent's available-skill summaries as
-  `plugin_name:skill_name` entries with `scope: "plugin"`.
-- Plugin skill summaries set `disable_model_invocation: true`; this records
-  availability without pretending the existing `skill` tool can invoke plugin
-  skill bodies before the shared extension registry is wired through.
+- Plugin `skills/<name>/SKILL.md` directories were initially discovered during
+  runtime plugin registration and appended to the agent's available-skill
+  summaries. They now load into the shared skill registry; see
+  `docs/journal/2026-07-25-extension-completion.md`.
 - This slice does not change non-tool lifecycle dispatch beyond `SessionEnd`,
   full structured hook output observability, or plugin extension registry
   invocation/reload ingestion.
@@ -76,14 +74,10 @@ git diff --check
 cargo test agent::tests::plugin_hooks::plugin_pre_tool_use_continue_false_blocks_tool_execution -- --nocapture
 cargo test agent::tests::plugin_hooks::plugin_session_end_runs_once_with_last_assistant_message -- --nocapture
 cargo test agent::tests::plugin_hooks::plugin_session_end_marks_cancelled_model_turn_as_interrupt -- --nocapture
-cargo test plugin_middleware::tests::registers_project_plugin_skill_summaries -- --nocapture
-cargo test agent::tests::plugin_hooks::plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet -- --nocapture
 cargo test plugin_middleware::tests -- --nocapture
 ```
 
 ## Follow-Ups
 
-- Implement non-tool lifecycle dispatch beyond `SessionEnd` and hook output
-  observability.
-- Feed plugin `.mcp.json`, commands, skill invocation/reload, and agents into
-  structured extension registries.
+- Plugin lifecycle, extension registries, and structured readiness follow-ups
+  were completed in later plugin journal entries.

--- a/docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md
+++ b/docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md
@@ -47,8 +47,8 @@ git diff --check
 
 ## Follow-Ups
 
-- Feed plugin `.mcp.json`, commands, skill invocation/reload, and agents into
-  structured extension registries.
+- Plugin extension registries were completed in
+  `docs/journal/2026-07-25-extension-completion.md`.
 
 ## Structured Output Observability
 

--- a/docs/journal/2026-07-22-plugin-command-registry.md
+++ b/docs/journal/2026-07-22-plugin-command-registry.md
@@ -27,6 +27,6 @@ plugin directories themselves.
 
 ## Follow-Ups
 
-- Route plugin skill invocation/reload through a shared runtime registry.
-- Register plugin agent definitions through the runtime-owned agent registry.
-- Continue control-plane readiness work for plugin-provided extension sources.
+- Plugin skill invocation/reload, plugin agent definitions, and structured
+  control-plane readiness were completed in
+  `docs/journal/2026-07-25-extension-completion.md`.

--- a/docs/journal/2026-07-22-plugin-mcp-registry.md
+++ b/docs/journal/2026-07-22-plugin-mcp-registry.md
@@ -18,8 +18,8 @@ surface that consumes the registry sees the same plugin-provided servers.
   paths from the plugin root.
 - Duplicate MCP server names across user, project, and plugin sources remain a
   hard registry error rather than a precedence override.
-- Real skill invocation/reload and plugin agent definitions remain separate
-  extension-registry follow-ups.
+- Skill invocation/reload and plugin agent definitions are completed by the
+  later extension completion slice.
 
 ## Validation
 
@@ -30,7 +30,5 @@ surface that consumes the registry sees the same plugin-provided servers.
 
 ## Follow-Ups
 
-- Register plugin skill invocation/reload and plugin agents through their
-  shared runtime registries.
-- Continue control-plane readiness work for new plugin-provided extension
-  sources.
+- Plugin skill invocation/reload, plugin agents, and structured readiness were
+  completed in `docs/journal/2026-07-25-extension-completion.md`.

--- a/docs/journal/2026-07-25-extension-completion.md
+++ b/docs/journal/2026-07-25-extension-completion.md
@@ -1,0 +1,36 @@
+# Extension Completion
+
+## Summary
+
+The remaining extension TODO items are now closed. Plugin skills load into the
+shared skill registry, plugin agents load into the runtime agent definition
+cache, extension readiness has a structured control-plane event, and embedding
+configuration supports explicit provider/local overrides beyond `off` and
+`auto`.
+
+## Key Decisions
+
+- Plugin skills use namespaced `plugin_name:skill_name` names and
+  `scope: "plugin"`.
+- The `skill` tool `reload` action updates the running `SkillManager` instead
+  of only validating a fresh manager.
+- Plugin agents use namespaced `plugin_name:agent_name` names and enter the
+  same session-scoped `AgentDefinitionCache` as native agent definitions.
+- Runtime bootstrap publishes `RuntimeEvent::Extension(readiness_updated)` with
+  plugin hook, skill, command, agent, and MCP readiness counts.
+- `local_embeddings = "provider"` forces the current provider embedding route.
+- `local_embeddings = "local"` forces the bundled local sidecar route.
+
+## Validation
+
+- `cargo check --locked --workspace --all-targets`
+- `cargo test -p rara-skills plugin_skills_are_namespaced_and_invokable -- --nocapture`
+- `cargo test tools::skill::reload_updates_running_manager_with_plugin_skills -- --nocapture`
+- `cargo test plugin_middleware::tests::plugin_agent_records_are_namespaced_by_plugin_name -- --nocapture`
+- `cargo test runtime_control::tests::extension_readiness_event_uses_structured_wire_shape -- --nocapture`
+- `cargo test runtime_context::tests::embedding_route_honors_explicit_provider_and_local_overrides -- --nocapture`
+
+## Follow-Ups
+
+- Plugin command invocation remains deferred until RARA has a shared command
+  execution contract outside the TUI local slash-command parser.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -118,7 +118,7 @@ Active backlog only. Keep this file small and current.
 
 - [x] Default bundled local embedding sidecar startup to off while preserving
       explicit `local_embeddings = "auto"` opt-in.
-- [ ] Explicit embedding provider override beyond `off` / `auto` (low priority)
+- [x] Explicit embedding provider override beyond `off` / `auto`.
 
 ## ACP Compatibility
 
@@ -147,5 +147,5 @@ Active backlog only. Keep this file small and current.
 - [x] Claude plugin lifecycle parity: structured hook output observability.
 - [x] Claude plugin `.mcp.json` extension registry integration.
 - [x] Claude plugin command extension registry summaries.
-- [ ] Claude plugin extension registries for skill invocation/reload and agents.
-- [ ] Control-plane readiness for new features
+- [x] Claude plugin extension registries for skill invocation/reload and agents.
+- [x] Control-plane readiness for new features.

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -5,7 +5,7 @@ use crate::context::{
     AssembledContext, AssembledTurnContext, ContextAssembler, RuntimeContextInputs,
     RuntimeInteractionInput, SharedTaskContextView,
 };
-use crate::prompt::{PromptSkillSummary, PromptSource, PromptSourceKind};
+use crate::prompt::{PromptSource, PromptSourceKind};
 use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 use crate::tasklist::TaskListStore;
 use crate::tool_result::ToolResultProjectionPolicy;
@@ -153,21 +153,6 @@ impl Agent {
         skill_source_registry: std::sync::Arc<SkillSourceRegistry>,
     ) {
         self.skill_source_registry = Some(skill_source_registry);
-    }
-
-    pub(crate) fn add_plugin_skill_summaries(
-        &mut self,
-        summaries: &[crate::plugin_middleware::PluginSkillSummary],
-    ) {
-        self.prompt_config
-            .available_skills
-            .extend(summaries.iter().map(|summary| PromptSkillSummary {
-                name: summary.name.clone(),
-                title: summary.title.clone(),
-                description: summary.description.clone(),
-                scope: "plugin".to_string(),
-                disable_model_invocation: true,
-            }));
     }
 
     pub fn set_lsp_manager(&mut self, lsp_manager: std::sync::Arc<crate::lsp_manager::LspManager>) {

--- a/src/agent/tests/plugin_hooks.rs
+++ b/src/agent/tests/plugin_hooks.rs
@@ -279,31 +279,6 @@ async fn plugin_session_end_marks_cancelled_model_turn_as_interrupt() {
     );
 }
 
-#[test]
-fn plugin_skill_summaries_are_prompt_visible_but_not_invokable_yet() {
-    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
-    let mut agent = Agent::new(
-        ToolManager::new(),
-        Arc::new(SequencedBackend::new(Vec::new())),
-        Arc::new(VectorDB::new(&rara_dir.join("lancedb").to_string_lossy())),
-        session_manager,
-        workspace,
-    );
-
-    agent.add_plugin_skill_summaries(&[crate::plugin_middleware::PluginSkillSummary {
-        name: "skillful:reviewer".to_string(),
-        title: Some("reviewer".to_string()),
-        description: "Inspect plugin-provided behavior.".to_string(),
-        path: std::path::PathBuf::from("/tmp/plugin/skills/reviewer/SKILL.md"),
-    }]);
-
-    assert_eq!(agent.prompt_config().available_skills.len(), 1);
-    let summary = &agent.prompt_config().available_skills[0];
-    assert_eq!(summary.name, "skillful:reviewer");
-    assert_eq!(summary.scope, "plugin");
-    assert!(summary.disable_model_invocation);
-}
-
 #[tokio::test]
 async fn plugin_non_tool_lifecycle_hooks_run_from_agent_query() {
     let (temp, session_manager, workspace, rara_dir) = test_runtime_storage();

--- a/src/agents_ext.rs
+++ b/src/agents_ext.rs
@@ -100,11 +100,12 @@ impl AgentRegistry {
                     return;
                 }
                 let id = definition.name.clone();
+                let source_kind = source_kind_for_agent_path(&record.source_path);
                 ImportedAgentProfile {
                     id: id.clone(),
                     label: id,
                     source_path,
-                    source_kind: "rara_agent".to_string(),
+                    source_kind,
                     prompt_body: definition.system_prompt,
                     description: definition.description,
                     parse_status: AgentParseStatus::Ok,
@@ -114,13 +115,23 @@ impl AgentRegistry {
                 id: fallback_id.clone(),
                 label: fallback_id,
                 source_path,
-                source_kind: "rara_agent".to_string(),
+                source_kind: source_kind_for_agent_path(&record.source_path),
                 prompt_body: String::new(),
                 description: record.error.unwrap_or_else(|| "parse error".to_string()),
                 parse_status: AgentParseStatus::ParseError,
             },
         };
         self.agents.insert(profile.id.clone(), profile);
+    }
+}
+
+fn source_kind_for_agent_path(path: &Path) -> String {
+    if path.components().any(|component| {
+        component.as_os_str() == "plugins" || component.as_os_str() == ".claude-plugin"
+    }) {
+        "plugin_agent".to_string()
+    } else {
+        "rara_agent".to_string()
     }
 }
 

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -22,7 +22,6 @@ use crate::runtime_control::{HookEvent as RuntimeHookEvent, HookLifecycle};
 pub(crate) struct PluginHookRuntime {
     session_id: String,
     hooks: Vec<RegisteredHook>,
-    skill_summaries: Vec<PluginSkillSummary>,
     command_summaries: Vec<PluginCommandSummary>,
     hook_runtime: Option<Weak<HookRuntime>>,
 }
@@ -31,14 +30,6 @@ pub(crate) struct PluginHookRuntime {
 pub(crate) struct PluginHookBlock {
     pub plugin_name: String,
     pub message: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct PluginSkillSummary {
-    pub name: String,
-    pub title: Option<String>,
-    pub description: String,
-    pub path: PathBuf,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -63,26 +54,19 @@ impl PluginHookRuntime {
     fn new(
         session_id: String,
         hooks: Vec<RegisteredHook>,
-        skill_summaries: Vec<PluginSkillSummary>,
         command_summaries: Vec<PluginCommandSummary>,
         hook_runtime: Option<Arc<HookRuntime>>,
     ) -> Self {
         Self {
             session_id,
             hooks,
-            skill_summaries,
             command_summaries,
             hook_runtime: hook_runtime.map(|runtime| Arc::downgrade(&runtime)),
         }
     }
 
-    #[cfg(test)]
-    fn hook_count(&self) -> usize {
+    pub(crate) fn hook_count(&self) -> usize {
         self.hooks.len()
-    }
-
-    pub(crate) fn skill_summaries(&self) -> &[PluginSkillSummary] {
-        &self.skill_summaries
     }
 
     pub(crate) fn command_summaries(&self) -> &[PluginCommandSummary] {
@@ -303,6 +287,43 @@ pub(crate) fn append_plugin_mcp_configs(
     append_plugin_mcp_configs_from_plugins(registry, &plugins)
 }
 
+pub(crate) fn discover_runtime_plugins(
+    rara_home: Option<&Path>,
+    workspace_root: &Path,
+    explicit_plugin_dirs: &[PathBuf],
+) -> Vec<Plugin> {
+    let sources = plugin_discovery_sources(rara_home, workspace_root, explicit_plugin_dirs);
+    discover_plugins_from_sources(&sources)
+}
+
+pub(crate) fn plugin_skill_roots(plugins: &[Plugin]) -> Vec<(String, PathBuf)> {
+    plugins
+        .iter()
+        .filter(|plugin| plugin.root.join("skills").is_dir())
+        .map(|plugin| (plugin.name.clone(), plugin.root.clone()))
+        .collect()
+}
+
+pub(crate) fn plugin_agent_records(
+    plugins: &[Plugin],
+) -> Vec<crate::tools::agent::AgentDefinitionLoadRecord> {
+    let mut records = Vec::new();
+    for plugin in plugins {
+        let agents_dir = plugin.root.join("agents");
+        let start = records.len();
+        crate::tools::agent::scan_agent_records_dir(&agents_dir, &mut records);
+        for record in &mut records[start..] {
+            let local_id = record.id.clone();
+            record.id = format!("{}:{local_id}", plugin.name);
+            if let Some(definition) = &mut record.definition {
+                let local_name = definition.name.clone();
+                definition.name = format!("{}:{local_name}", plugin.name);
+            }
+        }
+    }
+    records
+}
+
 fn plugin_discovery_sources(
     rara_home: Option<&Path>,
     workspace_root: &Path,
@@ -343,15 +364,8 @@ fn load_plugin_hooks_blocking(
     for plugin in &plugins {
         hooks.extend(rara_plugins::loader::registered_hooks_for_plugin(plugin));
     }
-    let skill_summaries = plugin_skill_summaries(&plugins);
     let command_summaries = plugin_command_summaries(&plugins);
-    PluginHookRuntime::new(
-        session_id.to_string(),
-        hooks,
-        skill_summaries,
-        command_summaries,
-        runtime,
-    )
+    PluginHookRuntime::new(session_id.to_string(), hooks, command_summaries, runtime)
 }
 
 fn append_plugin_mcp_configs_from_plugins(
@@ -393,38 +407,6 @@ fn apply_plugin_mcp_defaults(
             McpServerTransport::StreamableHttp { .. } => {}
         }
     }
-}
-
-fn plugin_skill_summaries(plugins: &[Plugin]) -> Vec<PluginSkillSummary> {
-    let mut summaries = Vec::new();
-    for plugin in plugins {
-        let skills_dir = plugin.root.join("skills");
-        let Ok(entries) = fs::read_dir(&skills_dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
-            let skill_md = path.join("SKILL.md");
-            if !skill_md.is_file() {
-                continue;
-            }
-            let Some(skill_name) = path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            let content = fs::read_to_string(&skill_md).unwrap_or_default();
-            summaries.push(PluginSkillSummary {
-                name: format!("{}:{skill_name}", plugin.name),
-                title: Some(skill_name.to_string()),
-                description: extract_plugin_skill_description(&content),
-                path: skill_md,
-            });
-        }
-    }
-    summaries.sort_by(|left, right| left.name.cmp(&right.name));
-    summaries
 }
 
 fn plugin_command_summaries(plugins: &[Plugin]) -> Vec<PluginCommandSummary> {
@@ -811,37 +793,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn registers_project_plugin_skill_summaries() {
-        let dir = tempdir().expect("tempdir");
-        let rara_home = dir.path().join("home").join(".rara");
-        let workspace_root = dir.path().join("workspace");
-        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-        let plugin_root = project_plugins_dir.join("skillful");
-        write_test_plugin(&plugin_root, "skillful", "echo project");
-        fs::create_dir_all(plugin_root.join("skills").join("reviewer")).expect("skill dir");
-        fs::write(
-            plugin_root.join("skills").join("reviewer").join("SKILL.md"),
-            "# Reviewer\nInspect plugin-provided behavior.",
-        )
-        .expect("skill");
-
-        let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
-        let registered =
-            register_plugin_hooks(&runtime, Some(rara_home), &workspace_root, &[], "session-1")
-                .await;
-
-        assert_eq!(
-            registered.skill_summaries(),
-            &[PluginSkillSummary {
-                name: "skillful:reviewer".to_string(),
-                title: Some("reviewer".to_string()),
-                description: "Inspect plugin-provided behavior.".to_string(),
-                path: plugin_root.join("skills").join("reviewer").join("SKILL.md"),
-            }]
-        );
-    }
-
-    #[tokio::test]
     async fn registers_project_plugin_command_summaries() {
         let dir = tempdir().expect("tempdir");
         let rara_home = dir.path().join("home").join(".rara");
@@ -883,6 +834,37 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn plugin_agent_records_are_namespaced_by_plugin_name() {
+        let dir = tempdir().expect("tempdir");
+        let plugin_root = dir.path().join("plugin");
+        write_test_plugin(&plugin_root, "helpers", "echo project");
+        fs::create_dir_all(plugin_root.join("agents")).expect("agents dir");
+        fs::write(
+            plugin_root.join("agents").join("reviewer.md"),
+            r#"---
+name: reviewer
+description: Reviews plugin-provided code.
+---
+
+Review code from the plugin context.
+"#,
+        )
+        .expect("agent");
+        let plugins = discover_plugins_from_sources(&[PluginDiscoverySource {
+            plugins_dir: dir.path().to_path_buf(),
+            source: PluginSource::Directory(dir.path().to_path_buf()),
+        }]);
+
+        let records = plugin_agent_records(&plugins);
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].id, "helpers:reviewer");
+        let definition = records[0].definition.as_ref().expect("definition");
+        assert_eq!(definition.name, "helpers:reviewer");
+        assert_eq!(definition.description, "Reviews plugin-provided code.");
     }
 
     #[test]
@@ -1131,7 +1113,6 @@ mod tests {
                 plugin_root,
             }],
             Vec::new(),
-            Vec::new(),
             None,
         );
 
@@ -1165,7 +1146,6 @@ mod tests {
                 plugin_name: "observer".to_string(),
                 plugin_root,
             }],
-            Vec::new(),
             Vec::new(),
             Some(hook_runtime.clone()),
         );

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -32,6 +32,7 @@ use crate::mcp_connection_manager::McpConnectionManager;
 use crate::mcp_tool_cache::McpToolCache;
 use crate::prompt::{PromptRuntimeConfig, PromptSkillSummary};
 use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
+use crate::runtime_control::{ExtensionEvent, ExtensionReadinessSnapshot, RuntimeEvent};
 use crate::runtime_event_bus::RuntimeEventBus;
 use crate::sandbox::SandboxManager;
 use crate::session::SessionManager;
@@ -62,6 +63,7 @@ pub(crate) struct RuntimeBootstrap {
     pub mcp_manager: Arc<McpConnectionManager>,
     pub lsp_manager: Arc<LspManager>,
     pub agent_definitions: AgentDefinitionCache,
+    extension_readiness: ExtensionReadinessSnapshot,
     plugin_dirs: Vec<PathBuf>,
     rara_home: Option<PathBuf>,
 }
@@ -147,6 +149,8 @@ impl RuntimeBootstrap {
         let plugin_dirs = self.plugin_dirs.clone();
         let rara_home = self.rara_home.clone();
         let hook_runtime = self.hook_runtime.clone();
+        let event_bus = self.event_bus.clone();
+        let mut extension_readiness = self.extension_readiness.clone();
         let mut parts = self.into_parts();
         let plugin_hook_runtime = crate::plugin_middleware::register_plugin_hooks(
             &hook_runtime,
@@ -156,10 +160,12 @@ impl RuntimeBootstrap {
             &parts.0.session_id,
         )
         .await;
-        parts
-            .0
-            .add_plugin_skill_summaries(plugin_hook_runtime.skill_summaries());
+        extension_readiness.hook_count = plugin_hook_runtime.hook_count();
+        extension_readiness.command_count = plugin_hook_runtime.command_summaries().len();
         parts.0.set_plugin_hook_runtime(plugin_hook_runtime);
+        event_bus.publish_control(RuntimeEvent::Extension(ExtensionEvent::ReadinessUpdated {
+            snapshot: extension_readiness,
+        }));
         parts
     }
 }
@@ -271,10 +277,27 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
         shell_env.env.get("PATH").cloned(),
     )?);
 
+    let config_manager = crate::config::ConfigManager::new()?;
+    let rara_home = ensure_rara_home_dir()?;
+    let plugins = crate::plugin_middleware::discover_runtime_plugins(
+        Some(&rara_home),
+        &workspace.root,
+        &options.plugin_dirs,
+    );
+    let plugin_skill_roots = crate::plugin_middleware::plugin_skill_roots(&plugins);
+    let plugin_agent_records = crate::plugin_middleware::plugin_agent_records(&plugins);
+
     let mut prompt_config = PromptRuntimeConfig::from_config(config);
-    let skill_manager = load_skill_manager(&mut prompt_config.warnings);
-    prompt_config.available_skills = skill_manager
-        .list_summaries()
+    let skill_manager = load_skill_manager(&mut prompt_config.warnings, &plugin_skill_roots);
+    let skill_summaries = skill_manager
+        .read()
+        .map_err(|err| anyhow::anyhow!("skill manager lock failed: {err}"))?
+        .list_summaries();
+    let extension_skill_count = skill_summaries
+        .iter()
+        .filter(|skill| skill.scope == rara_skills::SkillScope::Plugin)
+        .count();
+    prompt_config.available_skills = skill_summaries
         .into_iter()
         .map(|skill| {
             let scope = match skill.scope {
@@ -282,6 +305,7 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
                 rara_skills::SkillScope::Workspace
                 | rara_skills::SkillScope::Repo
                 | rara_skills::SkillScope::Cwd => "workspace",
+                rara_skills::SkillScope::Plugin => "plugin",
                 rara_skills::SkillScope::System => "system",
             };
             PromptSkillSummary {
@@ -309,8 +333,6 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
     mcp_tool_cache.clear();
     let lsp_manager = Arc::new(LspManager::new(workspace.root.clone()));
 
-    let config_manager = crate::config::ConfigManager::new()?;
-    let rara_home = ensure_rara_home_dir()?;
     let mut mcp_registry = config_manager
         .load_mcp_registry_for_project(&workspace.root)
         .unwrap_or_else(|_| crate::config::McpRegistry::empty());
@@ -320,6 +342,11 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
         &workspace.root,
         &options.plugin_dirs,
     )?;
+    let extension_mcp_server_count = mcp_registry
+        .servers
+        .values()
+        .filter(|server| server.source.scope == crate::config::McpServerScope::Plugin)
+        .count();
     let mcp_registry = Arc::new(mcp_registry);
 
     let mcp_manager = Arc::new(McpConnectionManager::new(
@@ -341,7 +368,14 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
         .collect();
     let file_hook_warnings = file_hooks.load_warnings.clone();
     let command_hook_registry = Arc::new(file_hooks);
-    let agent_definitions = AgentDefinitionCache::load(workspace.root.clone());
+    let extension_agent_count = crate::agents_ext::AgentRegistry::from_records(
+        plugin_agent_records.clone(),
+        &workspace.root,
+    )
+    .agents
+    .len();
+    let agent_definitions =
+        AgentDefinitionCache::load_with_records(workspace.root.clone(), plugin_agent_records);
     let tool_manager = create_full_tool_manager(
         backend.clone(),
         embedding_backend.clone(),
@@ -350,6 +384,7 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
         workspace.clone(),
         sandbox_manager.clone(),
         skill_manager,
+        plugin_skill_roots,
         prompt_config.clone(),
         Arc::new(shell_env.env),
         sandbox_network_access.clone(),
@@ -384,6 +419,14 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
         mcp_manager,
         lsp_manager,
         agent_definitions,
+        extension_readiness: ExtensionReadinessSnapshot {
+            plugin_count: plugins.len(),
+            hook_count: 0,
+            skill_count: extension_skill_count,
+            command_count: 0,
+            agent_count: extension_agent_count,
+            mcp_server_count: extension_mcp_server_count,
+        },
         plugin_dirs: options.plugin_dirs,
         rara_home: Some(rara_home),
     })
@@ -396,8 +439,14 @@ enum EmbeddingRoute {
 }
 
 fn embedding_route_for_config(config: &RaraConfig) -> EmbeddingRoute {
-    if config.local_embeddings == LocalEmbeddingPolicy::Off {
-        return EmbeddingRoute::CurrentLlmBackend;
+    match config.local_embeddings {
+        LocalEmbeddingPolicy::Off | LocalEmbeddingPolicy::Provider => {
+            return EmbeddingRoute::CurrentLlmBackend;
+        }
+        LocalEmbeddingPolicy::Local => {
+            return EmbeddingRoute::LocalModelServer;
+        }
+        LocalEmbeddingPolicy::Auto => {}
     }
     match config.provider.as_str() {
         "codex" | "mock" => EmbeddingRoute::CurrentLlmBackend,
@@ -882,6 +931,31 @@ mod tests {
             embedding_route_for_config(&gemini_code_assist),
             EmbeddingRoute::LocalModelServer
         );
+    }
+
+    #[test]
+    fn embedding_route_honors_explicit_provider_and_local_overrides() {
+        let deepseek_provider = RaraConfig {
+            provider: "deepseek".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Provider,
+            ..Default::default()
+        };
+        assert_eq!(
+            embedding_route_for_config(&deepseek_provider),
+            EmbeddingRoute::CurrentLlmBackend
+        );
+        assert!(!config_requires_local_embedding_sidecar(&deepseek_provider));
+
+        let codex_local = RaraConfig {
+            provider: "codex".to_string(),
+            local_embeddings: LocalEmbeddingPolicy::Local,
+            ..Default::default()
+        };
+        assert_eq!(
+            embedding_route_for_config(&codex_local),
+            EmbeddingRoute::LocalModelServer
+        );
+        assert!(config_requires_local_embedding_sidecar(&codex_local));
     }
 
     #[test]

--- a/src/runtime_context/tooling.rs
+++ b/src/runtime_context/tooling.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, OnceLock, atomic::AtomicBool};
+use std::sync::{Arc, OnceLock, RwLock, atomic::AtomicBool};
 
 use rara_background_tasks::{
     BackgroundTaskListTool, BackgroundTaskStatusTool, BackgroundTaskStopTool, BackgroundTaskStore,
@@ -59,7 +59,8 @@ pub(super) fn create_full_tool_manager(
     session_manager: Arc<SessionManager>,
     workspace: Arc<WorkspaceMemory>,
     sandbox: Arc<SandboxManager>,
-    skill_manager: Arc<SkillManager>,
+    skill_manager: Arc<RwLock<SkillManager>>,
+    plugin_roots: Vec<(String, std::path::PathBuf)>,
     prompt_config: PromptRuntimeConfig,
     shell_env: Arc<HashMap<String, String>>,
     sandbox_network_access: Arc<AtomicBool>,
@@ -182,6 +183,7 @@ pub(super) fn create_full_tool_manager(
     }));
     tm.register(Box::new(SkillTool {
         skill_manager: skill_manager.clone(),
+        plugin_roots,
     }));
     tm.register(Box::new(AgentTool {
         backend: backend.clone(),
@@ -247,12 +249,24 @@ pub(super) fn create_full_tool_manager(
     tm
 }
 
-pub(super) fn load_skill_manager(warnings: &mut Vec<String>) -> Arc<SkillManager> {
+pub(super) fn load_skill_manager(
+    warnings: &mut Vec<String>,
+    plugin_roots: &[(String, std::path::PathBuf)],
+) -> Arc<RwLock<SkillManager>> {
     let mut skill_manager = SkillManager::new();
     if let Err(err) = skill_manager.load_all() {
         warnings.push(format!("Skill loading failed: {err}"));
     }
-    Arc::new(skill_manager)
+    for (plugin_name, plugin_root) in plugin_roots {
+        if let Err(err) = skill_manager.load_plugin_skills_from_root(plugin_name, plugin_root) {
+            warnings.push(format!(
+                "Plugin skill loading failed for {} at {}: {err}",
+                plugin_name,
+                plugin_root.display()
+            ));
+        }
+    }
+    Arc::new(RwLock::new(skill_manager))
 }
 
 pub(crate) fn vector_db_uri_for_workspace(workspace: &WorkspaceMemory) -> String {

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -66,6 +66,7 @@ pub enum RuntimeEvent {
     Memory(MemoryEvent),
     Hook(HookEvent),
     Context(ContextEvent),
+    Extension(ExtensionEvent),
     Todo(TodoEvent),
     Warning(WarningEvent),
     Error(ErrorEvent),
@@ -358,6 +359,26 @@ pub enum ContextEvent {
     SnapshotUpdated,
     RetrievalOrchestrationUpdated { view: RetrievalOrchestrationView },
     ObservabilityUpdated { view: ContextObservabilityView },
+}
+
+#[allow(dead_code)] // ACP protocol type — reserved for future lifecycle events
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "payload", rename_all = "snake_case")]
+pub enum ExtensionEvent {
+    ReadinessUpdated {
+        snapshot: ExtensionReadinessSnapshot,
+    },
+}
+
+#[allow(dead_code)] // ACP protocol type — reserved for future lifecycle events
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionReadinessSnapshot {
+    pub plugin_count: usize,
+    pub hook_count: usize,
+    pub skill_count: usize,
+    pub command_count: usize,
+    pub agent_count: usize,
+    pub mcp_server_count: usize,
 }
 
 #[allow(dead_code)] // ACP protocol type — reserved for future lifecycle events
@@ -1270,6 +1291,40 @@ mod tests {
         assert_eq!(
             control_event.event,
             RuntimeEvent::Assistant(AssistantEvent::TextDelta("hello".to_string()))
+        );
+    }
+
+    #[test]
+    fn extension_readiness_event_uses_structured_wire_shape() {
+        let event = RuntimeEvent::Extension(ExtensionEvent::ReadinessUpdated {
+            snapshot: ExtensionReadinessSnapshot {
+                plugin_count: 2,
+                hook_count: 3,
+                skill_count: 4,
+                command_count: 5,
+                agent_count: 6,
+                mcp_server_count: 7,
+            },
+        });
+
+        assert_eq!(
+            serde_json::to_value(event).unwrap(),
+            json!({
+                "type": "extension",
+                "payload": {
+                    "type": "readiness_updated",
+                    "payload": {
+                        "snapshot": {
+                            "plugin_count": 2,
+                            "hook_count": 3,
+                            "skill_count": 4,
+                            "command_count": 5,
+                            "agent_count": 6,
+                            "mcp_server_count": 7
+                        }
+                    }
+                }
+            })
         );
     }
 }

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -64,9 +64,21 @@ pub struct AgentDefinitionCache {
 }
 
 impl AgentDefinitionCache {
+    #[cfg(test)]
     pub fn load(workspace_root: impl Into<PathBuf>) -> Self {
         let workspace_root = workspace_root.into();
-        let state = load_agent_definition_cache_state(&workspace_root);
+        let state = load_agent_definition_cache_state(&workspace_root, Vec::new());
+        Self {
+            state: Arc::new(state),
+        }
+    }
+
+    pub fn load_with_records(
+        workspace_root: impl Into<PathBuf>,
+        extra_records: Vec<AgentDefinitionLoadRecord>,
+    ) -> Self {
+        let workspace_root = workspace_root.into();
+        let state = load_agent_definition_cache_state(&workspace_root, extra_records);
         Self {
             state: Arc::new(state),
         }
@@ -94,8 +106,12 @@ impl AgentDefinitionCache {
     }
 }
 
-fn load_agent_definition_cache_state(workspace_root: &Path) -> AgentDefinitionCacheState {
-    let records = discover_agent_definition_records(workspace_root);
+fn load_agent_definition_cache_state(
+    workspace_root: &Path,
+    extra_records: Vec<AgentDefinitionLoadRecord>,
+) -> AgentDefinitionCacheState {
+    let mut records = discover_agent_definition_records(workspace_root);
+    records.extend(extra_records);
     let mut registry = AgentRegistry::new();
     for record in &records {
         match &record.definition {
@@ -164,7 +180,10 @@ fn agent_definition_dirs_for_root(root: &Path) -> Vec<PathBuf> {
     ]
 }
 
-fn scan_agent_records_dir(agents_dir: &Path, records: &mut Vec<AgentDefinitionLoadRecord>) {
+pub(crate) fn scan_agent_records_dir(
+    agents_dir: &Path,
+    records: &mut Vec<AgentDefinitionLoadRecord>,
+) {
     if !agents_dir.exists() || !agents_dir.is_dir() {
         return;
     }

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -1,4 +1,5 @@
-use std::sync::Arc;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use rara_tool_macros::tool_spec;
@@ -7,8 +8,14 @@ use serde_json::{Value, json};
 
 use crate::skill::SkillManager;
 
+#[cfg(test)]
+fn shared_skill_manager(manager: SkillManager) -> Arc<RwLock<SkillManager>> {
+    Arc::new(RwLock::new(manager))
+}
+
 pub struct SkillTool {
-    pub skill_manager: Arc<SkillManager>,
+    pub skill_manager: Arc<RwLock<SkillManager>>,
+    pub plugin_roots: Vec<(String, PathBuf)>,
 }
 #[tool_spec(
     name = "skill",
@@ -41,13 +48,15 @@ impl Tool for SkillTool {
             .ok_or(ToolError::InvalidInput("action".into()))?;
         match action {
             "list" => {
-                let scopes = self.skill_manager.active_scopes();
-                let skills: Vec<Value> = self
-                    .skill_manager
+                let skill_manager = self.skill_manager.read().map_err(|err| {
+                    ToolError::ExecutionFailed(format!("skill lock failed: {err}"))
+                })?;
+                let scopes = skill_manager.active_scopes();
+                let skills: Vec<Value> = skill_manager
                     .list_summaries()
                     .iter()
                     .map(|s| {
-                        let shadows = self.skill_manager.shadows_others(&s.name);
+                        let shadows = skill_manager.shadows_others(&s.name);
                         json!({
                             "name": s.name,
                             "title": s.title,
@@ -56,7 +65,7 @@ impl Tool for SkillTool {
                             "disable_model_invocation": s.disable_model_invocation,
                             "overrides_others": shadows,
                             "shadowed_scopes": if shadows {
-                                self.skill_manager.override_chain(&s.name)
+                                skill_manager.override_chain(&s.name)
                                     .iter()
                                     .map(|o| o.scope.as_str())
                                     .collect::<Vec<_>>()
@@ -69,8 +78,8 @@ impl Tool for SkillTool {
                 Ok(json!({
                     "skills": skills,
                     "scopes": scopes,
-                    "overrides": self.skill_manager.list_overrides(),
-                    "load_warnings": &self.skill_manager.load_warnings,
+                    "overrides": skill_manager.list_overrides(),
+                    "load_warnings": &skill_manager.load_warnings,
                 }))
             }
             "invoke" => {
@@ -78,14 +87,15 @@ impl Tool for SkillTool {
                     .as_str()
                     .ok_or(ToolError::InvalidInput("skill_name".into()))?;
                 let args = i.get("args").and_then(|v| v.as_str()).map(String::from);
-                let skill =
-                    self.skill_manager
-                        .get_skill(name)
-                        .ok_or(ToolError::ExecutionFailed(format!(
-                            "Skill not found: {name}"
-                        )))?;
-                let shadowed_scopes: Vec<String> = self
-                    .skill_manager
+                let skill_manager = self.skill_manager.read().map_err(|err| {
+                    ToolError::ExecutionFailed(format!("skill lock failed: {err}"))
+                })?;
+                let skill = skill_manager
+                    .get_skill(name)
+                    .ok_or(ToolError::ExecutionFailed(format!(
+                        "Skill not found: {name}"
+                    )))?;
+                let shadowed_scopes: Vec<String> = skill_manager
                     .override_chain(name)
                     .iter()
                     .map(|o| o.scope.as_str().to_string())
@@ -103,14 +113,30 @@ impl Tool for SkillTool {
             }
             "reload" => {
                 let mut verify = SkillManager::new();
-                match verify.load_all() {
-                    Ok(()) => Ok(json!({
-                        "reloaded": true,
-                        "skill_count": verify.list_summaries().len(),
-                        "warnings": &verify.load_warnings,
-                    })),
-                    Err(e) => Err(ToolError::ExecutionFailed(e.to_string())),
+                if let Err(err) = verify.load_all() {
+                    return Err(ToolError::ExecutionFailed(err.to_string()));
                 }
+                for (plugin_name, plugin_root) in &self.plugin_roots {
+                    if let Err(err) = verify.load_plugin_skills_from_root(plugin_name, plugin_root)
+                    {
+                        verify.load_warnings.push(format!(
+                            "Failed to load plugin skills from {}: {}",
+                            plugin_root.display(),
+                            err
+                        ));
+                    }
+                }
+                let skill_count = verify.list_summaries().len();
+                let warnings = verify.load_warnings.clone();
+                let mut skill_manager = self.skill_manager.write().map_err(|err| {
+                    ToolError::ExecutionFailed(format!("skill lock failed: {err}"))
+                })?;
+                *skill_manager = verify;
+                Ok(json!({
+                    "reloaded": true,
+                    "skill_count": skill_count,
+                    "warnings": warnings,
+                }))
             }
             _ => Err(ToolError::InvalidInput("Invalid action".into())),
         }
@@ -123,7 +149,8 @@ async fn list_returns_scopes_and_skills() {
     manager.load_warnings = vec!["test warning".into()];
 
     let tool = SkillTool {
-        skill_manager: Arc::new(manager),
+        skill_manager: shared_skill_manager(manager),
+        plugin_roots: Vec::new(),
     };
 
     let result = tool.call(json!({"action": "list"})).await.expect("list");
@@ -138,7 +165,8 @@ async fn list_returns_scopes_and_skills() {
 fn skill_tool_description_requires_exact_pre_task_invocation() {
     let manager = SkillManager::new();
     let tool = SkillTool {
-        skill_manager: Arc::new(manager),
+        skill_manager: shared_skill_manager(manager),
+        plugin_roots: Vec::new(),
     };
     let description = tool.description();
 
@@ -172,7 +200,8 @@ async fn invoke_returns_overridden_by_when_present() {
     );
 
     let tool = SkillTool {
-        skill_manager: Arc::new(manager),
+        skill_manager: shared_skill_manager(manager),
+        plugin_roots: Vec::new(),
     };
 
     let result = tool
@@ -192,7 +221,8 @@ async fn invoke_returns_overridden_by_when_present() {
 async fn invoke_missing_skill_returns_error() {
     let manager = SkillManager::new();
     let tool = SkillTool {
-        skill_manager: Arc::new(manager),
+        skill_manager: shared_skill_manager(manager),
+        plugin_roots: Vec::new(),
     };
 
     let err = tool
@@ -232,7 +262,8 @@ async fn list_shows_overridden_flag() {
     );
 
     let tool = SkillTool {
-        skill_manager: Arc::new(manager),
+        skill_manager: shared_skill_manager(manager),
+        plugin_roots: Vec::new(),
     };
 
     let result = tool.call(json!({"action": "list"})).await.expect("list");
@@ -276,7 +307,8 @@ async fn list_returns_active_scopes() {
     );
 
     let tool = SkillTool {
-        skill_manager: Arc::new(manager),
+        skill_manager: shared_skill_manager(manager),
+        plugin_roots: Vec::new(),
     };
 
     let result = tool.call(json!({"action": "list"})).await.expect("list");
@@ -284,4 +316,42 @@ async fn list_returns_active_scopes() {
     assert_eq!(scopes.len(), 2);
     assert_eq!(scopes[0].as_str(), Some("home"));
     assert_eq!(scopes[1].as_str(), Some("repo"));
+}
+
+#[tokio::test]
+async fn reload_updates_running_manager_with_plugin_skills() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let plugin_root = temp.path().join("plugin");
+    let skill_dir = plugin_root.join("skills").join("reviewer");
+    std::fs::create_dir_all(&skill_dir).expect("skill dir");
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "# Reviewer\nInspect plugin-provided behavior.",
+    )
+    .expect("skill");
+
+    let manager = shared_skill_manager(SkillManager::new());
+    let tool = SkillTool {
+        skill_manager: manager.clone(),
+        plugin_roots: vec![("quality".to_string(), plugin_root)],
+    };
+
+    let result = tool
+        .call(json!({"action": "reload"}))
+        .await
+        .expect("reload");
+    assert_eq!(result["reloaded"].as_bool(), Some(true));
+
+    let invoked = tool
+        .call(json!({"action": "invoke", "skill_name": "quality:reviewer"}))
+        .await
+        .expect("invoke plugin skill");
+    assert_eq!(invoked["scope"].as_str(), Some("plugin"));
+    assert_eq!(
+        invoked["instructions"].as_str(),
+        Some("# Reviewer\nInspect plugin-provided behavior.")
+    );
+
+    let guard = manager.read().expect("manager");
+    assert!(guard.get_skill("quality:reviewer").is_some());
 }

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -236,11 +236,7 @@ fn discover_extension_counts(cwd: &str, agent: &Agent) -> (usize, usize, Vec<Str
     let root = std::path::Path::new(cwd);
     let mut hook_registry = crate::hooks::HookRegistry::new();
     hook_registry.discover_repo_hooks(root);
-    let records = agent
-        .agent_definition_records()
-        .into_iter()
-        .filter(|record| record.source_path.starts_with(root))
-        .collect();
+    let records = agent.agent_definition_records();
     let agent_registry = crate::agents_ext::AgentRegistry::from_records(records, root);
     let agent_count = agent_registry.agents.len();
     let agent_status_lines = if agent_count == 0 {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -345,7 +345,7 @@ Reloaded prompt.
 }
 
 #[test]
-fn sync_snapshot_counts_only_repo_agent_definition_records() {
+fn sync_snapshot_counts_runtime_agent_definition_records() {
     let dir = tempdir().expect("tempdir");
     let root = dir.path().join("workspace");
     let rara_dir = root.join(".rara");
@@ -383,7 +383,7 @@ fn sync_snapshot_counts_only_repo_agent_definition_records() {
 
     app.sync_snapshot(&agent);
 
-    assert_eq!(app.snapshot.extension_agent_count, 1);
+    assert_eq!(app.snapshot.extension_agent_count, 2);
     assert!(
         app.snapshot
             .extension_agent_status_lines
@@ -391,7 +391,7 @@ fn sync_snapshot_counts_only_repo_agent_definition_records() {
             .any(|line| line.contains("repo-agent"))
     );
     assert!(
-        !app.snapshot
+        app.snapshot
             .extension_agent_status_lines
             .iter()
             .any(|line| line.contains("home-agent"))


### PR DESCRIPTION
## Summary

- Load Claude plugin skills into the shared `SkillManager` so `skill list`, `skill invoke`, and `skill reload` work for namespaced plugin skills.
- Load Claude plugin agent definitions into the session-scoped `AgentDefinitionCache` with `plugin_name:agent_name` names.
- Publish structured extension readiness snapshots on the runtime control bus.
- Add explicit `local_embeddings = "provider"` and `local_embeddings = "local"` overrides, plus matching environment aliases.
- Update plugin, runtime control-plane, embedding specs, implementation journals, and close the related TODO items.

## Purpose

This completes the remaining plugin extension registry work by moving plugin-owned runtime behavior into app-server/runtime assembly instead of prompt-only summaries. It also closes the embedding routing TODO by allowing users to explicitly choose provider-native or local sidecar embedding routing.

## Related Issues

- None.

## Testing

- `cargo test -p rara-skills plugin_skills_are_namespaced_and_invokable -- --nocapture`
- `cargo test plugin_middleware::tests::plugin_agent_records_are_namespaced_by_plugin_name -- --nocapture`
- `cargo test tools::skill::reload_updates_running_manager_with_plugin_skills -- --nocapture`
- `cargo test runtime_control::tests::extension_readiness_event_uses_structured_wire_shape -- --nocapture`
- `cargo test runtime_context::tests::embedding_route_honors_explicit_provider_and_local_overrides -- --nocapture`
- `cargo test -p rara-config local_embeddings -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
