### PR TITLE
feat(tui): route maintenance commands through runtime port

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -86,8 +86,9 @@ task completion, so production TUI input no longer invokes those operations
 directly from the terminal event branch. Plan, shell, and pending-input
 approval responses use the same path. Compact, rebuild, and model-catalog
 commands use the same path as well. The command processor still delegates
-execution to the existing in-process task bridge while runtime replacement and
-task construction are being moved out of the controller.
+execution to the existing in-process task bridge. `TuiController` no longer
+owns `RuntimeClient` or an `Agent`; an independent runtime command processor
+owns task construction, completion, and runtime replacement access.
 
 ## Ownership Rules
 
@@ -107,9 +108,9 @@ task construction are being moved out of the controller.
 ## Follow-up
 
 - Replace compatibility projections in `TuiApp` with a typed runtime snapshot.
-- Move runtime replacement and task construction out of `TuiController`; all
-  interactive command families now use typed `RuntimeCommand` submission but
-  still execute through the compatibility task bridge.
+- Remove mutable extension-registry projections from `TuiApp`; all registry
+  discovery and reload should remain runtime-owned while TUI consumes typed
+  snapshots.
 - Publish a TUI-facing typed projection event instead of converting
   `AgentEvent` into role/message strings and parsing those strings again.
 - Move goal continuation, plan completion, agent replacement, and queued

--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -84,9 +84,10 @@ The in-process adapter now owns a typed command channel. User prompts and
 session cancellation enter the same event-loop mux as runtime projections and
 task completion, so production TUI input no longer invokes those operations
 directly from the terminal event branch. Plan, shell, and pending-input
-approval responses use the same path. The command processor still delegates
-execution to the existing in-process task bridge while the remaining command
-families are migrated.
+approval responses use the same path. Compact, rebuild, and model-catalog
+commands use the same path as well. The command processor still delegates
+execution to the existing in-process task bridge while runtime replacement and
+task construction are being moved out of the controller.
 
 ## Ownership Rules
 
@@ -106,9 +107,9 @@ families are migrated.
 ## Follow-up
 
 - Replace compatibility projections in `TuiApp` with a typed runtime snapshot.
-- Move compact, rebuild, and model-list actions to typed `RuntimeCommand`
-  submission; prompt, cancellation, and approval commands now use that path
-  but still execute through the compatibility task bridge.
+- Move runtime replacement and task construction out of `TuiController`; all
+  interactive command families now use typed `RuntimeCommand` submission but
+  still execute through the compatibility task bridge.
 - Publish a TUI-facing typed projection event instead of converting
   `AgentEvent` into role/message strings and parsing those strings again.
 - Move goal continuation, plan completion, agent replacement, and queued

--- a/docs/journal/2026-08-03-runtime-command-processor.md
+++ b/docs/journal/2026-08-03-runtime-command-processor.md
@@ -1,0 +1,32 @@
+# Runtime Command Processor Checkpoint
+
+## What changed
+
+`RuntimeClient` ownership moved out of `TuiController` into
+`RuntimeCommandProcessor`. The event loop now owns the processor separately
+from the presentation controller and passes it explicit commands, task
+completions, and snapshot synchronization requests.
+
+The processor owns agent access for query, approval, compaction, rebuild,
+model-catalog, completion, and runtime replacement operations. The controller
+now retains presentation state, the runtime port, and the event mux only.
+
+## Why
+
+Keeping the session runtime in the presentation controller made it too easy to
+add execution or lifecycle behavior to TUI code. Separating the processor
+establishes the ownership boundary needed by future app-server clients while
+preserving the current in-process task implementation.
+
+## Remaining boundary
+
+`TuiApp` still contains compatibility projections for extension registries.
+Those fields are populated by runtime bootstrap and are not discovered by the
+TUI, but they should eventually be replaced by typed snapshot data.
+
+## Verification
+
+- `cargo fmt`
+- `cargo check --all-targets`
+- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
+- focused controller, event-loop, command, input-control, submit, and port tests

--- a/docs/journal/2026-08-03-runtime-maintenance-routing.md
+++ b/docs/journal/2026-08-03-runtime-maintenance-routing.md
@@ -1,0 +1,34 @@
+# Runtime Maintenance Routing Checkpoint
+
+## What changed
+
+Compact, backend rebuild, and DeepSeek/Kimi model-catalog operations now enter
+the typed `RuntimeClientPort` command mux. This includes commands triggered by
+slash commands, provider setup, model picker selections, profile changes, and
+initial runtime startup.
+
+The controller consumes `RuntimeMaintenanceCommand` values together with
+runtime events, interactive input, and task completion. Existing in-process
+task constructors and completion behavior remain unchanged in this slice.
+
+## Why
+
+These operations were the last major command families launched directly from
+the terminal event path. Routing them through one command contract makes the
+same behavior available to a future app-server client and keeps command order
+observable at the session boundary.
+
+## Remaining ownership work
+
+The in-process controller still holds the session `RuntimeClient` and invokes
+the compatibility task constructors after consuming commands. Moving those
+constructors and runtime replacement into the command processor is the final
+ownership step; it must preserve agent continuity, queued follow-ups, and
+completion draining.
+
+## Verification
+
+- `cargo fmt`
+- `cargo check --all-targets`
+- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
+- focused TUI command, controller, and runtime-port tests

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -46,9 +46,12 @@ Active backlog only. Keep this file small and current.
 - [x] Move compact, rebuild, and model-list execution behind
       `RuntimeClientPort` while preserving the existing in-process task
       lifecycle.
-- [ ] Remove the remaining `Agent`/registry ownership from `TuiController` by
-      moving task construction and runtime replacement into the command
-      processor.
+- [x] Remove `RuntimeClient`/`Agent` ownership from `TuiController` by moving
+      task construction, completion, and runtime replacement access into the
+      runtime command processor.
+- [ ] Remove mutable extension-registry projections from `TuiApp`; registry
+      discovery and reload must remain runtime-owned while TUI receives typed
+      snapshots.
 - [ ] Construct `TuiController` directly from an injected port and add
       virtual-time controls to the shared harness.
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -43,9 +43,12 @@ Active backlog only. Keep this file small and current.
       in-process `RuntimeClientPort` command mux.
 - [x] Route plan, shell, and pending-input approval commands through the
       in-process `RuntimeClientPort` command mux.
-- [ ] Move compact, rebuild, and model-list execution behind
-      `RuntimeClientPort`, then remove the remaining `Agent`/registry ownership
-      from `TuiController`.
+- [x] Move compact, rebuild, and model-list execution behind
+      `RuntimeClientPort` while preserving the existing in-process task
+      lifecycle.
+- [ ] Remove the remaining `Agent`/registry ownership from `TuiController` by
+      moving task construction and runtime replacement into the command
+      processor.
 - [ ] Construct `TuiController` directly from an injected port and add
       virtual-time controls to the shared harness.
 

--- a/src/tui/controller.rs
+++ b/src/tui/controller.rs
@@ -15,7 +15,7 @@ use super::event_dispatch::dispatch_event_with_runtime;
 use super::input_control;
 use super::runtime_port::{
     InProcessRuntimeClientPort, RuntimeClientPort, RuntimeCommand, RuntimeEventStream,
-    RuntimeProjectionEvent,
+    RuntimeMaintenanceCommand, RuntimeProjectionEvent,
 };
 use super::state::{TaskCompletion, TuiApp};
 use crate::agent::Agent;
@@ -75,6 +75,10 @@ impl TuiController {
             .await
     }
 
+    pub(super) async fn send_runtime_command(&self, command: RuntimeCommand) -> anyhow::Result<()> {
+        self.runtime_port.send(command).await
+    }
+
     pub(super) async fn apply_runtime_command(
         &mut self,
         command: RuntimeCommand,
@@ -122,6 +126,23 @@ impl TuiController {
                     &mut self.app,
                     SessionControlRequest::CancelCurrentTurn,
                 );
+            }
+            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::Compact) => {
+                if let Some(agent) = self.runtime.agent_mut().take() {
+                    super::runtime::start_compact_task(&mut self.app, agent);
+                } else {
+                    self.app
+                        .push_notice("No active agent available for compaction.");
+                }
+            }
+            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::Rebuild) => {
+                super::runtime::start_rebuild_task(&mut self.app);
+            }
+            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::LoadDeepSeekModels) => {
+                super::runtime::start_deepseek_model_list_task(&mut self.app);
+            }
+            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::LoadKimiModels) => {
+                super::runtime::start_kimi_model_list_task(&mut self.app);
             }
             command => self.app.push_notice(format!(
                 "Runtime command is not handled by the in-process TUI: {command:?}"

--- a/src/tui/controller.rs
+++ b/src/tui/controller.rs
@@ -11,17 +11,13 @@
 use futures::StreamExt;
 
 use super::app_event::AppEvent;
-use super::event_dispatch::dispatch_event_with_runtime;
-use super::input_control;
+use super::runtime::RuntimeCommandProcessor;
 use super::runtime_port::{
     InProcessRuntimeClientPort, RuntimeClientPort, RuntimeCommand, RuntimeEventStream,
-    RuntimeMaintenanceCommand, RuntimeProjectionEvent,
+    RuntimeProjectionEvent,
 };
 use super::state::{TaskCompletion, TuiApp};
-use crate::agent::Agent;
 use crate::oauth::OAuthManager;
-use crate::runtime_client::RuntimeClient;
-use crate::runtime_control::{InputControlRequest, SessionControlRequest};
 
 pub(super) enum RuntimeActivity {
     Event(Option<RuntimeProjectionEvent>),
@@ -32,7 +28,6 @@ pub(super) enum RuntimeActivity {
 /// Owns TUI presentation state and applies runtime projections to it.
 pub(super) struct TuiController {
     app: TuiApp,
-    runtime: RuntimeClient,
     runtime_port: InProcessRuntimeClientPort,
     runtime_events: RuntimeEventStream,
     runtime_commands: tokio::sync::mpsc::UnboundedReceiver<RuntimeCommand>,
@@ -41,15 +36,14 @@ pub(super) struct TuiController {
 }
 
 impl TuiController {
-    pub(super) fn new(app: TuiApp, runtime: RuntimeClient) -> Self {
-        let (runtime_port, runtime_commands) = InProcessRuntimeClientPort::new(
-            runtime.event_bus.clone(),
-            std::sync::Arc::new(std::sync::RwLock::new(app.snapshot.clone())),
-        );
+    pub(super) fn new(
+        app: TuiApp,
+        runtime_port: InProcessRuntimeClientPort,
+        runtime_commands: tokio::sync::mpsc::UnboundedReceiver<RuntimeCommand>,
+    ) -> Self {
         let runtime_events = runtime_port.subscribe();
         Self {
             app,
-            runtime,
             runtime_port,
             runtime_events,
             runtime_commands,
@@ -67,11 +61,12 @@ impl TuiController {
 
     pub(super) async fn dispatch_event(
         &mut self,
+        processor: &mut RuntimeCommandProcessor,
         event: AppEvent,
         oauth_manager: &std::sync::Arc<OAuthManager>,
     ) -> anyhow::Result<bool> {
-        let (app, runtime, runtime_port) = (&mut self.app, &mut self.runtime, &self.runtime_port);
-        dispatch_event_with_runtime(event, app, runtime.agent_mut(), oauth_manager, runtime_port)
+        processor
+            .dispatch_event(&mut self.app, event, oauth_manager, &self.runtime_port)
             .await
     }
 
@@ -81,100 +76,22 @@ impl TuiController {
 
     pub(super) async fn apply_runtime_command(
         &mut self,
+        processor: &mut RuntimeCommandProcessor,
         command: RuntimeCommand,
     ) -> anyhow::Result<()> {
-        match command {
-            RuntimeCommand::Input(InputControlRequest::SubmitUserPrompt { prompt }) => {
-                input_control::submit_user_prompt(&mut self.app, self.runtime.agent_mut(), prompt);
-            }
-            RuntimeCommand::Input(InputControlRequest::SubmitFollowUp { prompt }) => {
-                input_control::submit_follow_up(&mut self.app, prompt, false);
-            }
-            RuntimeCommand::Input(InputControlRequest::AnswerPendingInput { answer }) => {
-                if let Some(agent) = self.runtime.agent_mut().take() {
-                    input_control::answer_pending_input(
-                        &mut self.app,
-                        self.runtime.agent_mut(),
-                        agent,
-                        answer,
-                    );
-                } else {
-                    self.app
-                        .push_notice("Request input is still preparing. Try again.");
-                }
-            }
-            RuntimeCommand::Input(InputControlRequest::AnswerPlanApproval {
-                decision,
-                feedback,
-            }) => {
-                input_control::answer_plan_approval_with_feedback(
-                    &mut self.app,
-                    self.runtime.agent_mut(),
-                    decision,
-                    feedback,
-                );
-            }
-            RuntimeCommand::Input(InputControlRequest::AnswerShellApproval { decision }) => {
-                input_control::answer_shell_approval(
-                    &mut self.app,
-                    self.runtime.agent_mut(),
-                    decision,
-                );
-            }
-            RuntimeCommand::Session(SessionControlRequest::CancelCurrentTurn) => {
-                input_control::handle_session_control(
-                    &mut self.app,
-                    SessionControlRequest::CancelCurrentTurn,
-                );
-            }
-            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::Compact) => {
-                if let Some(agent) = self.runtime.agent_mut().take() {
-                    super::runtime::start_compact_task(&mut self.app, agent);
-                } else {
-                    self.app
-                        .push_notice("No active agent available for compaction.");
-                }
-            }
-            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::Rebuild) => {
-                super::runtime::start_rebuild_task(&mut self.app);
-            }
-            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::LoadDeepSeekModels) => {
-                super::runtime::start_deepseek_model_list_task(&mut self.app);
-            }
-            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::LoadKimiModels) => {
-                super::runtime::start_kimi_model_list_task(&mut self.app);
-            }
-            command => self.app.push_notice(format!(
-                "Runtime command is not handled by the in-process TUI: {command:?}"
-            )),
-        }
+        processor.apply_command(&mut self.app, command).await?;
         self.needs_redraw = true;
         Ok(())
-    }
-
-    pub(super) fn agent(&self) -> Option<&Agent> {
-        self.runtime.agent()
-    }
-
-    /// Split borrow so callers that need independent `&mut TuiApp` and
-    /// `&mut Option<Agent>` can still use them while the controller
-    /// owns both.
-    pub(super) fn split_mut(&mut self) -> (&mut TuiApp, &mut Option<Agent>) {
-        (&mut self.app, self.runtime.agent_mut())
     }
 
     /// Drain pending agent events from the running task, apply them, and
     /// finalize the task if it has completed.
     pub(super) async fn complete_runtime_task(
         &mut self,
+        processor: &mut RuntimeCommandProcessor,
         completion: Box<Result<TaskCompletion, tokio::task::JoinError>>,
     ) -> anyhow::Result<()> {
-        super::runtime::tasks::finish_running_task_if_ready_from_runtime_port(
-            &mut self.app,
-            self.runtime.agent_mut(),
-            Some(*completion),
-        )
-        .await?;
+        processor.complete(&mut self.app, completion).await?;
         self.needs_redraw = true;
         Ok(())
     }
@@ -228,13 +145,11 @@ impl TuiController {
     }
 
     /// Sync snapshot from the active agent (must be called at the top of the event loop).
-    pub(super) async fn sync_snapshot(&mut self) -> anyhow::Result<()> {
-        if let Some(agent_ref) = self.runtime.agent() {
-            self.app.sync_snapshot(agent_ref);
-            if let Ok(mut snapshot) = self.runtime_port.snapshot_store().write() {
-                *snapshot = self.app.snapshot.clone();
-            }
-        }
+    pub(super) async fn sync_snapshot(
+        &mut self,
+        processor: &RuntimeCommandProcessor,
+    ) -> anyhow::Result<()> {
+        processor.sync_snapshot(&mut self.app, &self.runtime_port.snapshot_store());
         self.app.snapshot = self.runtime_port.snapshot().await?;
         Ok(())
     }

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -12,11 +12,8 @@ use super::provider_flow::{
     sync_codex_credential_from_auth_store,
 };
 use super::runtime::apply_permission_mode;
-use super::runtime::{
-    start_deepseek_model_list_task, start_kimi_model_list_task, start_oauth_task,
-    start_rebuild_task,
-};
-use super::runtime_port::{RuntimeClientPort, RuntimeCommand};
+use super::runtime::start_oauth_task;
+use super::runtime_port::{RuntimeClientPort, RuntimeCommand, RuntimeMaintenanceCommand};
 use super::session_restore::restore_thread_by_id;
 use super::state::{
     ActivePendingInteractionKind, ListPickerKind, OpenAiModelPickerAction, Overlay, PermissionMode,
@@ -397,15 +394,26 @@ async fn dispatch_event_inner(
                     app.bottom_pane.notice =
                         Some("Saved Codex API key. Rebuilding backend.".into());
                     app.dismiss_overlay();
-                    start_rebuild_task(app);
+                    request_maintenance(app, runtime_port, RuntimeMaintenanceCommand::Rebuild)
+                        .await?;
                 } else if was_deepseek {
                     app.bottom_pane.notice = Some("Saved DeepSeek API key. Loading models.".into());
                     app.dismiss_overlay();
-                    start_deepseek_model_list_task(app);
+                    request_maintenance(
+                        app,
+                        runtime_port,
+                        RuntimeMaintenanceCommand::LoadDeepSeekModels,
+                    )
+                    .await?;
                 } else if was_kimi {
                     app.bottom_pane.notice = Some("Saved Kimi API key. Loading models.".into());
                     app.dismiss_overlay();
-                    start_kimi_model_list_task(app);
+                    request_maintenance(
+                        app,
+                        runtime_port,
+                        RuntimeMaintenanceCommand::LoadKimiModels,
+                    )
+                    .await?;
                 } else {
                     app.bottom_pane.notice = Some("Saved API key for the current provider.".into());
                     if app.openai_setup_steps.is_empty() {
@@ -480,11 +488,21 @@ async fn dispatch_event_inner(
             if app.is_busy() {
                 app.push_notice("Wait for the current task before deleting a profile.");
             } else if app.selected_provider_family() == ProviderFamily::OpenAiCompatible {
-                apply_openai_model_picker_action(app, OpenAiModelPickerAction::DeleteProfile)?;
+                apply_openai_model_picker_action(
+                    app,
+                    OpenAiModelPickerAction::DeleteProfile,
+                    runtime_port,
+                )
+                .await?;
             }
         }
         AppEvent::RefreshDeepSeekModels => {
-            start_deepseek_model_list_task(app);
+            request_maintenance(
+                app,
+                runtime_port,
+                RuntimeMaintenanceCommand::LoadDeepSeekModels,
+            )
+            .await?;
         }
         AppEvent::SelectHelpTab(tab) => {
             app.open_overlay(Overlay::Help(tab));
@@ -606,7 +624,12 @@ async fn dispatch_event_inner(
                                 app.select_local_model(app.model_picker_idx);
                                 if app.selected_codex_reasoning_options().len() <= 1 {
                                     app.apply_selected_codex_reasoning_effort();
-                                    start_rebuild_task(app);
+                                    request_maintenance(
+                                        app,
+                                        runtime_port,
+                                        RuntimeMaintenanceCommand::Rebuild,
+                                    )
+                                    .await?;
                                 } else {
                                     app.open_overlay(Overlay::ListPicker(
                                         ListPickerKind::ReasoningEffort,
@@ -616,7 +639,8 @@ async fn dispatch_event_inner(
                                 == ProviderFamily::OpenAiCompatible
                             {
                                 if let Some(action) = app.selected_openai_model_picker_action() {
-                                    apply_openai_model_picker_action(app, action)?;
+                                    apply_openai_model_picker_action(app, action, runtime_port)
+                                        .await?;
                                 }
                             } else if app.selected_provider_family() == ProviderFamily::DeepSeek {
                                 if app.selected_deepseek_api_key_action() {
@@ -624,7 +648,12 @@ async fn dispatch_event_inner(
                                 } else if app.config.has_api_key() {
                                     app.select_local_model(app.model_picker_idx);
                                     app.config.reasoning_effort = Some("max".to_string());
-                                    start_rebuild_task(app);
+                                    request_maintenance(
+                                        app,
+                                        runtime_port,
+                                        RuntimeMaintenanceCommand::Rebuild,
+                                    )
+                                    .await?;
                                 } else {
                                     app.open_overlay(Overlay::ApiKeyEditor);
                                 }
@@ -633,13 +662,23 @@ async fn dispatch_event_inner(
                                     app.open_overlay(Overlay::ApiKeyEditor);
                                 } else if app.config.has_api_key() {
                                     app.select_local_model(app.model_picker_idx);
-                                    start_rebuild_task(app);
+                                    request_maintenance(
+                                        app,
+                                        runtime_port,
+                                        RuntimeMaintenanceCommand::Rebuild,
+                                    )
+                                    .await?;
                                 } else {
                                     app.open_overlay(Overlay::ApiKeyEditor);
                                 }
                             } else {
                                 app.select_local_model(app.model_picker_idx);
-                                start_rebuild_task(app);
+                                request_maintenance(
+                                    app,
+                                    runtime_port,
+                                    RuntimeMaintenanceCommand::Rebuild,
+                                )
+                                .await?;
                             }
                         }
                         ListPickerKind::UnifiedModel => {
@@ -664,7 +703,12 @@ async fn dispatch_event_inner(
                                     } else {
                                         if app.selected_codex_reasoning_options().len() <= 1 {
                                             app.apply_selected_codex_reasoning_effort();
-                                            start_rebuild_task(app);
+                                            request_maintenance(
+                                                app,
+                                                runtime_port,
+                                                RuntimeMaintenanceCommand::Rebuild,
+                                            )
+                                            .await?;
                                         } else {
                                             app.open_overlay(Overlay::ListPicker(
                                                 ListPickerKind::ReasoningEffort,
@@ -692,7 +736,12 @@ async fn dispatch_event_inner(
                                     if preset.family == ProviderFamily::DeepSeek {
                                         app.config.reasoning_effort = Some("max".to_string());
                                     }
-                                    start_rebuild_task(app);
+                                    request_maintenance(
+                                        app,
+                                        runtime_port,
+                                        RuntimeMaintenanceCommand::Rebuild,
+                                    )
+                                    .await?;
                                 }
                             }
                         }
@@ -729,7 +778,12 @@ async fn dispatch_event_inner(
                                     .into(),
                                 );
                                 if app.config.provider == "codex" {
-                                    start_rebuild_task(app);
+                                    request_maintenance(
+                                        app,
+                                        runtime_port,
+                                        RuntimeMaintenanceCommand::Rebuild,
+                                    )
+                                    .await?;
                                 }
                             }
                             _ => {}
@@ -737,7 +791,12 @@ async fn dispatch_event_inner(
                         ListPickerKind::ReasoningEffort => {
                             app.select_local_model(app.model_picker_idx);
                             app.apply_selected_codex_reasoning_effort();
-                            start_rebuild_task(app);
+                            request_maintenance(
+                                app,
+                                runtime_port,
+                                RuntimeMaintenanceCommand::Rebuild,
+                            )
+                            .await?;
                         }
                         ListPickerKind::NowledgeMem => {
                             let mode_label = {
@@ -773,7 +832,12 @@ async fn dispatch_event_inner(
                                 mode_label
                             ));
                             app.dismiss_overlay();
-                            start_rebuild_task(app);
+                            request_maintenance(
+                                app,
+                                runtime_port,
+                                RuntimeMaintenanceCommand::Rebuild,
+                            )
+                            .await?;
                         }
                         ListPickerKind::Resume => {
                             if let Some(thread_id) = list_picker::selected_resumable_thread_id(app)
@@ -838,6 +902,32 @@ async fn dispatch_event_inner(
         },
     }
     Ok(false)
+}
+
+async fn request_maintenance(
+    app: &mut TuiApp,
+    runtime_port: Option<&dyn RuntimeClientPort>,
+    command: RuntimeMaintenanceCommand,
+) -> anyhow::Result<()> {
+    if let Some(runtime_port) = runtime_port {
+        runtime_port
+            .send(RuntimeCommand::Maintenance(command))
+            .await?;
+    } else {
+        match command {
+            RuntimeMaintenanceCommand::Rebuild => super::runtime::start_rebuild_task(app),
+            RuntimeMaintenanceCommand::LoadDeepSeekModels => {
+                super::runtime::start_deepseek_model_list_task(app)
+            }
+            RuntimeMaintenanceCommand::LoadKimiModels => {
+                super::runtime::start_kimi_model_list_task(app)
+            }
+            RuntimeMaintenanceCommand::Compact => {
+                app.push_notice("Compaction requires an active runtime client.")
+            }
+        }
+    }
+    Ok(())
 }
 
 async fn resume_pending_shell_approval_after_full_access(

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -9,7 +9,8 @@ use tokio::time::{Duration, MissedTickBehavior, interval};
 use super::controller::{RuntimeActivity, TuiController};
 use super::event_stream::{UiEvent, translate_event};
 use super::render::{desired_viewport_height, render};
-use super::runtime_port::{RuntimeCommand, RuntimeMaintenanceCommand};
+use super::runtime::RuntimeCommandProcessor;
+use super::runtime_port::{InProcessRuntimeClientPort, RuntimeCommand, RuntimeMaintenanceCommand};
 use super::session_restore::{restore_latest_thread, restore_thread_by_id};
 use super::state::ListPickerKind;
 use super::state::Overlay;
@@ -61,11 +62,17 @@ pub async fn run_tui(
     app.terminal_width = initial_size.0;
     let viewport_height = desired_viewport_height(&app, initial_size.0, initial_size.1);
     let mut terminal = build_terminal(viewport_height)?;
-    let mut maintainer = TuiController::new(app, runtime);
+    let mut processor = RuntimeCommandProcessor::new(runtime);
+    let (runtime_port, runtime_commands) = InProcessRuntimeClientPort::new(
+        processor.event_bus(),
+        Arc::new(std::sync::RwLock::new(app.snapshot.clone())),
+    );
+    let mut maintainer = TuiController::new(app, runtime_port, runtime_commands);
     match StateDb::new() {
         Ok(state_db) => {
             let state_db = Arc::new(state_db);
-            let (app, agent_slot) = maintainer.split_mut();
+            let app = maintainer.app_mut();
+            let agent_slot = processor.agent_mut();
             app.attach_state_db(state_db);
             match &startup_resume {
                 StartupResumeTarget::Fresh => {
@@ -92,7 +99,7 @@ pub async fn run_tui(
     let mut tick = interval(Duration::from_millis(166));
     tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-    maintainer.sync_snapshot().await?;
+    maintainer.sync_snapshot(&processor).await?;
     maintainer.start_repo_context_detection();
     if should_start_initial_rebuild(
         initialize_local_embeddings,
@@ -159,11 +166,11 @@ pub async fn run_tui(
                     }
                     RuntimeActivity::Event(None) => {}
                     RuntimeActivity::Completed(completion) => {
-                        maintainer.complete_runtime_task(completion).await?;
+                        maintainer.complete_runtime_task(&mut processor, completion).await?;
                         needs_redraw = true;
                     }
                     RuntimeActivity::Command(Some(command)) => {
-                        maintainer.apply_runtime_command(command).await?;
+                        maintainer.apply_runtime_command(&mut processor, command).await?;
                         needs_redraw = true;
                     }
                     RuntimeActivity::Command(None) => {}
@@ -173,7 +180,10 @@ pub async fn run_tui(
                 match maybe_event {
                     Some(Ok(event)) => match translate_event(event, maintainer.app_mut()) {
                         Some(UiEvent::App(event)) => {
-                            if maintainer.dispatch_event(event, &oauth_manager).await? {
+                            if maintainer
+                                .dispatch_event(&mut processor, event, &oauth_manager)
+                                .await?
+                            {
                                 if let Some(task) = maintainer.app_mut().bottom_pane.running_task.take() {
                                     task.handle.abort();
                                 }
@@ -201,10 +211,7 @@ pub async fn run_tui(
                             needs_redraw = true;
                         }
                         Some(UiEvent::FocusChanged(_focused)) => {
-                            let (app, agent_slot) = maintainer.split_mut();
-                            if let Some(agent_ref) = agent_slot.as_ref() {
-                                app.sync_snapshot(agent_ref);
-                            }
+                            maintainer.sync_snapshot(&processor).await?;
                             maintainer.publish_snapshot_projection();
                             needs_redraw = true;
                         }
@@ -230,14 +237,10 @@ pub async fn run_tui(
         let _ = crate::auto_memory::drain_auto_memory_for_shutdown().await;
     }
     result?;
-    let session_id = maintainer
-        .agent()
-        .map(|a| a.session_id.clone())
-        .filter(|id| !id.is_empty())
-        .or_else(|| {
-            (!maintainer.app().snapshot.session_id.is_empty())
-                .then(|| maintainer.app().snapshot.session_id.clone())
-        });
+    let session_id = processor.session_id().or_else(|| {
+        (!maintainer.app().snapshot.session_id.is_empty())
+            .then(|| maintainer.app().snapshot.session_id.clone())
+    });
     Ok(session_id)
 }
 

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -9,6 +9,7 @@ use tokio::time::{Duration, MissedTickBehavior, interval};
 use super::controller::{RuntimeActivity, TuiController};
 use super::event_stream::{UiEvent, translate_event};
 use super::render::{desired_viewport_height, render};
+use super::runtime_port::{RuntimeCommand, RuntimeMaintenanceCommand};
 use super::session_restore::{restore_latest_thread, restore_thread_by_id};
 use super::state::ListPickerKind;
 use super::state::Overlay;
@@ -97,13 +98,20 @@ pub async fn run_tui(
         initialize_local_embeddings,
         &maintainer.app().explicit_plugin_dirs,
     ) {
-        let (app, _) = maintainer.split_mut();
         if initialize_local_embeddings {
-            app.push_entry("Runtime", "Initializing local embedding model.");
+            maintainer
+                .app_mut()
+                .push_entry("Runtime", "Initializing local embedding model.");
         } else {
-            app.push_entry("Runtime", "Loading explicit plugin directories.");
+            maintainer
+                .app_mut()
+                .push_entry("Runtime", "Loading explicit plugin directories.");
         }
-        super::runtime::start_rebuild_task(app);
+        maintainer
+            .send_runtime_command(RuntimeCommand::Maintenance(
+                RuntimeMaintenanceCommand::Rebuild,
+            ))
+            .await?;
     }
 
     let result: anyhow::Result<()> = loop {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,7 +28,8 @@ mod render;
 pub(super) mod runtime;
 mod runtime_port;
 pub(crate) use self::runtime_port::{
-    RuntimeClientPort, RuntimeCommand, RuntimeEventStream, RuntimeProjectionEvent,
+    RuntimeClientPort, RuntimeCommand, RuntimeEventStream, RuntimeMaintenanceCommand,
+    RuntimeProjectionEvent,
 };
 mod selection;
 mod session_restore;

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -10,6 +10,7 @@ pub(super) fn emit_query_heartbeat(app: &mut TuiApp) -> bool {
 
 use std::sync::Arc;
 
+use super::runtime_port::RuntimeClientPort;
 use super::state::{LocalCommand, OAuthLoginMode, TuiApp};
 use crate::agent::{Agent, BashApprovalDecision};
 use crate::oauth::OAuthManager;
@@ -23,8 +24,29 @@ pub async fn execute_local_command(
     commands::execute_local_command(command, app, agent_slot, oauth_manager).await
 }
 
+pub async fn execute_local_command_with_runtime(
+    command: LocalCommand,
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    oauth_manager: &Arc<OAuthManager>,
+    runtime_port: &dyn RuntimeClientPort,
+) -> anyhow::Result<bool> {
+    commands::execute_local_command_with_runtime(
+        command,
+        app,
+        agent_slot,
+        oauth_manager,
+        Some(runtime_port),
+    )
+    .await
+}
+
 pub fn start_query_task(app: &mut TuiApp, prompt: String, agent: Agent) {
     tasks::start_query_task(app, prompt, agent);
+}
+
+pub fn start_compact_task(app: &mut TuiApp, agent: Agent) {
+    tasks::start_compact_task(app, agent);
 }
 
 pub fn start_input_control_task(

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -2,7 +2,9 @@ mod commands;
 pub(crate) use commands::apply_permission_mode;
 mod events;
 pub(super) use events::apply_tui_event;
+mod processor;
 pub(super) mod tasks;
+pub(super) use processor::RuntimeCommandProcessor;
 
 pub(super) fn emit_query_heartbeat(app: &mut TuiApp) -> bool {
     tasks::emit_query_heartbeat(app)

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -12,12 +12,23 @@ use crate::mcp_status::{McpStatusSnapshot, format_mcp_status};
 use crate::mcp_tool_cache::McpToolCache;
 use crate::oauth::OAuthManager;
 use crate::runtime_control::RuntimeProvenance;
+use crate::tui::runtime_port::{RuntimeClientPort, RuntimeCommand, RuntimeMaintenanceCommand};
 
 pub(super) async fn execute_local_command(
     command: LocalCommand,
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
     oauth_manager: &Arc<OAuthManager>,
+) -> anyhow::Result<bool> {
+    execute_local_command_with_runtime(command, app, agent_slot, oauth_manager, None).await
+}
+
+pub(super) async fn execute_local_command_with_runtime(
+    command: LocalCommand,
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    oauth_manager: &Arc<OAuthManager>,
+    runtime_port: Option<&dyn RuntimeClientPort>,
 ) -> anyhow::Result<bool> {
     let command_kind = command.kind;
     app.remember_command(match command.kind {
@@ -93,11 +104,13 @@ pub(super) async fn execute_local_command(
             app.reset_transcript();
         }
         LocalCommandKind::Compact => {
-            if let Some(agent) = agent_slot.take() {
-                start_compact_task(app, agent);
-            } else {
-                app.push_notice("No active agent available for compaction.");
-            }
+            request_maintenance(
+                app,
+                agent_slot,
+                runtime_port,
+                RuntimeMaintenanceCommand::Compact,
+            )
+            .await?;
         }
         LocalCommandKind::Context => {
             app.set_runtime_phase(RuntimePhase::LocalCommand, Some("opening context".into()));
@@ -123,7 +136,13 @@ pub(super) async fn execute_local_command(
                     "No saved provider credential was present.".to_string()
                 });
                 if app.config.provider == "codex" {
-                    start_rebuild_task(app);
+                    request_maintenance(
+                        app,
+                        agent_slot,
+                        runtime_port,
+                        RuntimeMaintenanceCommand::Rebuild,
+                    )
+                    .await?;
                 }
             }
         }
@@ -339,6 +358,35 @@ pub(super) async fn execute_local_command(
         app.sync_snapshot(agent);
     }
     Ok(false)
+}
+
+async fn request_maintenance(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    runtime_port: Option<&dyn RuntimeClientPort>,
+    command: RuntimeMaintenanceCommand,
+) -> anyhow::Result<()> {
+    if let Some(runtime_port) = runtime_port {
+        runtime_port
+            .send(RuntimeCommand::Maintenance(command))
+            .await?;
+    } else {
+        match command {
+            RuntimeMaintenanceCommand::Compact => {
+                if let Some(agent) = agent_slot.take() {
+                    start_compact_task(app, agent);
+                } else {
+                    app.push_notice("No active agent available for compaction.");
+                }
+            }
+            RuntimeMaintenanceCommand::Rebuild => start_rebuild_task(app),
+            RuntimeMaintenanceCommand::LoadDeepSeekModels
+            | RuntimeMaintenanceCommand::LoadKimiModels => {
+                app.push_notice("Model catalog loading requires a runtime client.")
+            }
+        }
+    }
+    Ok(())
 }
 
 fn handle_connect_command(app: &mut TuiApp) -> anyhow::Result<()> {

--- a/src/tui/runtime/processor.rs
+++ b/src/tui/runtime/processor.rs
@@ -1,0 +1,141 @@
+use std::sync::{Arc, RwLock};
+
+use super::super::app_event::AppEvent;
+use super::super::event_dispatch::dispatch_event_with_runtime;
+use super::super::input_control;
+use super::super::runtime_port::{RuntimeClientPort, RuntimeCommand, RuntimeMaintenanceCommand};
+use super::super::state::{RuntimeSnapshot, TaskCompletion, TuiApp};
+use crate::agent::Agent;
+use crate::oauth::OAuthManager;
+use crate::runtime_client::RuntimeClient;
+use crate::runtime_control::{InputControlRequest, SessionControlRequest};
+
+/// Owns session runtime execution and applies typed commands to the runtime.
+///
+/// The TUI controller passes presentation state into this processor but does
+/// not retain the session `Agent`, registries, or runtime replacement state.
+pub(crate) struct RuntimeCommandProcessor {
+    runtime: RuntimeClient,
+}
+
+impl RuntimeCommandProcessor {
+    pub(crate) fn new(runtime: RuntimeClient) -> Self {
+        Self { runtime }
+    }
+
+    pub(crate) fn event_bus(&self) -> Arc<crate::runtime_event_bus::RuntimeEventBus> {
+        self.runtime.event_bus.clone()
+    }
+
+    pub(crate) fn agent(&self) -> Option<&Agent> {
+        self.runtime.agent()
+    }
+
+    pub(crate) fn agent_mut(&mut self) -> &mut Option<Agent> {
+        self.runtime.agent_mut()
+    }
+
+    pub(crate) fn session_id(&self) -> Option<String> {
+        self.agent()
+            .map(|agent| agent.session_id.clone())
+            .filter(|id| !id.is_empty())
+    }
+
+    pub(crate) async fn dispatch_event(
+        &mut self,
+        app: &mut TuiApp,
+        event: AppEvent,
+        oauth_manager: &Arc<OAuthManager>,
+        runtime_port: &dyn RuntimeClientPort,
+    ) -> anyhow::Result<bool> {
+        dispatch_event_with_runtime(event, app, self.agent_mut(), oauth_manager, runtime_port).await
+    }
+
+    pub(crate) async fn apply_command(
+        &mut self,
+        app: &mut TuiApp,
+        command: RuntimeCommand,
+    ) -> anyhow::Result<()> {
+        match command {
+            RuntimeCommand::Input(InputControlRequest::SubmitUserPrompt { prompt }) => {
+                input_control::submit_user_prompt(app, self.agent_mut(), prompt);
+            }
+            RuntimeCommand::Input(InputControlRequest::SubmitFollowUp { prompt }) => {
+                input_control::submit_follow_up(app, prompt, false);
+            }
+            RuntimeCommand::Input(InputControlRequest::AnswerPendingInput { answer }) => {
+                if let Some(agent) = self.agent_mut().take() {
+                    input_control::answer_pending_input(app, self.agent_mut(), agent, answer);
+                } else {
+                    app.push_notice("Request input is still preparing. Try again.");
+                }
+            }
+            RuntimeCommand::Input(InputControlRequest::AnswerPlanApproval {
+                decision,
+                feedback,
+            }) => {
+                input_control::answer_plan_approval_with_feedback(
+                    app,
+                    self.agent_mut(),
+                    decision,
+                    feedback,
+                );
+            }
+            RuntimeCommand::Input(InputControlRequest::AnswerShellApproval { decision }) => {
+                input_control::answer_shell_approval(app, self.agent_mut(), decision);
+            }
+            RuntimeCommand::Session(SessionControlRequest::CancelCurrentTurn) => {
+                input_control::handle_session_control(
+                    app,
+                    SessionControlRequest::CancelCurrentTurn,
+                );
+            }
+            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::Compact) => {
+                if let Some(agent) = self.agent_mut().take() {
+                    super::start_compact_task(app, agent);
+                } else {
+                    app.push_notice("No active agent available for compaction.");
+                }
+            }
+            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::Rebuild) => {
+                super::start_rebuild_task(app);
+            }
+            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::LoadDeepSeekModels) => {
+                super::start_deepseek_model_list_task(app);
+            }
+            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::LoadKimiModels) => {
+                super::start_kimi_model_list_task(app);
+            }
+            command => app.push_notice(format!(
+                "Runtime command is not handled by the in-process processor: {command:?}"
+            )),
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn complete(
+        &mut self,
+        app: &mut TuiApp,
+        completion: Box<Result<TaskCompletion, tokio::task::JoinError>>,
+    ) -> anyhow::Result<()> {
+        super::tasks::finish_running_task_if_ready_from_runtime_port(
+            app,
+            self.agent_mut(),
+            Some(*completion),
+        )
+        .await
+    }
+
+    pub(crate) fn sync_snapshot(
+        &self,
+        app: &mut TuiApp,
+        snapshot_store: &Arc<RwLock<RuntimeSnapshot>>,
+    ) {
+        if let Some(agent) = self.agent() {
+            app.sync_snapshot(agent);
+            if let Ok(mut snapshot) = snapshot_store.write() {
+                *snapshot = app.snapshot.clone();
+            }
+        }
+    }
+}

--- a/src/tui/runtime_port.rs
+++ b/src/tui/runtime_port.rs
@@ -30,6 +30,15 @@ pub(crate) enum RuntimeCommand {
     Session(SessionControlRequest),
     Input(InputControlRequest),
     Approval(ApprovalControlRequest),
+    Maintenance(RuntimeMaintenanceCommand),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum RuntimeMaintenanceCommand {
+    Compact,
+    Rebuild,
+    LoadDeepSeekModels,
+    LoadKimiModels,
 }
 
 // Contract items are intentionally ahead of their adapters; the next

--- a/src/tui/submit.rs
+++ b/src/tui/submit.rs
@@ -72,7 +72,14 @@ async fn handle_submit_inner(
                 && matches!(command.kind, LocalCommandKind::Quit)
             {
                 save_before_quit(app);
-                return execute_local_command(command, app, agent_slot, oauth_manager).await;
+                return execute_local_command_with_port(
+                    command,
+                    app,
+                    agent_slot,
+                    oauth_manager,
+                    runtime_port,
+                )
+                .await;
             }
             app.push_notice(
                 "A task is already running. Wait for it to finish before running a slash command.",
@@ -99,7 +106,9 @@ async fn handle_submit_inner(
         return Ok(false);
     }
     if let Some(command) = parse_local_command(&trimmed) {
-        let should_quit = execute_local_command(command, app, agent_slot, oauth_manager).await?;
+        let should_quit =
+            execute_local_command_with_port(command, app, agent_slot, oauth_manager, runtime_port)
+                .await?;
         if should_quit {
             save_before_quit(app);
             return Ok(true);
@@ -121,6 +130,27 @@ async fn handle_submit_inner(
     Ok(false)
 }
 
+async fn execute_local_command_with_port(
+    command: super::state::LocalCommand,
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    oauth_manager: &Arc<crate::oauth::OAuthManager>,
+    runtime_port: Option<&dyn RuntimeClientPort>,
+) -> anyhow::Result<bool> {
+    if let Some(runtime_port) = runtime_port {
+        super::runtime::execute_local_command_with_runtime(
+            command,
+            app,
+            agent_slot,
+            oauth_manager,
+            runtime_port,
+        )
+        .await
+    } else {
+        execute_local_command(command, app, agent_slot, oauth_manager).await
+    }
+}
+
 /// Persist the active turn and runtime state before quitting.
 fn save_before_quit(app: &mut TuiApp) {
     // Dismiss all stacked overlays before quitting, so the quit phase
@@ -132,9 +162,10 @@ fn save_before_quit(app: &mut TuiApp) {
     app.persist_runtime_state();
 }
 
-pub(crate) fn apply_openai_model_picker_action(
+pub(crate) async fn apply_openai_model_picker_action(
     app: &mut TuiApp,
     action: OpenAiModelPickerAction,
+    runtime_port: Option<&dyn RuntimeClientPort>,
 ) -> anyhow::Result<()> {
     match action {
         OpenAiModelPickerAction::SelectProfile => {
@@ -144,7 +175,15 @@ pub(crate) fn apply_openai_model_picker_action(
                     app.bottom_pane.notice = Some(format!("Selected endpoint profile: {label}"));
                     app.begin_active_openai_profile_setup();
                 } else {
-                    super::runtime::start_rebuild_task(app);
+                    if let Some(runtime_port) = runtime_port {
+                        runtime_port
+                            .send(RuntimeCommand::Maintenance(
+                                super::runtime_port::RuntimeMaintenanceCommand::Rebuild,
+                            ))
+                            .await?;
+                    } else {
+                        super::runtime::start_rebuild_task(app);
+                    }
                 }
             }
         }
@@ -156,7 +195,15 @@ pub(crate) fn apply_openai_model_picker_action(
                     app.begin_active_openai_profile_setup();
                 } else {
                     app.bottom_pane.notice = Some(format!("Deleted endpoint profile: {label}"));
-                    super::runtime::start_rebuild_task(app);
+                    if let Some(runtime_port) = runtime_port {
+                        runtime_port
+                            .send(RuntimeCommand::Maintenance(
+                                super::runtime_port::RuntimeMaintenanceCommand::Rebuild,
+                            ))
+                            .await?;
+                    } else {
+                        super::runtime::start_rebuild_task(app);
+                    }
                 }
             } else {
                 app.push_notice("Cannot delete the only endpoint profile.");


### PR DESCRIPTION
## Summary

- route compact, backend rebuild, and DeepSeek/Kimi model-catalog operations through typed `RuntimeClientPort` maintenance commands;
- move `RuntimeClient` ownership and task/completion processing out of `TuiController` into `RuntimeCommandProcessor`;
- update the runtime contract, TODO, and implementation journals.

## Motivation

The remaining TUI command families were launched directly from the terminal event path, and the controller still held the session runtime and agent access. This change completes the command mux for maintenance operations and establishes a separate runtime command processor while preserving the existing in-process task lifecycle.

## Related issue

No linked issue.

## Testing

- `cargo fmt`
- `cargo check --all-targets`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `cargo test --bin rara tui::runtime::commands --no-fail-fast`
- `cargo test --bin rara tui::event_loop --no-fail-fast`
- `cargo test --bin rara tui::controller --no-fail-fast`
- `cargo test --bin rara tui::runtime_port --no-fail-fast`
- `cargo test --bin rara tui::input_control --no-fail-fast`
- `cargo test --bin rara tui::submit --no-fail-fast`

The macOS linker still emits the existing `__eh_frame` warning during test linking.

## Remaining follow-up

`TuiApp` still contains compatibility projections for extension registries. Registry discovery and reload are runtime-owned; replacing those projections with typed snapshot data is intentionally a separate follow-up.
