### PR TITLE
feat(goal): evaluate active goal completion

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -13,6 +13,8 @@ use crate::workspace::WorkspaceMemory;
 pub enum HookLifecycle {
     SessionStart,
     SessionEnd,
+    GoalCreated,
+    GoalCompleted,
     UserPromptSubmit,
     PreToolUse,
     PostToolUse,
@@ -28,6 +30,8 @@ impl HookLifecycle {
         match self {
             Self::SessionStart => "SessionStart",
             Self::SessionEnd => "SessionEnd",
+            Self::GoalCreated => "GoalCreated",
+            Self::GoalCompleted => "GoalCompleted",
             Self::UserPromptSubmit => "UserPromptSubmit",
             Self::PreToolUse => "PreToolUse",
             Self::PostToolUse => "PostToolUse",
@@ -44,6 +48,8 @@ impl HookLifecycle {
         match name {
             "session-start" | "session_start" => Some(Self::SessionStart),
             "session-end" | "session_end" => Some(Self::SessionEnd),
+            "goal-created" | "goal_created" => Some(Self::GoalCreated),
+            "goal-completed" | "goal_completed" => Some(Self::GoalCompleted),
             "user-prompt-submit" | "user_prompt_submit" => Some(Self::UserPromptSubmit),
             "pre-tool-use" | "pre_tool_use" => Some(Self::PreToolUse),
             "post-tool-use" | "post_tool_use" => Some(Self::PostToolUse),

--- a/crates/rara-app-server/src/runtime_control.rs
+++ b/crates/rara-app-server/src/runtime_control.rs
@@ -361,6 +361,22 @@ mod tests {
     }
 
     #[test]
+    fn hook_control_accepts_goal_lifecycle_phases() {
+        let request = HookControlRequest::Declare {
+            hook_id: "goal-created-hook".to_string(),
+            lifecycle: HookLifecycle::GoalCreated,
+            description: "observe goal creation".to_string(),
+        };
+
+        let value = serde_json::to_value(&request).unwrap();
+        let parsed: HookControlRequest = serde_json::from_value(value.clone()).unwrap();
+
+        assert_eq!(value["type"], json!("declare"));
+        assert_eq!(value["payload"]["lifecycle"], json!("GoalCreated"));
+        assert_eq!(parsed, request);
+    }
+
+    #[test]
     fn mcp_control_requests_use_structured_wire_shape() {
         let query = RuntimeControlRequest::Mcp(McpControlRequest::QueryStatus);
         assert_eq!(

--- a/crates/rara-plugins/src/loader.rs
+++ b/crates/rara-plugins/src/loader.rs
@@ -29,6 +29,10 @@ struct HooksJson {
     SessionStart: Vec<MatcherGroup>,
     #[serde(default)]
     SessionEnd: Vec<MatcherGroup>,
+    #[serde(default)]
+    GoalCreated: Vec<MatcherGroup>,
+    #[serde(default)]
+    GoalCompleted: Vec<MatcherGroup>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -182,6 +186,12 @@ fn parse_hooks_json(path: &Path) -> Result<Vec<HookHandler>, String> {
     for group in parsed.SessionEnd {
         handlers.extend(hooks_with_group_matcher(group));
     }
+    for group in parsed.GoalCreated {
+        handlers.extend(hooks_with_group_matcher(group));
+    }
+    for group in parsed.GoalCompleted {
+        handlers.extend(hooks_with_group_matcher(group));
+    }
     Ok(handlers)
 }
 
@@ -262,6 +272,26 @@ pub fn registered_hooks_for_plugin(plugin: &Plugin) -> Vec<RegisteredHook> {
         for h in hooks_with_group_matcher(group) {
             registered.push(RegisteredHook {
                 event: HookEvent::SessionEnd,
+                handler: h,
+                plugin_name: plugin.name.clone(),
+                plugin_root: plugin.root.clone(),
+            });
+        }
+    }
+    for group in parsed.GoalCreated {
+        for h in hooks_with_group_matcher(group) {
+            registered.push(RegisteredHook {
+                event: HookEvent::GoalCreated,
+                handler: h,
+                plugin_name: plugin.name.clone(),
+                plugin_root: plugin.root.clone(),
+            });
+        }
+    }
+    for group in parsed.GoalCompleted {
+        for h in hooks_with_group_matcher(group) {
+            registered.push(RegisteredHook {
+                event: HookEvent::GoalCompleted,
                 handler: h,
                 plugin_name: plugin.name.clone(),
                 plugin_root: plugin.root.clone(),
@@ -355,6 +385,44 @@ mod tests {
         assert_eq!(registered.len(), 2);
         assert_eq!(registered[0].handler.matcher.as_deref(), Some("Bash(*)"));
         assert_eq!(registered[1].handler.matcher.as_deref(), Some("Write|Edit"));
+    }
+
+    #[test]
+    fn registered_hooks_include_goal_lifecycle_events() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join(".claude-plugin")).unwrap();
+        fs::write(
+            dir.path().join(".claude-plugin").join("plugin.json"),
+            json!({
+                "name": "goal-plugin",
+                "description": "goal plugin"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        fs::create_dir_all(dir.path().join("hooks")).unwrap();
+        fs::write(
+            dir.path().join("hooks").join("hooks.json"),
+            json!({
+                "GoalCreated": [{
+                    "hooks": [{"type": "command", "command": "echo created"}]
+                }],
+                "GoalCompleted": [{
+                    "hooks": [{"type": "command", "command": "echo completed"}]
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let plugin = load_plugin(dir.path()).unwrap();
+        let registered = registered_hooks_for_plugin(&plugin);
+        let events = registered.iter().map(|hook| hook.event).collect::<Vec<_>>();
+
+        assert_eq!(
+            events,
+            vec![HookEvent::GoalCreated, HookEvent::GoalCompleted]
+        );
     }
 
     #[test]

--- a/crates/rara-plugins/src/types.rs
+++ b/crates/rara-plugins/src/types.rs
@@ -77,6 +77,8 @@ pub enum HookEvent {
     UserPromptSubmit,
     SessionStart,
     SessionEnd,
+    GoalCreated,
+    GoalCompleted,
 }
 
 impl HookEvent {
@@ -88,6 +90,8 @@ impl HookEvent {
             Self::UserPromptSubmit => "UserPromptSubmit",
             Self::SessionStart => "SessionStart",
             Self::SessionEnd => "SessionEnd",
+            Self::GoalCreated => "GoalCreated",
+            Self::GoalCompleted => "GoalCompleted",
         }
     }
 }

--- a/docs/features/goal-evaluator-loop.md
+++ b/docs/features/goal-evaluator-loop.md
@@ -2,8 +2,8 @@
 
 ## Status
 - [x] Evaluator placeholder wired into agent turn cycle
-- [ ] Real LLM evaluator call (small model, yes/no output)
-- [ ] `GoalCreated` / `GoalCompleted` hook phases
+- [x] Real LLM evaluator call through the backend classifier boundary
+- [x] `GoalCreated` / `GoalCompleted` hook lifecycle phases
 
 ## Design
 
@@ -14,19 +14,20 @@ User: /goal "run cargo test && all 14 pass"
 Loop:
   1. Agent runs normally (tools + reasoning)
   2. Turn completes
-  3. Evaluator pushes "no: goal not yet complete — ..." as System message
+  3. Evaluator asks the classifier boundary for `yes` or `no: <reason>`
   4. Agent sees evaluator context on next turn → continues working
   5. Agent eventually calls `update_goal(status=Complete)` or user stops
 ```
 
 ### Implementation
 - `RalphGoal.condition: Option<String>` set from objective at create_goal time
-- Evaluator placeholder injected in `tasks.rs` Ralph loop after budget check
+- Evaluator call runs in `tasks/goal_evaluator.rs` after each successful
+  non-plan goal turn and after budget accounting
 - Uses `app.push_system()` to push evaluator context as System message
 - Agent loop continues via existing `start_query_task()` with next_goal_prompt
 
-### Evaluator (future)
-The real evaluator will call a lightweight LLM with:
+### Evaluator
+The evaluator calls `LlmBackend::classify()` with:
 ```
 The goal is: {condition}
 Based on the work done in the last turn, is the goal satisfied?
@@ -35,7 +36,38 @@ Answer ONLY "yes" or "no: <one-sentence reason>".
 - "yes" → mark Complete, push notice
 - "no: reason" → push reason as System message, continue loop
 
+The current implementation reuses the active backend classifier path. A
+dedicated small-model route can be added behind the same boundary once auxiliary
+model routing is explicit in config.
+
 ### What's NOT included
-- Real LLM evaluation (placeholder always returns "not yet")
-- Goal lifecycle hook phases (GoalCreated / GoalCompleted)
+- Dedicated small-model provider selection for the evaluator
+- Automatic execution semantics for `GoalCreated` / `GoalCompleted` command
+  hooks
 - Prompt injection (evaluator context is a transcript message, not a prompt fragment)
+
+### Hook Lifecycle Phases
+
+`GoalCreated` and `GoalCompleted` are stable hook lifecycle phase names in the
+shared hook lifecycle enum, app-server control-plane declarations, and plugin
+`hooks.json` registration.
+
+The phase names are declaration-compatible before command execution is enabled
+for goal lifecycle hooks. Execution needs a separate input-payload and
+permission contract.
+
+## Validation
+
+- Evaluator parser accepts exact `yes` and `no: reason` classifier output.
+- Goal turn completion marks the goal complete and stops the continuation loop
+  when the evaluator returns `yes`.
+- Goal turn completion injects `no: reason` as system context and continues the
+  loop when the evaluator returns `no`.
+- Plugin `hooks.json` registers `GoalCreated` and `GoalCompleted` lifecycle
+  hooks.
+- App-server hook control declarations serialize and deserialize goal lifecycle
+  phases.
+
+## Source Journals
+
+- `docs/journal/2026-07-29-goal-evaluator-loop.md`

--- a/docs/journal/2026-07-29-goal-evaluator-loop.md
+++ b/docs/journal/2026-07-29-goal-evaluator-loop.md
@@ -1,0 +1,31 @@
+# Goal Evaluator Loop
+
+## What Changed
+
+- Added a goal evaluator module that calls `LlmBackend::classify()` and parses
+  exact `yes` / `no: reason` answers.
+- Replaced the fixed goal-loop placeholder with evaluator-driven completion and
+  continuation behavior.
+- Added `GoalCreated` and `GoalCompleted` lifecycle phase names to shared hook
+  lifecycle declarations and plugin hook registration.
+
+## Why
+
+The goal loop should not continue blindly after every turn. A classifier-style
+evaluator provides a narrow completion check while preserving the existing
+agent loop and `update_goal` tool contract.
+
+## Trade-Offs
+
+- The evaluator currently uses the active backend classifier path instead of a
+  dedicated small-model route. This keeps the implementation provider-neutral
+  and avoids adding config surface before auxiliary model routing is explicit.
+- Goal lifecycle hook phases are declaration-compatible, but command execution
+  for those phases remains deferred until the input payload and permission
+  semantics are specified.
+
+## Remaining Work
+
+- Add explicit auxiliary-model routing if the evaluator should use a different
+  provider/model from the main agent.
+- Define and implement command execution semantics for goal lifecycle hooks.

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -258,7 +258,9 @@ struct ClaudeHookHandler {
 fn phase_ordinal(phase: HookLifecycle) -> u8 {
     match phase {
         HookLifecycle::SessionStart => 0,
-        HookLifecycle::SessionEnd => 9,
+        HookLifecycle::SessionEnd => 11,
+        HookLifecycle::GoalCreated => 9,
+        HookLifecycle::GoalCompleted => 10,
         HookLifecycle::UserPromptSubmit => 1,
         HookLifecycle::PreToolUse => 2,
         HookLifecycle::PostToolUse => 3,
@@ -292,6 +294,14 @@ mod tests {
         assert_eq!(
             HookLifecycle::from_filename("stop"),
             Some(HookLifecycle::Stop)
+        );
+        assert_eq!(
+            HookLifecycle::from_filename("goal-created"),
+            Some(HookLifecycle::GoalCreated)
+        );
+        assert_eq!(
+            HookLifecycle::from_filename("goal-completed"),
+            Some(HookLifecycle::GoalCompleted)
         );
         assert_eq!(HookLifecycle::from_filename("unknown"), None);
     }

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -240,6 +240,8 @@ fn hook_event_to_lifecycle(event: HookEvent) -> HookLifecycle {
         HookEvent::UserPromptSubmit => HookLifecycle::UserPromptSubmit,
         HookEvent::SessionStart => HookLifecycle::SessionStart,
         HookEvent::SessionEnd => HookLifecycle::SessionEnd,
+        HookEvent::GoalCreated => HookLifecycle::GoalCreated,
+        HookEvent::GoalCompleted => HookLifecycle::GoalCompleted,
     }
 }
 

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -1,4 +1,5 @@
 mod builder;
+mod goal_evaluator;
 include!("tasks/completion.rs");
 mod oauth;
 #[cfg(test)]

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -1,6 +1,8 @@
 use crate::tui::command;
 use crate::tui::state::Overlay;
 
+use self::goal_evaluator::{GoalEvaluation, evaluate_goal_completion};
+
 pub(crate) async fn finish_running_task_if_ready(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
@@ -123,22 +125,40 @@ pub(crate) async fn finish_running_task_if_ready(
                                 start_query_task(app, next_goal_prompt, agent);
                                 return Ok(());
                             }
-                            let condition = app
-                                .goal
-                                .as_ref()
-                                .and_then(|g| g.condition.as_deref())
-                                .unwrap_or_default();
-                            if !condition.is_empty() {
-                                let eval_reason =
-                                    format!("no: goal not yet complete — {condition}");
-                                app.push_system(
-                                    eval_reason.clone(),
-                                    crate::tui::state::SystemMessageKind::Other,
-                                );
-                                agent.push_history_message(crate::agent::Message {
-                                    role: "system".into(),
-                                    content: serde_json::Value::String(eval_reason),
-                                });
+                            let goal_snapshot =
+                                app.goal.as_ref().expect("goal must exist").clone();
+                            match evaluate_goal_completion(&agent, &goal_snapshot).await {
+                                GoalEvaluation::Complete => {
+                                    if let Some(goal) = app.goal.as_mut() {
+                                        goal.status = GoalStatus::Complete;
+                                    }
+                                    *app.goal_handle.write().unwrap() = app.goal.clone();
+                                    *agent_slot = Some(agent);
+                                    if let Some(agent) = agent_slot.as_ref() {
+                                        app.sync_snapshot(agent);
+                                    }
+                                    app.release_pending_follow_ups();
+                                    app.finalize_agent_stream(None);
+                                    app.finalize_active_turn();
+                                    app.bottom_pane.notice =
+                                        Some("Goal evaluator marked the goal complete.".into());
+                                    app.set_runtime_phase(
+                                        RuntimePhase::Idle,
+                                        Some("goal complete".into()),
+                                    );
+                                    return Ok(());
+                                }
+                                GoalEvaluation::Continue { reason } => {
+                                    let eval_reason = format!("no: {reason}");
+                                    app.push_system(
+                                        eval_reason.clone(),
+                                        crate::tui::state::SystemMessageKind::Other,
+                                    );
+                                    agent.push_history_message(crate::agent::Message {
+                                        role: "system".into(),
+                                        content: serde_json::Value::String(eval_reason),
+                                    });
+                                }
                             }
                             app.finalize_active_turn();
                             start_query_task(app, next_goal_prompt, agent);

--- a/src/tui/runtime/tasks/goal_evaluator.rs
+++ b/src/tui/runtime/tasks/goal_evaluator.rs
@@ -1,0 +1,150 @@
+use crate::agent::{Agent, Message};
+use crate::tui::state::RalphGoal;
+
+const GOAL_EVALUATOR_INSTRUCTIONS: &str = "\
+You are a goal completion evaluator. Decide whether the active goal is fully satisfied by the current transcript.
+
+Output exactly one line:
+- yes
+- no: <one-sentence reason>
+
+Rules:
+- Answer yes only when the goal is complete, verified, and no required follow-up remains.
+- Answer no when evidence is missing, verification is incomplete, or more work is still required.
+- Do not include markdown, JSON, or extra explanation.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GoalEvaluation {
+    Complete,
+    Continue { reason: String },
+}
+
+pub(crate) async fn evaluate_goal_completion(agent: &Agent, goal: &RalphGoal) -> GoalEvaluation {
+    let condition = goal
+        .condition
+        .as_deref()
+        .filter(|condition| !condition.trim().is_empty())
+        .unwrap_or(goal.objective.as_str());
+    let messages = build_goal_evaluator_messages(condition, &agent.history);
+    match agent
+        .llm_backend
+        .classify(GOAL_EVALUATOR_INSTRUCTIONS, messages.as_slice())
+        .await
+    {
+        Ok(raw) => parse_goal_evaluation(raw.as_str()),
+        Err(err) => GoalEvaluation::Continue {
+            reason: format!("goal evaluator unavailable: {err}"),
+        },
+    }
+}
+
+fn build_goal_evaluator_messages(condition: &str, history: &[Message]) -> Vec<Message> {
+    let recent = history
+        .iter()
+        .rev()
+        .take(16)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .map(render_message_for_evaluator)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    vec![Message {
+        role: "user".to_string(),
+        content: serde_json::Value::String(format!(
+            "Goal:\n{condition}\n\nRecent transcript:\n{recent}\n\nIs the goal satisfied?"
+        )),
+    }]
+}
+
+fn render_message_for_evaluator(message: &Message) -> String {
+    let text = message
+        .content
+        .as_str()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| message.content.to_string());
+    format!("{}: {}", message.role, collapse_ws(text.as_str()))
+}
+
+fn collapse_ws(input: &str) -> String {
+    input.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+pub(crate) fn parse_goal_evaluation(raw: &str) -> GoalEvaluation {
+    let answer = raw.trim();
+    let lower = answer.to_ascii_lowercase();
+    if lower == "yes" || lower.starts_with("yes.") || lower.starts_with("yes\n") {
+        return GoalEvaluation::Complete;
+    }
+
+    if lower == "no" {
+        return GoalEvaluation::Continue {
+            reason: "goal not yet complete".to_string(),
+        };
+    }
+
+    for prefix in ["no:", "no -", "no --"] {
+        if lower.starts_with(prefix) {
+            let reason = answer[prefix.len()..].trim();
+            return GoalEvaluation::Continue {
+                reason: non_empty_reason(reason),
+            };
+        }
+    }
+
+    GoalEvaluation::Continue {
+        reason: format!(
+            "goal evaluator returned an unrecognized answer: {}",
+            truncate_for_prompt(answer)
+        ),
+    }
+}
+
+fn non_empty_reason(reason: &str) -> String {
+    if reason.trim().is_empty() {
+        "goal not yet complete".to_string()
+    } else {
+        reason.trim().to_string()
+    }
+}
+
+fn truncate_for_prompt(value: &str) -> String {
+    const MAX_CHARS: usize = 240;
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(MAX_CHARS).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_yes_as_complete() {
+        assert_eq!(parse_goal_evaluation("yes"), GoalEvaluation::Complete);
+        assert_eq!(parse_goal_evaluation("Yes."), GoalEvaluation::Complete);
+    }
+
+    #[test]
+    fn parses_no_reason_as_continuation() {
+        assert_eq!(
+            parse_goal_evaluation("no: tests have not run yet"),
+            GoalEvaluation::Continue {
+                reason: "tests have not run yet".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn unrecognized_answer_continues_goal() {
+        assert!(matches!(
+            parse_goal_evaluation("maybe after another check"),
+            GoalEvaluation::Continue { reason } if reason.contains("unrecognized answer")
+        ));
+    }
+}

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -31,12 +31,16 @@ use crate::runtime_control::{
 use crate::runtime_event_bus::RuntimeEventBus;
 use crate::session::SessionManager;
 use crate::tui::state::{
-    OAuthLoginMode, RalphGoal, RebuildSuccess, RunningTask, RuntimePhase, TaskCompletion, TaskKind,
-    TuiApp,
+    GoalStatus, OAuthLoginMode, RalphGoal, RebuildSuccess, RunningTask, RuntimePhase,
+    TaskCompletion, TaskKind, TuiApp,
 };
 use crate::workspace::WorkspaceMemory;
 
 struct PlainAnswerBackend;
+
+struct GoalEvaluatorBackend {
+    answer: String,
+}
 
 #[test]
 fn lifecycle_helper_publishes_turn_finished_for_success() {
@@ -178,6 +182,43 @@ impl LlmBackend for PlainAnswerBackend {
     }
 }
 
+#[async_trait::async_trait]
+impl LlmBackend for GoalEvaluatorBackend {
+    async fn ask(
+        &self,
+        _messages: &[crate::agent::Message],
+        _tools: &[serde_json::Value],
+    ) -> anyhow::Result<LlmResponse> {
+        Ok(LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "turn complete".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        })
+    }
+
+    async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0; 8])
+    }
+
+    async fn summarize(
+        &self,
+        _messages: &[crate::agent::Message],
+        _instruction: &str,
+    ) -> anyhow::Result<String> {
+        Ok("summary".to_string())
+    }
+
+    async fn classify(
+        &self,
+        _instructions: &str,
+        _messages: &[crate::agent::Message],
+    ) -> anyhow::Result<String> {
+        Ok(self.answer.clone())
+    }
+}
+
 struct AgentDrivenPlanBackend {
     calls: Mutex<usize>,
 }
@@ -270,6 +311,10 @@ impl LlmBackend for ExitPlanModeBackend {
 }
 
 fn create_test_agent(temp: &tempfile::TempDir) -> Agent {
+    create_test_agent_with_backend(temp, Arc::new(crate::llm::MockLlm))
+}
+
+fn create_test_agent_with_backend(temp: &tempfile::TempDir, backend: Arc<dyn LlmBackend>) -> Agent {
     let workspace_root = temp.path().join("workspace");
     let rara_dir = workspace_root.join(".rara");
     std::fs::create_dir_all(rara_dir.join("rollouts")).expect("rollouts");
@@ -286,7 +331,7 @@ fn create_test_agent(temp: &tempfile::TempDir) -> Agent {
     });
     Agent::new(
         ToolManager::new(),
-        Arc::new(crate::llm::MockLlm),
+        backend,
         Arc::new(VectorDB::new(
             &rara_dir.join("lancedb").display().to_string(),
         )),
@@ -373,6 +418,147 @@ async fn finish_ready_query_task(app: &mut TuiApp, agent_slot: &mut Option<Agent
             return;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+fn install_runtime_services(app: &mut TuiApp) {
+    let bus = Arc::new(RuntimeEventBus::new(10));
+    app.event_bus = Some(bus.clone());
+    app.prompt_source_registry = Some(Arc::new(
+        crate::protocol_sources::PromptSourceRegistry::new(bus.clone()),
+    ));
+    app.skill_source_registry = Some(Arc::new(crate::protocol_sources::SkillSourceRegistry::new(
+        bus.clone(),
+    )));
+    app.hook_registry = Some(Arc::new(crate::hook_registry::HookRegistry::new(
+        bus.clone(),
+    )));
+    app.mcp_manager = Some(Arc::new(
+        crate::mcp_connection_manager::McpConnectionManager::new(
+            Arc::new(crate::config::McpRegistry::empty()),
+            bus.clone(),
+        ),
+    ));
+    app.memory_handler = Some(Arc::new(
+        crate::protocol_sources::MemoryControlHandler::new(bus),
+    ));
+}
+
+#[tokio::test]
+async fn goal_evaluator_yes_marks_goal_complete_without_continuation() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    let goal = RalphGoal::new("finish the verification".to_string(), None);
+    app.goal = Some(goal.clone());
+    *app.goal_handle.write().unwrap() = Some(goal);
+
+    let mut agent = create_test_agent_with_backend(
+        &temp,
+        Arc::new(GoalEvaluatorBackend {
+            answer: "yes".to_string(),
+        }),
+    );
+    agent.total_input_tokens = 42;
+    agent.history.push(Message {
+        role: "assistant".to_string(),
+        content: json!("Verification finished."),
+    });
+    install_completed_query_task(&mut app, agent, Ok(()));
+
+    let mut agent_slot = None;
+    for _ in 0..20 {
+        finish_running_task_if_ready(&mut app, &mut agent_slot)
+            .await
+            .expect("finish task");
+        if app.bottom_pane.running_task.is_none() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    assert!(app.bottom_pane.running_task.is_none());
+    assert_eq!(
+        app.goal.as_ref().map(|goal| goal.status),
+        Some(GoalStatus::Complete)
+    );
+    assert_eq!(
+        app.goal_handle
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|goal| goal.status),
+        Some(GoalStatus::Complete)
+    );
+    assert_eq!(
+        app.bottom_pane.notice.as_deref(),
+        Some("Goal evaluator marked the goal complete.")
+    );
+}
+
+#[tokio::test]
+async fn goal_evaluator_no_injects_reason_and_continues() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    install_runtime_services(&mut app);
+    let goal = RalphGoal::new("run the missing test".to_string(), None);
+    app.goal = Some(goal.clone());
+    *app.goal_handle.write().unwrap() = Some(goal);
+
+    let mut agent = create_test_agent_with_backend(
+        &temp,
+        Arc::new(GoalEvaluatorBackend {
+            answer: "no: the focused test has not run yet".to_string(),
+        }),
+    );
+    agent.total_input_tokens = 10;
+    install_completed_query_task(&mut app, agent, Ok(()));
+
+    let mut agent_slot = None;
+    for _ in 0..20 {
+        finish_running_task_if_ready(&mut app, &mut agent_slot)
+            .await
+            .expect("finish task");
+        let reason_committed = app
+            .committed_turns
+            .iter()
+            .flat_map(|turn| turn.entries.iter())
+            .any(|entry| {
+                entry.role == "System"
+                    && entry
+                        .message
+                        .contains("no: the focused test has not run yet")
+            });
+        if reason_committed && app.bottom_pane.running_task.is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    assert!(app.bottom_pane.running_task.is_some());
+    assert_eq!(
+        app.goal.as_ref().map(|goal| goal.status),
+        Some(GoalStatus::Pursuing)
+    );
+    assert!(
+        app.committed_turns
+            .iter()
+            .flat_map(|turn| turn.entries.iter())
+            .any(|entry| {
+                entry.role == "System"
+                    && entry
+                        .message
+                        .contains("no: the focused test has not run yet")
+            })
+    );
+
+    if let Some(task) = app.bottom_pane.running_task.take() {
+        task.handle.abort();
     }
 }
 


### PR DESCRIPTION
## Summary

- add a classifier-backed goal evaluator that parses exact `yes` / `no: reason` answers
- stop the autonomous goal loop when the evaluator confirms completion
- inject evaluator `no` reasons as system context before continuing goal work
- add `GoalCreated` and `GoalCompleted` lifecycle phases to shared hook declarations and plugin hook registration
- update the goal evaluator spec and add an implementation journal

## Purpose

The goal loop previously continued with a fixed placeholder reason after each turn. This PR replaces that placeholder with a real evaluator call through the existing `LlmBackend::classify()` boundary while keeping dedicated auxiliary model routing and command hook execution as explicit follow-up work.

## Related Issues

None.

## Testing

- `cargo fmt --check`
- `cargo test goal_evaluator`
- `cargo test parses_hook_phases_from_claude_filenames`
- `cargo test -p rara-plugins registered_hooks_include_goal_lifecycle_events`
- `cargo test -p rara-app-server hook_control_accepts_goal_lifecycle_phases`
- `cargo check --workspace`
- `git diff --check`
