### PR TITLE
chore: remove stale Bazel lock todo

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -178,8 +178,6 @@ Active backlog only. Keep this file small and current.
 - [x] Explicit embedding provider override beyond `off` / `auto`.
 - [x] Remove bundled local embedding runtime from memory retrieval; keep
       `local_embeddings` as deprecated config compatibility only.
-- [ ] Regenerate Bazel lock metadata after embedded vector-memory dependency
-      removal if this branch needs Bazel CI validation.
 - [ ] Decide whether to keep or migrate away the deprecated
       `local_embeddings` config field.
 


### PR DESCRIPTION
## Summary

- Remove the stale Bazel lock regeneration TODO from `docs/todo.md`.

## Motivation

PR #804 already passed Bazel CI and merged after the embedded vector-memory dependency removal, so the conditional follow-up is no longer active backlog.

## Related issue

None.

## Testing

- `git diff --check`
