### PR TITLE
chore(codex): upgrade rust dependencies to 0.146

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -272,7 +272,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2007,18 +2007,19 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "codex-http-client",
  "codex-protocol",
  "crypto_box",
  "ed25519-dalek",
+ "http 1.4.2",
  "jsonwebtoken",
  "rand 0.9.4",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2026,8 +2027,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2058,8 +2059,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -2067,8 +2068,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2080,13 +2081,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 
 [[package]]
 name = "codex-config"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2130,8 +2131,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "clap",
@@ -2148,8 +2149,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -2160,8 +2161,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2173,8 +2174,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2186,8 +2187,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2211,8 +2212,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -2237,8 +2238,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "keyring",
  "tracing",
@@ -2246,8 +2247,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2265,7 +2266,6 @@ dependencies = [
  "once_cell",
  "os_info",
  "rand 0.9.4",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2280,8 +2280,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -2292,8 +2292,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -2311,8 +2311,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2342,12 +2342,13 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "codex-otel"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2377,8 +2378,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2416,8 +2417,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "age",
  "anyhow",
@@ -2435,16 +2436,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "dirs",
  "dunce",
@@ -2455,8 +2456,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "lru 0.16.4",
  "sha1",
@@ -2465,8 +2466,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2474,8 +2475,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2487,8 +2488,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2496,8 +2497,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2506,8 +2507,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -2521,16 +2522,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "rustls 0.23.41",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "regex-lite",
  "serde",
@@ -2539,13 +2540,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -2574,7 +2575,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4145,7 +4146,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4430,7 +4431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6790,7 +6791,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -8992,7 +8993,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10304,7 +10305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -10323,7 +10324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -10494,7 +10495,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -10532,7 +10533,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -11924,7 +11925,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11995,7 +11996,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12843,7 +12844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13324,7 +13325,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13346,7 +13347,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14271,7 +14272,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14918,7 +14919,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,10 @@ tempfile = "3.17"
 ignore = "0.4.26"
 nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
 rmcp = { version = "3.0", features = ["client", "transport-child-process"] }
-codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
-codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
+codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.146.0" }
+codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.146.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.146.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.146.0" }
 rara-instructions = { path = "crates/instructions" }
 
 [package]

--- a/docs/journal/2026-08-03-codex-146-upgrade.md
+++ b/docs/journal/2026-08-03-codex-146-upgrade.md
@@ -1,0 +1,27 @@
+# Codex Rust Dependency Upgrade
+
+## Change
+
+RARA's OpenAI Codex Rust dependencies were upgraded from `rust-v0.145.0` to
+the latest stable release, `rust-v0.146.0`. The lockfile now resolves the
+complete Codex dependency graph at commit `e363b08c`.
+
+## Compatibility
+
+Codex login now requires an explicit `AuthRouteConfig`. RARA supplies the
+default Codex `HttpClientFactory` to both model-catalog authentication and the
+browser login server. No provider behavior or credential storage policy was
+changed.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- `cargo test --bin rara oauth --no-fail-fast`
+- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
+- `git diff --check`
+
+## Follow-up
+
+The `0.147.0-alpha.*` tags are prereleases and are intentionally not used for
+the stable dependency path.

--- a/src/codex_model_catalog.rs
+++ b/src/codex_model_catalog.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use codex_http_client::{HttpClientFactory, OutboundProxyPolicy};
-use codex_login::{AuthCredentialsStoreMode, AuthKeyringBackendKind, AuthManager};
+use codex_login::{AuthCredentialsStoreMode, AuthKeyringBackendKind, AuthManager, AuthRouteConfig};
 use codex_models_manager::bundled_models_response;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy, StaticModelsManager};
 
@@ -39,7 +39,9 @@ pub async fn load_codex_model_catalog(
         None,
         None,
         AuthKeyringBackendKind::default(),
-        None,
+        AuthRouteConfig::from_http_client_factory(HttpClientFactory::new(
+            OutboundProxyPolicy::ReqwestDefault,
+        )),
     )
     .await;
     let manager = StaticModelsManager::new(Some(auth_manager), bundled_models_response()?);

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -3,8 +3,9 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, anyhow};
+use codex_http_client::{HttpClientFactory, OutboundProxyPolicy};
 use codex_login::{
-    AuthCredentialsStoreMode, AuthDotJson, AuthKeyringBackendKind, CLIENT_ID,
+    AuthCredentialsStoreMode, AuthDotJson, AuthKeyringBackendKind, AuthRouteConfig, CLIENT_ID,
     DeviceCode as CodexDeviceCode, LoginServer as CodexLoginServer, ServerOptions,
     complete_device_code_login as codex_complete_device_code_login, load_auth_dot_json,
     login_with_api_key as codex_login_with_api_key, logout as codex_logout,
@@ -191,7 +192,9 @@ impl OAuthManager {
             None,
             AuthCredentialsStoreMode::File,
             AuthKeyringBackendKind::default(),
-            None,
+            AuthRouteConfig::from_http_client_factory(HttpClientFactory::new(
+                OutboundProxyPolicy::ReqwestDefault,
+            )),
         );
         options.issuer = ISSUER.to_string();
         options.open_browser = open_browser;


### PR DESCRIPTION
## Summary

- upgrade the OpenAI Codex Rust dependency graph from `rust-v0.145.0` to the latest stable `rust-v0.146.0`
- adapt Codex login and model-catalog setup to the required `AuthRouteConfig`
- use the Codex `HttpClientFactory` for authentication route construction
- document the compatibility change and verification

## Testing

- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo test --bin rara oauth --no-fail-fast`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `git diff --check`

The `0.147.0-alpha.*` tags are prereleases and are intentionally excluded from
this stable dependency upgrade.
