### PR TITLE
feat(memory): configure cloud api key from cli

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -22,10 +22,11 @@ pub use self::mcp::{
 };
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{
-    BuiltinPluginConfig, ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy,
-    NowledgeMemMode, NowledgeMemPluginConfig, OpenAiEndpointKind, OpenAiEndpointProfile,
-    ProviderConfigState, RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig, TuiThemeConfig,
-    ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for, workspace_data_dir_for_home,
+    BuiltinPluginConfig, ConfigManager, ContextFileSearchPolicy, DEFAULT_NOWLEDGE_MEM_CLOUD_URL,
+    LocalEmbeddingPolicy, NowledgeMemMode, NowledgeMemPluginConfig, OpenAiEndpointKind,
+    OpenAiEndpointProfile, ProviderConfigState, RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig,
+    TuiThemeConfig, ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for,
+    workspace_data_dir_for_home,
 };
 pub use self::provider_surface::{
     ConfigValueSource, EffectiveProviderSurface, ResolvedProviderValue,

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -1548,8 +1548,10 @@ mod tests {
 
     #[test]
     fn builtin_nowledge_mem_cloud_mode_defaults_to_nowledge_cloud() {
-        let mut mem = NowledgeMemPluginConfig::default();
-        mem.mode = NowledgeMemMode::Cloud;
+        let mem = NowledgeMemPluginConfig {
+            mode: NowledgeMemMode::Cloud,
+            ..Default::default()
+        };
 
         assert_eq!(mem.mcp_url(), "https://cloud.nowledge.co/remote-api/mcp/");
     }

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -260,7 +260,9 @@ pub enum NowledgeMemMode {
     Cloud,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub const DEFAULT_NOWLEDGE_MEM_CLOUD_URL: &str = "https://cloud.nowledge.co";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct NowledgeMemPluginConfig {
     #[serde(default, skip_serializing_if = "NowledgeMemMode::is_default")]
@@ -268,6 +270,13 @@ pub struct NowledgeMemPluginConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
     pub url: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_secret_option",
+        deserialize_with = "deserialize_secret_option"
+    )]
+    pub api_key: Option<SecretString>,
     #[serde(
         default = "default_nowledge_mem_api_key_env_var",
         skip_serializing_if = "is_default_nowledge_mem_api_key_env_var"
@@ -282,12 +291,27 @@ pub struct NowledgeMemPluginConfig {
     pub http_headers: BTreeMap<String, String>,
 }
 
+impl PartialEq for NowledgeMemPluginConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.mode == other.mode
+            && self.enabled == other.enabled
+            && self.url == other.url
+            && self.api_key() == other.api_key()
+            && self.api_key_env_var == other.api_key_env_var
+            && self.space_id_env_var == other.space_id_env_var
+            && self.http_headers == other.http_headers
+    }
+}
+
+impl Eq for NowledgeMemPluginConfig {}
+
 impl Default for NowledgeMemPluginConfig {
     fn default() -> Self {
         Self {
             mode: NowledgeMemMode::Local,
             enabled: true,
             url: default_nowledge_mem_mcp_url(),
+            api_key: None,
             api_key_env_var: default_nowledge_mem_api_key_env_var(),
             space_id_env_var: default_nowledge_mem_space_id_env_var(),
             http_headers: BTreeMap::new(),
@@ -300,7 +324,14 @@ impl NowledgeMemPluginConfig {
         match self.mode {
             NowledgeMemMode::Local => self.url.clone(),
             NowledgeMemMode::Cloud => {
-                let base = self.url.trim_end_matches('/');
+                let configured_url = self.url.trim_end_matches('/');
+                let base = if configured_url.is_empty()
+                    || configured_url == default_nowledge_mem_mcp_url().trim_end_matches('/')
+                {
+                    DEFAULT_NOWLEDGE_MEM_CLOUD_URL
+                } else {
+                    configured_url
+                };
                 if base.ends_with("/mcp") {
                     format!("{base}/")
                 } else if base.ends_with("/remote-api") {
@@ -324,6 +355,18 @@ impl NowledgeMemPluginConfig {
             headers.insert("X-Nmem-Space-Id".to_string(), env_var.clone());
         }
         Some(headers)
+    }
+
+    pub fn api_key(&self) -> Option<&str> {
+        self.api_key.as_ref().map(SecretString::expose_secret)
+    }
+
+    pub fn set_api_key(&mut self, value: impl Into<String>) {
+        self.api_key = Some(SecretString::from(value.into()));
+    }
+
+    pub fn clear_api_key(&mut self) {
+        self.api_key = None;
     }
 
     pub fn mode_label(&self) -> &'static str {
@@ -1222,8 +1265,8 @@ mod tests {
 
     use super::{
         ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy, NowledgeMemMode,
-        OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState, RaraConfig,
-        workspace_data_dir_for_home,
+        NowledgeMemPluginConfig, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState,
+        RaraConfig, workspace_data_dir_for_home,
     };
     use crate::defaults::{
         DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL,
@@ -1478,7 +1521,7 @@ mod tests {
                 "builtin_plugins": {
                     "nowledge_mem": {
                         "mode": "cloud",
-                        "url": "https://mem.example.com",
+                        "url": "https://cloud.nowledge.co",
                         "api_key_env_var": "RARA_NMEM_API_KEY",
                         "space_id_env_var": "RARA_NMEM_SPACE"
                     }
@@ -1489,7 +1532,7 @@ mod tests {
 
         let mem = &config.builtin_plugins.nowledge_mem;
         assert_eq!(mem.mode, NowledgeMemMode::Cloud);
-        assert_eq!(mem.mcp_url(), "https://mem.example.com/remote-api/mcp/");
+        assert_eq!(mem.mcp_url(), "https://cloud.nowledge.co/remote-api/mcp/");
         assert_eq!(
             mem.env_http_headers(),
             Some(BTreeMap::from([
@@ -1500,6 +1543,31 @@ mod tests {
                 ),
                 ("X-Nmem-Space-Id".to_string(), "RARA_NMEM_SPACE".to_string())
             ]))
+        );
+    }
+
+    #[test]
+    fn builtin_nowledge_mem_cloud_mode_defaults_to_nowledge_cloud() {
+        let mut mem = NowledgeMemPluginConfig::default();
+        mem.mode = NowledgeMemMode::Cloud;
+
+        assert_eq!(mem.mcp_url(), "https://cloud.nowledge.co/remote-api/mcp/");
+    }
+
+    #[test]
+    fn builtin_nowledge_mem_api_key_roundtrips_through_config() {
+        let mut config = RaraConfig::default();
+        config
+            .builtin_plugins
+            .nowledge_mem
+            .set_api_key("nmem_test_key");
+
+        let serialized = serde_json::to_string(&config).expect("serialize config");
+        let restored: RaraConfig = serde_json::from_str(&serialized).expect("restore config");
+
+        assert_eq!(
+            restored.builtin_plugins.nowledge_mem.api_key(),
+            Some("nmem_test_key")
         );
     }
 

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -359,12 +359,19 @@ normal ordered de-duplication path. Builtin MCP servers also yield to already
 registered user or project MCP servers with the same name; normal non-builtin
 plugin MCP duplicates remain hard errors.
 
-Cloud mode is also supported. In cloud mode, url is treated as the Mem server
-base URL and the generated endpoint is /remote-api/mcp/. The transport emits
-Authorization and X-NMEM-API-Key from NMEM_API_KEY, plus the optional
-X-Nmem-Space-Id from NMEM_SPACE. These are environment-variable references,
-not persisted credentials; the environment variable names can be configured
-with api_key_env_var and space_id_env_var.
+Cloud mode is also supported. Cloud mode defaults to the fixed Nowledge Mem
+server `https://cloud.nowledge.co`. The generated endpoint is
+`/remote-api/mcp/`. The transport emits
+Authorization and X-NMEM-API-Key from the configured API key, plus the optional
+X-Nmem-Space-Id from NMEM_SPACE. The key is persisted using RARA's existing
+secret configuration field and is exposed to the runtime only through
+NMEM_API_KEY; the generated plugin file contains only the environment variable
+reference. The environment variable names can be configured with
+api_key_env_var and space_id_env_var.
+
+`rara mem --api-key <key>` saves the key to RARA's configuration and applies it
+to subsequent runs, including after restart. The user does not need to
+configure `NMEM_API_KEY` separately.
 
 Local Nowledge Mem endpoints must not use system HTTP proxies. The MCP
 transport contract exposes localhost proxy bypass detection for streamable HTTP

--- a/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
+++ b/docs/journal/2026-07-30-nowledge-mem-builtin-plugin.md
@@ -34,12 +34,16 @@ same plugin state.
 - Builtin MCP servers use `builtin` provenance and yield to already registered
   user or project MCP servers with the same name. Normal non-builtin plugin MCP
   duplicates remain hard errors.
-- Local mode preserves the loopback MCP endpoint. Cloud mode derives
-  /remote-api/mcp/ from the configured server base URL and emits API-key and
-  optional space headers as environment-variable references.
-- Cloud credentials are never persisted in RARA config or generated plugin
-  files. The generated transport references NMEM_API_KEY and NMEM_SPACE by
-  default, with configurable environment variable names.
+- Local mode preserves the loopback MCP endpoint. Cloud mode defaults to
+  `https://cloud.nowledge.co` and derives `/remote-api/mcp/`. It emits API-key
+  and optional space headers as environment-variable references.
+- Cloud credentials are persisted in RARA's existing secret configuration field
+  but never written to generated plugin files. The runtime exposes the saved
+  key through NMEM_API_KEY and keeps the generated transport on an environment
+  variable reference.
+- `rara mem --api-key <key>` saves the Cloud credential and enables Cloud mode;
+  the saved key is restored after restart, and users do not need to manage
+  NMEM_API_KEY separately.
 - TUI exposes `/mem` as an argument-free picker for disabled, local, or cloud
   mode. It saves the selected mode and requests a runtime rebuild; transport
   construction remains runtime-owned.

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -210,8 +210,9 @@ pub(crate) async fn run_cli() -> Result<()> {
     }
     let plugin_dirs = effective_plugin_dirs(&config, &cli_plugin_dirs)?;
     config.apply_provider_environment_defaults();
-    if let Some(api_key) = config.builtin_plugins.nowledge_mem.api_key() {
-        set_process_mem_api_key(api_key.to_string());
+    let mem_config = &config.builtin_plugins.nowledge_mem;
+    if let Some(api_key) = mem_config.api_key() {
+        set_process_mem_api_key(&mem_config.api_key_env_var, api_key.to_string());
     }
 
     let oauth_manager = OAuthManager::new()?;
@@ -287,7 +288,6 @@ fn apply_cli_overrides(config: &mut RaraConfig, cli: Cli) -> Option<Commands> {
     if let Some(Commands::Mem(args)) = cli.command.as_ref() {
         config.builtin_plugins.nowledge_mem.enabled = true;
         config.builtin_plugins.nowledge_mem.mode = NowledgeMemMode::Cloud;
-        config.builtin_plugins.nowledge_mem.api_key_env_var = "NMEM_API_KEY".to_string();
         config
             .builtin_plugins
             .nowledge_mem
@@ -296,10 +296,10 @@ fn apply_cli_overrides(config: &mut RaraConfig, cli: Cli) -> Option<Commands> {
     cli.command
 }
 
-fn set_process_mem_api_key(api_key: String) {
+fn set_process_mem_api_key(env_var: &str, api_key: String) {
     // SAFETY: CLI overrides are applied before RARA starts async runtimes or
     // worker threads, so no concurrent environment access is possible here.
-    unsafe { std::env::set_var("NMEM_API_KEY", api_key) };
+    unsafe { std::env::set_var(env_var, api_key) };
 }
 
 fn normalize_plugin_dirs(plugin_dirs: &[PathBuf]) -> Result<Vec<PathBuf>> {
@@ -853,6 +853,7 @@ mod tests {
         let cli = Cli::try_parse_from(["rara", "mem", "--api-key", "nmem_test_key"])
             .expect("parse mem api key");
         let mut config = RaraConfig::default();
+        config.builtin_plugins.nowledge_mem.api_key_env_var = "CUSTOM_MEM_KEY".to_string();
 
         assert!(matches!(
             apply_cli_overrides(&mut config, cli),
@@ -860,7 +861,7 @@ mod tests {
         ));
         assert_eq!(
             config.builtin_plugins.nowledge_mem.api_key_env_var,
-            "NMEM_API_KEY"
+            "CUSTOM_MEM_KEY"
         );
         assert_eq!(
             config.builtin_plugins.nowledge_mem.api_key(),

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -10,8 +10,8 @@ use secrecy::{ExposeSecret, SecretString};
 use crate::acp::RaraAcpAgent;
 use crate::config::{
     ConfigManager, DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_KIMI_BASE_URL,
-    DEFAULT_KIMI_MODEL, DEFAULT_REASONING_SUMMARY, OpenAiEndpointKind, OpenAiEndpointProfile,
-    RaraConfig, ensure_rara_home_dir,
+    DEFAULT_KIMI_MODEL, DEFAULT_REASONING_SUMMARY, NowledgeMemMode, OpenAiEndpointKind,
+    OpenAiEndpointProfile, RaraConfig, ensure_rara_home_dir,
 };
 use crate::oauth::{OAuthManager, SavedCodexAuthMode};
 use crate::plugin_cli::{PluginCommands, run_plugin_command};
@@ -94,6 +94,13 @@ struct ModelsShowArgs {
 }
 
 #[derive(Debug, clap::Args)]
+struct MemArgs {
+    /// Nowledge Mem Cloud API key to save.
+    #[arg(long)]
+    api_key: String,
+}
+
+#[derive(Debug, clap::Args)]
 struct ExecArgs {
     /// Print headless execution events to stdout as JSONL.
     #[arg(long, default_value_t = false)]
@@ -143,6 +150,8 @@ enum Commands {
     /// Install, list, or remove workspace plugins
     #[command(subcommand)]
     Plugin(PluginCommands),
+    /// Configure the builtin Nowledge Mem Cloud integration.
+    Mem(MemArgs),
     Ask {
         prompt: String,
     },
@@ -194,8 +203,16 @@ pub(crate) async fn run_cli() -> Result<()> {
     let config_manager = ConfigManager::new()?;
     let mut config = config_manager.load()?;
     let command = apply_cli_overrides(&mut config, cli);
+    if matches!(command, Some(Commands::Mem(_))) {
+        config_manager.save(&config)?;
+        println!("Nowledge Mem Cloud API key saved.");
+        return Ok(());
+    }
     let plugin_dirs = effective_plugin_dirs(&config, &cli_plugin_dirs)?;
     config.apply_provider_environment_defaults();
+    if let Some(api_key) = config.builtin_plugins.nowledge_mem.api_key() {
+        set_process_mem_api_key(api_key.to_string());
+    }
 
     let oauth_manager = OAuthManager::new()?;
 
@@ -204,6 +221,7 @@ pub(crate) async fn run_cli() -> Result<()> {
         Commands::Connect(args) => run_connect_command(&config, args)?,
         Commands::Models(cmd) => run_models_command(&config, cmd)?,
         Commands::Plugin(cmd) => run_plugin_command(cmd)?,
+        Commands::Mem(_) => unreachable!("mem configuration returns before runtime startup"),
         Commands::Ask { prompt } => run_ask_command(&config, prompt, plugin_dirs).await?,
         Commands::Exec(args) => run_exec_command(&config, args, plugin_dirs).await?,
         Commands::Fork { thread_id } => thread_cli::run_fork_command(&thread_id)?,
@@ -266,7 +284,22 @@ fn apply_cli_overrides(config: &mut RaraConfig, cli: Cli) -> Option<Commands> {
     if let Some(revision) = cli.revision {
         config.set_revision(Some(revision));
     }
+    if let Some(Commands::Mem(args)) = cli.command.as_ref() {
+        config.builtin_plugins.nowledge_mem.enabled = true;
+        config.builtin_plugins.nowledge_mem.mode = NowledgeMemMode::Cloud;
+        config.builtin_plugins.nowledge_mem.api_key_env_var = "NMEM_API_KEY".to_string();
+        config
+            .builtin_plugins
+            .nowledge_mem
+            .set_api_key(args.api_key.clone());
+    }
     cli.command
+}
+
+fn set_process_mem_api_key(api_key: String) {
+    // SAFETY: CLI overrides are applied before RARA starts async runtimes or
+    // worker threads, so no concurrent environment access is possible here.
+    unsafe { std::env::set_var("NMEM_API_KEY", api_key) };
 }
 
 fn normalize_plugin_dirs(plugin_dirs: &[PathBuf]) -> Result<Vec<PathBuf>> {
@@ -559,6 +592,7 @@ fn startup_resume_target_for_command(command: &Commands) -> Option<StartupResume
         | Commands::Connect(..)
         | Commands::Models(..)
         | Commands::Plugin(..)
+        | Commands::Mem(..)
         | Commands::Ask { .. }
         | Commands::Exec(..)
         | Commands::Distill { .. }
@@ -812,6 +846,28 @@ mod tests {
             Commands::Ask { prompt } => assert_eq!(prompt, "hello"),
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn mem_api_key_cli_override_persists_cloud_configuration() {
+        let cli = Cli::try_parse_from(["rara", "mem", "--api-key", "nmem_test_key"])
+            .expect("parse mem api key");
+        let mut config = RaraConfig::default();
+
+        assert!(matches!(
+            apply_cli_overrides(&mut config, cli),
+            Some(Commands::Mem(_))
+        ));
+        assert_eq!(
+            config.builtin_plugins.nowledge_mem.api_key_env_var,
+            "NMEM_API_KEY"
+        );
+        assert_eq!(
+            config.builtin_plugins.nowledge_mem.api_key(),
+            Some("nmem_test_key")
+        );
+        let serialized = serde_json::to_string(&config).expect("serialize config");
+        assert!(serialized.contains("nmem_test_key"));
     }
 
     #[test]

--- a/src/plugin_middleware/builtin.rs
+++ b/src/plugin_middleware/builtin.rs
@@ -10,7 +10,7 @@ pub(super) const NOWLEDGE_MEM_PLUGIN_DIR: &str = "nowledge-mem";
 #[cfg(test)]
 pub(super) const NOWLEDGE_MEM_MCP_URL: &str = "http://127.0.0.1:14242/mcp/";
 #[cfg(test)]
-pub(super) const NOWLEDGE_MEM_CLOUD_MCP_URL: &str = "https://mem.example.com/remote-api/mcp/";
+pub(super) const NOWLEDGE_MEM_CLOUD_MCP_URL: &str = "https://cloud.nowledge.co/remote-api/mcp/";
 
 const NOWLEDGE_MEM_PLUGIN_VERSION: &str = "0.1.29-rara.1";
 const NOWLEDGE_MEM_SKILL_ROOTS: &[(&str, &str)] = &[

--- a/src/plugin_middleware/tests.rs
+++ b/src/plugin_middleware/tests.rs
@@ -378,7 +378,7 @@ fn builtin_nowledge_mem_mcp_supports_cloud_auth_without_persisting_secrets() {
     let config = BuiltinPluginConfig {
         nowledge_mem: crate::config::NowledgeMemPluginConfig {
             mode: crate::config::NowledgeMemMode::Cloud,
-            url: "https://mem.example.com".to_string(),
+            url: "http://127.0.0.1:14242/mcp/".to_string(),
             api_key_env_var: "RARA_NMEM_API_KEY".to_string(),
             space_id_env_var: Some("RARA_NMEM_SPACE".to_string()),
             ..Default::default()

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -674,6 +674,8 @@ pub(crate) async fn dispatch_event(
                                     2 => {
                                         config.enabled = true;
                                         config.mode = crate::config::NowledgeMemMode::Cloud;
+                                        config.url = crate::config::DEFAULT_NOWLEDGE_MEM_CLOUD_URL
+                                            .to_string();
                                     }
                                     _ => return Ok(false),
                                 }

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -665,6 +665,8 @@ pub(crate) async fn dispatch_event(
                         ListPickerKind::NowledgeMem => {
                             let mode_label = {
                                 let config = &mut app.config.builtin_plugins.nowledge_mem;
+                                let was_cloud =
+                                    config.mode == crate::config::NowledgeMemMode::Cloud;
                                 match app.nowledge_mem_picker_idx {
                                     0 => config.enabled = false,
                                     1 => {
@@ -674,8 +676,11 @@ pub(crate) async fn dispatch_event(
                                     2 => {
                                         config.enabled = true;
                                         config.mode = crate::config::NowledgeMemMode::Cloud;
-                                        config.url = crate::config::DEFAULT_NOWLEDGE_MEM_CLOUD_URL
-                                            .to_string();
+                                        if !was_cloud {
+                                            config.url =
+                                                crate::config::DEFAULT_NOWLEDGE_MEM_CLOUD_URL
+                                                    .to_string();
+                                        }
                                     }
                                     _ => return Ok(false),
                                 }

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -269,7 +269,7 @@ impl ListPickerKind {
             ("Local", "Use the local loopback MCP endpoint."),
             (
                 "Cloud",
-                "Use the configured remote Mem server and env-backed auth.",
+                "Use https://cloud.nowledge.co with env-backed auth.",
             ),
         ]
         .into_iter()

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -838,6 +838,38 @@ async fn mem_picker_persists_selected_cloud_mode() {
     assert!(saved.contains("cloud"));
 }
 
+#[tokio::test]
+async fn mem_picker_preserves_existing_cloud_url() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.config.builtin_plugins.nowledge_mem.mode = crate::config::NowledgeMemMode::Cloud;
+    app.config.builtin_plugins.nowledge_mem.url = "https://custom.mem.example".to_string();
+    app.open_overlay(Overlay::ListPicker(ListPickerKind::NowledgeMem));
+    app.nowledge_mem_picker_idx = 2;
+
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = None;
+    dispatch_event(
+        AppEvent::ApplyOverlaySelection,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("apply memory mode selection");
+
+    assert_eq!(
+        app.config.builtin_plugins.nowledge_mem.url,
+        "https://custom.mem.example"
+    );
+}
+
 #[test]
 fn provider_picker_number_keys_cover_current_provider_families() {
     let temp = tempdir().expect("tempdir");

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -830,6 +830,10 @@ async fn mem_picker_persists_selected_cloud_mode() {
         app.config.builtin_plugins.nowledge_mem.mode,
         crate::config::NowledgeMemMode::Cloud
     );
+    assert_eq!(
+        app.config.builtin_plugins.nowledge_mem.url,
+        crate::config::DEFAULT_NOWLEDGE_MEM_CLOUD_URL
+    );
     let saved = std::fs::read_to_string(config_path).expect("saved config");
     assert!(saved.contains("cloud"));
 }


### PR DESCRIPTION
## Summary

- add `rara mem --api-key <key>` for configuring the builtin Nowledge Mem Cloud integration
- persist the API key using the existing secret configuration serialization
- restore the saved key into the runtime after restart without writing it to generated plugin files
- default Cloud traffic to `https://cloud.nowledge.co/remote-api/mcp/`
- keep `/mem` as the argument-free TUI mode picker

## Purpose

The previous CLI shape exposed a global memory flag and only configured the current process. This adds a semantic `mem` configuration subcommand and makes the saved Cloud credential take effect on subsequent RARA restarts.

## Related Issues

None.

## Testing

- `cargo fmt`
- `cargo test -p rara-config builtin_nowledge_mem_api_key_roundtrips_through_config -- --nocapture`
- `cargo test mem_api_key_cli_override_persists_cloud_configuration -- --nocapture`
- `cargo test -p rara-config builtin_nowledge_mem_cloud_mode_defaults_to_nowledge_cloud -- --nocapture`
- `git diff --check`
