### PR TITLE
chore(context): document file search selection

### DIFF
--- a/docs/features/file-search.md
+++ b/docs/features/file-search.md
@@ -15,7 +15,8 @@ no reusable search primitive for TUI file pickers or context file routing.
 ## Scope
 
 The first implementation introduces a reusable file-search crate and routes the
-`list_files` tool through it.
+`list_files` tool through it. A later slice also exposes fuzzy path matches as
+paths-only retrieval candidates for the shared `MemorySelection` pipeline.
 
 In scope:
 
@@ -78,6 +79,23 @@ The tool adapter owns RARA-specific default excludes such as `target`,
 `node_modules`, `dist`, and virtual environments. Those excludes do not belong
 in the generic crate because other callers may need exact git-aware traversal.
 
+### Memory Selection Adapter
+
+Runtime context routing uses `FileSearchCandidateProvider` to translate fuzzy
+path matches into `RetrievalCandidate` values with `kind = "file_search"`.
+Those candidates flow through the same `MemorySelection` ranking and budget
+allocator as memory, session, MCP, hook, and graph candidates.
+
+File-search candidates are deliberately paths-only:
+
+- `source_path` carries the matched workspace-relative path.
+- `detail` records file-search provenance and `paths_only`.
+- `budget_impact_tokens` estimates only path/provenance text.
+- file contents are not read or injected by this adapter.
+
+This keeps file routing observable in `/context` while preserving prompt-cache
+stability until an explicit excerpt-selection step exists.
+
 ## Validation Matrix
 
 - `.gitignore` in a git workspace suppresses ignored files.
@@ -87,6 +105,8 @@ in the generic crate because other callers may need exact git-aware traversal.
 - `list_files` still suppresses build artifacts by default.
 - `list_files include_ignored=true` includes those artifacts.
 - `list_files limit` reports `total_count` and `truncated`.
+- file-search retrieval candidates pass through `MemorySelection` as paths-only
+  candidates.
 
 ## Open Risks
 
@@ -95,15 +115,16 @@ in the generic crate because other callers may need exact git-aware traversal.
 - `glob` and `grep` still have their own traversal paths. They should move to
   the shared crate only when their output contracts and ignore semantics are
   updated deliberately.
-- File search is not yet connected to `MemorySelection`; automatic context
-  injection must preserve budget and cache-prefix stability.
+- Automatic file-content injection remains intentionally out of scope until
+  excerpt selection has a cache-stable budget contract.
 
 ## Follow-Up
 
 Future work should add a session-style incremental search surface for TUI
-pickers, then use the same crate for context file routing before injecting
-candidate files into `MemorySelection`.
+pickers. File-content injection should wait for an explicit excerpt-selection
+contract that preserves budget and cache-prefix stability.
 
 ## Source Journals
 
 - `docs/journal/2026-05-07-file-search-crate.md`
+- `docs/journal/2026-07-29-file-search-memory-selection.md`

--- a/docs/journal/2026-07-29-file-search-memory-selection.md
+++ b/docs/journal/2026-07-29-file-search-memory-selection.md
@@ -1,0 +1,29 @@
+# File Search Memory Selection
+
+## What Changed
+
+- Added focused coverage that proves `file_search` retrieval candidates pass
+  through the shared `MemorySelection` ranking and budget path.
+- Updated the file-search feature spec to record the current paths-only
+  adapter behavior.
+
+## Why
+
+File search is now part of context routing through precomputed
+`RetrievalCandidate` values. The contract needs to stay explicit because the
+adapter surfaces matched paths for selection and observability, but it does not
+read file contents or inject excerpts.
+
+## Trade-Offs
+
+- The adapter keeps file-search candidates cheap and cache-stable by charging
+  only path/provenance text.
+- File contents remain out of scope until an excerpt-selection step can own
+  token budgets, provenance, and prompt-cache impact.
+
+## Remaining Work
+
+- Add a session-style incremental search surface for large-workspace TUI
+  pickers.
+- Design a separate excerpt-selection contract before allowing file contents to
+  enter the prompt automatically.

--- a/src/context/memory_selection_tests.rs
+++ b/src/context/memory_selection_tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::context::retrieval_provider::retrieval_candidate_from_retrieved_memory;
 use crate::context::{
     RETRIEVED_THREAD_CONTEXT_KIND, RETRIEVED_WORKSPACE_MEMORY_KIND, RetrievalRequest,
-    RetrievedMemoryCandidate, retrieval_candidates,
+    RetrievalSourceRef, RetrievedMemoryCandidate, retrieval_candidates,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -475,6 +475,72 @@ fn typed_retrieval_candidate_priority_drives_selection_order() {
             RETRIEVED_WORKSPACE_MEMORY_KIND
         ],
         "typed priorities should preserve focused thread context before workspace memory"
+    );
+}
+
+#[test]
+fn file_search_candidates_flow_through_memory_selection() {
+    let history = vec![Message {
+        role: "user".to_string(),
+        content: json!([{"type":"text","text":"Open the provider tests"}]),
+    }];
+    let file_search = vec![RetrievalCandidate {
+        id: "file_search:1:src-context-provider-tests-rs".to_string(),
+        source: RetrievalSourceRef {
+            source_type: "file_search".to_string(),
+            source_id: None,
+            source_path: Some("src/context/provider_tests.rs".to_string()),
+            source_uri: None,
+            session_id: None,
+            thread_id: None,
+            workspace_id: None,
+        },
+        kind: "file_search".to_string(),
+        scope: "workspace".to_string(),
+        label: "src/context/provider_tests.rs".to_string(),
+        detail: "file_search(name_match, score=0.920); paths_only; content_not_read".to_string(),
+        summary: None,
+        rank: 1,
+        score: Some(0.92),
+        priority: 81,
+        dedupe_key: None,
+        budget_impact_tokens: Some(8),
+        selection_reason:
+            "paths-only candidate from file search (score 0.920); file contents were not read"
+                .to_string(),
+        availability_reason:
+            "available because fuzzy path search matched the current turn query".to_string(),
+        not_selected_reason:
+            "not selected after ranking this low-priority paths-only file-search candidate"
+                .to_string(),
+        selectable: true,
+    }];
+
+    let result = memory_selection_for_test(
+        &[],
+        None,
+        &[],
+        &[],
+        &[],
+        &history,
+        "session-1",
+        "",
+        &[],
+        file_search.as_slice(),
+        Some(10_000),
+    );
+
+    let selected = result
+        .selected_items
+        .iter()
+        .find(|item| item.kind == "file_search")
+        .expect("file-search candidate should enter memory selection");
+    assert_eq!(selected.label, "src/context/provider_tests.rs");
+    assert_eq!(selected.budget_impact_tokens, Some(8));
+    assert!(
+        selected.detail.contains("paths_only")
+            && selected.detail.contains("content_not_read"),
+        "file search selection must stay paths-only until an excerpt loader exists"
     );
 }
 


### PR DESCRIPTION
## Summary

- add focused coverage proving file-search retrieval candidates pass through `MemorySelection`
- update the file-search spec to record the current paths-only context-routing contract
- add a journal checkpoint for the file-search memory-selection slice

## Purpose

File search is already wired into the retrieval candidate boundary. This PR closes the stale documentation gap and locks the behavior with a regression test so future file-content injection work stays separate from paths-only routing.

## Related Issues

None.

## Testing

- `cargo fmt --check`
- `cargo test file_search_candidates_flow_through_memory_selection`
- `git diff --check`
