### PR TITLE
chore(release): keep v prefix in release title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,7 +365,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          name: ${{ needs.tag-check.outputs.version }}
+          name: ${{ needs.tag-check.outputs.tag }}
           tag_name: ${{ needs.tag-check.outputs.tag }}
           generate_release_notes: true
           prerelease: ${{ needs.tag-check.outputs.prerelease }}


### PR DESCRIPTION
## Summary

- use the validated release tag as the GitHub Release title
- keep `tag_name` unchanged so releases still attach to the same `vX.Y.Z` tag

## Purpose

Release tags already use the `vX.Y.Z` format, but the workflow previously used the stripped Cargo version as the GitHub Release title. This makes a release for `v0.0.16` display as `v0.0.16` instead of `0.0.16`.

## Related issues

- None

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts ".github/workflows/release.yml ok"'`
- `git diff --check`

## Notes

- No release tag was created or dispatched.
