### PR TITLE
feat(memory): split local vs Nowledge Mem memory ownership

### DIFF
--- a/docs/features/memory-records.md
+++ b/docs/features/memory-records.md
@@ -28,6 +28,21 @@ official Mem instead of an embedded vector database or bundled embedding model.
 Semantic retrieval, graph expansion, and cross-tool durable knowledge belong to
 official Mem. Local memory exists as a short-term and file-backed substrate.
 
+## Division of Labor
+
+Local memory and official Mem split ownership by durability and scope:
+
+- **Local (`memory.md` + `MemoryRecord`s)**: workspace-scoped, short-term,
+  file-backed substrate with deterministic plain-text search. It holds
+  project-specific facts and decisions that only matter inside this workspace.
+- **Official Mem (`distill-memory` skill / Nowledge Mem)**: the authority for
+  durable, cross-tool, and cross-workspace knowledge that must survive the
+  current thread or workspace.
+
+The model-facing write surfaces carry this routing rule so the same durable
+fact is not distilled into both stores: `update_project_memory` targets local
+memory, and the Nowledge Mem `distill-memory` skill targets official Mem.
+
 ## Architecture
 
 `MemoryStore` owns the local memory domain boundary:

--- a/docs/journal/2026-08-28-nowledge-mem-division-of-labor.md
+++ b/docs/journal/2026-08-28-nowledge-mem-division-of-labor.md
@@ -1,0 +1,38 @@
+# Nowledge Mem Division of Labor
+
+## What
+
+Clarified the division of labor between RARA's local memory and Nowledge Mem
+at the model-facing write surfaces, so the same durable fact is no longer
+distilled into both stores.
+
+## Why
+
+Both a local write surface (`update_project_memory` → `.rara/memory.md`) and
+the Nowledge Mem `distill-memory` skill exist for "remember something durable".
+The spec already stated the split (local = short-term file-backed substrate,
+official Mem = cross-tool semantic knowledge), but the tool/skill descriptions
+did not carry that routing rule, so the model had no call-time signal about
+which store to write.
+
+## What changed
+
+- `src/tools/workspace.rs`: `update_project_memory` now states it is the
+  workspace-local `.rara/memory.md` surface and points cross-tool/cross-workspace
+  knowledge at the Nowledge Mem `distill-memory` skill.
+- `src/plugin_middleware/builtin.rs`: the `distill-memory` skill description and
+  body now mark Nowledge Mem as the durable/cross-tool authority and tell the
+  model not to persist the same fact into local memory.
+- `docs/features/memory-records.md`: added a `Division of Labor` contract section.
+
+## Trade-offs
+
+This is a prompt/tool-description + spec change rather than a runtime code
+change. It does not remove the local `distill_thread_memories` path, which
+remains consistent with the spec (local records are the workspace-local
+file-backed substrate).
+
+## Remains
+
+- Runtime-side automatic read: pre-fetching the Nowledge Mem Context Bundle /
+  Working Memory into assembled context is still model-driven, not runtime-owned.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -62,6 +62,9 @@ Active backlog only. Keep this file small and current.
       stable append deduplication, and bounded shutdown drain in the runtime.
 - [x] Load Nowledge Mem context at session start and refresh it after
       compaction through the built-in plugin instructions.
+- [ ] Pre-fetch the Nowledge Mem Context Bundle / Working Memory into assembled
+      context at session start (runtime-owned read), instead of relying on the
+      model to invoke the MCP skills.
 
 - [x] Keep `rara-file-search` as the shared backend for TUI file suggestions
       and `list_files`; keep automatic retrieval as optional low-priority

--- a/src/plugin_middleware/builtin.rs
+++ b/src/plugin_middleware/builtin.rs
@@ -201,13 +201,18 @@ for cross-tool state and sourced decisions.
 
 const NOWLEDGE_MEM_DISTILL_MEMORY_SKILL: &str = r#"---
 name: distill-memory
-description: Save durable decisions, procedures, or reusable project knowledge to Nowledge Mem.
+description: Save durable cross-tool or cross-workspace decisions, procedures, and reusable knowledge to Nowledge Mem, the durable/semantic memory authority. Prefer this over RARA's workspace-local memory.md for knowledge that must outlive the workspace.
 ---
 
 # Distill Memory
 
 Use this skill when the user asks to remember something, save a durable
 decision, or preserve a reusable procedure across tools.
+
+Nowledge Mem is the authority for durable, cross-tool, and cross-workspace
+knowledge. RARA's local `memory.md` and `MemoryRecord` files are workspace-local,
+short-term, plain-text substrate. Write durable or cross-tool knowledge here
+instead of local memory, and do not persist the same fact into both stores.
 
 Search first to avoid duplicates:
 

--- a/src/tools/workspace.rs
+++ b/src/tools/workspace.rs
@@ -12,7 +12,7 @@ pub struct UpdateProjectMemoryTool {
 }
 #[tool_spec(
     name = "update_project_memory",
-    description = "Update memory.md",
+    description = "Update the workspace-local project memory file (.rara/memory.md). Use it for workspace-scoped, project-specific facts and decisions. For durable cross-tool or cross-workspace knowledge, use the Nowledge Mem distill-memory skill instead.",
     input_schema = {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## What

Clarify the division of labor between RARA's workspace-local memory and Nowledge Mem at the model-facing write surfaces, so the same durable fact is no longer distilled into both stores.

- `update_project_memory` description now marks `.rara/memory.md` as workspace-local and points cross-tool/cross-workspace knowledge at the Nowledge Mem `distill-memory` skill.
- `distill-memory` skill description + body now mark Nowledge Mem as the durable/cross-tool authority and tell the model not to persist the same fact into local memory.
- `docs/features/memory-records.md` gains a `Division of Labor` contract section.
- Journal + `docs/todo.md` follow-up for the remaining runtime-owned read path.

## Why

The spec already documented the split (local = short-term file-backed substrate; official Mem = cross-tool semantic knowledge), but the write surfaces carried no routing rule. The model saw `update_project_memory` and `distill-memory` as competing "remember this" entry points and could duplicate a fact into both stores.

## Validation

- `cargo fmt -- --check` — passed
- `cargo check -p rara` — passed

## Notes

No runtime logic changed; this is a prompt/tool-description + spec contract change.
