### PR TITLE
feat(prompt): require concise task-completion report

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -575,6 +575,7 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
                     "For design or prompt changes, preserve the existing ordering and section boundaries unless there is a concrete reason to move them.",
                     "After editing, review your own diff for unrelated churn, duplicated logic, stale names, missing tests, and accidental behavior changes.",
                     "If new information invalidates the plan, switch to the revised smallest path and explain the mismatch briefly.",
+                    "When you complete the task, respond with a concise report covering what was done, the exact validation result, and any remaining follow-up or next step. Do not end on a bare confirmation such as `done` or `finished`.",
                 ],
             ),
         ),

--- a/crates/instructions/src/prompt/tests.rs
+++ b/crates/instructions/src/prompt/tests.rs
@@ -434,6 +434,11 @@ fn default_system_prompt_includes_workflow_standards() {
     assert!(
         effective
             .text
+            .contains("When you complete the task, respond with a concise report")
+    );
+    assert!(
+        effective
+            .text
             .contains("Treat explicit task constraints as validation requirements")
     );
 

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -67,7 +67,9 @@ The default base prompt includes source-grounded engineering workflow guidance f
 - structured tool use, including edit-tool discipline and unfiltered command-output inspection;
 - reviewable implementation workflow, focused validation, sandbox-persistent verification, and PR
   hygiene;
-- Git conflict resolution when conflict markers are present.
+- Git conflict resolution when conflict markers are present;
+- task-completion reporting: a concise final report of what changed, the validation result, and any
+  remaining follow-up or next step, instead of ending on a bare confirmation.
 
 Software-engineering task interpretation is adapted from Claude-style task framing. In a repository,
 short user requests such as "rename this", "clean it up", "continue", or "review this" should be

--- a/docs/journal/2026-08-21-prompt-task-completion-report.md
+++ b/docs/journal/2026-08-21-prompt-task-completion-report.md
@@ -1,0 +1,38 @@
+# Require Task-Completion Report in Default Prompt
+
+## What
+
+Added one rule to the `Task Workflow` section of the default prompt in
+`crates/instructions/src/prompt.rs`:
+
+```text
+When you complete the task, respond with a concise report covering what was
+done, the exact validation result, and any remaining follow-up or next step.
+Do not end on a bare confirmation such as `done` or `finished`.
+```
+
+Also added a `task-completion reporting` bullet to the built-in engineering
+workflow guidance list in `docs/features/prompt-runtime.md`, plus a focused
+assertion in `crates/instructions/src/prompt/tests.rs`.
+
+## Why
+
+The default prompt constrained task start and in-progress behavior but never
+required a closing statement. `Task Workflow` said `verify, then report`
+without defining `report`, and the agent loop treated "no tool call" as the
+final answer mechanically. The model therefore ended on one-word confirmations.
+
+The wording mirrors Claude Code's `DEFAULT_AGENT_PROMPT`
+(`When you complete the task, respond with a concise report covering what was
+done and any key findings`) and Codex's `Presenting your work and final
+message` section.
+
+## Trade-offs
+
+- The rule is placed additively at the end of `Task Workflow` to preserve
+  provider cache-prefix stability (per the prompt-section ordering rule).
+- No new prompt section was added; the rule is scoped to the existing section.
+
+## Remains
+
+- Nothing for this change.


### PR DESCRIPTION
## What

Adds one rule to the `Task Workflow` section of the default agent prompt so the agent ends a finished task with a concise report instead of a bare confirmation.

```text
When you complete the task, respond with a concise report covering what was done, the exact validation result, and any remaining follow-up or next step. Do not end on a bare confirmation such as `done` or `finished`.
```

Also:
- `docs/features/prompt-runtime.md`: add a `task-completion reporting` bullet to the built-in workflow guidance list.
- `crates/instructions/src/prompt/tests.rs`: assert the new rule is present in the effective prompt.

## Why

The prompt constrained task start and in-progress behavior but never required a closing statement: `Task Workflow` said `verify, then report` without defining `report`, and the agent loop treated "no tool call" as the final answer mechanically. The model could therefore end on one-word confirmations.

The wording mirrors Claude Code's `DEFAULT_AGENT_PROMPT` ("When you complete the task, respond with a concise report covering what was done and any key findings") and Codex's "Presenting your work and final message" section. It is appended to the existing section to preserve provider cache-prefix stability.

## Validation

- `cargo fmt`
- `cargo test -p rara-instructions` → 34 passed, 0 failed