### PR TITLE
fix(tui): route connect credentials by provider

### DIFF
--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -595,6 +595,31 @@ impl RaraConfig {
         }
     }
 
+    pub fn set_provider_api_key(&mut self, provider: &str, value: impl Into<String>) {
+        let value = value.into();
+        if let Some(kind) = OpenAiEndpointKind::from_legacy_provider(provider) {
+            if self.provider == provider
+                || (self.provider == "openai-compatible"
+                    && self.active_openai_profile_kind() == Some(kind))
+            {
+                self.set_api_key(value);
+            } else {
+                let mut profile = self.profile_for_kind_or_default(kind);
+                profile.api_key = Some(SecretString::from(value));
+                self.openai_profiles.insert(profile.id.clone(), profile);
+            }
+            return;
+        }
+        if self.provider == provider {
+            self.set_api_key(value);
+            return;
+        }
+        self.provider_states
+            .entry(provider.to_string())
+            .or_default()
+            .api_key = Some(SecretString::from(value));
+    }
+
     pub fn set_provider(&mut self, provider: impl Into<String>) {
         self.sync_active_provider_state();
         let provider = provider.into();
@@ -1305,6 +1330,36 @@ mod tests {
 
         assert_eq!(restored.api_key(), Some("sk-test-value"));
         assert!(restored.has_api_key());
+    }
+
+    #[test]
+    fn setting_inactive_provider_api_key_preserves_active_provider_credentials() {
+        let mut config = RaraConfig {
+            provider: "codex".to_string(),
+            ..Default::default()
+        };
+        config.set_api_key("sk-codex");
+
+        config.set_provider_api_key("kimi", "sk-kimi");
+
+        assert_eq!(config.provider, "codex");
+        assert_eq!(config.api_key(), Some("sk-codex"));
+        let kimi_profile = config
+            .openai_profiles
+            .get(OpenAiEndpointKind::Kimi.default_profile_id())
+            .expect("Kimi profile");
+        assert_eq!(
+            kimi_profile
+                .api_key
+                .as_ref()
+                .map(ExposeSecret::expose_secret),
+            Some("sk-kimi")
+        );
+        assert_eq!(
+            kimi_profile.base_url.as_deref(),
+            Some(DEFAULT_KIMI_BASE_URL)
+        );
+        assert_eq!(kimi_profile.model.as_deref(), Some(DEFAULT_KIMI_MODEL));
     }
 
     #[test]

--- a/docs/features/provider-connection-redesign.md
+++ b/docs/features/provider-connection-redesign.md
@@ -55,6 +55,12 @@ configuration flow or its management view.
   connected" notice; model selection remains in `/model`.
 - API key, browser OAuth, device-code OAuth, endpoint URL, and profile details
   are `/connect` steps, not top-level commands.
+- Selecting a provider captures an immutable credential target for the rest of
+  that connection step. Prompt copy, validation, persistence, and model-catalog
+  refresh must use that target; they must not infer it from the currently
+  active model or provider.
+- Saving credentials for an inactive provider must not overwrite that active
+  provider's credentials or change the active provider/model selection.
 
 ### `/model`
 
@@ -89,6 +95,9 @@ Credential presence alone is not presented as verified availability.
 | --- | --- |
 | Command surface contains only the two provider entry points | Focused command parsing and palette tests |
 | `/connect` opens provider setup | Focused TUI state/event test |
+| Provider-specific API-key copy follows the captured connection target | Focused render test with a different active provider |
+| Saving an inactive provider key preserves the active provider key | Config and TUI event regression tests |
+| Model-catalog refresh uses the target provider key and base URL | Focused runtime task routing test |
 | `/model` opens the sole searchable model picker | Focused TUI state/event test |
 | Removed commands are not accepted by the TUI parser | Focused command tests |
 | Provider/model selection remains session-stable | Existing rebuild and runtime snapshot tests |
@@ -113,3 +122,4 @@ availability projection alongside model catalogs.
 
 - `docs/journal/2026-08-14-provider-entrypoint-consolidation.md`
 - `docs/journal/2026-08-04-provider-model-catalog.md`
+- `docs/journal/2026-08-15-provider-credential-targeting.md`

--- a/docs/journal/2026-08-15-provider-credential-targeting.md
+++ b/docs/journal/2026-08-15-provider-credential-targeting.md
@@ -1,0 +1,64 @@
+# 2026-08-15 Provider Credential Targeting
+
+## Summary
+
+The TUI API-key flow now carries an explicit provider target from `/connect`
+through prompt rendering, credential persistence, and model-catalog refresh.
+Choosing Kimi while Codex is active therefore shows Kimi copy and stores the
+key in the Kimi profile without overwriting the active Codex credential.
+
+## Background
+
+The API-key overlay previously inferred its provider from mutable TUI and
+configuration state. `/connect` could select Kimi while the active provider
+remained Codex, causing the modal to request a Codex key and the save handler
+to write the submitted value into Codex state.
+
+OpenCode avoids this ambiguity by carrying `providerID` or `integrationID` as
+an explicit connection-flow input. Its TUI `ApiMethodProps` sends that exact
+identifier to `auth.set`, and its app connection dialog sends the selected
+integration identifier with the API key. Codex and Claude Code have
+single-provider authentication flows, but likewise encode the selected auth
+method in typed flow state instead of reconstructing it from model state.
+
+## Scope
+
+- Added a typed API-key target to the setup overlay.
+- Made provider-specific modal copy exhaustive for Codex, DeepSeek, Kimi,
+  Gemini, and custom OpenAI-compatible profiles.
+- Added provider-scoped credential updates that preserve the active provider.
+- Routed model-catalog requests through a target-provider configuration copy so
+  API keys and base URLs cannot leak across providers.
+- Added config, render, event-flow, and runtime-routing regression coverage.
+
+## Key Decisions
+
+- Provider identity is captured when the connection step opens and remains the
+  authority for that step.
+- Credential storage remains in the existing `provider_states` and
+  `openai_profiles` compatibility model; this fix does not move provider state
+  ownership into the TUI.
+- Model-catalog routing switches only a cloned configuration to the target
+  provider. The user's active configuration remains unchanged.
+
+## Validation
+
+Validation commands:
+
+```bash
+cargo fmt --all
+cargo test -p rara-config setting_inactive_provider_api_key_preserves_active_provider_credentials
+cargo test kimi_api_key_editor_uses_explicit_target_when_codex_is_active
+cargo test kimi_connection_saves_to_kimi_without_overwriting_active_codex_key
+cargo test model_catalog_connection_uses_target_provider_credentials
+cargo test api_key
+cargo check --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
+git diff --check
+```
+
+## Follow-Ups
+
+No new follow-up is introduced. The existing provider-connection follow-up to
+move availability and authentication projection into the session-scoped
+runtime control plane remains applicable.

--- a/src/tui/event_dispatch.rs
+++ b/src/tui/event_dispatch.rs
@@ -16,8 +16,8 @@ use super::runtime::start_oauth_task;
 use super::runtime_port::{RuntimeClientPort, RuntimeCommand, RuntimeMaintenanceCommand};
 use super::session_restore::restore_thread_by_id;
 use super::state::{
-    ActivePendingInteractionKind, ListPickerKind, OpenAiModelPickerAction, Overlay, PermissionMode,
-    ProviderFamily, TuiApp,
+    ActivePendingInteractionKind, ApiKeyTarget, ListPickerKind, OpenAiModelPickerAction, Overlay,
+    PermissionMode, ProviderFamily, TuiApp,
 };
 use super::submit::{apply_openai_model_picker_action, handle_submit, handle_submit_with_port};
 use super::terminal_ui::is_ssh_session;
@@ -354,16 +354,18 @@ async fn dispatch_event_inner(
             }
         }
         AppEvent::SaveApiKeyInput => {
-            let value = app.api_key_input.trim();
+            let Some(Overlay::ApiKeyEditor(target)) = app.overlay else {
+                app.push_notice("API key editor is no longer active.");
+                return Ok(false);
+            };
+            let value = app.api_key_input.trim().to_string();
             if app.is_busy() {
                 app.push_notice("Wait for the current task before saving the API key.");
-            } else if value.is_empty() && app.config.provider == "codex" {
-                app.push_notice("Enter a Codex API key or press Esc to go back.");
-            } else if value.is_empty() && app.selected_provider_family() == ProviderFamily::DeepSeek
-            {
-                app.push_notice("Enter a DeepSeek API key or press Esc to go back.");
-            } else if value.is_empty() && app.selected_provider_family() == ProviderFamily::Kimi {
-                app.push_notice("Enter a Kimi API key or press Esc to go back.");
+            } else if value.is_empty() && target != ApiKeyTarget::OpenAiCompatible {
+                app.push_notice(format!(
+                    "Enter a {} API key or press Esc to go back.",
+                    target.label()
+                ));
             } else if value.is_empty() && app.openai_setup_keep_empty_api_key {
                 app.bottom_pane.notice =
                     Some("Kept existing API key for the current profile.".into());
@@ -381,22 +383,29 @@ async fn dispatch_event_inner(
                     app.advance_openai_profile_setup();
                 }
             } else {
-                let was_deepseek = app.selected_provider_family() == ProviderFamily::DeepSeek;
-                let was_kimi = app.selected_provider_family() == ProviderFamily::Kimi;
-                app.config.set_api_key(value.to_string());
-                if app.config.provider == "codex" {
+                let codex_is_active = app.config.provider == "codex";
+                match target {
+                    ApiKeyTarget::Codex => app.config.set_provider_api_key("codex", value),
+                    ApiKeyTarget::DeepSeek => app.config.set_provider_api_key("deepseek", value),
+                    ApiKeyTarget::Kimi => app.config.set_provider_api_key("kimi", value),
+                    ApiKeyTarget::OpenAiCompatible => app.config.set_api_key(value),
+                    ApiKeyTarget::Gemini => app.config.set_provider_api_key("gemini", value),
+                }
+                if target == ApiKeyTarget::Codex {
                     app.codex_auth_mode = Some(SavedCodexAuthMode::ApiKey);
-                    app.config
-                        .apply_codex_defaults_for_base_url(DEFAULT_CODEX_BASE_URL);
+                    if codex_is_active {
+                        app.config
+                            .apply_codex_defaults_for_base_url(DEFAULT_CODEX_BASE_URL);
+                    }
                 }
                 app.config_manager.save(&app.config)?;
-                if app.config.provider == "codex" {
+                if target == ApiKeyTarget::Codex && codex_is_active {
                     app.bottom_pane.notice =
                         Some("Saved Codex API key. Rebuilding backend.".into());
                     app.dismiss_overlay();
                     request_maintenance(app, runtime_port, RuntimeMaintenanceCommand::Rebuild)
                         .await?;
-                } else if was_deepseek {
+                } else if target == ApiKeyTarget::DeepSeek {
                     app.bottom_pane.notice = Some("Saved DeepSeek API key. Loading models.".into());
                     app.dismiss_overlay();
                     request_maintenance(
@@ -407,7 +416,7 @@ async fn dispatch_event_inner(
                         ),
                     )
                     .await?;
-                } else if was_kimi {
+                } else if target == ApiKeyTarget::Kimi {
                     app.bottom_pane.notice = Some("Saved Kimi API key. Loading models.".into());
                     app.dismiss_overlay();
                     request_maintenance(
@@ -417,7 +426,18 @@ async fn dispatch_event_inner(
                     )
                     .await?;
                 } else {
-                    app.bottom_pane.notice = Some("Saved API key for the current provider.".into());
+                    app.bottom_pane.notice = Some(
+                        match target {
+                            ApiKeyTarget::Codex => "Saved Codex API key.",
+                            ApiKeyTarget::DeepSeek => "Saved DeepSeek API key.",
+                            ApiKeyTarget::Kimi => "Saved Kimi API key.",
+                            ApiKeyTarget::OpenAiCompatible => {
+                                "Saved API key for the current endpoint profile."
+                            }
+                            ApiKeyTarget::Gemini => "Saved Gemini API key.",
+                        }
+                        .into(),
+                    );
                     if app.openai_setup_steps.is_empty() {
                         app.dismiss_overlay();
                     } else {
@@ -624,7 +644,7 @@ async fn dispatch_event_inner(
                                 }
                             } else if app.selected_provider_family() == ProviderFamily::DeepSeek {
                                 if app.selected_deepseek_api_key_action() {
-                                    app.open_overlay(Overlay::ApiKeyEditor);
+                                    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::DeepSeek));
                                 } else if app.config.has_api_key() {
                                     app.select_local_model(app.model_picker_idx);
                                     app.config.reasoning_effort = Some("max".to_string());
@@ -635,11 +655,11 @@ async fn dispatch_event_inner(
                                     )
                                     .await?;
                                 } else {
-                                    app.open_overlay(Overlay::ApiKeyEditor);
+                                    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::DeepSeek));
                                 }
                             } else if app.selected_provider_family() == ProviderFamily::Kimi {
                                 if app.selected_kimi_api_key_action() {
-                                    app.open_overlay(Overlay::ApiKeyEditor);
+                                    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::Kimi));
                                 } else if app.config.has_api_key() {
                                     app.select_local_model(app.model_picker_idx);
                                     request_maintenance(
@@ -649,7 +669,7 @@ async fn dispatch_event_inner(
                                     )
                                     .await?;
                                 } else {
-                                    app.open_overlay(Overlay::ApiKeyEditor);
+                                    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::Kimi));
                                 }
                             } else {
                                 app.select_local_model(app.model_picker_idx);
@@ -701,12 +721,14 @@ async fn dispatch_event_inner(
                                 {
                                     app.begin_active_openai_profile_setup();
                                 }
-                                ProviderFamily::DeepSeek
-                                | ProviderFamily::Kimi
-                                | ProviderFamily::Gemini
-                                    if !app.config.has_api_key() =>
-                                {
-                                    app.open_overlay(Overlay::ApiKeyEditor);
+                                ProviderFamily::DeepSeek if !app.config.has_api_key() => {
+                                    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::DeepSeek))
+                                }
+                                ProviderFamily::Kimi if !app.config.has_api_key() => {
+                                    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::Kimi))
+                                }
+                                ProviderFamily::Gemini if !app.config.has_api_key() => {
+                                    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::Gemini))
                                 }
                                 ProviderFamily::CandleLocal => {
                                     app.push_notice("Local models (alpha) are for preview only.");
@@ -743,7 +765,7 @@ async fn dispatch_event_inner(
                                     super::state::OAuthLoginMode::DeviceCode,
                                 );
                             }
-                            2 => app.open_overlay(Overlay::ApiKeyEditor),
+                            2 => app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::Codex)),
                             3 => {
                                 let removed = oauth_manager.clear_saved_auth()?;
                                 app.config.clear_provider_api_key("codex");

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -88,7 +88,7 @@ pub(crate) fn map_key_to_event(key: KeyEvent, app: &TuiApp) -> AppEvent {
             KeyCode::Char(c) => AppEvent::InputChar(c),
             _ => AppEvent::Noop,
         },
-        Some(Overlay::ApiKeyEditor) => match code {
+        Some(Overlay::ApiKeyEditor(_)) => match code {
             KeyCode::Esc => AppEvent::CloseOverlay,
             KeyCode::Enter => AppEvent::SaveApiKeyInput,
             KeyCode::Left => AppEvent::MoveCursorLeft,

--- a/src/tui/provider_flow.rs
+++ b/src/tui/provider_flow.rs
@@ -1,6 +1,6 @@
 use secrecy::{ExposeSecret, SecretString};
 
-use super::state::{ListPickerKind, Overlay, ProviderFamily, TuiApp};
+use super::state::{ApiKeyTarget, ListPickerKind, Overlay, ProviderFamily, TuiApp};
 use crate::agent::Agent;
 use crate::config::{OpenAiEndpointKind, ensure_rara_home_dir};
 use crate::oauth::OAuthManager;
@@ -126,12 +126,16 @@ pub(super) fn open_provider_connection(app: &mut TuiApp) {
     let label = super::state::PROVIDER_FAMILIES[app.provider_picker_idx].1;
 
     match family {
-        ProviderFamily::DeepSeek | ProviderFamily::Kimi => {
-            app.open_overlay(Overlay::ApiKeyEditor);
+        ProviderFamily::DeepSeek => {
+            app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::DeepSeek));
+            app.bottom_pane.notice = Some(format!("Enter your {label} API key."));
+        }
+        ProviderFamily::Kimi => {
+            app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::Kimi));
             app.bottom_pane.notice = Some(format!("Enter your {label} API key."));
         }
         ProviderFamily::Gemini => {
-            app.open_overlay(Overlay::ApiKeyEditor);
+            app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::Gemini));
             app.bottom_pane.notice = Some(format!("Enter your {label} API key."));
         }
         ProviderFamily::Codex => {

--- a/src/tui/render/overlay.rs
+++ b/src/tui/render/overlay.rs
@@ -86,13 +86,13 @@ pub(super) fn render_overlay(f: &mut Frame, app: &TuiApp, overlay: Overlay) -> O
             f.render_widget(popup_block(), popup);
             render_base_url_editor_modal(f, app, inner)
         }
-        Overlay::ApiKeyEditor => {
+        Overlay::ApiKeyEditor(target) => {
             let popup = setup_flow_rect(f.area());
             render_dimmer(f, f.area());
             f.render_widget(Clear, popup);
             let inner = popup_block().inner(popup);
             f.render_widget(popup_block(), popup);
-            render_api_key_editor_modal(f, app, inner)
+            render_api_key_editor_modal(f, app, target, inner)
         }
         Overlay::ModelNameEditor => {
             let popup = setup_flow_rect(f.area());

--- a/src/tui/render/overlay/setup.rs
+++ b/src/tui/render/overlay/setup.rs
@@ -10,7 +10,7 @@ use unicode_width::UnicodeWidthChar;
 
 use super::Frame;
 use crate::tui::render::bottom_pane::composer::editor_cursor_position;
-use crate::tui::state::{PermissionMode, ProviderFamily, TuiApp};
+use crate::tui::state::{ApiKeyTarget, PermissionMode, TuiApp};
 use crate::tui::theme::{ThemeToken, theme_color};
 
 fn wrapped_text_height(text: &str, area_width: u16) -> u16 {
@@ -184,20 +184,31 @@ pub(super) fn render_skills_picker_modal(f: &mut Frame, app: &TuiApp, area: Rect
 pub(super) fn render_api_key_editor_modal(
     f: &mut Frame,
     app: &TuiApp,
+    target: ApiKeyTarget,
     area: Rect,
 ) -> Option<(u16, u16)> {
-    let (intro_text, title, footer_text) = match app.selected_provider_family() {
-        ProviderFamily::OpenAiCompatible => (
+    let (intro_text, title, footer_text) = match target {
+        ApiKeyTarget::OpenAiCompatible => (
             "Paste the API key for the selected OpenAI-compatible endpoint profile.",
             " API Key ",
             "Enter save  Esc back to model picker",
         ),
-        ProviderFamily::DeepSeek => (
+        ApiKeyTarget::DeepSeek => (
             "Paste a DeepSeek API key. It is used to load /models and call the selected DeepSeek model.",
             " DeepSeek API Key ",
             "Enter save and load models  Esc back to model picker",
         ),
-        _ => (
+        ApiKeyTarget::Kimi => (
+            "Paste a Kimi API key. It is used to load /models and call the selected Kimi model.",
+            " Kimi API Key ",
+            "Enter save and load models  Esc back to model picker",
+        ),
+        ApiKeyTarget::Gemini => (
+            "Paste a Gemini API key. It is used to call the selected Gemini model.",
+            " Gemini API Key ",
+            "Enter save  Esc back to model picker",
+        ),
+        ApiKeyTarget::Codex => (
             "Paste a Codex API key. This is the recommended path for SSH/headless sessions.",
             " Codex API Key ",
             "Enter save and rebuild  Esc back to login guide",

--- a/src/tui/render/tests.rs
+++ b/src/tui/render/tests.rs
@@ -21,10 +21,10 @@ use crate::tools::bash::BashCommandInput;
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::SkillPickerEntry;
 use crate::tui::state::{
-    InteractionKind, ListPickerKind, Overlay, PendingApprovalSnapshot, PendingInteractionSnapshot,
-    PlanningApprovalStatus, PlanningLifecycleSnapshot, ProviderFamily, RuntimeSnapshot, StatusTab,
-    ToolTranscriptPayload, ToolTranscriptStatus, TranscriptEntry, TranscriptEntryPayload,
-    TranscriptTurn, TuiApp,
+    ApiKeyTarget, InteractionKind, ListPickerKind, Overlay, PendingApprovalSnapshot,
+    PendingInteractionSnapshot, PlanningApprovalStatus, PlanningLifecycleSnapshot, ProviderFamily,
+    RuntimeSnapshot, StatusTab, ToolTranscriptPayload, ToolTranscriptStatus, TranscriptEntry,
+    TranscriptEntryPayload, TranscriptTurn, TuiApp,
 };
 
 fn provider_family_idx(family: ProviderFamily) -> usize {
@@ -1108,7 +1108,7 @@ fn api_key_editor_renders_full_prompt_on_standard_terminal() {
     config.model = Some("deepseek-chat".into());
     app.config = config;
     app.provider_picker_idx = provider_family_idx(ProviderFamily::OpenAiCompatible);
-    app.open_overlay(Overlay::ApiKeyEditor);
+    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::OpenAiCompatible));
 
     let rendered = render_screen_text(&mut app, 100, 24);
     assert_snapshot!("api_key_editor_standard_terminal", rendered);
@@ -1125,7 +1125,7 @@ fn deepseek_api_key_editor_uses_deepseek_copy() {
     app.config
         .select_openai_profile("deepseek-default", "DeepSeek", OpenAiEndpointKind::Deepseek);
     app.config.set_api_key("sk-deepseek");
-    app.open_overlay(Overlay::ApiKeyEditor);
+    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::DeepSeek));
 
     let rendered = render_screen_text(&mut app, 100, 24);
     assert!(rendered.contains("DeepSeek API Key"));
@@ -1134,6 +1134,25 @@ fn deepseek_api_key_editor_uses_deepseek_copy() {
     assert!(rendered.contains("Esc back to model picker"));
     assert!(!rendered.contains("Codex API Key"));
     assert!(!rendered.contains("Esc back to login guide"));
+}
+
+#[test]
+fn kimi_api_key_editor_uses_explicit_target_when_codex_is_active() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.config.set_provider("codex");
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::Kimi);
+    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::Kimi));
+
+    let rendered = render_screen_text(&mut app, 100, 24);
+    assert!(rendered.contains("Kimi API Key"));
+    assert!(rendered.contains("Paste a Kimi API key"));
+    assert!(rendered.contains("Enter save and load models"));
+    assert!(!rendered.contains("Codex API Key"));
+    assert!(!rendered.contains("Paste a Codex API key"));
 }
 
 #[test]

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -15,7 +15,7 @@ use rara_persistence::redaction::sanitize_url_for_display;
 use rara_provider_catalog::{
     ModelCatalogProvider, ModelCatalogRequest, fallback_catalog, load_model_catalog,
 };
-use secrecy::ExposeSecret;
+use secrecy::{ExposeSecret, SecretString};
 use tokio::sync::mpsc;
 
 use super::super::state::{
@@ -24,6 +24,7 @@ use super::super::state::{
 };
 use super::events::{apply_tui_event, format_error_chain, runtime_event_from_agent_event};
 use crate::agent::{Agent, AgentEvent, AgentOutputMode, BashApprovalDecision};
+use crate::config::RaraConfig;
 use crate::runtime_client::RuntimeTaskServices;
 pub(crate) use crate::runtime_client::{goal_budget_limit_prompt, goal_continuation_prompt};
 use crate::runtime_control::RuntimeProvenance;
@@ -581,19 +582,7 @@ pub(super) fn start_oauth_task(
 
 pub(super) fn start_model_catalog_task(app: &mut TuiApp, provider: ModelCatalogProvider) {
     let (_sender, receiver) = mpsc::unbounded_channel();
-    let api_key = app.config.api_key_secret();
-    let surface = app.config.effective_provider_surface();
-    let default_base_url = match provider {
-        ModelCatalogProvider::DeepSeek => crate::config::DEFAULT_DEEPSEEK_BASE_URL,
-        ModelCatalogProvider::Kimi => crate::config::DEFAULT_KIMI_BASE_URL,
-    };
-    let base_url = Some(
-        surface
-            .base_url
-            .value
-            .unwrap_or(default_base_url)
-            .to_string(),
-    );
+    let (api_key, base_url) = model_catalog_connection(&app.config, provider);
     let provider_label = match provider {
         ModelCatalogProvider::DeepSeek => "DeepSeek",
         ModelCatalogProvider::Kimi => "Kimi",
@@ -609,7 +598,7 @@ pub(super) fn start_model_catalog_task(app: &mut TuiApp, provider: ModelCatalogP
             provider,
             ModelCatalogRequest {
                 api_key: api_key.as_ref(),
-                base_url: base_url.as_deref(),
+                base_url: Some(base_url.as_str()),
             },
         )
         .await
@@ -626,6 +615,26 @@ pub(super) fn start_model_catalog_task(app: &mut TuiApp, provider: ModelCatalogP
         cancellation_token: None,
         cancellation_requested: false,
     });
+}
+
+fn model_catalog_connection(
+    config: &RaraConfig,
+    provider: ModelCatalogProvider,
+) -> (Option<SecretString>, String) {
+    let (provider_id, default_base_url) = match provider {
+        ModelCatalogProvider::DeepSeek => ("deepseek", crate::config::DEFAULT_DEEPSEEK_BASE_URL),
+        ModelCatalogProvider::Kimi => ("kimi", crate::config::DEFAULT_KIMI_BASE_URL),
+    };
+    let mut provider_config = config.clone();
+    provider_config.set_provider(provider_id);
+    let api_key = provider_config.api_key_secret();
+    let base_url = provider_config
+        .effective_provider_surface()
+        .base_url
+        .value
+        .unwrap_or(default_base_url)
+        .to_string();
+    (api_key, base_url)
 }
 
 pub(super) fn request_running_task_cancellation(app: &mut TuiApp) {

--- a/src/tui/runtime/tasks/tests.rs
+++ b/src/tui/runtime/tasks/tests.rs
@@ -5,8 +5,10 @@ use std::sync::{
 use std::time::{Duration, Instant};
 
 use rara_memory::memory_handle::MemoryHandle;
+use rara_provider_catalog::ModelCatalogProvider;
 use rara_tools::planning::{EnterPlanModeTool, ExitPlanModeTool};
 use rara_tools::tool::ToolManager;
+use secrecy::ExposeSecret;
 use serde_json::json;
 use tempfile::tempdir;
 use tokio::sync::{Mutex, mpsc};
@@ -14,13 +16,13 @@ use tokio::sync::{Mutex, mpsc};
 use super::{
     emit_query_heartbeat, finish_running_task_if_ready, forward_optional_lifecycle_event_to_bus,
     forward_task_result_lifecycle, goal_budget_limit_prompt, goal_continuation_prompt,
-    merge_rebuilt_agent, request_running_task_cancellation, start_oauth_task, start_query_task,
-    try_start_queued_follow_up,
+    merge_rebuilt_agent, model_catalog_connection, request_running_task_cancellation,
+    start_oauth_task, start_query_task, try_start_queued_follow_up,
 };
 use crate::agent::{
     Agent, AgentExecutionMode, BashApprovalMode, Message, PlanStep, PlanStepStatus,
 };
-use crate::config::ConfigManager;
+use crate::config::{ConfigManager, DEFAULT_CODEX_BASE_URL, DEFAULT_KIMI_BASE_URL, RaraConfig};
 use crate::llm::{ContentBlock, LlmBackend, LlmResponse, TokenUsage};
 use crate::local_model_server::{LocalModelServerState, LocalModelServerStatus};
 use crate::oauth::OAuthManager;
@@ -40,6 +42,27 @@ struct PlainAnswerBackend;
 
 struct GoalEvaluatorBackend {
     answer: String,
+}
+
+#[test]
+fn model_catalog_connection_uses_target_provider_credentials() {
+    let mut config = RaraConfig {
+        provider: "codex".to_string(),
+        ..Default::default()
+    };
+    config.set_api_key("sk-codex");
+    config.set_base_url(Some(DEFAULT_CODEX_BASE_URL.to_string()));
+    config.set_provider_api_key("kimi", "sk-kimi");
+
+    let (api_key, base_url) = model_catalog_connection(&config, ModelCatalogProvider::Kimi);
+
+    assert_eq!(config.provider, "codex");
+    assert_eq!(config.api_key(), Some("sk-codex"));
+    assert_eq!(
+        api_key.as_ref().map(ExposeSecret::expose_secret),
+        Some("sk-kimi")
+    );
+    assert_eq!(base_url, DEFAULT_KIMI_BASE_URL);
 }
 
 #[test]

--- a/src/tui/state/composer.rs
+++ b/src/tui/state/composer.rs
@@ -8,7 +8,7 @@ impl TuiApp {
     fn active_text_input_target(&self) -> TextInputTarget {
         match self.overlay {
             Some(Overlay::BaseUrlEditor) => TextInputTarget::BaseUrl,
-            Some(Overlay::ApiKeyEditor) => TextInputTarget::ApiKey,
+            Some(Overlay::ApiKeyEditor(_)) => TextInputTarget::ApiKey,
             Some(Overlay::ModelNameEditor) => TextInputTarget::ModelName,
             Some(Overlay::OpenAiProfileLabelEditor) => TextInputTarget::OpenAiProfileLabel,
             _ => TextInputTarget::Composer,

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -29,7 +29,7 @@ use self::types::CommittedTranscriptRenderCache;
 pub use self::types::current_unix_timestamp_secs;
 pub use self::types::{
     ActiveLiveEvent, ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
-    AgentMarkdownStreamState, CommandSpec, CompactionTranscriptPayload,
+    AgentMarkdownStreamState, ApiKeyTarget, CommandSpec, CompactionTranscriptPayload,
     CompletedInteractionSnapshot, GoalHandle, GoalStatus, HelpTab, InteractionKind, ListPickerKind,
     LocalCommand, LocalCommandKind, ModelCatalogSnapshot, ModelRoutingView, OAuthLoginMode,
     OpenAiModelPickerAction, Overlay, PROVIDER_FAMILIES, PendingApprovalSnapshot,
@@ -1179,7 +1179,7 @@ impl TuiApp {
             steps.push(Overlay::BaseUrlEditor);
         }
         if !self.config.has_api_key() || matches!(kind, OpenAiEndpointKind::Custom) {
-            steps.push(Overlay::ApiKeyEditor);
+            steps.push(Overlay::ApiKeyEditor(ApiKeyTarget::OpenAiCompatible));
         }
         if matches!(kind, OpenAiEndpointKind::Custom)
             || self
@@ -1220,7 +1220,7 @@ impl TuiApp {
         self.openai_setup_keep_empty_api_key = true;
         self.openai_setup_steps = vec![
             Overlay::BaseUrlEditor,
-            Overlay::ApiKeyEditor,
+            Overlay::ApiKeyEditor(ApiKeyTarget::OpenAiCompatible),
             Overlay::ModelNameEditor,
         ];
         self.advance_openai_profile_setup();

--- a/src/tui/state/overlay_state.rs
+++ b/src/tui/state/overlay_state.rs
@@ -88,7 +88,7 @@ impl TuiApp {
             });
             self.base_url_cursor_offset = None;
         }
-        if matches!(overlay, Overlay::ApiKeyEditor) {
+        if matches!(overlay, Overlay::ApiKeyEditor(_)) {
             self.api_key_input.clear();
             self.api_key_cursor_offset = None;
         }
@@ -155,7 +155,7 @@ impl TuiApp {
     pub fn dismiss_overlay(&mut self) {
         if matches!(
             self.overlay,
-            Some(Overlay::BaseUrlEditor | Overlay::ApiKeyEditor | Overlay::ModelNameEditor)
+            Some(Overlay::BaseUrlEditor | Overlay::ApiKeyEditor(_) | Overlay::ModelNameEditor)
         ) {
             self.cancel_openai_profile_setup();
         }

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -55,13 +55,34 @@ pub enum StatusTab {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ApiKeyTarget {
+    Codex,
+    DeepSeek,
+    Kimi,
+    OpenAiCompatible,
+    Gemini,
+}
+
+impl ApiKeyTarget {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Codex => "Codex",
+            Self::DeepSeek => "DeepSeek",
+            Self::Kimi => "Kimi",
+            Self::OpenAiCompatible => "OpenAI-compatible",
+            Self::Gemini => "Gemini",
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Overlay {
     Help(HelpTab),
     CommandPalette,
     Status(StatusTab),
     Context,
     BaseUrlEditor,
-    ApiKeyEditor,
+    ApiKeyEditor(ApiKeyTarget),
     ModelNameEditor,
     OpenAiProfileLabelEditor,
     SkillsPicker,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -21,6 +21,7 @@ use crate::llm::MockLlm;
 use crate::session::SessionManager;
 use crate::tools::bash::BashCommandInput;
 use crate::tui::command::palette_commands;
+use crate::tui::state::ApiKeyTarget;
 use crate::workspace::WorkspaceMemory;
 
 fn key(code: KeyCode) -> KeyEvent {
@@ -2496,7 +2497,10 @@ async fn deepseek_provider_family_prompts_for_api_key_before_model_list() {
 
     open_provider_family_overlay(&mut app);
 
-    assert_eq!(app.overlay, Some(Overlay::ApiKeyEditor));
+    assert_eq!(
+        app.overlay,
+        Some(Overlay::ApiKeyEditor(ApiKeyTarget::DeepSeek))
+    );
 }
 
 #[tokio::test]
@@ -2530,7 +2534,7 @@ async fn deepseek_api_key_save_starts_model_catalog_task() {
     app.provider_picker_idx = provider_family_idx(ProviderFamily::DeepSeek);
     app.config
         .select_openai_profile("deepseek-default", "DeepSeek", OpenAiEndpointKind::Deepseek);
-    app.open_overlay(Overlay::ApiKeyEditor);
+    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::DeepSeek));
     app.api_key_input = "sk-deepseek-test".to_string();
 
     let oauth_manager = Arc::new(
@@ -2549,6 +2553,59 @@ async fn deepseek_api_key_save_starts_model_catalog_task() {
     .expect("save api key");
 
     assert_eq!(app.config.api_key(), Some("sk-deepseek-test"));
+    assert!(matches!(
+        app.bottom_pane.running_task.as_ref(),
+        Some(task) if matches!(task.kind, TaskKind::ModelCatalog)
+    ));
+    if let Some(task) = app.bottom_pane.running_task.take() {
+        task.handle.abort();
+    }
+}
+
+#[tokio::test]
+async fn kimi_connection_saves_to_kimi_without_overwriting_active_codex_key() {
+    let temp = tempdir().expect("tempdir");
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.config.set_provider("codex");
+    app.config.set_api_key("sk-codex");
+    app.provider_picker_idx = provider_family_idx(ProviderFamily::Kimi);
+
+    open_provider_family_overlay(&mut app);
+
+    assert_eq!(app.overlay, Some(Overlay::ApiKeyEditor(ApiKeyTarget::Kimi)));
+    app.api_key_input = "sk-kimi".to_string();
+    let oauth_manager = Arc::new(
+        crate::oauth::OAuthManager::new_for_config_dir(temp.path().join(".rara"))
+            .expect("oauth manager"),
+    );
+    let mut agent_slot = None;
+
+    dispatch_event(
+        AppEvent::SaveApiKeyInput,
+        &mut app,
+        &mut agent_slot,
+        &oauth_manager,
+    )
+    .await
+    .expect("save Kimi API key");
+
+    assert_eq!(app.config.provider, "codex");
+    assert_eq!(app.config.api_key(), Some("sk-codex"));
+    let kimi_profile = app
+        .config
+        .openai_profiles
+        .get(OpenAiEndpointKind::Kimi.default_profile_id())
+        .expect("Kimi profile");
+    assert_eq!(
+        kimi_profile
+            .api_key
+            .as_ref()
+            .map(ExposeSecret::expose_secret),
+        Some("sk-kimi")
+    );
     assert!(matches!(
         app.bottom_pane.running_task.as_ref(),
         Some(task) if matches!(task.kind, TaskKind::ModelCatalog)
@@ -2607,7 +2664,10 @@ async fn deepseek_model_picker_enter_without_api_key_opens_api_key_editor() {
     .await
     .expect("apply model selection");
 
-    assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
+    assert!(matches!(
+        app.overlay,
+        Some(Overlay::ApiKeyEditor(ApiKeyTarget::DeepSeek))
+    ));
     assert!(app.bottom_pane.running_task.is_none());
 }
 
@@ -2662,7 +2722,10 @@ async fn deepseek_model_picker_api_key_action_opens_editor_even_when_key_exists(
     .await
     .expect("apply api key action");
 
-    assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
+    assert!(matches!(
+        app.overlay,
+        Some(Overlay::ApiKeyEditor(ApiKeyTarget::DeepSeek))
+    ));
     assert!(app.bottom_pane.running_task.is_none());
 }
 
@@ -2730,7 +2793,10 @@ async fn openai_model_picker_edit_shortcut_starts_wizard_for_selected_profile() 
     assert!(matches!(app.overlay, Some(Overlay::BaseUrlEditor)));
     assert_eq!(
         app.openai_setup_steps,
-        vec![Overlay::ApiKeyEditor, Overlay::ModelNameEditor]
+        vec![
+            Overlay::ApiKeyEditor(ApiKeyTarget::OpenAiCompatible),
+            Overlay::ModelNameEditor
+        ]
     );
 }
 
@@ -2795,7 +2861,10 @@ async fn openai_profile_edit_wizard_keeps_existing_api_key_when_blank() {
     )
     .await
     .expect("save base url");
-    assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
+    assert!(matches!(
+        app.overlay,
+        Some(Overlay::ApiKeyEditor(ApiKeyTarget::OpenAiCompatible))
+    ));
     assert!(app.api_key_input.is_empty());
 
     dispatch_event(
@@ -3062,7 +3131,10 @@ async fn saving_openai_profile_label_creates_new_openrouter_profile() {
             .openai_profiles
             .contains_key("openrouter-openrouter-backup")
     );
-    assert!(matches!(app.overlay, Some(Overlay::ApiKeyEditor)));
+    assert!(matches!(
+        app.overlay,
+        Some(Overlay::ApiKeyEditor(ApiKeyTarget::OpenAiCompatible))
+    ));
     assert_eq!(app.openai_setup_steps, vec![Overlay::ModelNameEditor]);
 }
 
@@ -3096,7 +3168,7 @@ async fn save_api_key_input_allows_clearing_openai_compatible_credentials() {
 
     app.config.set_provider("openai-compatible");
     app.config.set_api_key("sk-existing");
-    app.open_overlay(Overlay::ApiKeyEditor);
+    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::OpenAiCompatible));
     app.api_key_input.clear();
 
     let oauth_manager = Arc::new(
@@ -3605,7 +3677,7 @@ async fn save_api_key_input_sets_codex_defaults_before_rebuild() {
     ));
 
     app.config.set_provider("codex");
-    app.open_overlay(Overlay::ApiKeyEditor);
+    app.open_overlay(Overlay::ApiKeyEditor(ApiKeyTarget::Codex));
     app.api_key_input = "sk-codex".into();
 
     let oauth_manager = Arc::new(


### PR DESCRIPTION
## Summary

- carry an explicit API-key target through the TUI connection flow
- save credentials to the selected provider without overwriting the active provider
- route DeepSeek and Kimi model-catalog requests through provider-scoped credentials and base URLs
- add focused config, render, event-flow, and runtime-routing regressions
- document the provider credential-targeting contract and implementation checkpoint

## Motivation

Selecting Kimi from `/connect` while Codex was active opened the shared API-key editor with Codex-specific text. The save path also inferred its destination from mutable active-provider state, so a Kimi key could be persisted as the Codex credential and later used with the wrong provider surface.

This change follows the OpenCode connection pattern: capture the provider identity when the flow starts and carry that identity through prompt rendering, persistence, and follow-up requests.

## Implementation

- add `ApiKeyTarget` to `Overlay::ApiKeyEditor`
- render exhaustive provider-specific API-key copy
- add provider-scoped credential mutation to `RaraConfig`
- build model-catalog request settings from a target-provider configuration clone
- preserve the active provider and its credential when connecting an inactive provider

## Related issue

None.

## Validation

- `cargo fmt --all`
- `cargo test -p rara-config setting_inactive_provider_api_key_preserves_active_provider_credentials`
- `cargo test kimi_api_key_editor_uses_explicit_target_when_codex_is_active`
- `cargo test kimi_connection_saves_to_kimi_without_overwriting_active_codex_key`
- `cargo test model_catalog_connection_uses_target_provider_credentials`
- `cargo test api_key`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
