### PR TITLE
feat(wasm): add patch preview core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9144,6 +9144,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rara-wasm-core"
+version = "0.0.15"
+dependencies = [
+ "rara-apply-patch",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/rara-state",
     "crates/rara-memory",
     "crates/rara-apply-patch",
+    "crates/rara-wasm-core",
     "crates/rara-observability",
     "crates/rara-tools",
     "crates/rara-plugins",

--- a/crates/rara-wasm-core/BUILD.bazel
+++ b/crates/rara-wasm-core/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@crate_index//:defs.bzl", "aliases", "all_crate_deps")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_library(
+    name = "rara_wasm_core",
+    srcs = glob(["src/**/*.rs"]),
+    aliases = aliases(),
+    crate_name = "rara_wasm_core",
+    edition = "2024",
+    deps = all_crate_deps(normal = True) + [
+        "//crates/rara-apply-patch:rara_apply_patch",
+    ],
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+)
+
+rust_test(
+    name = "rara_wasm_core_tests",
+    crate = ":rara_wasm_core",
+    aliases = aliases(
+        normal_dev = True,
+        proc_macro_dev = True,
+    ),
+    edition = "2024",
+    deps = all_crate_deps(normal_dev = True) + [
+        "//crates/rara-apply-patch:rara_apply_patch",
+    ],
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+)

--- a/crates/rara-wasm-core/Cargo.toml
+++ b/crates/rara-wasm-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rara-wasm-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Pure WASM-oriented core helpers for RARA clients"
+
+[dependencies]
+rara-apply-patch = { path = "../rara-apply-patch" }
+serde.workspace = true
+serde_json.workspace = true
+thiserror = "2"

--- a/crates/rara-wasm-core/src/lib.rs
+++ b/crates/rara-wasm-core/src/lib.rs
@@ -1,0 +1,298 @@
+//! Pure RARA core APIs intended for browser and worker integration.
+
+use std::collections::BTreeMap;
+
+use rara_apply_patch::{
+    PatchActionStats as ApplyPatchActionStats, PatchChange as ApplyPatchChange,
+    PatchError as ApplyPatchError, build_patch_action,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WasmCoreError {
+    #[error("patch preview failed: {0}")]
+    PatchPreview(String),
+}
+
+impl From<ApplyPatchError> for WasmCoreError {
+    fn from(error: ApplyPatchError) -> Self {
+        Self::PatchPreview(error.to_string())
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct VirtualFileSet {
+    #[serde(default)]
+    pub files: BTreeMap<String, String>,
+}
+
+impl VirtualFileSet {
+    pub fn get(&self, path: &str) -> Option<&String> {
+        self.files.get(path)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PatchPreviewRequest {
+    pub patch: String,
+    #[serde(default)]
+    pub files: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PatchPreview {
+    pub summary: Vec<String>,
+    pub stats: PatchActionStats,
+    pub preview: PatchTextPreview,
+    pub delta: VirtualPatchDelta,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct VirtualPatchDelta {
+    pub exact: bool,
+    pub changes: Vec<VirtualPatchChange>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct VirtualPatchChange {
+    pub path: String,
+    #[serde(flatten)]
+    pub change: VirtualPatchFileChange,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum VirtualPatchFileChange {
+    Add {
+        content: String,
+        overwritten_content: Option<String>,
+    },
+    Delete {
+        content: String,
+    },
+    Update {
+        move_to: Option<String>,
+        original_content: String,
+        overwritten_move_content: Option<String>,
+        new_content: String,
+    },
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PatchActionStats {
+    pub files_changed: usize,
+    pub hunks_applied: usize,
+    pub added_lines: usize,
+    pub removed_lines: usize,
+    pub created_files: Vec<String>,
+    pub deleted_files: Vec<String>,
+    pub moved_files: Vec<PatchMove>,
+    pub updated_files: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PatchMove {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct PatchTextPreview {
+    pub text: String,
+    pub truncated: bool,
+}
+
+pub fn preview_patch(request: PatchPreviewRequest) -> Result<PatchPreview, WasmCoreError> {
+    preview_patch_with_files(request.patch, request.files)
+}
+
+pub fn preview_patch_with_files(
+    patch: impl Into<String>,
+    files: BTreeMap<String, String>,
+) -> Result<PatchPreview, WasmCoreError> {
+    let patch = patch.into();
+    let action = build_patch_action(&patch, |path| Ok(files.get(path).cloned()))?;
+    let delta = VirtualPatchDelta {
+        exact: true,
+        changes: action
+            .changes
+            .iter()
+            .map(|change| virtual_patch_change(change, &files))
+            .collect(),
+    };
+
+    Ok(PatchPreview {
+        summary: action.summary(),
+        stats: patch_action_stats(action.stats),
+        preview: PatchTextPreview {
+            text: action.preview.text,
+            truncated: action.preview.truncated,
+        },
+        delta,
+    })
+}
+
+fn virtual_patch_change(
+    change: &ApplyPatchChange,
+    files: &BTreeMap<String, String>,
+) -> VirtualPatchChange {
+    match change {
+        ApplyPatchChange::Add { path, content, .. } => VirtualPatchChange {
+            path: path.clone(),
+            change: VirtualPatchFileChange::Add {
+                content: content.clone(),
+                overwritten_content: files.get(path).cloned(),
+            },
+        },
+        ApplyPatchChange::Delete { path, content, .. } => VirtualPatchChange {
+            path: path.clone(),
+            change: VirtualPatchFileChange::Delete {
+                content: content.clone(),
+            },
+        },
+        ApplyPatchChange::Update {
+            path,
+            move_to,
+            original_content,
+            new_content,
+            ..
+        } => VirtualPatchChange {
+            path: path.clone(),
+            change: VirtualPatchFileChange::Update {
+                move_to: move_to.clone(),
+                original_content: original_content.clone(),
+                overwritten_move_content: move_to
+                    .as_ref()
+                    .and_then(|target| files.get(target))
+                    .cloned(),
+                new_content: new_content.clone(),
+            },
+        },
+    }
+}
+
+fn patch_action_stats(stats: ApplyPatchActionStats) -> PatchActionStats {
+    PatchActionStats {
+        files_changed: stats.files_changed,
+        hunks_applied: stats.hunks_applied,
+        added_lines: stats.added_lines,
+        removed_lines: stats.removed_lines,
+        created_files: stats.created_files,
+        deleted_files: stats.deleted_files,
+        moved_files: stats
+            .moved_files
+            .into_iter()
+            .map(|move_entry| PatchMove {
+                from: move_entry.from,
+                to: move_entry.to,
+            })
+            .collect(),
+        updated_files: stats.updated_files,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde_json::json;
+
+    use super::{
+        PatchPreviewRequest, VirtualPatchFileChange, WasmCoreError, preview_patch,
+        preview_patch_with_files,
+    };
+
+    #[test]
+    fn previews_patch_as_serializable_virtual_delta() {
+        let files = BTreeMap::from([
+            ("old.txt".to_string(), "obsolete\n".to_string()),
+            ("src.txt".to_string(), "before\n".to_string()),
+            ("dst.txt".to_string(), "existing target\n".to_string()),
+        ]);
+        let preview = preview_patch_with_files(
+            "*** Begin Patch\n\
+             *** Add File: new.txt\n\
+             +created\n\
+             *** Delete File: old.txt\n\
+             *** Update File: src.txt\n\
+             *** Move to: dst.txt\n\
+             @@\n\
+             -before\n\
+             +after\n\
+             *** End Patch",
+            files,
+        )
+        .expect("patch previews");
+
+        assert_eq!(
+            preview.summary,
+            vec![
+                "Add file new.txt",
+                "Delete file old.txt",
+                "Update file src.txt -> dst.txt",
+            ]
+        );
+        assert_eq!(preview.stats.files_changed, 3);
+        assert_eq!(preview.stats.added_lines, 2);
+        assert_eq!(preview.stats.removed_lines, 2);
+        assert!(preview.delta.exact);
+        assert_eq!(preview.delta.changes.len(), 3);
+        assert!(matches!(
+            &preview.delta.changes[2].change,
+            VirtualPatchFileChange::Update {
+                move_to: Some(target),
+                original_content,
+                overwritten_move_content: Some(overwritten),
+                new_content,
+            } if target == "dst.txt"
+                && original_content == "before\n"
+                && overwritten == "existing target\n"
+                && new_content == "after\n"
+        ));
+
+        let value = serde_json::to_value(&preview.delta.changes[2]).expect("serializes");
+        assert_eq!(
+            value,
+            json!({
+                "path": "src.txt",
+                "kind": "update",
+                "move_to": "dst.txt",
+                "original_content": "before\n",
+                "overwritten_move_content": "existing target\n",
+                "new_content": "after\n",
+            })
+        );
+    }
+
+    #[test]
+    fn previews_request_payload() {
+        let preview = preview_patch(PatchPreviewRequest {
+            patch: "*** Begin Patch\n*** Add File: note.txt\n+hello\n*** End Patch".to_string(),
+            files: BTreeMap::new(),
+        })
+        .expect("patch previews");
+
+        assert_eq!(preview.delta.changes.len(), 1);
+        assert_eq!(preview.stats.created_files, vec!["note.txt"]);
+    }
+
+    #[test]
+    fn rejects_missing_update_target() {
+        let error = preview_patch_with_files(
+            "*** Begin Patch\n\
+             *** Update File: missing.txt\n\
+             @@\n\
+             -old\n\
+             +new\n\
+             *** End Patch",
+            BTreeMap::new(),
+        )
+        .expect_err("missing update target fails");
+
+        assert_eq!(
+            error,
+            WasmCoreError::PatchPreview("Cannot update missing file missing.txt".to_string())
+        );
+    }
+}

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -68,6 +68,8 @@ future appserver integrations can use.
   dispatch, and hook output context injection boundaries.
 - `tui-theme-tokens.md`: configurable semantic TUI theme tokens, renderer
   integration, and embedded syntax theme selection.
+- `wasm-core.md`: pure Rust browser/worker core boundary for deterministic
+  patch preview and future protocol/reducer logic.
 
 ## App Server Architecture
 

--- a/docs/features/wasm-core.md
+++ b/docs/features/wasm-core.md
@@ -1,0 +1,100 @@
+# WASM Core
+
+## Problem
+
+RARA has native runtime capabilities that cannot be compiled directly into a
+browser or worker target: PTY management, process execution, local filesystem
+mutation, SQLite-backed persistence, MCP/LSP transports, and terminal UI
+rendering. Browser clients still need a small, deterministic subset of RARA
+logic so they can preview user-visible effects before delegating native work to
+the runtime.
+
+## Scope
+
+- Introduce `rara-wasm-core` as a pure Rust crate for browser- and
+  worker-oriented logic.
+- Expose structured patch preview and virtual patch delta construction.
+- Keep the initial API independent of JavaScript binding tools so it remains
+  usable from Rust tests and future `wasm-bindgen` adapters.
+- Reuse `rara-apply-patch` as the source of truth for parsing and applying the
+  structured patch format.
+
+## Non-Goals
+
+- Compiling the full `rara` CLI/TUI binary to WASM.
+- Running tools, shell commands, PTYs, MCP servers, LSP processes, SQLite, or
+  local model execution in WASM.
+- Adding a JavaScript package or generated bindings in this phase.
+- Replacing native `apply_patch` execution. The WASM API only previews a
+  virtual file set.
+
+## Architecture
+
+`rara-wasm-core` is a leaf crate over pure logic crates. Its first contract is
+patch preview:
+
+1. A caller submits a patch string plus a virtual file map.
+2. The crate delegates parsing and hunk application to `rara-apply-patch`.
+3. The crate returns summary lines, action stats, bounded text preview, and a
+   serializable virtual delta.
+
+The virtual delta mirrors the native `AppliedPatchDelta` shape used by the
+tool layer, but it is computed without touching the host filesystem. This keeps
+browser clients and native tools aligned on the same patch semantics while
+preserving the native runtime as the authority for actual mutation.
+
+## Contracts
+
+### `PatchPreviewRequest`
+
+- `patch`: structured RARA patch text.
+- `files`: map from path to current file content.
+
+### `PatchPreview`
+
+- `summary`: human-readable operation summaries.
+- `stats`: file, hunk, added-line, removed-line, created, deleted, moved, and
+  updated counts.
+- `preview`: bounded patch text preview and truncation flag.
+- `delta`: exact virtual patch delta.
+
+### `VirtualPatchDelta`
+
+- `exact`: always `true` for successful pure previews because every input file
+  is supplied by the request.
+- `changes`: ordered patch changes.
+
+### `VirtualPatchFileChange`
+
+- `add`: new content plus optional overwritten virtual content.
+- `delete`: removed virtual content.
+- `update`: original content, optional move target, optional overwritten move
+  target content, and new content.
+
+Errors are surfaced as `WasmCoreError::PatchPreview` and preserve the
+underlying patch failure message.
+
+## Validation Matrix
+
+- `cargo test -p rara-wasm-core`
+  - serializable virtual delta for add, delete, update, and move operations;
+  - request payload wrapper behavior;
+  - missing update target failure.
+- `cargo check -p rara-wasm-core`
+  - verifies the new crate independently of native-only dependencies.
+- `bazel test //crates/rara-wasm-core:rara_wasm_core_tests`
+  - verifies the Bazel target mirrors Cargo wiring.
+- Future `wasm32-unknown-unknown` check
+  - should be added once CI installs the target and binding requirements are
+    settled.
+
+## Open Risks
+
+- The initial crate is WASM-oriented pure Rust, not yet a published JS package.
+- The repository still needs CI coverage for `wasm32-unknown-unknown`.
+- Future APIs must avoid accidentally depending on native-only crates through
+  convenience imports.
+
+## Source Journals
+
+- `docs/journal/2026-08-08-wasm-core-patch-preview.md`

--- a/docs/journal/2026-08-08-wasm-core-patch-preview.md
+++ b/docs/journal/2026-08-08-wasm-core-patch-preview.md
@@ -1,0 +1,52 @@
+# WASM Core Patch Preview
+
+## Summary
+
+Added `rara-wasm-core` as the first pure logic crate for future browser and
+worker integrations. The initial API exposes structured patch preview over a
+virtual file set and returns a serializable virtual delta aligned with the
+native patch application delta.
+
+## Background
+
+The full RARA runtime depends on native capabilities such as terminal control,
+process execution, local filesystem mutation, SQLite persistence, MCP/LSP
+processes, and local model runtimes. Those capabilities should remain in the
+native runtime. The WASM boundary should carry deterministic reducers,
+protocol helpers, validation, and preview logic that can be tested without host
+side effects.
+
+## Scope
+
+- Added `crates/rara-wasm-core`.
+- Reused `rara-apply-patch` for patch parsing, hunk validation, and text
+  application.
+- Added `PatchPreviewRequest`, `PatchPreview`, `VirtualPatchDelta`, and
+  serializable virtual patch change types.
+- Added focused unit tests for successful multi-operation preview and missing
+  update target failure.
+- Documented the WASM core boundary in `docs/features/wasm-core.md`.
+
+## Key Decisions
+
+- The crate does not depend on `wasm-bindgen` yet. The Rust API is the stable
+  internal boundary; JavaScript bindings can wrap it when a concrete browser
+  consumer exists.
+- Patch preview is dry-run only. Actual filesystem mutation remains native and
+  continues to use the tool-layer `AppliedPatchDelta`.
+- Successful virtual deltas are exact because all readable state is supplied by
+  the request payload.
+
+## Validation
+
+- `cargo test -p rara-wasm-core`
+- `cargo check -p rara-wasm-core`
+- `bazel test //crates/rara-wasm-core:rara_wasm_core_tests`
+- `git diff --check`
+
+## Follow-Ups
+
+- Add CI coverage for `wasm32-unknown-unknown` after the target is installed
+  in CI.
+- Add a JavaScript binding package around `rara-wasm-core` when there is a
+  browser client ready to consume it.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -181,6 +181,12 @@ Active backlog only. Keep this file small and current.
 - [ ] Decide whether to keep or migrate away the deprecated
       `local_embeddings` config field.
 
+## WASM Core
+
+- [ ] Add `wasm32-unknown-unknown` CI once the Rust target is installed in CI.
+- [ ] Add a JavaScript binding package around `rara-wasm-core` when a browser
+      client is ready to consume it.
+
 ## Provider Catalog
 
 - [x] Enrich connected DeepSeek/Kimi model lists with static and API-provided


### PR DESCRIPTION
## Summary

- add `rara-wasm-core` as a pure Rust crate for browser/worker-oriented logic
- expose structured patch preview over a virtual file set with a serializable virtual delta
- add Cargo/Bazel wiring, focused tests, feature spec, journal note, and WASM follow-up TODOs

## Purpose

This keeps WASM support scoped to deterministic pure logic instead of trying to compile the native CLI/TUI runtime. The first supported boundary is patch preview, reusing `rara-apply-patch` as the source of truth while leaving actual filesystem mutation in the native runtime.

## Related issues

- None

## Testing

- `cargo fmt --all`
- `cargo test -p rara-wasm-core`
- `cargo check -p rara-wasm-core`
- `bazel test //crates/rara-wasm-core:rara_wasm_core_tests`
- `git diff --check`

## Notes

- `wasm32-unknown-unknown` was not installed in the local toolchain, so the PR records CI target coverage as a follow-up instead of installing toolchain state locally.
