### PR TITLE
chore(provider): dedupe OpenAI-compatible backend setup

### DIFF
--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -676,25 +676,7 @@ pub(crate) async fn build_backend_with_progress(
                 .value
                 .unwrap_or_else(|| kind.default_base_url())
                 .to_string();
-            let mut backend = OpenAiCompatibleBackend::new_with_endpoint_kind_and_reasoning(
-                config.api_key_secret(),
-                base_url.clone(),
-                model.clone(),
-                kind,
-                config.reasoning_effort.clone(),
-                config.thinking,
-            )?
-            .with_auxiliary_model(config.auxiliary_model.clone());
-            if backend.context_budget(&[], &[]).is_none() {
-                backend.context_window_override = fetch_model_context_window(
-                    &backend.client,
-                    &base_url,
-                    backend.api_key.as_ref(),
-                    &model,
-                )
-                .await;
-            }
-            Ok(Box::new(backend))
+            build_openai_compatible_backend(config, base_url, model, kind).await
         }
         "ollama" | "ollama-native" => Ok(Box::new(OllamaBackend::new(
             config
@@ -731,25 +713,8 @@ pub(crate) async fn build_backend_with_progress(
                 .base_url
                 .clone()
                 .unwrap_or_else(|| DEFAULT_GEMINI_BASE_URL.to_string());
-            let mut backend = OpenAiCompatibleBackend::new_with_endpoint_kind_and_reasoning(
-                config.api_key_secret(),
-                base_url.clone(),
-                model.clone(),
-                OpenAiEndpointKind::Custom,
-                config.reasoning_effort.clone(),
-                config.thinking,
-            )?
-            .with_auxiliary_model(config.auxiliary_model.clone());
-            if backend.context_budget(&[], &[]).is_none() {
-                backend.context_window_override = fetch_model_context_window(
-                    &backend.client,
-                    &base_url,
-                    backend.api_key.as_ref(),
-                    &model,
-                )
-                .await;
-            }
-            Ok(Box::new(backend))
+            build_openai_compatible_backend(config, base_url, model, OpenAiEndpointKind::Custom)
+                .await
         }
         "gemini-code-assist" => {
             let model = config
@@ -789,28 +754,38 @@ pub(crate) async fn build_backend_with_progress(
             let base_url = config.base_url.clone().with_context(|| {
                 format!("Base URL required for configured provider '{provider}'")
             })?;
-            let mut backend = OpenAiCompatibleBackend::new_with_endpoint_kind_and_reasoning(
-                config.api_key_secret(),
-                base_url.clone(),
-                model.clone(),
-                OpenAiEndpointKind::Custom,
-                config.reasoning_effort.clone(),
-                config.thinking,
-            )?
-            .with_auxiliary_model(config.auxiliary_model.clone());
-            if backend.context_budget(&[], &[]).is_none() {
-                backend.context_window_override = fetch_model_context_window(
-                    &backend.client,
-                    &base_url,
-                    backend.api_key.as_ref(),
-                    &model,
-                )
-                .await;
-            }
-            Ok(Box::new(backend))
+            build_openai_compatible_backend(config, base_url, model, OpenAiEndpointKind::Custom)
+                .await
         }
         other => bail!("Unsupported provider '{other}'"),
     }
+}
+
+async fn build_openai_compatible_backend(
+    config: &RaraConfig,
+    base_url: String,
+    model: String,
+    kind: OpenAiEndpointKind,
+) -> Result<Box<dyn LlmBackend>> {
+    let mut backend = OpenAiCompatibleBackend::new_with_endpoint_kind_and_reasoning(
+        config.api_key_secret(),
+        base_url.clone(),
+        model.clone(),
+        kind,
+        config.reasoning_effort.clone(),
+        config.thinking,
+    )?
+    .with_auxiliary_model(config.auxiliary_model.clone());
+    if backend.context_budget(&[], &[]).is_none() {
+        backend.context_window_override = fetch_model_context_window(
+            &backend.client,
+            &base_url,
+            backend.api_key.as_ref(),
+            &model,
+        )
+        .await;
+    }
+    Ok(Box::new(backend))
 }
 
 fn ollama_thinking_enabled(config: &RaraConfig) -> bool {


### PR DESCRIPTION
## Summary

- extract shared OpenAI-compatible backend construction in `runtime_context`
- keep provider-family, Gemini OpenAI-compatible, and configured custom provider paths on the same context-window override path
- leave the existing `ollama-openai` path unchanged

## Purpose

This removes duplicated backend setup code after provider-target routing landed.
Future OpenAI-compatible provider additions should now reuse one helper instead
of copying auxiliary-model and context-window override logic.

## Related Issues

None.

## Testing

- `cargo fmt --check`
- `cargo test runtime_context::tests::config_subagent_backend_resolver_builds_configured_provider_state`
- `cargo test runtime_context::tests::config_subagent_backend_resolver_builds_target_backend`
- `cargo check`
- `git diff --check`
