### PR TITLE
chore: bump version to 0.0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11029,7 +11029,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "rara"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -11114,7 +11114,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -11123,14 +11123,14 @@ dependencies = [
 
 [[package]]
 name = "rara-apply-patch"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "async-trait",
  "libc",
@@ -11145,7 +11145,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -11156,7 +11156,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -11169,7 +11169,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -11177,7 +11177,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "ignore",
@@ -11188,7 +11188,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11198,7 +11198,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -11208,7 +11208,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -11226,14 +11226,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "fs2",
@@ -11248,7 +11248,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "serde",
  "serde_json",
@@ -11258,7 +11258,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11271,7 +11271,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11282,7 +11282,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "serde",
@@ -11291,7 +11291,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -11304,11 +11304,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.13"
+version = "0.0.15"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11317,7 +11317,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.13"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.13"
+version = "0.0.15"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

- Bump the workspace and local crate versions to `0.0.15`.
- Keep `Cargo.lock` aligned with the workspace package version.

## Motivation

Prepare the next RARA release with a single consistent Cargo package version.

## Related Issue

None.

## Testing

- `cargo metadata --no-deps --locked --format-version 1`
- `cargo fmt --all -- --check`
- `cargo check -p rara --locked`
- `git diff --check`
