### PR TITLE
feat(tui): render compaction timeline cells

### DIFF
--- a/docs/features/context-memory-optimization.md
+++ b/docs/features/context-memory-optimization.md
@@ -191,6 +191,9 @@ compatibility persistence.
 - [ ] Add completed tool summary to bottom pane footer.
 - [ ] Add `[cached]` tag to budget rows for memory section.
 
+Compaction entries use a dedicated timeline cell with token savings and recent
+file count. They are not rendered as generic assistant or tool messages.
+
 ### Phase 2: Memory retrieval throttle
 
 - [ ] Add `MemoryRetrievalCache` struct to `RalphAgent`.

--- a/docs/journal/2026-08-04-compaction-timeline-cell.md
+++ b/docs/journal/2026-08-04-compaction-timeline-cell.md
@@ -1,0 +1,26 @@
+# Compaction Timeline Cell
+
+## What changed
+
+The TUI now renders typed compaction transcript entries with a dedicated
+timeline cell. The cell shows the compaction number, before/after token counts,
+estimated tokens saved, summary, and recent file count.
+
+## Why
+
+OpenCode presents compaction as a first-class session item. Rendering it as a
+generic transcript message made the context boundary hard to scan and coupled
+the presentation to role strings. The dedicated cell consumes the structured
+payload produced by the runtime projection.
+
+## Trade-offs
+
+The cell is additive and supports both active and committed turns. Legacy
+role/message persistence remains unchanged. Tool identity correlation and the
+remaining role-based renderer paths are intentionally separate follow-ups.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo test --bin rara committed_turn_renders_compaction_as_a_dedicated_cell --no-fail-fast`
+- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`

--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use ratatui::text::Line;
 
+use super::compaction::CompactionCell;
 use super::interaction_cells::{
     CommittedInteractionCell, PendingInteractionCell, QueuedFollowUpCell,
 };
@@ -341,7 +342,18 @@ impl ActiveCell for ActiveTurnCell<'_> {
         };
         let has_running_summary = running_summary.is_some();
         let running_active = turn_live && has_running_summary;
-        if let Some(cell) = terminal_cell_from_entries(current_turn.iter().copied()) {
+        if let Some(entry) = current_turn.iter().find(|entry| {
+            matches!(
+                entry.payload,
+                Some(crate::tui::state::TranscriptEntryPayload::Compaction(_))
+            )
+        }) {
+            if let Some(crate::tui::state::TranscriptEntryPayload::Compaction(payload)) =
+                entry.payload.as_ref()
+            {
+                cells.push(Box::new(CompactionCell::new(payload, &entry.message)));
+            }
+        } else if let Some(cell) = terminal_cell_from_entries(current_turn.iter().copied()) {
             cells.push(Box::new(cell));
         } else if let Some(summary) = running_summary {
             cells.push(Box::new(RunningCell::new(summary, running_active)));

--- a/src/tui/render/cells/cells_tests/committed.rs
+++ b/src/tui/render/cells/cells_tests/committed.rs
@@ -1,4 +1,33 @@
 use super::*;
+use crate::tui::state::{CompactionTranscriptPayload, TranscriptEntryPayload};
+
+#[test]
+fn committed_turn_renders_compaction_as_a_dedicated_cell() {
+    let entries = vec![TranscriptEntry {
+        role: "Compaction".into(),
+        message: "Retained the active task.".into(),
+        payload: Some(TranscriptEntryPayload::Compaction(
+            CompactionTranscriptPayload {
+                count: 2,
+                before_tokens: 12_000,
+                after_tokens: 4_500,
+                recent_files: vec!["src/runtime_control.rs".into()],
+            },
+        )),
+    }];
+
+    let rendered = CommittedTurnCell::new(entries.as_slice(), Some(Path::new(".")), false, None)
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("Compaction #2"));
+    assert!(rendered.contains("12.0k -> 4.5k tokens"));
+    assert!(rendered.contains("saved 7.5k"));
+    assert!(rendered.contains("recent files: 1"));
+}
 
 #[test]
 fn explicit_progress_entry_groups_preserves_thinking_indentation() {

--- a/src/tui/render/cells/committed_turn.rs
+++ b/src/tui/render/cells/committed_turn.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use ratatui::text::Line;
 
+use super::compaction::CompactionCell;
 use super::interaction_cells::CommittedInteractionCell;
 use super::message_cell::MessageCell;
 use super::progress::{ProgressRole, progress_entry_message_lines, push_progress_group};
@@ -119,6 +120,11 @@ fn push_ordered_committed_activity<'a>(
 
         if let Some(cell) = terminal_cell_from_entries(std::iter::once(entry)) {
             cells.push(Box::new(cell));
+            continue;
+        }
+
+        if let Some(TranscriptEntryPayload::Compaction(payload)) = entry.payload.as_ref() {
+            cells.push(Box::new(CompactionCell::new(payload, &entry.message)));
             continue;
         }
 

--- a/src/tui/render/cells/compaction.rs
+++ b/src/tui/render/cells/compaction.rs
@@ -1,0 +1,60 @@
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+
+use super::HistoryCell;
+use crate::tui::state::CompactionTranscriptPayload;
+use crate::tui::status_display::format_token_count;
+use crate::tui::theme::{STATUS_INFO, TEXT_MUTED, TEXT_SECONDARY};
+
+pub(crate) struct CompactionCell<'a> {
+    payload: &'a CompactionTranscriptPayload,
+    summary: &'a str,
+}
+
+impl<'a> CompactionCell<'a> {
+    pub(crate) fn new(payload: &'a CompactionTranscriptPayload, summary: &'a str) -> Self {
+        Self { payload, summary }
+    }
+}
+
+impl HistoryCell for CompactionCell<'_> {
+    fn display_lines(&self, _width: u16) -> Vec<Line<'static>> {
+        let saved = self
+            .payload
+            .before_tokens
+            .saturating_sub(self.payload.after_tokens);
+        let mut lines = vec![Line::from(vec![
+            Span::styled(
+                format!("Compaction #{}", self.payload.count),
+                Style::default()
+                    .fg(STATUS_INFO)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!(
+                    "  {} -> {} tokens  (saved {})",
+                    format_token_count(self.payload.before_tokens),
+                    format_token_count(self.payload.after_tokens),
+                    format_token_count(saved),
+                ),
+                Style::default().fg(TEXT_SECONDARY),
+            ),
+        ])];
+
+        if !self.summary.trim().is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("  {}", self.summary.trim()),
+                Style::default().fg(TEXT_MUTED),
+            )));
+        }
+        if !self.payload.recent_files.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("  recent files: {}", self.payload.recent_files.len()),
+                Style::default().fg(TEXT_MUTED),
+            )));
+        }
+        lines
+    }
+}

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -4,6 +4,7 @@ use crate::tui::state::{TranscriptEntry, TranscriptEntryPayload};
 
 mod active_turn;
 mod committed_turn;
+mod compaction;
 mod interaction_cells;
 mod lsp_diagnostics;
 mod message_cell;
@@ -16,6 +17,7 @@ mod user_startup;
 
 pub(crate) use self::active_turn::ActiveTurnCell;
 pub(crate) use self::committed_turn::CommittedTurnCell;
+pub(crate) use self::compaction::CompactionCell;
 pub(crate) use self::interaction_cells::{
     CommittedInteractionCell, PendingInteractionCell, QueuedFollowUpCell, TerminalCell,
 };


### PR DESCRIPTION
## Summary

- add a dedicated TUI timeline cell for typed compaction entries
- show compaction number, token reduction, summary, and recent file count
- render the same structured entry in active and committed turns
- add focused render coverage and documentation

## Motivation

OpenCode treats compaction as a first-class session item. RARA now has a
runtime-owned typed compaction projection; this change gives that projection a
dedicated renderer instead of treating it as generic transcript text.

## Compatibility

Legacy role/message transcript persistence remains unchanged. The renderer only
uses the new typed payload for compaction entries and leaves existing tool and
assistant rendering paths intact.

## Verification

- `cargo fmt --all`
- `cargo test --bin rara committed_turn_renders_compaction_as_a_dedicated_cell --no-fail-fast`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`

## Related

- Builds on the runtime compaction projection merged in PR #793.
