### PR TITLE
feat(tui): unify runtime event wakeups

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -27,9 +27,12 @@ continues to hold compatibility projections used by the existing command and
 renderer modules. Those projections are not authoritative runtime state and
 must be removed as command handling moves behind the client boundary.
 
-Runtime task events are now awaited directly in the TUI event loop. A runtime
-event wakes the loop immediately; the 166 ms timer remains only for periodic
-UI work such as autoscroll, shared-task polling, and heartbeat display.
+Runtime task events and task completion are now awaited by one event-mux branch
+in the TUI event loop. A runtime event wakes the loop immediately, and a closed
+runtime receiver is drained through the task completion future instead of
+falling back to receiver polling. The 166 ms timer remains only for periodic UI
+work such as autoscroll, shared-task polling, and heartbeat display; it marks
+the screen dirty only when one of those operations changes state.
 
 Runtime-to-TUI task delivery uses `RuntimeControlEvent` directly. The TUI
 matches `RuntimeEvent` variants for assistant, tool, memory, todo, warning,

--- a/docs/journal/2026-08-02-runtime-event-mux-redraw.md
+++ b/docs/journal/2026-08-02-runtime-event-mux-redraw.md
@@ -1,0 +1,39 @@
+# Runtime Event Mux And Change-Driven Redraw
+
+## What Changed
+
+The TUI event loop now awaits runtime receiver messages and task completion in
+one `tokio::select!` activity. Runtime task completion results are passed into
+the existing completion reducer without polling or consuming the join handle
+twice. A closed runtime receiver waits for the task future before completion
+processing, which avoids a busy loop during task shutdown.
+
+Periodic TUI work remains on the 166 ms timer, but the timer only requests a
+redraw when autoscroll or shared-task polling changes visible state. Repository
+context completion also reports whether its projection changed before marking
+the screen dirty.
+
+## Why
+
+Runtime output should wake the TUI immediately, while idle sessions should not
+repaint at the timer frequency. Keeping completion in the same mux preserves a
+single wakeup path for runtime output, task shutdown, and terminal input.
+
+## Trade-offs
+
+The existing completion reducer remains the compatibility bridge for now. It
+accepts an optional completion result so existing focused tests can continue to
+exercise the legacy readiness path while the event loop uses the select-owned
+result path.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- Focused TUI runtime event and maintainer tests
+- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
+
+## Remaining Work
+
+Runtime commands and snapshots still need to move behind `RuntimeClient`; this
+change only removes event-receiver and redraw polling from the TUI loop.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -26,6 +26,8 @@ Active backlog only. Keep this file small and current.
       continuity, and runtime persistence helpers out of TUI task logic.
 - [x] Deliver RuntimeControlEvent directly to TUI task consumers and stop
       deriving runtime semantics from role/message transcript formatting.
+- [x] Route runtime receiver events and task completion through one
+      `tokio::select!` mux, and redraw only after a visible state change.
 - [ ] Replace the local `AgentEvent -> role/message -> parser` compatibility
       path with a typed TUI projection event carrying session and sequence
       identity.

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -8,7 +8,7 @@ use tokio::time::{Duration, MissedTickBehavior, interval};
 
 use super::event_dispatch::dispatch_event;
 use super::event_stream::{UiEvent, translate_event};
-use super::maintainer::TuiMaintainer;
+use super::maintainer::{RuntimeActivity, TuiMaintainer};
 use super::render::{desired_viewport_height, render};
 use super::session_restore::{restore_latest_thread, restore_thread_by_id};
 use super::state::ListPickerKind;
@@ -108,10 +108,10 @@ pub async fn run_tui(
     }
 
     let result: anyhow::Result<()> = loop {
-        maintainer.poll_repo_context().await;
-        maintainer.poll_agent_task().await?;
-
         let mut needs_redraw = maintainer.needs_redraw;
+        if maintainer.poll_repo_context().await {
+            needs_redraw = true;
+        }
         {
             let app = maintainer.app_mut();
             clamp_command_palette_selection(app);
@@ -134,20 +134,27 @@ pub async fn run_tui(
 
         tokio::select! {
             _ = tick.tick() => {
+                let mut changed = false;
                 let app = maintainer.app_mut();
                 if let Some(delta) = app.transcript_selection.autoscroll_delta() {
                     app.scroll_transcript(delta);
+                    changed = true;
                 }
-                let _ = app.poll_shared_task_files();
-                needs_redraw = true;
+                changed |= app.poll_shared_task_files();
+                needs_redraw |= changed;
             }
-            maybe_agent_event = maintainer.wait_for_agent_event() => {
-                if let Some(event) = maybe_agent_event {
-                    maintainer.apply_agent_event(event);
-                } else {
-                    maintainer.poll_agent_task().await?;
+            runtime_activity = maintainer.wait_for_runtime_activity() => {
+                match runtime_activity {
+                    RuntimeActivity::Event(Some(event)) => {
+                        maintainer.apply_agent_event(event);
+                        needs_redraw = true;
+                    }
+                    RuntimeActivity::Event(None) => {}
+                    RuntimeActivity::Completed(completion) => {
+                        maintainer.complete_runtime_task(completion).await?;
+                        needs_redraw = true;
+                    }
                 }
-                needs_redraw = true;
             }
             maybe_event = events.next() => {
                 let (app, agent_slot) = maintainer.split_mut();
@@ -189,6 +196,7 @@ pub async fn run_tui(
                     },
                     Some(Err(err)) => {
                         app.push_notice(format!("Terminal event error: {err}"));
+                        needs_redraw = true;
                     }
                     None => break Ok(()),
                 }

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -141,6 +141,7 @@ pub async fn run_tui(
                     changed = true;
                 }
                 changed |= app.poll_shared_task_files();
+                changed |= super::runtime::emit_query_heartbeat(app);
                 needs_redraw |= changed;
             }
             runtime_activity = maintainer.wait_for_runtime_activity() => {

--- a/src/tui/maintainer.rs
+++ b/src/tui/maintainer.rs
@@ -5,11 +5,16 @@
 //! ready/dirty signal so the event loop knows when to redraw.
 //!
 //! This is an incremental extraction of the apply logic already present in
-//! `finish_running_task_if_ready` / `apply_tui_event`; no behavior change.
+//! `finish_running_task_if_ready` / `apply_tui_event`.
 
-use super::state::{TuiApp, TuiEvent};
+use super::state::{TaskCompletion, TuiApp, TuiEvent};
 use crate::agent::Agent;
 use crate::runtime_client::RuntimeClient;
+
+pub(super) enum RuntimeActivity {
+    Event(Option<TuiEvent>),
+    Completed(Box<Result<TaskCompletion, tokio::task::JoinError>>),
+}
 
 /// Owns all TUI render state and applies agent-output events to it.
 pub(super) struct TuiMaintainer {
@@ -49,23 +54,26 @@ impl TuiMaintainer {
 
     /// Drain pending agent events from the running task, apply them, and
     /// finalize the task if it has completed.
-    pub(super) async fn poll_agent_task(&mut self) -> anyhow::Result<()> {
-        // Delegate to the existing logic; move it to TuiMaintainer in the next commit.
-        super::runtime::tasks::finish_running_task_if_ready(
+    pub(super) async fn complete_runtime_task(
+        &mut self,
+        completion: Box<Result<TaskCompletion, tokio::task::JoinError>>,
+    ) -> anyhow::Result<()> {
+        super::runtime::tasks::finish_running_task_if_ready_with_completion(
             &mut self.app,
             self.runtime.agent_mut(),
+            Some(*completion),
         )
         .await?;
         self.needs_redraw = true;
         Ok(())
     }
 
-    /// Wait for the next runtime event without a timer-driven try-receive.
-    pub(super) async fn wait_for_agent_event(&mut self) -> Option<TuiEvent> {
+    /// Wait for the next runtime event or task completion without polling.
+    pub(super) async fn wait_for_runtime_activity(&mut self) -> RuntimeActivity {
         let Some(task) = self.app.bottom_pane.running_task.as_mut() else {
             std::future::pending().await
         };
-        receive_agent_event(&mut task.receiver).await
+        select_runtime_activity(&mut task.receiver, &mut task.handle).await
     }
 
     pub(super) fn apply_agent_event(&mut self, event: TuiEvent) {
@@ -87,39 +95,75 @@ impl TuiMaintainer {
     }
 
     /// Poll and finish repo context task if ready.
-    pub(super) async fn poll_repo_context(&mut self) {
+    pub(super) async fn poll_repo_context(&mut self) -> bool {
+        let before = (self.app.repo_slug.clone(), self.app.current_pr_url.clone());
         self.app.finish_repo_context_task_if_ready().await;
+        before != (self.app.repo_slug.clone(), self.app.current_pr_url.clone())
     }
 }
 
-async fn receive_agent_event(
+async fn select_runtime_activity(
     receiver: &mut tokio::sync::mpsc::UnboundedReceiver<TuiEvent>,
-) -> Option<TuiEvent> {
-    receiver.recv().await
+    handle: &mut tokio::task::JoinHandle<TaskCompletion>,
+) -> RuntimeActivity {
+    let activity = tokio::select! {
+        event = receiver.recv() => RuntimeActivity::Event(event),
+        result = &mut *handle => RuntimeActivity::Completed(Box::new(result)),
+    };
+    match activity {
+        RuntimeActivity::Event(Some(event)) => RuntimeActivity::Event(Some(event)),
+        RuntimeActivity::Event(None) => RuntimeActivity::Completed(Box::new(handle.await)),
+        RuntimeActivity::Completed(result) => RuntimeActivity::Completed(result),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use tokio::sync::mpsc;
 
-    use super::receive_agent_event;
+    use super::{RuntimeActivity, select_runtime_activity};
     use crate::tui::state::TuiEvent;
 
     #[tokio::test]
-    async fn agent_event_receiver_wakes_on_event_and_reports_closure() {
-        let (sender, mut receiver) = mpsc::unbounded_channel();
-        let waiter = tokio::spawn(async move { receive_agent_event(&mut receiver).await });
+    async fn runtime_mux_wakes_on_event() {
+        let (sender, mut receiver) = mpsc::unbounded_channel::<TuiEvent>();
         sender
             .send(TuiEvent::Transcript {
                 role: "Status",
                 message: "ready".into(),
             })
             .expect("send event");
-        let event = waiter.await.expect("waiter").expect("event");
-        assert!(matches!(event, TuiEvent::Transcript { message, .. } if message == "ready"));
+        let mut handle = tokio::spawn(async {
+            std::future::pending::<crate::tui::state::TaskCompletion>().await
+        });
 
-        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let activity = select_runtime_activity(&mut receiver, &mut handle).await;
+        assert!(matches!(
+            activity,
+            RuntimeActivity::Event(Some(TuiEvent::Transcript { message, .. }))
+                if message == "ready"
+        ));
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn runtime_mux_waits_for_completion_after_receiver_closes() {
+        let (sender, mut receiver) = mpsc::unbounded_channel::<TuiEvent>();
         drop(sender);
-        assert!(receive_agent_event(&mut receiver).await.is_none());
+        let mut handle = tokio::spawn(async {
+            panic!("completion failure");
+            #[allow(unreachable_code)]
+            crate::tui::state::TaskCompletion::KimiModels {
+                result: Ok(Vec::new()),
+            }
+        });
+
+        let activity = select_runtime_activity(&mut receiver, &mut handle).await;
+        assert!(matches!(
+            activity,
+            RuntimeActivity::Completed(error)
+                if error.as_ref().as_ref().is_err_and(|error| error.is_panic())
+        ));
     }
 }

--- a/src/tui/maintainer.rs
+++ b/src/tui/maintainer.rs
@@ -98,7 +98,7 @@ impl TuiMaintainer {
     pub(super) async fn poll_repo_context(&mut self) -> bool {
         let before = (self.app.repo_slug.clone(), self.app.current_pr_url.clone());
         self.app.finish_repo_context_task_if_ready().await;
-        before != (self.app.repo_slug.clone(), self.app.current_pr_url.clone())
+        before.0 != self.app.repo_slug || before.1 != self.app.current_pr_url
     }
 }
 

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -4,6 +4,10 @@ mod events;
 pub(super) use events::apply_tui_event;
 pub(super) mod tasks;
 
+pub(super) fn emit_query_heartbeat(app: &mut TuiApp) -> bool {
+    tasks::emit_query_heartbeat(app)
+}
+
 use std::sync::Arc;
 
 use super::state::{LocalCommand, OAuthLoginMode, TuiApp};

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -415,18 +415,18 @@ pub(crate) async fn finish_running_task_if_ready_with_completion(
     Ok(())
 }
 
-fn emit_query_heartbeat(app: &mut TuiApp) {
+pub(super) fn emit_query_heartbeat(app: &mut TuiApp) -> bool {
     let elapsed = {
         let Some(task) = app.bottom_pane.running_task.as_mut() else {
-            return;
+            return false;
         };
         if !matches!(task.kind, TaskKind::Query) {
-            return;
+            return false;
         }
 
         let elapsed = task.started_at.elapsed().as_secs();
         if elapsed < task.next_heartbeat_after_secs {
-            return;
+            return false;
         }
         task.next_heartbeat_after_secs = elapsed.saturating_add(1);
         elapsed
@@ -480,4 +480,5 @@ fn emit_query_heartbeat(app: &mut TuiApp) {
 
     app.set_runtime_phase(phase, Some(detail));
     app.bottom_pane.notice = Some(notice);
+    true
 }

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -3,9 +3,18 @@ use crate::tui::state::Overlay;
 
 use crate::runtime_client::{GoalContinuation, RuntimeClient};
 
+#[cfg(test)]
 pub(crate) async fn finish_running_task_if_ready(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
+) -> anyhow::Result<()> {
+    finish_running_task_if_ready_with_completion(app, agent_slot, None).await
+}
+
+pub(crate) async fn finish_running_task_if_ready_with_completion(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    completion: Option<Result<TaskCompletion, tokio::task::JoinError>>,
 ) -> anyhow::Result<()> {
     if app.bottom_pane.running_task.is_none() {
         return Ok(());
@@ -21,7 +30,7 @@ pub(crate) async fn finish_running_task_if_ready(
         while let Ok(event) = task.receiver.try_recv() {
             pending_events.push(event);
         }
-        let is_finished = task.handle.is_finished();
+        let is_finished = completion.is_some() || task.handle.is_finished();
         (pending_events, is_finished)
     };
 
@@ -39,7 +48,10 @@ pub(crate) async fn finish_running_task_if_ready(
         .running_task
         .take()
         .expect("task should exist");
-    let completion = task.handle.await?;
+    let completion = match completion {
+        Some(completion) => completion?,
+        None => task.handle.await?,
+    };
     while let Ok(event) = task.receiver.try_recv() {
         apply_tui_event(app, event);
     }


### PR DESCRIPTION
## Summary

- Await runtime receiver events and task completion through one `tokio::select!` activity.
- Drain task completion after the runtime receiver closes without falling back to polling or consuming the join handle twice.
- Redraw only when runtime, repository context, terminal input, autoscroll, or shared-task state changes.
- Add focused mux tests and document the runtime/TUI event-loop contract.

## Motivation

The TUI event loop previously used a timer-driven readiness path for runtime task draining and marked the screen dirty on every timer tick. This delayed runtime wakeups and caused unnecessary redraws during idle sessions. Completion is now part of the same select-driven runtime activity as receiver messages.

## Related Issues

No linked issue.

## Testing

- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo test --bin rara --no-fail-fast` (1290 passed)
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `git diff --check`

The linker emits the existing macOS `__eh_frame` warning while building the test binary; no new Rust warnings were introduced.
