### PR TITLE
test(tui): add scripted runtime harness

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -55,6 +55,24 @@ live under `runtime_client` / `runtime_goal`. TUI completion code consumes
 these typed outcomes and only applies transcript, overlay, phase, and queued
 input presentation effects.
 
+## TUI Test Contract
+
+TUI tests use the same runtime projection reducer and renderer as production.
+`src/tui/testing` provides a test-only `FakeRuntimeClient` and `TuiHarness`;
+the fake records typed commands and scripts snapshots, runtime events, turn
+completion, cancellation, disconnect, and reconnect without constructing an
+`Agent`, registries, task handles, or a real terminal.
+
+The harness consumes `RuntimeProjectionEvent` through the same stream shape as
+the future app-server client. Rendering uses the existing custom terminal with
+an in-memory Ratatui backend adapter, so lifecycle tests do not create a second
+rendering path. Script actions are awaited directly; tests must not use sleeps
+to establish ordering.
+
+The current harness is intentionally a deterministic projection/lifecycle
+fixture. Virtual time, production `TuiController` construction from a port,
+and full command routing remain follow-up slices.
+
 ## Ownership Rules
 
 1. A session has one `RuntimeClient` and one runtime registry graph.

--- a/docs/journal/2026-08-02-tui-test-harness.md
+++ b/docs/journal/2026-08-02-tui-test-harness.md
@@ -1,0 +1,38 @@
+# TUI Test Harness
+
+## What changed
+
+Added a test-only `FakeRuntimeClient` and `TuiHarness` under
+`src/tui/testing`. The fake implements `RuntimeClientPort`, stores a scripted
+snapshot, publishes typed projection events, records commands, and exposes
+disconnect/reconnect controls. The harness applies events through the
+production TUI reducer and renders through the production renderer backed by
+an in-memory terminal adapter.
+
+The first regression covers snapshot synchronization, structured session and
+assistant events, typed cancellation, completion, disconnect, reconnect, and
+rendering without wall-clock sleeps or runtime construction.
+
+## Why
+
+The runtime port introduced in the previous migration slice needs a shared
+fixture before TUI concurrency and lifecycle behavior can be tested without
+assembling an `Agent`, registries, channels, and real task handles in every
+case. Keeping the fake behind the port also makes accidental dependencies on
+runtime ownership visible at compile time.
+
+## Trade-offs
+
+The project uses a custom terminal wrapper whose backend requires `io::Error`
+and `Write`, while Ratatui's `TestBackend` uses `Infallible` and does not
+implement `Write`. The harness therefore uses a small test-only adapter that
+delegates to `TestBackend` and preserves its in-memory buffer semantics.
+
+The production controller is not yet constructed from `RuntimeClientPort`;
+this slice deliberately establishes the reusable fake and projection/render
+fixture first. Virtual time and command routing are separate follow-ups.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo test --bin rara tui::testing --no-fail-fast`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -30,9 +30,14 @@ Active backlog only. Keep this file small and current.
       exposing `Agent`, registries, or task join handles to future fakes.
 - [x] Route runtime receiver events and task completion through one
       `tokio::select!` mux, and redraw only after a visible state change.
+- [x] Add a shared scripted `TuiHarness` and `FakeRuntimeClient` for
+      snapshot, event, completion, cancel, disconnect, reconnect, and render
+      lifecycle tests without wall-clock sleeps.
 - [ ] Replace the local `AgentEvent -> role/message -> parser` compatibility
       path with a typed TUI projection event carrying session and sequence
       identity.
+- [ ] Construct the production `TuiController` from `RuntimeClientPort` and
+      add virtual-time controls to the shared harness.
 
 - [x] Keep `rara-file-search` as the shared backend for TUI file suggestions
       and `list_files`; keep automatic retrieval as optional low-priority

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -39,6 +39,8 @@ mod submit;
 mod terminal_event;
 mod terminal_ui;
 #[cfg(test)]
+mod testing;
+#[cfg(test)]
 mod tests;
 mod theme;
 mod tool_text;

--- a/src/tui/testing.rs
+++ b/src/tui/testing.rs
@@ -1,0 +1,5 @@
+mod fake_runtime;
+mod harness;
+
+pub(crate) use fake_runtime::FakeRuntimeClient;
+pub(crate) use harness::TuiHarness;

--- a/src/tui/testing/fake_runtime.rs
+++ b/src/tui/testing/fake_runtime.rs
@@ -1,0 +1,91 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use tokio::sync::broadcast;
+
+use crate::tui::runtime_port::{
+    RuntimeClientPort, RuntimeCommand, RuntimeEventStream, RuntimeProjectionEvent,
+};
+use crate::tui::state::RuntimeSnapshot;
+
+const EVENT_BUFFER: usize = 64;
+
+/// A deterministic runtime port for TUI tests.
+///
+/// The fake owns only the port contract. Tests control snapshots, projected
+/// events, lifecycle transitions, and captured commands without constructing
+/// an `Agent`, registry, or task handle.
+#[derive(Clone)]
+pub(crate) struct FakeRuntimeClient {
+    snapshot: Arc<Mutex<RuntimeSnapshot>>,
+    commands: Arc<Mutex<Vec<RuntimeCommand>>>,
+    events: broadcast::Sender<RuntimeProjectionEvent>,
+    connected: Arc<Mutex<bool>>,
+}
+
+impl FakeRuntimeClient {
+    pub(crate) fn new(snapshot: RuntimeSnapshot) -> Self {
+        let (events, _) = broadcast::channel(EVENT_BUFFER);
+        Self {
+            snapshot: Arc::new(Mutex::new(snapshot)),
+            commands: Arc::new(Mutex::new(Vec::new())),
+            events,
+            connected: Arc::new(Mutex::new(true)),
+        }
+    }
+
+    pub(crate) fn set_snapshot(&self, snapshot: RuntimeSnapshot) {
+        *self.snapshot.lock().expect("snapshot lock") = snapshot;
+    }
+
+    pub(crate) fn emit(&self, event: RuntimeProjectionEvent) {
+        let _ = self.events.send(event);
+    }
+
+    pub(crate) fn disconnect(&self, reason: impl Into<String>) {
+        *self.connected.lock().expect("connection lock") = false;
+        self.emit(RuntimeProjectionEvent::Disconnected {
+            reason: reason.into(),
+        });
+    }
+
+    pub(crate) fn reconnect(&self) {
+        *self.connected.lock().expect("connection lock") = true;
+        self.emit(RuntimeProjectionEvent::Reconnected);
+    }
+
+    pub(crate) fn commands(&self) -> Vec<RuntimeCommand> {
+        self.commands.lock().expect("command lock").clone()
+    }
+}
+
+#[async_trait]
+impl RuntimeClientPort for FakeRuntimeClient {
+    async fn snapshot(&self) -> anyhow::Result<RuntimeSnapshot> {
+        Ok(self.snapshot.lock().expect("snapshot lock").clone())
+    }
+
+    async fn send(&self, command: RuntimeCommand) -> anyhow::Result<()> {
+        if !*self.connected.lock().expect("connection lock") {
+            anyhow::bail!("fake runtime is disconnected");
+        }
+        self.commands.lock().expect("command lock").push(command);
+        Ok(())
+    }
+
+    fn subscribe(&self) -> RuntimeEventStream {
+        let receiver = self.events.subscribe();
+        Box::pin(futures::stream::unfold(
+            receiver,
+            |mut receiver| async move {
+                loop {
+                    match receiver.recv().await {
+                        Ok(event) => return Some((event, receiver)),
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Closed) => return None,
+                    }
+                }
+            },
+        ))
+    }
+}

--- a/src/tui/testing/harness.rs
+++ b/src/tui/testing/harness.rs
@@ -1,0 +1,270 @@
+use std::io::{self, Write};
+
+use futures::StreamExt;
+use ratatui::backend::{Backend, ClearType, TestBackend, WindowSize};
+use ratatui::buffer::Cell;
+use ratatui::layout::{Position, Rect, Size};
+use tempfile::TempDir;
+
+use super::FakeRuntimeClient;
+use crate::config::ConfigManager;
+use crate::runtime_control::{RuntimeControlEvent, SessionControlRequest};
+use crate::tui::custom_terminal::Terminal;
+use crate::tui::render;
+use crate::tui::runtime::apply_tui_event;
+use crate::tui::runtime_port::{
+    RuntimeClientPort, RuntimeCommand, RuntimeEventStream, RuntimeProjectionEvent,
+};
+use crate::tui::state::{RuntimePhase, RuntimeSnapshot, TuiApp, TuiEvent};
+
+const DEFAULT_WIDTH: u16 = 100;
+const DEFAULT_HEIGHT: u16 = 30;
+
+/// Drives the production TUI projection and renderer with scripted runtime
+/// input. It intentionally has no wall-clock sleeps or real runtime objects.
+pub(crate) struct TuiHarness {
+    _config_dir: TempDir,
+    app: TuiApp,
+    runtime: FakeRuntimeClient,
+    events: RuntimeEventStream,
+    terminal: Terminal<TestBackendAdapter>,
+}
+
+impl TuiHarness {
+    pub(crate) fn new(snapshot: RuntimeSnapshot) -> anyhow::Result<Self> {
+        let config_dir = tempfile::tempdir()?;
+        let mut app = TuiApp::new(ConfigManager {
+            path: config_dir.path().join("config.json"),
+        })?;
+        app.snapshot = snapshot.clone();
+
+        let runtime = FakeRuntimeClient::new(snapshot);
+        let events = runtime.subscribe();
+        let mut terminal = Terminal::new(TestBackendAdapter::new(DEFAULT_WIDTH, DEFAULT_HEIGHT))?;
+        terminal.set_viewport_area(Rect::new(0, 0, DEFAULT_WIDTH, DEFAULT_HEIGHT));
+
+        Ok(Self {
+            _config_dir: config_dir,
+            app,
+            runtime,
+            events,
+            terminal,
+        })
+    }
+
+    pub(crate) async fn sync_snapshot(&mut self, snapshot: RuntimeSnapshot) {
+        self.runtime.set_snapshot(snapshot);
+        self.runtime.emit(RuntimeProjectionEvent::Snapshot(Box::new(
+            self.runtime.snapshot().await.expect("fake snapshot"),
+        )));
+        self.pump_one().await;
+    }
+
+    pub(crate) async fn emit_runtime(&mut self, event: RuntimeControlEvent) {
+        self.runtime
+            .emit(RuntimeProjectionEvent::Runtime(Box::new(event)));
+        self.pump_one().await;
+    }
+
+    pub(crate) async fn complete_turn(&mut self, reason: Option<String>) {
+        self.runtime
+            .emit(RuntimeProjectionEvent::Completed { reason });
+        self.pump_one().await;
+    }
+
+    pub(crate) async fn cancel(&self) -> anyhow::Result<()> {
+        self.runtime
+            .send(RuntimeCommand::Session(
+                SessionControlRequest::CancelCurrentTurn,
+            ))
+            .await
+    }
+
+    pub(crate) async fn disconnect(&mut self, reason: impl Into<String>) {
+        self.runtime.disconnect(reason);
+        self.pump_one().await;
+    }
+
+    pub(crate) async fn reconnect(&mut self) {
+        self.runtime.reconnect();
+        self.pump_one().await;
+    }
+
+    pub(crate) fn render(&mut self) -> anyhow::Result<()> {
+        self.terminal
+            .draw(|frame| render::render(frame, &mut self.app))?;
+        Ok(())
+    }
+
+    pub(crate) fn expect_command(&self, expected: RuntimeCommand) {
+        assert_eq!(self.runtime.commands(), [expected]);
+    }
+
+    pub(crate) fn expect_runtime_phase(&self, expected: RuntimePhase) {
+        assert_eq!(self.app.runtime_phase, expected);
+    }
+
+    pub(crate) fn expect_transcript_contains(&self, expected: &str) {
+        let found = self
+            .app
+            .committed_turns
+            .iter()
+            .chain(std::iter::once(&self.app.active_turn))
+            .flat_map(|turn| turn.entries.iter())
+            .any(|entry| entry.message.contains(expected));
+        assert!(found, "transcript does not contain {expected:?}");
+    }
+
+    pub(crate) async fn pump_one(&mut self) {
+        let event = self.events.next().await.expect("fake runtime event");
+        match event {
+            RuntimeProjectionEvent::Snapshot(snapshot) => self.app.snapshot = *snapshot,
+            RuntimeProjectionEvent::Runtime(event) => {
+                apply_tui_event(&mut self.app, TuiEvent::Runtime(event));
+            }
+            RuntimeProjectionEvent::Completed { reason } => {
+                self.app.set_runtime_phase(RuntimePhase::Idle, reason);
+            }
+            RuntimeProjectionEvent::Disconnected { reason } => {
+                self.app
+                    .set_runtime_phase(RuntimePhase::Failed, Some(reason));
+            }
+            RuntimeProjectionEvent::Reconnected => {
+                self.app.set_runtime_phase(RuntimePhase::Idle, None);
+            }
+        }
+    }
+}
+
+struct TestBackendAdapter {
+    inner: TestBackend,
+}
+
+impl TestBackendAdapter {
+    fn new(width: u16, height: u16) -> Self {
+        Self {
+            inner: TestBackend::new(width, height),
+        }
+    }
+}
+
+impl Write for TestBackendAdapter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Backend for TestBackendAdapter {
+    type Error = io::Error;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        Backend::draw(&mut self.inner, content).map_err(|error| match error {})
+    }
+
+    fn append_lines(&mut self, line_count: u16) -> Result<(), Self::Error> {
+        Backend::append_lines(&mut self.inner, line_count).map_err(|error| match error {})
+    }
+
+    fn hide_cursor(&mut self) -> Result<(), Self::Error> {
+        Backend::hide_cursor(&mut self.inner).map_err(|error| match error {})
+    }
+
+    fn show_cursor(&mut self) -> Result<(), Self::Error> {
+        Backend::show_cursor(&mut self.inner).map_err(|error| match error {})
+    }
+
+    fn get_cursor_position(&mut self) -> Result<Position, Self::Error> {
+        Backend::get_cursor_position(&mut self.inner).map_err(|error| match error {})
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), Self::Error> {
+        Backend::set_cursor_position(&mut self.inner, position).map_err(|error| match error {})
+    }
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
+        Backend::clear(&mut self.inner).map_err(|error| match error {})
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error> {
+        Backend::clear_region(&mut self.inner, clear_type).map_err(|error| match error {})
+    }
+
+    fn size(&self) -> Result<Size, Self::Error> {
+        Backend::size(&self.inner).map_err(|error| match error {})
+    }
+
+    fn window_size(&mut self) -> Result<WindowSize, Self::Error> {
+        Backend::window_size(&mut self.inner).map_err(|error| match error {})
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Backend::flush(&mut self.inner).map_err(|error| match error {})
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_control::{AssistantEvent, RuntimeEvent, RuntimeProvenance, SessionEvent};
+
+    fn session_event(event: SessionEvent) -> RuntimeControlEvent {
+        RuntimeControlEvent {
+            event_id: "event-1".into(),
+            provenance: RuntimeProvenance::local_tui("test-session"),
+            sequence: 1,
+            event: RuntimeEvent::Session(event),
+        }
+    }
+
+    fn assistant_event(event: AssistantEvent) -> RuntimeControlEvent {
+        RuntimeControlEvent {
+            event_id: "event-2".into(),
+            provenance: RuntimeProvenance::local_tui("test-session"),
+            sequence: 2,
+            event: RuntimeEvent::Assistant(event),
+        }
+    }
+
+    #[tokio::test]
+    async fn harness_scripts_lifecycle_and_typed_cancel() {
+        let mut harness = TuiHarness::new(RuntimeSnapshot::default()).expect("harness");
+        let snapshot = RuntimeSnapshot {
+            session_id: "scripted-session".into(),
+            ..RuntimeSnapshot::default()
+        };
+        harness.sync_snapshot(snapshot).await;
+
+        harness
+            .emit_runtime(session_event(SessionEvent::Status {
+                message: "Inspecting".into(),
+            }))
+            .await;
+        harness.expect_runtime_phase(RuntimePhase::ProcessingResponse);
+        harness
+            .emit_runtime(assistant_event(AssistantEvent::Text("Inspecting".into())))
+            .await;
+        harness.expect_transcript_contains("Inspecting");
+        harness
+            .cancel()
+            .await
+            .expect("cancel command should be accepted");
+        harness.expect_command(RuntimeCommand::Session(
+            SessionControlRequest::CancelCurrentTurn,
+        ));
+
+        harness.complete_turn(None).await;
+        harness.expect_runtime_phase(RuntimePhase::Idle);
+        harness.disconnect("transport closed").await;
+        harness.expect_runtime_phase(RuntimePhase::Failed);
+        harness.reconnect().await;
+        harness.expect_runtime_phase(RuntimePhase::Idle);
+        harness.render().expect("render test backend");
+    }
+}


### PR DESCRIPTION
## Summary

- add a test-only `FakeRuntimeClient` implementing `RuntimeClientPort`
- add a shared `TuiHarness` for scripted snapshots, runtime events, completion, cancel, disconnect, reconnect, and rendering
- drive the existing TUI reducer and custom renderer instead of duplicating production state logic
- document the test contract and keep virtual time and production port wiring as explicit follow-ups

## Motivation

TUI lifecycle tests previously needed to assemble runtime objects, channels, and task handles directly. This fixture makes runtime ordering deterministic without wall-clock sleeps or real model/network execution, while keeping the test boundary aligned with the session-scoped runtime port.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --bin rara tui::testing --no-fail-fast`
- `cargo test --bin rara tui::runtime_port --no-fail-fast`
- `cargo test --bin rara tui::controller --no-fail-fast`
- `git diff --check`

The macOS test linker emits the existing `__eh_frame` warning; Rust checks and tests pass.
