### PR TITLE
feat(provider): enrich model catalog metadata

### DIFF
--- a/crates/provider-catalog/src/deepseek.rs
+++ b/crates/provider-catalog/src/deepseek.rs
@@ -3,8 +3,8 @@ use rara_config::DEFAULT_DEEPSEEK_BASE_URL;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
-use crate::ModelCatalogRequest;
 use crate::redaction::{redact_known_secret, sanitize_url_for_display};
+use crate::{ModelCatalogEntry, ModelCatalogRequest};
 
 const MODELS_TIMEOUT_SECS: u64 = 15;
 
@@ -33,12 +33,24 @@ struct ModelsResponse {
 #[derive(Deserialize)]
 struct ModelEntry {
     id: String,
+    #[serde(alias = "context_window", alias = "max_context_length")]
+    context_length: Option<u32>,
 }
 
 pub fn fallback_models() -> Vec<String> {
     FALLBACK_MODELS
         .iter()
         .map(|model| (*model).to_string())
+        .collect()
+}
+
+pub fn fallback_catalog() -> Vec<ModelCatalogEntry> {
+    MODEL_WINDOWS
+        .iter()
+        .map(|(id, context_window)| ModelCatalogEntry {
+            id: (*id).to_string(),
+            context_window: Some(*context_window),
+        })
         .collect()
 }
 
@@ -52,18 +64,29 @@ pub fn models_url(base_url: Option<&str>) -> String {
     format!("{root}/models")
 }
 
-pub fn parse_models(body: &str) -> Result<Vec<String>> {
+pub fn parse_models(body: &str) -> Result<Vec<ModelCatalogEntry>> {
     let response: ModelsResponse = serde_json::from_str(body)?;
-    let models = response
+    let mut models = response
         .data
         .into_iter()
-        .map(|model| model.id.trim().to_string())
-        .filter(|id| !id.is_empty())
+        .filter_map(|model| {
+            let id = model.id.trim().to_string();
+            (!id.is_empty()).then_some(ModelCatalogEntry {
+                context_window: model.context_length.or_else(|| {
+                    MODEL_WINDOWS
+                        .iter()
+                        .find(|(name, _)| *name == id)
+                        .map(|(_, window)| *window)
+                }),
+                id,
+            })
+        })
         .collect::<Vec<_>>();
+    models.dedup_by(|left, right| left.id == right.id);
     Ok(models)
 }
 
-pub async fn load_models(request: ModelCatalogRequest<'_>) -> Result<Vec<String>> {
+pub async fn load_models(request: ModelCatalogRequest<'_>) -> Result<Vec<ModelCatalogEntry>> {
     let api_key = request
         .api_key
         .map(SecretString::expose_secret)
@@ -115,7 +138,7 @@ mod tests {
             r#"{
                 "object": "list",
                 "data": [
-                    {"id": "deepseek-reasoner", "object": "model"},
+                    {"id": "deepseek-reasoner", "object": "model", "context_length": 65536},
                     {"id": "deepseek-chat", "object": "model"},
                     {"id": "deepseek-chat", "object": "model"},
                     {"id": " ", "object": "model"}
@@ -126,7 +149,16 @@ mod tests {
 
         assert_eq!(
             models,
-            vec!["deepseek-reasoner", "deepseek-chat", "deepseek-chat"]
+            vec![
+                super::ModelCatalogEntry {
+                    id: "deepseek-reasoner".to_string(),
+                    context_window: Some(65_536),
+                },
+                super::ModelCatalogEntry {
+                    id: "deepseek-chat".to_string(),
+                    context_window: Some(65_536),
+                },
+            ]
         );
     }
 }

--- a/crates/provider-catalog/src/deepseek.rs
+++ b/crates/provider-catalog/src/deepseek.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::{Result, anyhow};
 use rara_config::DEFAULT_DEEPSEEK_BASE_URL;
 use secrecy::{ExposeSecret, SecretString};
@@ -66,12 +68,13 @@ pub fn models_url(base_url: Option<&str>) -> String {
 
 pub fn parse_models(body: &str) -> Result<Vec<ModelCatalogEntry>> {
     let response: ModelsResponse = serde_json::from_str(body)?;
-    let mut models = response
+    let mut seen = HashSet::new();
+    let models = response
         .data
         .into_iter()
         .filter_map(|model| {
             let id = model.id.trim().to_string();
-            (!id.is_empty()).then_some(ModelCatalogEntry {
+            (!id.is_empty() && seen.insert(id.clone())).then_some(ModelCatalogEntry {
                 context_window: model.context_length.or_else(|| {
                     MODEL_WINDOWS
                         .iter()
@@ -82,7 +85,6 @@ pub fn parse_models(body: &str) -> Result<Vec<ModelCatalogEntry>> {
             })
         })
         .collect::<Vec<_>>();
-    models.dedup_by(|left, right| left.id == right.id);
     Ok(models)
 }
 
@@ -140,7 +142,7 @@ mod tests {
                 "data": [
                     {"id": "deepseek-reasoner", "object": "model", "context_length": 65536},
                     {"id": "deepseek-chat", "object": "model"},
-                    {"id": "deepseek-chat", "object": "model"},
+                    {"id": "deepseek-reasoner", "object": "model"},
                     {"id": " ", "object": "model"}
                 ]
             }"#,

--- a/crates/provider-catalog/src/kimi.rs
+++ b/crates/provider-catalog/src/kimi.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use anyhow::{Result, anyhow};
 use rara_config::DEFAULT_KIMI_BASE_URL;
 use secrecy::{ExposeSecret, SecretString};
@@ -60,12 +62,13 @@ pub fn models_url(base_url: Option<&str>) -> String {
 
 pub fn parse_models(body: &str) -> Result<Vec<ModelCatalogEntry>> {
     let response: ModelsResponse = serde_json::from_str(body)?;
-    let mut models = response
+    let mut seen = HashSet::new();
+    let models = response
         .data
         .into_iter()
         .filter_map(|model| {
             let id = model.id.trim().to_string();
-            (!id.is_empty()).then_some(ModelCatalogEntry {
+            (!id.is_empty() && seen.insert(id.clone())).then_some(ModelCatalogEntry {
                 context_window: model.context_length.or_else(|| {
                     MODEL_WINDOWS
                         .iter()
@@ -76,7 +79,6 @@ pub fn parse_models(body: &str) -> Result<Vec<ModelCatalogEntry>> {
             })
         })
         .collect::<Vec<_>>();
-    models.dedup_by(|left, right| left.id == right.id);
     Ok(models)
 }
 
@@ -134,7 +136,7 @@ mod tests {
                 "data": [
                     {"id": "kimi-k2.6", "object": "model", "context_length": 262144},
                     {"id": "kimi-k2.5", "object": "model"},
-                    {"id": "kimi-k2.5", "object": "model"},
+                    {"id": "kimi-k2.6", "object": "model"},
                     {"id": " ", "object": "model"}
                 ]
             }"#,

--- a/crates/provider-catalog/src/kimi.rs
+++ b/crates/provider-catalog/src/kimi.rs
@@ -3,8 +3,8 @@ use rara_config::DEFAULT_KIMI_BASE_URL;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 
-use crate::ModelCatalogRequest;
 use crate::redaction::{redact_known_secret, sanitize_url_for_display};
+use crate::{ModelCatalogEntry, ModelCatalogRequest};
 
 const MODELS_TIMEOUT_SECS: u64 = 15;
 
@@ -27,6 +27,16 @@ pub fn fallback_models() -> Vec<String> {
         .collect()
 }
 
+pub fn fallback_catalog() -> Vec<ModelCatalogEntry> {
+    MODEL_WINDOWS
+        .iter()
+        .map(|(id, context_window)| ModelCatalogEntry {
+            id: (*id).to_string(),
+            context_window: Some(*context_window),
+        })
+        .collect()
+}
+
 #[derive(Deserialize)]
 struct ModelsResponse {
     data: Vec<ModelEntry>,
@@ -35,6 +45,8 @@ struct ModelsResponse {
 #[derive(Deserialize)]
 struct ModelEntry {
     id: String,
+    #[serde(alias = "context_window", alias = "max_context_length")]
+    context_length: Option<u32>,
 }
 
 pub fn models_url(base_url: Option<&str>) -> String {
@@ -46,18 +58,29 @@ pub fn models_url(base_url: Option<&str>) -> String {
     format!("{base_url}/models")
 }
 
-pub fn parse_models(body: &str) -> Result<Vec<String>> {
+pub fn parse_models(body: &str) -> Result<Vec<ModelCatalogEntry>> {
     let response: ModelsResponse = serde_json::from_str(body)?;
-    let models = response
+    let mut models = response
         .data
         .into_iter()
-        .map(|model| model.id.trim().to_string())
-        .filter(|id| !id.is_empty())
+        .filter_map(|model| {
+            let id = model.id.trim().to_string();
+            (!id.is_empty()).then_some(ModelCatalogEntry {
+                context_window: model.context_length.or_else(|| {
+                    MODEL_WINDOWS
+                        .iter()
+                        .find(|(name, _)| *name == id)
+                        .map(|(_, window)| *window)
+                }),
+                id,
+            })
+        })
         .collect::<Vec<_>>();
+    models.dedup_by(|left, right| left.id == right.id);
     Ok(models)
 }
 
-pub async fn load_models(request: ModelCatalogRequest<'_>) -> Result<Vec<String>> {
+pub async fn load_models(request: ModelCatalogRequest<'_>) -> Result<Vec<ModelCatalogEntry>> {
     let api_key = request
         .api_key
         .map(SecretString::expose_secret)
@@ -109,7 +132,7 @@ mod tests {
             r#"{
                 "object": "list",
                 "data": [
-                    {"id": "kimi-k2.6", "object": "model"},
+                    {"id": "kimi-k2.6", "object": "model", "context_length": 262144},
                     {"id": "kimi-k2.5", "object": "model"},
                     {"id": "kimi-k2.5", "object": "model"},
                     {"id": " ", "object": "model"}
@@ -118,7 +141,19 @@ mod tests {
         )
         .expect("parse models");
 
-        assert_eq!(models, vec!["kimi-k2.6", "kimi-k2.5", "kimi-k2.5"]);
+        assert_eq!(
+            models,
+            vec![
+                super::ModelCatalogEntry {
+                    id: "kimi-k2.6".to_string(),
+                    context_window: Some(262_144),
+                },
+                super::ModelCatalogEntry {
+                    id: "kimi-k2.5".to_string(),
+                    context_window: Some(262_144),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/provider-catalog/src/lib.rs
+++ b/crates/provider-catalog/src/lib.rs
@@ -20,13 +20,26 @@ pub struct ModelCatalogRequest<'a> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModelCatalog {
     pub provider: ModelCatalogProvider,
-    pub models: Vec<String>,
+    pub models: Vec<ModelCatalogEntry>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelCatalogEntry {
+    pub id: String,
+    pub context_window: Option<u32>,
 }
 
 pub fn fallback_models(provider: ModelCatalogProvider) -> Vec<String> {
     match provider {
         ModelCatalogProvider::DeepSeek => deepseek::fallback_models(),
         ModelCatalogProvider::Kimi => kimi::fallback_models(),
+    }
+}
+
+pub fn fallback_catalog(provider: ModelCatalogProvider) -> Vec<ModelCatalogEntry> {
+    match provider {
+        ModelCatalogProvider::DeepSeek => deepseek::fallback_catalog(),
+        ModelCatalogProvider::Kimi => kimi::fallback_catalog(),
     }
 }
 

--- a/docs/features/provider-connection-redesign.md
+++ b/docs/features/provider-connection-redesign.md
@@ -96,6 +96,10 @@ runtime availability projection. The runtime merges the response into typed
 `ModelCatalogEntry` values, preserving catalog context windows when the API
 does not return one and preferring an API-provided context length when it does.
 The TUI consumes those entries and does not parse provider response JSON.
+Catalog refresh is represented as one typed runtime command,
+`RefreshModelCatalog(provider)`, and the resulting entries are carried in
+`RuntimeSnapshot.model_catalogs` so model pickers can hydrate from the same
+projection used by future non-TUI clients.
 
 ## Future
 - Custom provider support (arbitrary API endpoint + API key)

--- a/docs/features/provider-connection-redesign.md
+++ b/docs/features/provider-connection-redesign.md
@@ -100,6 +100,8 @@ Catalog refresh is represented as one typed runtime command,
 `RefreshModelCatalog(provider)`, and the resulting entries are carried in
 `RuntimeSnapshot.model_catalogs` so model pickers can hydrate from the same
 projection used by future non-TUI clients.
+There are no provider-specific runtime commands or task kinds; the provider is
+data carried by the catalog request and completion.
 
 ## Future
 - Custom provider support (arbitrary API endpoint + API key)

--- a/docs/features/provider-connection-redesign.md
+++ b/docs/features/provider-connection-redesign.md
@@ -85,10 +85,17 @@ Model list: each row shows model name + context window size.
 ### Phase 4 — Model Catalog And API-List Polish (P1)
 - [x] Add Kimi as a first-class provider with catalog-backed model windows.
 - [x] Add DeepSeek v4 model-window metadata to the provider catalog.
-- [ ] Generalize ModelSearch display so every provider with catalog metadata
+- [x] Generalize ModelSearch display so every provider with catalog metadata
       shows context windows consistently.
-- [ ] Add provider API model-list loading for connected API-key providers, with
-      catalog metadata as fallback and enrichment.
+- [x] Add provider API model-list loading for connected API-key providers, with
+      catalog metadata as fallback and enrichment for DeepSeek and Kimi.
+
+The provider catalog follows the OpenCode boundary: static provider metadata
+is the durable catalog, while a connected provider's `/models` response is a
+runtime availability projection. The runtime merges the response into typed
+`ModelCatalogEntry` values, preserving catalog context windows when the API
+does not return one and preferring an API-provided context length when it does.
+The TUI consumes those entries and does not parse provider response JSON.
 
 ## Future
 - Custom provider support (arbitrary API endpoint + API key)

--- a/docs/journal/2026-08-04-provider-model-catalog.md
+++ b/docs/journal/2026-08-04-provider-model-catalog.md
@@ -11,8 +11,11 @@ order.
 
 The TUI keeps provider model selection compatible with existing string-based
 state while retaining context-window metadata for both provider-specific and
-unified model pickers. API failures continue to use the static fallback
-catalog.
+unified model pickers. Model refresh uses one provider-parameterized runtime
+maintenance command, and the catalog is retained in `RuntimeSnapshot` so a
+snapshot consumer can hydrate the picker without parsing provider responses.
+API failures continue to use the static fallback catalog and mark that
+projection as fallback data.
 
 ## Why
 

--- a/docs/journal/2026-08-04-provider-model-catalog.md
+++ b/docs/journal/2026-08-04-provider-model-catalog.md
@@ -17,6 +17,10 @@ snapshot consumer can hydrate the picker without parsing provider responses.
 API failures continue to use the static fallback catalog and mark that
 projection as fallback data.
 
+The refresh path was subsequently generalized so provider identity is data on
+one `RefreshModelCatalog(provider)` command and one model-catalog task result,
+rather than separate DeepSeek and Kimi commands.
+
 ## Why
 
 OpenCode separates a durable provider/model catalog from runtime provider

--- a/docs/journal/2026-08-04-provider-model-catalog.md
+++ b/docs/journal/2026-08-04-provider-model-catalog.md
@@ -1,0 +1,35 @@
+# Provider Model Catalog And API Fallback
+
+## What changed
+
+The provider catalog now returns typed model entries with an optional context
+window instead of bare model names. DeepSeek and Kimi API responses may provide
+`context_length`, `context_window`, or `max_context_length`; the catalog uses
+that value when present and enriches known models from the static provider
+catalog otherwise. Duplicate model IDs are removed while preserving provider
+order.
+
+The TUI keeps provider model selection compatible with existing string-based
+state while retaining context-window metadata for both provider-specific and
+unified model pickers. API failures continue to use the static fallback
+catalog.
+
+## Why
+
+OpenCode separates a durable provider/model catalog from runtime provider
+availability and exposes a unified model projection to the TUI. RARA had the
+API and fallback paths, but discarded metadata at the catalog boundary, so
+models loaded from `/models` could not display or use their context window.
+
+## Trade-offs
+
+This change generalizes the existing DeepSeek/Kimi catalog without introducing
+a network request for every provider or moving provider JSON parsing into the
+TUI. Other providers continue to use their existing static presets until they
+gain a provider-specific catalog adapter.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo test -p rara-provider-catalog --no-fail-fast`
+- `cargo check -p rara --locked`

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -173,6 +173,11 @@ Active backlog only. Keep this file small and current.
       explicit `local_embeddings = "auto"` opt-in.
 - [x] Explicit embedding provider override beyond `off` / `auto`.
 
+## Provider Catalog
+
+- [x] Enrich connected DeepSeek/Kimi model lists with static and API-provided
+      context-window metadata and show it in model pickers.
+
 ## Patch Engine
 
 - [x] Add a typed `PatchAction` preview API for approval UI and app-server

--- a/src/tui/app_event.rs
+++ b/src/tui/app_event.rs
@@ -56,10 +56,6 @@ pub enum AppEvent {
     /// profile actions move out of overlay-only dispatch (docs/todo.md).
     #[allow(dead_code)]
     DeleteOpenAiProfile,
-    /// Reserved for provider catalog refresh from the active model picker
-    /// (docs/todo.md).
-    #[allow(dead_code)]
-    RefreshDeepSeekModels,
     SelectHelpTab(HelpTab),
     SelectStatusTab(StatusTab),
     ApplyOverlaySelection,

--- a/src/tui/controller.rs
+++ b/src/tui/controller.rs
@@ -126,7 +126,11 @@ impl TuiController {
                     super::state::TuiEvent::Runtime(event),
                 );
             }
-            RuntimeProjectionEvent::Snapshot(snapshot) => self.app.snapshot = *snapshot,
+            RuntimeProjectionEvent::Snapshot(snapshot) => {
+                self.app.snapshot = *snapshot;
+                let catalogs = self.app.snapshot.model_catalogs.clone();
+                self.app.apply_model_catalog_snapshots(&catalogs);
+            }
             RuntimeProjectionEvent::Completed { reason } => {
                 self.app
                     .set_runtime_phase(super::state::RuntimePhase::Idle, reason);

--- a/src/tui/controller.rs
+++ b/src/tui/controller.rs
@@ -226,7 +226,8 @@ mod tests {
         let mut handle = tokio::spawn(async {
             panic!("completion failure");
             #[allow(unreachable_code)]
-            crate::tui::state::TaskCompletion::KimiModels {
+            crate::tui::state::TaskCompletion::ModelCatalog {
+                provider: rara_provider_catalog::ModelCatalogProvider::Kimi,
                 result: Ok(Vec::new()),
             }
         });

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use codex_models_manager::manager::RefreshStrategy;
+use rara_provider_catalog::ModelCatalogProvider;
 
 use super::app_event::AppEvent;
 use super::command::{palette_command_by_index, palette_commands};
@@ -402,7 +403,9 @@ async fn dispatch_event_inner(
                     request_maintenance(
                         app,
                         runtime_port,
-                        RuntimeMaintenanceCommand::LoadDeepSeekModels,
+                        RuntimeMaintenanceCommand::RefreshModelCatalog(
+                            ModelCatalogProvider::DeepSeek,
+                        ),
                     )
                     .await?;
                 } else if was_kimi {
@@ -411,7 +414,7 @@ async fn dispatch_event_inner(
                     request_maintenance(
                         app,
                         runtime_port,
-                        RuntimeMaintenanceCommand::LoadKimiModels,
+                        RuntimeMaintenanceCommand::RefreshModelCatalog(ModelCatalogProvider::Kimi),
                     )
                     .await?;
                 } else {
@@ -500,7 +503,7 @@ async fn dispatch_event_inner(
             request_maintenance(
                 app,
                 runtime_port,
-                RuntimeMaintenanceCommand::LoadDeepSeekModels,
+                RuntimeMaintenanceCommand::RefreshModelCatalog(ModelCatalogProvider::DeepSeek),
             )
             .await?;
         }
@@ -916,10 +919,10 @@ async fn request_maintenance(
     } else {
         match command {
             RuntimeMaintenanceCommand::Rebuild => super::runtime::start_rebuild_task(app),
-            RuntimeMaintenanceCommand::LoadDeepSeekModels => {
+            RuntimeMaintenanceCommand::RefreshModelCatalog(ModelCatalogProvider::DeepSeek) => {
                 super::runtime::start_deepseek_model_list_task(app)
             }
-            RuntimeMaintenanceCommand::LoadKimiModels => {
+            RuntimeMaintenanceCommand::RefreshModelCatalog(ModelCatalogProvider::Kimi) => {
                 super::runtime::start_kimi_model_list_task(app)
             }
             RuntimeMaintenanceCommand::Compact => {

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -499,14 +499,6 @@ async fn dispatch_event_inner(
                 .await?;
             }
         }
-        AppEvent::RefreshDeepSeekModels => {
-            request_maintenance(
-                app,
-                runtime_port,
-                RuntimeMaintenanceCommand::RefreshModelCatalog(ModelCatalogProvider::DeepSeek),
-            )
-            .await?;
-        }
         AppEvent::SelectHelpTab(tab) => {
             app.open_overlay(Overlay::Help(tab));
         }
@@ -919,11 +911,8 @@ async fn request_maintenance(
     } else {
         match command {
             RuntimeMaintenanceCommand::Rebuild => super::runtime::start_rebuild_task(app),
-            RuntimeMaintenanceCommand::RefreshModelCatalog(ModelCatalogProvider::DeepSeek) => {
-                super::runtime::start_deepseek_model_list_task(app)
-            }
-            RuntimeMaintenanceCommand::RefreshModelCatalog(ModelCatalogProvider::Kimi) => {
-                super::runtime::start_kimi_model_list_task(app)
+            RuntimeMaintenanceCommand::RefreshModelCatalog(provider) => {
+                super::runtime::start_model_catalog_task(app, provider)
             }
             RuntimeMaintenanceCommand::Compact => {
                 app.push_notice("Compaction requires an active runtime client.")

--- a/src/tui/list_picker.rs
+++ b/src/tui/list_picker.rs
@@ -177,32 +177,42 @@ impl ListPickerKind {
         use super::state::{PROVIDER_FAMILIES, ProviderFamily};
         let provider_label = PROVIDER_FAMILIES[app.provider_picker_idx].1;
         let family = app.selected_provider_family();
-        let mut items: Vec<ListItem<'static>> = if family == ProviderFamily::DeepSeek {
-            app.deepseek_model_options
-                .iter()
-                .enumerate()
-                .map(|(idx, model)| {
-                    ListItem::new(ratatui::text::Line::from(format!(
-                        "{} ({})",
-                        model, provider_label,
-                    )))
-                    .style(Self::selected_style(idx, selected))
-                })
-                .collect()
-        } else {
-            let presets = super::state::current_model_presets(app.provider_picker_idx);
-            presets
-                .iter()
-                .enumerate()
-                .map(|(idx, preset)| {
-                    ListItem::new(ratatui::text::Line::from(format!(
-                        "{} ({})",
-                        preset.1, provider_label,
-                    )))
-                    .style(Self::selected_style(idx, selected))
-                })
-                .collect()
-        };
+        let mut items: Vec<ListItem<'static>> =
+            if matches!(family, ProviderFamily::DeepSeek | ProviderFamily::Kimi) {
+                let models = if family == ProviderFamily::DeepSeek {
+                    &app.deepseek_model_options
+                } else {
+                    &app.kimi_model_options
+                };
+                models
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, model)| {
+                        let context = app
+                            .model_context_window(family, model)
+                            .map(|tokens| format!(" · {:.0}K", tokens as f64 / 1000.0))
+                            .unwrap_or_default();
+                        ListItem::new(ratatui::text::Line::from(format!(
+                            "{} ({}){}",
+                            model, provider_label, context,
+                        )))
+                        .style(Self::selected_style(idx, selected))
+                    })
+                    .collect()
+            } else {
+                let presets = super::state::current_model_presets(app.provider_picker_idx);
+                presets
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, preset)| {
+                        ListItem::new(ratatui::text::Line::from(format!(
+                            "{} ({})",
+                            preset.1, provider_label,
+                        )))
+                        .style(Self::selected_style(idx, selected))
+                    })
+                    .collect()
+            };
         if matches!(
             app.selected_provider_family(),
             ProviderFamily::OpenAiCompatible

--- a/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
+++ b/src/tui/render/snapshots/rara__tui__render__tests__unified_model_picker.snap
@@ -13,12 +13,12 @@ Type
 Star    DeepSeek/deepseek-chat
   /h    DeepSeek/deepseek-reasoner
   /m    DeepSeek/deepseek-v4-flash
-  /s    DeepSeek/deepseek-v4-pro
-  /q    DeepSeek/deepseek-v4-preview
-        Kimi/kimi-k3
-Prom    Kimi/kimi-k2.6
-  Re    Kimi/kimi-k2.5
-› As    Kimi/kimi-k2-0905-preview                                           s.
-        Kimi/kimi-k2-turbo-preview
+  /s    DeepSeek/deepseek-v4-preview
+  /q    DeepSeek/deepseek-v4-pro
+        Kimi/kimi-k2-0905-preview
+Prom    Kimi/kimi-k2-thinking
+  Re    Kimi/kimi-k2-thinking-turbo
+› As    Kimi/kimi-k2-turbo-preview                                          s.
+        Kimi/kimi-k2.5
                      Up/Down/jk move  Enter apply  Esc back
                                                                             tion

--- a/src/tui/runtime.rs
+++ b/src/tui/runtime.rs
@@ -91,10 +91,9 @@ pub fn start_oauth_task(app: &mut TuiApp, oauth_manager: Arc<OAuthManager>, mode
     tasks::start_oauth_task(app, oauth_manager, mode);
 }
 
-pub fn start_deepseek_model_list_task(app: &mut TuiApp) {
-    tasks::start_deepseek_model_list_task(app);
-}
-
-pub fn start_kimi_model_list_task(app: &mut TuiApp) {
-    tasks::start_kimi_model_list_task(app);
+pub fn start_model_catalog_task(
+    app: &mut TuiApp,
+    provider: rara_provider_catalog::ModelCatalogProvider,
+) {
+    tasks::start_model_catalog_task(app, provider);
 }

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -734,9 +734,14 @@ mod tests {
     fn mark_app_busy(app: &mut TuiApp) {
         let (_sender, receiver) = mpsc::unbounded_channel();
         app.bottom_pane.running_task = Some(RunningTask {
-            kind: TaskKind::DeepSeekModels,
+            kind: TaskKind::ModelCatalog,
             receiver,
-            handle: tokio::spawn(async { TaskCompletion::DeepSeekModels { result: Ok(vec![]) } }),
+            handle: tokio::spawn(async {
+                TaskCompletion::ModelCatalog {
+                    provider: rara_provider_catalog::ModelCatalogProvider::DeepSeek,
+                    result: Ok(vec![]),
+                }
+            }),
             started_at: Instant::now(),
             next_heartbeat_after_secs: 2,
             cancellation_token: None,

--- a/src/tui/runtime/commands.rs
+++ b/src/tui/runtime/commands.rs
@@ -383,8 +383,7 @@ async fn request_maintenance(
                 }
             }
             RuntimeMaintenanceCommand::Rebuild => start_rebuild_task(app),
-            RuntimeMaintenanceCommand::LoadDeepSeekModels
-            | RuntimeMaintenanceCommand::LoadKimiModels => {
+            RuntimeMaintenanceCommand::RefreshModelCatalog(_) => {
                 app.push_notice("Model catalog loading requires a runtime client.")
             }
         }

--- a/src/tui/runtime/processor.rs
+++ b/src/tui/runtime/processor.rs
@@ -132,12 +132,16 @@ impl RuntimeCommandProcessor {
             RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::Rebuild) => {
                 super::start_rebuild_task(app);
             }
-            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::LoadDeepSeekModels) => {
-                super::start_deepseek_model_list_task(app);
-            }
-            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::LoadKimiModels) => {
-                super::start_kimi_model_list_task(app);
-            }
+            RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::RefreshModelCatalog(
+                provider,
+            )) => match provider {
+                rara_provider_catalog::ModelCatalogProvider::DeepSeek => {
+                    super::start_deepseek_model_list_task(app)
+                }
+                rara_provider_catalog::ModelCatalogProvider::Kimi => {
+                    super::start_kimi_model_list_task(app)
+                }
+            },
             command => app.push_notice(format!(
                 "Runtime command is not handled by the in-process processor: {command:?}"
             )),

--- a/src/tui/runtime/processor.rs
+++ b/src/tui/runtime/processor.rs
@@ -134,14 +134,7 @@ impl RuntimeCommandProcessor {
             }
             RuntimeCommand::Maintenance(RuntimeMaintenanceCommand::RefreshModelCatalog(
                 provider,
-            )) => match provider {
-                rara_provider_catalog::ModelCatalogProvider::DeepSeek => {
-                    super::start_deepseek_model_list_task(app)
-                }
-                rara_provider_catalog::ModelCatalogProvider::Kimi => {
-                    super::start_kimi_model_list_task(app)
-                }
-            },
+            )) => super::start_model_catalog_task(app, provider),
             command => app.push_notice(format!(
                 "Runtime command is not handled by the in-process processor: {command:?}"
             )),

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -581,18 +581,26 @@ pub(super) fn start_oauth_task(
     oauth::start_oauth_task(app, oauth_manager, mode);
 }
 
-pub(super) fn start_deepseek_model_list_task(app: &mut TuiApp) {
+pub(super) fn start_model_catalog_task(app: &mut TuiApp, provider: ModelCatalogProvider) {
     let (_sender, receiver) = mpsc::unbounded_channel();
     let api_key = app.config.api_key_secret();
     let surface = app.config.effective_provider_surface();
+    let default_base_url = match provider {
+        ModelCatalogProvider::DeepSeek => crate::config::DEFAULT_DEEPSEEK_BASE_URL,
+        ModelCatalogProvider::Kimi => crate::config::DEFAULT_KIMI_BASE_URL,
+    };
     let base_url = Some(
         surface
             .base_url
             .value
-            .unwrap_or(crate::config::DEFAULT_DEEPSEEK_BASE_URL)
+            .unwrap_or(default_base_url)
             .to_string(),
     );
-    app.bottom_pane.notice = Some("Loading DeepSeek models.".into());
+    let provider_label = match provider {
+        ModelCatalogProvider::DeepSeek => "DeepSeek",
+        ModelCatalogProvider::Kimi => "Kimi",
+    };
+    app.bottom_pane.notice = Some(format!("Loading {provider_label} models."));
     app.set_runtime_phase(
         RuntimePhase::RebuildingBackend,
         Some("loading models".into()),
@@ -600,7 +608,7 @@ pub(super) fn start_deepseek_model_list_task(app: &mut TuiApp) {
 
     let handle = tokio::spawn(async move {
         let result = load_model_catalog(
-            ModelCatalogProvider::DeepSeek,
+            provider,
             ModelCatalogRequest {
                 api_key: api_key.as_ref(),
                 base_url: base_url.as_deref(),
@@ -608,52 +616,11 @@ pub(super) fn start_deepseek_model_list_task(app: &mut TuiApp) {
         )
         .await
         .map(|catalog| catalog.models);
-        TaskCompletion::DeepSeekModels { result }
+        TaskCompletion::ModelCatalog { provider, result }
     });
 
     app.bottom_pane.running_task = Some(RunningTask {
-        kind: TaskKind::DeepSeekModels,
-        receiver,
-        handle,
-        started_at: Instant::now(),
-        next_heartbeat_after_secs: u64::MAX,
-        cancellation_token: None,
-        cancellation_requested: false,
-    });
-}
-
-pub(super) fn start_kimi_model_list_task(app: &mut TuiApp) {
-    let (_sender, receiver) = mpsc::unbounded_channel();
-    let api_key = app.config.api_key_secret();
-    let surface = app.config.effective_provider_surface();
-    let base_url = Some(
-        surface
-            .base_url
-            .value
-            .unwrap_or(crate::config::DEFAULT_KIMI_BASE_URL)
-            .to_string(),
-    );
-    app.bottom_pane.notice = Some("Loading Kimi models.".into());
-    app.set_runtime_phase(
-        RuntimePhase::RebuildingBackend,
-        Some("loading models".into()),
-    );
-
-    let handle = tokio::spawn(async move {
-        let result = load_model_catalog(
-            ModelCatalogProvider::Kimi,
-            ModelCatalogRequest {
-                api_key: api_key.as_ref(),
-                base_url: base_url.as_deref(),
-            },
-        )
-        .await
-        .map(|catalog| catalog.models);
-        TaskCompletion::KimiModels { result }
-    });
-
-    app.bottom_pane.running_task = Some(RunningTask {
-        kind: TaskKind::KimiModels,
+        kind: TaskKind::ModelCatalog,
         receiver,
         handle,
         started_at: Instant::now(),

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 use builder::rebuild_agent_with_progress;
 use rara_persistence::redaction::sanitize_url_for_display;
 use rara_provider_catalog::{
-    ModelCatalogProvider, ModelCatalogRequest, fallback_models, load_model_catalog,
+    ModelCatalogProvider, ModelCatalogRequest, fallback_catalog, load_model_catalog,
 };
 use secrecy::ExposeSecret;
 use tokio::sync::mpsc;

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -472,7 +472,10 @@ async fn finish_running_task_if_ready_with_completion_mode(
                 app.open_overlay(Overlay::ListPicker(ListPickerKind::Model));
             }
             Err(err) => {
-                app.set_deepseek_model_catalog(fallback_catalog(ModelCatalogProvider::DeepSeek));
+                app.set_deepseek_model_catalog_with_source(
+                    fallback_catalog(ModelCatalogProvider::DeepSeek),
+                    true,
+                );
                 let message = format!(
                     "Failed to load DeepSeek models. Showing fallback list.\n{}",
                     format_error_chain(&err)
@@ -492,7 +495,10 @@ async fn finish_running_task_if_ready_with_completion_mode(
                 app.open_overlay(Overlay::ListPicker(ListPickerKind::Model));
             }
             Err(err) => {
-                app.set_kimi_model_catalog(fallback_catalog(ModelCatalogProvider::Kimi));
+                app.set_kimi_model_catalog_with_source(
+                    fallback_catalog(ModelCatalogProvider::Kimi),
+                    true,
+                );
                 let message = format!(
                     "Failed to load Kimi models. Showing fallback list.\n{}",
                     format_error_chain(&err)

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -463,44 +463,37 @@ async fn finish_running_task_if_ready_with_completion_mode(
                 app.push_notice(message);
             }
         },
-        TaskCompletion::DeepSeekModels { result } => match result {
+        TaskCompletion::ModelCatalog { provider, result } => match result {
             Ok(models) => {
                 let count = models.len();
-                app.set_deepseek_model_catalog(models);
-                app.bottom_pane.notice = Some(format!("Loaded {count} DeepSeek models."));
+                match provider {
+                    ModelCatalogProvider::DeepSeek => app.set_deepseek_model_catalog(models),
+                    ModelCatalogProvider::Kimi => app.set_kimi_model_catalog(models),
+                }
+                let label = match provider {
+                    ModelCatalogProvider::DeepSeek => "DeepSeek",
+                    ModelCatalogProvider::Kimi => "Kimi",
+                };
+                app.bottom_pane.notice = Some(format!("Loaded {count} {label} models."));
                 app.set_runtime_phase(RuntimePhase::Idle, Some("models loaded".into()));
                 app.open_overlay(Overlay::ListPicker(ListPickerKind::Model));
             }
             Err(err) => {
-                app.set_deepseek_model_catalog_with_source(
-                    fallback_catalog(ModelCatalogProvider::DeepSeek),
-                    true,
-                );
+                let fallback = fallback_catalog(provider);
+                match provider {
+                    ModelCatalogProvider::DeepSeek => {
+                        app.set_deepseek_model_catalog_with_source(fallback, true)
+                    }
+                    ModelCatalogProvider::Kimi => {
+                        app.set_kimi_model_catalog_with_source(fallback, true)
+                    }
+                }
+                let label = match provider {
+                    ModelCatalogProvider::DeepSeek => "DeepSeek",
+                    ModelCatalogProvider::Kimi => "Kimi",
+                };
                 let message = format!(
-                    "Failed to load DeepSeek models. Showing fallback list.\n{}",
-                    format_error_chain(&err)
-                );
-                app.push_system(message.clone(), SystemMessageKind::Other);
-                app.push_notice(message);
-                app.set_runtime_phase(RuntimePhase::Idle, Some("model list fallback".into()));
-                app.open_overlay(Overlay::ListPicker(ListPickerKind::Model));
-            }
-        },
-        TaskCompletion::KimiModels { result } => match result {
-            Ok(models) => {
-                let count = models.len();
-                app.set_kimi_model_catalog(models);
-                app.bottom_pane.notice = Some(format!("Loaded {count} Kimi models."));
-                app.set_runtime_phase(RuntimePhase::Idle, Some("models loaded".into()));
-                app.open_overlay(Overlay::ListPicker(ListPickerKind::Model));
-            }
-            Err(err) => {
-                app.set_kimi_model_catalog_with_source(
-                    fallback_catalog(ModelCatalogProvider::Kimi),
-                    true,
-                );
-                let message = format!(
-                    "Failed to load Kimi models. Showing fallback list.\n{}",
+                    "Failed to load {label} models. Showing fallback list.\n{}",
                     format_error_chain(&err)
                 );
                 app.push_system(message.clone(), SystemMessageKind::Other);

--- a/src/tui/runtime/tasks/completion.rs
+++ b/src/tui/runtime/tasks/completion.rs
@@ -466,13 +466,13 @@ async fn finish_running_task_if_ready_with_completion_mode(
         TaskCompletion::DeepSeekModels { result } => match result {
             Ok(models) => {
                 let count = models.len();
-                app.set_deepseek_model_options(models);
+                app.set_deepseek_model_catalog(models);
                 app.bottom_pane.notice = Some(format!("Loaded {count} DeepSeek models."));
                 app.set_runtime_phase(RuntimePhase::Idle, Some("models loaded".into()));
                 app.open_overlay(Overlay::ListPicker(ListPickerKind::Model));
             }
             Err(err) => {
-                app.set_deepseek_model_options(fallback_models(ModelCatalogProvider::DeepSeek));
+                app.set_deepseek_model_catalog(fallback_catalog(ModelCatalogProvider::DeepSeek));
                 let message = format!(
                     "Failed to load DeepSeek models. Showing fallback list.\n{}",
                     format_error_chain(&err)
@@ -486,13 +486,13 @@ async fn finish_running_task_if_ready_with_completion_mode(
         TaskCompletion::KimiModels { result } => match result {
             Ok(models) => {
                 let count = models.len();
-                app.set_kimi_model_options(models);
+                app.set_kimi_model_catalog(models);
                 app.bottom_pane.notice = Some(format!("Loaded {count} Kimi models."));
                 app.set_runtime_phase(RuntimePhase::Idle, Some("models loaded".into()));
                 app.open_overlay(Overlay::ListPicker(ListPickerKind::Model));
             }
             Err(err) => {
-                app.set_kimi_model_options(fallback_models(ModelCatalogProvider::Kimi));
+                app.set_kimi_model_catalog(fallback_catalog(ModelCatalogProvider::Kimi));
                 let message = format!(
                     "Failed to load Kimi models. Showing fallback list.\n{}",
                     format_error_chain(&err)

--- a/src/tui/runtime_port.rs
+++ b/src/tui/runtime_port.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use futures::Stream;
+use rara_provider_catalog::ModelCatalogProvider;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 
 use crate::runtime_control::{
@@ -37,8 +38,7 @@ pub(crate) enum RuntimeCommand {
 pub(crate) enum RuntimeMaintenanceCommand {
     Compact,
     Rebuild,
-    LoadDeepSeekModels,
-    LoadKimiModels,
+    RefreshModelCatalog(ModelCatalogProvider),
 }
 
 // Contract items are intentionally ahead of their adapters; the next

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -132,6 +132,7 @@ fn terminal_remote_label(remote: Option<&rara_terminal_detection::RemoteSession>
 }
 
 use rara_persistence::redaction::redact_secrets;
+use rara_provider_catalog::ModelCatalogEntry;
 use rara_provider_catalog::{ModelCatalogProvider, fallback_models};
 use rara_state::state_db::StateDb;
 
@@ -277,6 +278,18 @@ impl TuiApp {
             codex_model_options: Vec::new(),
             deepseek_model_options: fallback_models(ModelCatalogProvider::DeepSeek),
             kimi_model_options: fallback_models(ModelCatalogProvider::Kimi),
+            deepseek_model_context_windows: rara_provider_catalog::fallback_catalog(
+                ModelCatalogProvider::DeepSeek,
+            )
+            .into_iter()
+            .filter_map(|entry| entry.context_window.map(|window| (entry.id, window)))
+            .collect(),
+            kimi_model_context_windows: rara_provider_catalog::fallback_catalog(
+                ModelCatalogProvider::Kimi,
+            )
+            .into_iter()
+            .filter_map(|entry| entry.context_window.map(|window| (entry.id, window)))
+            .collect(),
             recent_commands: Vec::new(),
             recent_threads: Vec::new(),
             resume_picker_idx: 0,
@@ -636,7 +649,7 @@ impl TuiApp {
                                 model_id: model.clone(),
                                 model_label: model.clone(),
                                 status: None,
-                                context_window: None,
+                                context_window: self.model_context_window(*family, model),
                             });
                         }
                     }
@@ -661,7 +674,7 @@ impl TuiApp {
                                 model_id: model.clone(),
                                 model_label: model.clone(),
                                 status: None,
-                                context_window: None,
+                                context_window: self.model_context_window(*family, model),
                             });
                         }
                     }
@@ -762,19 +775,21 @@ impl TuiApp {
             }
         }
         for p in &mut results {
-            p.context_window = Self::resolve_context_window(&p.model_id);
+            if p.context_window.is_none() {
+                p.context_window = self.model_context_window(p.family, &p.model_id);
+            }
         }
         results
     }
 
     /// Look up context window tokens for a model from provider catalogs.
-    fn resolve_context_window(model_id: &str) -> Option<u32> {
-        for &(name, tokens) in rara_provider_catalog::deepseek::MODEL_WINDOWS {
-            if model_id == name {
-                return Some(tokens);
-            }
+    pub fn model_context_window(&self, family: ProviderFamily, model_id: &str) -> Option<u32> {
+        match family {
+            ProviderFamily::DeepSeek => self.deepseek_model_context_windows.get(model_id),
+            ProviderFamily::Kimi => self.kimi_model_context_windows.get(model_id),
+            _ => None,
         }
-        None
+        .copied()
     }
 
     pub fn select_unified_model(&mut self, idx: usize) {
@@ -985,6 +1000,18 @@ impl TuiApp {
         self.model_picker_idx = self.selected_preset_idx();
     }
 
+    pub fn set_deepseek_model_catalog(&mut self, catalog: Vec<ModelCatalogEntry>) {
+        self.deepseek_model_context_windows = catalog
+            .iter()
+            .filter_map(|entry| {
+                entry
+                    .context_window
+                    .map(|window| (entry.id.clone(), window))
+            })
+            .collect();
+        self.set_deepseek_model_options(catalog.into_iter().map(|entry| entry.id).collect());
+    }
+
     pub fn set_kimi_model_options(&mut self, options: Vec<String>) {
         let mut options = if options.is_empty() {
             fallback_models(ModelCatalogProvider::Kimi)
@@ -1005,6 +1032,18 @@ impl TuiApp {
         options.dedup();
         self.kimi_model_options = options;
         self.model_picker_idx = self.selected_preset_idx();
+    }
+
+    pub fn set_kimi_model_catalog(&mut self, catalog: Vec<ModelCatalogEntry>) {
+        self.kimi_model_context_windows = catalog
+            .iter()
+            .filter_map(|entry| {
+                entry
+                    .context_window
+                    .map(|window| (entry.id.clone(), window))
+            })
+            .collect();
+        self.set_kimi_model_options(catalog.into_iter().map(|entry| entry.id).collect());
     }
 
     fn selected_model_preset(&self) -> Option<(&'static str, &'static str, &'static str)> {

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -31,12 +31,13 @@ pub use self::types::{
     ActiveLiveEvent, ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
     AgentMarkdownStreamState, CommandSpec, CompactionTranscriptPayload,
     CompletedInteractionSnapshot, GoalHandle, GoalStatus, HelpTab, InteractionKind, ListPickerKind,
-    LocalCommand, LocalCommandKind, ModelRoutingView, OAuthLoginMode, OpenAiModelPickerAction,
-    Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot, PendingInteractionSnapshot,
-    PermissionMode, PickerIntent, ProviderFamily, RalphGoal, RunningTask, RuntimeExtensionSnapshot,
-    RuntimePhase, RuntimeSnapshot, SkillPickerEntry, StatusTab, SystemMessageKind, TaskCompletion,
-    TaskKind, TerminalDiagnosticsView, ToolTranscriptPayload, ToolTranscriptStatus,
-    TranscriptEntry, TranscriptEntryPayload, TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
+    LocalCommand, LocalCommandKind, ModelCatalogSnapshot, ModelRoutingView, OAuthLoginMode,
+    OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot,
+    PendingInteractionSnapshot, PermissionMode, PickerIntent, ProviderFamily, RalphGoal,
+    RunningTask, RuntimeExtensionSnapshot, RuntimePhase, RuntimeSnapshot, SkillPickerEntry,
+    StatusTab, SystemMessageKind, TaskCompletion, TaskKind, TerminalDiagnosticsView,
+    ToolTranscriptPayload, ToolTranscriptStatus, TranscriptEntry, TranscriptEntryPayload,
+    TranscriptTurn, TuiApp, TuiEvent, UnifiedModelPreset,
 };
 use crate::oauth::OAuthManager;
 pub(crate) use crate::runtime_client::RebuildSuccess;
@@ -338,6 +339,14 @@ impl TuiApp {
             mcp_tool_cache: None,
         };
 
+        app.set_deepseek_model_catalog_with_source(
+            rara_provider_catalog::fallback_catalog(ModelCatalogProvider::DeepSeek),
+            true,
+        );
+        app.set_kimi_model_catalog_with_source(
+            rara_provider_catalog::fallback_catalog(ModelCatalogProvider::Kimi),
+            true,
+        );
         app.refresh_provider_connection_status();
         app.refresh_recent_threads();
 
@@ -1001,6 +1010,14 @@ impl TuiApp {
     }
 
     pub fn set_deepseek_model_catalog(&mut self, catalog: Vec<ModelCatalogEntry>) {
+        self.set_deepseek_model_catalog_with_source(catalog, false);
+    }
+
+    pub fn set_deepseek_model_catalog_with_source(
+        &mut self,
+        catalog: Vec<ModelCatalogEntry>,
+        is_fallback: bool,
+    ) {
         self.deepseek_model_context_windows = catalog
             .iter()
             .filter_map(|entry| {
@@ -1009,7 +1026,8 @@ impl TuiApp {
                     .map(|window| (entry.id.clone(), window))
             })
             .collect();
-        self.set_deepseek_model_options(catalog.into_iter().map(|entry| entry.id).collect());
+        self.set_deepseek_model_options(catalog.iter().map(|entry| entry.id.clone()).collect());
+        self.upsert_model_catalog_snapshot("deepseek", catalog, is_fallback);
     }
 
     pub fn set_kimi_model_options(&mut self, options: Vec<String>) {
@@ -1035,6 +1053,14 @@ impl TuiApp {
     }
 
     pub fn set_kimi_model_catalog(&mut self, catalog: Vec<ModelCatalogEntry>) {
+        self.set_kimi_model_catalog_with_source(catalog, false);
+    }
+
+    pub fn set_kimi_model_catalog_with_source(
+        &mut self,
+        catalog: Vec<ModelCatalogEntry>,
+        is_fallback: bool,
+    ) {
         self.kimi_model_context_windows = catalog
             .iter()
             .filter_map(|entry| {
@@ -1043,7 +1069,78 @@ impl TuiApp {
                     .map(|window| (entry.id.clone(), window))
             })
             .collect();
-        self.set_kimi_model_options(catalog.into_iter().map(|entry| entry.id).collect());
+        self.set_kimi_model_options(catalog.iter().map(|entry| entry.id.clone()).collect());
+        self.upsert_model_catalog_snapshot("kimi", catalog, is_fallback);
+    }
+
+    fn upsert_model_catalog_snapshot(
+        &mut self,
+        provider_id: &str,
+        models: Vec<ModelCatalogEntry>,
+        is_fallback: bool,
+    ) {
+        if let Some(snapshot) = self
+            .snapshot
+            .model_catalogs
+            .iter_mut()
+            .find(|snapshot| snapshot.provider_id == provider_id)
+        {
+            *snapshot = ModelCatalogSnapshot {
+                provider_id: provider_id.to_string(),
+                models,
+                is_fallback,
+            };
+        } else {
+            self.snapshot.model_catalogs.push(ModelCatalogSnapshot {
+                provider_id: provider_id.to_string(),
+                models,
+                is_fallback,
+            });
+        }
+    }
+
+    pub fn apply_model_catalog_snapshots(&mut self, catalogs: &[ModelCatalogSnapshot]) {
+        for catalog in catalogs {
+            match catalog.provider_id.as_str() {
+                "deepseek" => {
+                    self.deepseek_model_context_windows = catalog
+                        .models
+                        .iter()
+                        .filter_map(|entry| {
+                            entry
+                                .context_window
+                                .map(|window| (entry.id.clone(), window))
+                        })
+                        .collect();
+                    self.set_deepseek_model_options(
+                        catalog
+                            .models
+                            .iter()
+                            .map(|entry| entry.id.clone())
+                            .collect(),
+                    );
+                }
+                "kimi" => {
+                    self.kimi_model_context_windows = catalog
+                        .models
+                        .iter()
+                        .filter_map(|entry| {
+                            entry
+                                .context_window
+                                .map(|window| (entry.id.clone(), window))
+                        })
+                        .collect();
+                    self.set_kimi_model_options(
+                        catalog
+                            .models
+                            .iter()
+                            .map(|entry| entry.id.clone())
+                            .collect(),
+                    );
+                }
+                _ => {}
+            }
+        }
     }
 
     fn selected_model_preset(&self) -> Option<(&'static str, &'static str, &'static str)> {

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -190,6 +190,7 @@ impl TuiApp {
             extension_command_count: extensions.command_count,
             extension_agent_count: extensions.agent_count,
             extension_agent_status_lines: extensions.agent_status_lines,
+            model_catalogs: self.snapshot.model_catalogs.clone(),
         };
         self.agent_execution_mode = agent.execution_mode;
         self.bash_approval_mode = agent.bash_approval_mode;

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1,5 +1,6 @@
 use rara_memory::vectordb::VectorDB;
 use rara_persistence::thread_turn_log;
+use rara_provider_catalog::ModelCatalogEntry;
 use rara_state::state_db::{
     PersistedCompactState, PersistedPromptRuntimeState, PersistedStructuredRolloutEvent, StateDb,
 };
@@ -8,7 +9,7 @@ use tempfile::tempdir;
 
 use super::{
     ActivePendingInteractionKind, AgentMarkdownStreamState, InteractionKind, ListPickerKind,
-    Overlay, PROVIDER_FAMILIES, PendingInteractionSnapshot, ProviderFamily,
+    ModelCatalogSnapshot, Overlay, PROVIDER_FAMILIES, PendingInteractionSnapshot, ProviderFamily,
     RuntimeExtensionSnapshot, RuntimeSnapshot, SystemMessageKind, TranscriptEntry, TranscriptTurn,
     TuiApp, input_requests_command_palette, parse_repo_slug, state_db_status_error,
 };
@@ -666,6 +667,31 @@ fn provider_catalog_context_window_flows_into_unified_model_presets() {
         .expect("Kimi K3 catalog entry");
 
     assert_eq!(kimi_k3.context_window, Some(1_048_576));
+}
+
+#[test]
+fn model_catalog_snapshot_hydrates_provider_picker_state() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+
+    let snapshot = ModelCatalogSnapshot {
+        provider_id: "kimi".to_string(),
+        models: vec![ModelCatalogEntry {
+            id: "kimi-runtime-model".to_string(),
+            context_window: Some(131_072),
+        }],
+        is_fallback: false,
+    };
+    app.apply_model_catalog_snapshots(&[snapshot]);
+
+    assert_eq!(app.kimi_model_options, vec!["kimi-runtime-model"]);
+    assert_eq!(
+        app.model_context_window(ProviderFamily::Kimi, "kimi-runtime-model"),
+        Some(131_072)
+    );
 }
 
 #[test]

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -652,6 +652,23 @@ fn deepseek_catalog_options_keep_current_custom_model_selectable() {
 }
 
 #[test]
+fn provider_catalog_context_window_flows_into_unified_model_presets() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let app = TuiApp::new(cm).expect("app");
+
+    let presets = app.all_unified_model_presets();
+    let kimi_k3 = presets
+        .iter()
+        .find(|preset| preset.provider_id == "kimi" && preset.model_id == "kimi-k3")
+        .expect("Kimi K3 catalog entry");
+
+    assert_eq!(kimi_k3.context_window, Some(1_048_576));
+}
+
+#[test]
 fn model_routing_view_infers_deepseek_auxiliary_model() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -1,8 +1,10 @@
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, atomic::AtomicBool};
 use std::time::Instant;
 
+use rara_provider_catalog::ModelCatalogEntry;
 use rara_state::state_db::StateDb;
 use rara_tools::tool::ToolOutputStream;
 use ratatui::text::Line;
@@ -402,10 +404,10 @@ pub enum TaskCompletion {
         result: anyhow::Result<secrecy::SecretString>,
     },
     DeepSeekModels {
-        result: anyhow::Result<Vec<String>>,
+        result: anyhow::Result<Vec<ModelCatalogEntry>>,
     },
     KimiModels {
-        result: anyhow::Result<Vec<String>>,
+        result: anyhow::Result<Vec<ModelCatalogEntry>>,
     },
 }
 
@@ -801,6 +803,8 @@ pub struct TuiApp {
     pub codex_model_options: Vec<CodexModelOption>,
     pub deepseek_model_options: Vec<String>,
     pub kimi_model_options: Vec<String>,
+    pub deepseek_model_context_windows: HashMap<String, u32>,
+    pub kimi_model_context_windows: HashMap<String, u32>,
     pub recent_commands: Vec<String>,
     pub recent_threads: Vec<ThreadSummary>,
     pub resume_picker_idx: usize,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -303,6 +303,14 @@ pub struct RuntimeSnapshot {
     pub extension_command_count: usize,
     pub extension_agent_count: usize,
     pub extension_agent_status_lines: Vec<String>,
+    pub model_catalogs: Vec<ModelCatalogSnapshot>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ModelCatalogSnapshot {
+    pub provider_id: String,
+    pub models: Vec<ModelCatalogEntry>,
+    pub is_fallback: bool,
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -382,8 +382,7 @@ pub enum TaskKind {
     Compact,
     Rebuild,
     OAuth,
-    DeepSeekModels,
-    KimiModels,
+    ModelCatalog,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -411,10 +410,8 @@ pub enum TaskCompletion {
         mode: OAuthLoginMode,
         result: anyhow::Result<secrecy::SecretString>,
     },
-    DeepSeekModels {
-        result: anyhow::Result<Vec<ModelCatalogEntry>>,
-    },
-    KimiModels {
+    ModelCatalog {
+        provider: rara_provider_catalog::ModelCatalogProvider,
         result: anyhow::Result<Vec<ModelCatalogEntry>>,
     },
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2551,7 +2551,7 @@ async fn deepseek_api_key_save_starts_model_catalog_task() {
     assert_eq!(app.config.api_key(), Some("sk-deepseek-test"));
     assert!(matches!(
         app.bottom_pane.running_task.as_ref(),
-        Some(task) if matches!(task.kind, TaskKind::DeepSeekModels)
+        Some(task) if matches!(task.kind, TaskKind::ModelCatalog)
     ));
     if let Some(task) = app.bottom_pane.running_task.take() {
         task.handle.abort();


### PR DESCRIPTION
## Summary

- Return typed provider model catalog entries with optional context-window metadata.
- Enrich DeepSeek and Kimi `/models` responses from static catalog metadata while preferring API-provided context lengths.
- Deduplicate dynamic model IDs and keep static fallback catalogs on request failure.
- Display context windows in provider-specific and unified model pickers.
- Add focused catalog, state, and TUI regression coverage.

## Design

This follows OpenCode's provider boundary: static catalog metadata is durable provider knowledge, while a connected provider API supplies runtime model availability. The TUI consumes the typed projection and does not parse provider response JSON.

## Compatibility

Existing string-based TUI model state and fallback behavior remain compatible. Providers without a dedicated dynamic catalog adapter continue to use their existing static presets.

## Verification

- `cargo fmt --all`
- `cargo test -p rara-provider-catalog --no-fail-fast`
- `cargo test --bin rara provider_catalog_context_window_flows_into_unified_model_presets --no-fail-fast`
- `cargo test --bin rara deepseek_model_picker_renders_catalog_models_and_refresh_hint --no-fail-fast`
- `cargo check -p rara --locked`
- `cargo clippy --locked --workspace --all-targets --no-deps -- -D warnings`
- `git diff --check`
