### PR TITLE
feat(tui): consume structured runtime events

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -31,6 +31,12 @@ Runtime task events are now awaited directly in the TUI event loop. A runtime
 event wakes the loop immediately; the 166 ms timer remains only for periodic
 UI work such as autoscroll, shared-task polling, and heartbeat display.
 
+Runtime-to-TUI task delivery uses `RuntimeControlEvent` directly. The TUI
+matches `RuntimeEvent` variants for assistant, tool, memory, todo, warning,
+and error behavior; it does not infer those semantics from transcript roles or
+formatted message text. `Transcript` remains only for presentation-only
+progress such as OAuth and model download messages.
+
 The lifecycle slice is now runtime-owned as well. Goal token accounting,
 completion evaluation, continuation prompt construction, plan continuation
 decisions, rebuilt-agent continuity merging, and runtime persistence helpers

--- a/docs/journal/2026-08-01-structured-tui-events.md
+++ b/docs/journal/2026-08-01-structured-tui-events.md
@@ -1,0 +1,40 @@
+# Structured TUI Runtime Events
+
+## What changed
+
+Query, compact, and review task callbacks now deliver `RuntimeControlEvent`
+values directly to the TUI task channel. The TUI consumes structured
+`RuntimeEvent` variants for assistant output, tool lifecycle, memory notices,
+todo updates, warnings, and errors.
+
+The old AgentEvent-to-role/message conversion remains only as a test adapter
+for legacy renderer tests. Runtime task production no longer uses it to derive
+TUI semantics. OAuth and model-download progress continue to use transcript
+events because those messages are presentation-only status.
+
+## Why
+
+Formatted transcript messages are a lossy compatibility surface. Parsing their
+roles and prefixes in the TUI duplicated runtime semantics and made changes to
+tool output formatting capable of changing behavior. RuntimeControlEvent
+already carries the typed event family, provenance, and sequence identity, so
+the TUI should consume that contract directly.
+
+## Trade-offs
+
+Tool result payloads may still contain user-visible delegated-agent text whose
+content must be interpreted for request-input display. This parsing is scoped
+to the typed `ToolEvent::Result` payload and is not a role/message dispatch
+mechanism.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- `cargo test --bin rara tui::runtime::events --no-fail-fast`
+- `git diff --check`
+
+## Remaining work
+
+Remove the legacy test-only AgentEvent adapter after the renderer test suite
+is migrated to construct structured runtime events directly.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -24,6 +24,8 @@ Active backlog only. Keep this file small and current.
       runtime registries and completion orchestration from `TuiApp`.
 - [x] Move goal continuation, plan continuation decisions, rebuilt-agent
       continuity, and runtime persistence helpers out of TUI task logic.
+- [x] Deliver RuntimeControlEvent directly to TUI task consumers and stop
+      deriving runtime semantics from role/message transcript formatting.
 - [ ] Replace the local `AgentEvent -> role/message -> parser` compatibility
       path with a typed TUI projection event carrying session and sequence
       identity.

--- a/src/todo.rs
+++ b/src/todo.rs
@@ -155,6 +155,7 @@ pub fn normalize_todo_write_input(input: &Value) -> Result<TodoState> {
     })
 }
 
+#[cfg(test)]
 pub fn format_todo_update(state: &TodoState) -> String {
     let summary = state.summary();
     let mut lines = vec![format!(
@@ -177,6 +178,7 @@ pub fn format_todo_update(state: &TodoState) -> String {
     lines.join("\n")
 }
 
+#[cfg(test)]
 fn status_marker(status: &TodoStatus) -> &'static str {
     match status {
         TodoStatus::Pending => "[ ]",

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -5,20 +5,25 @@ mod tests;
 use rara_persistence::redaction::redact_secrets;
 
 use self::helpers::{
-    append_tool_progress, exploration_action_label, exploration_note_lines,
-    exploration_result_note, format_tool_result, format_tool_use, is_exploration_tool_name,
-    is_oauth_prompt_message, planning_action_label, planning_note_lines, planning_result_note,
+    append_tool_progress, exploration_action_label, exploration_action_label_for,
+    exploration_note_lines, exploration_result_note, format_tool_result, format_tool_use,
+    is_exploration_tool_name, is_oauth_prompt_message, planning_action_label,
+    planning_action_label_for, planning_note_lines, planning_result_note,
     scrub_internal_control_tokens, subagent_request_input, tool_action_label,
+    tool_action_label_for,
 };
 use super::super::state::{
     RuntimePhase, SystemMessageKind, TuiApp, TuiEvent, contains_structured_planning_output,
 };
 use crate::agent::AgentEvent;
 use crate::memory_notice::{count_label, memory_notice};
-use crate::runtime_control::MemoryEvent;
+use crate::runtime_control::{
+    AssistantEvent, MemoryEvent, RuntimeControlEvent, RuntimeEvent, SessionEvent, ToolEvent,
+};
 use crate::session_promotion::{
     SessionShardPromotionDecision, SessionShardPromotionOutcome, SessionShardPromotionSkipReason,
 };
+#[cfg(test)]
 use crate::todo::format_todo_update;
 use crate::tui::display_sanitize::sanitize_display_text;
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
@@ -28,6 +33,7 @@ const MEMORY_QUERY_PREVIEW_LIMIT: usize = 120;
 
 pub(crate) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
     match event {
+        TuiEvent::Runtime(event) => apply_runtime_control_event(app, event),
         TuiEvent::Transcript { role, message } => {
             if role == "Status" {
                 app.set_runtime_phase(
@@ -262,12 +268,199 @@ pub(crate) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                 Some(format!("streaming {name} output")),
             );
         }
+        #[cfg(test)]
         TuiEvent::UpdateTodo(view) => {
             app.snapshot.todo = view;
         }
     }
 }
 
+fn apply_runtime_control_event(app: &mut TuiApp, event: RuntimeControlEvent) {
+    match event.event {
+        RuntimeEvent::Assistant(AssistantEvent::Text(text)) => {
+            let text = scrub_internal_control_tokens(&text);
+            if text.trim().is_empty() {
+                app.set_runtime_phase(
+                    RuntimePhase::ProcessingResponse,
+                    Some("receiving model output".into()),
+                );
+            } else {
+                app.set_runtime_phase(
+                    RuntimePhase::ProcessingResponse,
+                    Some("receiving model output".into()),
+                );
+                app.finalize_agent_stream(Some(text));
+            }
+        }
+        RuntimeEvent::Assistant(AssistantEvent::TextDelta(text)) => {
+            app.set_runtime_phase(
+                RuntimePhase::ProcessingResponse,
+                Some("streaming model output".into()),
+            );
+            app.append_agent_delta(&text);
+        }
+        RuntimeEvent::Assistant(AssistantEvent::ThinkingDelta(text)) => {
+            app.set_runtime_phase(RuntimePhase::ProcessingResponse, Some("thinking".into()));
+            app.append_agent_thinking_delta(&text);
+        }
+        RuntimeEvent::Session(SessionEvent::Status { message }) => {
+            app.set_runtime_phase(
+                RuntimePhase::ProcessingResponse,
+                Some(
+                    message
+                        .lines()
+                        .next()
+                        .unwrap_or("status")
+                        .trim()
+                        .to_string(),
+                ),
+            );
+        }
+        RuntimeEvent::Session(SessionEvent::TurnStarted)
+        | RuntimeEvent::Session(SessionEvent::ModelRequest { .. }) => {}
+        RuntimeEvent::Session(SessionEvent::TurnFinished { .. })
+        | RuntimeEvent::Session(SessionEvent::TurnCancelled)
+        | RuntimeEvent::Session(SessionEvent::TurnInterrupted)
+        | RuntimeEvent::Session(SessionEvent::Created { .. })
+        | RuntimeEvent::Session(SessionEvent::Resumed { .. })
+        | RuntimeEvent::Session(SessionEvent::ModelResponse { .. }) => {}
+        RuntimeEvent::Tool(ToolEvent::Use { name, input }) => {
+            if name == crate::tools::todo::TODO_WRITE_TOOL_NAME {
+                if let Ok(state) = crate::todo::normalize_todo_write_input(&input) {
+                    app.snapshot.todo = crate::context::TodoContextView::from_state(Some(state));
+                } else {
+                    log::warn!("failed to normalize todo_write runtime event");
+                }
+                return;
+            }
+            if let Some(event) = TerminalEvent::from_tool_use(&name, &input) {
+                apply_tui_event(app, TuiEvent::Terminal(event));
+                return;
+            }
+            app.finalize_agent_stream(None);
+            if let Some(action) = exploration_action_label_for(&name, &input) {
+                app.record_exploration_action(action);
+            } else if let Some(action) = planning_action_label_for(&name, &input) {
+                app.record_planning_action(action);
+            } else if let Some(action) = tool_action_label_for(&name, &input) {
+                app.record_running_action(action);
+            }
+            app.set_runtime_phase(RuntimePhase::RunningTool, Some(name.clone()));
+            app.push_entry("Tool", format_tool_use(&name, &input));
+        }
+        RuntimeEvent::Tool(ToolEvent::Result {
+            name,
+            content,
+            is_error,
+        }) => {
+            if name == crate::tools::todo::TODO_WRITE_TOOL_NAME || is_exploration_tool_name(&name) {
+                return;
+            }
+            if let Some(event) = TerminalEvent::from_tool_result(&name, &content, is_error) {
+                apply_tui_event(app, TuiEvent::Terminal(event));
+                return;
+            }
+            app.finalize_agent_stream(None);
+            if let Some(request) = subagent_request_input(&content) {
+                app.advance_running_tool_boundary();
+                let source = name.as_str();
+                app.record_local_request_input(
+                    source,
+                    request.question,
+                    request.options,
+                    request.note,
+                );
+            } else if let Some(note) = exploration_result_note(&content) {
+                app.advance_running_tool_boundary();
+                app.record_exploration_note(note);
+            } else if let Some(note) = planning_result_note(&content) {
+                app.advance_running_tool_boundary();
+                app.record_planning_note(note);
+            } else {
+                app.advance_running_tool_boundary();
+            }
+            app.set_runtime_phase(RuntimePhase::RunningTool, Some(name.clone()));
+            app.push_entry(
+                if is_error {
+                    "Tool Error"
+                } else {
+                    "Tool Result"
+                },
+                format_tool_result(&name, &content),
+            );
+        }
+        RuntimeEvent::Tool(ToolEvent::Progress {
+            name,
+            stream,
+            chunk,
+        }) => {
+            if let Some(event) = TerminalEvent::from_tool_progress(&name, stream.into(), &chunk) {
+                apply_tui_event(app, TuiEvent::Terminal(event));
+            } else {
+                apply_tui_event(
+                    app,
+                    TuiEvent::ToolProgress {
+                        name,
+                        stream: stream.into(),
+                        chunk,
+                    },
+                );
+            }
+        }
+        RuntimeEvent::Memory(event) => {
+            app.push_system(
+                format_memory_event_notice(&event),
+                SystemMessageKind::Memory,
+            );
+        }
+        RuntimeEvent::Todo(crate::runtime_control::TodoEvent::Updated { state }) => {
+            app.snapshot.todo = crate::context::TodoContextView::from_state(Some(state));
+        }
+        RuntimeEvent::Plan(crate::runtime_control::PlanEvent::Updated { steps, explanation }) => {
+            app.snapshot.plan_steps = steps
+                .into_iter()
+                .map(|step| {
+                    let status = match step.status {
+                        crate::runtime_control::PlanStepStatusEvent::Pending => "pending",
+                        crate::runtime_control::PlanStepStatusEvent::InProgress => "in_progress",
+                        crate::runtime_control::PlanStepStatusEvent::Completed => "completed",
+                    };
+                    (step.step, status.to_string())
+                })
+                .collect();
+            app.snapshot.plan_explanation = explanation;
+        }
+        RuntimeEvent::Plan(_) | RuntimeEvent::Approval(_) | RuntimeEvent::Mcp(_) => {}
+        RuntimeEvent::Warning(crate::runtime_control::WarningEvent::RuntimeWarning { message }) => {
+            app.push_system(message, SystemMessageKind::Other);
+        }
+        RuntimeEvent::Error(crate::runtime_control::ErrorEvent::RuntimeError {
+            message, ..
+        }) => {
+            app.push_system(message, SystemMessageKind::Other);
+        }
+        RuntimeEvent::Input(_)
+        | RuntimeEvent::PromptSource(_)
+        | RuntimeEvent::Skill(_)
+        | RuntimeEvent::Hook(_)
+        | RuntimeEvent::Context(_)
+        | RuntimeEvent::Extension(_) => {}
+    }
+}
+
+pub(super) fn runtime_event_from_agent_event(
+    event: AgentEvent,
+    provenance: crate::runtime_control::RuntimeProvenance,
+) -> TuiEvent {
+    TuiEvent::Runtime(crate::runtime_control::wrap_agent_event(
+        uuid::Uuid::new_v4().to_string(),
+        0,
+        provenance,
+        event,
+    ))
+}
+
+#[cfg(test)]
 pub(super) fn convert_agent_event(event: AgentEvent) -> Option<TuiEvent> {
     match event {
         AgentEvent::Status(message) => Some(TuiEvent::Transcript {

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -33,7 +33,7 @@ const MEMORY_QUERY_PREVIEW_LIMIT: usize = 120;
 
 pub(crate) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
     match event {
-        TuiEvent::Runtime(event) => apply_runtime_control_event(app, event),
+        TuiEvent::Runtime(event) => apply_runtime_control_event(app, *event),
         TuiEvent::Transcript { role, message } => {
             if role == "Status" {
                 app.set_runtime_phase(
@@ -113,55 +113,7 @@ pub(crate) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                     Some(message.lines().next().unwrap_or(role).trim().to_string()),
                 );
             } else if role == "Agent" {
-                let message = scrub_internal_control_tokens(&message);
-                if message.trim().is_empty() {
-                    app.set_runtime_phase(
-                        RuntimePhase::ProcessingResponse,
-                        Some("receiving model output".into()),
-                    );
-                    return;
-                }
-                let planning_mode = matches!(
-                    app.agent_execution_mode,
-                    crate::agent::AgentExecutionMode::Plan
-                );
-                let structured_planning_output = contains_structured_planning_output(&message);
-                let has_live_exploration = !app.active_live.exploration_actions.is_empty()
-                    || !app.active_live.exploration_notes.is_empty();
-                let planning_notes = if planning_mode && !structured_planning_output {
-                    planning_note_lines(&message)
-                } else {
-                    Vec::new()
-                };
-                if !app.active_live.exploration_actions.is_empty()
-                    && matches!(
-                        app.runtime_phase,
-                        RuntimePhase::RunningTool | RuntimePhase::SendingPrompt
-                    )
-                    && (!planning_mode
-                        || (planning_notes.is_empty() && !structured_planning_output))
-                {
-                    for note in exploration_note_lines(&message, planning_mode) {
-                        app.record_exploration_note(note);
-                    }
-                }
-                app.set_runtime_phase(
-                    RuntimePhase::ProcessingResponse,
-                    Some("receiving model output".into()),
-                );
-                if planning_mode && !structured_planning_output {
-                    for note in planning_notes {
-                        app.record_planning_note(note);
-                    }
-                    if has_live_exploration
-                        || !app.active_live.planning_actions.is_empty()
-                        || !app.active_live.planning_notes.is_empty()
-                    {
-                        app.agent_markdown_stream = None;
-                        return;
-                    }
-                }
-                app.finalize_agent_stream(Some(message));
+                apply_assistant_text(app, message);
                 return;
             } else if role == "Download" {
                 let detail = message.lines().next().unwrap_or(role).trim().to_string();
@@ -277,21 +229,7 @@ pub(crate) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
 
 fn apply_runtime_control_event(app: &mut TuiApp, event: RuntimeControlEvent) {
     match event.event {
-        RuntimeEvent::Assistant(AssistantEvent::Text(text)) => {
-            let text = scrub_internal_control_tokens(&text);
-            if text.trim().is_empty() {
-                app.set_runtime_phase(
-                    RuntimePhase::ProcessingResponse,
-                    Some("receiving model output".into()),
-                );
-            } else {
-                app.set_runtime_phase(
-                    RuntimePhase::ProcessingResponse,
-                    Some("receiving model output".into()),
-                );
-                app.finalize_agent_stream(Some(text));
-            }
-        }
+        RuntimeEvent::Assistant(AssistantEvent::Text(text)) => apply_assistant_text(app, text),
         RuntimeEvent::Assistant(AssistantEvent::TextDelta(text)) => {
             app.set_runtime_phase(
                 RuntimePhase::ProcessingResponse,
@@ -448,16 +386,68 @@ fn apply_runtime_control_event(app: &mut TuiApp, event: RuntimeControlEvent) {
     }
 }
 
+fn apply_assistant_text(app: &mut TuiApp, message: String) {
+    let message = scrub_internal_control_tokens(&message);
+    if message.trim().is_empty() {
+        app.set_runtime_phase(
+            RuntimePhase::ProcessingResponse,
+            Some("receiving model output".into()),
+        );
+        return;
+    }
+
+    let planning_mode = matches!(
+        app.agent_execution_mode,
+        crate::agent::AgentExecutionMode::Plan
+    );
+    let structured_planning_output = contains_structured_planning_output(&message);
+    let has_live_exploration = !app.active_live.exploration_actions.is_empty()
+        || !app.active_live.exploration_notes.is_empty();
+    let planning_notes = if planning_mode && !structured_planning_output {
+        planning_note_lines(&message)
+    } else {
+        Vec::new()
+    };
+    if !app.active_live.exploration_actions.is_empty()
+        && matches!(
+            app.runtime_phase,
+            RuntimePhase::RunningTool | RuntimePhase::SendingPrompt
+        )
+        && (!planning_mode || (planning_notes.is_empty() && !structured_planning_output))
+    {
+        for note in exploration_note_lines(&message, planning_mode) {
+            app.record_exploration_note(note);
+        }
+    }
+    app.set_runtime_phase(
+        RuntimePhase::ProcessingResponse,
+        Some("receiving model output".into()),
+    );
+    if planning_mode && !structured_planning_output {
+        for note in planning_notes {
+            app.record_planning_note(note);
+        }
+        if has_live_exploration
+            || !app.active_live.planning_actions.is_empty()
+            || !app.active_live.planning_notes.is_empty()
+        {
+            app.agent_markdown_stream = None;
+            return;
+        }
+    }
+    app.finalize_agent_stream(Some(message));
+}
+
 pub(super) fn runtime_event_from_agent_event(
     event: AgentEvent,
     provenance: crate::runtime_control::RuntimeProvenance,
 ) -> TuiEvent {
-    TuiEvent::Runtime(crate::runtime_control::wrap_agent_event(
+    TuiEvent::Runtime(Box::new(crate::runtime_control::wrap_agent_event(
         uuid::Uuid::new_v4().to_string(),
         0,
         provenance,
         event,
-    ))
+    )))
 }
 
 #[cfg(test)]

--- a/src/tui/runtime/events/helpers.rs
+++ b/src/tui/runtime/events/helpers.rs
@@ -160,6 +160,59 @@ pub(super) fn tool_action_label(message: &str) -> Option<String> {
     }
 }
 
+fn input_text(input: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| input.get(*key).and_then(serde_json::Value::as_str))
+        .filter(|value| !value.trim().is_empty())
+        .map(ToString::to_string)
+}
+
+pub(super) fn exploration_action_label_for(
+    name: &str,
+    input: &serde_json::Value,
+) -> Option<String> {
+    let detail = input_text(input, &["path", "pattern", "query", "command", "prompt"]);
+    match name {
+        "list_files" => Some(format!("List {}", detail.as_deref().unwrap_or("."))),
+        "read_file" => Some(format!("Read {}", detail.as_deref().unwrap_or("file"))),
+        "glob" => Some(format!("Glob {}", detail.as_deref().unwrap_or("workspace"))),
+        "grep" => Some(format!(
+            "Search {}",
+            detail.as_deref().unwrap_or("workspace")
+        )),
+        "explore_agent" => Some(format!(
+            "Delegate repository exploration{}",
+            detail.map(|value| format!(": {value}")).unwrap_or_default()
+        )),
+        _ => None,
+    }
+}
+
+pub(super) fn planning_action_label_for(name: &str, input: &serde_json::Value) -> Option<String> {
+    if name != "plan_agent" {
+        return None;
+    }
+    let detail = input_text(input, &["prompt", "task", "objective"]);
+    Some(format!(
+        "Delegate plan refinement{}",
+        detail.map(|value| format!(": {value}")).unwrap_or_default()
+    ))
+}
+
+pub(super) fn tool_action_label_for(name: &str, input: &serde_json::Value) -> Option<String> {
+    let detail = input_text(input, &["command", "path", "file_path", "pattern"]);
+    match name {
+        "bash" => Some(format!("Run {}", detail.as_deref().unwrap_or("command"))),
+        "apply_patch" => Some(format!(
+            "Apply patch {}",
+            detail.as_deref().unwrap_or("changes")
+        )),
+        "write_file" => Some(format!("Write {}", detail.as_deref().unwrap_or("file"))),
+        "replace" | "multi_edit" => Some(format!("Edit {}", detail.as_deref().unwrap_or("file"))),
+        _ => None,
+    }
+}
+
 pub(super) fn exploration_note_lines(message: &str, planning_mode: bool) -> Vec<String> {
     let mut notes = Vec::new();
     for line in message

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -47,7 +47,7 @@ fn structured_tool_event_updates_running_action_without_role_parsing() {
         path: temp.path().join("config.json"),
     })
     .expect("app");
-    let event = TuiEvent::Runtime(crate::runtime_control::RuntimeControlEvent {
+    let event = TuiEvent::Runtime(Box::new(crate::runtime_control::RuntimeControlEvent {
         event_id: "event-1".into(),
         provenance: RuntimeProvenance::local_tui("session-1"),
         sequence: 1,
@@ -55,7 +55,7 @@ fn structured_tool_event_updates_running_action_without_role_parsing() {
             name: "write_file".into(),
             input: json!({"path": "src/runtime.rs", "content": "fn main() {}"}),
         }),
-    });
+    }));
 
     apply_tui_event(&mut app, event);
 
@@ -567,6 +567,39 @@ fn plan_mode_routes_planning_prose_to_planning_not_exploring() {
             role: "Agent",
             message: "Based on the inspection of `crates/instructions/src/workspace.rs`, I propose the following plan:<channel|>\n1. Generalize prompt discovery.\n2. Keep the current merge semantics.".into(),
         },
+    );
+
+    assert!(app.active_live.exploration_notes.is_empty());
+    assert_eq!(
+        app.active_live.planning_notes,
+        vec![
+            "1. Generalize prompt discovery.".to_string(),
+            "2. Keep the current merge semantics.".to_string()
+        ]
+    );
+}
+
+#[test]
+fn structured_assistant_text_preserves_plan_mode_routing() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    app.set_agent_execution_mode(AgentExecutionMode::Plan);
+    app.record_exploration_action("Read crates/instructions/src/workspace.rs");
+    app.runtime_phase = RuntimePhase::RunningTool;
+
+    apply_tui_event(
+        &mut app,
+        TuiEvent::Runtime(Box::new(crate::runtime_control::RuntimeControlEvent {
+            event_id: "event-1".into(),
+            provenance: crate::runtime_control::RuntimeProvenance::local_tui("session-1"),
+            sequence: 1,
+            event: RuntimeEvent::Assistant(crate::runtime_control::AssistantEvent::Text(
+                "Based on the inspection of `crates/instructions/src/workspace.rs`, I propose the following plan:<channel|>\n1. Generalize prompt discovery.\n2. Keep the current merge semantics.".into(),
+            )),
+        })),
     );
 
     assert!(app.active_live.exploration_notes.is_empty());

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -7,11 +7,14 @@ use super::helpers::{
     format_tool_use, is_oauth_prompt_message, planning_note_lines, scrub_internal_control_tokens,
     subagent_request_input,
 };
-use super::{apply_tui_event, convert_agent_event, format_memory_event_notice};
+use super::{
+    apply_tui_event, convert_agent_event, format_memory_event_notice,
+    runtime_event_from_agent_event,
+};
 use crate::agent::{AgentEvent, AgentExecutionMode};
 use crate::config::ConfigManager;
 use crate::control_tokens::has_pending_internal_control_context;
-use crate::runtime_control::{MemoryEvent, MemoryRecordSummary};
+use crate::runtime_control::{MemoryEvent, MemoryRecordSummary, RuntimeEvent, RuntimeProvenance};
 use crate::session_promotion::{
     SessionShardPromotionDecision, SessionShardPromotionOutcome, SessionShardPromotionPlan,
     SessionShardPromotionSkipReason, SessionShardPromotionTrigger,
@@ -19,6 +22,49 @@ use crate::session_promotion::{
 use crate::tui::state::{ActivePendingInteractionKind, TranscriptEntryPayload};
 use crate::tui::state::{RuntimePhase, TuiApp, TuiEvent};
 use crate::tui::terminal_event::{TerminalEvent, TerminalTarget};
+
+#[test]
+fn runtime_agent_event_preserves_structured_semantics_for_tui() {
+    let event = runtime_event_from_agent_event(
+        AgentEvent::ToolUse {
+            name: "write_file".into(),
+            input: json!({"path": "src/runtime.rs", "content": "fn main() {}"}),
+        },
+        RuntimeProvenance::local_tui("session-1"),
+    );
+
+    assert!(matches!(
+        event,
+        TuiEvent::Runtime(envelope)
+            if matches!(envelope.event, RuntimeEvent::Tool(_))
+    ));
+}
+
+#[test]
+fn structured_tool_event_updates_running_action_without_role_parsing() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    let event = TuiEvent::Runtime(crate::runtime_control::RuntimeControlEvent {
+        event_id: "event-1".into(),
+        provenance: RuntimeProvenance::local_tui("session-1"),
+        sequence: 1,
+        event: RuntimeEvent::Tool(crate::runtime_control::ToolEvent::Use {
+            name: "write_file".into(),
+            input: json!({"path": "src/runtime.rs", "content": "fn main() {}"}),
+        }),
+    });
+
+    apply_tui_event(&mut app, event);
+
+    assert_eq!(
+        app.active_live.running_actions,
+        vec!["Write src/runtime.rs".to_string()]
+    );
+    assert_eq!(app.active_turn.entries[0].role, "Tool");
+}
 
 #[test]
 fn parses_delegated_request_input_from_subagent_result() {

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -228,7 +228,7 @@ pub(super) fn start_input_control_task(
                         _ => return,
                     };
                     forward_event_to_bus(&bus_arg, &agent_event, &event_provenance);
-                    let _ = tx.send(TuiEvent::Runtime(control_event));
+                    let _ = tx.send(TuiEvent::Runtime(Box::new(control_event)));
                 } else if let crate::runtime_control::RuntimeEvent::Tool(te) = &control_event.event
                 {
                     let agent_event = match te {
@@ -258,9 +258,9 @@ pub(super) fn start_input_control_task(
                         },
                     };
                     forward_event_to_bus(&bus_arg, &agent_event, &event_provenance);
-                    let _ = tx.send(TuiEvent::Runtime(control_event));
+                    let _ = tx.send(TuiEvent::Runtime(Box::new(control_event)));
                 } else {
-                    let _ = tx.send(TuiEvent::Runtime(control_event));
+                    let _ = tx.send(TuiEvent::Runtime(Box::new(control_event)));
                 }
             },
         )

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -22,9 +22,7 @@ use super::super::state::{
     ListPickerKind, OAuthLoginMode, PermissionMode, RunningTask, RuntimePhase, SystemMessageKind,
     TaskCompletion, TaskKind, TuiApp, TuiEvent,
 };
-use super::events::{
-    apply_tui_event, convert_agent_event, format_error_chain, format_memory_event_notice,
-};
+use super::events::{apply_tui_event, format_error_chain, runtime_event_from_agent_event};
 use crate::agent::{Agent, AgentEvent, AgentOutputMode, BashApprovalDecision};
 pub(crate) use crate::runtime_client::{goal_budget_limit_prompt, goal_continuation_prompt};
 use crate::runtime_control::RuntimeProvenance;
@@ -230,9 +228,7 @@ pub(super) fn start_input_control_task(
                         _ => return,
                     };
                     forward_event_to_bus(&bus_arg, &agent_event, &event_provenance);
-                    if let Some(tui_event) = convert_agent_event(agent_event) {
-                        let _ = tx.send(tui_event);
-                    }
+                    let _ = tx.send(TuiEvent::Runtime(control_event));
                 } else if let crate::runtime_control::RuntimeEvent::Tool(te) = &control_event.event
                 {
                     let agent_event = match te {
@@ -262,16 +258,9 @@ pub(super) fn start_input_control_task(
                         },
                     };
                     forward_event_to_bus(&bus_arg, &agent_event, &event_provenance);
-                    if let Some(tui_event) = convert_agent_event(agent_event) {
-                        let _ = tx.send(tui_event);
-                    }
-                } else if let crate::runtime_control::RuntimeEvent::Memory(me) =
-                    &control_event.event
-                {
-                    let _ = tx.send(TuiEvent::Transcript {
-                        role: "System",
-                        message: format_memory_event_notice(me),
-                    });
+                    let _ = tx.send(TuiEvent::Runtime(control_event));
+                } else {
+                    let _ = tx.send(TuiEvent::Runtime(control_event));
                 }
             },
         )
@@ -334,9 +323,10 @@ pub(super) fn start_compact_task(app: &mut TuiApp, mut agent: Agent) {
         let result = agent
             .compact_now_with_reporter(move |event| {
                 forward_event_to_bus(&bus, &event, &event_provenance);
-                if let Some(tui_event) = convert_agent_event(event) {
-                    let _ = tx.send(tui_event);
-                }
+                let _ = tx.send(runtime_event_from_agent_event(
+                    event,
+                    event_provenance.clone(),
+                ));
             })
             .await;
         forward_optional_task_result_lifecycle(&lifecycle_bus, &lifecycle_provenance, &result);
@@ -381,9 +371,10 @@ pub(super) fn start_review_task(app: &mut TuiApp, prompt: String, mut agent: Age
         let result = agent
             .query_with_mode_and_events(prompt, AgentOutputMode::Silent, move |event| {
                 forward_event_to_bus(&bus, &event, &event_provenance);
-                if let Some(tui_event) = convert_agent_event(event) {
-                    let _ = tx.send(tui_event);
-                }
+                let _ = tx.send(runtime_event_from_agent_event(
+                    event,
+                    event_provenance.clone(),
+                ));
             })
             .await;
         forward_optional_task_result_lifecycle(&lifecycle_bus, &lifecycle_provenance, &result);

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -397,6 +397,9 @@ pub enum TaskCompletion {
 }
 
 pub enum TuiEvent {
+    /// Structured runtime event. Runtime semantics must be consumed from this
+    /// variant instead of inferred from transcript role or message text.
+    Runtime(crate::runtime_control::RuntimeControlEvent),
     Transcript {
         role: &'static str,
         message: String,
@@ -407,7 +410,8 @@ pub enum TuiEvent {
         stream: ToolOutputStream,
         chunk: String,
     },
-    /// Agent called todo_write — update the sidebar todo display.
+    /// Legacy test adapter for the removed AgentEvent compatibility path.
+    #[cfg(test)]
     UpdateTodo(crate::context::TodoContextView),
 }
 

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -399,7 +399,7 @@ pub enum TaskCompletion {
 pub enum TuiEvent {
     /// Structured runtime event. Runtime semantics must be consumed from this
     /// variant instead of inferred from transcript role or message text.
-    Runtime(crate::runtime_control::RuntimeControlEvent),
+    Runtime(Box<crate::runtime_control::RuntimeControlEvent>),
     Transcript {
         role: &'static str,
         message: String,


### PR DESCRIPTION
## Summary

- Deliver `RuntimeControlEvent` directly to query, compact, and review TUI task consumers.
- Render assistant, tool, memory, todo, plan, warning, and error behavior from typed `RuntimeEvent` variants.
- Replace role/message-based tool action classification with typed tool name and input handling.
- Keep transcript events only for presentation-only OAuth and model-download progress.
- Add structured event regression tests and document the new runtime-to-TUI contract.

## Motivation

The runtime already emits structured control events with provenance and sequence identity, but the TUI converted them back to `AgentEvent`, then to role/message strings, and inferred behavior from prefixes and formatting. That made presentation text part of the runtime contract and allowed formatting changes to alter TUI state.

## Related work

Follow-up to PR #772 and the session-scoped RuntimeClient migration in PR #771.

## Testing

- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo test --bin rara tui::runtime::events --no-fail-fast` (69 passed)
- `cargo test --bin rara --no-fail-fast` (1288 passed)
- `git diff --check`

## Compatibility note

The old AgentEvent conversion is retained only under test configuration for existing renderer tests. Runtime production task delivery no longer uses that adapter.
