### PR TITLE
chore(ci): enable bazel flaky test retries

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# Retry tests that Bazel classifies as flaky up to three total attempts.
+test --flaky_test_attempts=3

--- a/docs/journal/2026-08-03-bazel-flaky-test-retry.md
+++ b/docs/journal/2026-08-03-bazel-flaky-test-retry.md
@@ -1,0 +1,31 @@
+# Bazel Flaky Test Retry
+
+## What changed
+
+Added a repository-level `.bazelrc` with `test --flaky_test_attempts=3`.
+Bazel test invocations now retry a flaky test up to three total attempts by
+default.
+
+## Why
+
+Transient test failures should be retried by the test runner before CI reports
+the target as failed. Keeping this in the repository configuration makes the
+behavior consistent for local and CI Bazel test invocations without requiring
+each workflow or developer command to repeat the flag.
+
+The setting applies only to Bazel test commands. It does not change build
+actions or hide ordinary test failures: a test that fails on every attempt
+still fails.
+
+## Trade-offs
+
+Retries can increase test duration when a test is genuinely flaky. Three total
+attempts provide bounded mitigation while keeping repeated failures visible to
+CI.
+
+## Verification
+
+- `bazel help test` confirms that Bazel 9.1.1 supports
+  `--flaky_test_attempts`.
+- Run the affected Bazel test targets without an explicit retry flag and
+  confirm the repository configuration is applied.


### PR DESCRIPTION
## Summary

- add a repository-level `.bazelrc`
- enable three total attempts for Bazel tests classified as flaky
- document the configuration and verification checkpoint

## Motivation

Transient test failures should be retried consistently in local and CI Bazel
test invocations. The bounded retry setting reduces one-off failures without
changing build actions or masking tests that fail on every attempt.

## Related issue

Not applicable.

## Testing

- `cargo fmt --all -- --check`
- `bazel help test` confirmed that Bazel 9.1.1 supports
  `--flaky_test_attempts`
- `bazel --output_base=/tmp/rara-bazel-retry-verify test --announce_rc --nobuild //crates/rara-plugins:rara_plugins_tests`
  confirmed that the repository `.bazelrc` supplies
  `--flaky_test_attempts=3`; the first dependency analysis was interrupted
  after 169 seconds without completing the target analysis
