### PR TITLE
feat(tui): remove snapshot discovery compatibility path

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -58,8 +58,8 @@ input presentation effects.
 Extension status projection now has a typed `RuntimeExtensionSnapshot`. The
 runtime command processor computes extension counts, scopes, and agent status
 lines from the session runtime and passes the projection to the TUI snapshot
-reducer. The legacy agent-based snapshot entry point remains only for restore
-and focused compatibility tests while registry ownership is migrated.
+reducer. The TUI snapshot reducer no longer discovers extension state from an
+agent; restore paths use the same runtime-owned projection helper.
 
 ## TUI Test Contract
 
@@ -113,10 +113,10 @@ owns task construction, completion, and runtime replacement access.
 
 ## Follow-up
 
-- Replace compatibility projections in `TuiApp` with a typed runtime snapshot.
 - Remove mutable extension-registry projections from `TuiApp`; all registry
   discovery and reload should remain runtime-owned while TUI consumes typed
-  snapshots.
+  snapshots. The snapshot entry point is now typed; task construction still
+  needs the registry handles during the remaining compatibility migration.
 - Publish a TUI-facing typed projection event instead of converting
   `AgentEvent` into role/message strings and parsing those strings again.
 - Move goal continuation, plan completion, agent replacement, and queued

--- a/docs/journal/2026-08-03-runtime-snapshot-compat-cleanup.md
+++ b/docs/journal/2026-08-03-runtime-snapshot-compat-cleanup.md
@@ -1,0 +1,26 @@
+# Runtime Snapshot Compatibility Cleanup
+
+## What changed
+
+Removed the TUI-owned extension discovery path and the
+`TuiApp::sync_snapshot(&Agent)` entry point. Restore, command, and completion
+paths now apply a typed `RuntimeExtensionSnapshot` produced by runtime code.
+
+## Why
+
+Extension discovery is runtime work. Keeping it in the TUI snapshot reducer
+allowed presentation code to recreate hook and agent registries and made the
+runtime snapshot contract dependent on an `Agent` implementation detail.
+
+## Remaining boundary
+
+The in-process task bridge still needs registry handles to execute control
+requests. Those handles remain in the transitional TUI state until task
+construction is fully passed through the runtime processor. They are no
+longer used to discover or assemble TUI extension status.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- `cargo test --bin rara tui::state::tests::sync_snapshot -- --nocapture`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,8 +51,8 @@ Active backlog only. Keep this file small and current.
       runtime command processor.
 - [ ] Remove mutable extension-registry projections from `TuiApp`; registry
       discovery and reload must remain runtime-owned while TUI receives typed
-      snapshots. The first typed `RuntimeExtensionSnapshot` projection is now
-      runtime-generated; remove the compatibility fields and entry point next.
+      snapshots. Snapshot discovery and the agent-based entry point are done;
+      remove the remaining registry handles used by the task bridge next.
 - [ ] Construct `TuiController` directly from an injected port and add
       virtual-time controls to the shared harness.
 

--- a/src/runtime_client.rs
+++ b/src/runtime_client.rs
@@ -146,6 +146,13 @@ impl RuntimeClient {
         let Some(agent) = self.agent() else {
             return RuntimeExtensionSnapshot::default();
         };
+        Self::extension_snapshot_for_agent(agent, self.hook_runtime.hook_count())
+    }
+
+    pub(crate) fn extension_snapshot_for_agent(
+        agent: &Agent,
+        runtime_hook_count: usize,
+    ) -> RuntimeExtensionSnapshot {
         let runtime_context = agent.shared_runtime_context();
         let records = agent.agent_definition_records();
         let root = std::path::Path::new(&runtime_context.cwd);
@@ -162,13 +169,14 @@ impl RuntimeClient {
                 .collect::<BTreeSet<_>>()
                 .into_iter()
                 .collect(),
-            hook_count: file_hook_registry
-                .hooks
-                .len()
-                .max(self.hook_runtime.hook_count()),
+            hook_count: file_hook_registry.hooks.len().max(runtime_hook_count),
             command_count: agent.plugin_command_count(),
             agent_count: agent_registry.agents.len(),
-            agent_status_lines: agent_registry.status_lines(),
+            agent_status_lines: if agent_registry.agents.is_empty() {
+                Vec::new()
+            } else {
+                agent_registry.status_lines()
+            },
         }
     }
 

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -355,7 +355,10 @@ pub(super) async fn execute_local_command_with_runtime(
     if command_kind != LocalCommandKind::Tasks
         && let Some(agent) = agent_slot.as_ref()
     {
-        app.sync_snapshot(agent);
+        app.apply_runtime_snapshot(
+            agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(agent, 0),
+        );
     }
     Ok(false)
 }
@@ -582,7 +585,10 @@ fn handle_tasks_command(arg: Option<&str>, app: &mut TuiApp, agent_slot: &mut Op
 
     if let Some(agent) = agent_slot.as_mut() {
         agent.set_task_list_id(requested);
-        app.sync_snapshot(agent);
+        app.apply_runtime_snapshot(
+            agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(agent, 0),
+        );
     } else {
         app.switch_active_shared_task_list(requested);
     }
@@ -1190,7 +1196,11 @@ command = "docs-server"
             OAuthManager::new_for_config_dir(dir.path().join("oauth")).expect("oauth manager"),
         );
         let mut agent_slot = Some(test_agent_with_shared_task_tool(&dir));
-        app.sync_snapshot(agent_slot.as_ref().expect("agent"));
+        let agent = agent_slot.as_ref().expect("agent");
+        app.apply_runtime_snapshot(
+            agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(agent, 0),
+        );
 
         execute_local_command(
             LocalCommand {

--- a/src/tui/runtime/processor.rs
+++ b/src/tui/runtime/processor.rs
@@ -132,7 +132,7 @@ impl RuntimeCommandProcessor {
         snapshot_store: &Arc<RwLock<RuntimeSnapshot>>,
     ) {
         if let Some(agent) = self.agent() {
-            app.sync_snapshot_with_extensions(agent, self.runtime.extension_snapshot());
+            app.apply_runtime_snapshot(agent, self.runtime.extension_snapshot());
             if let Ok(mut snapshot) = snapshot_store.write() {
                 *snapshot = app.snapshot.clone();
             }

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -142,7 +142,12 @@ async fn finish_running_task_if_ready_with_completion_mode(
                                 goal.tokens_used,
                                 goal.token_budget.unwrap_or(0)
                             ));
-                            app.sync_snapshot(&agent);
+                            app.apply_runtime_snapshot(
+                                &agent,
+                                crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(
+                                    &agent, 0,
+                                ),
+                            );
                             app.finalize_active_turn();
                             *agent_slot = Some(agent);
                             start_query_task(app, prompt, agent_slot.take().expect("agent"));
@@ -151,7 +156,13 @@ async fn finish_running_task_if_ready_with_completion_mode(
                         GoalContinuation::Complete { goal } => {
                             app.goal = Some(goal);
                             *agent_slot = Some(agent);
-                            app.sync_snapshot(agent_slot.as_ref().expect("agent"));
+                            let agent = agent_slot.as_ref().expect("agent");
+                            app.apply_runtime_snapshot(
+                                agent,
+                                crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(
+                                    agent, 0,
+                                ),
+                            );
                             app.release_pending_follow_ups();
                             app.finalize_agent_stream(None);
                             app.finalize_active_turn();
@@ -163,7 +174,12 @@ async fn finish_running_task_if_ready_with_completion_mode(
                         GoalContinuation::Continue { goal, prompt, reason } => {
                             app.goal = Some(goal);
                             app.push_system(reason, crate::tui::state::SystemMessageKind::Other);
-                            app.sync_snapshot(&agent);
+                            app.apply_runtime_snapshot(
+                                &agent,
+                                crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(
+                                    &agent, 0,
+                                ),
+                            );
                             app.finalize_active_turn();
                             start_query_task(app, prompt, agent);
                             return Ok(());
@@ -173,7 +189,12 @@ async fn finish_running_task_if_ready_with_completion_mode(
                     *agent_slot = Some(agent);
                     app.goal = app.goal_handle.read().unwrap().clone();
                     if let Some(a) = agent_slot.as_ref() {
-                        app.sync_snapshot(a);
+                            app.apply_runtime_snapshot(
+                                a,
+                                crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(
+                                    a, 0,
+                                ),
+                            );
                     }
                     app.release_pending_follow_ups();
                     app.finalize_agent_stream(None);
@@ -209,7 +230,12 @@ async fn finish_running_task_if_ready_with_completion_mode(
                     app.clear_pending_plan_approval();
                     *agent_slot = Some(agent);
                     if let Some(agent) = agent_slot.as_ref() {
-                        app.sync_snapshot(agent);
+                        app.apply_runtime_snapshot(
+                            agent,
+                            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(
+                                agent, 0,
+                            ),
+                        );
                     }
                     app.release_pending_follow_ups();
                     app.finalize_agent_stream(None);
@@ -242,7 +268,12 @@ async fn finish_running_task_if_ready_with_completion_mode(
         TaskCompletion::Compact { agent, result } => {
             *agent_slot = Some(agent);
             if let Some(agent) = agent_slot.as_ref() {
-                app.sync_snapshot(agent);
+                        app.apply_runtime_snapshot(
+                            agent,
+                            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(
+                                agent, 0,
+                            ),
+                        );
             }
             match result {
                 Ok(true) => {
@@ -325,7 +356,12 @@ async fn finish_running_task_if_ready_with_completion_mode(
                 app.bottom_pane.notice = app.setup_status.clone();
                 *agent_slot = Some(agent);
                 if let Some(agent) = agent_slot.as_ref() {
-                    app.sync_snapshot(agent);
+                    app.apply_runtime_snapshot(
+                        agent,
+                        crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(
+                            agent, 0,
+                        ),
+                    );
                 }
                 app.dismiss_overlay();
                 app.set_runtime_phase(RuntimePhase::BackendReady, Some("backend ready".into()));

--- a/src/tui/session_restore.rs
+++ b/src/tui/session_restore.rs
@@ -213,7 +213,10 @@ pub(super) fn restore_thread_by_id(
             .map(|entry| TranscriptEntry::new(entry.role, entry.message))
             .collect();
     }
-    app.sync_snapshot(agent);
+    app.apply_runtime_snapshot(
+        agent,
+        crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(agent, 0),
+    );
     let pending_plan_tool_id = latest_plan_lifecycle
         .as_ref()
         .filter(|(phase, _)| phase == "plan_ready")
@@ -226,7 +229,10 @@ pub(super) fn restore_thread_by_id(
         if let Some(tool_id) = pending_plan_tool_id {
             agent.restore_pending_plan_exit_approval(tool_id);
         }
-        app.sync_snapshot(agent);
+        app.apply_runtime_snapshot(
+            agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(agent, 0),
+        );
         app.show_pending_plan_approval(pending_plan_tool_id);
         app.set_runtime_phase(
             super::state::RuntimePhase::Idle,
@@ -390,7 +396,10 @@ mod tests {
         })
         .expect("app");
         original_app.attach_state_db(state_db.clone());
-        original_app.sync_snapshot(&original_agent);
+        original_app.apply_runtime_snapshot(
+            &original_agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(&original_agent, 0),
+        );
 
         original_agent.execution_mode = AgentExecutionMode::Execute;
         let expected_runtime = original_agent.shared_runtime_context();
@@ -525,7 +534,10 @@ mod tests {
         })
         .expect("app");
         original_app.attach_state_db(state_db.clone());
-        original_app.sync_snapshot(&original_agent);
+        original_app.apply_runtime_snapshot(
+            &original_agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(&original_agent, 0),
+        );
 
         let rollout_dir = rara_dir
             .join("rollouts")
@@ -604,7 +616,10 @@ mod tests {
         })
         .expect("app");
         original_app.attach_state_db(state_db.clone());
-        original_app.sync_snapshot(&original_agent);
+        original_app.apply_runtime_snapshot(
+            &original_agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(&original_agent, 0),
+        );
         rara_persistence::thread_turn_log::append_rollout_fragment(
             &state_db.rollout_root(),
             &original_agent.session_id,
@@ -735,7 +750,10 @@ mod tests {
         })
         .expect("app");
         original_app.attach_state_db(state_db.clone());
-        original_app.sync_snapshot(&original_agent);
+        original_app.apply_runtime_snapshot(
+            &original_agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(&original_agent, 0),
+        );
 
         let restored_agent = Agent::new(
             ToolManager::new(),
@@ -833,7 +851,10 @@ mod tests {
         })
         .expect("app");
         original_app.attach_state_db(state_db.clone());
-        original_app.sync_snapshot(&original_agent);
+        original_app.apply_runtime_snapshot(
+            &original_agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(&original_agent, 0),
+        );
         original_app.show_pending_plan_approval(Some("exit-plan-restore"));
 
         let restored_agent = Agent::new(
@@ -928,7 +949,10 @@ mod tests {
         })
         .expect("app");
         original_app.attach_state_db(state_db.clone());
-        original_app.sync_snapshot(&original_agent);
+        original_app.apply_runtime_snapshot(
+            &original_agent,
+            crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(&original_agent, 0),
+        );
         original_app.show_pending_plan_approval(Some("exit-plan-completed"));
         original_app.clear_pending_plan_approval();
         original_app.record_completed_interaction(

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::sync::atomic::Ordering;
 
 use super::{
@@ -9,39 +8,7 @@ use super::{
 use crate::agent::Agent;
 
 impl TuiApp {
-    pub fn sync_snapshot(&mut self, agent: &Agent) {
-        let (hook_count, agent_count, agent_status_lines) =
-            discover_extension_counts(&agent.shared_runtime_context().cwd, agent);
-        let runtime_hook_count = self
-            .hook_runtime
-            .as_ref()
-            .map(|runtime| runtime.hook_count())
-            .unwrap_or(0);
-        self.sync_snapshot_with_extensions(
-            agent,
-            RuntimeExtensionSnapshot {
-                skill_count: agent.prompt_config().available_skills.len(),
-                skill_scopes: agent
-                    .prompt_config()
-                    .available_skills
-                    .iter()
-                    .map(|skill| skill.scope.clone())
-                    .collect::<BTreeSet<_>>()
-                    .into_iter()
-                    .collect(),
-                hook_count: hook_count.max(runtime_hook_count),
-                command_count: agent.plugin_command_count(),
-                agent_count,
-                agent_status_lines,
-            },
-        );
-    }
-
-    pub fn sync_snapshot_with_extensions(
-        &mut self,
-        agent: &Agent,
-        extensions: RuntimeExtensionSnapshot,
-    ) {
+    pub fn apply_runtime_snapshot(&mut self, agent: &Agent, extensions: RuntimeExtensionSnapshot) {
         let runtime_context = agent.shared_runtime_context();
         let shared_task_root = agent.workspace.rara_dir.join("tasks");
         let existing_pending_approval_id = self
@@ -247,19 +214,4 @@ impl TuiApp {
         self.skill_picker_entries
             .sort_by(|a, b| a.name.cmp(&b.name));
     }
-}
-
-fn discover_extension_counts(cwd: &str, agent: &Agent) -> (usize, usize, Vec<String>) {
-    let root = std::path::Path::new(cwd);
-    let mut hook_registry = crate::hooks::HookRegistry::new();
-    hook_registry.discover_repo_hooks(root);
-    let records = agent.agent_definition_records();
-    let agent_registry = crate::agents_ext::AgentRegistry::from_records(records, root);
-    let agent_count = agent_registry.agents.len();
-    let agent_status_lines = if agent_count == 0 {
-        Vec::new()
-    } else {
-        agent_registry.status_lines()
-    };
-    (hook_registry.hooks.len(), agent_count, agent_status_lines)
 }

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -234,7 +234,7 @@ fn sync_snapshot_reports_effective_network_access_for_pending_approval() {
         },
     });
 
-    app.sync_snapshot(&agent);
+    app.apply_runtime_snapshot(&agent, RuntimeExtensionSnapshot::default());
 
     let approval = app
         .pending_command_approval()
@@ -273,7 +273,7 @@ async fn sync_snapshot_reports_registered_runtime_hooks() {
     );
     app.hook_runtime = Some(runtime);
 
-    app.sync_snapshot_with_extensions(
+    app.apply_runtime_snapshot(
         &agent,
         RuntimeExtensionSnapshot {
             hook_count: 1,
@@ -331,7 +331,10 @@ Reloaded prompt.
     )
     .expect("updated agent definition");
 
-    app.sync_snapshot(&agent);
+    app.apply_runtime_snapshot(
+        &agent,
+        crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(&agent, 0),
+    );
 
     assert!(
         app.snapshot
@@ -387,7 +390,10 @@ fn sync_snapshot_counts_runtime_agent_definition_records() {
         },
     ]);
 
-    app.sync_snapshot(&agent);
+    app.apply_runtime_snapshot(
+        &agent,
+        crate::runtime_client::RuntimeClient::extension_snapshot_for_agent(&agent, 0),
+    );
 
     assert_eq!(app.snapshot.extension_agent_count, 2);
     assert!(


### PR DESCRIPTION
## Summary

- remove TUI-side extension discovery from the runtime snapshot reducer
- replace `TuiApp::sync_snapshot(&Agent)` with typed runtime extension data
- update restore, command, and completion paths to use the runtime snapshot helper
- document the remaining task-bridge registry migration

## Motivation

The previous snapshot path allowed TUI state code to discover repository hooks
and agent definitions from an `Agent`. Extension discovery belongs to the
session runtime, so all presentation paths should consume the same typed
`RuntimeExtensionSnapshot` produced by runtime code.

## Related issue

Not applicable.

## Testing

- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo test --bin rara tui::state::tests::sync_snapshot -- --nocapture`

The existing macOS linker emits the known `__eh_frame` warning during test
linking.

## Follow-up

The transitional in-process task bridge still stores registry handles in TUI
state because task construction has not fully moved behind the runtime
processor. A subsequent PR will move those services to the processor and
remove the remaining fields from `TuiApp`.
