### PR TITLE
feat(tui): route commands through runtime port

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -80,10 +80,12 @@ to observe completion and is drained without replaying events. This prevents
 the same runtime event from being applied once through the port and again
 through the compatibility channel.
 
-The adapter intentionally rejects command submission for now. Interactive
-commands still use the compatibility task bridge until runtime command
-execution is moved behind the port; callers must surface that error rather
-than treating it as a successful runtime mutation.
+The in-process adapter now owns a typed command channel. User prompts and
+session cancellation enter the same event-loop mux as runtime projections and
+task completion, so production TUI input no longer invokes those operations
+directly from the terminal event branch. The command processor still delegates
+execution to the existing in-process task bridge while the remaining command
+families are migrated.
 
 ## Ownership Rules
 
@@ -103,8 +105,9 @@ than treating it as a successful runtime mutation.
 ## Follow-up
 
 - Replace compatibility projections in `TuiApp` with a typed runtime snapshot.
-- Move query, approval, compact, rebuild, and model-list actions to typed
-  `RuntimeCommand` submission.
+- Move approval, compact, rebuild, and model-list actions to typed
+  `RuntimeCommand` submission; prompt submission and session cancellation now
+  use that path but still execute through the compatibility task bridge.
 - Publish a TUI-facing typed projection event instead of converting
   `AgentEvent` into role/message strings and parsing those strings again.
 - Move goal continuation, plan completion, agent replacement, and queued

--- a/docs/journal/2026-08-02-runtime-command-routing.md
+++ b/docs/journal/2026-08-02-runtime-command-routing.md
@@ -1,0 +1,32 @@
+# Runtime Command Routing Checkpoint
+
+## What changed
+
+The in-process `RuntimeClientPort` now has a typed command channel. Production
+TUI prompt submission and current-turn cancellation are sent through that port
+and consumed by the same `tokio::select!` mux that handles runtime events and
+task completion.
+
+The command processor delegates to the existing runtime task bridge for this
+slice. Test-only direct dispatch helpers remain available for focused TUI
+tests, but the production terminal event loop no longer invokes them for
+prompt or cancellation commands.
+
+## Why
+
+This removes a second production command path and makes command ordering
+observable at the runtime boundary without prematurely moving every task
+constructor and registry owner in one change.
+
+## Trade-offs
+
+Approval, compact, rebuild, and model-list commands still use the compatibility
+bridge. The next migration must move those command families behind the same
+port before `TuiController` can stop holding the in-process runtime objects.
+
+## Verification
+
+- `cargo fmt`
+- `cargo check --all-targets`
+- `cargo test --bin rara tui::controller --no-fail-fast`
+- `cargo test --bin rara tui::runtime_port --no-fail-fast`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -39,8 +39,11 @@ Active backlog only. Keep this file small and current.
 - [ ] Replace the local `AgentEvent -> role/message -> parser` compatibility
       path with a typed TUI projection event carrying session and sequence
       identity.
-- [ ] Move interactive command submission behind `RuntimeClientPort`, then
-      remove the remaining `Agent`/registry ownership from `TuiController`.
+- [x] Route interactive user prompts and session cancellation through the
+      in-process `RuntimeClientPort` command mux.
+- [ ] Move query, approval, compact, rebuild, and model-list execution behind
+      `RuntimeClientPort`, then remove the remaining `Agent`/registry ownership
+      from `TuiController`.
 - [ ] Construct `TuiController` directly from an injected port and add
       virtual-time controls to the shared harness.
 

--- a/src/tui/controller.rs
+++ b/src/tui/controller.rs
@@ -10,13 +10,22 @@
 
 use futures::StreamExt;
 
-use super::runtime_port::{InProcessRuntimeClientPort, RuntimeClientPort, RuntimeProjectionEvent};
+use super::app_event::AppEvent;
+use super::event_dispatch::dispatch_event_with_runtime;
+use super::input_control;
+use super::runtime_port::{
+    InProcessRuntimeClientPort, RuntimeClientPort, RuntimeCommand, RuntimeEventStream,
+    RuntimeProjectionEvent,
+};
 use super::state::{TaskCompletion, TuiApp};
 use crate::agent::Agent;
+use crate::oauth::OAuthManager;
 use crate::runtime_client::RuntimeClient;
+use crate::runtime_control::{InputControlRequest, SessionControlRequest};
 
 pub(super) enum RuntimeActivity {
     Event(Option<RuntimeProjectionEvent>),
+    Command(Option<RuntimeCommand>),
     Completed(Box<Result<TaskCompletion, tokio::task::JoinError>>),
 }
 
@@ -25,14 +34,15 @@ pub(super) struct TuiController {
     app: TuiApp,
     runtime: RuntimeClient,
     runtime_port: InProcessRuntimeClientPort,
-    runtime_events: super::runtime_port::RuntimeEventStream,
+    runtime_events: RuntimeEventStream,
+    runtime_commands: tokio::sync::mpsc::UnboundedReceiver<RuntimeCommand>,
     /// Set to true every time an event is applied and the screen should repaint.
     pub(super) needs_redraw: bool,
 }
 
 impl TuiController {
     pub(super) fn new(app: TuiApp, runtime: RuntimeClient) -> Self {
-        let runtime_port = InProcessRuntimeClientPort::new(
+        let (runtime_port, runtime_commands) = InProcessRuntimeClientPort::new(
             runtime.event_bus.clone(),
             std::sync::Arc::new(std::sync::RwLock::new(app.snapshot.clone())),
         );
@@ -42,6 +52,7 @@ impl TuiController {
             runtime,
             runtime_port,
             runtime_events,
+            runtime_commands,
             needs_redraw: true,
         }
     }
@@ -52,6 +63,41 @@ impl TuiController {
 
     pub(super) fn app_mut(&mut self) -> &mut TuiApp {
         &mut self.app
+    }
+
+    pub(super) async fn dispatch_event(
+        &mut self,
+        event: AppEvent,
+        oauth_manager: &std::sync::Arc<OAuthManager>,
+    ) -> anyhow::Result<bool> {
+        let (app, runtime, runtime_port) = (&mut self.app, &mut self.runtime, &self.runtime_port);
+        dispatch_event_with_runtime(event, app, runtime.agent_mut(), oauth_manager, runtime_port)
+            .await
+    }
+
+    pub(super) async fn apply_runtime_command(
+        &mut self,
+        command: RuntimeCommand,
+    ) -> anyhow::Result<()> {
+        match command {
+            RuntimeCommand::Input(InputControlRequest::SubmitUserPrompt { prompt }) => {
+                input_control::submit_user_prompt(&mut self.app, self.runtime.agent_mut(), prompt);
+            }
+            RuntimeCommand::Input(InputControlRequest::SubmitFollowUp { prompt }) => {
+                input_control::submit_follow_up(&mut self.app, prompt, false);
+            }
+            RuntimeCommand::Session(SessionControlRequest::CancelCurrentTurn) => {
+                input_control::handle_session_control(
+                    &mut self.app,
+                    SessionControlRequest::CancelCurrentTurn,
+                );
+            }
+            command => self.app.push_notice(format!(
+                "Runtime command is not handled by the in-process TUI: {command:?}"
+            )),
+        }
+        self.needs_redraw = true;
+        Ok(())
     }
 
     pub(super) fn agent(&self) -> Option<&Agent> {
@@ -83,10 +129,19 @@ impl TuiController {
 
     /// Wait for the next runtime event or task completion without polling.
     pub(super) async fn wait_for_runtime_activity(&mut self) -> RuntimeActivity {
-        let Some(task) = self.app.bottom_pane.running_task.as_mut() else {
-            std::future::pending().await
-        };
-        select_runtime_activity(&mut self.runtime_events, &mut task.handle).await
+        if let Some(task) = self.app.bottom_pane.running_task.as_mut() {
+            select_runtime_activity(
+                &mut self.runtime_events,
+                &mut self.runtime_commands,
+                &mut task.handle,
+            )
+            .await
+        } else {
+            tokio::select! {
+                event = self.runtime_events.next() => RuntimeActivity::Event(event),
+                command = self.runtime_commands.recv() => RuntimeActivity::Command(command),
+            }
+        }
     }
 
     pub(super) fn apply_runtime_event(&mut self, event: RuntimeProjectionEvent) {
@@ -146,16 +201,19 @@ impl TuiController {
 }
 
 async fn select_runtime_activity(
-    runtime_events: &mut super::runtime_port::RuntimeEventStream,
+    runtime_events: &mut RuntimeEventStream,
+    runtime_commands: &mut tokio::sync::mpsc::UnboundedReceiver<RuntimeCommand>,
     handle: &mut tokio::task::JoinHandle<TaskCompletion>,
 ) -> RuntimeActivity {
     let activity = tokio::select! {
         event = runtime_events.next() => RuntimeActivity::Event(event),
+        command = runtime_commands.recv() => RuntimeActivity::Command(command),
         result = &mut *handle => RuntimeActivity::Completed(Box::new(result)),
     };
     match activity {
         RuntimeActivity::Event(Some(event)) => RuntimeActivity::Event(Some(event)),
         RuntimeActivity::Event(None) => RuntimeActivity::Completed(Box::new(handle.await)),
+        RuntimeActivity::Command(command) => RuntimeActivity::Command(command),
         RuntimeActivity::Completed(result) => RuntimeActivity::Completed(result),
     }
 }
@@ -164,7 +222,8 @@ async fn select_runtime_activity(
 mod tests {
     use futures::stream;
 
-    use super::{RuntimeActivity, select_runtime_activity};
+    use super::{RuntimeActivity, RuntimeCommand, select_runtime_activity};
+    use crate::runtime_control::SessionControlRequest;
     use crate::tui::runtime_port::{RuntimeEventStream, RuntimeProjectionEvent};
 
     #[tokio::test]
@@ -174,8 +233,10 @@ mod tests {
         });
         let mut runtime_events: RuntimeEventStream =
             Box::pin(stream::once(async { RuntimeProjectionEvent::Reconnected }));
+        let (_sender, mut runtime_commands) = tokio::sync::mpsc::unbounded_channel();
 
-        let activity = select_runtime_activity(&mut runtime_events, &mut handle).await;
+        let activity =
+            select_runtime_activity(&mut runtime_events, &mut runtime_commands, &mut handle).await;
         assert!(matches!(
             activity,
             RuntimeActivity::Event(Some(RuntimeProjectionEvent::Reconnected))
@@ -194,12 +255,39 @@ mod tests {
             }
         });
         let mut runtime_events: RuntimeEventStream = Box::pin(stream::empty());
+        let (_sender, mut runtime_commands) = tokio::sync::mpsc::unbounded_channel();
 
-        let activity = select_runtime_activity(&mut runtime_events, &mut handle).await;
+        let activity =
+            select_runtime_activity(&mut runtime_events, &mut runtime_commands, &mut handle).await;
         assert!(matches!(
             activity,
             RuntimeActivity::Completed(error)
                 if error.as_ref().as_ref().is_err_and(|error| error.is_panic())
         ));
+    }
+
+    #[tokio::test]
+    async fn runtime_mux_wakes_on_command_without_running_task() {
+        let (sender, mut commands) = tokio::sync::mpsc::unbounded_channel();
+        sender
+            .send(RuntimeCommand::Session(
+                SessionControlRequest::CancelCurrentTurn,
+            ))
+            .expect("command send");
+        let mut runtime_events: RuntimeEventStream = Box::pin(stream::pending());
+        let mut handle = tokio::spawn(async {
+            std::future::pending::<crate::tui::state::TaskCompletion>().await
+        });
+
+        let activity =
+            select_runtime_activity(&mut runtime_events, &mut commands, &mut handle).await;
+        assert!(matches!(
+            activity,
+            RuntimeActivity::Command(Some(RuntimeCommand::Session(
+                SessionControlRequest::CancelCurrentTurn
+            )))
+        ));
+        handle.abort();
+        let _ = handle.await;
     }
 }

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -16,23 +16,45 @@ use super::runtime::{
     start_deepseek_model_list_task, start_kimi_model_list_task, start_oauth_task,
     start_rebuild_task,
 };
+use super::runtime_port::{RuntimeClientPort, RuntimeCommand};
 use super::session_restore::restore_thread_by_id;
 use super::state::{
     ActivePendingInteractionKind, ListPickerKind, OpenAiModelPickerAction, Overlay, PermissionMode,
     PickerIntent, ProviderFamily, TuiApp,
 };
-use super::submit::{apply_openai_model_picker_action, handle_submit};
+use super::submit::{apply_openai_model_picker_action, handle_submit, handle_submit_with_port};
 use super::terminal_ui::is_ssh_session;
 use crate::agent::Agent;
 use crate::config::DEFAULT_CODEX_BASE_URL;
 use crate::oauth::{OAuthManager, SavedCodexAuthMode};
 use crate::runtime_control::{SessionControlRequest, ShellApprovalDecision};
 
+#[cfg(test)]
 pub(crate) async fn dispatch_event(
     event: AppEvent,
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
     oauth_manager: &Arc<OAuthManager>,
+) -> anyhow::Result<bool> {
+    dispatch_event_inner(event, app, agent_slot, oauth_manager, None).await
+}
+
+pub(crate) async fn dispatch_event_with_runtime(
+    event: AppEvent,
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    oauth_manager: &Arc<OAuthManager>,
+    runtime_port: &dyn RuntimeClientPort,
+) -> anyhow::Result<bool> {
+    dispatch_event_inner(event, app, agent_slot, oauth_manager, Some(runtime_port)).await
+}
+
+async fn dispatch_event_inner(
+    event: AppEvent,
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    oauth_manager: &Arc<OAuthManager>,
+    runtime_port: Option<&dyn RuntimeClientPort>,
 ) -> anyhow::Result<bool> {
     match event {
         AppEvent::Noop => {}
@@ -50,7 +72,18 @@ pub(crate) async fn dispatch_event(
             app.dismiss_overlay();
         }
         AppEvent::CancelRunningTask => {
-            input_control::handle_session_control(app, SessionControlRequest::CancelCurrentTurn);
+            if let Some(runtime_port) = runtime_port {
+                runtime_port
+                    .send(RuntimeCommand::Session(
+                        SessionControlRequest::CancelCurrentTurn,
+                    ))
+                    .await?;
+            } else {
+                input_control::handle_session_control(
+                    app,
+                    SessionControlRequest::CancelCurrentTurn,
+                );
+            }
         }
         AppEvent::ClearComposer => {
             app.bottom_pane.input.clear();
@@ -67,7 +100,12 @@ pub(crate) async fn dispatch_event(
             if resume_pending_shell_approval_after_full_access(app, agent_slot) {
                 return Ok(false);
             }
-            if handle_submit(app, agent_slot, oauth_manager).await? {
+            let should_quit = if let Some(runtime_port) = runtime_port {
+                handle_submit_with_port(app, agent_slot, oauth_manager, runtime_port).await?
+            } else {
+                handle_submit(app, agent_slot, oauth_manager).await?
+            };
+            if should_quit {
                 return Ok(true);
             }
         }
@@ -473,7 +511,13 @@ pub(crate) async fn dispatch_event(
                     app.dismiss_overlay();
                     app.bottom_pane.input = usage;
                     app.bottom_pane.input_cursor_offset = None;
-                    if handle_submit(app, agent_slot, oauth_manager).await? {
+                    let should_quit = if let Some(runtime_port) = runtime_port {
+                        handle_submit_with_port(app, agent_slot, oauth_manager, runtime_port)
+                            .await?
+                    } else {
+                        handle_submit(app, agent_slot, oauth_manager).await?
+                    };
+                    if should_quit {
                         return Ok(true);
                     }
                 }

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -7,7 +7,6 @@ use rara_state::state_db::StateDb;
 use tokio::time::{Duration, MissedTickBehavior, interval};
 
 use super::controller::{RuntimeActivity, TuiController};
-use super::event_dispatch::dispatch_event;
 use super::event_stream::{UiEvent, translate_event};
 use super::render::{desired_viewport_height, render};
 use super::session_restore::{restore_latest_thread, restore_thread_by_id};
@@ -155,15 +154,19 @@ pub async fn run_tui(
                         maintainer.complete_runtime_task(completion).await?;
                         needs_redraw = true;
                     }
+                    RuntimeActivity::Command(Some(command)) => {
+                        maintainer.apply_runtime_command(command).await?;
+                        needs_redraw = true;
+                    }
+                    RuntimeActivity::Command(None) => {}
                 }
             }
             maybe_event = events.next() => {
-                let (app, agent_slot) = maintainer.split_mut();
                 match maybe_event {
-                    Some(Ok(event)) => match translate_event(event, app) {
+                    Some(Ok(event)) => match translate_event(event, maintainer.app_mut()) {
                         Some(UiEvent::App(event)) => {
-                            if dispatch_event(event, app, agent_slot, &oauth_manager).await? {
-                                if let Some(task) = app.bottom_pane.running_task.take() {
+                            if maintainer.dispatch_event(event, &oauth_manager).await? {
+                                if let Some(task) = maintainer.app_mut().bottom_pane.running_task.take() {
                                     task.handle.abort();
                                 }
                                 break Ok(());
@@ -171,6 +174,7 @@ pub async fn run_tui(
                             needs_redraw = true;
                         }
                         Some(UiEvent::Draw) => {
+                            let app = maintainer.app_mut();
                             let size = terminal_size()?;
                             let desired_height = desired_viewport_height(app, size.0, size.1);
                             match update_terminal_viewport(&mut terminal, desired_height, app) {
@@ -184,10 +188,12 @@ pub async fn run_tui(
                             needs_redraw = true;
                         }
                         Some(UiEvent::Paste(text)) => {
+                            let app = maintainer.app_mut();
                             handle_paste(text, app);
                             needs_redraw = true;
                         }
                         Some(UiEvent::FocusChanged(_focused)) => {
+                            let (app, agent_slot) = maintainer.split_mut();
                             if let Some(agent_ref) = agent_slot.as_ref() {
                                 app.sync_snapshot(agent_ref);
                             }
@@ -197,7 +203,9 @@ pub async fn run_tui(
                         None => {}
                     },
                     Some(Err(err)) => {
-                        app.push_notice(format!("Terminal event error: {err}"));
+                        maintainer
+                            .app_mut()
+                            .push_notice(format!("Terminal event error: {err}"));
                         needs_redraw = true;
                     }
                     None => break Ok(()),

--- a/src/tui/runtime_port.rs
+++ b/src/tui/runtime_port.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use futures::Stream;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use crate::runtime_control::{
     ApprovalControlRequest, InputControlRequest, RuntimeControlEvent, SessionControlRequest,
@@ -65,17 +66,23 @@ pub(crate) trait RuntimeClientPort: Send {
 pub(crate) struct InProcessRuntimeClientPort {
     event_bus: Arc<RuntimeEventBus>,
     snapshot: Arc<RwLock<RuntimeSnapshot>>,
+    command_sender: UnboundedSender<RuntimeCommand>,
 }
 
 impl InProcessRuntimeClientPort {
     pub(crate) fn new(
         event_bus: Arc<RuntimeEventBus>,
         snapshot: Arc<RwLock<RuntimeSnapshot>>,
-    ) -> Self {
-        Self {
-            event_bus,
-            snapshot,
-        }
+    ) -> (Self, UnboundedReceiver<RuntimeCommand>) {
+        let (command_sender, command_receiver) = unbounded_channel();
+        (
+            Self {
+                event_bus,
+                snapshot,
+                command_sender,
+            },
+            command_receiver,
+        )
     }
 
     pub(crate) fn snapshot_store(&self) -> Arc<RwLock<RuntimeSnapshot>> {
@@ -92,8 +99,10 @@ impl RuntimeClientPort for InProcessRuntimeClientPort {
             .map_err(|_| anyhow::anyhow!("runtime snapshot lock is poisoned"))
     }
 
-    async fn send(&self, _command: RuntimeCommand) -> anyhow::Result<()> {
-        anyhow::bail!("in-process runtime commands still use the compatibility bridge")
+    async fn send(&self, command: RuntimeCommand) -> anyhow::Result<()> {
+        self.command_sender
+            .send(command)
+            .map_err(|_| anyhow::anyhow!("in-process runtime command channel is closed"))
     }
 
     fn subscribe(&self) -> RuntimeEventStream {
@@ -182,7 +191,7 @@ mod tests {
     #[tokio::test]
     async fn in_process_port_projects_control_bus_events() {
         let bus = std::sync::Arc::new(RuntimeEventBus::new(8));
-        let port = InProcessRuntimeClientPort::new(
+        let (port, _commands) = InProcessRuntimeClientPort::new(
             bus.clone(),
             std::sync::Arc::new(std::sync::RwLock::new(RuntimeSnapshot::default())),
         );

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use super::command::parse_local_command;
 use super::input_control;
 use super::runtime::execute_local_command;
+use super::runtime_port::{RuntimeClientPort, RuntimeCommand};
 use super::state::{
     ActivePendingInteractionKind, LocalCommandKind, OpenAiModelPickerAction, TuiApp,
 };
@@ -14,6 +15,24 @@ pub(crate) async fn handle_submit(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
     oauth_manager: &Arc<crate::oauth::OAuthManager>,
+) -> anyhow::Result<bool> {
+    handle_submit_inner(app, agent_slot, oauth_manager, None).await
+}
+
+pub(crate) async fn handle_submit_with_port(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    oauth_manager: &Arc<crate::oauth::OAuthManager>,
+    runtime_port: &dyn RuntimeClientPort,
+) -> anyhow::Result<bool> {
+    handle_submit_inner(app, agent_slot, oauth_manager, Some(runtime_port)).await
+}
+
+async fn handle_submit_inner(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    oauth_manager: &Arc<crate::oauth::OAuthManager>,
+    runtime_port: Option<&dyn RuntimeClientPort>,
 ) -> anyhow::Result<bool> {
     if app.bottom_pane.input.is_empty() {
         if let Some(interaction) = app.active_pending_interaction()
@@ -58,6 +77,14 @@ pub(crate) async fn handle_submit(
             app.push_notice(
                 "A task is already running. Wait for it to finish before running a slash command.",
             );
+        } else if let Some(runtime_port) = runtime_port {
+            runtime_port
+                .send(RuntimeCommand::Input(
+                    crate::runtime_control::InputControlRequest::SubmitUserPrompt {
+                        prompt: trimmed,
+                    },
+                ))
+                .await?;
         } else {
             input_control::submit_user_prompt(app, agent_slot, trimmed);
         }
@@ -81,6 +108,12 @@ pub(crate) async fn handle_submit(
         app.push_notice(format!("Unknown command '{}'. Use /help.", trimmed));
     } else if pending::handle_pending_option_submit(app, agent_slot, &trimmed) {
         return Ok(false);
+    } else if let Some(runtime_port) = runtime_port {
+        runtime_port
+            .send(RuntimeCommand::Input(
+                crate::runtime_control::InputControlRequest::SubmitUserPrompt { prompt: trimmed },
+            ))
+            .await?;
     } else {
         input_control::submit_user_prompt(app, agent_slot, trimmed);
     }


### PR DESCRIPTION
## Summary

- route production TUI user prompts and current-turn cancellation through the typed `RuntimeClientPort` command channel;
- consume commands alongside runtime projections and task completion in the event-loop mux;
- add command routing tests and update the runtime client specification, TODO, and implementation journal.

## Motivation

The production TUI previously invoked prompt and cancellation handling directly from the terminal event branch while runtime projections used a separate port. This change gives interactive commands one typed entry point without moving the remaining task constructors and registry ownership prematurely.

## Related issue

No linked issue.

## Testing

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --bin rara tui::controller --no-fail-fast`
- `cargo test --bin rara tui::runtime_port --no-fail-fast`

The macOS linker still emits the existing `__eh_frame` warning during test linking.
