### PR TITLE
feat(runtime): add typed extension snapshot

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -55,6 +55,12 @@ live under `runtime_client` / `runtime_goal`. TUI completion code consumes
 these typed outcomes and only applies transcript, overlay, phase, and queued
 input presentation effects.
 
+Extension status projection now has a typed `RuntimeExtensionSnapshot`. The
+runtime command processor computes extension counts, scopes, and agent status
+lines from the session runtime and passes the projection to the TUI snapshot
+reducer. The legacy agent-based snapshot entry point remains only for restore
+and focused compatibility tests while registry ownership is migrated.
+
 ## TUI Test Contract
 
 TUI tests use the same runtime projection reducer and renderer as production.

--- a/docs/journal/2026-08-03-runtime-extension-snapshot.md
+++ b/docs/journal/2026-08-03-runtime-extension-snapshot.md
@@ -1,0 +1,29 @@
+# Runtime Extension Snapshot
+
+## What changed
+
+Added `RuntimeExtensionSnapshot` as the typed presentation projection for
+extension counts, skill scopes, and agent status lines. `RuntimeClient` now
+builds this projection from the session-owned registries and agent definition
+cache. The runtime command processor passes it to the TUI snapshot reducer.
+
+## Why
+
+The TUI should display extension state without discovering hooks or agent
+definitions itself. Moving the projection source into the runtime makes the
+ownership boundary explicit and gives future app-server clients the same
+snapshot contract.
+
+## Trade-offs
+
+The existing `TuiApp::sync_snapshot(&Agent)` entry point remains temporarily
+for session restore and compatibility tests. It still contains the old local
+projection path, so removing that entry point and the registry fields is the
+next migration slice.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- Focused state snapshot coverage for applying a runtime-owned extension
+  projection

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,7 +51,8 @@ Active backlog only. Keep this file small and current.
       runtime command processor.
 - [ ] Remove mutable extension-registry projections from `TuiApp`; registry
       discovery and reload must remain runtime-owned while TUI receives typed
-      snapshots.
+      snapshots. The first typed `RuntimeExtensionSnapshot` projection is now
+      runtime-generated; remove the compatibility fields and entry point next.
 - [ ] Construct `TuiController` directly from an injected port and add
       virtual-time controls to the shared harness.
 

--- a/src/runtime_client.rs
+++ b/src/runtime_client.rs
@@ -4,6 +4,7 @@
 //! surfaces may retain this client and submit commands through its API, but
 //! they must not construct or own the underlying registries independently.
 
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::{Arc, atomic::AtomicBool};
 
@@ -18,7 +19,7 @@ use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 use crate::runtime_context::RuntimeBootstrap;
 use crate::runtime_event_bus::RuntimeEventBus;
 use crate::runtime_goal::{GoalEvaluation, evaluate_goal_completion};
-use crate::tui::state::{GoalHandle, GoalStatus, RalphGoal};
+use crate::tui::state::{GoalHandle, GoalStatus, RalphGoal, RuntimeExtensionSnapshot};
 
 /// Fully initialized replacement runtime returned by a backend rebuild.
 pub(crate) struct RebuildSuccess {
@@ -139,6 +140,36 @@ impl RuntimeClient {
 
     pub(crate) fn agent_mut(&mut self) -> &mut Option<Agent> {
         &mut self.agent
+    }
+
+    pub(crate) fn extension_snapshot(&self) -> RuntimeExtensionSnapshot {
+        let Some(agent) = self.agent() else {
+            return RuntimeExtensionSnapshot::default();
+        };
+        let runtime_context = agent.shared_runtime_context();
+        let records = agent.agent_definition_records();
+        let root = std::path::Path::new(&runtime_context.cwd);
+        let agent_registry = crate::agents_ext::AgentRegistry::from_records(records, root);
+        let mut file_hook_registry = crate::hooks::HookRegistry::new();
+        file_hook_registry.discover_repo_hooks(root);
+        RuntimeExtensionSnapshot {
+            skill_count: agent.prompt_config().available_skills.len(),
+            skill_scopes: agent
+                .prompt_config()
+                .available_skills
+                .iter()
+                .map(|skill| skill.scope.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect(),
+            hook_count: file_hook_registry
+                .hooks
+                .len()
+                .max(self.hook_runtime.hook_count()),
+            command_count: agent.plugin_command_count(),
+            agent_count: agent_registry.agents.len(),
+            agent_status_lines: agent_registry.status_lines(),
+        }
     }
 
     /// Decide the next plan action after a completed model turn.

--- a/src/tui/runtime/processor.rs
+++ b/src/tui/runtime/processor.rs
@@ -132,7 +132,7 @@ impl RuntimeCommandProcessor {
         snapshot_store: &Arc<RwLock<RuntimeSnapshot>>,
     ) {
         if let Some(agent) = self.agent() {
-            app.sync_snapshot(agent);
+            app.sync_snapshot_with_extensions(agent, self.runtime.extension_snapshot());
             if let Ok(mut snapshot) = snapshot_store.write() {
                 *snapshot = app.snapshot.clone();
             }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -33,9 +33,9 @@ pub use self::types::{
     HelpTab, InteractionKind, ListPickerKind, LocalCommand, LocalCommandKind, ModelRoutingView,
     OAuthLoginMode, OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot,
     PendingInteractionSnapshot, PermissionMode, PickerIntent, ProviderFamily, RalphGoal,
-    RunningTask, RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab, SystemMessageKind,
-    TaskCompletion, TaskKind, TerminalDiagnosticsView, TranscriptEntry, TranscriptEntryPayload,
-    TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
+    RunningTask, RuntimeExtensionSnapshot, RuntimePhase, RuntimeSnapshot, SkillPickerEntry,
+    StatusTab, SystemMessageKind, TaskCompletion, TaskKind, TerminalDiagnosticsView,
+    TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
 };
 use crate::oauth::OAuthManager;
 pub(crate) use crate::runtime_client::RebuildSuccess;

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -3,13 +3,45 @@ use std::sync::atomic::Ordering;
 
 use super::{
     CompletedInteractionSnapshot, InteractionKind, PendingApprovalSnapshot,
-    PendingInteractionSnapshot, PlanningLifecycleSnapshot, RuntimeSnapshot, SkillPickerEntry,
-    TuiApp,
+    PendingInteractionSnapshot, PlanningLifecycleSnapshot, RuntimeExtensionSnapshot,
+    RuntimeSnapshot, SkillPickerEntry, TuiApp,
 };
 use crate::agent::Agent;
 
 impl TuiApp {
     pub fn sync_snapshot(&mut self, agent: &Agent) {
+        let (hook_count, agent_count, agent_status_lines) =
+            discover_extension_counts(&agent.shared_runtime_context().cwd, agent);
+        let runtime_hook_count = self
+            .hook_runtime
+            .as_ref()
+            .map(|runtime| runtime.hook_count())
+            .unwrap_or(0);
+        self.sync_snapshot_with_extensions(
+            agent,
+            RuntimeExtensionSnapshot {
+                skill_count: agent.prompt_config().available_skills.len(),
+                skill_scopes: agent
+                    .prompt_config()
+                    .available_skills
+                    .iter()
+                    .map(|skill| skill.scope.clone())
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect(),
+                hook_count: hook_count.max(runtime_hook_count),
+                command_count: agent.plugin_command_count(),
+                agent_count,
+                agent_status_lines,
+            },
+        );
+    }
+
+    pub fn sync_snapshot_with_extensions(
+        &mut self,
+        agent: &Agent,
+        extensions: RuntimeExtensionSnapshot,
+    ) {
         let runtime_context = agent.shared_runtime_context();
         let shared_task_root = agent.workspace.rara_dir.join("tasks");
         let existing_pending_approval_id = self
@@ -118,12 +150,6 @@ impl TuiApp {
                 interaction.source.as_deref(),
             );
         }
-        let ext_counts = discover_extension_counts(&runtime_context.cwd, agent);
-        let runtime_hook_count = self
-            .hook_runtime
-            .as_ref()
-            .map(|runtime| runtime.hook_count())
-            .unwrap_or(0);
         let planning_lifecycle = PlanningLifecycleSnapshot::from_interactions(
             &runtime_context.session_id,
             &pending_interactions,
@@ -191,21 +217,12 @@ impl TuiApp {
             memory_selection: runtime_context.retrieval.memory_selection,
             context_observability: runtime_context.observability,
             assembly_entries: runtime_context.assembly.entries,
-            extension_skill_count: agent.prompt_config().available_skills.len(),
-            extension_skill_scopes: {
-                agent
-                    .prompt_config()
-                    .available_skills
-                    .iter()
-                    .map(|s| s.scope.clone())
-                    .collect::<BTreeSet<_>>()
-                    .into_iter()
-                    .collect()
-            },
-            extension_hook_count: ext_counts.0.max(runtime_hook_count),
-            extension_command_count: agent.plugin_command_count(),
-            extension_agent_count: ext_counts.1,
-            extension_agent_status_lines: ext_counts.2,
+            extension_skill_count: extensions.skill_count,
+            extension_skill_scopes: extensions.skill_scopes,
+            extension_hook_count: extensions.hook_count,
+            extension_command_count: extensions.command_count,
+            extension_agent_count: extensions.agent_count,
+            extension_agent_status_lines: extensions.agent_status_lines,
         };
         self.agent_execution_mode = agent.execution_mode;
         self.bash_approval_mode = agent.bash_approval_mode;

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -8,9 +8,9 @@ use tempfile::tempdir;
 
 use super::{
     ActivePendingInteractionKind, AgentMarkdownStreamState, InteractionKind, ListPickerKind,
-    Overlay, PROVIDER_FAMILIES, PendingInteractionSnapshot, ProviderFamily, RuntimeSnapshot,
-    SystemMessageKind, TranscriptEntry, TranscriptTurn, TuiApp, input_requests_command_palette,
-    parse_repo_slug, state_db_status_error,
+    Overlay, PROVIDER_FAMILIES, PendingInteractionSnapshot, ProviderFamily,
+    RuntimeExtensionSnapshot, RuntimeSnapshot, SystemMessageKind, TranscriptEntry, TranscriptTurn,
+    TuiApp, input_requests_command_palette, parse_repo_slug, state_db_status_error,
 };
 use crate::agent::{Agent, PendingApproval};
 use crate::codex_model_catalog::{CodexModelOption, CodexReasoningOption};
@@ -273,7 +273,13 @@ async fn sync_snapshot_reports_registered_runtime_hooks() {
     );
     app.hook_runtime = Some(runtime);
 
-    app.sync_snapshot(&agent);
+    app.sync_snapshot_with_extensions(
+        &agent,
+        RuntimeExtensionSnapshot {
+            hook_count: 1,
+            ..RuntimeExtensionSnapshot::default()
+        },
+    );
 
     assert_eq!(app.snapshot.extension_hook_count, 1);
 }

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -300,6 +300,16 @@ pub struct RuntimeSnapshot {
     pub extension_agent_status_lines: Vec<String>,
 }
 
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeExtensionSnapshot {
+    pub skill_count: usize,
+    pub skill_scopes: Vec<String>,
+    pub hook_count: usize,
+    pub command_count: usize,
+    pub agent_count: usize,
+    pub agent_status_lines: Vec<String>,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InteractionKind {
     RequestInput,


### PR DESCRIPTION
## Summary

- add a typed `RuntimeExtensionSnapshot` for extension status shown by the TUI
- compute extension counts, scopes, and agent status lines in `RuntimeClient`
- apply the runtime-owned projection through `RuntimeCommandProcessor`
- document the migration boundary and retain focused compatibility coverage

## Motivation

The session runtime owns plugin, hook, skill, and agent registries, but the TUI
was still deriving extension status from the active `Agent` and its local
registry projections. This change makes the runtime-to-TUI snapshot contract
explicit and prepares the next slice to remove those mutable registry fields
from `TuiApp`.

## Related issue

Not applicable.

## Testing

- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo test --bin rara tui::state::tests::sync_snapshot_reports_registered_runtime_hooks -- --exact`

The existing macOS linker emits the known `__eh_frame` warning during test
linking.

## Follow-up

The legacy `TuiApp::sync_snapshot(&Agent)` path remains for restore and
compatibility tests. A follow-up will remove that path and the mutable
registry fields after runtime task construction consumes session-owned
services directly.
