### PR TITLE
feat(tui): route approvals through runtime port

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -83,7 +83,8 @@ through the compatibility channel.
 The in-process adapter now owns a typed command channel. User prompts and
 session cancellation enter the same event-loop mux as runtime projections and
 task completion, so production TUI input no longer invokes those operations
-directly from the terminal event branch. The command processor still delegates
+directly from the terminal event branch. Plan, shell, and pending-input
+approval responses use the same path. The command processor still delegates
 execution to the existing in-process task bridge while the remaining command
 families are migrated.
 
@@ -105,9 +106,9 @@ families are migrated.
 ## Follow-up
 
 - Replace compatibility projections in `TuiApp` with a typed runtime snapshot.
-- Move approval, compact, rebuild, and model-list actions to typed
-  `RuntimeCommand` submission; prompt submission and session cancellation now
-  use that path but still execute through the compatibility task bridge.
+- Move compact, rebuild, and model-list actions to typed `RuntimeCommand`
+  submission; prompt, cancellation, and approval commands now use that path
+  but still execute through the compatibility task bridge.
 - Publish a TUI-facing typed projection event instead of converting
   `AgentEvent` into role/message strings and parsing those strings again.
 - Move goal continuation, plan completion, agent replacement, and queued

--- a/docs/journal/2026-08-03-runtime-approval-routing.md
+++ b/docs/journal/2026-08-03-runtime-approval-routing.md
@@ -1,0 +1,32 @@
+# Runtime Approval Routing Checkpoint
+
+## What changed
+
+Production TUI approval actions now submit typed `InputControlRequest` values
+through `RuntimeClientPort`. This includes plan decisions with feedback, shell
+approval scope, pending request-input answers, numeric approval shortcuts, and
+the automatic shell approval triggered by full-access mode.
+
+The controller consumes these commands from the same event-loop mux used for
+runtime projections and task completion, then invokes the existing approval
+task constructors through the runtime-owned agent slot.
+
+## Why
+
+Approval was the remaining interactive path that could bypass the runtime port
+after prompt submission and cancellation had migrated. Keeping it on a single
+typed command path makes ordering and transport replacement consistent without
+changing approval semantics or task lifecycle behavior.
+
+## Trade-offs
+
+Compact, rebuild, and model-list commands still use the compatibility path.
+The in-process controller still owns the runtime adapter and agent slot until
+those command families are migrated.
+
+## Verification
+
+- `cargo fmt`
+- `cargo check --all-targets`
+- `cargo test --bin rara tui::submit --no-fail-fast`
+- `cargo test --bin rara tui::input_control --no-fail-fast`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -41,7 +41,9 @@ Active backlog only. Keep this file small and current.
       identity.
 - [x] Route interactive user prompts and session cancellation through the
       in-process `RuntimeClientPort` command mux.
-- [ ] Move query, approval, compact, rebuild, and model-list execution behind
+- [x] Route plan, shell, and pending-input approval commands through the
+      in-process `RuntimeClientPort` command mux.
+- [ ] Move compact, rebuild, and model-list execution behind
       `RuntimeClientPort`, then remove the remaining `Agent`/registry ownership
       from `TuiController`.
 - [ ] Construct `TuiController` directly from an injected port and add

--- a/src/tui/controller.rs
+++ b/src/tui/controller.rs
@@ -86,6 +86,37 @@ impl TuiController {
             RuntimeCommand::Input(InputControlRequest::SubmitFollowUp { prompt }) => {
                 input_control::submit_follow_up(&mut self.app, prompt, false);
             }
+            RuntimeCommand::Input(InputControlRequest::AnswerPendingInput { answer }) => {
+                if let Some(agent) = self.runtime.agent_mut().take() {
+                    input_control::answer_pending_input(
+                        &mut self.app,
+                        self.runtime.agent_mut(),
+                        agent,
+                        answer,
+                    );
+                } else {
+                    self.app
+                        .push_notice("Request input is still preparing. Try again.");
+                }
+            }
+            RuntimeCommand::Input(InputControlRequest::AnswerPlanApproval {
+                decision,
+                feedback,
+            }) => {
+                input_control::answer_plan_approval_with_feedback(
+                    &mut self.app,
+                    self.runtime.agent_mut(),
+                    decision,
+                    feedback,
+                );
+            }
+            RuntimeCommand::Input(InputControlRequest::AnswerShellApproval { decision }) => {
+                input_control::answer_shell_approval(
+                    &mut self.app,
+                    self.runtime.agent_mut(),
+                    decision,
+                );
+            }
             RuntimeCommand::Session(SessionControlRequest::CancelCurrentTurn) => {
                 input_control::handle_session_control(
                     &mut self.app,

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -97,7 +97,9 @@ async fn dispatch_event_inner(
         }
         AppEvent::SubmitComposer => {
             app.bottom_pane.expand_large_paste();
-            if resume_pending_shell_approval_after_full_access(app, agent_slot) {
+            if resume_pending_shell_approval_after_full_access(app, agent_slot, runtime_port)
+                .await?
+            {
                 return Ok(false);
             }
             let should_quit = if let Some(runtime_port) = runtime_port {
@@ -262,7 +264,9 @@ async fn dispatch_event_inner(
             app.permission_picker_idx = idx.min(3usize);
         }
         AppEvent::SelectPendingOption(idx) => {
-            if resume_pending_shell_approval_after_full_access(app, agent_slot) {
+            if resume_pending_shell_approval_after_full_access(app, agent_slot, runtime_port)
+                .await?
+            {
                 return Ok(false);
             }
             if let Some(interaction) = app.active_pending_interaction() {
@@ -270,7 +274,18 @@ async fn dispatch_event_inner(
                     ActivePendingInteractionKind::PlanApproval => {
                         if let Some(decision) = input_control::plan_approval_decision_for_index(idx)
                         {
-                            input_control::answer_plan_approval(app, agent_slot, decision);
+                            if let Some(runtime_port) = runtime_port {
+                                runtime_port
+                                    .send(RuntimeCommand::Input(
+                                        crate::runtime_control::InputControlRequest::AnswerPlanApproval {
+                                            decision,
+                                            feedback: None,
+                                        },
+                                    ))
+                                    .await?;
+                            } else {
+                                input_control::answer_plan_approval(app, agent_slot, decision);
+                            }
                         } else {
                             app.push_notice("Invalid plan approval option.");
                         }
@@ -282,14 +297,32 @@ async fn dispatch_event_inner(
                             2 => ShellApprovalDecision::Always,
                             _ => ShellApprovalDecision::Suggestion,
                         };
-                        input_control::answer_shell_approval(app, agent_slot, selection);
+                        if let Some(runtime_port) = runtime_port {
+                            runtime_port
+                                .send(RuntimeCommand::Input(
+                                    crate::runtime_control::InputControlRequest::AnswerShellApproval {
+                                        decision: selection,
+                                    },
+                                ))
+                                .await?;
+                        } else {
+                            input_control::answer_shell_approval(app, agent_slot, selection);
+                        }
                     }
                     ActivePendingInteractionKind::PlanningQuestion
                     | ActivePendingInteractionKind::ExplorationQuestion
                     | ActivePendingInteractionKind::SubAgentQuestion
                     | ActivePendingInteractionKind::RequestInput => {
                         if let Some(label) = app.pending_question_option_label(idx) {
-                            if let Some(agent) = agent_slot.take() {
+                            if let Some(runtime_port) = runtime_port {
+                                runtime_port
+                                        .send(RuntimeCommand::Input(
+                                            crate::runtime_control::InputControlRequest::AnswerPendingInput {
+                                                answer: label,
+                                            },
+                                        ))
+                                        .await?;
+                            } else if let Some(agent) = agent_slot.take() {
                                 input_control::answer_pending_input(app, agent_slot, agent, label);
                             } else {
                                 app.push_notice(
@@ -790,7 +823,13 @@ async fn dispatch_event_inner(
                     app.permission_mode = mode;
                     let label = mode.label();
                     app.dismiss_overlay();
-                    if !resume_pending_shell_approval_after_full_access(app, agent_slot) {
+                    if !(resume_pending_shell_approval_after_full_access(
+                        app,
+                        agent_slot,
+                        runtime_port,
+                    )
+                    .await?)
+                    {
                         app.push_notice(format!("Permission mode: {label}."));
                     }
                 }
@@ -801,23 +840,32 @@ async fn dispatch_event_inner(
     Ok(false)
 }
 
-fn resume_pending_shell_approval_after_full_access(
+async fn resume_pending_shell_approval_after_full_access(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
-) -> bool {
+    runtime_port: Option<&dyn RuntimeClientPort>,
+) -> anyhow::Result<bool> {
     if app.permission_mode != PermissionMode::FullAccess
         || !app.active_pending_interaction().is_some_and(|interaction| {
             interaction.kind == ActivePendingInteractionKind::ShellApproval
         })
         || app.is_busy()
     {
-        return false;
+        return Ok(false);
     }
 
-    if agent_slot.is_some() {
+    if let Some(runtime_port) = runtime_port {
+        runtime_port
+            .send(RuntimeCommand::Input(
+                crate::runtime_control::InputControlRequest::AnswerShellApproval {
+                    decision: ShellApprovalDecision::Once,
+                },
+            ))
+            .await?;
+    } else if agent_slot.is_some() {
         input_control::answer_shell_approval(app, agent_slot, ShellApprovalDecision::Once);
     } else {
         app.push_notice("Permission mode: full-access. Approval is still preparing.");
     }
-    true
+    Ok(true)
 }

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -92,7 +92,7 @@ async fn handle_submit_inner(
     }
 
     if app.has_pending_plan_approval() && !trimmed.starts_with('/') {
-        if pending::handle_pending_option_submit(app, agent_slot, &trimmed) {
+        if pending::handle_pending_option_submit(app, agent_slot, &trimmed, runtime_port).await? {
             return Ok(false);
         }
         handle_pending_plan_approval_submit(app);
@@ -106,7 +106,8 @@ async fn handle_submit_inner(
         }
     } else if trimmed.starts_with('/') {
         app.push_notice(format!("Unknown command '{}'. Use /help.", trimmed));
-    } else if pending::handle_pending_option_submit(app, agent_slot, &trimmed) {
+    } else if pending::handle_pending_option_submit(app, agent_slot, &trimmed, runtime_port).await?
+    {
         return Ok(false);
     } else if let Some(runtime_port) = runtime_port {
         runtime_port

--- a/src/tui/submit/pending.rs
+++ b/src/tui/submit/pending.rs
@@ -1,31 +1,41 @@
 use crate::agent::Agent;
-use crate::runtime_control::ShellApprovalDecision;
+use crate::runtime_control::{InputControlRequest, ShellApprovalDecision};
 use crate::tui::input_control;
+use crate::tui::runtime_port::{RuntimeClientPort, RuntimeCommand};
 use crate::tui::state::{ActivePendingInteractionKind, TuiApp};
 
-pub(super) fn handle_pending_option_submit(
+pub(super) async fn handle_pending_option_submit(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
     trimmed: &str,
-) -> bool {
+    runtime_port: Option<&dyn RuntimeClientPort>,
+) -> anyhow::Result<bool> {
     let Some(index) = pending_option_index_from_text(trimmed) else {
-        return false;
+        return Ok(false);
     };
     if index >= app.active_pending_option_count() {
-        return false;
+        return Ok(false);
     }
     let Some(interaction) = app.active_pending_interaction() else {
-        return false;
+        return Ok(false);
     };
     match interaction.kind {
         ActivePendingInteractionKind::PlanApproval => {
             if let Some(decision) = input_control::plan_approval_decision_for_index(index) {
                 let feedback = pending_option_feedback_from_text(trimmed);
-                input_control::answer_plan_approval_with_feedback(
-                    app, agent_slot, decision, feedback,
-                );
+                if let Some(runtime_port) = runtime_port {
+                    runtime_port
+                        .send(RuntimeCommand::Input(
+                            InputControlRequest::AnswerPlanApproval { decision, feedback },
+                        ))
+                        .await?;
+                } else {
+                    input_control::answer_plan_approval_with_feedback(
+                        app, agent_slot, decision, feedback,
+                    );
+                }
             }
-            true
+            Ok(true)
         }
         ActivePendingInteractionKind::ShellApproval => {
             let selection = match index {
@@ -34,22 +44,38 @@ pub(super) fn handle_pending_option_submit(
                 2 => ShellApprovalDecision::Always,
                 _ => ShellApprovalDecision::Suggestion,
             };
-            input_control::answer_shell_approval(app, agent_slot, selection);
-            true
+            if let Some(runtime_port) = runtime_port {
+                runtime_port
+                    .send(RuntimeCommand::Input(
+                        InputControlRequest::AnswerShellApproval {
+                            decision: selection,
+                        },
+                    ))
+                    .await?;
+            } else {
+                input_control::answer_shell_approval(app, agent_slot, selection);
+            }
+            Ok(true)
         }
         ActivePendingInteractionKind::PlanningQuestion
         | ActivePendingInteractionKind::ExplorationQuestion
         | ActivePendingInteractionKind::SubAgentQuestion
         | ActivePendingInteractionKind::RequestInput => {
             if let Some(label) = app.pending_question_option_label(index) {
-                if let Some(agent) = agent_slot.take() {
+                if let Some(runtime_port) = runtime_port {
+                    runtime_port
+                        .send(RuntimeCommand::Input(
+                            InputControlRequest::AnswerPendingInput { answer: label },
+                        ))
+                        .await?;
+                } else if let Some(agent) = agent_slot.take() {
                     input_control::answer_pending_input(app, agent_slot, agent, label);
                 } else {
                     app.push_notice("Request input is still preparing. Try the shortcut again.");
                 }
-                return true;
+                return Ok(true);
             }
-            false
+            Ok(false)
         }
     }
 }


### PR DESCRIPTION
## Summary

- route plan, shell, and pending-input approval responses through the typed `RuntimeClientPort` command mux;
- cover numeric shortcuts, feedback-bearing plan decisions, and full-access automatic shell approval;
- update the runtime client contract, TODO, and implementation journal.

## Motivation

Approval handling was the remaining interactive TUI path that could bypass the runtime port after prompt submission and cancellation had migrated. This change gives approval actions the same typed command boundary while preserving the existing approval task and agent lifecycle behavior.

## Related issue

No linked issue.

## Testing

- `cargo fmt`
- `cargo check --all-targets`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --bin rara tui::event_dispatch --no-fail-fast`
- `cargo test --bin rara tui::submit --no-fail-fast`
- `cargo test --bin rara tui::input_control --no-fail-fast`

The macOS linker still emits the existing `__eh_frame` warning during test linking.
