### PR TITLE
feat(agent): define plugin capability policy

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -229,6 +229,9 @@ impl PromptSection {
 pub struct PromptRuntimeConfig {
     pub system_prompt: Option<String>,
     pub append_system_prompt: Option<String>,
+    /// Final child-session capability section, kept separate from append text
+    /// so runtime policy remains observable and ordered independently.
+    pub subagent_capability_policy: Option<String>,
     pub compact_prompt: Option<String>,
     pub protocol_prompt_sources: Vec<PromptSource>,
     pub available_skills: Vec<PromptSkillSummary>,
@@ -262,6 +265,7 @@ impl PromptRuntimeConfig {
         Self {
             system_prompt,
             append_system_prompt,
+            subagent_capability_policy: None,
             compact_prompt,
             protocol_prompt_sources: Vec::new(),
             available_skills: Vec::new(),
@@ -388,6 +392,10 @@ pub fn build_effective_prompt(
     if let Some(append) = &runtime.append_system_prompt {
         final_sections.push(append.clone());
         section_keys.push("append_system_prompt");
+    }
+    if let Some(policy) = &runtime.subagent_capability_policy {
+        final_sections.push(policy.clone());
+        section_keys.push("subagent_capability_policy");
     }
 
     EffectivePrompt {

--- a/crates/instructions/src/prompt/tests.rs
+++ b/crates/instructions/src/prompt/tests.rs
@@ -669,6 +669,7 @@ fn effective_prompt_reports_base_kind_and_active_sections() {
     let workspace = WorkspaceMemory::from_paths(root, rara_dir);
     let runtime = PromptRuntimeConfig {
         append_system_prompt: Some("tail".to_string()),
+        subagent_capability_policy: Some("policy".to_string()),
         ..Default::default()
     };
 
@@ -677,6 +678,12 @@ fn effective_prompt_reports_base_kind_and_active_sections() {
     assert!(effective.section_keys.contains(&"dynamic_boundary"));
     assert!(effective.section_keys.contains(&"runtime_context"));
     assert!(effective.section_keys.contains(&"append_system_prompt"));
+    assert!(
+        effective
+            .section_keys
+            .contains(&"subagent_capability_policy")
+    );
+    assert!(effective.text.ends_with("policy"));
     assert!(effective.text.contains(super::DYNAMIC_BOUNDARY));
     assert!(effective.dynamic_boundary_index.is_some());
 }

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -380,9 +380,10 @@ HTTP MCP connector must call this helper before constructing its HTTP client.
 
 The builtin subagent does not receive additional external execution authority.
 It is a registry-provided routing agent that can explain which Nowledge Mem
-skill, MCP tool, or CLI fallback the parent runtime should use. Opening direct
-MCP, shell, or skill invocation inside subagents is a separate tool-surface
-decision.
+skill, MCP tool, or CLI fallback the parent runtime should use. Every child
+runtime receives a default-deny `SubagentPluginCapabilityPolicy`; direct MCP,
+shell, or skill invocation inside subagents requires a later scoped executor
+and explicit capability allowlist.
 
 TUI displays this integration in the `/status` Overview Extensions section.
 The `/mem` configuration command opens a picker for Disabled, Local, or Cloud;

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -29,6 +29,7 @@ The effective prompt may draw from:
 - the default built-in prompt family;
 - a configured custom system prompt;
 - an optional append prompt;
+- an optional final subagent capability policy section;
 - workspace instruction files;
 - local memory files;
 - protocol-registered prompt sources routed through the runtime control plane;
@@ -52,6 +53,7 @@ The effective prompt is assembled in this order:
 4. runtime context;
 5. mode-specific addenda such as execute mode, plan mode, and review mode;
 6. append prompt.
+7. subagent capability policy section, when a child session is active.
 
 ### 3.1) Built-In Engineering Workflow Guidance
 

--- a/docs/features/subagent-claude-compat.md
+++ b/docs/features/subagent-claude-compat.md
@@ -212,6 +212,29 @@ Claude Code doesn't support task resume (`task_id`). RARA won't either
 for now — each `spawn_agent` creates a new session. This keeps
 compatibility with Claude Code semantics.
 
+### Plugin Capability Policy
+
+Subagents do not inherit the parent session's plugin authority implicitly.
+Runtime-owned child construction attaches a
+`SubagentPluginCapabilityPolicy` with these defaults:
+
+- plugin skill execution is denied;
+- MCP server and MCP tool execution are denied;
+- plugin memory read and write access are denied independently;
+- subagent delegation depth is limited to one.
+
+The policy is included as a separate final prompt section so the model has an
+honest description of its authority, but prompt text is not the enforcement
+boundary.
+Actual plugin skill and MCP execution will require scoped runtime executors in
+later slices. Until those executors exist, child tool managers must not expose
+those capabilities, and a child must not infer permission from the parent
+registry, credentials, or tool descriptions.
+
+This separates plugin skill guidance from MCP execution authority. A future
+allowlist may grant selected skills or MCP tools per agent definition, but
+memory reads and writes remain separate capabilities.
+
 ### Display
 
 TUI subagent sidebar shows:
@@ -231,3 +254,7 @@ TUI subagent sidebar shows:
 4. Add tool filtering to subagent spawning.
 5. Add `SubagentProgress` tracking.
 6. Update TUI subagent display.
+7. Attach the default-deny plugin capability policy to every child runtime.
+
+The remaining follow-up is to implement scoped plugin skill and MCP executors;
+this policy does not enable either execution path.

--- a/docs/journal/2026-08-01-subagent-plugin-capability-policy.md
+++ b/docs/journal/2026-08-01-subagent-plugin-capability-policy.md
@@ -1,0 +1,40 @@
+# Subagent Plugin Capability Policy
+
+## What Changed
+
+RARA now attaches a runtime-owned `SubagentPluginCapabilityPolicy` to every
+child subagent prompt as a separate final section. The policy denies plugin
+skill execution, MCP server and tool execution, and plugin memory reads and
+writes by default. It also records the maximum child delegation depth as one.
+
+## Why
+
+Plugin discovery and MCP registration belong to the app/runtime assembly layer.
+A child session must not acquire the parent session's plugin registry,
+credentials, or external execution authority merely because it was spawned.
+The policy makes this boundary explicit while leaving the existing subagent
+tool filtering unchanged.
+
+## Trade-offs
+
+The policy follows the existing RARA section pipeline, keeping the stable
+prompt prefix and making the capability section observable as
+`subagent_capability_policy`. It is descriptive and establishes the runtime
+contract; prompt text is not enforcement. Direct skill and MCP execution remain
+disabled until scoped runtime executors and explicit allowlists are
+implemented. Memory read and write capabilities are modeled separately so a
+future read-only Nowledge Mem integration does not implicitly grant persistence
+authority.
+
+## Verification
+
+- `cargo test subagent_plugin_capability_policy_defaults_to_deny -- --nocapture`
+- `cargo fmt --check`
+- `cargo clippy --package rara --tests -- -D warnings`
+- `git diff --check`
+
+## Follow-up
+
+Implement a runtime-owned scoped plugin skill executor first, then a read-only
+MCP executor. Add memory write capability only after lifecycle, provenance, and
+failure propagation are covered.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -78,9 +78,10 @@ Active backlog only. Keep this file small and current.
       overrides.
 - [x] Surface configured subagent provider/model targets in runtime status for
       agent definitions.
-- [ ] Decide whether subagents should receive direct plugin skill or MCP tool
-      access. Builtin plugin agent definitions are registered, but external
-      execution authority remains parent-owned.
+- [x] Define the default-deny policy for subagent plugin skill and MCP access.
+      Builtin plugin agent definitions remain registered, but external
+      execution authority remains parent-owned until scoped skill/MCP
+      executors are added.
 
 ## Shared Task Lists
 

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1369,6 +1369,7 @@ pub(crate) async fn run_sub_agent(
     sub.set_bash_approval_mode(permission_mode.bash_approval_mode(plan_required));
     sub.set_full_access_mode(permission_mode.full_access_mode(plan_required));
     sub.set_token_budget(token_budget);
+    let capability_policy = SubagentPluginCapabilityPolicy::default();
     let role_prompt = subagent_role_prompt(kind, definition);
     let appended_prompt = match definition
         .map(|d| d.system_prompt.trim())
@@ -1377,7 +1378,9 @@ pub(crate) async fn run_sub_agent(
         Some(system_prompt) => format!("{role_prompt}\n\n{system_prompt}"),
         None => role_prompt,
     };
-    sub.set_prompt_config(append_subagent_prompt(prompt_config, &appended_prompt));
+    let mut prompt_config = append_subagent_prompt(prompt_config, &appended_prompt);
+    prompt_config.subagent_capability_policy = Some(capability_policy.prompt_instructions());
+    sub.set_prompt_config(prompt_config);
     sub.task_list_id = task_list_id;
 
     let def_max_turns = definition

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -1,3 +1,68 @@
+/// Runtime capability boundary for plugin-backed sub-agent execution.
+///
+/// The default policy is intentionally deny-by-default. Plugin skills and MCP
+/// execution will be enabled only after their runtime-owned scoped executors
+/// exist; defining the boundary here prevents child sessions from inheriting
+/// the parent's plugin authority implicitly.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubagentPluginCapabilityPolicy {
+    pub plugin_skills: Vec<String>,
+    pub mcp_servers: Vec<String>,
+    pub mcp_tools: Vec<String>,
+    pub allow_memory_read: bool,
+    pub allow_memory_write: bool,
+    pub max_depth: u8,
+}
+
+impl Default for SubagentPluginCapabilityPolicy {
+    fn default() -> Self {
+        Self {
+            plugin_skills: Vec::new(),
+            mcp_servers: Vec::new(),
+            mcp_tools: Vec::new(),
+            allow_memory_read: false,
+            allow_memory_write: false,
+            max_depth: 1,
+        }
+    }
+}
+
+impl SubagentPluginCapabilityPolicy {
+    pub fn prompt_instructions(&self) -> String {
+        let format_allowlist = |items: &[String]| {
+            if items.is_empty() {
+                "denied".to_string()
+            } else {
+                format!("allowlisted: [{}]", items.join(", "))
+            }
+        };
+        let skills = format_allowlist(&self.plugin_skills);
+        let mcp_servers = format_allowlist(&self.mcp_servers);
+        let mcp_tools = format_allowlist(&self.mcp_tools);
+        format!(
+            "## Plugin Capability Policy\n\
+- Direct plugin skill execution: {skills}.\n\
+- Direct MCP server access: {mcp_servers}.\n\
+- Direct MCP tool execution: {mcp_tools}.\n\
+- Plugin memory read access: {}.\n\
+- Plugin memory write access: {}.\n\
+- Maximum sub-agent delegation depth: {}.\n\
+- Do not infer additional plugin authority from the parent session or tool descriptions.",
+            if self.allow_memory_read {
+                "allowed"
+            } else {
+                "denied"
+            },
+            if self.allow_memory_write {
+                "allowed"
+            } else {
+                "denied"
+            },
+            self.max_depth,
+        )
+    }
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentDefinition {

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -33,7 +33,7 @@ use crate::tasklist::{DEFAULT_TASK_LIST_ID, TaskListStore};
 use crate::thread_store::{ThreadMetadataSource, ThreadStore};
 use crate::tools::agent::{
     AgentTool, ExploreAgentTool, PlanAgentTool, SubAgentListTool, SubAgentResumeTool,
-    SubAgentStopTool, TeamCreateTool,
+    SubAgentStopTool, SubagentPluginCapabilityPolicy, TeamCreateTool,
 };
 use crate::workspace::WorkspaceMemory;
 
@@ -408,6 +408,38 @@ fn append_subagent_prompt_preserves_existing_append_prompt() {
         updated.append_system_prompt.as_deref(),
         Some("existing tail\n\nsub-agent")
     );
+}
+
+#[test]
+fn subagent_plugin_capability_policy_defaults_to_deny() {
+    let policy = SubagentPluginCapabilityPolicy::default();
+
+    assert!(policy.plugin_skills.is_empty());
+    assert!(policy.mcp_servers.is_empty());
+    assert!(policy.mcp_tools.is_empty());
+    assert!(!policy.allow_memory_read);
+    assert!(!policy.allow_memory_write);
+    assert_eq!(policy.max_depth, 1);
+    let prompt = policy.prompt_instructions();
+    assert!(prompt.contains("Direct MCP server access: denied."));
+    assert!(prompt.contains("Direct MCP tool execution: denied."));
+}
+
+#[test]
+fn subagent_plugin_capability_policy_renders_explicit_allowlists() {
+    let policy = SubagentPluginCapabilityPolicy {
+        plugin_skills: vec!["nowledge-mem:search-memory".into()],
+        mcp_servers: vec!["nowledge-mem".into()],
+        mcp_tools: vec!["memory_search".into()],
+        allow_memory_read: true,
+        ..Default::default()
+    };
+
+    let prompt = policy.prompt_instructions();
+    assert!(prompt.contains("allowlisted: [nowledge-mem:search-memory]"));
+    assert!(prompt.contains("allowlisted: [nowledge-mem]"));
+    assert!(prompt.contains("allowlisted: [memory_search]"));
+    assert!(prompt.contains("Plugin memory read access: allowed."));
 }
 
 #[test]
@@ -1038,6 +1070,14 @@ Custom reviewer prompt from workspace definition.
     assert!(!system_prompt.contains("You do not have repository"));
     assert!(!system_prompt.contains("answer only from the provided instruction/context"));
     assert!(system_prompt.contains("Custom reviewer prompt from workspace definition."));
+    assert!(
+        system_prompt
+            .find("## Plugin Capability Policy")
+            .expect("capability policy")
+            > system_prompt
+                .find("Custom reviewer prompt from workspace definition.")
+                .expect("custom prompt")
+    );
 
     let mut tool_names = request.tool_names.clone();
     tool_names.sort();


### PR DESCRIPTION
## Summary

- Add a runtime-owned `SubagentPluginCapabilityPolicy` for child sessions.
- Make plugin skills, MCP servers/tools, and memory read/write access deny-by-default.
- Attach the policy to every subagent prompt without granting direct plugin execution.
- Document the boundary and the follow-up scoped executor work.

## Motivation

Subagents must not inherit plugin registries, credentials, or external execution authority from the parent session implicitly. The policy separates plugin skill guidance from MCP execution authority and keeps memory reads and writes as independent capabilities.

## Related Issue

None.

## Validation

- `cargo test subagent_plugin_capability_policy_defaults_to_deny -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --package rara --tests -- -D warnings`
- `git diff --check`

## Follow-up

Implement scoped runtime-owned plugin skill and read-only MCP executors before enabling any non-default capability.
