### PR TITLE
feat(runtime): introduce session runtime client

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -1,0 +1,56 @@
+# Session Runtime Client
+
+## Contract
+
+RARA owns one runtime execution graph per interactive session. The graph
+contains the `Agent`, goal handle, MCP and LSP managers, hook and skill
+registries, prompt registries, sandbox state, and the runtime event bus.
+
+`RuntimeClient` is the session-scoped ownership boundary for that graph. The
+CLI constructs it from `RuntimeBootstrap` and passes the client to the TUI.
+The TUI must not receive the bootstrap parts as independent arguments or
+construct a second registry set.
+
+The intended surface is:
+
+- TUI submits typed runtime commands through the client;
+- runtime execution publishes typed events and snapshots;
+- TUI keeps only presentation state and local interaction state;
+- runtime completion, continuation, rebuild, and persistence remain runtime
+  responsibilities.
+
+## Current Migration Slice
+
+The first slice establishes session ownership and removes the wide bootstrap
+argument list from `run_tui`. `TuiMaintainer` owns the client while `TuiApp`
+continues to hold compatibility projections used by the existing command and
+renderer modules. Those projections are not authoritative runtime state and
+must be removed as command handling moves behind the client boundary.
+
+Runtime task events are now awaited directly in the TUI event loop. A runtime
+event wakes the loop immediately; the 166 ms timer remains only for periodic
+UI work such as autoscroll, shared-task polling, and heartbeat display.
+
+## Ownership Rules
+
+1. A session has one `RuntimeClient` and one runtime registry graph.
+2. TUI code may retain immutable handles needed to render a compatibility
+   projection, but it must not discover plugins, register hooks, rebuild the
+   runtime, or mutate the runtime registry directly.
+3. Runtime commands and events must carry session identity when they cross a
+   transport boundary.
+4. Completion logic belongs to the runtime command processor. TUI completion
+   handling is a migration compatibility layer and must not become a second
+   goal or plan state machine.
+5. Snapshot hydration and live events must have an explicit ordering contract;
+   a late snapshot must not overwrite newer live state.
+
+## Follow-up
+
+- Replace compatibility projections in `TuiApp` with a typed runtime snapshot.
+- Move query, approval, compact, rebuild, and model-list actions to typed
+  `RuntimeCommand` submission.
+- Publish a TUI-facing typed projection event instead of converting
+  `AgentEvent` into role/message strings and parsing those strings again.
+- Move goal continuation, plan completion, agent replacement, and queued
+  execution into the runtime command processor.

--- a/docs/journal/2026-08-01-runtime-client-boundary.md
+++ b/docs/journal/2026-08-01-runtime-client-boundary.md
@@ -1,0 +1,38 @@
+# Runtime Client Boundary
+
+## What changed
+
+Added a session-scoped `RuntimeClient` created from `RuntimeBootstrap`. It owns
+the session Agent and runtime handles for goal, MCP, LSP, hooks, skills,
+prompts, sandbox state, and the event bus. `run_tui` now receives one client
+instead of a long list of independent runtime objects.
+
+`TuiMaintainer` owns the client alongside presentation state. Agent task
+events are awaited directly from the event loop's `tokio::select!`; the timer
+is no longer the mechanism that wakes the TUI for agent output.
+
+## Why
+
+Passing bootstrap parts directly to a presentation surface made ownership
+ambiguous and allowed TUI state to become a second runtime orchestrator. The
+client creates one explicit session boundary while keeping the existing
+runtime behavior available during migration.
+
+## Trade-offs
+
+The current slice retains compatibility projections in `TuiApp` and legacy
+task completion code. They are still transitional and are not the target
+architecture. Moving them requires typed command and snapshot contracts so
+goal and plan state do not get duplicated between runtime and TUI.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- `cargo test --bin rara tui::runtime::events --no-fail-fast`
+
+## Remaining work
+
+Move command submission and completion orchestration behind `RuntimeClient`,
+then replace the role/message compatibility path with typed runtime
+projection events and snapshots.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -19,6 +19,13 @@ Active backlog only. Keep this file small and current.
 
 ## TUI / UX
 
+- [ ] Complete the session-scoped `RuntimeClient` migration: route typed
+      commands and runtime snapshots/events through the client, then remove
+      runtime registries and completion orchestration from `TuiApp`.
+- [ ] Replace the local `AgentEvent -> role/message -> parser` compatibility
+      path with a typed TUI projection event carrying session and sequence
+      identity.
+
 - [x] Keep `rara-file-search` as the shared backend for TUI file suggestions
       and `list_files`; keep automatic retrieval as optional low-priority
       paths-only `RetrievalCandidate` / `MemorySelection` input.

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -517,36 +517,12 @@ async fn run_tui_command(
         .await?
     };
     emit_bootstrap_warnings(&bootstrap.warnings);
-    let event_bus = bootstrap.event_bus.clone();
-    let (
-        agent,
-        _warnings,
-        sandbox_network_access,
-        goal_handle,
-        mcp_tool_cache,
-        mcp_manager,
-        prompt_source_registry,
-        skill_source_registry,
-        hook_registry,
-        hook_runtime,
-        lsp_manager,
-    ) = bootstrap.into_parts_with_runtime_extensions().await;
+    let runtime_client = crate::runtime_client::RuntimeClient::from_bootstrap(bootstrap).await;
     let resumed_thread_id = crate::tui::run_tui(
-        agent,
-        goal_handle,
-        mcp_tool_cache,
+        runtime_client,
         oauth_manager,
         startup_resume,
-        sandbox_network_access,
-        event_bus,
-        mcp_manager,
-        prompt_source_registry,
-        skill_source_registry,
-        hook_registry,
-        hook_runtime,
-        lsp_manager,
         initialize_local_embeddings,
-        plugin_dirs,
     )
     .await?;
     if let Some(thread_id) = resumed_thread_id {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,7 @@ mod plugin_middleware;
 mod print_consumer;
 mod prompt;
 mod protocol_sources;
+mod runtime_client;
 mod runtime_context;
 mod runtime_control;
 mod runtime_event_bus;

--- a/src/runtime_client.rs
+++ b/src/runtime_client.rs
@@ -38,20 +38,22 @@ impl RuntimeClient {
     /// Convert a fully bootstrapped runtime into a session-owned client.
     pub(crate) async fn from_bootstrap(bootstrap: RuntimeBootstrap) -> Self {
         let event_bus = bootstrap.event_bus.clone();
-        let explicit_plugin_dirs = bootstrap.plugin_dirs_for_client();
         let (
-            agent,
-            _warnings,
-            sandbox_network_access,
-            goal_handle,
-            mcp_tool_cache,
-            mcp_manager,
-            prompt_source_registry,
-            skill_source_registry,
-            hook_registry,
-            hook_runtime,
-            lsp_manager,
-        ) = bootstrap.into_parts_with_runtime_extensions().await;
+            (
+                agent,
+                _warnings,
+                sandbox_network_access,
+                goal_handle,
+                mcp_tool_cache,
+                mcp_manager,
+                prompt_source_registry,
+                skill_source_registry,
+                hook_registry,
+                hook_runtime,
+                lsp_manager,
+            ),
+            explicit_plugin_dirs,
+        ) = bootstrap.into_runtime_client_parts().await;
         Self {
             agent: Some(agent),
             goal_handle,

--- a/src/runtime_client.rs
+++ b/src/runtime_client.rs
@@ -1,0 +1,78 @@
+//! Session-scoped runtime ownership for presentation surfaces.
+//!
+//! A runtime client owns the execution objects for one session. Presentation
+//! surfaces may retain this client and submit commands through its API, but
+//! they must not construct or own the underlying registries independently.
+
+use std::path::PathBuf;
+use std::sync::{Arc, atomic::AtomicBool};
+
+use crate::agent::Agent;
+use crate::hook_registry::HookRegistry;
+use crate::hook_runtime::HookRuntime;
+use crate::lsp_manager::LspManager;
+use crate::mcp_connection_manager::McpConnectionManager;
+use crate::mcp_tool_cache::McpToolCache;
+use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
+use crate::runtime_context::RuntimeBootstrap;
+use crate::runtime_event_bus::RuntimeEventBus;
+use crate::tui::state::GoalHandle;
+
+/// Runtime objects owned by one interactive session.
+pub(crate) struct RuntimeClient {
+    agent: Option<Agent>,
+    pub(crate) goal_handle: GoalHandle,
+    pub(crate) mcp_tool_cache: McpToolCache,
+    pub(crate) mcp_manager: Arc<McpConnectionManager>,
+    pub(crate) prompt_source_registry: Arc<PromptSourceRegistry>,
+    pub(crate) skill_source_registry: Arc<SkillSourceRegistry>,
+    pub(crate) hook_registry: Arc<HookRegistry>,
+    pub(crate) hook_runtime: Arc<HookRuntime>,
+    pub(crate) lsp_manager: Arc<LspManager>,
+    pub(crate) sandbox_network_access: Arc<AtomicBool>,
+    pub(crate) event_bus: Arc<RuntimeEventBus>,
+    pub(crate) explicit_plugin_dirs: Vec<PathBuf>,
+}
+
+impl RuntimeClient {
+    /// Convert a fully bootstrapped runtime into a session-owned client.
+    pub(crate) async fn from_bootstrap(bootstrap: RuntimeBootstrap) -> Self {
+        let event_bus = bootstrap.event_bus.clone();
+        let explicit_plugin_dirs = bootstrap.plugin_dirs_for_client();
+        let (
+            agent,
+            _warnings,
+            sandbox_network_access,
+            goal_handle,
+            mcp_tool_cache,
+            mcp_manager,
+            prompt_source_registry,
+            skill_source_registry,
+            hook_registry,
+            hook_runtime,
+            lsp_manager,
+        ) = bootstrap.into_parts_with_runtime_extensions().await;
+        Self {
+            agent: Some(agent),
+            goal_handle,
+            mcp_tool_cache,
+            mcp_manager,
+            prompt_source_registry,
+            skill_source_registry,
+            hook_registry,
+            hook_runtime,
+            lsp_manager,
+            sandbox_network_access,
+            event_bus,
+            explicit_plugin_dirs,
+        }
+    }
+
+    pub(crate) fn agent(&self) -> Option<&Agent> {
+        self.agent.as_ref()
+    }
+
+    pub(crate) fn agent_mut(&mut self) -> &mut Option<Agent> {
+        &mut self.agent
+    }
+}

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -71,12 +71,6 @@ pub(crate) struct RuntimeBootstrap {
     builtin_plugins: BuiltinPluginConfig,
 }
 
-impl RuntimeBootstrap {
-    pub(crate) fn plugin_dirs_for_client(&self) -> Vec<PathBuf> {
-        self.plugin_dirs.clone()
-    }
-}
-
 #[derive(Clone)]
 pub(crate) struct ConfigSubagentBackendResolver {
     config: Arc<RaraConfig>,
@@ -217,6 +211,53 @@ impl RuntimeBootstrap {
     ) {
         let workspace_root = self.workspace.root.clone();
         let plugin_dirs = self.plugin_dirs.clone();
+        self.into_parts_with_runtime_extensions_for_plugin_dirs(&workspace_root, &plugin_dirs)
+            .await
+    }
+
+    pub(crate) async fn into_runtime_client_parts(
+        mut self,
+    ) -> (
+        (
+            Agent,
+            Vec<String>,
+            Arc<AtomicBool>,
+            GoalHandle,
+            McpToolCache,
+            Arc<McpConnectionManager>,
+            Arc<PromptSourceRegistry>,
+            Arc<SkillSourceRegistry>,
+            Arc<HookRegistry>,
+            Arc<HookRuntime>,
+            Arc<LspManager>,
+        ),
+        Vec<PathBuf>,
+    ) {
+        let plugin_dirs = std::mem::take(&mut self.plugin_dirs);
+        let workspace_root = self.workspace.root.clone();
+        let parts = self
+            .into_parts_with_runtime_extensions_for_plugin_dirs(&workspace_root, &plugin_dirs)
+            .await;
+        (parts, plugin_dirs)
+    }
+
+    async fn into_parts_with_runtime_extensions_for_plugin_dirs(
+        self,
+        workspace_root: &Path,
+        plugin_dirs: &[PathBuf],
+    ) -> (
+        Agent,
+        Vec<String>,
+        Arc<AtomicBool>,
+        GoalHandle,
+        McpToolCache,
+        Arc<McpConnectionManager>,
+        Arc<PromptSourceRegistry>,
+        Arc<SkillSourceRegistry>,
+        Arc<HookRegistry>,
+        Arc<HookRuntime>,
+        Arc<LspManager>,
+    ) {
         let rara_home = self.rara_home.clone();
         let builtin_plugins = self.builtin_plugins.clone();
         let hook_runtime = self.hook_runtime.clone();
@@ -226,8 +267,8 @@ impl RuntimeBootstrap {
         let plugin_hook_runtime = crate::plugin_middleware::register_plugin_hooks(
             &hook_runtime,
             rara_home,
-            &workspace_root,
-            &plugin_dirs,
+            workspace_root,
+            plugin_dirs,
             &builtin_plugins,
             &parts.0.session_id,
         )

--- a/src/runtime_context.rs
+++ b/src/runtime_context.rs
@@ -71,6 +71,12 @@ pub(crate) struct RuntimeBootstrap {
     builtin_plugins: BuiltinPluginConfig,
 }
 
+impl RuntimeBootstrap {
+    pub(crate) fn plugin_dirs_for_client(&self) -> Vec<PathBuf> {
+        self.plugin_dirs.clone()
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct ConfigSubagentBackendResolver {
     config: Arc<RaraConfig>,

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 
 use crossterm::{event::EventStream, terminal::enable_raw_mode, terminal::size as terminal_size};
 use futures::StreamExt;
@@ -12,7 +11,6 @@ use super::event_stream::{UiEvent, translate_event};
 use super::maintainer::TuiMaintainer;
 use super::render::{desired_viewport_height, render};
 use super::session_restore::{restore_latest_thread, restore_thread_by_id};
-use super::state::GoalHandle;
 use super::state::ListPickerKind;
 use super::state::Overlay;
 use super::state::TuiApp;
@@ -20,10 +18,8 @@ use super::submit::clamp_command_palette_selection;
 use super::terminal_ui::{
     build_terminal, handle_paste, teardown_terminal, update_terminal_viewport,
 };
-use crate::agent::Agent;
-use crate::mcp_tool_cache::McpToolCache;
 use crate::oauth::OAuthManager;
-use crate::runtime_event_bus::RuntimeEventBus;
+use crate::runtime_client::RuntimeClient;
 
 #[derive(Debug, Clone)]
 pub enum StartupResumeTarget {
@@ -38,45 +34,31 @@ use crate::lsp_manager::LspManager;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 
-#[allow(clippy::too_many_arguments)]
-// TUI startup is the boundary where RuntimeBootstrap handles are handed to the
-// terminal loop; keeping them explicit avoids hidden global state.
 pub async fn run_tui(
-    agent: Agent,
-    goal_handle: GoalHandle,
-    mcp_tool_cache: McpToolCache,
+    runtime: RuntimeClient,
     oauth_manager: OAuthManager,
     startup_resume: StartupResumeTarget,
-    sandbox_network_access: Arc<AtomicBool>,
-    event_bus: Arc<RuntimeEventBus>,
-    mcp_manager: Arc<McpConnectionManager>,
-    prompt_source_registry: Arc<PromptSourceRegistry>,
-    skill_source_registry: Arc<SkillSourceRegistry>,
-    hook_registry: Arc<crate::hook_registry::HookRegistry>,
-    hook_runtime: Arc<crate::hook_runtime::HookRuntime>,
-    lsp_manager: Arc<LspManager>,
     initialize_local_embeddings: bool,
-    explicit_plugin_dirs: Vec<PathBuf>,
 ) -> anyhow::Result<Option<String>> {
     enable_raw_mode()?;
     let initial_size = terminal_size()?;
     let mut app = TuiApp::new(crate::config::ConfigManager::new()?)?;
-    app.goal_handle = goal_handle;
-    app.goal = app.goal_handle.read().unwrap().clone();
-    app.mcp_tool_cache = Some(mcp_tool_cache);
-    app.sandbox_network_access = sandbox_network_access;
-    app.event_bus = Some(event_bus.clone());
-    app.mcp_manager = Some(mcp_manager);
-    app.prompt_source_registry = Some(prompt_source_registry);
-    app.skill_source_registry = Some(skill_source_registry);
-    app.hook_registry = Some(hook_registry);
-    app.hook_runtime = Some(hook_runtime);
-    app.explicit_plugin_dirs = explicit_plugin_dirs;
-    app.lsp_manager = Some(lsp_manager);
+    app.goal_handle = runtime.goal_handle.clone();
+    app.goal = runtime.goal_handle.read().unwrap().clone();
+    app.mcp_tool_cache = Some(runtime.mcp_tool_cache.clone());
+    app.sandbox_network_access = runtime.sandbox_network_access.clone();
+    app.event_bus = Some(runtime.event_bus.clone());
+    app.mcp_manager = Some(runtime.mcp_manager.clone());
+    app.prompt_source_registry = Some(runtime.prompt_source_registry.clone());
+    app.skill_source_registry = Some(runtime.skill_source_registry.clone());
+    app.hook_registry = Some(runtime.hook_registry.clone());
+    app.hook_runtime = Some(runtime.hook_runtime.clone());
+    app.explicit_plugin_dirs = runtime.explicit_plugin_dirs.clone();
+    app.lsp_manager = Some(runtime.lsp_manager.clone());
     app.memory_handler = Some(Arc::new(
         crate::protocol_sources::MemoryControlHandler::with_store(
-            event_bus,
-            agent.memory_store.clone(),
+            runtime.event_bus.clone(),
+            runtime.agent().expect("runtime agent").memory_store.clone(),
         ),
     ));
     app.sandbox_network_access
@@ -84,7 +66,7 @@ pub async fn run_tui(
     app.terminal_width = initial_size.0;
     let viewport_height = desired_viewport_height(&app, initial_size.0, initial_size.1);
     let mut terminal = build_terminal(viewport_height)?;
-    let mut maintainer = TuiMaintainer::new(app, Some(agent));
+    let mut maintainer = TuiMaintainer::new(app, runtime);
     match StateDb::new() {
         Ok(state_db) => {
             let state_db = Arc::new(state_db);
@@ -134,36 +116,46 @@ pub async fn run_tui(
         maintainer.poll_repo_context().await;
         maintainer.poll_agent_task().await?;
 
-        let needs_redraw = maintainer.needs_redraw;
-        let (app, agent_slot) = maintainer.split_mut();
-        let mut needs_redraw = needs_redraw;
-        clamp_command_palette_selection(app);
-        let size = terminal_size()?;
-        app.terminal_width = size.0;
-        let desired_height = desired_viewport_height(app, size.0, size.1);
-        match update_terminal_viewport(&mut terminal, desired_height, app) {
-            Ok(()) => {}
-            Err(err) => app.push_notice(format!("Skipped viewport update: {err}")),
-        }
+        let mut needs_redraw = maintainer.needs_redraw;
+        {
+            let app = maintainer.app_mut();
+            clamp_command_palette_selection(app);
+            let size = terminal_size()?;
+            app.terminal_width = size.0;
+            let desired_height = desired_viewport_height(app, size.0, size.1);
+            match update_terminal_viewport(&mut terminal, desired_height, app) {
+                Ok(()) => {}
+                Err(err) => app.push_notice(format!("Skipped viewport update: {err}")),
+            }
 
-        if needs_redraw {
-            terminal.draw(|f| render(f, app))?;
-            needs_redraw = false;
-        }
-        // Flush any buffered paste burst before next event poll
-        if app.bottom_pane.check_paste_burst_flush() {
-            needs_redraw = true;
+            if needs_redraw {
+                terminal.draw(|f| render(f, app))?;
+                needs_redraw = false;
+            }
+            if app.bottom_pane.check_paste_burst_flush() {
+                needs_redraw = true;
+            }
         }
 
         tokio::select! {
             _ = tick.tick() => {
+                let app = maintainer.app_mut();
                 if let Some(delta) = app.transcript_selection.autoscroll_delta() {
                     app.scroll_transcript(delta);
                 }
                 let _ = app.poll_shared_task_files();
                 needs_redraw = true;
             }
+            maybe_agent_event = maintainer.wait_for_agent_event() => {
+                if let Some(event) = maybe_agent_event {
+                    maintainer.apply_agent_event(event);
+                } else {
+                    maintainer.poll_agent_task().await?;
+                }
+                needs_redraw = true;
+            }
             maybe_event = events.next() => {
+                let (app, agent_slot) = maintainer.split_mut();
                 match maybe_event {
                     Some(Ok(event)) => match translate_event(event, app) {
                         Some(UiEvent::App(event)) => {
@@ -207,8 +199,6 @@ pub async fn run_tui(
                 }
             }
         }
-        let _ = agent_slot;
-        let _ = app;
         maintainer.needs_redraw = needs_redraw;
     };
     if let Some(handle) = maintainer.app_mut().repo_context_task.take() {

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -29,11 +29,6 @@ pub enum StartupResumeTarget {
     Picker,
 }
 
-use crate::hook_registry::HookRegistry;
-use crate::lsp_manager::LspManager;
-use crate::mcp_connection_manager::McpConnectionManager;
-use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
-
 pub async fn run_tui(
     runtime: RuntimeClient,
     oauth_manager: OAuthManager,

--- a/src/tui/maintainer.rs
+++ b/src/tui/maintainer.rs
@@ -65,7 +65,7 @@ impl TuiMaintainer {
         let Some(task) = self.app.bottom_pane.running_task.as_mut() else {
             std::future::pending().await
         };
-        task.receiver.recv().await
+        receive_agent_event(&mut task.receiver).await
     }
 
     pub(super) fn apply_agent_event(&mut self, event: TuiEvent) {
@@ -89,5 +89,37 @@ impl TuiMaintainer {
     /// Poll and finish repo context task if ready.
     pub(super) async fn poll_repo_context(&mut self) {
         self.app.finish_repo_context_task_if_ready().await;
+    }
+}
+
+async fn receive_agent_event(
+    receiver: &mut tokio::sync::mpsc::UnboundedReceiver<TuiEvent>,
+) -> Option<TuiEvent> {
+    receiver.recv().await
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+
+    use super::receive_agent_event;
+    use crate::tui::state::TuiEvent;
+
+    #[tokio::test]
+    async fn agent_event_receiver_wakes_on_event_and_reports_closure() {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let waiter = tokio::spawn(async move { receive_agent_event(&mut receiver).await });
+        sender
+            .send(TuiEvent::Transcript {
+                role: "Status",
+                message: "ready".into(),
+            })
+            .expect("send event");
+        let event = waiter.await.expect("waiter").expect("event");
+        assert!(matches!(event, TuiEvent::Transcript { message, .. } if message == "ready"));
+
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        drop(sender);
+        assert!(receive_agent_event(&mut receiver).await.is_none());
     }
 }

--- a/src/tui/maintainer.rs
+++ b/src/tui/maintainer.rs
@@ -7,22 +7,23 @@
 //! This is an incremental extraction of the apply logic already present in
 //! `finish_running_task_if_ready` / `apply_tui_event`; no behavior change.
 
-use super::state::TuiApp;
+use super::state::{TuiApp, TuiEvent};
 use crate::agent::Agent;
+use crate::runtime_client::RuntimeClient;
 
 /// Owns all TUI render state and applies agent-output events to it.
 pub(super) struct TuiMaintainer {
     app: TuiApp,
-    agent: Option<Agent>,
+    runtime: RuntimeClient,
     /// Set to true every time an event is applied and the screen should repaint.
     pub(super) needs_redraw: bool,
 }
 
 impl TuiMaintainer {
-    pub(super) fn new(app: TuiApp, agent: Option<Agent>) -> Self {
+    pub(super) fn new(app: TuiApp, runtime: RuntimeClient) -> Self {
         Self {
             app,
-            agent,
+            runtime,
             needs_redraw: true,
         }
     }
@@ -36,29 +37,47 @@ impl TuiMaintainer {
     }
 
     pub(super) fn agent(&self) -> Option<&Agent> {
-        self.agent.as_ref()
+        self.runtime.agent()
     }
 
     /// Split borrow so callers that need independent `&mut TuiApp` and
     /// `&mut Option<Agent>` can still use them while the maintainer
     /// owns both.
     pub(super) fn split_mut(&mut self) -> (&mut TuiApp, &mut Option<Agent>) {
-        (&mut self.app, &mut self.agent)
+        (&mut self.app, self.runtime.agent_mut())
     }
 
     /// Drain pending agent events from the running task, apply them, and
     /// finalize the task if it has completed.
     pub(super) async fn poll_agent_task(&mut self) -> anyhow::Result<()> {
         // Delegate to the existing logic; move it to TuiMaintainer in the next commit.
-        super::runtime::tasks::finish_running_task_if_ready(&mut self.app, &mut self.agent).await?;
+        super::runtime::tasks::finish_running_task_if_ready(
+            &mut self.app,
+            self.runtime.agent_mut(),
+        )
+        .await?;
         self.needs_redraw = true;
         Ok(())
     }
 
+    /// Wait for the next runtime event without a timer-driven try-receive.
+    pub(super) async fn wait_for_agent_event(&mut self) -> Option<TuiEvent> {
+        let Some(task) = self.app.bottom_pane.running_task.as_mut() else {
+            std::future::pending().await
+        };
+        task.receiver.recv().await
+    }
+
+    pub(super) fn apply_agent_event(&mut self, event: TuiEvent) {
+        super::runtime::apply_tui_event(&mut self.app, event);
+        self.needs_redraw = true;
+    }
+
     /// Sync snapshot from the active agent (must be called at the top of the event loop).
     pub(super) fn sync_snapshot(&mut self) {
-        if let Some(agent_ref) = self.agent.as_ref() {
-            self.app.sync_snapshot(agent_ref);
+        let (app, runtime) = (&mut self.app, &self.runtime);
+        if let Some(agent_ref) = runtime.agent() {
+            app.sync_snapshot(agent_ref);
         }
     }
 

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -1,6 +1,7 @@
 mod commands;
 pub(crate) use commands::apply_permission_mode;
 mod events;
+pub(super) use events::apply_tui_event;
 pub(super) mod tasks;
 
 use std::sync::Arc;

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -26,7 +26,7 @@ use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
 const TOOL_PROGRESS_LINE_LIMIT: usize = 16;
 const MEMORY_QUERY_PREVIEW_LIMIT: usize = 120;
 
-pub(super) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
+pub(crate) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
     match event {
         TuiEvent::Transcript { role, message } => {
             if role == "Status" {


### PR DESCRIPTION
## Summary

- Introduce a session-scoped `RuntimeClient` as the ownership boundary for Agent and runtime registries.
- Pass one runtime client into `run_tui` instead of independent bootstrap handles.
- Keep runtime ownership in `TuiMaintainer`, outside `TuiApp` construction.
- Wake the TUI directly from agent task events through `tokio::select!`; retain the timer only for periodic UI work.
- Add the runtime-client architecture spec, journal, and follow-up TODOs.

## Motivation

The local TUI was receiving Agent, goal, MCP, LSP, hook, skill, and event-bus objects independently, which made the presentation layer look like the runtime owner. Agent output also depended on a 166 ms tick before the TUI tried to receive it. This change establishes the session boundary and removes the timer from the agent-event wake-up path.

## Related Issues

None.

## Validation

- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo clippy --bin rara --tests -- -D warnings`
- `cargo test --bin rara tui::runtime::events --no-fail-fast`

The focused runtime event suite passed with 67 tests.

## Follow-up

The compatibility projection fields in `TuiApp`, typed `RuntimeCommand` submission, runtime-owned completion orchestration, and typed snapshot/projection events remain explicitly tracked in `docs/todo.md`.
