### PR TITLE
feat(runtime): correlate tool event identities

### DIFF
--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -15,6 +15,20 @@ The transcript should move toward Codex/Claude-style tool visibility:
 
 ## Current Contract
 
+### Runtime tool identity
+
+- Structured runtime tool events carry an optional `call_id`.
+- The runtime event bus assigns an ID to tool-use events that do not already
+  have one, and correlates progress and result events by session and tool name.
+- Correlation state is runtime-owned and isolated by session; TUI and ACP
+  consumers must use the projected ID instead of reconstructing it from
+  transcript text.
+- Producers that already provide a provider-native call ID retain that ID.
+
+This is an incremental compatibility boundary. Legacy transcript persistence
+continues to store role/message fields while typed projections become the
+source of live tool identity.
+
 ### Edit tools
 
 - `apply_patch` tool-use rows must include the touched file paths when they can be derived from the patch.

--- a/docs/journal/2026-08-04-runtime-tool-identity.md
+++ b/docs/journal/2026-08-04-runtime-tool-identity.md
@@ -1,0 +1,28 @@
+# Runtime Tool Identity Projection
+
+## What changed
+
+The runtime event bus now assigns and correlates tool call IDs for structured
+events that do not already provide one. The tracker is keyed by session and
+tool name, assigns an ID on `Use`, reuses it for `Progress`, and consumes it on
+`Result`.
+
+## Why
+
+OpenCode models tools as stable session parts. TUI and ACP consumers should not
+guess which result belongs to which invocation, especially when multiple
+sessions or repeated calls use the same tool name.
+
+## Trade-offs
+
+The existing agent event model does not always expose provider-native IDs, so
+the runtime uses a deterministic event-derived fallback. Explicit IDs remain
+unchanged. The fallback correlation assumes results for a given tool are
+observed in invocation order; provider-native IDs should be preferred when
+available.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo test --bin rara runtime_event_bus --no-fail-fast`
+- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`

--- a/src/runtime_event_bus.rs
+++ b/src/runtime_event_bus.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
 use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
@@ -23,6 +25,55 @@ pub struct RuntimeEventBus {
     raw_sender: broadcast::Sender<AgentEvent>,
     control_sender: broadcast::Sender<RuntimeControlEvent>,
     next_sequence: Arc<AtomicU64>,
+    tool_identities: Arc<Mutex<ToolIdentityTracker>>,
+}
+
+#[derive(Debug, Default)]
+struct ToolIdentityTracker {
+    pending: HashMap<(Option<String>, String), VecDeque<String>>,
+}
+
+impl ToolIdentityTracker {
+    fn project(&mut self, event: &mut RuntimeControlEvent) {
+        let session_id = event.provenance.session_id.clone();
+        let event_id = event.event_id.clone();
+        let RuntimeEvent::Tool(tool_event) = &mut event.event else {
+            return;
+        };
+
+        match tool_event {
+            crate::runtime_control::ToolEvent::Use { call_id, name, .. } => {
+                if call_id.is_none() {
+                    let id = format!("tool-{event_id}");
+                    *call_id = Some(id.clone());
+                    self.pending
+                        .entry((session_id, name.clone()))
+                        .or_default()
+                        .push_back(id);
+                }
+            }
+            crate::runtime_control::ToolEvent::Result { call_id, name, .. } => {
+                if call_id.is_none() {
+                    let key = (session_id, name.clone());
+                    if let Some(ids) = self.pending.get_mut(&key) {
+                        *call_id = ids.pop_front();
+                        if ids.is_empty() {
+                            self.pending.remove(&key);
+                        }
+                    }
+                }
+            }
+            crate::runtime_control::ToolEvent::Progress { call_id, name, .. } => {
+                if call_id.is_none() {
+                    *call_id = self
+                        .pending
+                        .get(&(session_id, name.clone()))
+                        .and_then(VecDeque::front)
+                        .cloned();
+                }
+            }
+        }
+    }
 }
 
 impl RuntimeEventBus {
@@ -35,6 +86,7 @@ impl RuntimeEventBus {
             raw_sender,
             control_sender,
             next_sequence: Arc::new(AtomicU64::new(0)),
+            tool_identities: Arc::new(Mutex::new(ToolIdentityTracker::default())),
         }
     }
 
@@ -49,16 +101,29 @@ impl RuntimeEventBus {
             (false, true) => {
                 let sequence = self.next_sequence.fetch_add(1, Ordering::SeqCst) + 1;
                 let event_id = format!("evt-{sequence:016x}");
-                let control_event = wrap_agent_event(event_id, sequence, provenance, event);
+                let mut control_event = wrap_agent_event(event_id, sequence, provenance, event);
+                self.project_tool_identity(&mut control_event);
                 self.control_sender.send(control_event).unwrap_or(0)
             }
             (true, true) => {
                 let sequence = self.next_sequence.fetch_add(1, Ordering::SeqCst) + 1;
                 let event_id = format!("evt-{sequence:016x}");
-                let control_event = wrap_agent_event(event_id, sequence, provenance, event.clone());
+                let mut control_event =
+                    wrap_agent_event(event_id, sequence, provenance, event.clone());
+                self.project_tool_identity(&mut control_event);
                 let raw_count = self.raw_sender.send(event).unwrap_or(0);
                 let control_count = self.control_sender.send(control_event).unwrap_or(0);
                 raw_count + control_count
+            }
+        }
+    }
+
+    fn project_tool_identity(&self, event: &mut RuntimeControlEvent) {
+        match self.tool_identities.lock() {
+            Ok(mut tracker) => tracker.project(event),
+            Err(poisoned) => {
+                log::warn!("runtime tool identity tracker lock was poisoned; recovering");
+                poisoned.into_inner().project(event);
             }
         }
     }
@@ -239,5 +304,109 @@ mod tests {
         assert_eq!(received.event_id, "acp-1");
         assert_eq!(received.sequence, 7);
         assert_eq!(received.provenance.session_id.as_deref(), Some("session-1"));
+    }
+
+    #[test]
+    fn runtime_projects_one_tool_identity_across_use_progress_and_result() {
+        let bus = RuntimeEventBus::new(8);
+        let mut control = bus.subscribe_control();
+        let provenance = RuntimeProvenance::local_tui("session-1");
+
+        bus.send_with_provenance(
+            AgentEvent::ToolUse {
+                name: "bash".into(),
+                input: json!({"command": "pwd"}),
+            },
+            provenance.clone(),
+        );
+        bus.send_with_provenance(
+            AgentEvent::ToolProgress {
+                name: "bash".into(),
+                stream: rara_tools::tool::ToolOutputStream::Stdout,
+                chunk: "/workspace\n".into(),
+            },
+            provenance.clone(),
+        );
+        bus.send_with_provenance(
+            AgentEvent::ToolResult {
+                name: "bash".into(),
+                content: "done".into(),
+                is_error: false,
+            },
+            provenance,
+        );
+
+        let use_id = match control.try_recv().expect("tool use").event {
+            RuntimeEvent::Tool(crate::runtime_control::ToolEvent::Use {
+                call_id: Some(call_id),
+                ..
+            }) => call_id,
+            event => panic!("expected identified tool use, got {event:?}"),
+        };
+        let progress_id = match control.try_recv().expect("tool progress").event {
+            RuntimeEvent::Tool(crate::runtime_control::ToolEvent::Progress {
+                call_id: Some(call_id),
+                ..
+            }) => call_id,
+            event => panic!("expected identified tool progress, got {event:?}"),
+        };
+        let result_id = match control.try_recv().expect("tool result").event {
+            RuntimeEvent::Tool(crate::runtime_control::ToolEvent::Result {
+                call_id: Some(call_id),
+                ..
+            }) => call_id,
+            event => panic!("expected identified tool result, got {event:?}"),
+        };
+
+        assert_eq!(use_id, progress_id);
+        assert_eq!(use_id, result_id);
+    }
+
+    #[test]
+    fn runtime_keeps_tool_identities_isolated_between_sessions() {
+        let bus = RuntimeEventBus::new(8);
+        let mut control = bus.subscribe_control();
+
+        for session in ["session-a", "session-b"] {
+            bus.send_with_provenance(
+                AgentEvent::ToolUse {
+                    name: "bash".into(),
+                    input: json!({"command": session}),
+                },
+                RuntimeProvenance::local_tui(session),
+            );
+        }
+        let first_id = match control.try_recv().expect("first tool use").event {
+            RuntimeEvent::Tool(crate::runtime_control::ToolEvent::Use {
+                call_id: Some(call_id),
+                ..
+            }) => call_id,
+            event => panic!("expected identified tool use, got {event:?}"),
+        };
+        let second_id = match control.try_recv().expect("second tool use").event {
+            RuntimeEvent::Tool(crate::runtime_control::ToolEvent::Use {
+                call_id: Some(call_id),
+                ..
+            }) => call_id,
+            event => panic!("expected identified tool use, got {event:?}"),
+        };
+        assert_ne!(first_id, second_id);
+
+        bus.send_with_provenance(
+            AgentEvent::ToolResult {
+                name: "bash".into(),
+                content: "done".into(),
+                is_error: false,
+            },
+            RuntimeProvenance::local_tui("session-a"),
+        );
+        let result_id = match control.try_recv().expect("session result").event {
+            RuntimeEvent::Tool(crate::runtime_control::ToolEvent::Result {
+                call_id: Some(call_id),
+                ..
+            }) => call_id,
+            event => panic!("expected identified tool result, got {event:?}"),
+        };
+        assert_eq!(result_id, first_id);
     }
 }


### PR DESCRIPTION
## Summary

- add runtime-owned tool identity tracking to `RuntimeEventBus`
- correlate `Use`, `Progress`, and `Result` events by session and tool name
- preserve provider-supplied `call_id` values
- add isolation tests for repeated tools across sessions
- document the live tool identity contract

## Motivation

OpenCode treats tool calls as stable session parts. TUI, ACP, and future
app-server consumers need one identity for a tool invocation instead of
reconstructing relationships from role strings or tool names.

The runtime bus is the shared projection boundary, so correlation belongs there
and is isolated by session. Existing transcript persistence is unchanged.

## Compatibility

Events with an explicit `call_id` are left unchanged. For legacy agent events,
the runtime assigns an event-derived fallback ID and correlates results in
invocation order.

## Verification

- `cargo fmt --all`
- `cargo test --bin rara runtime_event_bus --no-fail-fast`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`

## Related

- Builds on the typed tool payload work from PR #792.
