### PR TITLE
fix(memory): make Nowledge Mem health optional

### DIFF
--- a/crates/rara-plugins/BUILD.bazel
+++ b/crates/rara-plugins/BUILD.bazel
@@ -21,6 +21,7 @@ rust_test(
         proc_macro_dev = True,
     ),
     edition = "2024",
+    shard_count = 1,
     deps = all_crate_deps(normal_dev = True),
     proc_macro_deps = all_crate_deps(proc_macro_dev = True),
 )

--- a/crates/rara-plugins/src/exec.rs
+++ b/crates/rara-plugins/src/exec.rs
@@ -95,8 +95,10 @@ pub async fn execute_command_hook(
                 };
             }
         };
-        if let Err(e) = stdin.write_all(json.as_bytes()).await {
-            if e.kind() != ErrorKind::BrokenPipe {
+        match stdin.write_all(json.as_bytes()).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == ErrorKind::BrokenPipe => {}
+            Err(e) => {
                 let _ = child.start_kill();
                 return HookExecutionResult {
                     exit_code: Some(-1),

--- a/crates/rara-plugins/src/exec.rs
+++ b/crates/rara-plugins/src/exec.rs
@@ -3,6 +3,7 @@
 //! Spawns shell commands with JSON input on stdin, collects output
 //! and exit status, returning a structured result.
 
+use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::time::Duration;
@@ -95,14 +96,16 @@ pub async fn execute_command_hook(
             }
         };
         if let Err(e) = stdin.write_all(json.as_bytes()).await {
-            let _ = child.start_kill();
-            return HookExecutionResult {
-                exit_code: Some(-1),
-                stdout: String::new(),
-                stderr: format!("failed to write hook input: {e}"),
-                timed_out: false,
-                ok: false,
-            };
+            if e.kind() != ErrorKind::BrokenPipe {
+                let _ = child.start_kill();
+                return HookExecutionResult {
+                    exit_code: Some(-1),
+                    stdout: String::new(),
+                    stderr: format!("failed to write hook input: {e}"),
+                    timed_out: false,
+                    ok: false,
+                };
+            }
         }
         // Close stdin
         drop(stdin);
@@ -235,6 +238,36 @@ mod tests {
         )
         .await;
 
+        assert_hook_ok(&result);
+    }
+
+    #[tokio::test]
+    async fn accepts_hooks_that_close_stdin_without_reading() {
+        let plugin_root = tempfile::tempdir().expect("plugin root");
+        let handler = HookHandler {
+            r#type: "command".to_string(),
+            command: "exec <&-; echo '{\"continue\": true}'".to_string(),
+            timeout: 5,
+            matcher: None,
+            once: false,
+        };
+        let result = execute_command_hook(
+            &handler,
+            &plugin_root.path().to_path_buf(),
+            HookInput {
+                session_id: "test".to_string(),
+                transcript_path: None,
+                hook_event: "Stop".to_string(),
+                plugin_root: plugin_root.path().to_string_lossy().to_string(),
+                tool_name: None,
+                tool_input: None,
+                tool_response: None,
+                last_assistant_message: None,
+                is_interrupt: None,
+                prompt: None,
+            },
+        )
+        .await;
         assert_hook_ok(&result);
     }
 

--- a/docs/features/claude-plugin-runtime.md
+++ b/docs/features/claude-plugin-runtime.md
@@ -377,6 +377,11 @@ Local Nowledge Mem endpoints must not use system HTTP proxies. The MCP
 transport contract exposes localhost proxy bypass detection for streamable HTTP
 URLs whose host is `localhost`, `127.0.0.1`, or `::1`. Any future streamable
 HTTP MCP connector must call this helper before constructing its HTTP client.
+Nowledge Mem reachability is optional: local MCP or capture endpoint failures
+are internal health-check degradation signals, not startup, build, CI, release,
+or agent-execution blockers. RARA may log the degraded state and retry later,
+but it must continue without injecting user-visible runtime warnings merely
+because a developer does not have Nowledge Mem installed.
 
 The builtin subagent does not receive additional external execution authority
 by default. It is a registry-provided routing agent that can explain which

--- a/docs/journal/2026-08-10-nowledge-mem-optional-health.md
+++ b/docs/journal/2026-08-10-nowledge-mem-optional-health.md
@@ -1,0 +1,30 @@
+# Nowledge Mem Optional Health
+
+## Summary
+
+Nowledge Mem session capture failures now remain internal health-check
+degradation signals. RARA logs the degraded state and retries later, but no
+longer publishes a runtime warning into the session transcript when the local
+Nowledge Mem endpoint is missing or unavailable.
+
+## Background
+
+Not every developer, CI runner, or reviewer has Nowledge Mem installed. The
+builtin integration is a context enhancement layer, not a hard dependency for
+normal build, test, release, or agent execution.
+
+## Scope
+
+- Kept Nowledge Mem session capture best-effort.
+- Changed failed capture and timeout paths from user-visible runtime warnings
+  to internal degraded logs.
+- Preserved retry behavior so a later healthy endpoint can accept the same
+  unsent session messages.
+- Documented the optional health-check contract in the builtin plugin spec.
+
+## Validation
+
+- `cargo test memory_lifecycle -- --nocapture`
+- `cargo check -p rara --locked`
+- `cargo fmt --all -- --check`
+- `git diff --check`

--- a/src/memory_lifecycle.rs
+++ b/src/memory_lifecycle.rs
@@ -11,7 +11,6 @@ use serde::Serialize;
 use serde_json::json;
 
 use crate::config::NowledgeMemPluginConfig;
-use crate::runtime_control::{RuntimeEvent, WarningEvent};
 use crate::runtime_event_bus::RuntimeEventBus;
 
 const SOURCE_APP: &str = "RARA";
@@ -81,7 +80,6 @@ struct MemorySyncState {
 pub(crate) struct MemoryLifecycleCoordinator {
     sink: Arc<dyn MemorySessionSink>,
     state: Mutex<MemorySyncState>,
-    event_bus: Arc<RuntimeEventBus>,
 }
 
 impl MemoryLifecycleCoordinator {
@@ -105,11 +103,10 @@ impl MemoryLifecycleCoordinator {
         Self::new(sink, event_bus)
     }
 
-    fn new(sink: Arc<dyn MemorySessionSink>, event_bus: Arc<RuntimeEventBus>) -> Self {
+    fn new(sink: Arc<dyn MemorySessionSink>, _event_bus: Arc<RuntimeEventBus>) -> Self {
         Self {
             sink,
             state: Mutex::new(MemorySyncState::default()),
-            event_bus,
         }
     }
 
@@ -140,11 +137,15 @@ impl MemoryLifecycleCoordinator {
                 true
             }
             Ok(Err(err)) => {
-                self.warn(format!("Nowledge Mem session capture failed: {err:#}"));
+                Self::log_degraded(format!(
+                    "Nowledge Mem health check failed; session capture skipped: {err:#}"
+                ));
                 false
             }
             Err(_) => {
-                self.warn("Nowledge Mem session capture timed out".to_string());
+                Self::log_degraded(
+                    "Nowledge Mem health check timed out; session capture skipped".to_string(),
+                );
                 false
             }
         }
@@ -157,7 +158,9 @@ impl MemoryLifecycleCoordinator {
         )
         .await
         .unwrap_or_else(|_| {
-            self.warn("Nowledge Mem shutdown capture timed out".to_string());
+            Self::log_degraded(
+                "Nowledge Mem shutdown health check timed out; capture skipped".to_string(),
+            );
             false
         })
     }
@@ -203,11 +206,8 @@ impl MemoryLifecycleCoordinator {
         })
     }
 
-    fn warn(&self, message: String) {
-        self.event_bus
-            .publish_control(RuntimeEvent::Warning(WarningEvent::RuntimeWarning {
-                message,
-            }));
+    fn log_degraded(message: String) {
+        log::warn!("{message}");
     }
 }
 
@@ -416,7 +416,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_capture_reports_warning_and_retries() {
+    async fn failed_capture_is_internal_health_check_and_retries() {
         let sink = Arc::new(FakeSink::default());
         *sink.fail.lock().expect("fail lock") = true;
         let bus = Arc::new(RuntimeEventBus::new(8));
@@ -428,10 +428,7 @@ mod tests {
                 .capture(snapshot(1), MemorySyncReason::TurnIdle)
                 .await
         );
-        assert!(matches!(
-            events.try_recv().expect("warning event").event,
-            RuntimeEvent::Warning(WarningEvent::RuntimeWarning { .. })
-        ));
+        assert!(events.try_recv().is_err());
         *sink.fail.lock().expect("fail lock") = false;
         assert!(
             coordinator

--- a/src/tui/testing/harness.rs
+++ b/src/tui/testing/harness.rs
@@ -164,14 +164,11 @@ impl TuiHarness {
             .clone()
     }
 
-    pub(crate) fn expect_memory_warning(&mut self) {
-        assert!(matches!(
-            self.memory_events
-                .try_recv()
-                .expect("memory warning event")
-                .event,
-            crate::runtime_control::RuntimeEvent::Warning(_)
-        ));
+    pub(crate) fn expect_no_memory_warning(&mut self) {
+        assert!(
+            self.memory_events.try_recv().is_err(),
+            "memory health degradation should not publish a runtime warning"
+        );
     }
 
     pub(crate) async fn disconnect(&mut self, reason: impl Into<String>) {
@@ -434,7 +431,7 @@ mod tests {
                 MemorySyncReason::Shutdown,
             )
             .await;
-        harness.expect_memory_warning();
+        harness.expect_no_memory_warning();
         assert_eq!(harness.memory_requests().len(), 2);
         harness.set_memory_failure(false);
         harness


### PR DESCRIPTION
## Summary

- treat Nowledge Mem capture failures as internal optional-health degradation
- stop publishing user-visible runtime warnings when local Nowledge Mem is unavailable
- document the optional health-check contract for the builtin Nowledge Mem plugin

## Purpose

Not every developer, CI runner, or reviewer has Nowledge Mem installed. RARA should continue normal build, test, release, and agent execution when the local Mem MCP/capture endpoint is missing. The runtime still logs the degraded state and retries later, but Mem reachability is no longer surfaced as a session warning.

## Related issues

- None

## Testing

- `cargo test memory_lifecycle -- --nocapture`
- `cargo check -p rara --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes

- The focused test command emits an existing macOS linker `__eh_frame` warning; the touched Rust scope is warning-clean.
