### PR TITLE
feat(runtime): project compaction session events

### DIFF
--- a/docs/features/context-memory-optimization.md
+++ b/docs/features/context-memory-optimization.md
@@ -179,7 +179,12 @@ section uses its appropriate factor.
 - [x] Preserve optional tool call IDs in structured runtime events.
 - [x] Attach typed tool lifecycle payloads to TUI transcript entries while
       retaining legacy role/message persistence.
-- [ ] Add runtime-owned compaction events and typed session projection records.
+- [x] Add runtime-owned compaction events and typed session projection records.
+
+Compaction records reuse the existing durable `PersistedCompactionEvent` path.
+The runtime reporter publishes the same boundary as a structured session event,
+and the TUI stores a typed compaction payload while retaining role/message
+compatibility persistence.
 
 ### Phase 1: Display
 

--- a/docs/journal/2026-08-04-runtime-compaction-projection.md
+++ b/docs/journal/2026-08-04-runtime-compaction-projection.md
@@ -1,0 +1,34 @@
+# Runtime-Owned Compaction Projection
+
+## What changed
+
+Compaction now emits a structured runtime session event after the existing
+durable compaction record is written. The event carries the compaction count,
+before/after token estimates, summary, and recent files. The TUI consumes it as
+a typed transcript entry and updates its runtime snapshot.
+
+## Why
+
+OpenCode treats compaction as a first-class session message rather than only a
+status counter. RARA already had durable compaction records, so the runtime
+event is a projection of that source of truth instead of a second persistence
+mechanism.
+
+## Trade-offs
+
+The legacy role/message transcript fields remain unchanged for restore and
+export compatibility. The typed payload is currently additive; renderer
+cleanup that removes remaining role matching is a separate step.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo test --bin rara tui::runtime::events --no-fail-fast`
+- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
+
+## Remaining work
+
+- Render compaction entries with a dedicated OpenCode-style timeline cell.
+- Correlate tool use, progress, and result events with one runtime-owned tool
+  identity.
+- Move completed-tool summaries fully onto typed session projection data.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -161,6 +161,15 @@ pub enum AgentEvent {
         output_tokens: u32,
         finish_reason: Option<String>,
     },
+    /// Context history was compacted and the resulting session projection is
+    /// available to presentation clients.
+    Compaction {
+        count: usize,
+        before_tokens: usize,
+        after_tokens: usize,
+        summary: String,
+        recent_files: Vec<String>,
+    },
 }
 
 #[derive(Debug)]

--- a/src/agent/compact/main.rs
+++ b/src/agent/compact/main.rs
@@ -99,6 +99,7 @@ impl Agent {
         });
         self.compact_state.consecutive_auto_compaction_failures = 0;
         self.compact_state.auto_compaction_retry_after_tokens = None;
+        let summary_for_event = summary.clone();
         self.persist_compaction_event(&PersistedCompactionEvent {
             event_index: self.compact_state.compaction_count,
             before_tokens: current_tokens,
@@ -110,6 +111,13 @@ impl Agent {
             recent_files: self.compact_state.last_compaction_recent_files.clone(),
             summary,
         })?;
+        report(AgentEvent::Compaction {
+            count: self.compact_state.compaction_count,
+            before_tokens: current_tokens,
+            after_tokens: compacted_tokens,
+            summary: summary_for_event,
+            recent_files: self.compact_state.last_compaction_recent_files.clone(),
+        });
         Ok(true)
     }
 
@@ -225,6 +233,7 @@ impl Agent {
         });
         self.compact_state.consecutive_auto_compaction_failures = 0;
         self.compact_state.auto_compaction_retry_after_tokens = None;
+        let summary_for_event = summary.clone();
         self.persist_compaction_event(&PersistedCompactionEvent {
             event_index: self.compact_state.compaction_count,
             before_tokens: current_tokens,
@@ -236,6 +245,13 @@ impl Agent {
             recent_files: self.compact_state.last_compaction_recent_files.clone(),
             summary,
         })?;
+        report(AgentEvent::Compaction {
+            count: self.compact_state.compaction_count,
+            before_tokens: current_tokens,
+            after_tokens: compacted_tokens,
+            summary: summary_for_event,
+            recent_files: self.compact_state.last_compaction_recent_files.clone(),
+        });
         Ok(())
     }
 

--- a/src/exec_consumer.rs
+++ b/src/exec_consumer.rs
@@ -299,7 +299,8 @@ impl ExecJsonlProcessor {
             AgentEvent::AgentStop { .. } => Ok(()),
             AgentEvent::PlanUpdated { .. }
             | AgentEvent::ApprovalRequested { .. }
-            | AgentEvent::ApprovalAnswered { .. } => Ok(()),
+            | AgentEvent::ApprovalAnswered { .. }
+            | AgentEvent::Compaction { .. } => Ok(()),
             AgentEvent::AssistantText(text) => {
                 self.final_message
                     .get_or_insert_with(String::new)

--- a/src/hook_runtime.rs
+++ b/src/hook_runtime.rs
@@ -168,7 +168,8 @@ fn lifecycle_for_event(event: &AgentEvent) -> Option<HookLifecycle> {
         | AgentEvent::PlanUpdated { .. }
         | AgentEvent::ApprovalRequested { .. }
         | AgentEvent::ApprovalAnswered { .. }
-        | AgentEvent::AgentError { .. } => None,
+        | AgentEvent::AgentError { .. }
+        | AgentEvent::Compaction { .. } => None,
     }
 }
 

--- a/src/runtime_control.rs
+++ b/src/runtime_control.rs
@@ -105,6 +105,13 @@ pub enum SessionEvent {
         output_tokens: u32,
         finish_reason: Option<String>,
     },
+    Compacted {
+        count: usize,
+        before_tokens: usize,
+        after_tokens: usize,
+        summary: String,
+        recent_files: Vec<String>,
+    },
 }
 
 #[allow(dead_code)] // ACP protocol type — reserved for future lifecycle events
@@ -495,6 +502,19 @@ pub fn agent_event_to_runtime_event(event: AgentEvent) -> RuntimeEvent {
             model,
             output_tokens,
             finish_reason,
+        }),
+        AgentEvent::Compaction {
+            count,
+            before_tokens,
+            after_tokens,
+            summary,
+            recent_files,
+        } => RuntimeEvent::Session(SessionEvent::Compacted {
+            count,
+            before_tokens,
+            after_tokens,
+            summary,
+            recent_files,
         }),
     }
 }

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -248,6 +248,23 @@ fn apply_runtime_control_event(app: &mut TuiApp, event: RuntimeControlEvent) {
                 ),
             );
         }
+        RuntimeEvent::Session(SessionEvent::Compacted {
+            count,
+            before_tokens,
+            after_tokens,
+            summary,
+            recent_files,
+        }) => {
+            app.snapshot.compaction_count = count;
+            app.snapshot.last_compaction_before_tokens = Some(before_tokens);
+            app.snapshot.last_compaction_after_tokens = Some(after_tokens);
+            app.snapshot.last_compaction_recent_files = recent_files.clone();
+            app.push_compaction_entry(count, before_tokens, after_tokens, summary, recent_files);
+            app.set_runtime_phase(
+                RuntimePhase::ProcessingResponse,
+                Some("context history compacted".into()),
+            );
+        }
         RuntimeEvent::Session(SessionEvent::TurnStarted)
         | RuntimeEvent::Session(SessionEvent::ModelRequest { .. }) => {}
         RuntimeEvent::Session(SessionEvent::TurnFinished { .. })

--- a/src/tui/runtime/events/tests.rs
+++ b/src/tui/runtime/events/tests.rs
@@ -76,6 +76,42 @@ fn structured_tool_event_updates_running_action_without_role_parsing() {
 }
 
 #[test]
+fn structured_compaction_event_becomes_a_typed_transcript_entry() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("app");
+    apply_tui_event(
+        &mut app,
+        TuiEvent::Runtime(Box::new(crate::runtime_control::RuntimeControlEvent {
+            event_id: "compact-1".into(),
+            provenance: RuntimeProvenance::local_tui("session-1"),
+            sequence: 1,
+            event: RuntimeEvent::Session(crate::runtime_control::SessionEvent::Compacted {
+                count: 2,
+                before_tokens: 12_000,
+                after_tokens: 4_500,
+                summary: "Retained the active task and recent files.".into(),
+                recent_files: vec!["src/runtime_control.rs".into()],
+            }),
+        })),
+    );
+
+    assert_eq!(app.snapshot.compaction_count, 2);
+    assert_eq!(app.active_turn.entries[0].role, "Compaction");
+    match app.active_turn.entries[0].payload.as_ref() {
+        Some(TranscriptEntryPayload::Compaction(payload)) => {
+            assert_eq!(payload.count, 2);
+            assert_eq!(payload.before_tokens, 12_000);
+            assert_eq!(payload.after_tokens, 4_500);
+            assert_eq!(payload.recent_files, vec!["src/runtime_control.rs"]);
+        }
+        payload => panic!("expected compaction payload, got {payload:?}"),
+    }
+}
+
+#[test]
 fn parses_delegated_request_input_from_subagent_result() {
     let parsed = subagent_request_input(
         "plan_agent refine the workspace logic\nrequest_user_input: Which discovery strategy should we keep?\noption: Minimal | Keep the current root-level files.\noption: Generic | Scan all instruction markdown files.\nnote: We need one product decision before editing.",

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -29,14 +29,14 @@ use self::types::CommittedTranscriptRenderCache;
 pub use self::types::current_unix_timestamp_secs;
 pub use self::types::{
     ActiveLiveEvent, ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
-    AgentMarkdownStreamState, CommandSpec, CompletedInteractionSnapshot, GoalHandle, GoalStatus,
-    HelpTab, InteractionKind, ListPickerKind, LocalCommand, LocalCommandKind, ModelRoutingView,
-    OAuthLoginMode, OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot,
-    PendingInteractionSnapshot, PermissionMode, PickerIntent, ProviderFamily, RalphGoal,
-    RunningTask, RuntimeExtensionSnapshot, RuntimePhase, RuntimeSnapshot, SkillPickerEntry,
-    StatusTab, SystemMessageKind, TaskCompletion, TaskKind, TerminalDiagnosticsView,
-    ToolTranscriptPayload, ToolTranscriptStatus, TranscriptEntry, TranscriptEntryPayload,
-    TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
+    AgentMarkdownStreamState, CommandSpec, CompactionTranscriptPayload,
+    CompletedInteractionSnapshot, GoalHandle, GoalStatus, HelpTab, InteractionKind, ListPickerKind,
+    LocalCommand, LocalCommandKind, ModelRoutingView, OAuthLoginMode, OpenAiModelPickerAction,
+    Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot,
+    PermissionMode, PickerIntent, ProviderFamily, RalphGoal, RunningTask, RuntimeExtensionSnapshot,
+    RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab, SystemMessageKind, TaskCompletion,
+    TaskKind, TerminalDiagnosticsView, ToolTranscriptPayload, ToolTranscriptStatus,
+    TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
 };
 use crate::oauth::OAuthManager;
 pub(crate) use crate::runtime_client::RebuildSuccess;

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -49,6 +49,7 @@ fn is_agent_segment_boundary(entry: &TranscriptEntry) -> bool {
     match &entry.payload {
         Some(crate::tui::state::TranscriptEntryPayload::Terminal(_)) => true,
         Some(crate::tui::state::TranscriptEntryPayload::Tool(payload)) => !payload.name.is_empty(),
+        Some(crate::tui::state::TranscriptEntryPayload::Compaction(payload)) => payload.count > 0,
         _ => false,
     }
 }
@@ -114,6 +115,29 @@ impl TuiApp {
         message: impl Into<String>,
     ) {
         let entry = super::TranscriptEntry::tool(call_id, name, status, message);
+        self.record_entry_realtime(&PersistedTurnEntry {
+            role: entry.role.clone(),
+            message: entry.message.clone(),
+        });
+        self.active_turn.entries.push(entry);
+        self.reset_transcript_scroll_if_following_tail();
+    }
+
+    pub fn push_compaction_entry(
+        &mut self,
+        count: usize,
+        before_tokens: usize,
+        after_tokens: usize,
+        summary: impl Into<String>,
+        recent_files: Vec<String>,
+    ) {
+        let entry = super::TranscriptEntry::compaction(
+            count,
+            before_tokens,
+            after_tokens,
+            summary,
+            recent_files,
+        );
         self.record_entry_realtime(&PersistedTurnEntry {
             role: entry.role.clone(),
             message: entry.message.clone(),

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -499,6 +499,7 @@ pub struct TranscriptEntry {
 pub enum TranscriptEntryPayload {
     Terminal(TerminalEvent),
     Tool(ToolTranscriptPayload),
+    Compaction(CompactionTranscriptPayload),
     /// Reserved for semantic transcript filtering and future per-kind system
     /// rendering; current committed cells only need to know it is system text
     /// (docs/todo.md).
@@ -518,6 +519,14 @@ pub struct ToolTranscriptPayload {
     pub call_id: Option<String>,
     pub name: String,
     pub status: ToolTranscriptStatus,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactionTranscriptPayload {
+    pub count: usize,
+    pub before_tokens: usize,
+    pub after_tokens: usize,
+    pub recent_files: Vec<String>,
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
@@ -577,6 +586,27 @@ impl TranscriptEntry {
             role: "System".to_string(),
             message: message.into(),
             payload: Some(TranscriptEntryPayload::System(kind)),
+        }
+    }
+
+    pub fn compaction(
+        count: usize,
+        before_tokens: usize,
+        after_tokens: usize,
+        summary: impl Into<String>,
+        recent_files: Vec<String>,
+    ) -> Self {
+        Self {
+            role: "Compaction".to_string(),
+            message: summary.into(),
+            payload: Some(TranscriptEntryPayload::Compaction(
+                CompactionTranscriptPayload {
+                    count,
+                    before_tokens,
+                    after_tokens,
+                    recent_files,
+                },
+            )),
         }
     }
 }


### PR DESCRIPTION
## Summary

- emit a structured runtime session event after durable compaction succeeds
- project compaction count, token boundaries, summary, and recent files to TUI
- store compaction as a typed transcript payload while preserving legacy fields
- document the runtime-owned compaction projection boundary

## Motivation

OpenCode treats compaction as a first-class session message. RARA already has
durable `PersistedCompactionEvent` records, so this change projects that source
of truth through the existing agent reporter and runtime event bus instead of
adding another persistence path.

## Compatibility

Existing role/message transcript persistence is unchanged. The typed payload is
additive and allows the renderer to move away from role-string interpretation
incrementally.

## Verification

- `cargo fmt --all`
- `cargo test --bin rara tui::runtime::events --no-fail-fast`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`

## Related

- Follow-up: render a dedicated compaction timeline cell and complete runtime
  tool identity correlation.
