### PR TITLE
feat(tui): prefer typed tool summaries

### DIFF
--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -29,6 +29,16 @@ This is an incremental compatibility boundary. Legacy transcript persistence
 continues to store role/message fields while typed projections become the
 source of live tool identity.
 
+### Completed-tool summaries
+
+- The active-turn TUI summary matches running and completed tool entries by
+  typed payload identity, preferring the provider `call_id` and otherwise the
+  runtime-assigned tool identity.
+- Role/message parsing remains only as a compatibility fallback for legacy
+  transcript entries without a typed tool payload.
+- A completed result is rendered only when it matches a pending typed tool
+  entry, so repeated tool names do not cause unrelated results to be paired.
+
 ### Edit tools
 
 - `apply_patch` tool-use rows must include the touched file paths when they can be derived from the patch.

--- a/docs/journal/2026-08-04-typed-tool-summary.md
+++ b/docs/journal/2026-08-04-typed-tool-summary.md
@@ -1,0 +1,29 @@
+# Typed Tool Summary Projection
+
+## What changed
+
+The active-turn TUI tool summary now consumes `ToolTranscriptPayload` entries
+before inspecting legacy role strings. Running and completed entries are
+paired by provider or runtime-assigned `call_id`, with the tool name as the
+fallback identity. Legacy role/message parsing remains available for older
+persisted transcript entries.
+
+## Why
+
+OpenCode keeps tool lifecycle data in structured session parts with stable
+identity. Pairing tool output through role strings makes repeated or concurrent
+calls harder to represent correctly and keeps runtime semantics in the display
+layer. This change makes the TUI follow the typed runtime projection while
+preserving compatibility with existing transcripts.
+
+## Trade-offs
+
+The summary still contains a legacy parser until all persisted transcript
+writers emit typed payloads. Typed entries are authoritative and do not depend
+on their role strings, while legacy entries retain the previous behavior.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo test --bin rara tool_summary_uses_typed_tool_identity_before_role_strings --no-fail-fast`
+- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -312,25 +312,58 @@ pub(crate) fn current_turn_tool_summary(
     const RESULT_LINE_LIMIT: usize = 10;
 
     let mut lines = Vec::new();
-    let mut pending_tool = false;
+    let mut pending_tool = std::collections::HashSet::<String>::new();
+    let mut pending_legacy_tool = false;
     for entry in current_turn {
+        if let Some(crate::tui::state::TranscriptEntryPayload::Tool(payload)) =
+            entry.payload.as_ref()
+        {
+            match payload.status {
+                crate::tui::state::ToolTranscriptStatus::Running => {
+                    if let Some(action) = tool_action_label(&entry.message) {
+                        lines.push(format!("└ {action}"));
+                    } else {
+                        lines.push(format!("└ {}", payload.name));
+                    }
+                    pending_tool.insert(
+                        payload
+                            .call_id
+                            .clone()
+                            .unwrap_or_else(|| payload.name.clone()),
+                    );
+                }
+                crate::tui::state::ToolTranscriptStatus::Completed
+                | crate::tui::state::ToolTranscriptStatus::Error => {
+                    let identity = payload.call_id.as_deref().unwrap_or(payload.name.as_str());
+                    if pending_tool.remove(identity) {
+                        lines.extend(
+                            tool_result_summary_lines(&entry.message, RESULT_LINE_LIMIT)
+                                .into_iter()
+                                .map(|line| format!("  {line}")),
+                        );
+                    }
+                }
+            }
+            continue;
+        }
+
         use crate::tui::message_role::MessageRole;
         match MessageRole::try_from_str(&entry.role) {
             Some(MessageRole::Tool) => {
                 if let Some(action) = tool_action_label(&entry.message) {
                     lines.push(format!("└ {action}"));
-                    pending_tool = true;
+                    pending_legacy_tool = true;
                 } else {
-                    pending_tool = false;
+                    pending_legacy_tool = false;
                 }
             }
-            Some(MessageRole::ToolResult) | Some(MessageRole::ToolError) if pending_tool => {
+            Some(MessageRole::ToolResult) | Some(MessageRole::ToolError) if pending_legacy_tool => {
                 lines.extend(
                     tool_result_summary_lines(&entry.message, RESULT_LINE_LIMIT)
                         .into_iter()
                         .map(|line| format!("  {line}")),
                 );
-                pending_tool = false;
+                pending_legacy_tool = false;
             }
             _ => {}
         }

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -23,7 +23,8 @@ use crate::tui::state::SkillPickerEntry;
 use crate::tui::state::{
     InteractionKind, ListPickerKind, Overlay, PendingApprovalSnapshot, PendingInteractionSnapshot,
     PlanningApprovalStatus, PlanningLifecycleSnapshot, ProviderFamily, RuntimeSnapshot, StatusTab,
-    TranscriptEntry, TranscriptTurn, TuiApp,
+    ToolTranscriptPayload, ToolTranscriptStatus, TranscriptEntry, TranscriptEntryPayload,
+    TranscriptTurn, TuiApp,
 };
 
 fn provider_family_idx(family: ProviderFamily) -> usize {
@@ -264,6 +265,36 @@ fn tool_summary_includes_bash_result_status_and_output_tail() {
     assert!(rendered.contains("stdout:"));
     assert!(rendered.contains("Compiling rara v0.1.0"));
     assert!(rendered.contains("error[E0425]"));
+}
+
+#[test]
+fn tool_summary_uses_typed_tool_identity_before_role_strings() {
+    let entries = [
+        TranscriptEntry {
+            role: "legacy-start".into(),
+            message: "bash cargo check".into(),
+            payload: Some(TranscriptEntryPayload::Tool(ToolTranscriptPayload {
+                call_id: Some("tool-call-1".into()),
+                name: "bash".into(),
+                status: ToolTranscriptStatus::Running,
+            })),
+        },
+        TranscriptEntry {
+            role: "legacy-end".into(),
+            message: "bash finished with exit code 0".into(),
+            payload: Some(TranscriptEntryPayload::Tool(ToolTranscriptPayload {
+                call_id: Some("tool-call-1".into()),
+                name: "bash".into(),
+                status: ToolTranscriptStatus::Completed,
+            })),
+        },
+    ];
+
+    let refs = entries.iter().collect::<Vec<_>>();
+    let rendered = current_turn_tool_summary(&refs, false, None).expect("tool summary");
+
+    assert!(rendered.contains("Run cargo check"));
+    assert!(rendered.contains("bash finished with exit code 0"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Prefer typed `ToolTranscriptPayload` entries and `call_id` identity when rendering completed-tool summaries.
- Keep role/message parsing as a compatibility fallback for legacy transcript entries.
- Add a regression test proving typed tool identity works independently of legacy role strings.
- Document the completed-tool summary projection contract and implementation checkpoint.

## Motivation

Runtime-owned typed tool projections provide stable lifecycle identity, matching the session-part model used by OpenCode. The TUI should consume that identity instead of pairing tool results through role strings whenever the typed payload is available.

## Compatibility

Existing persisted transcripts without typed tool payloads continue to use the legacy role/message fallback.

## Verification

- `cargo fmt --all`
- `cargo test --bin rara tool_summary_uses_typed_tool_identity_before_role_strings --no-fail-fast`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `git diff --check`
