### PR TITLE
feat(memory): support Nowledge Mem cloud mode

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -23,9 +23,9 @@ pub use self::mcp::{
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{
     BuiltinPluginConfig, ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy,
-    NowledgeMemPluginConfig, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState,
-    RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig, TuiThemeConfig, ensure_rara_home_dir,
-    rara_home_dir, workspace_data_dir_for, workspace_data_dir_for_home,
+    NowledgeMemMode, NowledgeMemPluginConfig, OpenAiEndpointKind, OpenAiEndpointProfile,
+    ProviderConfigState, RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig, TuiThemeConfig,
+    ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for, workspace_data_dir_for_home,
 };
 pub use self::provider_surface::{
     ConfigValueSource, EffectiveProviderSurface, ResolvedProviderValue,

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -252,12 +252,32 @@ impl BuiltinPluginConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum NowledgeMemMode {
+    #[default]
+    Local,
+    Cloud,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct NowledgeMemPluginConfig {
+    #[serde(default, skip_serializing_if = "NowledgeMemMode::is_default")]
+    pub mode: NowledgeMemMode,
     #[serde(default = "default_true")]
     pub enabled: bool,
     pub url: String,
+    #[serde(
+        default = "default_nowledge_mem_api_key_env_var",
+        skip_serializing_if = "is_default_nowledge_mem_api_key_env_var"
+    )]
+    pub api_key_env_var: String,
+    #[serde(
+        default = "default_nowledge_mem_space_id_env_var",
+        skip_serializing_if = "is_default_nowledge_mem_space_id_env_var"
+    )]
+    pub space_id_env_var: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub http_headers: BTreeMap<String, String>,
 }
@@ -265,21 +285,83 @@ pub struct NowledgeMemPluginConfig {
 impl Default for NowledgeMemPluginConfig {
     fn default() -> Self {
         Self {
+            mode: NowledgeMemMode::Local,
             enabled: true,
             url: default_nowledge_mem_mcp_url(),
+            api_key_env_var: default_nowledge_mem_api_key_env_var(),
+            space_id_env_var: default_nowledge_mem_space_id_env_var(),
             http_headers: BTreeMap::new(),
         }
     }
 }
 
 impl NowledgeMemPluginConfig {
+    pub fn mcp_url(&self) -> String {
+        match self.mode {
+            NowledgeMemMode::Local => self.url.clone(),
+            NowledgeMemMode::Cloud => {
+                let base = self.url.trim_end_matches('/');
+                if base.ends_with("/mcp") {
+                    format!("{base}/")
+                } else if base.ends_with("/remote-api") {
+                    format!("{base}/mcp/")
+                } else {
+                    format!("{base}/remote-api/mcp/")
+                }
+            }
+        }
+    }
+
+    pub fn env_http_headers(&self) -> Option<BTreeMap<String, String>> {
+        if self.mode != NowledgeMemMode::Cloud {
+            return None;
+        }
+        let mut headers = BTreeMap::from([
+            ("Authorization".to_string(), self.api_key_env_var.clone()),
+            ("X-NMEM-API-Key".to_string(), self.api_key_env_var.clone()),
+        ]);
+        if let Some(env_var) = &self.space_id_env_var {
+            headers.insert("X-Nmem-Space-Id".to_string(), env_var.clone());
+        }
+        Some(headers)
+    }
+
+    pub fn mode_label(&self) -> &'static str {
+        match self.mode {
+            NowledgeMemMode::Local => "local",
+            NowledgeMemMode::Cloud => "cloud",
+        }
+    }
+
     pub fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+impl NowledgeMemMode {
+    fn is_default(&self) -> bool {
         *self == Self::default()
     }
 }
 
 fn default_nowledge_mem_mcp_url() -> String {
     "http://127.0.0.1:14242/mcp/".to_string()
+}
+
+fn default_nowledge_mem_api_key_env_var() -> String {
+    "NMEM_API_KEY".to_string()
+}
+
+fn is_default_nowledge_mem_api_key_env_var(value: &str) -> bool {
+    value == "NMEM_API_KEY"
+}
+
+fn default_nowledge_mem_space_id_env_var() -> Option<String> {
+    Some("NMEM_SPACE".to_string())
+}
+
+fn is_default_nowledge_mem_space_id_env_var(value: &Option<String>) -> bool {
+    value.as_deref() == Some("NMEM_SPACE")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1139,8 +1221,9 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy, OpenAiEndpointKind,
-        OpenAiEndpointProfile, ProviderConfigState, RaraConfig, workspace_data_dir_for_home,
+        ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy, NowledgeMemMode,
+        OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState, RaraConfig,
+        workspace_data_dir_for_home,
     };
     use crate::defaults::{
         DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL,
@@ -1384,6 +1467,39 @@ mod tests {
                 ("APP".to_string(), "CustomRara".to_string()),
                 ("X-NMEM-Space".to_string(), "workspace".to_string())
             ])
+        );
+    }
+
+    #[test]
+    fn builtin_nowledge_mem_cloud_mode_derives_remote_mcp_and_env_headers() {
+        let config: RaraConfig = serde_json::from_str(
+            r#"{
+                "provider": "deepseek",
+                "builtin_plugins": {
+                    "nowledge_mem": {
+                        "mode": "cloud",
+                        "url": "https://mem.example.com",
+                        "api_key_env_var": "RARA_NMEM_API_KEY",
+                        "space_id_env_var": "RARA_NMEM_SPACE"
+                    }
+                }
+            }"#,
+        )
+        .expect("deserialize config");
+
+        let mem = &config.builtin_plugins.nowledge_mem;
+        assert_eq!(mem.mode, NowledgeMemMode::Cloud);
+        assert_eq!(mem.mcp_url(), "https://mem.example.com/remote-api/mcp/");
+        assert_eq!(
+            mem.env_http_headers(),
+            Some(BTreeMap::from([
+                ("Authorization".to_string(), "RARA_NMEM_API_KEY".to_string()),
+                (
+                    "X-NMEM-API-Key".to_string(),
+                    "RARA_NMEM_API_KEY".to_string()
+                ),
+                ("X-Nmem-Space-Id".to_string(), "RARA_NMEM_SPACE".to_string())
+            ]))
         );
     }
 

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -338,6 +338,7 @@ The builtin plugin is configurable through `config.json`:
   "builtin_plugins": {
     "nowledge_mem": {
       "enabled": true,
+      "mode": "local",
       "url": "http://127.0.0.1:14242/mcp/",
       "http_headers": {
         "APP": "RARA"
@@ -357,6 +358,13 @@ CLI plugins with the same plugin name override the builtin plugin through the
 normal ordered de-duplication path. Builtin MCP servers also yield to already
 registered user or project MCP servers with the same name; normal non-builtin
 plugin MCP duplicates remain hard errors.
+
+Cloud mode is also supported. In cloud mode, url is treated as the Mem server
+base URL and the generated endpoint is /remote-api/mcp/. The transport emits
+Authorization and X-NMEM-API-Key from NMEM_API_KEY, plus the optional
+X-Nmem-Space-Id from NMEM_SPACE. These are environment-variable references,
+not persisted credentials; the environment variable names can be configured
+with api_key_env_var and space_id_env_var.
 
 Local Nowledge Mem endpoints must not use system HTTP proxies. The MCP
 transport contract exposes localhost proxy bypass detection for streamable HTTP

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -383,7 +383,6 @@ and switch between local and cloud mode. Cloud configuration accepts the server
 URL and environment variable names only; it never accepts an API-key value.
 Saving a change persists the config and asks the runtime to rebuild. The TUI
 does not assemble the MCP transport itself.
-`/nowledge-mem` remains a compatibility alias.
 The status display reports the builtin MCP entry as
 `nowledge-mem builtin`, shows the configured endpoint with secret-bearing URL
 parts redacted, and marks localhost endpoints as `local/direct` to make the

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -378,7 +378,12 @@ MCP, shell, or skill invocation inside subagents is a separate tool-surface
 decision.
 
 TUI displays this integration in the `/status` Overview Extensions section.
-The display is read-only: it reports the builtin MCP entry as
+The `/nowledge-mem` command can also enable or disable the builtin plugin and
+switch between local and cloud mode. Cloud configuration accepts the server
+URL and environment variable names only; it never accepts an API-key value.
+Saving a change persists the config and asks the runtime to rebuild. The TUI
+does not assemble the MCP transport itself.
+The status display reports the builtin MCP entry as
 `nowledge-mem builtin`, shows the configured endpoint with secret-bearing URL
 parts redacted, and marks localhost endpoints as `local/direct` to make the
 no-proxy contract visible. Disabled builtin configuration renders as
@@ -433,7 +438,7 @@ scope for now.
 | Builtin Nowledge Mem plugin materializes skills, MCP, and agent definition | `cargo test plugin_middleware::tests::builtin_nowledge_mem_plugin_materializes_skills_mcp_and_agent -- --nocapture` |
 | Builtin Nowledge Mem MCP registers as builtin fallback | `cargo test plugin_middleware::tests::appends_builtin_nowledge_mem_mcp_config -- --nocapture` and `cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_yields_to_existing_registry_server -- --nocapture` |
 | Builtin Nowledge Mem config controls endpoint, headers, and enabled state | `cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_uses_configured_url_and_headers -- --nocapture`, `cargo test plugin_middleware::tests::disabled_builtin_nowledge_mem_plugin_is_not_discovered -- --nocapture`, and `cargo test -p rara-config builtin_nowledge_mem_config_can_override_endpoint_and_headers -- --nocapture` |
-| TUI shows builtin Nowledge Mem status without owning runtime assembly | `cargo test tui::status_display::tests::overview_status_reports_builtin_nowledge_mem -- --nocapture`, `cargo test tui::status_display::tests::overview_status_reports_disabled_nowledge_mem -- --nocapture`, and `cargo test tui::status_display::tests::overview_status_reports_custom_nowledge_mem_endpoint_and_headers -- --nocapture` |
+| TUI configures and shows builtin Nowledge Mem without owning runtime assembly | `cargo test tui::command::tests::parses_nowledge_mem_configuration_command -- --nocapture`, `cargo test tui::status_display::tests::overview_status_reports_builtin_nowledge_mem -- --nocapture`, `cargo test tui::status_display::tests::overview_status_reports_disabled_nowledge_mem -- --nocapture`, and `cargo test tui::status_display::tests::overview_status_reports_custom_nowledge_mem_endpoint_and_headers -- --nocapture` |
 | Local streamable HTTP MCP endpoints bypass proxy | `cargo test -p rara-config streamable_http_localhost_bypasses_proxy -- --nocapture` |
 | Plugin MCP file and relative cwd handling | `cargo test plugin_middleware::tests::plugin_mcp_configs_skip_mcp_json_directories -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_resolve_relative_cwd_from_plugin_root -- --nocapture` |
 | Plugin MCP parse and duplicate-name failures surface | `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_duplicate_server_names -- --nocapture` and `cargo test plugin_middleware::tests::plugin_mcp_configs_fail_on_invalid_json -- --nocapture` |

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -378,11 +378,12 @@ MCP, shell, or skill invocation inside subagents is a separate tool-surface
 decision.
 
 TUI displays this integration in the `/status` Overview Extensions section.
-The `/nowledge-mem` command can also enable or disable the builtin plugin and
-switch between local and cloud mode. Cloud configuration accepts the server
+The `/mem` configuration command can also enable or disable the builtin plugin
+and switch between local and cloud mode. Cloud configuration accepts the server
 URL and environment variable names only; it never accepts an API-key value.
 Saving a change persists the config and asks the runtime to rebuild. The TUI
 does not assemble the MCP transport itself.
+`/nowledge-mem` remains a compatibility alias.
 The status display reports the builtin MCP entry as
 `nowledge-mem builtin`, shows the configured endpoint with secret-bearing URL
 parts redacted, and marks localhost endpoints as `local/direct` to make the

--- a/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
+++ b/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
@@ -40,9 +40,10 @@ same plugin state.
 - Cloud credentials are never persisted in RARA config or generated plugin
   files. The generated transport references NMEM_API_KEY and NMEM_SPACE by
   default, with configurable environment variable names.
-- TUI exposes `/nowledge-mem` for enablement, local/cloud mode selection, and
-  endpoint or environment-variable-name updates. It saves configuration and
-  requests a runtime rebuild; transport construction remains runtime-owned.
+- TUI exposes `/mem` for enablement, local/cloud mode selection, and endpoint
+  or environment-variable-name updates. It saves configuration and requests a
+  runtime rebuild; transport construction remains runtime-owned. The longer
+  `/nowledge-mem` form remains a compatibility alias.
 - `builtin_plugins.nowledge_mem` controls whether the plugin is materialized
   and which MCP URL or headers are written into its generated `.mcp.json`.
 - The builtin plugin accepts Codex-style `.codex-plugin/plugin.json` metadata.

--- a/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
+++ b/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
@@ -40,6 +40,9 @@ same plugin state.
 - Cloud credentials are never persisted in RARA config or generated plugin
   files. The generated transport references NMEM_API_KEY and NMEM_SPACE by
   default, with configurable environment variable names.
+- TUI exposes `/nowledge-mem` for enablement, local/cloud mode selection, and
+  endpoint or environment-variable-name updates. It saves configuration and
+  requests a runtime rebuild; transport construction remains runtime-owned.
 - `builtin_plugins.nowledge_mem` controls whether the plugin is materialized
   and which MCP URL or headers are written into its generated `.mcp.json`.
 - The builtin plugin accepts Codex-style `.codex-plugin/plugin.json` metadata.

--- a/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
+++ b/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
@@ -42,8 +42,7 @@ same plugin state.
   default, with configurable environment variable names.
 - TUI exposes `/mem` for enablement, local/cloud mode selection, and endpoint
   or environment-variable-name updates. It saves configuration and requests a
-  runtime rebuild; transport construction remains runtime-owned. The longer
-  `/nowledge-mem` form remains a compatibility alias.
+  runtime rebuild; transport construction remains runtime-owned.
 - `builtin_plugins.nowledge_mem` controls whether the plugin is materialized
   and which MCP URL or headers are written into its generated `.mcp.json`.
 - The builtin plugin accepts Codex-style `.codex-plugin/plugin.json` metadata.

--- a/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
+++ b/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
@@ -16,6 +16,7 @@ runtime registries:
   routing.
 - memory query event notices that show the sanitized query preview and result
   count without rendering returned memory content.
+- local/cloud mode selection with environment-backed cloud authentication.
 
 ## Background
 
@@ -33,6 +34,12 @@ same plugin state.
 - Builtin MCP servers use `builtin` provenance and yield to already registered
   user or project MCP servers with the same name. Normal non-builtin plugin MCP
   duplicates remain hard errors.
+- Local mode preserves the loopback MCP endpoint. Cloud mode derives
+  /remote-api/mcp/ from the configured server base URL and emits API-key and
+  optional space headers as environment-variable references.
+- Cloud credentials are never persisted in RARA config or generated plugin
+  files. The generated transport references NMEM_API_KEY and NMEM_SPACE by
+  default, with configurable environment variable names.
 - `builtin_plugins.nowledge_mem` controls whether the plugin is materialized
   and which MCP URL or headers are written into its generated `.mcp.json`.
 - The builtin plugin accepts Codex-style `.codex-plugin/plugin.json` metadata.
@@ -59,12 +66,15 @@ cargo test plugin_middleware::tests::builtin_nowledge_mem_plugin_materializes_sk
 cargo test plugin_middleware::tests::appends_builtin_nowledge_mem_mcp_config -- --nocapture
 cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_yields_to_existing_registry_server -- --nocapture
 cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_uses_configured_url_and_headers -- --nocapture
+cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_supports_cloud_auth_without_persisting_secrets -- --nocapture
 cargo test plugin_middleware::tests::disabled_builtin_nowledge_mem_plugin_is_not_discovered -- --nocapture
+cargo test -p rara-config builtin_nowledge_mem_cloud_mode_derives_remote_mcp_and_env_headers -- --nocapture
 cargo test -p rara-plugins loads_codex_plugin_metadata_directory -- --nocapture
 cargo test -p rara-config streamable_http_localhost_bypasses_proxy -- --nocapture
 cargo test tui::status_display::tests::overview_status_reports_builtin_nowledge_mem -- --nocapture
 cargo test tui::status_display::tests::overview_status_reports_disabled_nowledge_mem -- --nocapture
 cargo test tui::status_display::tests::overview_status_reports_custom_nowledge_mem_endpoint_and_headers -- --nocapture
+cargo test tui::status_display::tests::overview_status_reports_cloud_nowledge_mem_auth_source -- --nocapture
 cargo test runtime_control::tests::memory_label_and_metadata_events_use_structured_wire_shape -- --nocapture
 cargo test protocol_sources::tests::memory_control_update_delete_and_labels_use_memory_store -- --nocapture
 cargo test tui::runtime::events::tests::memory_query_notice -- --nocapture

--- a/src/plugin_middleware/builtin.rs
+++ b/src/plugin_middleware/builtin.rs
@@ -9,6 +9,8 @@ pub(super) const BUILTIN_PLUGINS_DIR: &str = "builtin-plugins";
 pub(super) const NOWLEDGE_MEM_PLUGIN_DIR: &str = "nowledge-mem";
 #[cfg(test)]
 pub(super) const NOWLEDGE_MEM_MCP_URL: &str = "http://127.0.0.1:14242/mcp/";
+#[cfg(test)]
+pub(super) const NOWLEDGE_MEM_CLOUD_MCP_URL: &str = "https://mem.example.com/remote-api/mcp/";
 
 const NOWLEDGE_MEM_PLUGIN_VERSION: &str = "0.1.29-rara.1";
 const NOWLEDGE_MEM_SKILL_ROOTS: &[(&str, &str)] = &[
@@ -62,8 +64,9 @@ fn materialize_nowledge_mem_plugin(
             "mcpServers": {
                 "nowledge-mem": {
                     "type": "http",
-                    "url": config.url.clone(),
-                    "http_headers": nowledge_mem_http_headers(config)
+                    "url": config.mcp_url(),
+                    "http_headers": nowledge_mem_http_headers(config),
+                    "env_http_headers": config.env_http_headers()
                 }
             }
         })

--- a/src/plugin_middleware/tests.rs
+++ b/src/plugin_middleware/tests.rs
@@ -371,6 +371,67 @@ fn builtin_nowledge_mem_mcp_uses_configured_url_and_headers() {
 }
 
 #[test]
+fn builtin_nowledge_mem_mcp_supports_cloud_auth_without_persisting_secrets() {
+    let dir = tempdir().expect("tempdir");
+    let rara_home = dir.path().join("home").join(".rara");
+    let workspace_root = dir.path().join("workspace");
+    let config = BuiltinPluginConfig {
+        nowledge_mem: crate::config::NowledgeMemPluginConfig {
+            mode: crate::config::NowledgeMemMode::Cloud,
+            url: "https://mem.example.com".to_string(),
+            api_key_env_var: "RARA_NMEM_API_KEY".to_string(),
+            space_id_env_var: Some("RARA_NMEM_SPACE".to_string()),
+            ..Default::default()
+        },
+    };
+
+    let mut registry = McpRegistry::empty();
+    append_plugin_mcp_configs(
+        &mut registry,
+        Some(&rara_home),
+        &workspace_root,
+        &[],
+        &config,
+    )
+    .expect("append builtin plugin mcp config");
+
+    let server = registry
+        .servers
+        .get("nowledge-mem")
+        .expect("nowledge mem server");
+    assert_eq!(
+        server.config.transport,
+        McpServerTransport::StreamableHttp {
+            r#type: Some("http".to_string()),
+            url: builtin::NOWLEDGE_MEM_CLOUD_MCP_URL.to_string(),
+            bearer_token_env_var: None,
+            http_headers: Some(std::collections::BTreeMap::from([(
+                "APP".to_string(),
+                "RARA".to_string()
+            )])),
+            env_http_headers: Some(std::collections::BTreeMap::from([
+                ("Authorization".to_string(), "RARA_NMEM_API_KEY".to_string()),
+                (
+                    "X-NMEM-API-Key".to_string(),
+                    "RARA_NMEM_API_KEY".to_string()
+                ),
+                ("X-Nmem-Space-Id".to_string(), "RARA_NMEM_SPACE".to_string())
+            ])),
+        }
+    );
+
+    let materialized = std::fs::read_to_string(
+        rara_home
+            .join(builtin::BUILTIN_PLUGINS_DIR)
+            .join(builtin::NOWLEDGE_MEM_PLUGIN_DIR)
+            .join(".mcp.json"),
+    )
+    .expect("materialized mcp config");
+    assert!(materialized.contains("RARA_NMEM_API_KEY"));
+    assert!(!materialized.contains("secret"));
+}
+
+#[test]
 fn builtin_nowledge_mem_mcp_yields_to_existing_registry_server() {
     let dir = tempdir().expect("tempdir");
     let rara_home = dir.path().join("home").join(".rara");

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -124,10 +124,10 @@ pub const COMMAND_SPECS: [CommandSpec; 26] = [
     },
     CommandSpec {
         category: "Setup",
-        name: "nowledge-mem",
-        usage: "/nowledge-mem [on|off|local [url]|cloud <url> [api-key-env] [space-env]]",
+        name: "mem",
+        usage: "/mem [on|off|local [url]|cloud <url> [api-key-env] [space-env]]",
         summary: "Configure the builtin Nowledge Mem local or cloud MCP connection.",
-        detail: "Show or update the builtin Nowledge Mem connection. Cloud mode stores only the endpoint and environment variable names; it never accepts or persists an API key value.",
+        detail: "Show or update the builtin Nowledge Mem connection. Cloud mode stores only the endpoint and environment variable names; it never accepts or persists an API key value. /nowledge-mem remains a compatibility alias.",
     },
     CommandSpec {
         category: "Setup",
@@ -212,7 +212,7 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
         "model" | "models" => LocalCommandKind::Model,
         "connect" => LocalCommandKind::Connect,
         "base-url" => LocalCommandKind::BaseUrl,
-        "nowledge-mem" | "mem-config" => LocalCommandKind::NowledgeMem,
+        "mem" | "nowledge-mem" | "mem-config" => LocalCommandKind::NowledgeMem,
         "login" | "auth" => LocalCommandKind::Login,
         "logout" => LocalCommandKind::Logout,
         "review" => LocalCommandKind::Review,

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -127,7 +127,7 @@ pub const COMMAND_SPECS: [CommandSpec; 26] = [
         name: "mem",
         usage: "/mem [on|off|local [url]|cloud <url> [api-key-env] [space-env]]",
         summary: "Configure the builtin Nowledge Mem local or cloud MCP connection.",
-        detail: "Show or update the builtin Nowledge Mem connection. Cloud mode stores only the endpoint and environment variable names; it never accepts or persists an API key value. /nowledge-mem remains a compatibility alias.",
+        detail: "Show or update the builtin Nowledge Mem connection. Cloud mode stores only the endpoint and environment variable names; it never accepts or persists an API key value.",
     },
     CommandSpec {
         category: "Setup",
@@ -212,7 +212,7 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
         "model" | "models" => LocalCommandKind::Model,
         "connect" => LocalCommandKind::Connect,
         "base-url" => LocalCommandKind::BaseUrl,
-        "mem" | "nowledge-mem" | "mem-config" => LocalCommandKind::NowledgeMem,
+        "mem" => LocalCommandKind::NowledgeMem,
         "login" | "auth" => LocalCommandKind::Login,
         "logout" => LocalCommandKind::Logout,
         "review" => LocalCommandKind::Review,

--- a/src/tui/command/specs.rs
+++ b/src/tui/command/specs.rs
@@ -2,7 +2,7 @@
 
 use crate::tui::state::{CommandSpec, LocalCommand, LocalCommandKind, TuiApp};
 
-pub const COMMAND_SPECS: [CommandSpec; 25] = [
+pub const COMMAND_SPECS: [CommandSpec; 26] = [
     CommandSpec {
         category: "Session",
         name: "permissions",
@@ -124,6 +124,13 @@ pub const COMMAND_SPECS: [CommandSpec; 25] = [
     },
     CommandSpec {
         category: "Setup",
+        name: "nowledge-mem",
+        usage: "/nowledge-mem [on|off|local [url]|cloud <url> [api-key-env] [space-env]]",
+        summary: "Configure the builtin Nowledge Mem local or cloud MCP connection.",
+        detail: "Show or update the builtin Nowledge Mem connection. Cloud mode stores only the endpoint and environment variable names; it never accepts or persists an API key value.",
+    },
+    CommandSpec {
+        category: "Setup",
         name: "login",
         usage: "/login",
         summary: "Open the provider auth picker.",
@@ -205,6 +212,7 @@ pub fn parse_local_command(input: &str) -> Option<LocalCommand> {
         "model" | "models" => LocalCommandKind::Model,
         "connect" => LocalCommandKind::Connect,
         "base-url" => LocalCommandKind::BaseUrl,
+        "nowledge-mem" | "mem-config" => LocalCommandKind::NowledgeMem,
         "login" | "auth" => LocalCommandKind::Login,
         "logout" => LocalCommandKind::Logout,
         "review" => LocalCommandKind::Review,

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -89,15 +89,21 @@ fn parses_base_url_command() {
 
 #[test]
 fn parses_nowledge_mem_configuration_command() {
-    let command = parse_local_command(
-        "/nowledge-mem cloud https://mem.example.com RARA_NMEM_API_KEY RARA_NMEM_SPACE",
-    )
-    .expect("command should parse");
+    let command =
+        parse_local_command("/mem cloud https://mem.example.com RARA_NMEM_API_KEY RARA_NMEM_SPACE")
+            .expect("command should parse");
     assert!(matches!(command.kind, LocalCommandKind::NowledgeMem));
     assert_eq!(
         command.arg.as_deref(),
         Some("cloud https://mem.example.com RARA_NMEM_API_KEY RARA_NMEM_SPACE")
     );
+
+    let compatibility_alias =
+        parse_local_command("/nowledge-mem off").expect("compatibility alias should parse");
+    assert!(matches!(
+        compatibility_alias.kind,
+        LocalCommandKind::NowledgeMem
+    ));
 
     let alias = parse_local_command("/mem-config off").expect("alias should parse");
     assert!(matches!(alias.kind, LocalCommandKind::NowledgeMem));

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -97,17 +97,6 @@ fn parses_nowledge_mem_configuration_command() {
         command.arg.as_deref(),
         Some("cloud https://mem.example.com RARA_NMEM_API_KEY RARA_NMEM_SPACE")
     );
-
-    let compatibility_alias =
-        parse_local_command("/nowledge-mem off").expect("compatibility alias should parse");
-    assert!(matches!(
-        compatibility_alias.kind,
-        LocalCommandKind::NowledgeMem
-    ));
-
-    let alias = parse_local_command("/mem-config off").expect("alias should parse");
-    assert!(matches!(alias.kind, LocalCommandKind::NowledgeMem));
-    assert_eq!(alias.arg.as_deref(), Some("off"));
 }
 
 #[test]

--- a/src/tui/command/tests.rs
+++ b/src/tui/command/tests.rs
@@ -88,6 +88,23 @@ fn parses_base_url_command() {
 }
 
 #[test]
+fn parses_nowledge_mem_configuration_command() {
+    let command = parse_local_command(
+        "/nowledge-mem cloud https://mem.example.com RARA_NMEM_API_KEY RARA_NMEM_SPACE",
+    )
+    .expect("command should parse");
+    assert!(matches!(command.kind, LocalCommandKind::NowledgeMem));
+    assert_eq!(
+        command.arg.as_deref(),
+        Some("cloud https://mem.example.com RARA_NMEM_API_KEY RARA_NMEM_SPACE")
+    );
+
+    let alias = parse_local_command("/mem-config off").expect("alias should parse");
+    assert!(matches!(alias.kind, LocalCommandKind::NowledgeMem));
+    assert_eq!(alias.arg.as_deref(), Some("off"));
+}
+
+#[test]
 fn parses_resume_command() {
     let command = parse_local_command("/resume").expect("command should parse");
     assert!(matches!(command.kind, LocalCommandKind::Resume));

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -33,6 +33,7 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Logout => "logout",
         LocalCommandKind::Mcp => "mcp",
         LocalCommandKind::Model => "model",
+        LocalCommandKind::NowledgeMem => "nowledge-mem",
         LocalCommandKind::Plan => "plan",
         LocalCommandKind::Quit => "quit",
         LocalCommandKind::Resume => "resume",
@@ -78,6 +79,9 @@ pub(super) async fn execute_local_command(
             app.push_notice(notice);
         }
         LocalCommandKind::BaseUrl => handle_base_url_command(command.arg.as_deref(), app)?,
+        LocalCommandKind::NowledgeMem => {
+            handle_nowledge_mem_command(command.arg.as_deref(), app)?;
+        }
         LocalCommandKind::Help => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening help".into()));
             app.open_overlay(Overlay::Help(HelpTab::General));
@@ -344,6 +348,77 @@ fn handle_connect_command(app: &mut TuiApp) -> anyhow::Result<()> {
     app.bottom_pane.notice = Some(
         "Connect a provider — select the provider family, then configure API key and model.".into(),
     );
+    Ok(())
+}
+
+fn handle_nowledge_mem_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::Result<()> {
+    let arg = arg.unwrap_or("").trim();
+    if arg.is_empty() {
+        let config = &app.config.builtin_plugins.nowledge_mem;
+        app.push_notice(format!(
+            "Nowledge Mem: {} {}",
+            if config.enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            config.mode_label()
+        ));
+        return Ok(());
+    }
+
+    let mut parts = arg.split_whitespace();
+    let action = parts.next().unwrap_or_default();
+    let mut next = app.config.builtin_plugins.nowledge_mem.clone();
+    match action {
+        "on" => {
+            if parts.next().is_some() {
+                anyhow::bail!("Usage: /nowledge-mem on");
+            }
+            next.enabled = true;
+        }
+        "off" => {
+            if parts.next().is_some() {
+                anyhow::bail!("Usage: /nowledge-mem off");
+            }
+            next.enabled = false;
+        }
+        "local" => {
+            next.mode = crate::config::NowledgeMemMode::Local;
+            next.enabled = true;
+            if let Some(url) = parts.next() {
+                next.url = url.to_string();
+            }
+            if parts.next().is_some() {
+                anyhow::bail!("Usage: /nowledge-mem local [mcp-url]");
+            }
+        }
+        "cloud" => {
+            let url = parts.next().ok_or_else(|| {
+                anyhow::anyhow!("Usage: /nowledge-mem cloud <url> [api-key-env] [space-env]")
+            })?;
+            next.mode = crate::config::NowledgeMemMode::Cloud;
+            next.enabled = true;
+            next.url = url.to_string();
+            if let Some(api_key_env) = parts.next() {
+                next.api_key_env_var = api_key_env.to_string();
+            }
+            if let Some(space_env) = parts.next() {
+                next.space_id_env_var = (space_env != "-").then(|| space_env.to_string());
+            }
+            if parts.next().is_some() {
+                anyhow::bail!("Usage: /nowledge-mem cloud <url> [api-key-env] [space-env]");
+            }
+        }
+        _ => anyhow::bail!(
+            "Usage: /nowledge-mem [on|off|local [url]|cloud <url> [api-key-env] [space-env]]"
+        ),
+    }
+
+    app.config.builtin_plugins.nowledge_mem = next;
+    app.config_manager.save(&app.config)?;
+    start_rebuild_task(app);
+    app.push_notice("Nowledge Mem configuration saved; rebuilding runtime.");
     Ok(())
 }
 
@@ -680,13 +755,14 @@ mod tests {
     use tokio::sync::mpsc;
 
     use super::{
-        execute_local_command, handle_mcp_command, mcp_project_root_from_cwd,
-        parse_goal_objective_and_budget, parse_goal_token_budget, spawn_mcp_tool_cache_population,
+        execute_local_command, handle_mcp_command, handle_nowledge_mem_command,
+        mcp_project_root_from_cwd, parse_goal_objective_and_budget, parse_goal_token_budget,
+        spawn_mcp_tool_cache_population,
     };
     use crate::agent::{Agent, AgentEvent, BashApprovalMode};
     use crate::config::{
         ConfigManager, McpRegistry, McpServerConfig, McpServerScope, McpServerSource,
-        McpServerTransport, SourcedMcpServerConfig,
+        McpServerTransport, NowledgeMemMode, SourcedMcpServerConfig,
     };
     use crate::llm::MockLlm;
     use crate::mcp_tool_cache::McpToolCache;
@@ -785,6 +861,32 @@ mod tests {
             parse_goal_objective_and_budget("fix the build").expect("no budget"),
             ("fix the build".to_string(), None)
         );
+    }
+
+    #[tokio::test]
+    async fn nowledge_mem_command_saves_cloud_config_and_env_names_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: dir.path().join("config.json"),
+        })
+        .expect("app");
+
+        handle_nowledge_mem_command(
+            Some("cloud https://mem.example.com RARA_NMEM_API_KEY RARA_NMEM_SPACE"),
+            &mut app,
+        )
+        .expect("cloud configuration should save");
+
+        let config = &app.config.builtin_plugins.nowledge_mem;
+        assert!(config.enabled);
+        assert_eq!(config.mode, NowledgeMemMode::Cloud);
+        assert_eq!(config.url, "https://mem.example.com");
+        assert_eq!(config.api_key_env_var, "RARA_NMEM_API_KEY");
+        assert_eq!(config.space_id_env_var.as_deref(), Some("RARA_NMEM_SPACE"));
+
+        let saved = fs::read_to_string(dir.path().join("config.json")).expect("saved config");
+        assert!(saved.contains("RARA_NMEM_API_KEY"));
+        assert!(!saved.contains("secret-value"));
     }
 
     #[test]

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -33,7 +33,7 @@ pub(super) async fn execute_local_command(
         LocalCommandKind::Logout => "logout",
         LocalCommandKind::Mcp => "mcp",
         LocalCommandKind::Model => "model",
-        LocalCommandKind::NowledgeMem => "nowledge-mem",
+        LocalCommandKind::NowledgeMem => "mem",
         LocalCommandKind::Plan => "plan",
         LocalCommandKind::Quit => "quit",
         LocalCommandKind::Resume => "resume",
@@ -373,13 +373,13 @@ fn handle_nowledge_mem_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::R
     match action {
         "on" => {
             if parts.next().is_some() {
-                anyhow::bail!("Usage: /nowledge-mem on");
+                anyhow::bail!("Usage: /mem on");
             }
             next.enabled = true;
         }
         "off" => {
             if parts.next().is_some() {
-                anyhow::bail!("Usage: /nowledge-mem off");
+                anyhow::bail!("Usage: /mem off");
             }
             next.enabled = false;
         }
@@ -390,12 +390,12 @@ fn handle_nowledge_mem_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::R
                 next.url = url.to_string();
             }
             if parts.next().is_some() {
-                anyhow::bail!("Usage: /nowledge-mem local [mcp-url]");
+                anyhow::bail!("Usage: /mem local [mcp-url]");
             }
         }
         "cloud" => {
             let url = parts.next().ok_or_else(|| {
-                anyhow::anyhow!("Usage: /nowledge-mem cloud <url> [api-key-env] [space-env]")
+                anyhow::anyhow!("Usage: /mem cloud <url> [api-key-env] [space-env]")
             })?;
             next.mode = crate::config::NowledgeMemMode::Cloud;
             next.enabled = true;
@@ -407,12 +407,12 @@ fn handle_nowledge_mem_command(arg: Option<&str>, app: &mut TuiApp) -> anyhow::R
                 next.space_id_env_var = (space_env != "-").then(|| space_env.to_string());
             }
             if parts.next().is_some() {
-                anyhow::bail!("Usage: /nowledge-mem cloud <url> [api-key-env] [space-env]");
+                anyhow::bail!("Usage: /mem cloud <url> [api-key-env] [space-env]");
             }
         }
-        _ => anyhow::bail!(
-            "Usage: /nowledge-mem [on|off|local [url]|cloud <url> [api-key-env] [space-env]]"
-        ),
+        _ => {
+            anyhow::bail!("Usage: /mem [on|off|local [url]|cloud <url> [api-key-env] [space-env]]")
+        }
     }
 
     app.config.builtin_plugins.nowledge_mem = next;

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -153,6 +153,7 @@ pub enum LocalCommandKind {
     Model,
     Connect,
     BaseUrl,
+    NowledgeMem,
     Login,
     Mcp,
     Permissions,

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -153,15 +153,24 @@ fn render_nowledge_mem_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
     } else {
         format!("{} custom headers", config.http_headers.len())
     };
+    let auth_label = if config.mode_label() == "cloud" {
+        format!(", api key env {}", config.api_key_env_var)
+    } else {
+        String::new()
+    };
     kv(lines, "mcp", "nowledge-mem builtin", Color::LightBlue);
     kv(
         lines,
         "nowledge",
         &format!(
-            "{} ({proxy_label}, {header_label})",
-            sanitize_url_for_display(&config.url)
+            "{} ({} / {}, {}{})",
+            sanitize_url_for_display(&config.mcp_url()),
+            config.mode_label(),
+            proxy_label,
+            header_label,
+            auth_label
         ),
-        if proxy_label == "local/direct" {
+        if config.mode_label() == "local" {
             Color::LightGreen
         } else {
             Color::LightBlue
@@ -172,14 +181,14 @@ fn render_nowledge_mem_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
 fn nowledge_mem_transport(config: &crate::config::NowledgeMemPluginConfig) -> McpServerTransport {
     McpServerTransport::StreamableHttp {
         r#type: Some("http".to_string()),
-        url: config.url.clone(),
+        url: config.mcp_url(),
         bearer_token_env_var: None,
         http_headers: if config.http_headers.is_empty() {
             None
         } else {
             Some(config.http_headers.clone())
         },
-        env_http_headers: None,
+        env_http_headers: config.env_http_headers(),
     }
 }
 
@@ -666,6 +675,28 @@ mod tests {
         assert!(rendered.contains("remote"));
         assert!(rendered.contains("1 custom headers"));
         assert!(!rendered.contains("token=secret"));
+    }
+
+    #[test]
+    fn overview_status_reports_cloud_nowledge_mem_auth_source() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.config.builtin_plugins.nowledge_mem.mode = crate::config::NowledgeMemMode::Cloud;
+        app.config.builtin_plugins.nowledge_mem.url = "https://mem.example.com".to_string();
+        app.config.builtin_plugins.nowledge_mem.api_key_env_var = "RARA_NMEM_API_KEY".to_string();
+
+        let rendered = render_status_lines(&app, StatusTab::Overview)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("https://mem.example.com/remote-api/mcp/"));
+        assert!(rendered.contains("cloud / remote"));
+        assert!(rendered.contains("api key env RARA_NMEM_API_KEY"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add explicit local/cloud modes to the builtin Nowledge Mem plugin
- derive the cloud MCP endpoint from the configured Mem server base URL
- authenticate cloud MCP through environment-variable header references
- add `/mem` as the TUI configuration command for enablement, local/cloud mode, and env var names
- display cloud mode and the API-key environment variable in TUI status without reading secrets
- document the local/cloud contract and validation coverage

## Motivation

Nowledge Mem supports both the local loopback MCP server and the authenticated
Cloud gateway. RARA previously only generated a local endpoint or accepted
static custom headers, which made Cloud setup easy to misconfigure and
encouraged credentials to be stored in configuration.

## Design

Local mode keeps the existing `http://127.0.0.1:14242/mcp/` default and
localhost proxy-bypass behavior. Cloud mode treats `url` as the server base
URL, generates `/remote-api/mcp/`, and references `NMEM_API_KEY` and
`NMEM_SPACE` through `env_http_headers`. Custom environment variable names are
supported. API-key values are never serialized into `config.json`, the
materialized plugin, or TUI state.

The `/mem` command persists configuration and requests a runtime rebuild.
Plugin discovery, MCP registration, and transport construction remain owned by
runtime/app-server assembly.

## Related Issue

No issue; follows the existing builtin Nowledge Mem plugin integration.

## Validation

- `cargo test tui::command::tests::parses_nowledge_mem_configuration_command -- --nocapture`
- `cargo test tui::runtime::commands::tests::nowledge_mem_command_saves_cloud_config_and_env_names_only -- --nocapture`
- `cargo test tui::status_display::tests::overview_status_reports_cloud_nowledge_mem_auth_source -- --nocapture`
- `cargo test -p rara-config builtin_nowledge_mem_cloud_mode_derives_remote_mcp_and_env_headers -- --nocapture`
- `cargo test plugin_middleware::tests::builtin_nowledge_mem_mcp_supports_cloud_auth_without_persisting_secrets -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `git diff --check`
