### PR TITLE
feat(tui): add runtime client port

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -22,7 +22,7 @@ The intended surface is:
 ## Current Migration Slice
 
 The first slice establishes session ownership and removes the wide bootstrap
-argument list from `run_tui`. `TuiMaintainer` owns the client while `TuiApp`
+argument list from `run_tui`. `TuiController` owns the client while `TuiApp`
 continues to hold compatibility projections used by the existing command and
 renderer modules. Those projections are not authoritative runtime state and
 must be removed as command handling moves behind the client boundary.
@@ -39,6 +39,14 @@ matches `RuntimeEvent` variants for assistant, tool, memory, todo, warning,
 and error behavior; it does not infer those semantics from transcript roles or
 formatted message text. `Transcript` remains only for presentation-only
 progress such as OAuth and model download messages.
+
+The controller boundary now has a narrow `RuntimeClientPort` contract. It
+exchanges typed commands, runtime projection events, snapshots, completion,
+and transport lifecycle notifications without exposing `Agent`, registries, or
+task join handles. The current in-process controller still uses the
+compatibility task bridge behind this boundary; an app-server client and test
+fake can be introduced without making those runtime objects part of the TUI
+contract.
 
 The lifecycle slice is now runtime-owned as well. Goal token accounting,
 completion evaluation, continuation prompt construction, plan continuation

--- a/docs/journal/2026-08-02-runtime-client-port.md
+++ b/docs/journal/2026-08-02-runtime-client-port.md
@@ -1,0 +1,30 @@
+# Runtime Client Port And TUI Controller Boundary
+
+## What Changed
+
+The TUI maintainer boundary is now named `TuiController`. A narrow
+`RuntimeClientPort` contract defines typed runtime commands, snapshots,
+projection events, completion, and transport lifecycle notifications. The
+contract does not expose agents, registries, or task join handles.
+
+The existing in-process runtime and compatibility task bridge remain unchanged
+in this slice. This keeps production behavior stable while giving the future
+app-server adapter and test fake a concrete seam to implement.
+
+## Why
+
+The TUI needs a replaceable runtime boundary before a scripted fake and shared
+test harness can be added. Defining the contract first prevents the harness
+from reproducing the current `Agent` and `RunningTask` coupling.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- Contract test verifies a fake captures typed commands without runtime objects.
+
+## Remaining Work
+
+- Route the production controller through `RuntimeClientPort`.
+- Move snapshot projection out of `TuiApp::sync_snapshot(&Agent)`.
+- Add `FakeRuntimeClient` and `TuiHarness` with a Ratatui `TestBackend`.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -26,6 +26,8 @@ Active backlog only. Keep this file small and current.
       continuity, and runtime persistence helpers out of TUI task logic.
 - [x] Deliver RuntimeControlEvent directly to TUI task consumers and stop
       deriving runtime semantics from role/message transcript formatting.
+- [x] Establish the `RuntimeClientPort` and `TuiController` seam without
+      exposing `Agent`, registries, or task join handles to future fakes.
 - [x] Route runtime receiver events and task completion through one
       `tokio::select!` mux, and redraw only after a visible state change.
 - [ ] Replace the local `AgentEvent -> role/message -> parser` compatibility

--- a/src/tui/controller.rs
+++ b/src/tui/controller.rs
@@ -1,11 +1,12 @@
-//! TUI maintainer — owns all render state and applies agent-output events.
+//! TUI controller — owns presentation state and applies runtime projections.
 //!
-//! The agent task sends `TuiEvent`s through an mpsc channel. The maintainer
+//! The agent task sends `TuiEvent`s through an mpsc channel. The controller
 //! is the sole consumer: it drains events, mutates `TuiApp`, and exposes a
 //! ready/dirty signal so the event loop knows when to redraw.
 //!
 //! This is an incremental extraction of the apply logic already present in
-//! `finish_running_task_if_ready` / `apply_tui_event`.
+//! `finish_running_task_if_ready` / `apply_tui_event`. The compatibility task
+//! bridge remains here until it is replaced by `RuntimeClientPort`.
 
 use super::state::{TaskCompletion, TuiApp, TuiEvent};
 use crate::agent::Agent;
@@ -16,15 +17,15 @@ pub(super) enum RuntimeActivity {
     Completed(Box<Result<TaskCompletion, tokio::task::JoinError>>),
 }
 
-/// Owns all TUI render state and applies agent-output events to it.
-pub(super) struct TuiMaintainer {
+/// Owns TUI presentation state and applies runtime projections to it.
+pub(super) struct TuiController {
     app: TuiApp,
     runtime: RuntimeClient,
     /// Set to true every time an event is applied and the screen should repaint.
     pub(super) needs_redraw: bool,
 }
 
-impl TuiMaintainer {
+impl TuiController {
     pub(super) fn new(app: TuiApp, runtime: RuntimeClient) -> Self {
         Self {
             app,
@@ -46,7 +47,7 @@ impl TuiMaintainer {
     }
 
     /// Split borrow so callers that need independent `&mut TuiApp` and
-    /// `&mut Option<Agent>` can still use them while the maintainer
+    /// `&mut Option<Agent>` can still use them while the controller
     /// owns both.
     pub(super) fn split_mut(&mut self) -> (&mut TuiApp, &mut Option<Agent>) {
         (&mut self.app, self.runtime.agent_mut())

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -6,9 +6,9 @@ use futures::StreamExt;
 use rara_state::state_db::StateDb;
 use tokio::time::{Duration, MissedTickBehavior, interval};
 
+use super::controller::{RuntimeActivity, TuiController};
 use super::event_dispatch::dispatch_event;
 use super::event_stream::{UiEvent, translate_event};
-use super::maintainer::{RuntimeActivity, TuiMaintainer};
 use super::render::{desired_viewport_height, render};
 use super::session_restore::{restore_latest_thread, restore_thread_by_id};
 use super::state::ListPickerKind;
@@ -61,7 +61,7 @@ pub async fn run_tui(
     app.terminal_width = initial_size.0;
     let viewport_height = desired_viewport_height(&app, initial_size.0, initial_size.1);
     let mut terminal = build_terminal(viewport_height)?;
-    let mut maintainer = TuiMaintainer::new(app, runtime);
+    let mut maintainer = TuiController::new(app, runtime);
     match StateDb::new() {
         Ok(state_db) => {
             let state_db = Arc::new(state_db);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,6 +3,7 @@ mod auth_mode_picker;
 mod clipboard;
 mod command;
 mod context_display;
+mod controller;
 mod custom_terminal;
 mod display_sanitize;
 mod event_dispatch;
@@ -16,7 +17,6 @@ mod keymap;
 mod layout_utils;
 mod line_utils;
 mod list_picker;
-mod maintainer;
 mod markdown;
 mod markdown_render;
 mod markdown_stream;
@@ -26,6 +26,10 @@ mod provider_flow;
 mod queued_input;
 mod render;
 pub(super) mod runtime;
+mod runtime_port;
+pub(crate) use self::runtime_port::{
+    RuntimeClientPort, RuntimeCommand, RuntimeEventStream, RuntimeProjectionEvent,
+};
 mod selection;
 mod session_restore;
 pub(crate) mod state;

--- a/src/tui/runtime_port.rs
+++ b/src/tui/runtime_port.rs
@@ -1,0 +1,112 @@
+//! The narrow runtime contract consumed by the TUI controller.
+//!
+//! The in-process runtime still uses the compatibility task bridge today. This
+//! contract is the seam for a future app-server client and the test-only fake;
+//! it must not expose `Agent`, registries, or task join handles.
+
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use futures::Stream;
+
+use crate::runtime_control::{
+    ApprovalControlRequest, InputControlRequest, RuntimeControlEvent, SessionControlRequest,
+};
+use crate::tui::state::RuntimeSnapshot;
+
+// Contract items are intentionally ahead of their adapters; the next
+// in-process and scripted implementations will consume them.
+#[allow(dead_code)]
+pub(crate) type RuntimeEventStream = Pin<Box<dyn Stream<Item = RuntimeProjectionEvent> + Send>>;
+
+// Contract items are intentionally ahead of their adapters; the next
+// in-process and scripted implementations will consume them.
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum RuntimeCommand {
+    Session(SessionControlRequest),
+    Input(InputControlRequest),
+    Approval(ApprovalControlRequest),
+}
+
+// Contract items are intentionally ahead of their adapters; the next
+// in-process and scripted implementations will consume them.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub(crate) enum RuntimeProjectionEvent {
+    Snapshot(Box<RuntimeSnapshot>),
+    Runtime(Box<RuntimeControlEvent>),
+    Completed { reason: Option<String> },
+    Disconnected { reason: String },
+    Reconnected,
+}
+
+/// Runtime capabilities required by the TUI controller.
+///
+/// Implementations own execution state and transport details. They must not
+/// require the controller to know about agents, registries, or task handles.
+// Contract items are intentionally ahead of their adapters; the next
+// in-process and scripted implementations will consume them.
+#[allow(dead_code)]
+#[async_trait]
+pub(crate) trait RuntimeClientPort: Send {
+    async fn snapshot(&self) -> anyhow::Result<RuntimeSnapshot>;
+    async fn send(&self, command: RuntimeCommand) -> anyhow::Result<()>;
+    fn subscribe(&self) -> RuntimeEventStream;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use futures::stream;
+
+    use super::{RuntimeClientPort, RuntimeCommand, RuntimeEventStream};
+    use crate::runtime_control::SessionControlRequest;
+    use crate::tui::state::RuntimeSnapshot;
+
+    struct FakePort {
+        commands: Arc<Mutex<Vec<RuntimeCommand>>>,
+    }
+
+    #[async_trait]
+    impl RuntimeClientPort for FakePort {
+        async fn snapshot(&self) -> anyhow::Result<RuntimeSnapshot> {
+            Ok(RuntimeSnapshot::default())
+        }
+
+        async fn send(&self, command: RuntimeCommand) -> anyhow::Result<()> {
+            self.commands
+                .lock()
+                .expect("command log lock")
+                .push(command);
+            Ok(())
+        }
+
+        fn subscribe(&self) -> RuntimeEventStream {
+            Box::pin(stream::empty())
+        }
+    }
+
+    #[tokio::test]
+    async fn fake_port_can_capture_typed_commands_without_runtime_objects() {
+        let commands = Arc::new(Mutex::new(Vec::new()));
+        let port = FakePort {
+            commands: commands.clone(),
+        };
+
+        port.send(RuntimeCommand::Session(
+            SessionControlRequest::CancelCurrentTurn,
+        ))
+        .await
+        .expect("send command");
+
+        assert!(matches!(
+            commands.lock().expect("command log lock").as_slice(),
+            [RuntimeCommand::Session(
+                SessionControlRequest::CancelCurrentTurn
+            )]
+        ));
+    }
+}

--- a/src/wire_consumer.rs
+++ b/src/wire_consumer.rs
@@ -1,6 +1,6 @@
 //! Wire-mode consumer: subscribes to RuntimeEventBus and renders
 //! AgentEvent as Wire JSON-RPC over stdout. Peer consumer to
-//! PrintConsumer (text) and TuiMaintainer (Ratatui).
+//! PrintConsumer (text) and TuiController (Ratatui).
 //!
 //! Wire and print consumers subscribe to the same event bus.
 


### PR DESCRIPTION
## Summary

- Rename the TUI runtime ownership boundary from `TuiMaintainer` to `TuiController`.
- Add a narrow `RuntimeClientPort` contract for typed commands, snapshots, projection events, completion, and transport lifecycle.
- Keep `Agent`, runtime registries, and task join handles out of the new contract.
- Add a contract test proving a fake port can capture typed commands without constructing runtime objects.
- Document the migration boundary and remaining adapter/harness work.

## Motivation

The next TUI testing slice needs a replaceable runtime seam. The current TUI still depends on the concrete in-process runtime and compatibility task bridge, so adding a fake directly would reproduce those couplings instead of testing the production controller. This PR establishes the contract first while preserving current behavior.

## Scope

This PR intentionally does not route the production task bridge through the new port yet. Snapshot projection extraction, the in-process adapter, `FakeRuntimeClient`, and `TuiHarness` will follow as separate slices.

## Related Issues

No linked issue.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --bin rara tui::runtime_port --no-fail-fast`
- `cargo test --bin rara tui::controller --no-fail-fast`
- `git diff --check`

The linker emits the existing macOS `__eh_frame` warning while building the test binary; no new Rust warnings were introduced.
