### PR TITLE
chore: bump version to 0.0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8895,7 +8895,7 @@ dependencies = [
 
 [[package]]
 name = "rara"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -8976,7 +8976,7 @@ dependencies = [
 
 [[package]]
 name = "rara-app-server"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "rara-instructions",
  "serde",
@@ -8985,14 +8985,14 @@ dependencies = [
 
 [[package]]
 name = "rara-apply-patch"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "rara-background-tasks"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "async-trait",
  "libc",
@@ -9007,7 +9007,7 @@ dependencies = [
 
 [[package]]
 name = "rara-bedrock"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9018,7 +9018,7 @@ dependencies = [
 
 [[package]]
 name = "rara-config"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "codex-execpolicy",
@@ -9031,7 +9031,7 @@ dependencies = [
 
 [[package]]
 name = "rara-core"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -9039,7 +9039,7 @@ dependencies = [
 
 [[package]]
 name = "rara-file-search"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "ignore",
@@ -9050,7 +9050,7 @@ dependencies = [
 
 [[package]]
 name = "rara-instructions"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -9060,7 +9060,7 @@ dependencies = [
 
 [[package]]
 name = "rara-mcp-client"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "rmcp",
@@ -9070,7 +9070,7 @@ dependencies = [
 
 [[package]]
 name = "rara-memory"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "fs2",
@@ -9085,14 +9085,14 @@ dependencies = [
 
 [[package]]
 name = "rara-observability"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "rara-persistence"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "fs2",
@@ -9107,7 +9107,7 @@ dependencies = [
 
 [[package]]
 name = "rara-plugins"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -9117,7 +9117,7 @@ dependencies = [
 
 [[package]]
 name = "rara-provider-catalog"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -9130,7 +9130,7 @@ dependencies = [
 
 [[package]]
 name = "rara-sandbox"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -9141,7 +9141,7 @@ dependencies = [
 
 [[package]]
 name = "rara-skills"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "serde",
@@ -9150,7 +9150,7 @@ dependencies = [
 
 [[package]]
 name = "rara-state"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "rara-config",
@@ -9163,11 +9163,11 @@ dependencies = [
 
 [[package]]
 name = "rara-terminal-detection"
-version = "0.0.16"
+version = "0.0.19"
 
 [[package]]
 name = "rara-tool-macros"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9176,7 +9176,7 @@ dependencies = [
 
 [[package]]
 name = "rara-tools"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9196,7 +9196,7 @@ dependencies = [
 
 [[package]]
 name = "rara-wasm-core"
-version = "0.0.16"
+version = "0.0.19"
 dependencies = [
  "rara-apply-patch",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.16"
+version = "0.0.19"
 edition = "2024"
 license = "Apache-2.0"
 


### PR DESCRIPTION
## Summary

- bump the workspace package version from `0.0.16` to `0.0.19`
- refresh `Cargo.lock` so every workspace crate records the same version

## Purpose

Prepare the repository for the `v0.0.19` release tag while keeping Cargo package metadata and the lockfile consistent.

## Related issue

None.

## Validation

- `cargo fmt --all --check`
- `cargo check -p rara --locked --offline`