### PR TITLE
chore(tools): report apply patch deltas

### DIFF
--- a/crates/rara-apply-patch/src/lib.rs
+++ b/crates/rara-apply-patch/src/lib.rs
@@ -85,6 +85,75 @@ pub enum PatchChange {
     },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AppliedPatchDelta {
+    changes: Vec<AppliedPatchChange>,
+    exact: bool,
+}
+
+impl Default for AppliedPatchDelta {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl AppliedPatchDelta {
+    pub fn empty() -> Self {
+        Self {
+            changes: Vec::new(),
+            exact: true,
+        }
+    }
+
+    pub fn changes(&self) -> &[AppliedPatchChange] {
+        &self.changes
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
+    }
+
+    pub fn is_exact(&self) -> bool {
+        self.exact
+    }
+
+    pub fn mark_inexact(&mut self) {
+        self.exact = false;
+    }
+
+    pub fn push_change(&mut self, change: AppliedPatchChange) -> usize {
+        self.changes.push(change);
+        self.changes.len() - 1
+    }
+
+    pub fn replace_change(&mut self, index: usize, change: AppliedPatchChange) {
+        self.changes[index] = change;
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AppliedPatchChange {
+    pub path: String,
+    pub change: AppliedPatchFileChange,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AppliedPatchFileChange {
+    Add {
+        content: String,
+        overwritten_content: Option<String>,
+    },
+    Delete {
+        content: String,
+    },
+    Update {
+        move_to: Option<String>,
+        original_content: String,
+        overwritten_move_content: Option<String>,
+        new_content: String,
+    },
+}
+
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct PatchActionStats {
     pub files_changed: usize,
@@ -583,9 +652,9 @@ mod tests {
     use std::string::ToString;
 
     use super::{
-        PatchChange, PatchError, PatchMove, PatchOp, PatchStats, apply_update_chunks,
-        build_patch_action, normalise_unicode, parse_patch, seek_sequence,
-        validate_patch_update_context,
+        AppliedPatchChange, AppliedPatchDelta, AppliedPatchFileChange, PatchChange, PatchError,
+        PatchMove, PatchOp, PatchStats, apply_update_chunks, build_patch_action, normalise_unicode,
+        parse_patch, seek_sequence, validate_patch_update_context,
     };
 
     fn to_vec(strings: &[&str]) -> Vec<String> {
@@ -742,6 +811,45 @@ mod tests {
             error,
             PatchError::ExecutionFailed("Cannot update missing file missing.txt".to_string())
         );
+    }
+
+    #[test]
+    fn applied_patch_delta_defaults_to_exact_empty_state() {
+        let mut delta = AppliedPatchDelta::default();
+
+        assert!(delta.is_empty());
+        assert!(delta.is_exact());
+
+        let index = delta.push_change(AppliedPatchChange {
+            path: "created.txt".to_string(),
+            change: AppliedPatchFileChange::Add {
+                content: "hello\n".to_string(),
+                overwritten_content: None,
+            },
+        });
+        assert_eq!(index, 0);
+        assert!(!delta.is_empty());
+        assert!(delta.is_exact());
+
+        delta.replace_change(
+            index,
+            AppliedPatchChange {
+                path: "created.txt".to_string(),
+                change: AppliedPatchFileChange::Update {
+                    move_to: None,
+                    original_content: "hello\n".to_string(),
+                    overwritten_move_content: None,
+                    new_content: "hi\n".to_string(),
+                },
+            },
+        );
+        delta.mark_inexact();
+
+        assert!(!delta.is_exact());
+        assert!(matches!(
+            &delta.changes()[0].change,
+            AppliedPatchFileChange::Update { new_content, .. } if new_content == "hi\n"
+        ));
     }
 
     #[test]

--- a/crates/rara-tools/src/patch.rs
+++ b/crates/rara-tools/src/patch.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 
 use async_trait::async_trait;
 use rara_apply_patch::{
-    PatchChange, PatchError, PatchOp, build_patch_action_from_ops, parse_patch,
-    validate_patch_update_context,
+    AppliedPatchChange, AppliedPatchDelta, AppliedPatchFileChange, PatchChange, PatchError,
+    PatchOp, build_patch_action_from_ops, parse_patch, validate_patch_update_context,
 };
 use rara_tool_macros::tool_spec;
 use serde_json::{Value, json};
@@ -79,38 +79,63 @@ impl Tool for ApplyPatchTool {
             },
         };
         let action = build_patch_action_from_ops(patch, ops, &mut read_for_action)?;
+        let mut delta = AppliedPatchDelta::empty();
 
         for change in &action.changes {
             match change {
                 PatchChange::Add { path, content, .. } => {
                     if Path::new(&path).exists() {
-                        return Err(ToolError::ExecutionFailed(format!(
-                            "Cannot add existing file {path}"
-                        )));
+                        return Err(patch_apply_failure(
+                            format!("Cannot add existing file {path}"),
+                            &delta,
+                        ));
                     }
                     if !dry_run {
-                        write_text_file(path, content)?;
+                        write_text_file(path, content, &mut delta)?;
+                        delta.push_change(AppliedPatchChange {
+                            path: path.clone(),
+                            change: AppliedPatchFileChange::Add {
+                                content: content.clone(),
+                                overwritten_content: None,
+                            },
+                        });
                         if let Some(read_state) = &self.read_state {
                             record_patch_write_best_effort(read_state, path, content);
                         }
                     }
                 }
-                PatchChange::Delete { path, .. } => {
+                PatchChange::Delete { path, content, .. } => {
                     if !Path::new(&path).exists() {
-                        return Err(ToolError::ExecutionFailed(format!(
-                            "Cannot delete missing file {path}"
-                        )));
+                        return Err(patch_apply_failure(
+                            format!("Cannot delete missing file {path}"),
+                            &delta,
+                        ));
                     }
                     if !dry_run {
                         if let Some(read_state) = &self.read_state {
                             read_state.forget(path)?;
                         }
-                        fs::remove_file(path)?;
+                        if let Err(err) = fs::remove_file(path) {
+                            if !file_still_matches(path, content) {
+                                delta.mark_inexact();
+                            }
+                            return Err(patch_apply_failure(
+                                format!("Failed to delete file {path}: {err}"),
+                                &delta,
+                            ));
+                        }
+                        delta.push_change(AppliedPatchChange {
+                            path: path.clone(),
+                            change: AppliedPatchFileChange::Delete {
+                                content: content.clone(),
+                            },
+                        });
                     }
                 }
                 PatchChange::Update {
                     path,
                     move_to,
+                    original_content,
                     new_content,
                     ..
                 } => {
@@ -119,15 +144,55 @@ impl Tool for ApplyPatchTool {
                         if let Some(target) = &move_to
                             && target != path
                         {
-                            if let Some(parent) = Path::new(target).parent() {
-                                fs::create_dir_all(parent)?;
-                            }
+                            let overwritten_move_content =
+                                read_optional_existing_text(target, &mut delta);
+                            write_text_file(target, new_content, &mut delta)?;
+                            let target_delta_index = delta.push_change(AppliedPatchChange {
+                                path: target.clone(),
+                                change: AppliedPatchFileChange::Add {
+                                    content: new_content.clone(),
+                                    overwritten_content: overwritten_move_content.clone(),
+                                },
+                            });
                             if let Some(read_state) = &self.read_state {
                                 read_state.forget(path)?;
                             }
-                            fs::remove_file(path)?;
+                            if let Err(err) = fs::remove_file(path) {
+                                if !file_still_matches(path, original_content) {
+                                    delta.mark_inexact();
+                                }
+                                return Err(patch_apply_failure(
+                                    format!("Failed to delete moved source file {path}: {err}"),
+                                    &delta,
+                                ));
+                            }
+                            delta.replace_change(
+                                target_delta_index,
+                                AppliedPatchChange {
+                                    path: path.clone(),
+                                    change: AppliedPatchFileChange::Update {
+                                        move_to: Some(target.clone()),
+                                        original_content: original_content.clone(),
+                                        overwritten_move_content,
+                                        new_content: new_content.clone(),
+                                    },
+                                },
+                            );
+                            if let Some(read_state) = &self.read_state {
+                                record_patch_write_best_effort(read_state, target, new_content);
+                            }
+                            continue;
                         }
-                        write_text_file(write_path, new_content)?;
+                        write_text_file(write_path, new_content, &mut delta)?;
+                        delta.push_change(AppliedPatchChange {
+                            path: path.clone(),
+                            change: AppliedPatchFileChange::Update {
+                                move_to: None,
+                                original_content: original_content.clone(),
+                                overwritten_move_content: None,
+                                new_content: new_content.clone(),
+                            },
+                        });
                         if let Some(read_state) = &self.read_state {
                             record_patch_write_best_effort(read_state, write_path, new_content);
                         }
@@ -153,6 +218,7 @@ impl Tool for ApplyPatchTool {
             "summary": action.summary(),
             "diff_preview": action.preview.text,
             "diff_truncated": action.preview.truncated,
+            "applied_delta": applied_delta_json(&delta),
         }))
     }
 }
@@ -163,12 +229,89 @@ fn record_patch_write_best_effort(read_state: &FileReadState, path: &str, conten
     }
 }
 
-fn write_text_file(path: &str, content: &str) -> Result<(), ToolError> {
-    if let Some(parent) = Path::new(path).parent() {
-        fs::create_dir_all(parent)?;
+fn write_text_file(
+    path: &str,
+    content: &str,
+    delta: &mut AppliedPatchDelta,
+) -> Result<(), ToolError> {
+    if let Some(parent) = Path::new(path).parent()
+        && let Err(err) = fs::create_dir_all(parent)
+    {
+        return Err(patch_apply_failure(
+            format!("Failed to create parent directory for {path}: {err}"),
+            delta,
+        ));
     }
-    fs::write(path, content)?;
+    if let Err(err) = fs::write(path, content) {
+        delta.mark_inexact();
+        return Err(patch_apply_failure(
+            format!("Failed to write file {path}: {err}"),
+            delta,
+        ));
+    }
     Ok(())
+}
+
+fn patch_apply_failure(message: impl Into<String>, delta: &AppliedPatchDelta) -> ToolError {
+    ToolError::ExecutionFailed(format!(
+        "{}\napplied_delta: {}",
+        message.into(),
+        applied_delta_json(delta)
+    ))
+}
+
+fn applied_delta_json(delta: &AppliedPatchDelta) -> Value {
+    json!({
+        "exact": delta.is_exact(),
+        "changes": delta.changes().iter().map(applied_patch_change_json).collect::<Vec<_>>(),
+    })
+}
+
+fn applied_patch_change_json(change: &AppliedPatchChange) -> Value {
+    match &change.change {
+        AppliedPatchFileChange::Add {
+            content,
+            overwritten_content,
+        } => json!({
+            "path": change.path,
+            "kind": "add",
+            "content": content,
+            "overwritten_content": overwritten_content,
+        }),
+        AppliedPatchFileChange::Delete { content } => json!({
+            "path": change.path,
+            "kind": "delete",
+            "content": content,
+        }),
+        AppliedPatchFileChange::Update {
+            move_to,
+            original_content,
+            overwritten_move_content,
+            new_content,
+        } => json!({
+            "path": change.path,
+            "kind": "update",
+            "move_to": move_to,
+            "original_content": original_content,
+            "overwritten_move_content": overwritten_move_content,
+            "new_content": new_content,
+        }),
+    }
+}
+
+fn file_still_matches(path: &str, expected_content: &str) -> bool {
+    read_file_content(path).is_ok_and(|content| content == expected_content)
+}
+
+fn read_optional_existing_text(path: &str, delta: &mut AppliedPatchDelta) -> Option<String> {
+    match read_file_content(path) {
+        Ok(content) => Some(content),
+        Err(ToolError::Io(err)) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(_) => {
+            delta.mark_inexact();
+            None
+        }
+    }
 }
 
 impl From<PatchError> for ToolError {
@@ -227,6 +370,16 @@ mod tests {
                 .expect("diff preview")
                 .contains("-hello\n+hi")
         );
+        assert_eq!(result["applied_delta"]["exact"], true);
+        assert_eq!(result["applied_delta"]["changes"][0]["kind"], "update");
+        assert_eq!(
+            result["applied_delta"]["changes"][0]["original_content"],
+            "hello\nworld\n"
+        );
+        assert_eq!(
+            result["applied_delta"]["changes"][0]["new_content"],
+            "hi\nworld\n"
+        );
     }
 
     #[tokio::test]
@@ -252,6 +405,11 @@ mod tests {
             "hello\nworld\n"
         );
         assert_eq!(result["status"], "validated");
+        assert_eq!(result["applied_delta"]["exact"], true);
+        assert_eq!(
+            result["applied_delta"]["changes"].as_array().unwrap().len(),
+            0
+        );
     }
 
     #[tokio::test]
@@ -276,6 +434,54 @@ mod tests {
         );
         assert_eq!(result["status"], "applied");
         assert_eq!(result["created_files"][0], file.display().to_string());
+        assert_eq!(result["applied_delta"]["changes"][0]["kind"], "add");
+        assert_eq!(
+            result["applied_delta"]["changes"][0]["content"],
+            "hello\nworld\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_applied_delta_after_partial_patch_failure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let created = dir.path().join("created.txt");
+        let parent_file = dir.path().join("not_a_directory");
+        let blocked_child = parent_file.join("child.txt");
+        std::fs::write(&parent_file, "parent\n").expect("write parent file");
+
+        let tool = ApplyPatchTool::default();
+        let error = tool
+            .call(json!({
+                "patch": format!(
+                    "*** Begin Patch\n*** Add File: {}\n+created\n*** Add File: {}\n+blocked\n*** End Patch",
+                    created.display(),
+                    blocked_child.display()
+                )
+            }))
+            .await
+            .expect_err("second write should fail");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("Failed to create parent directory"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("\"exact\":true"),
+            "delta should be exact when failure happens before the blocked write: {message}"
+        );
+        assert!(
+            message.contains("\"kind\":\"add\""),
+            "delta should include the committed add: {message}"
+        );
+        assert!(
+            message.contains(&created.display().to_string()),
+            "delta should include the committed path: {message}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&created).expect("created file remains"),
+            "created\n"
+        );
     }
 
     #[tokio::test]

--- a/docs/journal/2026-07-27-apply-patch-crate.md
+++ b/docs/journal/2026-07-27-apply-patch-crate.md
@@ -36,6 +36,14 @@ side effects.
   app-server surfaces.
 - Keep filesystem writes in `rara-tools` for this step. A later PR can add an
   applied-delta failure contract once this crate boundary is stable.
+- Represent filesystem side effects with `AppliedPatchDelta` in the core crate,
+  but let `rara-tools` populate it at the I/O boundary. The delta records
+  committed add/delete/update effects and whether the report is exact after a
+  failure.
+- Apply move updates by writing the target first and deleting the source after
+  the target write succeeds. During a failed source delete, the tool can still
+  report the target write as an applied add, including any overwritten target
+  content.
 
 ## Validation
 
@@ -51,4 +59,6 @@ git diff --check
 
 ## Follow-Ups
 
-- Add structured applied-delta failure reporting for partial filesystem writes.
+- Consider promoting apply-patch failure details from the current error-message
+  JSON payload into a structured `ToolError` details field if other tools need
+  the same recovery contract.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -129,7 +129,7 @@ Active backlog only. Keep this file small and current.
 
 - [x] Add a typed `PatchAction` preview API for approval UI and app-server
       surfaces.
-- [ ] Add structured applied-delta failure reporting for partial filesystem
+- [x] Add structured applied-delta failure reporting for partial filesystem
       writes.
 
 ## ACP Compatibility


### PR DESCRIPTION
## Summary

- Add `AppliedPatchDelta` typed side-effect reporting to `rara-apply-patch`.
- Include `applied_delta` in successful `apply_patch` tool results and failed apply errors.
- Apply move patches by writing the target before deleting the source so partial failures can report the committed target write.
- Mark the patch-engine TODO complete and update the implementation journal.

## Purpose

This closes the remaining patch-engine recovery gap after extracting the core crate. When a multi-file patch partially applies and then fails, callers now get enough information to understand which filesystem changes were committed and whether that report is exact.

## Related Issue

Not linked.

## Testing

```bash
cargo test -p rara-apply-patch
cargo test -p rara-tools patch::tests -- --nocapture
cargo check -p rara-apply-patch -p rara-tools
cargo clippy -p rara-apply-patch -p rara-tools --all-targets -- -D warnings
cargo fmt --check
git diff --check
```
