### PR TITLE
feat(tui): add typed tool session projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -272,7 +272,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2007,18 +2007,19 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "codex-http-client",
  "codex-protocol",
  "crypto_box",
  "ed25519-dalek",
+ "http 1.4.2",
  "jsonwebtoken",
  "rand 0.9.4",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2026,8 +2027,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -2058,8 +2059,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -2067,8 +2068,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2080,13 +2081,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 
 [[package]]
 name = "codex-config"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2130,8 +2131,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "clap",
@@ -2148,8 +2149,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -2160,8 +2161,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2173,8 +2174,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2186,8 +2187,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2211,8 +2212,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -2237,8 +2238,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "keyring",
  "tracing",
@@ -2246,8 +2247,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2265,7 +2266,6 @@ dependencies = [
  "once_cell",
  "os_info",
  "rand 0.9.4",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -2280,8 +2280,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -2292,8 +2292,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -2311,8 +2311,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2342,12 +2342,13 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "codex-otel"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2377,8 +2378,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2416,8 +2417,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "age",
  "anyhow",
@@ -2435,16 +2436,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "dirs",
  "dunce",
@@ -2455,8 +2456,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "lru 0.16.4",
  "sha1",
@@ -2465,8 +2466,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2474,8 +2475,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -2487,8 +2488,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2496,8 +2497,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2506,8 +2507,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -2521,16 +2522,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "rustls 0.23.41",
 ]
 
 [[package]]
 name = "codex-utils-string"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "regex-lite",
  "serde",
@@ -2539,13 +2540,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.145.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.145.0#25af12f7e61572b0bc18ddb1008be543b91519b0"
+version = "0.146.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.146.0#e363b08c9175ac1cbe5893615dd2cb9ddf95043b"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -2574,7 +2575,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4145,7 +4146,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4430,7 +4431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6790,7 +6791,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -8992,7 +8993,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10304,7 +10305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "petgraph",
@@ -10323,7 +10324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -10494,7 +10495,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.41",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -10532,7 +10533,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -11924,7 +11925,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11995,7 +11996,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12843,7 +12844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13324,7 +13325,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13346,7 +13347,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14271,7 +14272,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14918,7 +14919,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,10 @@ tempfile = "3.17"
 ignore = "0.4.26"
 nucleo = { git = "https://github.com/helix-editor/nucleo.git", rev = "4253de9faabb4e5c6d81d946a5e35a90f87347ee" }
 rmcp = { version = "3.0", features = ["client", "transport-child-process"] }
-codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
-codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.145.0" }
+codex-execpolicy = { git = "https://github.com/openai/codex", tag = "rust-v0.146.0" }
+codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.146.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.146.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.146.0" }
 rara-instructions = { path = "crates/instructions" }
 
 [package]

--- a/docs/features/context-memory-optimization.md
+++ b/docs/features/context-memory-optimization.md
@@ -21,6 +21,23 @@ model for todo persistence and tool visibility, and add retrieval throttling
 as a RARA-specific optimization — since RARA runs a local vector database,
 each retrieval costs more than a hosted backend call.
 
+## OpenCode TUI Boundary
+
+OpenCode's TUI consumes a server-owned session projection. Messages and tool
+parts have stable identities and explicit lifecycle states; compaction is a
+first-class session item. RARA follows the same boundary incrementally:
+
+- runtime events may carry an optional `call_id` and the TUI stores a typed
+  tool payload alongside the legacy role/message representation;
+- role/message remains a persistence compatibility format, not the source of
+  runtime semantics;
+- retrieval caching and compaction decisions remain runtime-owned;
+- TUI rendering consumes snapshots and structured events and only presents
+  status, summaries, and inspectable details.
+
+The next implementation step is to complete the runtime session projection
+for tool lifecycle and compaction events before adding retrieval-cache UI.
+
 ## Goals
 
 1. Cache the previous turn's memory retrieval set. Only refresh when the
@@ -156,6 +173,13 @@ section uses its appropriate factor.
 ---
 
 ## Implementation Plan
+
+### Phase 0: Session projection
+
+- [x] Preserve optional tool call IDs in structured runtime events.
+- [x] Attach typed tool lifecycle payloads to TUI transcript entries while
+      retaining legacy role/message persistence.
+- [ ] Add runtime-owned compaction events and typed session projection records.
 
 ### Phase 1: Display
 

--- a/docs/journal/2026-08-03-codex-146-upgrade.md
+++ b/docs/journal/2026-08-03-codex-146-upgrade.md
@@ -1,0 +1,27 @@
+# Codex Rust Dependency Upgrade
+
+## Change
+
+RARA's OpenAI Codex Rust dependencies were upgraded from `rust-v0.145.0` to
+the latest stable release, `rust-v0.146.0`. The lockfile now resolves the
+complete Codex dependency graph at commit `e363b08c`.
+
+## Compatibility
+
+Codex login now requires an explicit `AuthRouteConfig`. RARA supplies the
+default Codex `HttpClientFactory` to both model-catalog authentication and the
+browser login server. No provider behavior or credential storage policy was
+changed.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- `cargo test --bin rara oauth --no-fail-fast`
+- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
+- `git diff --check`
+
+## Follow-up
+
+The `0.147.0-alpha.*` tags are prereleases and are intentionally not used for
+the stable dependency path.

--- a/docs/journal/2026-08-04-opencode-tui-session-projection.md
+++ b/docs/journal/2026-08-04-opencode-tui-session-projection.md
@@ -1,0 +1,35 @@
+# OpenCode-Inspired TUI Session Projection
+
+## What changed
+
+RARA runtime tool events now carry an optional `call_id`. TUI transcript
+entries retain a typed tool payload with the tool name, call ID, and lifecycle
+status while continuing to persist the existing role/message fields.
+
+## Why
+
+OpenCode keeps session state and tool parts in the runtime/server projection and
+lets the TUI render that projection. RARA previously exposed tool semantics to
+the TUI primarily through role strings. The typed payload is the first
+backward-compatible step toward the same boundary.
+
+## Trade-offs
+
+The current agent event model does not yet assign a shared ID to every tool
+use/result pair, so the field is optional and existing producers remain
+compatible. Persisted transcript records are intentionally unchanged. A later
+change must add runtime-owned compaction records and complete tool identity
+correlation before removing the compatibility role path.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --all-targets`
+- Focused runtime event tests cover tool payload construction and lifecycle
+  status.
+
+## Remaining work
+
+- Add a typed session projection owned by the runtime.
+- Emit and render compaction as a structured session event.
+- Move completed-tool rendering from role matching to projection matching.

--- a/src/acp.rs
+++ b/src/acp.rs
@@ -297,7 +297,11 @@ impl RaraAcpAgent {
                     );
                 }
                 crate::runtime_control::RuntimeEvent::Tool(
-                    crate::runtime_control::ToolEvent::Use { name, input },
+                    crate::runtime_control::ToolEvent::Use {
+                        call_id: _,
+                        name,
+                        input,
+                    },
                 ) => {
                     let id = format!("{event_id}-{name}");
                     tool_ids
@@ -312,6 +316,7 @@ impl RaraAcpAgent {
                 }
                 crate::runtime_control::RuntimeEvent::Tool(
                     crate::runtime_control::ToolEvent::Result {
+                        call_id: _,
                         name,
                         content,
                         is_error,
@@ -340,6 +345,7 @@ impl RaraAcpAgent {
                 }
                 crate::runtime_control::RuntimeEvent::Tool(
                     crate::runtime_control::ToolEvent::Progress {
+                        call_id: _,
                         name,
                         stream,
                         chunk,

--- a/src/codex_model_catalog.rs
+++ b/src/codex_model_catalog.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use codex_http_client::{HttpClientFactory, OutboundProxyPolicy};
-use codex_login::{AuthCredentialsStoreMode, AuthKeyringBackendKind, AuthManager};
+use codex_login::{AuthCredentialsStoreMode, AuthKeyringBackendKind, AuthManager, AuthRouteConfig};
 use codex_models_manager::bundled_models_response;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy, StaticModelsManager};
 
@@ -39,7 +39,9 @@ pub async fn load_codex_model_catalog(
         None,
         None,
         AuthKeyringBackendKind::default(),
-        None,
+        AuthRouteConfig::from_http_client_factory(HttpClientFactory::new(
+            OutboundProxyPolicy::ReqwestDefault,
+        )),
     )
     .await;
     let manager = StaticModelsManager::new(Some(auth_manager), bundled_models_response()?);

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -3,8 +3,9 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, anyhow};
+use codex_http_client::{HttpClientFactory, OutboundProxyPolicy};
 use codex_login::{
-    AuthCredentialsStoreMode, AuthDotJson, AuthKeyringBackendKind, CLIENT_ID,
+    AuthCredentialsStoreMode, AuthDotJson, AuthKeyringBackendKind, AuthRouteConfig, CLIENT_ID,
     DeviceCode as CodexDeviceCode, LoginServer as CodexLoginServer, ServerOptions,
     complete_device_code_login as codex_complete_device_code_login, load_auth_dot_json,
     login_with_api_key as codex_login_with_api_key, logout as codex_logout,
@@ -191,7 +192,9 @@ impl OAuthManager {
             None,
             AuthCredentialsStoreMode::File,
             AuthKeyringBackendKind::default(),
-            None,
+            AuthRouteConfig::from_http_client_factory(HttpClientFactory::new(
+                OutboundProxyPolicy::ReqwestDefault,
+            )),
         );
         options.issuer = ISSUER.to_string();
         options.open_browser = open_browser;

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -162,15 +162,21 @@ impl From<ToolStream> for ToolOutputStream {
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum ToolEvent {
     Use {
+        #[serde(default)]
+        call_id: Option<String>,
         name: String,
         input: Value,
     },
     Result {
+        #[serde(default)]
+        call_id: Option<String>,
         name: String,
         content: String,
         is_error: bool,
     },
     Progress {
+        #[serde(default)]
+        call_id: Option<String>,
         name: String,
         stream: ToolStream,
         chunk: String,
@@ -414,12 +420,17 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
         AgentEvent::AssistantThinkingDelta(delta) => {
             RuntimeEvent::Assistant(AssistantEvent::ThinkingDelta(delta))
         }
-        AgentEvent::ToolUse { name, input } => RuntimeEvent::Tool(ToolEvent::Use { name, input }),
+        AgentEvent::ToolUse { name, input } => RuntimeEvent::Tool(ToolEvent::Use {
+            call_id: None,
+            name,
+            input,
+        }),
         AgentEvent::ToolResult {
             name,
             content,
             is_error,
         } => RuntimeEvent::Tool(ToolEvent::Result {
+            call_id: None,
             name,
             content,
             is_error,
@@ -429,6 +440,7 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
             stream,
             chunk,
         } => RuntimeEvent::Tool(ToolEvent::Progress {
+            call_id: None,
             name,
             stream: stream.into(),
             chunk,
@@ -519,6 +531,7 @@ mod tests {
         assert_eq!(
             event,
             RuntimeEvent::Tool(ToolEvent::Progress {
+                call_id: None,
                 name: "bash".to_string(),
                 stream: ToolStream::Stderr,
                 chunk: "error\n".to_string(),

--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -101,7 +101,10 @@ impl ActiveCell for ActiveTurnCell<'_> {
             matches!(
                 entry.role.as_str(),
                 "Tool" | "Tool Result" | "Tool Error" | "Tool Progress"
-            ) || matches!(entry.payload, Some(TranscriptEntryPayload::Terminal(_)))
+            ) || matches!(
+                entry.payload,
+                Some(TranscriptEntryPayload::Terminal(_) | TranscriptEntryPayload::Tool(_))
+            )
         });
         let user_message = current_turn
             .iter()

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -256,7 +256,11 @@ fn apply_runtime_control_event(app: &mut TuiApp, event: RuntimeControlEvent) {
         | RuntimeEvent::Session(SessionEvent::Created { .. })
         | RuntimeEvent::Session(SessionEvent::Resumed { .. })
         | RuntimeEvent::Session(SessionEvent::ModelResponse { .. }) => {}
-        RuntimeEvent::Tool(ToolEvent::Use { name, input }) => {
+        RuntimeEvent::Tool(ToolEvent::Use {
+            call_id,
+            name,
+            input,
+        }) => {
             if name == crate::tools::todo::TODO_WRITE_TOOL_NAME {
                 if let Ok(state) = crate::todo::normalize_todo_write_input(&input) {
                     app.snapshot.todo = crate::context::TodoContextView::from_state(Some(state));
@@ -278,9 +282,15 @@ fn apply_runtime_control_event(app: &mut TuiApp, event: RuntimeControlEvent) {
                 app.record_running_action(action);
             }
             app.set_runtime_phase(RuntimePhase::RunningTool, Some(name.clone()));
-            app.push_entry("Tool", format_tool_use(&name, &input));
+            app.push_tool_entry(
+                call_id.as_deref(),
+                &name,
+                crate::tui::state::ToolTranscriptStatus::Running,
+                format_tool_use(&name, &input),
+            );
         }
         RuntimeEvent::Tool(ToolEvent::Result {
+            call_id,
             name,
             content,
             is_error,
@@ -312,16 +322,19 @@ fn apply_runtime_control_event(app: &mut TuiApp, event: RuntimeControlEvent) {
                 app.advance_running_tool_boundary();
             }
             app.set_runtime_phase(RuntimePhase::RunningTool, Some(name.clone()));
-            app.push_entry(
+            app.push_tool_entry(
+                call_id.as_deref(),
+                &name,
                 if is_error {
-                    "Tool Error"
+                    crate::tui::state::ToolTranscriptStatus::Error
                 } else {
-                    "Tool Result"
+                    crate::tui::state::ToolTranscriptStatus::Completed
                 },
                 format_tool_result(&name, &content),
             );
         }
         RuntimeEvent::Tool(ToolEvent::Progress {
+            call_id: _,
             name,
             stream,
             chunk,

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -49,6 +49,7 @@ fn structured_tool_event_updates_running_action_without_role_parsing() {
         provenance: RuntimeProvenance::local_tui("session-1"),
         sequence: 1,
         event: RuntimeEvent::Tool(crate::runtime_control::ToolEvent::Use {
+            call_id: Some("call-1".into()),
             name: "write_file".into(),
             input: json!({"path": "src/runtime.rs", "content": "fn main() {}"}),
         }),
@@ -61,6 +62,17 @@ fn structured_tool_event_updates_running_action_without_role_parsing() {
         vec!["Write src/runtime.rs".to_string()]
     );
     assert_eq!(app.active_turn.entries[0].role, "Tool");
+    match app.active_turn.entries[0].payload.as_ref() {
+        Some(crate::tui::state::TranscriptEntryPayload::Tool(payload)) => {
+            assert_eq!(payload.call_id.as_deref(), Some("call-1"));
+            assert_eq!(payload.name, "write_file");
+            assert_eq!(
+                payload.status,
+                crate::tui::state::ToolTranscriptStatus::Running
+            );
+        }
+        payload => panic!("expected structured tool payload, got {payload:?}"),
+    }
 }
 
 #[test]

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -35,7 +35,8 @@ pub use self::types::{
     PendingInteractionSnapshot, PermissionMode, PickerIntent, ProviderFamily, RalphGoal,
     RunningTask, RuntimeExtensionSnapshot, RuntimePhase, RuntimeSnapshot, SkillPickerEntry,
     StatusTab, SystemMessageKind, TaskCompletion, TaskKind, TerminalDiagnosticsView,
-    TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
+    ToolTranscriptPayload, ToolTranscriptStatus, TranscriptEntry, TranscriptEntryPayload,
+    TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
 };
 use crate::oauth::OAuthManager;
 pub(crate) use crate::runtime_client::RebuildSuccess;

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -33,7 +33,7 @@ fn legacy_active_live_sections(live: &ActiveLiveSections) -> Vec<(&'static str, 
 }
 
 fn is_agent_segment_boundary(entry: &TranscriptEntry) -> bool {
-    matches!(
+    if matches!(
         entry.role.as_str(),
         "Tool"
             | "Tool Result"
@@ -43,10 +43,14 @@ fn is_agent_segment_boundary(entry: &TranscriptEntry) -> bool {
             | "Exploring"
             | "Planning"
             | "Running"
-    ) || matches!(
-        entry.payload,
-        Some(crate::tui::state::TranscriptEntryPayload::Terminal(_))
-    )
+    ) {
+        return true;
+    }
+    match &entry.payload {
+        Some(crate::tui::state::TranscriptEntryPayload::Terminal(_)) => true,
+        Some(crate::tui::state::TranscriptEntryPayload::Tool(payload)) => !payload.name.is_empty(),
+        _ => false,
+    }
 }
 
 impl TuiApp {
@@ -94,6 +98,22 @@ impl TuiApp {
             self.commit_active_turn();
         }
         let entry = TranscriptEntry::new(role, message);
+        self.record_entry_realtime(&PersistedTurnEntry {
+            role: entry.role.clone(),
+            message: entry.message.clone(),
+        });
+        self.active_turn.entries.push(entry);
+        self.reset_transcript_scroll_if_following_tail();
+    }
+
+    pub fn push_tool_entry(
+        &mut self,
+        call_id: Option<&str>,
+        name: &str,
+        status: super::ToolTranscriptStatus,
+        message: impl Into<String>,
+    ) {
+        let entry = super::TranscriptEntry::tool(call_id, name, status, message);
         self.record_entry_realtime(&PersistedTurnEntry {
             role: entry.role.clone(),
             message: entry.message.clone(),

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -498,11 +498,26 @@ pub struct TranscriptEntry {
 #[derive(Clone, Debug)]
 pub enum TranscriptEntryPayload {
     Terminal(TerminalEvent),
+    Tool(ToolTranscriptPayload),
     /// Reserved for semantic transcript filtering and future per-kind system
     /// rendering; current committed cells only need to know it is system text
     /// (docs/todo.md).
     #[allow(dead_code)]
     System(SystemMessageKind),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToolTranscriptStatus {
+    Running,
+    Completed,
+    Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolTranscriptPayload {
+    pub call_id: Option<String>,
+    pub name: String,
+    pub status: ToolTranscriptStatus,
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
@@ -532,6 +547,28 @@ impl TranscriptEntry {
             role: "Terminal Event".to_string(),
             message: event.to_transcript_message(),
             payload: Some(TranscriptEntryPayload::Terminal(event)),
+        }
+    }
+
+    pub fn tool(
+        call_id: Option<&str>,
+        name: impl Into<String>,
+        status: ToolTranscriptStatus,
+        message: impl Into<String>,
+    ) -> Self {
+        let role = match status {
+            ToolTranscriptStatus::Running => "Tool",
+            ToolTranscriptStatus::Completed => "Tool Result",
+            ToolTranscriptStatus::Error => "Tool Error",
+        };
+        Self {
+            role: role.to_string(),
+            message: message.into(),
+            payload: Some(TranscriptEntryPayload::Tool(ToolTranscriptPayload {
+                call_id: call_id.map(ToString::to_string),
+                name: name.into(),
+                status,
+            })),
         }
     }
 


### PR DESCRIPTION
## Summary

- add an optional `call_id` to structured runtime tool events
- retain typed tool lifecycle payloads in TUI transcript entries
- keep legacy `role`/`message` persistence unchanged for compatibility
- document the OpenCode-inspired server-owned session projection boundary

## Motivation

OpenCode renders a runtime-owned session projection with stable tool parts and
explicit lifecycle state. RARA can adopt that boundary incrementally without
rewriting existing transcript files or moving execution behavior into the TUI.

This change establishes the first compatibility-preserving projection layer.
Runtime-owned compaction records and complete tool identity correlation remain
follow-up work.

## Verification

- `cargo fmt --all`
- `cargo check --all-targets`
- `cargo test --bin rara tui::runtime::events --no-fail-fast`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`

## Related

- Follow-up: add runtime-owned typed compaction/session projection records.
