### PR TITLE
feat(runtime): move task services out of tui

### DIFF
--- a/docs/features/runtime-client.md
+++ b/docs/features/runtime-client.md
@@ -61,6 +61,10 @@ lines from the session runtime and passes the projection to the TUI snapshot
 reducer. The TUI snapshot reducer no longer discovers extension state from an
 agent; restore paths use the same runtime-owned projection helper.
 
+Production TUI state no longer stores prompt, skill, or hook registry handles.
+The runtime command processor owns these registries and passes cloned
+`RuntimeTaskServices` to query, approval, and completion task construction.
+
 ## TUI Test Contract
 
 TUI tests use the same runtime projection reducer and renderer as production.
@@ -115,8 +119,8 @@ owns task construction, completion, and runtime replacement access.
 
 - Remove mutable extension-registry projections from `TuiApp`; all registry
   discovery and reload should remain runtime-owned while TUI consumes typed
-  snapshots. The snapshot entry point is now typed; task construction still
-  needs the registry handles during the remaining compatibility migration.
+  snapshots. Production task construction now receives explicit runtime-owned
+  services; test-only fixtures retain local setup helpers.
 - Publish a TUI-facing typed projection event instead of converting
   `AgentEvent` into role/message strings and parsing those strings again.
 - Move goal continuation, plan completion, agent replacement, and queued

--- a/docs/journal/2026-08-03-runtime-task-service-ownership.md
+++ b/docs/journal/2026-08-03-runtime-task-service-ownership.md
@@ -1,0 +1,30 @@
+# Runtime Task Service Ownership
+
+## What changed
+
+Added `RuntimeTaskServices` as a runtime-owned bundle for prompt, skill, and
+hook registries. `RuntimeCommandProcessor` now supplies this bundle to query,
+approval, queued follow-up, and rebuild completion paths. Production `TuiApp`
+state no longer stores these registry handles.
+
+Rebuild completion updates the processor-owned service bundle when a new
+runtime is installed. Test-only compatibility fixtures keep local registry
+fields so existing unit tests can assemble isolated task environments.
+
+## Why
+
+Registry discovery and execution are runtime responsibilities. Passing an
+explicit service bundle keeps task construction tied to the session runtime
+without making registry ownership part of the presentation model.
+
+## Trade-offs
+
+Legacy no-port task helpers remain available for focused tests and transitional
+callers. Production event-loop command handling uses the processor-owned
+bundle; the remaining legacy helpers are the next cleanup target.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- Focused TUI input-control and task lifecycle tests

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -49,10 +49,10 @@ Active backlog only. Keep this file small and current.
 - [x] Remove `RuntimeClient`/`Agent` ownership from `TuiController` by moving
       task construction, completion, and runtime replacement access into the
       runtime command processor.
-- [ ] Remove mutable extension-registry projections from `TuiApp`; registry
+- [x] Remove mutable extension-registry projections from `TuiApp`; registry
       discovery and reload must remain runtime-owned while TUI receives typed
-      snapshots. Snapshot discovery and the agent-based entry point are done;
-      remove the remaining registry handles used by the task bridge next.
+      snapshots. Production task construction now receives explicit runtime
+      services; only test-only fixtures retain local registry setup helpers.
 - [ ] Construct `TuiController` directly from an injected port and add
       virtual-time controls to the shared harness.
 

--- a/src/runtime_client.rs
+++ b/src/runtime_client.rs
@@ -38,6 +38,13 @@ pub(crate) struct RebuildSuccess {
     pub(crate) lsp_manager: Arc<LspManager>,
 }
 
+#[derive(Clone)]
+pub(crate) struct RuntimeTaskServices {
+    pub(crate) prompt_source_registry: Arc<PromptSourceRegistry>,
+    pub(crate) skill_source_registry: Arc<SkillSourceRegistry>,
+    pub(crate) hook_registry: Arc<HookRegistry>,
+}
+
 #[derive(Debug)]
 pub(crate) enum PlanContinuation {
     None,
@@ -140,6 +147,20 @@ impl RuntimeClient {
 
     pub(crate) fn agent_mut(&mut self) -> &mut Option<Agent> {
         &mut self.agent
+    }
+
+    pub(crate) fn task_services(&self) -> RuntimeTaskServices {
+        RuntimeTaskServices {
+            prompt_source_registry: self.prompt_source_registry.clone(),
+            skill_source_registry: self.skill_source_registry.clone(),
+            hook_registry: self.hook_registry.clone(),
+        }
+    }
+
+    pub(crate) fn update_task_services(&mut self, services: &RuntimeTaskServices) {
+        self.prompt_source_registry = services.prompt_source_registry.clone();
+        self.skill_source_registry = services.skill_source_registry.clone();
+        self.hook_registry = services.hook_registry.clone();
     }
 
     pub(crate) fn extension_snapshot(&self) -> RuntimeExtensionSnapshot {

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -45,9 +45,6 @@ pub async fn run_tui(
     app.sandbox_network_access = runtime.sandbox_network_access.clone();
     app.event_bus = Some(runtime.event_bus.clone());
     app.mcp_manager = Some(runtime.mcp_manager.clone());
-    app.prompt_source_registry = Some(runtime.prompt_source_registry.clone());
-    app.skill_source_registry = Some(runtime.skill_source_registry.clone());
-    app.hook_registry = Some(runtime.hook_registry.clone());
     app.hook_runtime = Some(runtime.hook_runtime.clone());
     app.explicit_plugin_dirs = runtime.explicit_plugin_dirs.clone();
     app.lsp_manager = Some(runtime.lsp_manager.clone());

--- a/src/tui/input_control.rs
+++ b/src/tui/input_control.rs
@@ -1,4 +1,5 @@
 use crate::agent::{Agent, BashApprovalDecision};
+use crate::runtime_client::RuntimeTaskServices;
 use crate::runtime_control::{
     InputEvent, PlanApprovalDecision, RuntimeEvent, SessionControlRequest, SessionEvent,
     ShellApprovalDecision,
@@ -6,6 +7,9 @@ use crate::runtime_control::{
 use crate::tui::runtime::{
     request_running_task_cancellation, start_input_control_task, start_pending_approval_task,
     start_plan_approval_resume_task, start_query_task,
+    tasks::start_input_control_task_with_services,
+    tasks::start_pending_approval_task_with_services,
+    tasks::start_plan_approval_resume_task_with_services, tasks::start_query_task_with_services,
 };
 use crate::tui::state::{
     ActivePendingInteractionKind, InteractionKind, RuntimePhase, TaskKind, TuiApp,
@@ -25,6 +29,15 @@ pub(crate) fn submit_user_prompt(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
     prompt: String,
+) -> InputControlOutcome {
+    submit_user_prompt_with_services(app, agent_slot, prompt, None)
+}
+
+pub(crate) fn submit_user_prompt_with_services(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    prompt: String,
+    services: Option<RuntimeTaskServices>,
 ) -> InputControlOutcome {
     let prompt = prompt.trim().to_string();
     if prompt.is_empty() {
@@ -70,13 +83,17 @@ pub(crate) fn submit_user_prompt(
     };
 
     if app.pending_request_input().is_some() {
-        answer_pending_input(app, agent_slot, agent, prompt);
+        answer_pending_input_with_services(app, agent_slot, agent, prompt, services);
         return InputControlOutcome::Answered;
     }
 
     app.clear_pending_planning_suggestion();
     publish_input_event(app, InputEvent::UserPromptSubmitted);
-    start_query_task(app, prompt, agent);
+    if let Some(services) = services {
+        start_query_task_with_services(app, prompt, agent, services);
+    } else {
+        start_query_task(app, prompt, agent);
+    }
     InputControlOutcome::Submitted
 }
 
@@ -127,22 +144,44 @@ pub(crate) fn answer_pending_input(
     agent: Agent,
     answer: String,
 ) {
+    answer_pending_input_with_services(app, agent_slot, agent, answer, None);
+}
+
+pub(crate) fn answer_pending_input_with_services(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    agent: Agent,
+    answer: String,
+    services: Option<RuntimeTaskServices>,
+) {
     publish_input_event(app, InputEvent::PendingInputAnswered);
     if app.has_local_pending_request_input() {
-        start_local_request_input_continuation(app, agent, answer);
+        start_local_request_input_continuation(app, agent, answer, services);
         return;
     }
 
     let request = crate::runtime_control::InputControlRequest::AnswerPendingInput { answer };
 
-    start_input_control_task(
-        app,
-        agent,
-        request,
-        "Answering pending input.".into(),
-        RuntimePhase::ProcessingResponse,
-        Some("resuming after input".into()),
-    );
+    if let Some(services) = services {
+        start_input_control_task_with_services(
+            app,
+            agent,
+            request,
+            "Answering pending input.".into(),
+            RuntimePhase::ProcessingResponse,
+            Some("resuming after input".into()),
+            services,
+        );
+    } else {
+        start_input_control_task(
+            app,
+            agent,
+            request,
+            "Answering pending input.".into(),
+            RuntimePhase::ProcessingResponse,
+            Some("resuming after input".into()),
+        );
+    }
     *agent_slot = None;
 }
 
@@ -159,6 +198,16 @@ pub(crate) fn answer_plan_approval_with_feedback(
     agent_slot: &mut Option<Agent>,
     decision: PlanApprovalDecision,
     feedback: Option<String>,
+) -> InputControlOutcome {
+    answer_plan_approval_with_feedback_and_services(app, agent_slot, decision, feedback, None)
+}
+
+pub(crate) fn answer_plan_approval_with_feedback_and_services(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    decision: PlanApprovalDecision,
+    feedback: Option<String>,
+    services: Option<RuntimeTaskServices>,
 ) -> InputControlOutcome {
     if !app.has_pending_plan_approval() {
         app.push_notice("No pending plan approval.");
@@ -224,7 +273,11 @@ pub(crate) fn answer_plan_approval_with_feedback(
         feedback.clone(),
         plan_revision,
     );
-    start_plan_approval_resume_task(app, decision, feedback, agent);
+    if let Some(services) = services {
+        start_plan_approval_resume_task_with_services(app, decision, feedback, agent, services);
+    } else {
+        start_plan_approval_resume_task(app, decision, feedback, agent);
+    }
     InputControlOutcome::Answered
 }
 
@@ -250,6 +303,15 @@ pub(crate) fn answer_shell_approval(
     agent_slot: &mut Option<Agent>,
     decision: ShellApprovalDecision,
 ) -> InputControlOutcome {
+    answer_shell_approval_with_services(app, agent_slot, decision, None)
+}
+
+pub(crate) fn answer_shell_approval_with_services(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    decision: ShellApprovalDecision,
+    services: Option<RuntimeTaskServices>,
+) -> InputControlOutcome {
     let Some(interaction) = app.active_pending_interaction() else {
         app.push_notice("No pending shell approval.");
         return InputControlOutcome::Rejected;
@@ -263,7 +325,11 @@ pub(crate) fn answer_shell_approval(
         return InputControlOutcome::Rejected;
     };
     let decision = BashApprovalDecision::from(decision);
-    start_pending_approval_task(app, decision, agent);
+    if let Some(services) = services {
+        start_pending_approval_task_with_services(app, decision, agent, services);
+    } else {
+        start_pending_approval_task(app, decision, agent);
+    }
     InputControlOutcome::Answered
 }
 
@@ -304,10 +370,19 @@ pub(crate) fn handle_session_control(
     }
 }
 
-fn start_local_request_input_continuation(app: &mut TuiApp, agent: Agent, answer: String) {
+fn start_local_request_input_continuation(
+    app: &mut TuiApp,
+    agent: Agent,
+    answer: String,
+    services: Option<RuntimeTaskServices>,
+) {
     let Some(interaction) = app.pending_request_input().cloned() else {
         app.clear_pending_planning_suggestion();
-        start_query_task(app, answer, agent);
+        if let Some(services) = services {
+            start_query_task_with_services(app, answer, agent, services);
+        } else {
+            start_query_task(app, answer, agent);
+        }
         return;
     };
 
@@ -332,7 +407,11 @@ fn start_local_request_input_continuation(app: &mut TuiApp, agent: Agent, answer
     {
         prompt.push_str(&format!("\nContext: {}", note.trim()));
     }
-    start_query_task(app, prompt, agent);
+    if let Some(services) = services {
+        start_query_task_with_services(app, prompt, agent, services);
+    } else {
+        start_query_task(app, prompt, agent);
+    }
 }
 
 fn publish_input_event(app: &TuiApp, event: InputEvent) {

--- a/src/tui/runtime/processor.rs
+++ b/src/tui/runtime/processor.rs
@@ -8,6 +8,7 @@ use super::super::state::{RuntimeSnapshot, TaskCompletion, TuiApp};
 use crate::agent::Agent;
 use crate::oauth::OAuthManager;
 use crate::runtime_client::RuntimeClient;
+use crate::runtime_client::RuntimeTaskServices;
 use crate::runtime_control::{InputControlRequest, SessionControlRequest};
 
 /// Owns session runtime execution and applies typed commands to the runtime.
@@ -58,14 +59,29 @@ impl RuntimeCommandProcessor {
     ) -> anyhow::Result<()> {
         match command {
             RuntimeCommand::Input(InputControlRequest::SubmitUserPrompt { prompt }) => {
-                input_control::submit_user_prompt(app, self.agent_mut(), prompt);
+                let services = self.runtime.task_services();
+                let agent_slot = self.runtime.agent_mut();
+                input_control::submit_user_prompt_with_services(
+                    app,
+                    agent_slot,
+                    prompt,
+                    Some(services),
+                );
             }
             RuntimeCommand::Input(InputControlRequest::SubmitFollowUp { prompt }) => {
                 input_control::submit_follow_up(app, prompt, false);
             }
             RuntimeCommand::Input(InputControlRequest::AnswerPendingInput { answer }) => {
-                if let Some(agent) = self.agent_mut().take() {
-                    input_control::answer_pending_input(app, self.agent_mut(), agent, answer);
+                let services = self.runtime.task_services();
+                let agent_slot = self.runtime.agent_mut();
+                if let Some(agent) = agent_slot.take() {
+                    input_control::answer_pending_input_with_services(
+                        app,
+                        agent_slot,
+                        agent,
+                        answer,
+                        Some(services),
+                    );
                 } else {
                     app.push_notice("Request input is still preparing. Try again.");
                 }
@@ -74,15 +90,25 @@ impl RuntimeCommandProcessor {
                 decision,
                 feedback,
             }) => {
-                input_control::answer_plan_approval_with_feedback(
+                let services = self.runtime.task_services();
+                let agent_slot = self.runtime.agent_mut();
+                input_control::answer_plan_approval_with_feedback_and_services(
                     app,
-                    self.agent_mut(),
+                    agent_slot,
                     decision,
                     feedback,
+                    Some(services),
                 );
             }
             RuntimeCommand::Input(InputControlRequest::AnswerShellApproval { decision }) => {
-                input_control::answer_shell_approval(app, self.agent_mut(), decision);
+                let services = self.runtime.task_services();
+                let agent_slot = self.runtime.agent_mut();
+                input_control::answer_shell_approval_with_services(
+                    app,
+                    agent_slot,
+                    decision,
+                    Some(services),
+                );
             }
             RuntimeCommand::Session(SessionControlRequest::CancelCurrentTurn) => {
                 input_control::handle_session_control(
@@ -118,12 +144,17 @@ impl RuntimeCommandProcessor {
         app: &mut TuiApp,
         completion: Box<Result<TaskCompletion, tokio::task::JoinError>>,
     ) -> anyhow::Result<()> {
+        let mut services = self.runtime.task_services();
+        let agent_slot = self.runtime.agent_mut();
         super::tasks::finish_running_task_if_ready_from_runtime_port(
             app,
-            self.agent_mut(),
+            agent_slot,
             Some(*completion),
+            Some(&mut services),
         )
-        .await
+        .await?;
+        self.runtime.update_task_services(&services);
+        Ok(())
     }
 
     pub(crate) fn sync_snapshot(

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -24,6 +24,7 @@ use super::super::state::{
 };
 use super::events::{apply_tui_event, format_error_chain, runtime_event_from_agent_event};
 use crate::agent::{Agent, AgentEvent, AgentOutputMode, BashApprovalDecision};
+use crate::runtime_client::RuntimeTaskServices;
 pub(crate) use crate::runtime_client::{goal_budget_limit_prompt, goal_continuation_prompt};
 use crate::runtime_control::RuntimeProvenance;
 use crate::runtime_event_bus::RuntimeEventBus;
@@ -116,7 +117,11 @@ fn merge_rebuilt_agent(rebuilt: Agent, previous: Agent) -> Agent {
     crate::runtime_client::RuntimeClient::merge_rebuilt_agent(rebuilt, previous)
 }
 
-fn try_start_queued_follow_up(app: &mut TuiApp, agent_slot: &mut Option<Agent>) {
+fn try_start_queued_follow_up(
+    app: &mut TuiApp,
+    agent_slot: &mut Option<Agent>,
+    services: Option<RuntimeTaskServices>,
+) {
     if app.bottom_pane.running_task.is_none() {
         app.release_pending_follow_ups();
     }
@@ -140,7 +145,11 @@ fn try_start_queued_follow_up(app: &mut TuiApp, agent_slot: &mut Option<Agent>) 
     };
 
     app.bottom_pane.notice = Some("Running queued follow-up.".to_string());
-    start_query_task(app, prompt, agent);
+    if let Some(services) = services {
+        start_query_task_with_services(app, prompt, agent, services);
+    } else {
+        start_query_task(app, prompt, agent);
+    }
 }
 
 fn sync_bash_prefixes_from_config(app: &TuiApp, agent: &mut Agent) {
@@ -154,6 +163,28 @@ fn sync_bash_prefixes_from_config(app: &TuiApp, agent: &mut Agent) {
     }
 }
 
+fn legacy_task_services(app: &TuiApp) -> RuntimeTaskServices {
+    #[cfg(test)]
+    {
+        return RuntimeTaskServices {
+            prompt_source_registry: app
+                .prompt_source_registry
+                .clone()
+                .expect("prompt_registry must exist"),
+            skill_source_registry: app
+                .skill_source_registry
+                .clone()
+                .expect("skill_registry must exist"),
+            hook_registry: app.hook_registry.clone().expect("hook_registry must exist"),
+        };
+    }
+    #[cfg(not(test))]
+    {
+        let _ = app;
+        panic!("runtime task services must be supplied by RuntimeCommandProcessor");
+    }
+}
+
 pub(super) fn start_input_control_task(
     app: &mut TuiApp,
     agent: Agent,
@@ -161,6 +192,26 @@ pub(super) fn start_input_control_task(
     notice: String,
     phase: RuntimePhase,
     phase_detail: Option<String>,
+) {
+    start_input_control_task_with_services(
+        app,
+        agent,
+        request,
+        notice,
+        phase,
+        phase_detail,
+        legacy_task_services(app),
+    );
+}
+
+pub(crate) fn start_input_control_task_with_services(
+    app: &mut TuiApp,
+    agent: Agent,
+    request: crate::runtime_control::InputControlRequest,
+    notice: String,
+    phase: RuntimePhase,
+    phase_detail: Option<String>,
+    services: RuntimeTaskServices,
 ) {
     let (sender, receiver) = mpsc::unbounded_channel();
     let cancellation_token = Arc::new(AtomicBool::new(false));
@@ -174,19 +225,13 @@ pub(super) fn start_input_control_task(
     app.set_runtime_phase(phase, phase_detail);
 
     let mcp_manager = app.mcp_manager.clone().expect("mcp_manager must exist");
-    let prompt_registry = app
-        .prompt_source_registry
-        .clone()
-        .expect("prompt_registry must exist");
-    let skill_registry = app
-        .skill_source_registry
-        .clone()
-        .expect("skill_registry must exist");
+    let prompt_registry = services.prompt_source_registry;
+    let skill_registry = services.skill_source_registry;
     let memory_handler = app
         .memory_handler
         .clone()
         .expect("memory_handler must exist");
-    let hook_registry = app.hook_registry.clone().expect("hook_registry must exist");
+    let hook_registry = services.hook_registry;
 
     let mut agent = agent;
     agent.set_execution_mode(app.agent_execution_mode);
@@ -287,17 +332,27 @@ pub(super) fn start_input_control_task(
 }
 
 pub(super) fn start_query_task(app: &mut TuiApp, prompt: String, agent: Agent) {
+    start_query_task_with_services(app, prompt, agent, legacy_task_services(app));
+}
+
+pub(crate) fn start_query_task_with_services(
+    app: &mut TuiApp,
+    prompt: String,
+    agent: Agent,
+    services: RuntimeTaskServices,
+) {
     let request = crate::runtime_control::InputControlRequest::SubmitUserPrompt {
         prompt: prompt.clone(),
     };
     app.push_entry("You", prompt);
-    start_input_control_task(
+    start_input_control_task_with_services(
         app,
         agent,
         request,
         "Running prompt.".into(),
         RuntimePhase::SendingPrompt,
         Some("sending prompt".into()),
+        services,
     );
 }
 
@@ -399,7 +454,16 @@ pub(super) fn start_review_task(app: &mut TuiApp, prompt: String, mut agent: Age
 pub(super) fn start_pending_approval_task(
     app: &mut TuiApp,
     selection: BashApprovalDecision,
+    agent: Agent,
+) {
+    start_pending_approval_task_with_services(app, selection, agent, legacy_task_services(app));
+}
+
+pub(crate) fn start_pending_approval_task_with_services(
+    app: &mut TuiApp,
+    selection: BashApprovalDecision,
     mut agent: Agent,
+    services: RuntimeTaskServices,
 ) {
     if selection == BashApprovalDecision::Always {
         app.permission_mode = PermissionMode::FullAccess;
@@ -424,13 +488,14 @@ pub(super) fn start_pending_approval_task(
     };
 
     app.clear_pending_command_approval();
-    start_input_control_task(
+    start_input_control_task_with_services(
         app,
         agent,
         request,
         format!("Answering approval request: {selection_label}."),
         RuntimePhase::ProcessingResponse,
         Some("resuming after approval".into()),
+        services,
     );
 }
 
@@ -439,6 +504,22 @@ pub(super) fn start_plan_approval_resume_task(
     decision: crate::runtime_control::PlanApprovalDecision,
     feedback: Option<String>,
     agent: Agent,
+) {
+    start_plan_approval_resume_task_with_services(
+        app,
+        decision,
+        feedback,
+        agent,
+        legacy_task_services(app),
+    );
+}
+
+pub(crate) fn start_plan_approval_resume_task_with_services(
+    app: &mut TuiApp,
+    decision: crate::runtime_control::PlanApprovalDecision,
+    feedback: Option<String>,
+    agent: Agent,
+    services: RuntimeTaskServices,
 ) {
     let (notice, phase_detail) = match decision {
         crate::runtime_control::PlanApprovalDecision::Approve => (
@@ -457,30 +538,47 @@ pub(super) fn start_plan_approval_resume_task(
     let request =
         crate::runtime_control::InputControlRequest::AnswerPlanApproval { decision, feedback };
 
-    start_input_control_task(
+    start_input_control_task_with_services(
         app,
         agent,
         request,
         notice.to_string(),
         RuntimePhase::ProcessingResponse,
         Some(phase_detail.into()),
+        services,
     );
 }
 
-fn start_automatic_plan_implementation_task(app: &mut TuiApp, agent: Agent) {
+fn start_automatic_plan_implementation_task(
+    app: &mut TuiApp,
+    agent: Agent,
+    services: Option<RuntimeTaskServices>,
+) {
     let request = crate::runtime_control::InputControlRequest::AnswerPlanApproval {
         decision: crate::runtime_control::PlanApprovalDecision::Approve,
         feedback: None,
     };
 
-    start_input_control_task(
-        app,
-        agent,
-        request,
-        "Plan generated automatically. Continuing with implementation.".into(),
-        RuntimePhase::ProcessingResponse,
-        Some("resuming approved plan".into()),
-    );
+    if let Some(services) = services {
+        start_input_control_task_with_services(
+            app,
+            agent,
+            request,
+            "Plan generated automatically. Continuing with implementation.".into(),
+            RuntimePhase::ProcessingResponse,
+            Some("resuming approved plan".into()),
+            services,
+        );
+    } else {
+        start_input_control_task(
+            app,
+            agent,
+            request,
+            "Plan generated automatically. Continuing with implementation.".into(),
+            RuntimePhase::ProcessingResponse,
+            Some("resuming approved plan".into()),
+        );
+    }
 }
 
 pub(super) fn start_rebuild_task(app: &mut TuiApp) {

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -166,7 +166,7 @@ fn sync_bash_prefixes_from_config(app: &TuiApp, agent: &mut Agent) {
 fn legacy_task_services(app: &TuiApp) -> RuntimeTaskServices {
     #[cfg(test)]
     {
-        return RuntimeTaskServices {
+        RuntimeTaskServices {
             prompt_source_registry: app
                 .prompt_source_registry
                 .clone()
@@ -176,7 +176,7 @@ fn legacy_task_services(app: &TuiApp) -> RuntimeTaskServices {
                 .clone()
                 .expect("skill_registry must exist"),
             hook_registry: app.hook_registry.clone().expect("hook_registry must exist"),
-        };
+        }
     }
     #[cfg(not(test))]
     {

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -13,6 +13,7 @@ pub(crate) async fn finish_running_task_if_ready(
         agent_slot,
         None,
         true,
+        None,
     )
     .await
 }
@@ -24,12 +25,14 @@ pub(crate) async fn finish_running_task_if_ready_from_runtime_port(
     app: &mut TuiApp,
     agent_slot: &mut Option<Agent>,
     completion: Option<Result<TaskCompletion, tokio::task::JoinError>>,
+    runtime: Option<&mut RuntimeTaskServices>,
 ) -> anyhow::Result<()> {
     finish_running_task_if_ready_with_completion_mode(
         app,
         agent_slot,
         completion,
         false,
+        runtime,
     )
     .await
 }
@@ -39,6 +42,7 @@ async fn finish_running_task_if_ready_with_completion_mode(
     agent_slot: &mut Option<Agent>,
     completion: Option<Result<TaskCompletion, tokio::task::JoinError>>,
     apply_compatibility_events: bool,
+    mut runtime: Option<&mut RuntimeTaskServices>,
 ) -> anyhow::Result<()> {
     if app.bottom_pane.running_task.is_none() {
         return Ok(());
@@ -114,7 +118,11 @@ async fn finish_running_task_if_ready_with_completion_mode(
                             crate::runtime_client::PlanContinuation::AutomaticImplementation => {
                                 app.release_pending_follow_ups();
                                 app.finalize_agent_stream(None);
-                                start_automatic_plan_implementation_task(app, agent);
+                                start_automatic_plan_implementation_task(
+                                    app,
+                                    agent,
+                                    runtime.as_deref().cloned(),
+                                );
                                 return Ok(());
                             }
                             crate::runtime_client::PlanContinuation::None => {
@@ -150,7 +158,12 @@ async fn finish_running_task_if_ready_with_completion_mode(
                             );
                             app.finalize_active_turn();
                             *agent_slot = Some(agent);
-                            start_query_task(app, prompt, agent_slot.take().expect("agent"));
+                            let agent = agent_slot.take().expect("agent");
+                            if let Some(services) = runtime.as_deref().cloned() {
+                                start_query_task_with_services(app, prompt, agent, services);
+                            } else {
+                                start_query_task(app, prompt, agent);
+                            }
                             return Ok(());
                         }
                         GoalContinuation::Complete { goal } => {
@@ -181,7 +194,11 @@ async fn finish_running_task_if_ready_with_completion_mode(
                                 ),
                             );
                             app.finalize_active_turn();
-                            start_query_task(app, prompt, agent);
+                            if let Some(services) = runtime.as_deref().cloned() {
+                                start_query_task_with_services(app, prompt, agent, services);
+                            } else {
+                                start_query_task(app, prompt, agent);
+                            }
                             return Ok(());
                         }
                         GoalContinuation::NotActive => {}
@@ -214,7 +231,7 @@ async fn finish_running_task_if_ready_with_completion_mode(
                         }
                         app.bottom_pane.notice = Some("Prompt finished.".into());
                         app.set_runtime_phase(RuntimePhase::Idle, Some("prompt finished".into()));
-                        try_start_queued_follow_up(app, agent_slot);
+                        try_start_queued_follow_up(app, agent_slot, runtime.as_deref().cloned());
                     }
                 }
                 Err(err) => {
@@ -243,7 +260,7 @@ async fn finish_running_task_if_ready_with_completion_mode(
                         app.finalize_active_turn();
                         app.bottom_pane.notice = Some("Query cancelled.".into());
                         app.set_runtime_phase(RuntimePhase::Idle, Some("query cancelled".into()));
-                        try_start_queued_follow_up(app, agent_slot);
+                        try_start_queued_follow_up(app, agent_slot, runtime.as_deref().cloned());
                         return Ok(());
                     }
                     app.set_runtime_phase(RuntimePhase::Failed, Some("query failed".into()));
@@ -261,7 +278,7 @@ async fn finish_running_task_if_ready_with_completion_mode(
                     }
                     app.push_system(message.clone(), SystemMessageKind::Other);
                     app.push_notice(message);
-                    try_start_queued_follow_up(app, agent_slot);
+                    try_start_queued_follow_up(app, agent_slot, runtime.as_deref().cloned());
                 }
             }
         }
@@ -295,7 +312,7 @@ async fn finish_running_task_if_ready_with_completion_mode(
                     }
                     app.finalize_active_turn();
                     app.set_runtime_phase(RuntimePhase::Idle, Some("history compacted".into()));
-                    try_start_queued_follow_up(app, agent_slot);
+                    try_start_queued_follow_up(app, agent_slot, runtime.as_deref().cloned());
                 }
                 Ok(false) => {
                     app.clear_active_live_sections();
@@ -305,7 +322,7 @@ async fn finish_running_task_if_ready_with_completion_mode(
                     app.push_notice(message);
                     app.finalize_active_turn();
                     app.set_runtime_phase(RuntimePhase::Idle, Some("compact skipped".into()));
-                    try_start_queued_follow_up(app, agent_slot);
+                    try_start_queued_follow_up(app, agent_slot, runtime.as_deref().cloned());
                 }
                 Err(err) => {
                     app.clear_active_live_sections();
@@ -340,10 +357,23 @@ async fn finish_running_task_if_ready_with_completion_mode(
                 app.mcp_tool_cache = Some(rebuilt.mcp_tool_cache);
                 app.mcp_manager = Some(rebuilt.mcp_manager);
                 app.lsp_manager = Some(rebuilt.lsp_manager);
-                app.prompt_source_registry = Some(rebuilt.prompt_source_registry);
-                app.skill_source_registry = Some(rebuilt.skill_source_registry);
+                if let Some(runtime) = runtime.as_deref_mut() {
+                    *runtime = RuntimeTaskServices {
+                        prompt_source_registry: rebuilt.prompt_source_registry.clone(),
+                        skill_source_registry: rebuilt.skill_source_registry.clone(),
+                        hook_registry: rebuilt.hook_registry.clone(),
+                    };
+                }
+                #[cfg(test)]
+                {
+                    app.prompt_source_registry = Some(rebuilt.prompt_source_registry);
+                    app.skill_source_registry = Some(rebuilt.skill_source_registry);
+                }
                 app.memory_handler = Some(rebuilt.memory_handler);
-                app.hook_registry = Some(rebuilt.hook_registry);
+                #[cfg(test)]
+                {
+                    app.hook_registry = Some(rebuilt.hook_registry);
+                }
                 app.hook_runtime = Some(rebuilt.hook_runtime.clone());
                 app.local_model_server = rebuilt.local_model_server;
                 RuntimeClient::persist_config(&app.config_manager, &app.config)?;
@@ -392,7 +422,7 @@ async fn finish_running_task_if_ready_with_completion_mode(
                     app.bottom_pane.notice = Some(notice);
                 }
                 app.finalize_active_turn();
-                try_start_queued_follow_up(app, agent_slot);
+                try_start_queued_follow_up(app, agent_slot, runtime.as_deref().cloned());
             }
             Err(err) => {
                 app.set_runtime_phase(RuntimePhase::Failed, Some("backend rebuild failed".into()));

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -862,7 +862,7 @@ async fn queued_follow_ups_start_as_one_multiline_turn() {
     );
     let mut agent_slot = Some(agent);
 
-    try_start_queued_follow_up(&mut app, &mut agent_slot);
+    try_start_queued_follow_up(&mut app, &mut agent_slot, None);
 
     assert_eq!(app.queued_follow_up_count(), 0);
     assert!(app.bottom_pane.running_task.is_some());

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -300,8 +300,11 @@ impl TuiApp {
             local_model_server,
             mcp_manager: None,
             lsp_manager: None,
+            #[cfg(test)]
             prompt_source_registry: None,
+            #[cfg(test)]
             skill_source_registry: None,
+            #[cfg(test)]
             hook_registry: None,
             hook_runtime: None,
             explicit_plugin_dirs: Vec::new(),

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -22,12 +22,15 @@ use crate::context::{
     RetrievalSourceContextEntry,
 };
 use crate::control_tokens::{has_pending_internal_control_context, scrub_internal_control_tokens};
+#[cfg(test)]
 use crate::hook_registry::HookRegistry;
 use crate::lsp_manager::LspManager;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::mcp_tool_cache::McpToolCache;
 use crate::oauth::SavedCodexAuthMode;
-use crate::protocol_sources::{MemoryControlHandler, PromptSourceRegistry, SkillSourceRegistry};
+use crate::protocol_sources::MemoryControlHandler;
+#[cfg(test)]
+use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 use crate::runtime_event_bus::RuntimeEventBus;
 use crate::thread_store::ThreadSummary;
 use crate::tools::bash::BashCommandInput;
@@ -758,8 +761,11 @@ pub struct TuiApp {
     pub local_model_server: crate::local_model_server::LocalModelServerStatus,
     pub mcp_manager: Option<Arc<McpConnectionManager>>,
     pub lsp_manager: Option<Arc<LspManager>>,
+    #[cfg(test)]
     pub prompt_source_registry: Option<Arc<PromptSourceRegistry>>,
+    #[cfg(test)]
     pub skill_source_registry: Option<Arc<SkillSourceRegistry>>,
+    #[cfg(test)]
     pub hook_registry: Option<Arc<HookRegistry>>,
     pub hook_runtime: Option<Arc<crate::hook_runtime::HookRuntime>>,
     pub explicit_plugin_dirs: Vec<PathBuf>,


### PR DESCRIPTION
## Summary

- add a runtime-owned `RuntimeTaskServices` bundle for prompt, skill, and hook registries
- pass task services explicitly from `RuntimeCommandProcessor` to query, approval, queued follow-up, and completion paths
- remove production registry fields and bootstrap assignments from `TuiApp`
- update rebuild handling, tests, and runtime ownership documentation

## Motivation

The previous migration moved runtime execution into `RuntimeCommandProcessor`,
but task construction still read registry handles from `TuiApp`. That left the
presentation model coupled to runtime extension ownership and made rebuild
replacement update presentation state directly.

This change keeps the registry graph in the session runtime and passes only an
explicit service bundle to the in-process task bridge. Rebuild completion also
refreshes the processor-owned bundle.

## Related issue

Not applicable.

## Testing

- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo test --bin rara tui::input_control --no-fail-fast`
- `cargo test --bin rara tui::runtime::tasks --no-fail-fast`

The existing macOS linker emits the known `__eh_frame` warning during test
linking.

## Follow-up

Legacy no-port task helpers remain for focused tests and transitional callers.
The next migration can remove those helpers and complete direct
`RuntimeClientPort` construction for `TuiController`.
