### PR TITLE
feat(memory): add builtin Nowledge Mem plugin

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -22,10 +22,10 @@ pub use self::mcp::{
 };
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{
-    ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy, OpenAiEndpointKind,
-    OpenAiEndpointProfile, ProviderConfigState, RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig,
-    TuiThemeConfig, ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for,
-    workspace_data_dir_for_home,
+    BuiltinPluginConfig, ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy,
+    NowledgeMemPluginConfig, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState,
+    RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig, TuiThemeConfig, ensure_rara_home_dir,
+    rara_home_dir, workspace_data_dir_for, workspace_data_dir_for_home,
 };
 pub use self::provider_surface::{
     ConfigValueSource, EffectiveProviderSurface, ResolvedProviderValue,

--- a/crates/config/src/mcp.rs
+++ b/crates/config/src/mcp.rs
@@ -105,6 +105,8 @@ pub struct McpServerConfig {
 #[serde(untagged, deny_unknown_fields)]
 pub enum McpServerTransport {
     Stdio {
+        #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
+        r#type: Option<String>,
         command: String,
         #[serde(default)]
         args: Vec<String>,
@@ -114,6 +116,8 @@ pub enum McpServerTransport {
         cwd: Option<PathBuf>,
     },
     StreamableHttp {
+        #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
+        r#type: Option<String>,
         url: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         bearer_token_env_var: Option<String>,
@@ -122,6 +126,32 @@ pub enum McpServerTransport {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         env_http_headers: Option<BTreeMap<String, String>>,
     },
+}
+
+impl McpServerTransport {
+    pub fn bypasses_proxy(&self) -> bool {
+        match self {
+            Self::Stdio { .. } => false,
+            Self::StreamableHttp { url, .. } => streamable_http_url_bypasses_proxy(url),
+        }
+    }
+}
+
+fn streamable_http_url_bypasses_proxy(url: &str) -> bool {
+    let Some(after_scheme) = url.split_once("://").map(|(_, rest)| rest) else {
+        return false;
+    };
+    let authority = after_scheme.split('/').next().unwrap_or_default();
+    let host = authority
+        .rsplit_once('@')
+        .map(|(_, host)| host)
+        .unwrap_or(authority);
+    let host = if let Some(stripped) = host.strip_prefix('[') {
+        stripped.split(']').next().unwrap_or_default()
+    } else {
+        host.split(':').next().unwrap_or_default()
+    };
+    matches!(host, "localhost" | "127.0.0.1" | "::1")
 }
 
 const fn default_enabled() -> bool {
@@ -245,6 +275,78 @@ bearer_token_env_var = "MCP_TOKEN"
         assert_eq!(
             registry.servers["docs"].config.enabled_tools.as_deref(),
             Some(&["search".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn loads_codex_style_http_mcp_json_type_field() {
+        let content = r#"{
+  "mcpServers": {
+    "nowledge-mem": {
+      "type": "http",
+      "url": "http://127.0.0.1:14242/mcp/",
+      "http_headers": {
+        "APP": "RARA"
+      }
+    }
+  }
+}"#;
+
+        let servers = parse_mcp_servers_json(content).expect("mcp servers");
+
+        assert_eq!(
+            servers["nowledge-mem"].transport,
+            McpServerTransport::StreamableHttp {
+                r#type: Some("http".to_string()),
+                url: "http://127.0.0.1:14242/mcp/".to_string(),
+                bearer_token_env_var: None,
+                http_headers: Some(BTreeMap::from([("APP".to_string(), "RARA".to_string())])),
+                env_http_headers: None,
+            }
+        );
+    }
+
+    #[test]
+    fn streamable_http_localhost_bypasses_proxy() {
+        assert!(
+            McpServerTransport::StreamableHttp {
+                r#type: None,
+                url: "http://localhost:14242/mcp/".to_string(),
+                bearer_token_env_var: None,
+                http_headers: None,
+                env_http_headers: None,
+            }
+            .bypasses_proxy()
+        );
+        assert!(
+            McpServerTransport::StreamableHttp {
+                r#type: None,
+                url: "http://127.0.0.1:14242/mcp/".to_string(),
+                bearer_token_env_var: None,
+                http_headers: None,
+                env_http_headers: None,
+            }
+            .bypasses_proxy()
+        );
+        assert!(
+            McpServerTransport::StreamableHttp {
+                r#type: None,
+                url: "http://[::1]:14242/mcp/".to_string(),
+                bearer_token_env_var: None,
+                http_headers: None,
+                env_http_headers: None,
+            }
+            .bypasses_proxy()
+        );
+        assert!(
+            !McpServerTransport::StreamableHttp {
+                r#type: None,
+                url: "https://mem.example.com/mcp/".to_string(),
+                bearer_token_env_var: None,
+                http_headers: None,
+                env_http_headers: None,
+            }
+            .bypasses_proxy()
         );
     }
 

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -241,6 +241,57 @@ impl TuiConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
+pub struct BuiltinPluginConfig {
+    #[serde(default, skip_serializing_if = "NowledgeMemPluginConfig::is_default")]
+    pub nowledge_mem: NowledgeMemPluginConfig,
+}
+
+impl Default for BuiltinPluginConfig {
+    fn default() -> Self {
+        Self {
+            nowledge_mem: NowledgeMemPluginConfig::default(),
+        }
+    }
+}
+
+impl BuiltinPluginConfig {
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct NowledgeMemPluginConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    pub url: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub http_headers: BTreeMap<String, String>,
+}
+
+impl Default for NowledgeMemPluginConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            url: default_nowledge_mem_mcp_url(),
+            http_headers: BTreeMap::new(),
+        }
+    }
+}
+
+impl NowledgeMemPluginConfig {
+    pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+fn default_nowledge_mem_mcp_url() -> String {
+    "http://127.0.0.1:14242/mcp/".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct TuiThemeConfig {
     pub name: String,
     pub syntax_theme: Option<String>,
@@ -314,6 +365,8 @@ pub struct RaraConfig {
     pub local_embeddings: LocalEmbeddingPolicy,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub plugin_dirs: Vec<PathBuf>,
+    #[serde(default, skip_serializing_if = "BuiltinPluginConfig::is_default")]
+    pub builtin_plugins: BuiltinPluginConfig,
     #[serde(default, skip_serializing_if = "TuiConfig::is_default")]
     pub tui: TuiConfig,
 }
@@ -1292,6 +1345,53 @@ mod tests {
         assert_eq!(
             config.plugin_dirs,
             vec![PathBuf::from("plugins-a"), PathBuf::from("/tmp/plugins-b")]
+        );
+    }
+
+    #[test]
+    fn builtin_plugins_default_enabled_and_omitted() {
+        let config = RaraConfig::default();
+
+        assert!(config.builtin_plugins.nowledge_mem.enabled);
+        assert_eq!(
+            config.builtin_plugins.nowledge_mem.url,
+            "http://127.0.0.1:14242/mcp/"
+        );
+
+        let json = serde_json::to_string(&config).expect("serialize config");
+        assert!(!json.contains("builtin_plugins"));
+    }
+
+    #[test]
+    fn builtin_nowledge_mem_config_can_override_endpoint_and_headers() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "deepseek",
+                "builtin_plugins": {
+                    "nowledge_mem": {
+                        "enabled": false,
+                        "url": "http://localhost:24242/mcp/",
+                        "http_headers": {
+                            "APP": "CustomRara",
+                            "X-NMEM-Space": "workspace"
+                        }
+                    }
+                }
+            }"#,
+        )
+        .expect("deserialize config");
+
+        assert!(!config.builtin_plugins.nowledge_mem.enabled);
+        assert_eq!(
+            config.builtin_plugins.nowledge_mem.url,
+            "http://localhost:24242/mcp/"
+        );
+        assert_eq!(
+            config.builtin_plugins.nowledge_mem.http_headers,
+            BTreeMap::from([
+                ("APP".to_string(), "CustomRara".to_string()),
+                ("X-NMEM-Space".to_string(), "workspace".to_string())
+            ])
         );
     }
 

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -239,19 +239,11 @@ impl TuiConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(default)]
 pub struct BuiltinPluginConfig {
     #[serde(default, skip_serializing_if = "NowledgeMemPluginConfig::is_default")]
     pub nowledge_mem: NowledgeMemPluginConfig,
-}
-
-impl Default for BuiltinPluginConfig {
-    fn default() -> Self {
-        Self {
-            nowledge_mem: NowledgeMemPluginConfig::default(),
-        }
-    }
 }
 
 impl BuiltinPluginConfig {

--- a/crates/rara-plugins/src/exec.rs
+++ b/crates/rara-plugins/src/exec.rs
@@ -162,6 +162,7 @@ mod tests {
 
     #[tokio::test]
     async fn executes_simple_echo_hook() {
+        let plugin_root = tempfile::tempdir().expect("plugin root");
         let handler = HookHandler {
             r#type: "command".to_string(),
             command: "echo '{\"continue\": true}'".to_string(),
@@ -171,12 +172,12 @@ mod tests {
         };
         let result = execute_command_hook(
             &handler,
-            &PathBuf::from("/tmp"),
+            &plugin_root.path().to_path_buf(),
             HookInput {
                 session_id: "test".to_string(),
                 transcript_path: None,
                 hook_event: "Stop".to_string(),
-                plugin_root: "/tmp".to_string(),
+                plugin_root: plugin_root.path().to_string_lossy().to_string(),
                 tool_name: None,
                 tool_input: None,
                 tool_response: None,

--- a/crates/rara-plugins/src/exec.rs
+++ b/crates/rara-plugins/src/exec.rs
@@ -61,6 +61,7 @@ pub async fn execute_command_hook(
         .arg(&handler.command)
         .current_dir(plugin_root)
         .env("CLAUDE_PLUGIN_ROOT", plugin_root.to_string_lossy().as_ref())
+        .env("PLUGIN_ROOT", plugin_root.to_string_lossy().as_ref())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -185,6 +186,42 @@ mod tests {
             },
         )
         .await;
+        assert!(result.ok);
+    }
+
+    #[tokio::test]
+    async fn exposes_plugin_root_environment_aliases() {
+        let plugin_root = tempfile::tempdir().expect("plugin root");
+        let plugin_root = plugin_root.path().to_path_buf();
+        let expected = plugin_root.to_string_lossy();
+        let handler = HookHandler {
+            r#type: "command".to_string(),
+            command: format!(
+                "test \"$CLAUDE_PLUGIN_ROOT\" = '{expected}' && test \"$PLUGIN_ROOT\" = '{expected}'"
+            ),
+            timeout: 5,
+            matcher: None,
+            once: false,
+        };
+
+        let result = execute_command_hook(
+            &handler,
+            &plugin_root,
+            HookInput {
+                session_id: "test".to_string(),
+                transcript_path: None,
+                hook_event: "Stop".to_string(),
+                plugin_root: plugin_root.to_string_lossy().to_string(),
+                tool_name: None,
+                tool_input: None,
+                tool_response: None,
+                last_assistant_message: None,
+                is_interrupt: None,
+                prompt: None,
+            },
+        )
+        .await;
+
         assert!(result.ok);
     }
 

--- a/crates/rara-plugins/src/loader.rs
+++ b/crates/rara-plugins/src/loader.rs
@@ -99,10 +99,7 @@ pub fn load_plugin(root: &Path) -> Option<Plugin> {
 
 /// Load a single plugin from a directory with explicit source metadata.
 pub fn load_plugin_with_source(root: &Path, source: PluginSource) -> Option<Plugin> {
-    let plugin_dir = root.join(".claude-plugin");
-    if !plugin_dir.is_dir() {
-        return None;
-    }
+    let plugin_dir = plugin_metadata_dir(root)?;
 
     let mut load_warnings = Vec::new();
 
@@ -157,6 +154,13 @@ pub fn load_plugin_with_source(root: &Path, source: PluginSource) -> Option<Plug
         mcp_config,
         load_warnings,
     })
+}
+
+fn plugin_metadata_dir(root: &Path) -> Option<PathBuf> {
+    [".claude-plugin", ".codex-plugin"]
+        .into_iter()
+        .map(|dir| root.join(dir))
+        .find(|dir| dir.is_dir())
 }
 
 fn parse_hooks_json(path: &Path) -> Result<Vec<HookHandler>, String> {
@@ -318,6 +322,29 @@ mod tests {
         assert_eq!(registered[0].event, HookEvent::Stop);
         assert_eq!(registered[0].handler.command, "echo ok");
         assert_eq!(registered[0].handler.matcher.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn loads_codex_plugin_metadata_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let plugin_dir = dir.path().join(".codex-plugin");
+        fs::create_dir_all(&plugin_dir).unwrap();
+        fs::write(
+            plugin_dir.join("plugin.json"),
+            json!({
+                "name": "nowledge-mem",
+                "version": "0.1.29",
+                "description": "Memory that follows the user"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let plugin = load_plugin(dir.path()).expect("codex plugin should load");
+
+        assert_eq!(plugin.name, "nowledge-mem");
+        assert_eq!(plugin.version.as_deref(), Some("0.1.29"));
+        assert_eq!(plugin.description, "Memory that follows the user");
     }
 
     #[test]

--- a/crates/rara-plugins/src/types.rs
+++ b/crates/rara-plugins/src/types.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 /// Origin of a discovered Claude Code plugin.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PluginSource {
+    Builtin(PathBuf),
     User(PathBuf),
     Project(PathBuf),
     Cli(PathBuf),
@@ -15,14 +16,17 @@ pub enum PluginSource {
 impl PluginSource {
     pub fn path(&self) -> &Path {
         match self {
-            Self::User(path) | Self::Project(path) | Self::Cli(path) | Self::Directory(path) => {
-                path
-            }
+            Self::Builtin(path)
+            | Self::User(path)
+            | Self::Project(path)
+            | Self::Cli(path)
+            | Self::Directory(path) => path,
         }
     }
 
     pub fn label(&self) -> &'static str {
         match self {
+            Self::Builtin(_) => "builtin",
             Self::User(_) => "user",
             Self::Project(_) => "project",
             Self::Cli(_) => "cli",

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -16,7 +16,8 @@ This spec covers:
 
 - A new `rara-plugins` crate that owns plugin discovery, loading, and command
   hook execution.
-- Parsing of `.claude-plugin/plugin.json` (name, version, description,
+- Parsing of `.claude-plugin/plugin.json` and compatible
+  `.codex-plugin/plugin.json` metadata (name, version, description,
   configSchema, uiHints).
 - Parsing of `hooks/hooks.json` into strongly-typed handler configurations with
   event binding (Stop, PreToolUse, PostToolUse, UserPromptSubmit, SessionStart,
@@ -76,6 +77,7 @@ RARA will scan:
 
 | Path | Priority | Content |
 |---|---|---|
+| `~/.rara/builtin-plugins/<name>/` | Builtin | RARA-owned compatibility plugins |
 | `~/.rara/plugins/<name>/` | User | per-user plugins |
 | `<workspace>/.rara/plugins/<name>/` | Project | per-project plugins |
 | `--plugin-dir <path>` | CLI | manual override for TUI sessions |
@@ -84,7 +86,7 @@ A valid plugin directory contains:
 
 ```
 <name>/
-├── .claude-plugin/
+├── .claude-plugin/           # or .codex-plugin/
 │   └── plugin.json          # required
 ├── hooks/
 │   └── hooks.json            # optional
@@ -111,6 +113,7 @@ pub struct Plugin {
 }
 
 pub enum PluginSource {
+    Builtin(PathBuf),
     User(PathBuf),
     Project(PathBuf),
     Cli(PathBuf),
@@ -278,6 +281,11 @@ duplicate server name fails registry assembly with both source paths, matching
 the base MCP registry contract. Stdio plugin MCP servers receive `cwd` set to
 the plugin root when the existing MCP runtime later connects them.
 
+MCP JSON parsing accepts Codex-style HTTP entries with an informational
+`"type": "http"` field and maps them onto RARA's existing streamable HTTP
+transport. RARA does not run a plugin-specific MCP lifecycle manager; it only
+registers server definitions into the shared runtime registry.
+
 ### Command Extension Registry
 
 Runtime bootstrap discovers plugin `commands/**/*.md` files from loaded
@@ -303,6 +311,71 @@ which avoids collisions with built-in, user, and workspace agents.
 Plugin agent definitions use the existing Claude-compatible agent frontmatter
 contract: `description`, `tools`, `disallowed_tools`, `model`, `max_turns`,
 `token_budget`, `permission_mode`, `plan_mode_required`, and `hidden`.
+
+### Builtin Nowledge Mem Plugin
+
+RARA materializes a builtin `nowledge-mem` plugin under
+`~/.rara/builtin-plugins/nowledge-mem` during runtime plugin discovery. This
+plugin is based on the Nowledge Mem community Codex plugin shape, but is kept as
+a compact RARA-owned compatibility package instead of vendoring the whole
+community repository.
+
+The builtin plugin provides:
+
+- `.codex-plugin/plugin.json` metadata so the same loader path accepts Codex
+  plugin manifests.
+- A `nowledge-mem` streamable HTTP MCP server pointing at
+  `http://127.0.0.1:14242/mcp/` with `APP: RARA`.
+- Plugin skills for working memory, memory search, memory distillation, thread
+  save guidance, and status diagnostics.
+- A `nowledge-mem:nowledge-mem` plugin agent definition for subagent routing
+  guidance.
+
+The builtin plugin is configurable through `config.json`:
+
+```json
+{
+  "builtin_plugins": {
+    "nowledge_mem": {
+      "enabled": true,
+      "url": "http://127.0.0.1:14242/mcp/",
+      "http_headers": {
+        "APP": "RARA"
+      }
+    }
+  }
+}
+```
+
+Default values are omitted when config is serialized. `enabled: false` disables
+materialization and discovery of the builtin Nowledge Mem plugin. `url` and
+`http_headers` override the generated builtin `.mcp.json`; custom headers merge
+with the default `APP: RARA` header and may replace it.
+
+Builtin plugins are the lowest-precedence source. User, project, and explicit
+CLI plugins with the same plugin name override the builtin plugin through the
+normal ordered de-duplication path. Builtin MCP servers also yield to already
+registered user or project MCP servers with the same name; normal non-builtin
+plugin MCP duplicates remain hard errors.
+
+Local Nowledge Mem endpoints must not use system HTTP proxies. The MCP
+transport contract exposes localhost proxy bypass detection for streamable HTTP
+URLs whose host is `localhost`, `127.0.0.1`, or `::1`. Any future streamable
+HTTP MCP connector must call this helper before constructing its HTTP client.
+
+The builtin subagent does not receive additional external execution authority.
+It is a registry-provided routing agent that can explain which Nowledge Mem
+skill, MCP tool, or CLI fallback the parent runtime should use. Opening direct
+MCP, shell, or skill invocation inside subagents is a separate tool-surface
+decision.
+
+TUI displays this integration in the `/status` Overview Extensions section.
+The display is read-only: it reports the builtin MCP entry as
+`nowledge-mem builtin`, shows the configured endpoint with secret-bearing URL
+parts redacted, and marks localhost endpoints as `local/direct` to make the
+no-proxy contract visible. Disabled builtin configuration renders as
+`nowledge-mem disabled`. TUI does not own plugin discovery, MCP registration,
+or generated plugin files.
 
 ## Contracts
 
@@ -348,6 +421,12 @@ scope for now.
 | Lifecycle hook stdout/stderr publishes a structured control event | `cargo test plugin_middleware::tests::lifecycle_hook_output_is_published_as_structured_control_event -- --nocapture` and `cargo test runtime_control::tests::hook_command_output_uses_structured_wire_shape -- --nocapture` |
 | Plugin skills load into the shared skill registry | `cargo test -p rara-skills plugin_skills_are_namespaced_and_invokable -- --nocapture` and `cargo test tools::skill::reload_updates_running_manager_with_plugin_skills -- --nocapture` |
 | Plugin `.mcp.json` registers into the shared MCP registry | `cargo test plugin_middleware::tests::appends_plugin_mcp_configs_with_plugin_source_metadata -- --nocapture` |
+| Codex-style HTTP MCP JSON parses | `cargo test -p rara-config loads_codex_style_http_mcp_json_type_field -- --nocapture` |
+| Builtin Nowledge Mem plugin materializes skills, MCP, and agent definition | `cargo test plugin_middleware::tests::builtin_nowledge_mem_plugin_materializes_skills_mcp_and_agent -- --nocapture` |
+| Builtin Nowledge Mem MCP registers as builtin fallback | `cargo test plugin_middleware::tests::appends_builtin_nowledge_mem_mcp_config -- --nocapture` and `cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_yields_to_existing_registry_server -- --nocapture` |
+| Builtin Nowledge Mem config controls endpoint, headers, and enabled state | `cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_uses_configured_url_and_headers -- --nocapture`, `cargo test plugin_middleware::tests::disabled_builtin_nowledge_mem_plugin_is_not_discovered -- --nocapture`, and `cargo test -p rara-config builtin_nowledge_mem_config_can_override_endpoint_and_headers -- --nocapture` |
+| TUI shows builtin Nowledge Mem status without owning runtime assembly | `cargo test tui::status_display::tests::overview_status_reports_builtin_nowledge_mem -- --nocapture`, `cargo test tui::status_display::tests::overview_status_reports_disabled_nowledge_mem -- --nocapture`, and `cargo test tui::status_display::tests::overview_status_reports_custom_nowledge_mem_endpoint_and_headers -- --nocapture` |
+| Local streamable HTTP MCP endpoints bypass proxy | `cargo test -p rara-config streamable_http_localhost_bypasses_proxy -- --nocapture` |
 | Plugin MCP file and relative cwd handling | `cargo test plugin_middleware::tests::plugin_mcp_configs_skip_mcp_json_directories -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_resolve_relative_cwd_from_plugin_root -- --nocapture` |
 | Plugin MCP parse and duplicate-name failures surface | `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_duplicate_server_names -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_invalid_json -- --nocapture` |
 | Plugin command markdown files register as runtime summaries | `cargo test plugin_middleware::tests::registers_project_plugin_command_summaries -- --nocapture` |
@@ -428,6 +507,15 @@ Implemented in the first merged slice:
   `AgentDefinitionCache` with namespaced `plugin_name:agent_name` names and can
   be used by `spawn_agent`, `explore_agent`, `plan_agent`, and team creation
   paths through the existing agent resolution contract.
+- `.codex-plugin/plugin.json` is accepted as a compatible plugin metadata
+  directory alongside `.claude-plugin/plugin.json`.
+- RARA materializes the builtin `nowledge-mem` plugin under
+  `~/.rara/builtin-plugins/nowledge-mem` and includes it as the lowest
+  precedence discovery source before user, project, configured, and CLI plugin
+  directories.
+- The builtin `nowledge-mem` plugin registers streamable HTTP MCP, prompt-visible
+  memory skills, and a namespaced subagent definition through the same runtime
+  registries as external plugins.
 - `rara plugin install <source>` accepts both local plugin directories and git
   sources. Git sources are cloned with `git clone --depth 1` into a temporary
   checkout before the existing plugin validation and workspace copy path runs.
@@ -458,3 +546,4 @@ Implemented in the first merged slice:
 - `docs/journal/2026-07-21-plugin-non-tool-lifecycle-hooks.md`
 - `docs/journal/2026-07-22-plugin-command-registry.md`
 - `docs/journal/2026-07-25-extension-completion.md`
+- `docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md`

--- a/docs/features/runtime-control-plane.md
+++ b/docs/features/runtime-control-plane.md
@@ -316,11 +316,12 @@ string fields and integer importance basis points so ACP/Wire adapters do not
 depend on internal Rust enums or floating-point formatting.
 
 Memory activity that affects the local agent turn must also produce a
-content-free TUI notice. Query notices may expose the operation and result
-count, and write notices may expose the operation and shortened record id, but
-they must not render stored memory content, query text, or titles in the
-transcript. Automatic workspace-memory retrieval and session checkpoint writes
-use the same notice style as protocol memory-control events.
+content-free TUI notice. Query notices may expose the operation, a sanitized
+and bounded query preview, and result count. Write notices may expose the
+operation and shortened record id. Notices must not render stored memory
+content, record titles, or unbounded query text in the transcript. Automatic
+workspace-memory retrieval and session checkpoint writes use the same notice
+style as protocol memory-control events.
 
 ### Hook Declaration
 

--- a/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
+++ b/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
@@ -1,0 +1,77 @@
+# Nowledge Mem Builtin Plugin
+
+## Summary
+
+RARA now ships a builtin `nowledge-mem` plugin that is materialized under the
+runtime home directory during plugin discovery. The plugin follows the Nowledge
+Mem community Codex plugin shape closely enough to reuse the existing plugin
+runtime registries:
+
+- `.codex-plugin/plugin.json` metadata compatibility;
+- streamable HTTP MCP registration for the local Nowledge Mem MCP endpoint;
+- memory-oriented plugin skills;
+- a namespaced `nowledge-mem:nowledge-mem` plugin agent definition.
+- config-driven enablement, endpoint URL, and HTTP headers.
+- read-only TUI `/status` display for builtin status, endpoint, and local direct
+  routing.
+- memory query event notices that show the sanitized query preview and result
+  count without rendering returned memory content.
+
+## Background
+
+The Nowledge Mem community repository already publishes a Codex plugin with
+skills, hooks, and MCP metadata. RARA should not vendor the whole community
+repository or make TUI own the plugin. The integration belongs in runtime
+assembly so TUI, headless, ACP, Wire, and future app-server surfaces all see the
+same plugin state.
+
+## Key Decisions
+
+- Builtin plugin discovery is the lowest-precedence source:
+  `builtin -> user -> project -> configured/CLI`. Later sources still override
+  earlier plugin names through the existing de-duplication rule.
+- Builtin MCP servers use `builtin` provenance and yield to already registered
+  user or project MCP servers with the same name. Normal non-builtin plugin MCP
+  duplicates remain hard errors.
+- `builtin_plugins.nowledge_mem` controls whether the plugin is materialized
+  and which MCP URL or headers are written into its generated `.mcp.json`.
+- The builtin plugin accepts Codex-style `.codex-plugin/plugin.json` metadata.
+- MCP JSON parsing accepts Codex-style informational `"type": "http"` fields
+  and maps the entry to the existing streamable HTTP transport.
+- Streamable HTTP MCP transports expose localhost proxy bypass detection for
+  `localhost`, `127.0.0.1`, and `::1`. The future HTTP MCP connector must use
+  this helper so local Nowledge Mem traffic never goes through system proxies.
+- The builtin subagent is a routing agent definition only. It does not expand
+  the restricted subagent tool surface with direct shell, MCP, or skill
+  invocation.
+- TUI status rendering reports the builtin integration from runtime/config
+  state only. It does not scan plugin directories or register plugin/MCP
+  resources.
+- Runtime memory query events carry the original query string so presentation
+  surfaces can report what was queried. TUI renders only a sanitized and
+  bounded preview, and still suppresses returned memory titles and content.
+
+## Validation
+
+```bash
+cargo test -p config loads_codex_style_http_mcp_json_type_field -- --nocapture
+cargo test plugin_middleware::tests::builtin_nowledge_mem_plugin_materializes_skills_mcp_and_agent -- --nocapture
+cargo test plugin_middleware::tests::appends_builtin_nowledge_mem_mcp_config -- --nocapture
+cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_yields_to_existing_registry_server -- --nocapture
+cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_uses_configured_url_and_headers -- --nocapture
+cargo test plugin_middleware::tests::disabled_builtin_nowledge_mem_plugin_is_not_discovered -- --nocapture
+cargo test -p rara-plugins loads_codex_plugin_metadata_directory -- --nocapture
+cargo test -p rara-config streamable_http_localhost_bypasses_proxy -- --nocapture
+cargo test tui::status_display::tests::overview_status_reports_builtin_nowledge_mem -- --nocapture
+cargo test tui::status_display::tests::overview_status_reports_disabled_nowledge_mem -- --nocapture
+cargo test tui::status_display::tests::overview_status_reports_custom_nowledge_mem_endpoint_and_headers -- --nocapture
+cargo test runtime_control::tests::memory_label_and_metadata_events_use_structured_wire_shape -- --nocapture
+cargo test protocol_sources::tests::memory_control_update_delete_and_labels_use_memory_store -- --nocapture
+cargo test tui::runtime::events::tests::memory_query_notice -- --nocapture
+```
+
+## Follow-Ups
+
+- Decide separately whether subagents should get direct access to plugin skills
+  or MCP tools. That changes the child-agent execution authority and should be
+  reviewed as a tool-surface change, not hidden inside the builtin plugin.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -78,6 +78,9 @@ Active backlog only. Keep this file small and current.
       overrides.
 - [x] Surface configured subagent provider/model targets in runtime status for
       agent definitions.
+- [ ] Decide whether subagents should receive direct plugin skill or MCP tool
+      access. Builtin plugin agent definitions are registered, but external
+      execution authority remains parent-owned.
 
 ## Shared Task Lists
 

--- a/src/agent/tests/plugin_hooks.rs
+++ b/src/agent/tests/plugin_hooks.rs
@@ -94,6 +94,7 @@ async fn plugin_pre_tool_use_continue_false_blocks_tool_execution() {
         None,
         temp.path(),
         &[],
+        &crate::config::BuiltinPluginConfig::default(),
         "session-1",
     )
     .await;
@@ -156,6 +157,7 @@ async fn plugin_session_end_runs_once_with_last_assistant_message() {
         None,
         temp.path(),
         &[],
+        &crate::config::BuiltinPluginConfig::default(),
         "session-1",
     )
     .await;
@@ -225,6 +227,7 @@ async fn plugin_session_end_marks_cancelled_model_turn_as_interrupt() {
         None,
         temp.path(),
         &[],
+        &crate::config::BuiltinPluginConfig::default(),
         "session-1",
     )
     .await;
@@ -308,6 +311,7 @@ async fn plugin_non_tool_lifecycle_hooks_run_from_agent_query() {
         None,
         temp.path(),
         &[],
+        &crate::config::BuiltinPluginConfig::default(),
         "session-1",
     )
     .await;
@@ -400,6 +404,7 @@ async fn plugin_session_start_waits_until_plugin_runtime_is_attached() {
         None,
         temp.path(),
         &[],
+        &crate::config::BuiltinPluginConfig::default(),
         "session-1",
     )
     .await;

--- a/src/mcp_tool_cache.rs
+++ b/src/mcp_tool_cache.rs
@@ -101,6 +101,7 @@ impl McpToolCache {
                     args,
                     env,
                     cwd,
+                    ..
                 } => {
                     let cmd = std::ffi::OsString::from(command);
                     let argv: Vec<std::ffi::OsString> = args.iter().map(|a| a.into()).collect();

--- a/src/plugin_middleware.rs
+++ b/src/plugin_middleware.rs
@@ -1,5 +1,7 @@
 //! Bridge between `rara-plugins` and RARA's runtime registries.
 
+mod builtin;
+
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Weak};
@@ -12,8 +14,8 @@ use serde_json::Value;
 
 use crate::agent::AgentEvent;
 use crate::config::{
-    McpRegistry, McpServerConfig, McpServerScope, McpServerSource, McpServerTransport,
-    load_mcp_servers_from_json_path,
+    BuiltinPluginConfig, McpRegistry, McpServerConfig, McpServerScope, McpServerSource,
+    McpServerTransport, load_mcp_servers_from_json_path,
 };
 use crate::hook_runtime::HookRuntime;
 use crate::runtime_control::{HookEvent as RuntimeHookEvent, HookLifecycle};
@@ -248,11 +250,13 @@ pub(crate) async fn register_plugin_hooks(
     rara_home: Option<PathBuf>,
     workspace_root: &Path,
     explicit_plugin_dirs: &[PathBuf],
+    builtin_plugins: &BuiltinPluginConfig,
     session_id: &str,
 ) -> Arc<PluginHookRuntime> {
     let runtime = runtime.clone();
     let workspace_root = workspace_root.to_path_buf();
     let explicit_plugin_dirs = explicit_plugin_dirs.to_vec();
+    let builtin_plugins = builtin_plugins.clone();
     let session_id = session_id.to_string();
     match tokio::task::spawn_blocking(move || {
         let resolved_rara_home = rara_home.or_else(|| crate::config::ensure_rara_home_dir().ok());
@@ -260,6 +264,7 @@ pub(crate) async fn register_plugin_hooks(
             resolved_rara_home.as_deref(),
             &workspace_root,
             &explicit_plugin_dirs,
+            &builtin_plugins,
         );
         let plugin_runtime =
             load_plugin_hooks_blocking(sources, &session_id, Some(runtime.clone()));
@@ -281,8 +286,14 @@ pub(crate) fn append_plugin_mcp_configs(
     rara_home: Option<&Path>,
     workspace_root: &Path,
     explicit_plugin_dirs: &[PathBuf],
+    builtin_plugins: &BuiltinPluginConfig,
 ) -> anyhow::Result<()> {
-    let sources = plugin_discovery_sources(rara_home, workspace_root, explicit_plugin_dirs);
+    let sources = plugin_discovery_sources(
+        rara_home,
+        workspace_root,
+        explicit_plugin_dirs,
+        builtin_plugins,
+    );
     let plugins = discover_plugins_from_sources(&sources);
     append_plugin_mcp_configs_from_plugins(registry, &plugins)
 }
@@ -291,8 +302,14 @@ pub(crate) fn discover_runtime_plugins(
     rara_home: Option<&Path>,
     workspace_root: &Path,
     explicit_plugin_dirs: &[PathBuf],
+    builtin_plugins: &BuiltinPluginConfig,
 ) -> Vec<Plugin> {
-    let sources = plugin_discovery_sources(rara_home, workspace_root, explicit_plugin_dirs);
+    let sources = plugin_discovery_sources(
+        rara_home,
+        workspace_root,
+        explicit_plugin_dirs,
+        builtin_plugins,
+    );
     discover_plugins_from_sources(&sources)
 }
 
@@ -328,10 +345,15 @@ fn plugin_discovery_sources(
     rara_home: Option<&Path>,
     workspace_root: &Path,
     explicit_plugin_dirs: &[PathBuf],
+    builtin_plugins: &BuiltinPluginConfig,
 ) -> Vec<PluginDiscoverySource> {
     let project_plugins_dir = workspace_root.join(".rara").join("plugins");
     let mut sources = Vec::new();
     if let Some(rara_home) = rara_home {
+        sources.extend(builtin::discovery_sources(
+            rara_home,
+            &builtin_plugins.nowledge_mem,
+        ));
         let user_plugins_dir = rara_home.join("plugins");
         sources.push(PluginDiscoverySource {
             plugins_dir: user_plugins_dir.clone(),
@@ -379,9 +401,16 @@ fn append_plugin_mcp_configs_from_plugins(
         }
         let mut servers = load_mcp_servers_from_json_path(&mcp_path)?;
         apply_plugin_mcp_defaults(&mut servers, &plugin.root);
+        let scope = plugin_mcp_scope(plugin);
+        if scope == McpServerScope::Builtin {
+            servers.retain(|name, _| !registry.servers.contains_key(name));
+            if servers.is_empty() {
+                continue;
+            }
+        }
         registry.insert_source(
             McpServerSource {
-                scope: McpServerScope::Plugin,
+                scope,
                 path: mcp_path,
             },
             servers,
@@ -406,6 +435,14 @@ fn apply_plugin_mcp_defaults(
             }
             McpServerTransport::StreamableHttp { .. } => {}
         }
+    }
+}
+
+fn plugin_mcp_scope(plugin: &Plugin) -> McpServerScope {
+    if matches!(plugin.source, PluginSource::Builtin(_)) {
+        McpServerScope::Builtin
+    } else {
+        McpServerScope::Plugin
     }
 }
 
@@ -708,510 +745,4 @@ fn plugin_hook_block_message(stdout: &str, stderr: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::fs;
-
-    use serde_json::json;
-    use tempfile::tempdir;
-
-    use super::*;
-    use crate::runtime_event_bus::RuntimeEventBus;
-
-    #[test]
-    fn plugin_discovery_sources_order_user_project_then_cli() {
-        let dir = tempdir().expect("tempdir");
-        let rara_home = dir.path().join("home").join(".rara");
-        let workspace_root = dir.path().join("workspace");
-        let explicit_plugins_dir = dir.path().join("explicit-plugins");
-
-        let sources = plugin_discovery_sources(
-            Some(&rara_home),
-            &workspace_root,
-            std::slice::from_ref(&explicit_plugins_dir),
-        );
-
-        assert_eq!(sources.len(), 3);
-        assert_eq!(sources[0].source.label(), "user");
-        assert_eq!(sources[0].plugins_dir, rara_home.join("plugins"));
-        assert_eq!(sources[1].source.label(), "project");
-        assert_eq!(
-            sources[1].plugins_dir,
-            workspace_root.join(".rara").join("plugins")
-        );
-        assert_eq!(sources[2].source.label(), "cli");
-        assert_eq!(sources[2].plugins_dir, explicit_plugins_dir);
-    }
-
-    #[test]
-    fn plugin_discovery_sources_keep_project_when_user_home_is_unavailable() {
-        let dir = tempdir().expect("tempdir");
-        let workspace_root = dir.path().join("workspace");
-        let explicit_plugins_dir = dir.path().join("explicit-plugins");
-
-        let sources = plugin_discovery_sources(
-            None,
-            &workspace_root,
-            std::slice::from_ref(&explicit_plugins_dir),
-        );
-
-        assert_eq!(sources.len(), 2);
-        assert_eq!(sources[0].source.label(), "project");
-        assert_eq!(
-            sources[0].plugins_dir,
-            workspace_root.join(".rara").join("plugins")
-        );
-        assert_eq!(sources[1].source.label(), "cli");
-        assert_eq!(sources[1].plugins_dir, explicit_plugins_dir);
-    }
-
-    #[tokio::test]
-    async fn registers_user_and_project_plugins_with_project_precedence() {
-        let dir = tempdir().expect("tempdir");
-        let rara_home = dir.path().join("home").join(".rara");
-        let workspace_root = dir.path().join("workspace");
-        let user_plugins_dir = rara_home.join("plugins");
-        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-        write_test_plugin(&user_plugins_dir.join("shared"), "shared", "echo user");
-        write_test_plugin(
-            &project_plugins_dir.join("shared"),
-            "shared",
-            "echo project",
-        );
-        write_test_plugin(
-            &project_plugins_dir.join("project-only"),
-            "project-only",
-            "echo project-only",
-        );
-
-        let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
-        let registered =
-            register_plugin_hooks(&runtime, Some(rara_home), &workspace_root, &[], "session-1")
-                .await;
-
-        assert_eq!(registered.hook_count(), 2);
-        assert_eq!(runtime.hook_count(), 2);
-    }
-
-    #[tokio::test]
-    async fn registers_project_plugin_command_summaries() {
-        let dir = tempdir().expect("tempdir");
-        let rara_home = dir.path().join("home").join(".rara");
-        let workspace_root = dir.path().join("workspace");
-        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-        let plugin_root = project_plugins_dir.join("commands");
-        write_test_plugin(&plugin_root, "commands", "echo project");
-        fs::create_dir_all(plugin_root.join("commands").join("git")).expect("commands dir");
-        fs::write(
-            plugin_root.join("commands").join("git").join("review.md"),
-            "---\ndescription: Review the current diff.\n---\n# Review\nBody text.",
-        )
-        .expect("command");
-        fs::write(
-            plugin_root.join("commands").join("explain.md"),
-            "# Explain\nExplain selected code.",
-        )
-        .expect("command");
-
-        let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
-        let registered =
-            register_plugin_hooks(&runtime, Some(rara_home), &workspace_root, &[], "session-1")
-                .await;
-
-        assert_eq!(
-            registered.command_summaries(),
-            &[
-                PluginCommandSummary {
-                    name: "commands:explain".to_string(),
-                    title: Some("explain".to_string()),
-                    description: "Explain selected code.".to_string(),
-                    path: plugin_root.join("commands").join("explain.md"),
-                },
-                PluginCommandSummary {
-                    name: "commands:git/review".to_string(),
-                    title: Some("git/review".to_string()),
-                    description: "Review the current diff.".to_string(),
-                    path: plugin_root.join("commands").join("git").join("review.md"),
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn plugin_agent_records_are_namespaced_by_plugin_name() {
-        let dir = tempdir().expect("tempdir");
-        let plugin_root = dir.path().join("plugin");
-        write_test_plugin(&plugin_root, "helpers", "echo project");
-        fs::create_dir_all(plugin_root.join("agents")).expect("agents dir");
-        fs::write(
-            plugin_root.join("agents").join("reviewer.md"),
-            r#"---
-name: reviewer
-description: Reviews plugin-provided code.
----
-
-Review code from the plugin context.
-"#,
-        )
-        .expect("agent");
-        let plugins = discover_plugins_from_sources(&[PluginDiscoverySource {
-            plugins_dir: dir.path().to_path_buf(),
-            source: PluginSource::Directory(dir.path().to_path_buf()),
-        }]);
-
-        let records = plugin_agent_records(&plugins);
-
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0].id, "helpers:reviewer");
-        let definition = records[0].definition.as_ref().expect("definition");
-        assert_eq!(definition.name, "helpers:reviewer");
-        assert_eq!(definition.description, "Reviews plugin-provided code.");
-    }
-
-    #[test]
-    fn appends_plugin_mcp_configs_with_plugin_source_metadata() {
-        let dir = tempdir().expect("tempdir");
-        let workspace_root = dir.path().join("workspace");
-        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-        let plugin_root = project_plugins_dir.join("mcp-plugin");
-        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
-        write_test_plugin_mcp_config(&plugin_root, "docs", "docs-server", &["--stdio"]);
-
-        let mut registry = McpRegistry::empty();
-        append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
-            .expect("append plugin mcp config");
-
-        let server = registry.servers.get("docs").expect("docs server");
-        assert_eq!(server.source.scope, McpServerScope::Plugin);
-        assert_eq!(server.source.path, plugin_root.join(".mcp.json"));
-        assert_eq!(
-            server.config.transport,
-            McpServerTransport::Stdio {
-                command: "docs-server".to_string(),
-                args: vec!["--stdio".to_string()],
-                env: None,
-                cwd: Some(plugin_root),
-            }
-        );
-    }
-
-    #[test]
-    fn plugin_mcp_configs_resolve_relative_cwd_from_plugin_root() {
-        let dir = tempdir().expect("tempdir");
-        let workspace_root = dir.path().join("workspace");
-        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-        let plugin_root = project_plugins_dir.join("mcp-plugin");
-        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
-        fs::write(
-            plugin_root.join(".mcp.json"),
-            json!({
-                "mcpServers": {
-                    "docs": {
-                        "command": "docs-server",
-                        "cwd": "server"
-                    }
-                }
-            })
-            .to_string(),
-        )
-        .expect("mcp json");
-
-        let mut registry = McpRegistry::empty();
-        append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
-            .expect("append plugin mcp config");
-
-        let server = registry.servers.get("docs").expect("docs server");
-        assert_eq!(
-            server.config.transport,
-            McpServerTransport::Stdio {
-                command: "docs-server".to_string(),
-                args: Vec::new(),
-                env: None,
-                cwd: Some(plugin_root.join("server")),
-            }
-        );
-    }
-
-    #[test]
-    fn plugin_mcp_configs_skip_mcp_json_directories() {
-        let dir = tempdir().expect("tempdir");
-        let workspace_root = dir.path().join("workspace");
-        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-        let plugin_root = project_plugins_dir.join("mcp-plugin");
-        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
-        fs::create_dir_all(plugin_root.join(".mcp.json")).expect("mcp json dir");
-
-        let mut registry = McpRegistry::empty();
-        append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
-            .expect("directory should be skipped");
-
-        assert!(registry.servers.is_empty());
-    }
-
-    #[test]
-    fn plugin_mcp_configs_fail_on_duplicate_server_names() {
-        let dir = tempdir().expect("tempdir");
-        let workspace_root = dir.path().join("workspace");
-        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-        let plugin_root = project_plugins_dir.join("mcp-plugin");
-        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
-        write_test_plugin_mcp_config(&plugin_root, "docs", "docs-server", &[]);
-
-        let mut registry = McpRegistry::empty();
-        registry
-            .insert_source(
-                McpServerSource {
-                    scope: McpServerScope::Project,
-                    path: workspace_root.join(".mcp.json"),
-                },
-                std::collections::BTreeMap::from([(
-                    "docs".to_string(),
-                    McpServerConfig {
-                        transport: McpServerTransport::Stdio {
-                            command: "project-docs".to_string(),
-                            args: Vec::new(),
-                            env: None,
-                            cwd: None,
-                        },
-                        enabled: true,
-                        required: false,
-                        supports_parallel_tool_calls: false,
-                        startup_timeout_sec: None,
-                        tool_timeout_sec: None,
-                        enabled_tools: None,
-                        disabled_tools: None,
-                    },
-                )]),
-            )
-            .expect("insert project source");
-
-        let err = append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
-            .expect_err("duplicate server should fail");
-
-        let message = err.to_string();
-        assert!(message.contains("MCP server `docs` is defined in both project"));
-        assert!(message.contains("plugin"));
-    }
-
-    #[test]
-    fn plugin_mcp_configs_fail_on_invalid_json() {
-        let dir = tempdir().expect("tempdir");
-        let workspace_root = dir.path().join("workspace");
-        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-        let plugin_root = project_plugins_dir.join("mcp-plugin");
-        write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
-        fs::write(plugin_root.join(".mcp.json"), "{invalid json").expect("mcp json");
-
-        let mut registry = McpRegistry::empty();
-        let err = append_plugin_mcp_configs(&mut registry, None, &workspace_root, &[])
-            .expect_err("invalid plugin mcp json should fail");
-
-        let message = err.to_string();
-        assert!(message.contains("parse"));
-        assert!(message.contains(".mcp.json"));
-    }
-
-    #[test]
-    fn plugin_skill_description_uses_first_markdown_body_section() {
-        let content = "---\nname: reviewer\ndescription: metadata\n---\n# Reviewer\nInspect plugin-provided behavior.\n\n## Details\nMore.";
-
-        assert_eq!(
-            extract_plugin_skill_description(content),
-            "Inspect plugin-provided behavior."
-        );
-    }
-
-    #[tokio::test]
-    async fn plugin_callbacks_do_not_retain_hook_runtime_strong_reference() {
-        let dir = tempdir().expect("tempdir");
-        let rara_home = dir.path().join("home").join(".rara");
-        let workspace_root = dir.path().join("workspace");
-        let project_plugins_dir = workspace_root.join(".rara").join("plugins");
-        write_test_plugin(
-            &project_plugins_dir.join("project-only"),
-            "project-only",
-            "echo project-only",
-        );
-
-        let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
-        register_plugin_hooks(&runtime, Some(rara_home), &workspace_root, &[], "session-1").await;
-
-        assert_eq!(runtime.hook_count(), 1);
-        assert_eq!(Arc::strong_count(&runtime), 1);
-    }
-
-    #[test]
-    fn hook_matcher_filters_tool_events_by_tool_name() {
-        let bash_hook = rara_plugins::HookHandler {
-            r#type: "command".to_string(),
-            command: "echo bash".to_string(),
-            timeout: 1,
-            matcher: Some("Bash(*)".to_string()),
-            once: false,
-        };
-        let edit_hook = rara_plugins::HookHandler {
-            r#type: "command".to_string(),
-            command: "echo edit".to_string(),
-            timeout: 1,
-            matcher: Some("Write|Edit".to_string()),
-            once: false,
-        };
-        let bash_event = AgentEvent::ToolUse {
-            name: "bash".to_string(),
-            input: serde_json::json!({}),
-        };
-        let edit_event = AgentEvent::ToolUse {
-            name: "Edit".to_string(),
-            input: serde_json::json!({}),
-        };
-
-        assert!(hook_matches_agent_event(&bash_hook, &bash_event));
-        assert!(!hook_matches_agent_event(&bash_hook, &edit_event));
-        assert!(hook_matches_agent_event(&edit_hook, &edit_event));
-        assert!(!hook_matches_agent_event(&edit_hook, &bash_event));
-    }
-
-    #[test]
-    fn extracts_tool_result_content_for_post_tool_use_hooks() {
-        let event = AgentEvent::ToolResult {
-            name: "stub_tool".to_string(),
-            content: json!({ "status": "ok" }).to_string(),
-            is_error: false,
-        };
-
-        assert_eq!(
-            extract_tool_response(&event),
-            Some(json!({ "status": "ok" }))
-        );
-    }
-
-    #[test]
-    fn plugin_hook_block_message_falls_back_to_plain_stdout() {
-        assert_eq!(
-            plugin_hook_block_message("plain stdout failure", ""),
-            "plain stdout failure"
-        );
-    }
-
-    #[tokio::test]
-    async fn pre_tool_use_control_stdout_is_not_buffered_as_context() {
-        let hook_runtime = HookRuntime::new(Arc::new(RuntimeEventBus::new(4)));
-        let dir = tempdir().expect("tempdir");
-        let plugin_root = dir.path().join("plugin");
-        fs::create_dir_all(&plugin_root).expect("plugin root");
-        let plugin_hooks = PluginHookRuntime::new(
-            "session-1".to_string(),
-            vec![rara_plugins::RegisteredHook {
-                event: HookEvent::PreToolUse,
-                handler: rara_plugins::HookHandler {
-                    r#type: "command".to_string(),
-                    command: "cat >/dev/null; echo '{\"continue\":true}'".to_string(),
-                    timeout: 1,
-                    matcher: Some("stub_tool".to_string()),
-                    once: false,
-                },
-                plugin_name: "control".to_string(),
-                plugin_root,
-            }],
-            Vec::new(),
-            None,
-        );
-
-        let block = plugin_hooks
-            .run_pre_tool_use("stub_tool", &json!({ "path": "src/lib.rs" }))
-            .await;
-
-        assert_eq!(block, None);
-        assert!(hook_runtime.blocking_drain_outputs().is_empty());
-    }
-
-    #[tokio::test]
-    async fn lifecycle_hook_output_is_published_as_structured_control_event() {
-        let bus = Arc::new(RuntimeEventBus::new(8));
-        let mut events = bus.subscribe_control();
-        let hook_runtime = Arc::new(HookRuntime::new(bus));
-        let dir = tempdir().expect("tempdir");
-        let plugin_root = dir.path().join("plugin");
-        fs::create_dir_all(&plugin_root).expect("plugin root");
-        let plugin_hooks = PluginHookRuntime::new(
-            "session-1".to_string(),
-            vec![rara_plugins::RegisteredHook {
-                event: HookEvent::SessionStart,
-                handler: rara_plugins::HookHandler {
-                    r#type: "command".to_string(),
-                    command: "cat >/dev/null; echo visible; echo warn >&2".to_string(),
-                    timeout: 1,
-                    matcher: None,
-                    once: false,
-                },
-                plugin_name: "observer".to_string(),
-                plugin_root,
-            }],
-            Vec::new(),
-            Some(hook_runtime.clone()),
-        );
-
-        plugin_hooks.run_session_start().await;
-
-        let event = events.try_recv().expect("hook output event");
-        assert_eq!(
-            event.event,
-            crate::runtime_control::RuntimeEvent::Hook(
-                crate::runtime_control::HookEvent::CommandOutput {
-                    plugin_name: "observer".to_string(),
-                    hook_event: "SessionStart".to_string(),
-                    stdout: "visible\n".to_string(),
-                    stderr: "warn\n".to_string(),
-                    exit_code: Some(0),
-                    timed_out: false,
-                    ok: true,
-                }
-            )
-        );
-        assert!(hook_runtime.blocking_drain_outputs().is_empty());
-    }
-
-    fn write_test_plugin(root: &Path, name: &str, command: &str) {
-        fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");
-        fs::write(
-            root.join(".claude-plugin").join("plugin.json"),
-            json!({
-                "name": name,
-                "version": "1.0.0",
-                "description": "test plugin"
-            })
-            .to_string(),
-        )
-        .expect("plugin json");
-        fs::create_dir_all(root.join("hooks")).expect("hooks dir");
-        fs::write(
-            root.join("hooks").join("hooks.json"),
-            json!({
-                "Stop": [{
-                    "hooks": [{
-                        "type": "command",
-                        "command": command,
-                        "timeout": 1
-                    }]
-                }]
-            })
-            .to_string(),
-        )
-        .expect("hooks json");
-    }
-
-    fn write_test_plugin_mcp_config(root: &Path, name: &str, command: &str, args: &[&str]) {
-        fs::write(
-            root.join(".mcp.json"),
-            json!({
-                "mcpServers": {
-                    name: {
-                        "command": command,
-                        "args": args
-                    }
-                }
-            })
-            .to_string(),
-        )
-        .expect("mcp json");
-    }
-}
+mod tests;

--- a/src/plugin_middleware/builtin.rs
+++ b/src/plugin_middleware/builtin.rs
@@ -1,0 +1,260 @@
+use std::fs;
+use std::path::Path;
+
+use rara_plugins::{PluginDiscoverySource, PluginSource};
+
+use crate::config::NowledgeMemPluginConfig;
+
+pub(super) const BUILTIN_PLUGINS_DIR: &str = "builtin-plugins";
+pub(super) const NOWLEDGE_MEM_PLUGIN_DIR: &str = "nowledge-mem";
+#[cfg(test)]
+pub(super) const NOWLEDGE_MEM_MCP_URL: &str = "http://127.0.0.1:14242/mcp/";
+
+const NOWLEDGE_MEM_PLUGIN_VERSION: &str = "0.1.29-rara.1";
+const NOWLEDGE_MEM_SKILL_ROOTS: &[(&str, &str)] = &[
+    ("working-memory", NOWLEDGE_MEM_WORKING_MEMORY_SKILL),
+    ("search-memory", NOWLEDGE_MEM_SEARCH_MEMORY_SKILL),
+    ("distill-memory", NOWLEDGE_MEM_DISTILL_MEMORY_SKILL),
+    ("save-thread", NOWLEDGE_MEM_SAVE_THREAD_SKILL),
+    ("status", NOWLEDGE_MEM_STATUS_SKILL),
+];
+
+pub(super) fn discovery_sources(
+    rara_home: &Path,
+    config: &NowledgeMemPluginConfig,
+) -> Vec<PluginDiscoverySource> {
+    if !config.enabled {
+        return Vec::new();
+    }
+    let plugins_dir = rara_home.join(BUILTIN_PLUGINS_DIR);
+    let plugin_root = plugins_dir.join(NOWLEDGE_MEM_PLUGIN_DIR);
+    if let Err(err) = materialize_nowledge_mem_plugin(&plugin_root, config) {
+        log::warn!(
+            "failed to materialize builtin Nowledge Mem plugin at {}: {err}",
+            plugin_root.display()
+        );
+        return Vec::new();
+    }
+    vec![PluginDiscoverySource {
+        plugins_dir: plugins_dir.clone(),
+        source: PluginSource::Builtin(plugins_dir),
+    }]
+}
+
+fn materialize_nowledge_mem_plugin(
+    plugin_root: &Path,
+    config: &NowledgeMemPluginConfig,
+) -> std::io::Result<()> {
+    write_file_if_changed(
+        &plugin_root.join(".codex-plugin").join("plugin.json"),
+        &serde_json::json!({
+            "name": NOWLEDGE_MEM_PLUGIN_DIR,
+            "version": NOWLEDGE_MEM_PLUGIN_VERSION,
+            "description": "Nowledge Mem integration for RARA runtime memory, cross-tool recall, and thread handoff.",
+            "skills": "./skills/",
+            "mcpServers": "./.mcp.json"
+        })
+        .to_string(),
+    )?;
+    write_file_if_changed(
+        &plugin_root.join(".mcp.json"),
+        &serde_json::json!({
+            "mcpServers": {
+                "nowledge-mem": {
+                    "type": "http",
+                    "url": config.url.clone(),
+                    "http_headers": nowledge_mem_http_headers(config)
+                }
+            }
+        })
+        .to_string(),
+    )?;
+    write_file_if_changed(&plugin_root.join("AGENTS.md"), NOWLEDGE_MEM_AGENTS_MD)?;
+    for (name, content) in NOWLEDGE_MEM_SKILL_ROOTS {
+        write_file_if_changed(
+            &plugin_root.join("skills").join(name).join("SKILL.md"),
+            content,
+        )?;
+    }
+    write_file_if_changed(
+        &plugin_root.join("agents").join("nowledge-mem.md"),
+        NOWLEDGE_MEM_AGENT_DEFINITION,
+    )
+}
+
+fn nowledge_mem_http_headers(
+    config: &NowledgeMemPluginConfig,
+) -> std::collections::BTreeMap<String, String> {
+    let mut headers = std::collections::BTreeMap::from([("APP".to_string(), "RARA".to_string())]);
+    headers.extend(config.http_headers.clone());
+    headers
+}
+
+fn write_file_if_changed(path: &Path, content: &str) -> std::io::Result<()> {
+    if fs::read_to_string(path).is_ok_and(|current| current == content) {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, content)
+}
+
+const NOWLEDGE_MEM_AGENTS_MD: &str = r#"# Nowledge Mem
+
+Nowledge Mem is the source for cross-tool context, current Working Memory, exact
+prior threads, and sourced decisions. RARA local memory remains available for
+local workspace recall, but do not treat it as a replacement for Nowledge Mem
+when the user asks about prior cross-tool context or exact history.
+
+Prefer the Nowledge Mem MCP server when it is reachable. Use the plugin skills
+as routing guidance and CLI fallback procedures when MCP tools are not exposed
+in the current session.
+"#;
+
+const NOWLEDGE_MEM_AGENT_DEFINITION: &str = r#"---
+name: nowledge-mem
+description: Routes memory-heavy tasks through Nowledge Mem skills and MCP context.
+tools: []
+---
+
+You are the Nowledge Mem routing subagent for RARA.
+
+Use this role when the parent agent asks how to retrieve, save, or verify
+cross-tool memory. Inspect the Nowledge Mem skill descriptions available in the
+session prompt and return the exact memory route the parent should use.
+
+You do not call external tools directly from this subagent role. The parent
+agent owns MCP, shell, and skill invocation decisions for the active session.
+"#;
+
+const NOWLEDGE_MEM_WORKING_MEMORY_SKILL: &str = r#"---
+name: working-memory
+description: Load the Nowledge Mem working context or daily briefing before context-sensitive work.
+---
+
+# Working Memory
+
+Use this skill when a task depends on current priorities, prior decisions,
+active project context, or cross-tool continuity.
+
+Prefer Nowledge Mem MCP context tools when they are exposed in the session. If
+MCP is not available, use:
+
+```bash
+nmem --json context --source-app rara
+```
+
+For a lighter daily briefing, use:
+
+```bash
+nmem --json wm read
+```
+
+Keep the returned context as sourced task context. Do not copy large memory
+payloads into durable RARA prompts unless the user explicitly asks for a
+summary or handoff.
+"#;
+
+const NOWLEDGE_MEM_SEARCH_MEMORY_SKILL: &str = r#"---
+name: search-memory
+description: Search Nowledge Mem for durable decisions, prior threads, or exact cross-tool history.
+---
+
+# Search Memory
+
+Use this skill before answering continuation, review, regression, release,
+connector, prior-decision, or exact-history questions.
+
+Prefer Nowledge Mem MCP search tools when they are available. If MCP is not
+available, start with durable memory search:
+
+```bash
+nmem --json m search "query"
+```
+
+Use thread search when the user asks about a previous conversation or exact
+session history:
+
+```bash
+nmem --json t search "query" --limit 5
+nmem --json t show <thread_id> --limit 8 --offset 0 --content-limit 1200
+```
+
+Treat Codex or RARA local memory as hints. Nowledge Mem remains the authority
+for cross-tool state and sourced decisions.
+"#;
+
+const NOWLEDGE_MEM_DISTILL_MEMORY_SKILL: &str = r#"---
+name: distill-memory
+description: Save durable decisions, procedures, or reusable project knowledge to Nowledge Mem.
+---
+
+# Distill Memory
+
+Use this skill when the user asks to remember something, save a durable
+decision, or preserve a reusable procedure across tools.
+
+Search first to avoid duplicates:
+
+```bash
+nmem --json m search "concept"
+```
+
+If an existing memory should change, update it:
+
+```bash
+nmem --json m update <memory_id> -c "updated content"
+```
+
+If this is new durable knowledge, add it:
+
+```bash
+nmem --json m add "content" -t "Title" --unit-type decision -l "label" -s rara -i 0.8
+```
+
+Keep memory entries concise, sourced by the current task, and focused on
+knowledge that should survive the current thread.
+"#;
+
+const NOWLEDGE_MEM_SAVE_THREAD_SKILL: &str = r#"---
+name: save-thread
+description: Save or hand off the current RARA thread into Nowledge Mem when the user asks for a durable thread record.
+---
+
+# Save Thread
+
+Use this skill when the user asks to save the current thread, create a handoff,
+or preserve exact conversation context for another tool.
+
+Prefer a real transcript import when the host exposes one. If the only
+available route is the Nowledge Mem CLI, use:
+
+```bash
+nmem --json t save --from rara -p . -s "Brief summary"
+```
+
+Do not fabricate a transcript. If the host cannot expose the real session
+transcript, save a concise handoff summary only after the user explicitly asks
+for it.
+"#;
+
+const NOWLEDGE_MEM_STATUS_SKILL: &str = r#"---
+name: status
+description: Check whether Nowledge Mem is reachable through MCP or the nmem CLI.
+---
+
+# Status
+
+Use this skill when memory tools are missing, MCP search fails, or the user asks
+whether Nowledge Mem is connected.
+
+Prefer MCP status tools if exposed. For CLI fallback, run:
+
+```bash
+nmem --json status
+```
+
+If the local MCP server is unavailable, verify that Nowledge Mem is running and
+that the local endpoint is available at `http://127.0.0.1:14242/mcp/`.
+"#;

--- a/src/plugin_middleware/tests.rs
+++ b/src/plugin_middleware/tests.rs
@@ -1,0 +1,776 @@
+use std::fs;
+
+use serde_json::json;
+use tempfile::tempdir;
+
+use super::*;
+use crate::runtime_event_bus::RuntimeEventBus;
+
+#[test]
+fn plugin_discovery_sources_order_user_project_then_cli() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+    let explicit_plugins_dir = dir.path().join("explicit-plugins");
+
+    let sources = plugin_discovery_sources(
+        Some(&rara_home),
+        &workspace_root,
+        std::slice::from_ref(&explicit_plugins_dir),
+        &BuiltinPluginConfig::default(),
+    );
+
+    assert_eq!(sources.len(), 4);
+    assert_eq!(sources[0].source.label(), "builtin");
+    assert_eq!(
+        sources[0].plugins_dir,
+        rara_home.join(builtin::BUILTIN_PLUGINS_DIR)
+    );
+    assert_eq!(sources[1].source.label(), "user");
+    assert_eq!(sources[1].plugins_dir, rara_home.join("plugins"));
+    assert_eq!(sources[2].source.label(), "project");
+    assert_eq!(
+        sources[2].plugins_dir,
+        workspace_root.join(".rara").join("plugins")
+    );
+    assert_eq!(sources[3].source.label(), "cli");
+    assert_eq!(sources[3].plugins_dir, explicit_plugins_dir);
+}
+
+#[test]
+fn plugin_discovery_sources_keep_project_when_user_home_is_unavailable() {
+    let dir = tempdir().expect("tempdir");
+    let workspace_root = dir.path().join("workspace");
+    let explicit_plugins_dir = dir.path().join("explicit-plugins");
+
+    let sources = plugin_discovery_sources(
+        None,
+        &workspace_root,
+        std::slice::from_ref(&explicit_plugins_dir),
+        &BuiltinPluginConfig::default(),
+    );
+
+    assert_eq!(sources.len(), 2);
+    assert_eq!(sources[0].source.label(), "project");
+    assert_eq!(
+        sources[0].plugins_dir,
+        workspace_root.join(".rara").join("plugins")
+    );
+    assert_eq!(sources[1].source.label(), "cli");
+    assert_eq!(sources[1].plugins_dir, explicit_plugins_dir);
+}
+
+#[test]
+fn builtin_nowledge_mem_plugin_materializes_skills_mcp_and_agent() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+
+    let plugins = discover_runtime_plugins(
+        Some(&rara_home),
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+    );
+
+    let plugin = plugins
+        .iter()
+        .find(|plugin| plugin.name == builtin::NOWLEDGE_MEM_PLUGIN_DIR)
+        .expect("builtin nowledge mem plugin");
+    assert!(matches!(plugin.source, PluginSource::Builtin(_)));
+    assert!(
+        plugin
+            .root
+            .join(".codex-plugin")
+            .join("plugin.json")
+            .is_file()
+    );
+    assert!(plugin.root.join(".mcp.json").is_file());
+    assert!(
+        plugin
+            .root
+            .join("skills")
+            .join("working-memory")
+            .join("SKILL.md")
+            .is_file()
+    );
+
+    let skill_roots = plugin_skill_roots(&plugins);
+    assert!(skill_roots.iter().any(|(name, _)| name == "nowledge-mem"));
+
+    let records = plugin_agent_records(&plugins);
+    let mem_agent = records
+        .iter()
+        .find(|record| record.id == "nowledge-mem:nowledge-mem")
+        .expect("builtin mem agent");
+    assert_eq!(
+        mem_agent
+            .definition
+            .as_ref()
+            .expect("definition")
+            .description,
+        "Routes memory-heavy tasks through Nowledge Mem skills and MCP context."
+    );
+}
+
+#[test]
+fn disabled_builtin_nowledge_mem_plugin_is_not_discovered() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+    let config = BuiltinPluginConfig {
+        nowledge_mem: crate::config::NowledgeMemPluginConfig {
+            enabled: false,
+            ..Default::default()
+        },
+    };
+
+    let plugins = discover_runtime_plugins(Some(&rara_home), &workspace_root, &[], &config);
+
+    assert!(
+        plugins
+            .iter()
+            .all(|plugin| plugin.name != builtin::NOWLEDGE_MEM_PLUGIN_DIR)
+    );
+    assert!(
+        !rara_home
+            .join(builtin::BUILTIN_PLUGINS_DIR)
+            .join(builtin::NOWLEDGE_MEM_PLUGIN_DIR)
+            .exists()
+    );
+}
+
+#[tokio::test]
+async fn registers_user_and_project_plugins_with_project_precedence() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+    let user_plugins_dir = rara_home.join("plugins");
+    let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+    write_test_plugin(&user_plugins_dir.join("shared"), "shared", "echo user");
+    write_test_plugin(
+        &project_plugins_dir.join("shared"),
+        "shared",
+        "echo project",
+    );
+    write_test_plugin(
+        &project_plugins_dir.join("project-only"),
+        "project-only",
+        "echo project-only",
+    );
+
+    let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
+    let registered = register_plugin_hooks(
+        &runtime,
+        Some(rara_home),
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+        "session-1",
+    )
+    .await;
+
+    assert_eq!(registered.hook_count(), 2);
+    assert_eq!(runtime.hook_count(), 2);
+}
+
+#[tokio::test]
+async fn registers_project_plugin_command_summaries() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+    let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+    let plugin_root = project_plugins_dir.join("commands");
+    write_test_plugin(&plugin_root, "commands", "echo project");
+    fs::create_dir_all(plugin_root.join("commands").join("git")).expect("commands dir");
+    fs::write(
+        plugin_root.join("commands").join("git").join("review.md"),
+        "---\ndescription: Review the current diff.\n---\n# Review\nBody text.",
+    )
+    .expect("command");
+    fs::write(
+        plugin_root.join("commands").join("explain.md"),
+        "# Explain\nExplain selected code.",
+    )
+    .expect("command");
+
+    let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
+    let registered = register_plugin_hooks(
+        &runtime,
+        Some(rara_home),
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+        "session-1",
+    )
+    .await;
+
+    assert_eq!(
+        registered.command_summaries(),
+        &[
+            PluginCommandSummary {
+                name: "commands:explain".to_string(),
+                title: Some("explain".to_string()),
+                description: "Explain selected code.".to_string(),
+                path: plugin_root.join("commands").join("explain.md"),
+            },
+            PluginCommandSummary {
+                name: "commands:git/review".to_string(),
+                title: Some("git/review".to_string()),
+                description: "Review the current diff.".to_string(),
+                path: plugin_root.join("commands").join("git").join("review.md"),
+            },
+        ]
+    );
+}
+
+#[test]
+fn plugin_agent_records_are_namespaced_by_plugin_name() {
+    let dir = tempdir().expect("tempdir");
+    let plugin_root = dir.path().join("plugin");
+    write_test_plugin(&plugin_root, "helpers", "echo project");
+    fs::create_dir_all(plugin_root.join("agents")).expect("agents dir");
+    fs::write(
+        plugin_root.join("agents").join("reviewer.md"),
+        r#"---
+name: reviewer
+description: Reviews plugin-provided code.
+---
+
+Review code from the plugin context.
+"#,
+    )
+    .expect("agent");
+    let plugins = discover_plugins_from_sources(&[PluginDiscoverySource {
+        plugins_dir: dir.path().to_path_buf(),
+        source: PluginSource::Directory(dir.path().to_path_buf()),
+    }]);
+
+    let records = plugin_agent_records(&plugins);
+
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].id, "helpers:reviewer");
+    let definition = records[0].definition.as_ref().expect("definition");
+    assert_eq!(definition.name, "helpers:reviewer");
+    assert_eq!(definition.description, "Reviews plugin-provided code.");
+}
+
+#[test]
+fn appends_plugin_mcp_configs_with_plugin_source_metadata() {
+    let dir = tempdir().expect("tempdir");
+    let workspace_root = dir.path().join("workspace");
+    let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+    let plugin_root = project_plugins_dir.join("mcp-plugin");
+    write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+    write_test_plugin_mcp_config(&plugin_root, "docs", "docs-server", &["--stdio"]);
+
+    let mut registry = McpRegistry::empty();
+    append_plugin_mcp_configs(
+        &mut registry,
+        None,
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+    )
+    .expect("append plugin mcp config");
+
+    let server = registry.servers.get("docs").expect("docs server");
+    assert_eq!(server.source.scope, McpServerScope::Plugin);
+    assert_eq!(server.source.path, plugin_root.join(".mcp.json"));
+    assert_eq!(
+        server.config.transport,
+        McpServerTransport::Stdio {
+            r#type: None,
+            command: "docs-server".to_string(),
+            args: vec!["--stdio".to_string()],
+            env: None,
+            cwd: Some(plugin_root),
+        }
+    );
+}
+
+#[test]
+fn appends_builtin_nowledge_mem_mcp_config() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+
+    let mut registry = McpRegistry::empty();
+    append_plugin_mcp_configs(
+        &mut registry,
+        Some(&rara_home),
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+    )
+    .expect("append builtin plugin mcp config");
+
+    let server = registry
+        .servers
+        .get("nowledge-mem")
+        .expect("nowledge mem server");
+    assert_eq!(server.source.scope, McpServerScope::Builtin);
+    assert_eq!(
+        server.config.transport,
+        McpServerTransport::StreamableHttp {
+            r#type: Some("http".to_string()),
+            url: builtin::NOWLEDGE_MEM_MCP_URL.to_string(),
+            bearer_token_env_var: None,
+            http_headers: Some(std::collections::BTreeMap::from([(
+                "APP".to_string(),
+                "RARA".to_string()
+            )])),
+            env_http_headers: None,
+        }
+    );
+}
+
+#[test]
+fn builtin_nowledge_mem_mcp_uses_configured_url_and_headers() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+    let config = BuiltinPluginConfig {
+        nowledge_mem: crate::config::NowledgeMemPluginConfig {
+            url: "http://localhost:24242/mcp/".to_string(),
+            http_headers: std::collections::BTreeMap::from([
+                ("APP".to_string(), "CustomRara".to_string()),
+                ("X-NMEM-Space".to_string(), "workspace".to_string()),
+            ]),
+            ..Default::default()
+        },
+    };
+
+    let mut registry = McpRegistry::empty();
+    append_plugin_mcp_configs(
+        &mut registry,
+        Some(&rara_home),
+        &workspace_root,
+        &[],
+        &config,
+    )
+    .expect("append builtin plugin mcp config");
+
+    let server = registry
+        .servers
+        .get("nowledge-mem")
+        .expect("nowledge mem server");
+    assert_eq!(
+        server.config.transport,
+        McpServerTransport::StreamableHttp {
+            r#type: Some("http".to_string()),
+            url: "http://localhost:24242/mcp/".to_string(),
+            bearer_token_env_var: None,
+            http_headers: Some(std::collections::BTreeMap::from([
+                ("APP".to_string(), "CustomRara".to_string()),
+                ("X-NMEM-Space".to_string(), "workspace".to_string()),
+            ])),
+            env_http_headers: None,
+        }
+    );
+}
+
+#[test]
+fn builtin_nowledge_mem_mcp_yields_to_existing_registry_server() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+
+    let mut registry = McpRegistry::empty();
+    registry
+        .insert_source(
+            McpServerSource {
+                scope: McpServerScope::User,
+                path: dir.path().join("config.toml"),
+            },
+            std::collections::BTreeMap::from([(
+                "nowledge-mem".to_string(),
+                McpServerConfig {
+                    transport: McpServerTransport::StreamableHttp {
+                        r#type: None,
+                        url: "https://mem.example.com/mcp/".to_string(),
+                        bearer_token_env_var: Some("NMEM_TOKEN".to_string()),
+                        http_headers: None,
+                        env_http_headers: None,
+                    },
+                    enabled: true,
+                    required: false,
+                    supports_parallel_tool_calls: false,
+                    startup_timeout_sec: None,
+                    tool_timeout_sec: None,
+                    enabled_tools: None,
+                    disabled_tools: None,
+                },
+            )]),
+        )
+        .expect("insert user source");
+
+    append_plugin_mcp_configs(
+        &mut registry,
+        Some(&rara_home),
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+    )
+    .expect("append builtin plugin mcp config");
+
+    assert_eq!(registry.servers.len(), 1);
+    assert_eq!(
+        registry.servers["nowledge-mem"].source.scope,
+        McpServerScope::User
+    );
+}
+
+#[test]
+fn plugin_mcp_configs_resolve_relative_cwd_from_plugin_root() {
+    let dir = tempdir().expect("tempdir");
+    let workspace_root = dir.path().join("workspace");
+    let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+    let plugin_root = project_plugins_dir.join("mcp-plugin");
+    write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+    fs::write(
+        plugin_root.join(".mcp.json"),
+        json!({
+            "mcpServers": {
+                "docs": {
+                    "command": "docs-server",
+                    "cwd": "server"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("mcp json");
+
+    let mut registry = McpRegistry::empty();
+    append_plugin_mcp_configs(
+        &mut registry,
+        None,
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+    )
+    .expect("append plugin mcp config");
+
+    let server = registry.servers.get("docs").expect("docs server");
+    assert_eq!(
+        server.config.transport,
+        McpServerTransport::Stdio {
+            r#type: None,
+            command: "docs-server".to_string(),
+            args: Vec::new(),
+            env: None,
+            cwd: Some(plugin_root.join("server")),
+        }
+    );
+}
+
+#[test]
+fn plugin_mcp_configs_skip_mcp_json_directories() {
+    let dir = tempdir().expect("tempdir");
+    let workspace_root = dir.path().join("workspace");
+    let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+    let plugin_root = project_plugins_dir.join("mcp-plugin");
+    write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+    fs::create_dir_all(plugin_root.join(".mcp.json")).expect("mcp json dir");
+
+    let mut registry = McpRegistry::empty();
+    append_plugin_mcp_configs(
+        &mut registry,
+        None,
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+    )
+    .expect("directory should be skipped");
+
+    assert!(registry.servers.is_empty());
+}
+
+#[test]
+fn plugin_mcp_configs_fail_on_duplicate_server_names() {
+    let dir = tempdir().expect("tempdir");
+    let workspace_root = dir.path().join("workspace");
+    let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+    let plugin_root = project_plugins_dir.join("mcp-plugin");
+    write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+    write_test_plugin_mcp_config(&plugin_root, "docs", "docs-server", &[]);
+
+    let mut registry = McpRegistry::empty();
+    registry
+        .insert_source(
+            McpServerSource {
+                scope: McpServerScope::Project,
+                path: workspace_root.join(".mcp.json"),
+            },
+            std::collections::BTreeMap::from([(
+                "docs".to_string(),
+                McpServerConfig {
+                    transport: McpServerTransport::Stdio {
+                        r#type: None,
+                        command: "project-docs".to_string(),
+                        args: Vec::new(),
+                        env: None,
+                        cwd: None,
+                    },
+                    enabled: true,
+                    required: false,
+                    supports_parallel_tool_calls: false,
+                    startup_timeout_sec: None,
+                    tool_timeout_sec: None,
+                    enabled_tools: None,
+                    disabled_tools: None,
+                },
+            )]),
+        )
+        .expect("insert project source");
+
+    let err = append_plugin_mcp_configs(
+        &mut registry,
+        None,
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+    )
+    .expect_err("duplicate server should fail");
+
+    let message = err.to_string();
+    assert!(message.contains("MCP server `docs` is defined in both project"));
+    assert!(message.contains("plugin"));
+}
+
+#[test]
+fn plugin_mcp_configs_fail_on_invalid_json() {
+    let dir = tempdir().expect("tempdir");
+    let workspace_root = dir.path().join("workspace");
+    let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+    let plugin_root = project_plugins_dir.join("mcp-plugin");
+    write_test_plugin(&plugin_root, "mcp-plugin", "echo project");
+    fs::write(plugin_root.join(".mcp.json"), "{invalid json").expect("mcp json");
+
+    let mut registry = McpRegistry::empty();
+    let err = append_plugin_mcp_configs(
+        &mut registry,
+        None,
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+    )
+    .expect_err("invalid plugin mcp json should fail");
+
+    let message = err.to_string();
+    assert!(message.contains("parse"));
+    assert!(message.contains(".mcp.json"));
+}
+
+#[test]
+fn plugin_skill_description_uses_first_markdown_body_section() {
+    let content = "---\nname: reviewer\ndescription: metadata\n---\n# Reviewer\nInspect plugin-provided behavior.\n\n## Details\nMore.";
+
+    assert_eq!(
+        extract_plugin_skill_description(content),
+        "Inspect plugin-provided behavior."
+    );
+}
+
+#[tokio::test]
+async fn plugin_callbacks_do_not_retain_hook_runtime_strong_reference() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+    let project_plugins_dir = workspace_root.join(".rara").join("plugins");
+    write_test_plugin(
+        &project_plugins_dir.join("project-only"),
+        "project-only",
+        "echo project-only",
+    );
+
+    let runtime = Arc::new(HookRuntime::new(Arc::new(RuntimeEventBus::new(4))));
+    register_plugin_hooks(
+        &runtime,
+        Some(rara_home),
+        &workspace_root,
+        &[],
+        &BuiltinPluginConfig::default(),
+        "session-1",
+    )
+    .await;
+
+    assert_eq!(runtime.hook_count(), 1);
+    assert_eq!(Arc::strong_count(&runtime), 1);
+}
+
+#[test]
+fn hook_matcher_filters_tool_events_by_tool_name() {
+    let bash_hook = rara_plugins::HookHandler {
+        r#type: "command".to_string(),
+        command: "echo bash".to_string(),
+        timeout: 1,
+        matcher: Some("Bash(*)".to_string()),
+        once: false,
+    };
+    let edit_hook = rara_plugins::HookHandler {
+        r#type: "command".to_string(),
+        command: "echo edit".to_string(),
+        timeout: 1,
+        matcher: Some("Write|Edit".to_string()),
+        once: false,
+    };
+    let bash_event = AgentEvent::ToolUse {
+        name: "bash".to_string(),
+        input: serde_json::json!({}),
+    };
+    let edit_event = AgentEvent::ToolUse {
+        name: "Edit".to_string(),
+        input: serde_json::json!({}),
+    };
+    assert!(hook_matches_agent_event(&bash_hook, &bash_event));
+    assert!(!hook_matches_agent_event(&bash_hook, &edit_event));
+    assert!(hook_matches_agent_event(&edit_hook, &edit_event));
+    assert!(!hook_matches_agent_event(&edit_hook, &bash_event));
+}
+
+#[test]
+fn extracts_tool_result_content_for_post_tool_use_hooks() {
+    let event = AgentEvent::ToolResult {
+        name: "stub_tool".to_string(),
+        content: json!({ "status": "ok" }).to_string(),
+        is_error: false,
+    };
+
+    assert_eq!(
+        extract_tool_response(&event),
+        Some(json!({ "status": "ok" }))
+    );
+}
+
+#[test]
+fn plugin_hook_block_message_falls_back_to_plain_stdout() {
+    assert_eq!(
+        plugin_hook_block_message("plain stdout failure", ""),
+        "plain stdout failure"
+    );
+}
+
+#[tokio::test]
+async fn pre_tool_use_control_stdout_is_not_buffered_as_context() {
+    let hook_runtime = HookRuntime::new(Arc::new(RuntimeEventBus::new(4)));
+    let dir = tempdir().expect("tempdir");
+    let plugin_root = dir.path().join("plugin");
+    fs::create_dir_all(&plugin_root).expect("plugin root");
+    let plugin_hooks = PluginHookRuntime::new(
+        "session-1".to_string(),
+        vec![rara_plugins::RegisteredHook {
+            event: HookEvent::PreToolUse,
+            handler: rara_plugins::HookHandler {
+                r#type: "command".to_string(),
+                command: "cat >/dev/null; echo '{\"continue\":true}'".to_string(),
+                timeout: 1,
+                matcher: Some("stub_tool".to_string()),
+                once: false,
+            },
+            plugin_name: "control".to_string(),
+            plugin_root,
+        }],
+        Vec::new(),
+        None,
+    );
+
+    let block = plugin_hooks
+        .run_pre_tool_use("stub_tool", &json!({ "path": "src/lib.rs" }))
+        .await;
+
+    assert_eq!(block, None);
+    assert!(hook_runtime.blocking_drain_outputs().is_empty());
+}
+
+#[tokio::test]
+async fn lifecycle_hook_output_is_published_as_structured_control_event() {
+    let bus = Arc::new(RuntimeEventBus::new(8));
+    let mut events = bus.subscribe_control();
+    let hook_runtime = Arc::new(HookRuntime::new(bus));
+    let dir = tempdir().expect("tempdir");
+    let plugin_root = dir.path().join("plugin");
+    fs::create_dir_all(&plugin_root).expect("plugin root");
+    let plugin_hooks = PluginHookRuntime::new(
+        "session-1".to_string(),
+        vec![rara_plugins::RegisteredHook {
+            event: HookEvent::SessionStart,
+            handler: rara_plugins::HookHandler {
+                r#type: "command".to_string(),
+                command: "cat >/dev/null; echo visible; echo warn >&2".to_string(),
+                timeout: 1,
+                matcher: None,
+                once: false,
+            },
+            plugin_name: "observer".to_string(),
+            plugin_root,
+        }],
+        Vec::new(),
+        Some(hook_runtime.clone()),
+    );
+
+    plugin_hooks.run_session_start().await;
+
+    let event = events.try_recv().expect("hook output event");
+    assert_eq!(
+        event.event,
+        crate::runtime_control::RuntimeEvent::Hook(
+            crate::runtime_control::HookEvent::CommandOutput {
+                plugin_name: "observer".to_string(),
+                hook_event: "SessionStart".to_string(),
+                stdout: "visible\n".to_string(),
+                stderr: "warn\n".to_string(),
+                exit_code: Some(0),
+                timed_out: false,
+                ok: true,
+            }
+        )
+    );
+    assert!(hook_runtime.blocking_drain_outputs().is_empty());
+}
+
+fn write_test_plugin(root: &Path, name: &str, command: &str) {
+    fs::create_dir_all(root.join(".claude-plugin")).expect("metadata dir");
+    fs::write(
+        root.join(".claude-plugin").join("plugin.json"),
+        json!({
+            "name": name,
+            "version": "1.0.0",
+            "description": "test plugin"
+        })
+        .to_string(),
+    )
+    .expect("plugin json");
+    fs::create_dir_all(root.join("hooks")).expect("hooks dir");
+    fs::write(
+        root.join("hooks").join("hooks.json"),
+        json!({
+            "Stop": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": command,
+                    "timeout": 1
+                }]
+            }]
+        })
+        .to_string(),
+    )
+    .expect("hooks json");
+}
+
+fn write_test_plugin_mcp_config(root: &Path, name: &str, command: &str, args: &[&str]) {
+    fs::write(
+        root.join(".mcp.json"),
+        json!({
+            "mcpServers": {
+                name: {
+                    "command": command,
+                    "args": args
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("mcp json");
+}

--- a/src/protocol_sources.rs
+++ b/src/protocol_sources.rs
@@ -410,7 +410,10 @@ impl MemoryControlHandler {
                     .take(*limit)
                     .map(memory_record_summary)
                     .collect();
-                self.publish_memory_event(MemoryEvent::RecordsQueried { records });
+                self.publish_memory_event(MemoryEvent::RecordsQueried {
+                    query: query.clone(),
+                    records,
+                });
             }
             MemoryControlRequest::QueryMetadata => {
                 let labels = memory_store.list_labels(None).await?;
@@ -442,7 +445,8 @@ impl MemoryControlHandler {
                 scope: scope.clone(),
                 labels: Vec::new(),
             },
-            MemoryControlRequest::QueryRecords { .. } => MemoryEvent::RecordsQueried {
+            MemoryControlRequest::QueryRecords { query, .. } => MemoryEvent::RecordsQueried {
+                query: query.clone(),
                 records: Vec::new(),
             },
             MemoryControlRequest::QueryMetadata => MemoryEvent::MetadataQueried {
@@ -855,9 +859,11 @@ mod tests {
             .expect("query records");
 
         let event = events.recv().await.expect("records queried event");
-        let RuntimeEvent::Memory(MemoryEvent::RecordsQueried { records }) = event.event else {
+        let RuntimeEvent::Memory(MemoryEvent::RecordsQueried { query, records }) = event.event
+        else {
             panic!("expected records queried event");
         };
+        assert_eq!(query, "Initial memory");
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].id, "protocol-memory-2");
         assert_eq!(records[0].labels, vec!["procedure"]);
@@ -897,6 +903,22 @@ mod tests {
             event.event,
             RuntimeEvent::Memory(MemoryEvent::LabelsListed { scope: Some(ControlMemoryScope::Thread), labels })
                 if labels.is_empty()
+        ));
+
+        handler
+            .handle_control(&MemoryControlRequest::QueryRecords {
+                query: "fallback query".to_string(),
+                scope: None,
+                limit: 5,
+            })
+            .await
+            .expect("query records");
+
+        let event = events.recv().await.expect("query event");
+        assert!(matches!(
+            event.event,
+            RuntimeEvent::Memory(MemoryEvent::RecordsQueried { query, records })
+                if query == "fallback query" && records.is_empty()
         ));
     }
 

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -10,9 +10,9 @@ use rara_tools::tool::ToolManager;
 use self::tooling::{create_full_tool_manager, load_skill_manager, vector_db_uri_for_workspace};
 use crate::agent::Agent;
 use crate::config::{
-    DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, DEFAULT_GEMINI_BASE_URL, DEFAULT_GEMINI_MODEL,
-    LocalEmbeddingPolicy, OpenAiEndpointKind, REASONING_SUMMARY_NONE, RaraConfig,
-    ensure_rara_home_dir,
+    BuiltinPluginConfig, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_MODEL, DEFAULT_GEMINI_BASE_URL,
+    DEFAULT_GEMINI_MODEL, LocalEmbeddingPolicy, OpenAiEndpointKind, REASONING_SUMMARY_NONE,
+    RaraConfig, ensure_rara_home_dir,
 };
 use crate::embedding::EmbeddingOverrideBackend;
 use crate::google_oauth::GoogleOAuthManager;
@@ -68,6 +68,7 @@ pub(crate) struct RuntimeBootstrap {
     extension_readiness: ExtensionReadinessSnapshot,
     plugin_dirs: Vec<PathBuf>,
     rara_home: Option<PathBuf>,
+    builtin_plugins: BuiltinPluginConfig,
 }
 
 #[derive(Clone)]
@@ -211,6 +212,7 @@ impl RuntimeBootstrap {
         let workspace_root = self.workspace.root.clone();
         let plugin_dirs = self.plugin_dirs.clone();
         let rara_home = self.rara_home.clone();
+        let builtin_plugins = self.builtin_plugins.clone();
         let hook_runtime = self.hook_runtime.clone();
         let event_bus = self.event_bus.clone();
         let mut extension_readiness = self.extension_readiness.clone();
@@ -220,6 +222,7 @@ impl RuntimeBootstrap {
             rara_home,
             &workspace_root,
             &plugin_dirs,
+            &builtin_plugins,
             &parts.0.session_id,
         )
         .await;
@@ -346,6 +349,7 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
         Some(&rara_home),
         &workspace.root,
         &options.plugin_dirs,
+        &config.builtin_plugins,
     );
     let plugin_skill_roots = crate::plugin_middleware::plugin_skill_roots(&plugins);
     let plugin_agent_records = crate::plugin_middleware::plugin_agent_records(&plugins);
@@ -404,11 +408,17 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
         Some(&rara_home),
         &workspace.root,
         &options.plugin_dirs,
+        &config.builtin_plugins,
     )?;
     let extension_mcp_server_count = mcp_registry
         .servers
         .values()
-        .filter(|server| server.source.scope == crate::config::McpServerScope::Plugin)
+        .filter(|server| {
+            matches!(
+                server.source.scope,
+                crate::config::McpServerScope::Plugin | crate::config::McpServerScope::Builtin
+            )
+        })
         .count();
     let mcp_registry = Arc::new(mcp_registry);
 
@@ -495,6 +505,7 @@ pub(crate) async fn initialize_rara_context_with_options_and_local_embedding_boo
         },
         plugin_dirs: options.plugin_dirs,
         rara_home: Some(rara_home),
+        builtin_plugins: config.builtin_plugins.clone(),
     })
 }
 

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -291,6 +291,7 @@ pub enum MemoryEvent {
         labels: Vec<MemoryLabelSummary>,
     },
     RecordsQueried {
+        query: String,
         records: Vec<MemoryRecordSummary>,
     },
     ActionObserved {
@@ -1188,6 +1189,7 @@ mod tests {
         );
 
         let records = serde_json::to_value(RuntimeEvent::Memory(MemoryEvent::RecordsQueried {
+            query: "project path".to_string(),
             records: vec![MemoryRecordSummary {
                 id: "memory-1".to_string(),
                 title: "Reference project path".to_string(),
@@ -1208,6 +1210,7 @@ mod tests {
                 "payload": {
                     "type": "records_queried",
                     "payload": {
+                        "query": "project path",
                         "records": [{
                             "id": "memory-1",
                             "title": "Reference project path",

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -867,6 +867,7 @@ command = "docs-server"
             SourcedMcpServerConfig {
                 config: McpServerConfig {
                     transport: McpServerTransport::StreamableHttp {
+                        r#type: None,
                         url: "http://127.0.0.1:1/mcp".to_string(),
                         bearer_token_env_var: None,
                         http_headers: None,

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -2,6 +2,8 @@ mod helpers;
 #[cfg(test)]
 mod tests;
 
+use rara_persistence::redaction::redact_secrets;
+
 use self::helpers::{
     append_tool_progress, exploration_action_label, exploration_note_lines,
     exploration_result_note, format_tool_result, format_tool_use, is_exploration_tool_name,
@@ -18,9 +20,11 @@ use crate::session_promotion::{
     SessionShardPromotionDecision, SessionShardPromotionOutcome, SessionShardPromotionSkipReason,
 };
 use crate::todo::format_todo_update;
+use crate::tui::display_sanitize::sanitize_display_text;
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 
 const TOOL_PROGRESS_LINE_LIMIT: usize = 16;
+const MEMORY_QUERY_PREVIEW_LIMIT: usize = 120;
 
 pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
     match event {
@@ -382,8 +386,9 @@ pub(super) fn format_memory_event_notice(event: &MemoryEvent) -> String {
             record_count,
             count_label("record", *record_count)
         )),
-        MemoryEvent::RecordsQueried { records } => memory_notice(format!(
-            "queried records: {} {}",
+        MemoryEvent::RecordsQueried { query, records } => memory_notice(format!(
+            "queried records for \"{}\": {} {}",
+            memory_query_preview(query),
             records.len(),
             count_label("result", records.len())
         )),
@@ -393,6 +398,25 @@ pub(super) fn format_memory_event_notice(event: &MemoryEvent) -> String {
         }
         MemoryEvent::SelectionUpdated => memory_notice("refreshed selection snapshot"),
     }
+}
+
+fn memory_query_preview(query: &str) -> String {
+    let sanitized = sanitize_display_text(&redact_secrets(query));
+    let condensed = sanitized.split_whitespace().collect::<Vec<_>>().join(" ");
+    truncate_memory_query_preview(&condensed)
+}
+
+fn truncate_memory_query_preview(query: &str) -> String {
+    if query.chars().count() <= MEMORY_QUERY_PREVIEW_LIMIT {
+        return query.to_string();
+    }
+
+    let mut truncated = query
+        .chars()
+        .take(MEMORY_QUERY_PREVIEW_LIMIT.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
 }
 
 fn format_session_shard_promotion_outcome(outcome: &SessionShardPromotionOutcome) -> String {

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -56,6 +56,7 @@ fn memory_action_event_becomes_renderable_system_notice() {
 #[test]
 fn memory_query_notice_reports_count_without_record_content() {
     let notice = format_memory_event_notice(&MemoryEvent::RecordsQueried {
+        query: "repo notes".into(),
         records: vec![MemoryRecordSummary {
             id: "memory-1234567890".into(),
             title: "Useful title".into(),
@@ -69,9 +70,26 @@ fn memory_query_notice_reports_count_without_record_content() {
         }],
     });
 
-    assert_eq!(notice, "Memory · queried records: 1 result");
+    assert_eq!(
+        notice,
+        "Memory · queried records for \"repo notes\": 1 result"
+    );
     assert!(!notice.contains("secret memory content"));
     assert!(!notice.contains("Useful title"));
+}
+
+#[test]
+fn memory_query_notice_sanitizes_query_preview() {
+    let notice = format_memory_event_notice(&MemoryEvent::RecordsQueried {
+        query: format!("{}\n{}", "token=sk-test-secret", "word ".repeat(40)),
+        records: Vec::new(),
+    });
+
+    assert!(notice.starts_with("Memory · queried records for \""));
+    assert!(notice.ends_with("\": 0 results"));
+    assert!(!notice.contains("sk-test-secret"));
+    assert!(!notice.contains('\n'));
+    assert!(notice.len() < 180);
 }
 
 #[test]

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -4,9 +4,11 @@
 // actually render in the TUI, not just plain text.
 use std::sync::atomic::Ordering;
 
+use rara_persistence::redaction::sanitize_url_for_display;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
+use crate::config::McpServerTransport;
 use crate::tui::state::{PlanningApprovalStatus, StatusTab, TuiApp};
 
 pub(crate) fn render_status_lines(app: &TuiApp, tab: StatusTab) -> Vec<Line<'static>> {
@@ -124,11 +126,60 @@ fn render_overview_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
         &snap.extension_agent_count.to_string(),
         Color::DarkGray,
     );
+    render_nowledge_mem_status(app, lines);
     for line in &snap.extension_agent_status_lines {
         lines.push(Line::from(Span::styled(
             line.clone(),
             Style::default().fg(Color::DarkGray),
         )));
+    }
+}
+
+fn render_nowledge_mem_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
+    let config = &app.config.builtin_plugins.nowledge_mem;
+    if !config.enabled {
+        kv(lines, "mcp", "nowledge-mem disabled", Color::DarkGray);
+        kv(lines, "nowledge", "disabled", Color::DarkGray);
+        return;
+    }
+
+    let proxy_label = if nowledge_mem_transport(config).bypasses_proxy() {
+        "local/direct"
+    } else {
+        "remote"
+    };
+    let header_label = if config.http_headers.is_empty() {
+        "default headers".to_string()
+    } else {
+        format!("{} custom headers", config.http_headers.len())
+    };
+    kv(lines, "mcp", "nowledge-mem builtin", Color::LightBlue);
+    kv(
+        lines,
+        "nowledge",
+        &format!(
+            "{} ({proxy_label}, {header_label})",
+            sanitize_url_for_display(&config.url)
+        ),
+        if proxy_label == "local/direct" {
+            Color::LightGreen
+        } else {
+            Color::LightBlue
+        },
+    );
+}
+
+fn nowledge_mem_transport(config: &crate::config::NowledgeMemPluginConfig) -> McpServerTransport {
+    McpServerTransport::StreamableHttp {
+        r#type: Some("http".to_string()),
+        url: config.url.clone(),
+        bearer_token_env_var: None,
+        http_headers: if config.http_headers.is_empty() {
+            None
+        } else {
+            Some(config.http_headers.clone())
+        },
+        env_http_headers: None,
     }
 }
 
@@ -550,6 +601,71 @@ mod tests {
         assert!(rendered.contains("2"));
         assert!(rendered.contains("code-reviewer"));
         assert!(rendered.contains(".rara/agents/code-reviewer.md"));
+    }
+
+    #[test]
+    fn overview_status_reports_builtin_nowledge_mem() {
+        let temp = tempdir().expect("tempdir");
+        let app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+
+        let rendered = render_status_lines(&app, StatusTab::Overview)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("nowledge-mem builtin"));
+        assert!(rendered.contains("http://127.0.0.1:14242/mcp/"));
+        assert!(rendered.contains("local/direct"));
+        assert!(rendered.contains("default headers"));
+    }
+
+    #[test]
+    fn overview_status_reports_disabled_nowledge_mem() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.config.builtin_plugins.nowledge_mem.enabled = false;
+
+        let rendered = render_status_lines(&app, StatusTab::Overview)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("nowledge-mem disabled"));
+    }
+
+    #[test]
+    fn overview_status_reports_custom_nowledge_mem_endpoint_and_headers() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.config.builtin_plugins.nowledge_mem.url =
+            "https://mem.example.com/mcp/?token=secret".to_string();
+        app.config
+            .builtin_plugins
+            .nowledge_mem
+            .http_headers
+            .insert("X-NMEM-Space".to_string(), "workspace".to_string());
+
+        let rendered = render_status_lines(&app, StatusTab::Overview)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("https://mem.example.com/mcp/?token=%3Credacted%3E"));
+        assert!(rendered.contains("remote"));
+        assert!(rendered.contains("1 custom headers"));
+        assert!(!rendered.contains("token=secret"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a builtin `nowledge-mem` plugin source owned by runtime assembly
- materialize Codex-compatible plugin metadata, skills, MCP config, and a routing-only subagent definition
- expose builtin Nowledge Mem config, localhost proxy-bypass detection, and TUI read-only status/query notices
- split plugin middleware tests into a dedicated module and document the implementation checkpoint

## Purpose

RARA should ship a first-class Nowledge Mem integration while preserving the runtime boundary: app-server/runtime assembly owns plugin discovery and MCP registration, and TUI only renders runtime/config state.

## Related Issue

None.

## Testing

- `cargo test -p rara-config -- --nocapture`
- `cargo test plugin_middleware::tests:: -- --nocapture`
- `cargo test -p rara-plugins -- --nocapture`
- `cargo test agent::tests::plugin_hooks -- --nocapture`
- `cargo test tui::status_display::tests::overview_status_reports_builtin_nowledge_mem -- --nocapture`
- `cargo test tui::status_display::tests::overview_status_reports_disabled_nowledge_mem -- --nocapture`
- `cargo test tui::status_display::tests::overview_status_reports_custom_nowledge_mem_endpoint_and_headers -- --nocapture`
- `cargo test runtime_control::tests::memory_label_and_metadata_events_use_structured_wire_shape -- --nocapture`
- `cargo test protocol_sources::tests::memory_control_update_delete_and_labels_use_memory_store -- --nocapture`
- `cargo test protocol_sources::tests::memory_control_without_store_keeps_scaffold_events -- --nocapture`
- `cargo test tui::runtime::events::tests::memory_query_notice -- --nocapture`
- `cargo check --workspace`
- `git diff --check`
