### PR TITLE
feat(agent): add built-in specialist roles

### DIFF
--- a/docs/features/subagent-claude-compat.md
+++ b/docs/features/subagent-claude-compat.md
@@ -79,7 +79,8 @@ pub struct AgentDefinition {
 ### Loading And Runtime Cache
 
 `AgentDefinitionCache::load()` scans:
-1. Built-in agents (General, Explore, Plan) — hardcoded in RARA.
+1. Built-in agents (`general`, `explore`, `plan`, `code-reviewer`, `architect`,
+   and `researcher`) — hardcoded in RARA.
 2. `~/.claude/agents/*.md` files in the user home.
 3. `~/.rara/agents/*.md` files in the user home.
 4. `.claude/agents/*.md` files in the workspace root.
@@ -87,8 +88,9 @@ pub struct AgentDefinition {
 
 Resolves conflicts by loading lower-precedence roots first. Workspace agents
 override user agents, and `.rara/agents` overrides `.claude/agents` at the same
-scope. Built-in agents are always available as "general", "explore", "plan"
-when no custom definition with the requested name is loaded.
+scope. Built-in agents are always available when no custom definition with the
+requested name is loaded. A user or workspace definition with the same name
+overrides the built-in fallback through the normal definition precedence.
 
 The cache is constructed with the runtime and shared by the `spawn_agent`
 tool and `/status` extension summary. Running `spawn_agent` must resolve
@@ -103,6 +105,37 @@ The `/status` extension summary only lists repo-local agent definition records.
 Definitions with `hidden: true` are omitted from listing/status surfaces while
 remaining valid for direct `spawn_agent` resolution. Visible definitions include
 their frontmatter `description` in the status line when present.
+
+### Built-In Specialist Roles
+
+RARA exposes three reusable specialist profiles through `spawn_agent`:
+
+- `code-reviewer` performs independent, findings-first code review;
+- `architect` analyzes boundaries, invariants, failure modes, and design
+  trade-offs;
+- `researcher` answers one well-scoped question using repository, documentation,
+  and web evidence; it cites a URL or repository path for every material claim
+  and separates facts, inferences, and unknowns.
+
+All three profiles inherit the active provider and model. `code-reviewer` and
+`architect` allow only `Read`, `Glob`, and `Grep`. `researcher` adds
+`WebSearch` and `WebFetch` to that read-only repository tool set. It treats
+search results as discovery leads and fetches the primary source before relying
+on them. All three exclude shell, edit, patch, task-mutation, MCP, interactive
+browser automation, and recursive agent tools. Their descriptions live in the
+`spawn_agent` tool contract so the parent model can select a role at call time.
+The existing `plan_agent` remains the canonical implementation-planning surface;
+no separate `planner` alias is added.
+
+The researcher boundary follows the `Web researcher` pattern in the extracted
+Claude Code prompt reference: multi-source search is distinct from the built-in
+`Explore` role, whose responsibility is repository file search. The extracted
+prompt repository is a behavioral reference from compiled Claude Code packages,
+not Anthropic-maintained source code.
+
+This checkpoint does not add description-driven automatic delegation or custom
+role selection to `team_create`, whose task kinds remain `general`, `explore`,
+and `plan`.
 
 `permissionMode` controls the spawned subagent's local execution policy. Values
 are parsed ASCII case-insensitively:

--- a/docs/features/web-tools.md
+++ b/docs/features/web-tools.md
@@ -59,6 +59,20 @@ unavailable search honestly. The target architecture is stricter:
 - `/status`, `/context`, ACP, and Wire expose the active web capability and
   reason when search is disabled.
 
+### 1.2) Subagent Capability Scoping
+
+Named `spawn_agent` profiles receive web tools only through an explicit
+`AgentDefinition.tools` allowlist. The child-owned custom tool manager registers
+`web_search` and `web_fetch` before applying the definition filter; profiles that
+do not request those names never receive them. A plan-mode or read-only
+permission override still selects the stricter repository-only manager.
+
+The built-in `researcher` profile explicitly requests both web tools alongside
+`Read`, `Glob`, and `Grep`. The built-in `code-reviewer` and `architect` profiles
+remain repository-only. This is capability construction, not inheritance from
+the parent session, and it does not grant shell, file mutation, MCP, interactive
+browser automation, or recursive delegation authority.
+
 ### 2) Search Result Handling
 
 Search results are an index, not proof. A web-backed answer should fetch or open
@@ -157,6 +171,9 @@ without changing the tool contract.
   system, developer, workspace, or user instructions.
 - Web results that are truncated must be reported as truncated and should not be
   treated as complete evidence.
+- Named subagents receive web tools only when their definition explicitly
+  allowlists them; built-in researcher access must not widen other specialist
+  profiles.
 - Runtime events should expose query, provider, source URLs, truncation state,
   and source-reporting readiness so `/context`, `/status`, ACP, and Wire can show
   what happened without parsing prose.
@@ -172,6 +189,8 @@ without changing the tool contract.
   and model-facing compact output.
 - Runtime event tests should assert structured query/source metadata for web
   search and fetch calls.
+- Subagent tests assert that `researcher` receives `web_search` and `web_fetch`,
+  while `code-reviewer` and `architect` do not.
 
 ## Open Risks
 
@@ -186,3 +205,4 @@ without changing the tool contract.
 ## Source Journals
 
 - `docs/journal/2026-05-04-web-search-prompt-guidance.md`
+- `docs/journal/2026-08-08-built-in-specialist-agents.md`

--- a/docs/journal/2026-08-08-built-in-specialist-agents.md
+++ b/docs/journal/2026-08-08-built-in-specialist-agents.md
@@ -1,0 +1,58 @@
+# Built-In Specialist Agents
+
+## Summary
+
+Added three reusable read-only subagent profiles: `code-reviewer`, `architect`,
+and `researcher`. The existing `plan` profile remains the planning specialist.
+
+## Background
+
+The runtime already accepted Claude-compatible user and workspace agent
+definitions, but common specialist names required a local definition and were
+not described by the `spawn_agent` tool contract. Claude Code and Codex both
+use small built-in role registries with explicit purpose and capability
+descriptions, so this checkpoint adopts that pattern with role-specific child
+authority.
+
+The prompt comparison used the local Claude Code implementation and the
+`claude-code-system-prompts` extraction repository. The latter is reference
+material extracted from compiled packages, not Anthropic-maintained source. Its
+`Explore` prompt is repository-search-specific, while the managed `Web
+researcher` example enables `read`, `glob`, `grep`, `web_fetch`, and
+`web_search`, and requires a source URL or file path for each claim.
+
+## Key Decisions
+
+- Keep `code-reviewer` and `architect` repository-only with `Read`, `Glob`, and
+  `Grep`.
+- Give `researcher` the same repository tools plus `WebSearch` and `WebFetch`;
+  require source URLs or repository paths, prefer primary sources, and treat
+  search results as leads rather than proof.
+- Register web tools in the child-owned custom tool manager, then rely on the
+  existing per-definition whitelist so no other specialist is widened.
+- Inherit the parent provider and model instead of pinning a model.
+- Keep `plan_agent` as the dedicated implementation-planning surface instead
+  of adding a `planner` alias.
+- Allow user and workspace definitions to override a built-in specialist with
+  the existing definition precedence.
+- Expose the built-in role purposes in the `spawn_agent` tool description.
+- Defer description-driven automatic delegation and `team_create` custom-role
+  routing.
+
+## Validation
+
+```bash
+cargo test builtin_specialist -- --nocapture
+cargo test resolve_spawn_agent_definition -- --nocapture
+cargo fmt --all -- --check
+cargo check --locked --workspace --all-targets
+cargo clippy --locked --workspace --all-targets -- -D warnings
+git diff --check
+```
+
+## Follow-Ups
+
+- Evaluate a structured agent catalog in the runtime prompt before adding
+  automatic role selection.
+- Decide separately whether `team_create` should accept named agent
+  definitions in addition to its built-in task kinds.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -126,6 +126,10 @@ Active backlog only. Keep this file small and current.
 - [x] Add a runtime-owned scoped plugin skill executor for explicit
       `AgentDefinition.pluginSkills` allowlists; child reload and discovery stay
       disabled. MCP and plugin memory authority remain parent-owned.
+- [ ] Evaluate a structured runtime agent catalog before adding
+      description-driven automatic selection for built-in and custom profiles.
+- [ ] Decide whether `team_create` should accept named agent definitions in
+      addition to the built-in `general`, `explore`, and `plan` task kinds.
 
 ## Shared Task Lists
 

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -34,6 +34,7 @@ use crate::tasklist::TaskListStore;
 use crate::thread_store::{ThreadRecorder, ThreadRuntimeLineage, ThreadRuntimeState};
 use crate::tools::skill::{SkillReloadPolicy, SkillTool};
 use crate::tools::tasklist::{TaskCreateTool, TaskGetTool, TaskListTool, TaskUpdateTool};
+use crate::tools::web::{WebFetchTool, WebSearchTool};
 use crate::workspace::WorkspaceMemory;
 
 #[path = "agent_budget.rs"]
@@ -363,7 +364,7 @@ pub struct AgentTool {
 
 #[tool_spec(
     name = "spawn_agent",
-    description = "Spawn a shared-task worker sub-agent. It cannot inspect files, run shell commands, edit files, or spawn other agents; it can inspect and update shared task-list entries. Use explore_agent or plan_agent for read-only repository inspection.",
+    description = "Spawn a bounded worker sub-agent. Built-in names: general for shared-task reasoning, code-reviewer for independent code review, architect for architecture and trade-off analysis, and researcher for multi-source research with file or URL evidence. The specialist roles are read-only and cannot run shell commands, edit files, or spawn agents. Use explore_agent for generic repository inspection or plan_agent for implementation planning.",
     input_schema = {
         "type": "object",
         "properties": {
@@ -1670,6 +1671,8 @@ fn build_custom_spawn_agent_tool_manager(
 ) -> ToolManager {
     let task_store = Arc::new(TaskListStore::new(task_root));
     let mut tool_manager = build_read_only_tool_manager(task_store.clone(), default_task_list_id);
+    tool_manager.register(Box::new(WebFetchTool));
+    tool_manager.register(Box::new(WebSearchTool::from_env()));
     tool_manager.register(Box::new(TaskCreateTool {
         store: task_store.clone(),
         default_task_list_id: default_task_list_id.to_string(),
@@ -2005,9 +2008,9 @@ fn subagent_role_prompt(kind: SubAgentKind, definition: Option<&AgentDefinition>
             "- Treat the assigned instruction as the complete task contract.\n",
             "- Honor every constraint in the assigned instruction, including workspace, branch, network, and output limits.\n",
             "- Stay inside the current workspace unless the assigned instruction explicitly allows another path.\n",
-            "- Repository inspection is allowed only through the read-only tools exposed to you.\n",
+            "- Inspect repository or web evidence only through the read-only tools exposed to you.\n",
             "- You may use shared task-list tools to inspect, claim, update, or complete project tasks when they are exposed.\n",
-            "- You do not have shell, editing, patching, browser, or agent-spawning tools in this role.\n",
+            "- You do not have shell, editing, patching, interactive browser automation, or agent-spawning tools in this role.\n",
             "- If the assigned instruction requires unavailable tools, report the limitation and answer from the available context.\n",
             "- Do not delegate to another agent or spawn sub-agents; complete the assigned work directly."
         )

--- a/src/tools/agent_def.rs
+++ b/src/tools/agent_def.rs
@@ -366,7 +366,7 @@ fn split_frontmatter(content: &str) -> (String, String) {
     }
 }
 
-/// Resolve a named agent to its definition. Checks built-ins first, then registry.
+/// Resolve a named agent to its definition. Checks the registry first, then built-in fallbacks.
 pub fn resolve_agent(name: &str, registry: &AgentRegistry) -> Option<AgentDefinition> {
     match registry.get(name) {
         Some(d) => Some(d.clone()),
@@ -421,6 +421,73 @@ fn builtin_agent_definition(name: &str) -> Option<AgentDefinition> {
             hidden: false,
             system_prompt: String::new(),
         }),
+        "code-reviewer" => Some(read_only_specialist_definition(
+            "code-reviewer",
+            "Independent code reviewer focused on concrete, source-backed findings",
+            &["Read", "Glob", "Grep"],
+            concat!(
+                "You are an independent code reviewer. Inspect the assigned scope and report ",
+                "actionable findings before any summary. Prioritize correctness, edge cases, ",
+                "security, concurrency, performance, maintainability, and missing tests. Cite ",
+                "repository paths and line numbers for every concrete finding. Distinguish ",
+                "verified defects from questions or assumptions. Do not modify files. If no ",
+                "findings remain, say so explicitly and identify any residual verification gap."
+            ),
+        )),
+        "architect" => Some(read_only_specialist_definition(
+            "architect",
+            "Architecture specialist for boundaries, invariants, and design trade-offs",
+            &["Read", "Glob", "Grep"],
+            concat!(
+                "You are a software architecture specialist. Analyze the assigned problem from ",
+                "the existing code and contracts before proposing changes. Identify component ",
+                "boundaries, invariants, dependencies, failure modes, and compatibility risks. ",
+                "Compare only materially different options, explain their trade-offs, and ",
+                "recommend the smallest maintainable design. Include concrete integration points ",
+                "and validation criteria. Do not modify files or turn unverified assumptions into ",
+                "repository facts."
+            ),
+        )),
+        "researcher" => Some(read_only_specialist_definition(
+            "researcher",
+            "Read-only multi-source researcher for code, documentation, and web evidence",
+            &["Read", "Glob", "Grep", "WebSearch", "WebFetch"],
+            concat!(
+                "You are a read-only multi-source technical researcher. Answer exactly the ",
+                "well-scoped question you are given. Search and read as much as needed across ",
+                "repository code, local documentation, and the web. Provide a source URL or ",
+                "repository file path for every material claim. Prefer official documentation, ",
+                "upstream repositories, standards, and primary research. Treat search results as ",
+                "leads rather than proof: fetch the relevant source before relying on it. Trace ",
+                "local call paths when the question depends on repository behavior. Separate ",
+                "confirmed facts, reasonable inferences, and unresolved unknowns, and report ",
+                "conflicting evidence explicitly. Do not modify files or expand the task beyond ",
+                "the requested research scope."
+            ),
+        )),
         _ => None,
+    }
+}
+
+fn read_only_specialist_definition(
+    name: &str,
+    description: &str,
+    tools: &[&str],
+    system_prompt: &str,
+) -> AgentDefinition {
+    AgentDefinition {
+        token_budget: None,
+        name: name.to_string(),
+        description: description.to_string(),
+        tools: tools.iter().map(|tool| (*tool).to_string()).collect(),
+        disallowed_tools: vec![],
+        plugin_skills: vec![],
+        model: None,
+        provider: None,
+        max_turns: 50,
+        permission_mode: None,
+        plan_mode_required: false,
+        hidden: false,
+        system_prompt: system_prompt.to_string(),
     }
 }

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -22,7 +22,8 @@ use super::{
     build_read_only_tool_manager, build_subagent_tool_manager, home_dir_from_vars,
     latest_assistant_text_from_history, parse_agent_permission_mode, parse_agent_token_budget,
     parse_team_task_kind, provider_target_from_parts, register_scoped_plugin_skill_tool,
-    resolve_kind_definition, resolve_spawn_agent_definition, validate_agent_id_label,
+    resolve_kind_definition, resolve_spawn_agent_definition, subagent_role_prompt,
+    validate_agent_id_label,
 };
 use crate::agent::Message;
 use crate::llm::{ContentBlock, EmbeddingBackend, LlmBackend, LlmResponse, MockLlm, TokenUsage};
@@ -2227,6 +2228,87 @@ fn resolve_spawn_agent_definition_resolves_builtin() {
     let cache = test_agent_definition_cache(temp.path());
     let def = resolve_spawn_agent_definition(&cache, "explore");
     assert_eq!(def.name, "explore");
+}
+
+#[test]
+fn resolve_spawn_agent_definition_resolves_builtin_specialists() {
+    let temp = tempdir().expect("tempdir");
+    let cache = test_agent_definition_cache(temp.path());
+
+    for (name, prompt_fragment) in [
+        ("code-reviewer", "independent code reviewer"),
+        ("architect", "software architecture specialist"),
+    ] {
+        let definition = resolve_spawn_agent_definition(&cache, name);
+
+        assert_eq!(definition.name, name);
+        assert_eq!(definition.tools, vec!["Read", "Glob", "Grep"]);
+        assert_eq!(definition.max_turns, 50);
+        assert!(!definition.plan_mode_required);
+        assert!(definition.system_prompt.contains(prompt_fragment));
+    }
+
+    let researcher = resolve_spawn_agent_definition(&cache, "researcher");
+    assert_eq!(
+        researcher.tools,
+        vec!["Read", "Glob", "Grep", "WebSearch", "WebFetch"]
+    );
+    assert_eq!(researcher.max_turns, 50);
+    assert!(!researcher.plan_mode_required);
+    assert!(
+        researcher
+            .system_prompt
+            .contains("source URL or repository file path")
+    );
+    assert!(researcher.system_prompt.contains("Treat search results as"));
+}
+
+#[test]
+fn builtin_specialist_tool_managers_are_read_only() {
+    let temp = tempdir().expect("tempdir");
+    let cache = test_agent_definition_cache(temp.path());
+
+    for name in ["code-reviewer", "architect", "researcher"] {
+        let definition = resolve_spawn_agent_definition(&cache, name);
+        let manager = build_filtered_tool_manager(
+            SubAgentKind::General,
+            &definition,
+            test_task_root(),
+            DEFAULT_TASK_LIST_ID,
+        )
+        .expect("built-in specialist tool manager");
+
+        assert!(manager.get_tool("read_file").is_some());
+        assert!(manager.get_tool("glob").is_some());
+        assert!(manager.get_tool("grep").is_some());
+        assert_eq!(
+            manager.get_tool("web_search").is_some(),
+            name == "researcher"
+        );
+        assert_eq!(
+            manager.get_tool("web_fetch").is_some(),
+            name == "researcher"
+        );
+        assert!(manager.get_tool("task_create").is_none());
+        assert!(manager.get_tool("task_update").is_none());
+        assert!(manager.get_tool("bash").is_none());
+        assert!(manager.get_tool("write_file").is_none());
+        assert!(manager.get_tool("apply_patch").is_none());
+        assert!(manager.get_tool("spawn_agent").is_none());
+    }
+}
+
+#[test]
+fn researcher_role_prompt_describes_read_only_web_evidence_access() {
+    let temp = tempdir().expect("tempdir");
+    let cache = test_agent_definition_cache(temp.path());
+    let researcher = resolve_spawn_agent_definition(&cache, "researcher");
+
+    let prompt = subagent_role_prompt(SubAgentKind::General, Some(&researcher));
+
+    assert!(prompt.contains("repository or web evidence"));
+    assert!(prompt.contains("interactive browser automation"));
+    assert!(!prompt.contains("You do not have shell, editing, patching, browser,"));
 }
 
 #[test]

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -1170,7 +1170,7 @@ Custom reviewer prompt from workspace definition.
     assert!(system_prompt.contains("Planning mode is active."));
     assert!(system_prompt.contains("You are a custom workspace sub-agent."));
     assert!(system_prompt.contains(
-        "Repository inspection is allowed only through the read-only tools exposed to you."
+        "Inspect repository or web evidence only through the read-only tools exposed to you."
     ));
     assert!(!system_prompt.contains("You do not have repository"));
     assert!(!system_prompt.contains("answer only from the provided instruction/context"));


### PR DESCRIPTION
## Summary

- add built-in `code-reviewer`, `architect`, and `researcher` profiles to `spawn_agent`
- keep reviewer and architect repository-only while giving researcher explicit read-only web search and fetch capabilities
- preserve workspace and user overrides through the existing agent-definition precedence
- document the role boundaries, capability filtering, and remaining catalog/team routing work

## Motivation

Common specialist roles previously required local agent definitions. The new built-ins provide reusable defaults without making a role name an implicit permission grant. The researcher role is intentionally multi-source: repository search remains distinct from external evidence gathering, and material claims require a source URL or repository path.

## Implementation

- define the three specialist profiles with inherited provider/model selection
- register `web_search` and `web_fetch` in the child-owned custom tool manager, then apply the existing per-definition allowlist
- keep shell, file mutation, task mutation, MCP, interactive browser automation, and recursive delegation unavailable to built-in specialists
- update prompt wording so read-only web evidence access is represented accurately
- add focused definition, prompt, and effective-tool-manager coverage

## Nowledge Mem hook audit

This PR does not add Nowledge Mem lifecycle hooks to subagents. The current RARA builtin materializes MCP, skills, prompt guidance, and a routing agent, but no `hooks/hooks.json`. Child agents also do not receive a `PluginHookRuntime`, and the hook event model has no `SubagentStart` lifecycle. Adding bounded, fail-open subagent context injection should be designed and validated separately rather than hidden inside this role change.

## Related issues

None.

## Testing

Validation commands:

```bash
cargo test builtin_specialist -- --nocapture
cargo test researcher_role_prompt -- --nocapture
cargo test resolve_spawn_agent_definition -- --nocapture
cargo check --locked --workspace --all-targets
cargo clippy --locked --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
git diff --check
```
