### PR TITLE
fix(tui): preserve turn event chronology

### DIFF
--- a/docs/features/session-transcript.md
+++ b/docs/features/session-transcript.md
@@ -194,6 +194,23 @@ thinking and progress tails, but those live events have the same ordering
 contract: event order is the user-visible ordering boundary, with only adjacent
 same-role progress compaction allowed.
 
+Closed semantic segments have exactly one chronology owner: the active turn's
+ordered entry list. A currently open assistant-text or thinking stream may stay
+transient for incremental Markdown rendering, but it must enter that entry list
+at the boundary to the next semantic segment. In particular, the first text
+delta closes an open thinking stream before opening assistant text, and a later
+thinking delta closes an open assistant-text stream first. Turn commit must not
+append a second progress sidecar after the assistant response.
+
+Wall-clock timestamps are not an ordering source. The structured runtime stream
+sequence defines order, and in-process dispatch events are re-sequenced into the
+session bus's monotonic ordering domain before the TUI consumes them. A query
+turn may commit only after both its task result and a terminal runtime projection
+(`TurnFinished`, cancellation/interruption, an unrecoverable runtime error, or a
+transport terminal event) have arrived. This completion barrier ensures that a
+ready `JoinHandle` cannot commit the turn while earlier reasoning or progress
+events remain queued.
+
 Fallback rendering for plain tool and tool-progress messages keeps the newest
 tail lines when the message exceeds the main-view line budget. Recent command
 or tool output is usually the actionable state; full-output fidelity belongs to
@@ -221,6 +238,10 @@ terminal cells and transcript-detail surfaces.
 | Render committed mixed turn | `You`, thinking/exploring/running, tool calls, approvals, terminal output, and agent messages render in recorded order. |
 | Render long fallback tool message | The main view shows a hidden-earlier-lines marker plus the newest tail lines. |
 | Render live progress turn | Streaming thinking and progress events render in event order while adjacent same-role progress may compact. |
+| Close thinking before assistant text | The closed `Thinking` entry precedes the assistant segment in both active and committed views. |
+| Interleave assistant and progress segments | Repeated assistant, thinking, and tool/progress segments retain their structured event order. |
+| Query task finishes before terminal event | The active turn remains uncommitted until the terminal runtime projection is consumed. |
+| Start a second local dispatch | Request-local sequence resets are normalized by the runtime bus and do not cause the second turn's events to be dropped. |
 
 ## Open Risks
 
@@ -250,3 +271,4 @@ terminal cells and transcript-detail surfaces.
 - 2026-05-05-subagent-spawn-edge-index.md
 - 2026-05-05-subagent-background-control.md
 - 2026-07-03-subagent-reconnect.md
+- 2026-08-21-tui-turn-event-chronology.md

--- a/docs/features/thinking-display.md
+++ b/docs/features/thinking-display.md
@@ -24,6 +24,9 @@ RARA previously rendered thinking as `# Thinking` section header with full inlin
 2. **Dimmed border-left accent** (`┊ `) for expanded thinking lines
 3. **Auto-expand** during live streaming; always collapsed for committed
 4. **Unify** `ThinkingTextCell` + `ThinkingGroupCell` → single `ThinkingBlockCell`
+5. **Chronological closure** — only the currently open thinking stream is kept
+   outside the transcript; closing it inserts a `Thinking` entry at that exact
+   event boundary before assistant text, tools, or later progress
 
 ## Display state
 
@@ -56,13 +59,15 @@ Committed (collapsed):
 ## Verification
 
 - `cargo fmt` / `cargo clippy` — zero new errors
-- `cargo test tui::render::cells::tests` — 66/66 passed
+- state tests cover thinking-before-answer and interleaved assistant/progress
+  segments
+- active and committed render tests verify that closed and streaming thinking
+  remain at their recorded positions
+- controller tests cover both task-first and terminal-event-first completion
 
 ## Follow-up (planned, not implemented)
 
 - **Enter-key toggle**: committed thinking blocks currently always collapsed. Adding an
   `expanded` state independent of `is_streaming` would enable Enter to toggle.
   Needs plumbing through `input_control.rs` and `terminal_ui.rs`.
-- **Committed turn positioning**: position thinking block as a separate section
-  between `# You` and agent response in committed turns (`committed_turn.rs`).
 - **Runtime elapsed time**: display elapsed duration in the collapsed summary line.

--- a/docs/journal/2026-08-21-tui-turn-event-chronology.md
+++ b/docs/journal/2026-08-21-tui-turn-event-chronology.md
@@ -1,0 +1,94 @@
+# TUI Turn Event Chronology
+
+## What changed
+
+The TUI now uses the active turn entry list as the single chronology owner for
+closed assistant and progress segments. A thinking stream is inserted at its
+event boundary before assistant text starts, and an open assistant stream is
+closed before a later thinking segment starts. Turn commit no longer
+materializes a separate live-event sidecar at the end of the turn.
+
+Only the currently open Markdown or thinking stream remains transient. Derived
+tool labels stay in the active display cache because the typed tool or terminal
+entry already owns that event's transcript position. Explicit thinking,
+planning, exploration, and running events enter the ordered transcript and the
+active renderer preserves interleaved assistant/progress order while retaining
+adjacent progress compaction.
+
+Query completion now waits for both the task result and a terminal runtime
+projection. In-process control-plane events are re-sequenced by the runtime bus
+across dispatch requests, while legacy raw lifecycle subscribers receive a
+raw-only start/stop projection so the ordered control stream has exactly one
+terminal boundary per turn.
+
+## Why
+
+Previously, assistant text was written directly to `active_turn.entries`, but
+closed thinking and progress were kept in `active_live.events`. Commit appended
+that sidecar after all transcript entries, so a real event sequence of
+`Thinking -> Agent` became `Agent -> Thinking` in committed history.
+
+The event loop also selected independently between the query `JoinHandle` and
+the structured runtime stream. A ready task could therefore commit the turn
+before already-published tail events were consumed. Request-local dispatch
+sequence numbers reset on each turn, which could additionally make the TUI
+reject a later turn's terminal event as stale.
+
+## Reference patterns
+
+The implementation adapts current upstream ordering boundaries:
+
+- Codex `536f86e5cc9ec1ff38457d099bf320b9d08eeeba` finalizes a completed
+  reasoning item into history at the reasoning-item boundary instead of
+  appending reasoning at turn completion.
+- OpenCode `ba72a6ff2b62aaf614b8e745193e86a51be6142c` assigns ascending part
+  identities to reasoning, text, and tool parts, closes reasoning on explicit
+  lifecycle boundaries, and renders message parts in that stored order.
+- The current public Claude Code source surface does not expose an equivalent
+  transcript processor. Its older hybrid transport flush-before-terminal
+  behavior was used only as corroboration, not as the implementation basis.
+
+## Design decisions
+
+### One ordered closed-segment projection
+
+Closed segments move immediately into `TranscriptEntry`. This avoids wall-clock
+sorting, role sorting, and commit-time reconstruction. The display caches still
+support compact live summaries, but they no longer own durable ordering.
+
+### Two-signal query completion
+
+Normal query completion requires a task result and a terminal structured event,
+regardless of which arrives first. A failed task join is terminal by necessity
+because no producer remains to publish a lifecycle event. A closed runtime
+stream is projected as a disconnect so the TUI fails visibly instead of
+waiting indefinitely.
+
+### Bus-owned local sequence
+
+External adapter events keep their original event identity and sequence. Only
+in-process dispatch events enter the bus-owned monotonic sequence domain. This
+keeps cross-turn TUI ordering stable without changing ACP or Wire provenance
+contracts.
+
+## Verification
+
+- `cargo fmt`
+- `cargo check --all-targets`
+- `cargo test --all-targets --quiet` (`1321` library tests and the embedded
+  integration test passed)
+- `cargo clippy --all-targets -- -D warnings`
+- focused active-turn, committed-turn, controller-barrier, runtime-event-bus,
+  and runtime-event projection tests
+- `git diff --check`
+
+The local machine has no CUDA compiler, so an exploratory
+`cargo clippy --all-targets --all-features -- -D warnings` stops in the
+`cudarc`/Candle build scripts before checking RARA. The default feature gate
+above is warning-clean.
+
+## Remaining work
+
+No follow-up is required for this chronology correction. Interactive expansion
+and richer elapsed-time display remain the independent thinking-display items
+already documented in the feature spec.

--- a/src/runtime_event_bus.rs
+++ b/src/runtime_event_bus.rs
@@ -128,6 +128,19 @@ impl RuntimeEventBus {
         }
     }
 
+    /// Publish only to legacy raw-event consumers.
+    ///
+    /// The in-process control-plane dispatcher publishes its own structured
+    /// lifecycle events. This path keeps hooks and legacy consumers informed
+    /// without duplicating those lifecycle boundaries on the ordered control
+    /// stream.
+    pub(crate) fn publish_raw(&self, event: AgentEvent) -> usize {
+        if self.raw_sender.receiver_count() == 0 {
+            return 0;
+        }
+        self.raw_sender.send(event).unwrap_or(0)
+    }
+
     /// Create a new receiver that will see all future events.  Past events
     /// are not replayed.
     pub fn subscribe(&self) -> broadcast::Receiver<AgentEvent> {
@@ -175,6 +188,26 @@ impl RuntimeEventBus {
         if self.control_sender.receiver_count() == 0 {
             return 0;
         }
+        self.control_sender.send(event).unwrap_or(0)
+    }
+
+    /// Publish an in-process control event using the bus-owned ordering domain.
+    ///
+    /// Control-plane dispatch assigns request-local sequence numbers. Local
+    /// runtime consumers need one monotonically increasing stream across
+    /// requests, while external protocol adapters must keep using
+    /// [`Self::publish_control_event`] to preserve their original identity.
+    pub(crate) fn publish_resequenced_control_event(
+        &self,
+        mut event: RuntimeControlEvent,
+    ) -> usize {
+        if self.control_sender.receiver_count() == 0 {
+            return 0;
+        }
+        let sequence = self.next_sequence.fetch_add(1, Ordering::SeqCst) + 1;
+        event.event_id = format!("ctl-{sequence:016x}");
+        event.sequence = sequence;
+        self.project_tool_identity(&mut event);
         self.control_sender.send(event).unwrap_or(0)
     }
 }
@@ -304,6 +337,50 @@ mod tests {
         assert_eq!(received.event_id, "acp-1");
         assert_eq!(received.sequence, 7);
         assert_eq!(received.provenance.session_id.as_deref(), Some("session-1"));
+    }
+
+    #[test]
+    fn in_process_events_are_resequenced_across_dispatch_requests() {
+        let bus = RuntimeEventBus::new(8);
+        let mut control = bus.subscribe_control();
+        let provenance = RuntimeProvenance::local_tui("session-1");
+
+        for event in [
+            RuntimeEvent::Session(crate::runtime_control::SessionEvent::TurnStarted),
+            RuntimeEvent::Session(crate::runtime_control::SessionEvent::TurnFinished {
+                reason: Some("turn complete".into()),
+            }),
+        ] {
+            let local_event = RuntimeControlEvent {
+                event_id: "evt-dispatch-1".into(),
+                provenance: provenance.clone(),
+                sequence: 1,
+                event,
+            };
+            assert_eq!(bus.publish_resequenced_control_event(local_event), 1);
+        }
+
+        let started = control.try_recv().expect("turn started");
+        let finished = control.try_recv().expect("turn finished");
+        assert_eq!((started.sequence, finished.sequence), (1, 2));
+        assert_eq!(started.event_id, "ctl-0000000000000001");
+        assert_eq!(finished.event_id, "ctl-0000000000000002");
+        assert_eq!(started.provenance, provenance);
+        assert_eq!(finished.provenance, provenance);
+    }
+
+    #[test]
+    fn raw_lifecycle_events_do_not_duplicate_control_boundaries() {
+        let bus = RuntimeEventBus::new(8);
+        let mut raw = bus.subscribe();
+        let mut control = bus.subscribe_control();
+
+        assert_eq!(bus.publish_raw(AgentEvent::AgentStart), 1);
+        assert!(matches!(
+            raw.try_recv().expect("raw lifecycle event"),
+            AgentEvent::AgentStart
+        ));
+        assert!(control.try_recv().is_err());
     }
 
     #[test]

--- a/src/tui/controller.rs
+++ b/src/tui/controller.rs
@@ -18,11 +18,55 @@ use super::runtime_port::{
 };
 use super::state::{TaskCompletion, TuiApp};
 use crate::oauth::OAuthManager;
+use crate::runtime_control::{ErrorEvent, RuntimeEvent, SessionEvent};
 
 pub(super) enum RuntimeActivity {
     Event(Option<RuntimeProjectionEvent>),
     Command(Option<RuntimeCommand>),
     Completed(Box<Result<TaskCompletion, tokio::task::JoinError>>),
+}
+
+#[derive(Default)]
+struct QueryCompletionBarrier {
+    terminal_event_seen: bool,
+    pending_completion: Option<Box<Result<TaskCompletion, tokio::task::JoinError>>>,
+}
+
+impl QueryCompletionBarrier {
+    fn observe_terminal_event(&mut self) {
+        self.terminal_event_seen = true;
+    }
+
+    fn defer(&mut self, completion: Box<Result<TaskCompletion, tokio::task::JoinError>>) {
+        let task_join_failed = completion.is_err();
+        if self.pending_completion.replace(completion).is_some() {
+            log::warn!("replaced a pending query completion before its terminal event");
+        }
+        if task_join_failed {
+            // A failed task no longer has a producer that can publish a
+            // terminal runtime event. Treat the join failure as that boundary
+            // so the TUI can surface the task error instead of waiting forever.
+            self.terminal_event_seen = true;
+        }
+    }
+
+    fn take_ready(&mut self) -> Option<Box<Result<TaskCompletion, tokio::task::JoinError>>> {
+        if !self.terminal_event_seen {
+            return None;
+        }
+        let completion = self.pending_completion.take()?;
+        self.terminal_event_seen = false;
+        Some(completion)
+    }
+
+    fn has_pending_completion(&self) -> bool {
+        self.pending_completion.is_some()
+    }
+
+    fn reset(&mut self) {
+        self.terminal_event_seen = false;
+        self.pending_completion = None;
+    }
 }
 
 /// Owns TUI presentation state and applies runtime projections to it.
@@ -32,6 +76,7 @@ pub(super) struct TuiController {
     runtime_events: RuntimeEventStream,
     runtime_commands: tokio::sync::mpsc::UnboundedReceiver<RuntimeCommand>,
     last_runtime_event: Option<(Option<String>, u64, String)>,
+    query_completion_barrier: QueryCompletionBarrier,
     /// Set to true every time an event is applied and the screen should repaint.
     pub(super) needs_redraw: bool,
 }
@@ -49,6 +94,7 @@ impl TuiController {
             runtime_events,
             runtime_commands,
             last_runtime_event: None,
+            query_completion_barrier: QueryCompletionBarrier::default(),
             needs_redraw: true,
         }
     }
@@ -86,20 +132,60 @@ impl TuiController {
         Ok(())
     }
 
-    /// Drain pending agent events from the running task, apply them, and
-    /// finalize the task if it has completed.
-    pub(super) async fn complete_runtime_task(
+    /// Defer query completion until the ordered runtime stream reaches a
+    /// terminal event. Maintenance tasks do not emit turn lifecycle events and
+    /// continue to complete directly from their join handle.
+    pub(super) async fn receive_runtime_task_completion(
         &mut self,
         processor: &mut RuntimeCommandProcessor,
         completion: Box<Result<TaskCompletion, tokio::task::JoinError>>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
+        if self.running_task_is_query() {
+            self.query_completion_barrier.defer(completion);
+            return self.complete_query_if_ready(processor).await;
+        }
+        processor.complete(&mut self.app, completion).await?;
+        self.query_completion_barrier.reset();
+        self.needs_redraw = true;
+        Ok(true)
+    }
+
+    pub(super) async fn complete_query_if_ready(
+        &mut self,
+        processor: &mut RuntimeCommandProcessor,
+    ) -> anyhow::Result<bool> {
+        let Some(completion) = self.query_completion_barrier.take_ready() else {
+            return Ok(false);
+        };
         processor.complete(&mut self.app, completion).await?;
         self.needs_redraw = true;
-        Ok(())
+        Ok(true)
+    }
+
+    fn running_task_is_query(&self) -> bool {
+        self.app
+            .bottom_pane
+            .running_task
+            .as_ref()
+            .is_some_and(|task| matches!(&task.kind, super::state::TaskKind::Query))
     }
 
     /// Wait for the next runtime event or task completion without polling.
     pub(super) async fn wait_for_runtime_activity(&mut self) -> RuntimeActivity {
+        if self.query_completion_barrier.has_pending_completion() {
+            let activity = tokio::select! {
+                event = self.runtime_events.next() => RuntimeActivity::Event(event),
+                command = self.runtime_commands.recv() => RuntimeActivity::Command(command),
+            };
+            return match activity {
+                RuntimeActivity::Event(None) => {
+                    RuntimeActivity::Event(Some(RuntimeProjectionEvent::Disconnected {
+                        reason: "runtime event stream closed before turn completion".into(),
+                    }))
+                }
+                activity => activity,
+            };
+        }
         if let Some(task) = self.app.bottom_pane.running_task.as_mut() {
             select_runtime_activity(
                 &mut self.runtime_events,
@@ -116,6 +202,7 @@ impl TuiController {
     }
 
     pub(super) fn apply_runtime_event(&mut self, event: RuntimeProjectionEvent) -> bool {
+        let terminal_event = is_terminal_projection_event(&event);
         match event {
             RuntimeProjectionEvent::Runtime(event) => {
                 if !accept_runtime_event(&mut self.last_runtime_event, &event) {
@@ -143,6 +230,9 @@ impl TuiController {
                 self.app
                     .set_runtime_phase(super::state::RuntimePhase::Idle, None);
             }
+        }
+        if terminal_event && self.running_task_is_query() {
+            self.query_completion_barrier.observe_terminal_event();
         }
         self.needs_redraw = true;
         true
@@ -176,6 +266,26 @@ impl TuiController {
     }
 }
 
+fn is_terminal_projection_event(event: &RuntimeProjectionEvent) -> bool {
+    match event {
+        RuntimeProjectionEvent::Runtime(event) => matches!(
+            &event.event,
+            RuntimeEvent::Session(
+                SessionEvent::TurnFinished { .. }
+                    | SessionEvent::TurnCancelled
+                    | SessionEvent::TurnInterrupted
+            ) | RuntimeEvent::Error(ErrorEvent::RuntimeError {
+                recoverable: false,
+                ..
+            })
+        ),
+        RuntimeProjectionEvent::Completed { .. } | RuntimeProjectionEvent::Disconnected { .. } => {
+            true
+        }
+        RuntimeProjectionEvent::Snapshot(_) | RuntimeProjectionEvent::Reconnected => false,
+    }
+}
+
 async fn select_runtime_activity(
     runtime_events: &mut RuntimeEventStream,
     runtime_commands: &mut tokio::sync::mpsc::UnboundedReceiver<RuntimeCommand>,
@@ -198,9 +308,79 @@ async fn select_runtime_activity(
 mod tests {
     use futures::stream;
 
-    use super::{RuntimeActivity, RuntimeCommand, select_runtime_activity};
-    use crate::runtime_control::SessionControlRequest;
+    use super::{
+        QueryCompletionBarrier, RuntimeActivity, RuntimeCommand, is_terminal_projection_event,
+        select_runtime_activity,
+    };
+    use crate::runtime_control::{
+        RuntimeControlEvent, RuntimeEvent, RuntimeProvenance, SessionControlRequest, SessionEvent,
+    };
     use crate::tui::runtime_port::{RuntimeEventStream, RuntimeProjectionEvent};
+    use crate::tui::state::TaskCompletion;
+
+    fn test_completion() -> Box<Result<TaskCompletion, tokio::task::JoinError>> {
+        Box::new(Ok(TaskCompletion::ModelCatalog {
+            provider: rara_provider_catalog::ModelCatalogProvider::Kimi,
+            result: Ok(Vec::new()),
+        }))
+    }
+
+    fn runtime_projection(event: RuntimeEvent) -> RuntimeProjectionEvent {
+        RuntimeProjectionEvent::Runtime(Box::new(RuntimeControlEvent {
+            event_id: "test-event".into(),
+            provenance: RuntimeProvenance::local_tui("test-session"),
+            sequence: 1,
+            event,
+        }))
+    }
+
+    #[test]
+    fn query_completion_waits_for_terminal_event_when_task_finishes_first() {
+        let mut barrier = QueryCompletionBarrier::default();
+
+        barrier.defer(test_completion());
+        assert!(barrier.take_ready().is_none());
+
+        barrier.observe_terminal_event();
+        assert!(barrier.take_ready().is_some());
+        assert!(barrier.take_ready().is_none());
+    }
+
+    #[test]
+    fn query_completion_finishes_when_terminal_event_arrives_first() {
+        let mut barrier = QueryCompletionBarrier::default();
+
+        barrier.observe_terminal_event();
+        barrier.defer(test_completion());
+
+        assert!(barrier.take_ready().is_some());
+        assert!(barrier.take_ready().is_none());
+    }
+
+    #[tokio::test]
+    async fn query_join_failure_does_not_wait_for_an_event_that_cannot_arrive() {
+        let handle = tokio::spawn(async { std::future::pending::<TaskCompletion>().await });
+        handle.abort();
+        let completion = handle.await;
+        assert!(completion.is_err());
+
+        let mut barrier = QueryCompletionBarrier::default();
+        barrier.defer(Box::new(completion));
+
+        assert!(barrier.take_ready().is_some());
+    }
+
+    #[test]
+    fn turn_finished_is_a_terminal_projection_event() {
+        assert!(is_terminal_projection_event(&runtime_projection(
+            RuntimeEvent::Session(SessionEvent::TurnFinished {
+                reason: Some("turn complete".into()),
+            }),
+        )));
+        assert!(!is_terminal_projection_event(&runtime_projection(
+            RuntimeEvent::Session(SessionEvent::TurnStarted),
+        )));
+    }
 
     #[tokio::test]
     async fn runtime_mux_wakes_on_event() {

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -152,11 +152,13 @@ pub async fn run_tui(
                 match runtime_activity {
                     RuntimeActivity::Event(Some(event)) => {
                         needs_redraw |= maintainer.apply_runtime_event(event);
+                        needs_redraw |= maintainer.complete_query_if_ready(&mut processor).await?;
                     }
                     RuntimeActivity::Event(None) => {}
                     RuntimeActivity::Completed(completion) => {
-                        maintainer.complete_runtime_task(&mut processor, completion).await?;
-                        needs_redraw = true;
+                        needs_redraw |= maintainer
+                            .receive_runtime_task_completion(&mut processor, completion)
+                            .await?;
                     }
                     RuntimeActivity::Command(Some(command)) => {
                         maintainer.apply_runtime_command(&mut processor, command).await?;

--- a/src/tui/render/cells/active_turn.rs
+++ b/src/tui/render/cells/active_turn.rs
@@ -12,7 +12,7 @@ use super::plan_cells::{
     PlanModeCell, PlanSummaryCell, PlanningSuggestionCell, planning_suggestion_text,
 };
 use super::progress::{
-    ProgressRole, explicit_progress_entry_groups, push_live_events, push_progress_group,
+    ProgressRole, explicit_progress_entry_groups, push_progress_group, push_streaming_thinking,
 };
 use super::responding_cell::RespondingCell;
 use super::summary_cells::{ExploringCell, PlanningCell, RunningCell};
@@ -148,9 +148,16 @@ impl ActiveCell for ActiveTurnCell<'_> {
         let has_live_planning = !self.app.active_live.planning_actions.is_empty()
             || !self.app.active_live.planning_notes.is_empty();
         let has_live_running = !self.app.active_live.running_actions.is_empty();
-        let live_events = self.app.active_live.events.as_slice();
-        let has_live_events = !live_events.is_empty();
+        let has_live_progress = has_live_exploration || has_live_planning || has_live_running;
         let has_active_pending_interaction = self.app.active_pending_interaction().is_some();
+        let suppress_ordered_planning_chatter = matches!(
+            self.app.agent_execution_mode,
+            crate::agent::AgentExecutionMode::Plan
+        ) && has_live_exploration
+            && latest_agent.is_some_and(|message| !contains_structured_planning_output(message))
+            && self.app.snapshot.plan_steps.is_empty()
+            && self.app.pending_request_input().is_none()
+            && !self.app.has_pending_plan_approval();
 
         if !user_message.is_empty() {
             cells.push(Box::new(UserCell::new(user_message)));
@@ -162,12 +169,7 @@ impl ActiveCell for ActiveTurnCell<'_> {
         }
 
         let ordered_exploration_agent_segments =
-            if !has_live_events && !has_live_exploration && !has_live_planning && !has_live_running
-            {
-                ordered_exploration_agent_segments(current_turn.as_slice())
-            } else {
-                None
-            };
+            ordered_exploration_agent_segments(current_turn.as_slice(), has_thinking_stream);
         let uses_ordered_exploration_agent_segments = ordered_exploration_agent_segments.is_some();
 
         if let Some(segments) = ordered_exploration_agent_segments.as_ref() {
@@ -189,30 +191,21 @@ impl ActiveCell for ActiveTurnCell<'_> {
                         );
                     }
                     OrderedActiveSegment::Agent(message) => {
-                        cells.push(Box::new(MessageCell::new(
-                            "Agent",
-                            message,
-                            usize::MAX,
-                            self.cwd,
-                        )));
+                        if !suppress_ordered_planning_chatter {
+                            cells.push(Box::new(MessageCell::new(
+                                "Agent",
+                                message,
+                                usize::MAX,
+                                self.cwd,
+                            )));
+                        }
                     }
                 }
             }
         }
 
-        let mut has_event_exploration_summary = false;
-        let mut has_event_planning_summary = false;
-        let mut has_event_running_summary = false;
         let has_live_thinking = turn_live && has_thinking_stream;
-        if has_live_events || has_live_thinking {
-            for event in live_events {
-                match ProgressRole::from_live_event(event) {
-                    ProgressRole::Exploring => has_event_exploration_summary = true,
-                    ProgressRole::Planning => has_event_planning_summary = true,
-                    ProgressRole::Running => has_event_running_summary = true,
-                    ProgressRole::Thinking => {}
-                }
-            }
+        if has_live_thinking {
             let thinking_dur = self
                 .app
                 .active_live
@@ -220,19 +213,17 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 .map(|start| start.elapsed());
             // Live streaming thinking is always expanded (tail mode).
             // The toggle only affects committed (finalized) thinking blocks.
-            push_live_events(
+            push_streaming_thinking(
                 &mut cells,
-                live_events,
                 streaming_thinking_lines.filter(|_| has_live_thinking),
-                true,
                 false,
                 thinking_dur,
             );
         }
 
         let explicit_progress_groups = (!uses_ordered_exploration_agent_segments
-            && !has_live_events
             && !has_live_thinking
+            && !has_live_progress
             && !has_active_pending_interaction)
             .then(|| explicit_progress_entry_groups(current_turn.iter().copied()));
         if let Some(groups) = explicit_progress_groups.as_ref() {
@@ -256,31 +247,29 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Exploring")
             .map(|entry| entry.message.clone());
 
-        let exploration_summary = if has_live_events
-            || has_explicit_progress_groups
-            || uses_ordered_exploration_agent_segments
-        {
-            None
-        } else if has_live_exploration {
-            Some(compact_progress_summary_lines(
-                self.app.active_live.exploration_actions.as_slice(),
-                self.app.active_live.exploration_notes.as_slice(),
-                4,
-                "more exploration step(s)",
-            ))
-        } else if !turn_live {
-            None
-        } else {
-            explicit_exploration
-                .map(|summary| compact_summary_text(&summary, 4, "more exploration step(s)"))
-                .or_else(|| {
-                    current_turn_exploration_summary_from_entries(
-                        current_turn.as_slice(),
-                        self.app.is_busy() && turn_live,
-                        self.app.runtime_phase_detail.as_deref(),
-                    )
-                })
-        };
+        let exploration_summary =
+            if has_explicit_progress_groups || uses_ordered_exploration_agent_segments {
+                None
+            } else if has_live_exploration {
+                Some(compact_progress_summary_lines(
+                    self.app.active_live.exploration_actions.as_slice(),
+                    self.app.active_live.exploration_notes.as_slice(),
+                    4,
+                    "more exploration step(s)",
+                ))
+            } else if !turn_live {
+                None
+            } else {
+                explicit_exploration
+                    .map(|summary| compact_summary_text(&summary, 4, "more exploration step(s)"))
+                    .or_else(|| {
+                        current_turn_exploration_summary_from_entries(
+                            current_turn.as_slice(),
+                            self.app.is_busy() && turn_live,
+                            self.app.runtime_phase_detail.as_deref(),
+                        )
+                    })
+            };
         let has_exploration_summary = exploration_summary.is_some();
         let exploration_active = turn_live && has_exploration_summary;
         if let Some(summary) = exploration_summary {
@@ -292,22 +281,20 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Planning")
             .map(|entry| entry.message.clone());
 
-        let planning_summary = if has_live_events
-            || has_explicit_progress_groups
-            || uses_ordered_exploration_agent_segments
-        {
-            None
-        } else if has_live_planning {
-            Some(compact_progress_summary_lines(
-                self.app.active_live.planning_actions.as_slice(),
-                self.app.active_live.planning_notes.as_slice(),
-                4,
-                "more planning step(s)",
-            ))
-        } else {
-            explicit_planning
-                .map(|summary| compact_summary_text(&summary, 4, "more planning step(s)"))
-        };
+        let planning_summary =
+            if has_explicit_progress_groups || uses_ordered_exploration_agent_segments {
+                None
+            } else if has_live_planning {
+                Some(compact_progress_summary_lines(
+                    self.app.active_live.planning_actions.as_slice(),
+                    self.app.active_live.planning_notes.as_slice(),
+                    4,
+                    "more planning step(s)",
+                ))
+            } else {
+                explicit_planning
+                    .map(|summary| compact_summary_text(&summary, 4, "more planning step(s)"))
+            };
         let has_planning_summary = planning_summary.is_some();
         if let Some(summary) = planning_summary {
             cells.push(Box::new(PlanningCell::new(summary, turn_live)));
@@ -318,28 +305,26 @@ impl ActiveCell for ActiveTurnCell<'_> {
             .find(|entry| entry.role == "Running")
             .map(|entry| entry.message.clone());
 
-        let running_summary = if has_live_events
-            || has_explicit_progress_groups
-            || uses_ordered_exploration_agent_segments
-        {
-            None
-        } else if has_live_running {
-            Some(compact_recent_first_summary_lines(
-                self.app.active_live.running_actions.as_slice(),
-                4,
-                "more running step(s)",
-            ))
-        } else {
-            explicit_running
-                .map(|summary| compact_summary_text(&summary, 4, "more running step(s)"))
-                .or_else(|| {
-                    current_turn_tool_summary(
-                        current_turn.as_slice(),
-                        turn_live,
-                        self.app.runtime_phase_detail.as_deref(),
-                    )
-                })
-        };
+        let running_summary =
+            if has_explicit_progress_groups || uses_ordered_exploration_agent_segments {
+                None
+            } else if has_live_running {
+                Some(compact_recent_first_summary_lines(
+                    self.app.active_live.running_actions.as_slice(),
+                    4,
+                    "more running step(s)",
+                ))
+            } else {
+                explicit_running
+                    .map(|summary| compact_summary_text(&summary, 4, "more running step(s)"))
+                    .or_else(|| {
+                        current_turn_tool_summary(
+                            current_turn.as_slice(),
+                            turn_live,
+                            self.app.runtime_phase_detail.as_deref(),
+                        )
+                    })
+            };
         let has_running_summary = running_summary.is_some();
         let running_active = turn_live && has_running_summary;
         if let Some(entry) = current_turn.iter().find(|entry| {
@@ -358,13 +343,8 @@ impl ActiveCell for ActiveTurnCell<'_> {
         } else if let Some(summary) = running_summary {
             cells.push(Box::new(RunningCell::new(summary, running_active)));
         }
-        let compact_live_response = turn_live
-            && (has_exploration_summary
-                || has_planning_summary
-                || has_running_summary
-                || has_event_exploration_summary
-                || has_event_planning_summary
-                || has_event_running_summary);
+        let compact_live_response =
+            turn_live && (has_exploration_summary || has_planning_summary || has_running_summary);
 
         let inline_plan_summary = latest_agent.and_then(parse_render_plan_block).filter(|_| {
             self.app.snapshot.plan_steps.is_empty()
@@ -454,15 +434,16 @@ impl ActiveCell for ActiveTurnCell<'_> {
                 self.app.runtime_phase,
                 RuntimePhase::RunningTool | RuntimePhase::SendingPrompt
             );
-        let suppress_planning_chatter = matches!(
-            self.app.agent_execution_mode,
-            crate::agent::AgentExecutionMode::Plan
-        ) && (has_exploration_summary
-            || has_event_exploration_summary)
-            && latest_agent.is_some_and(|message| !contains_structured_planning_output(message))
-            && self.app.snapshot.plan_steps.is_empty()
-            && self.app.pending_request_input().is_none()
-            && !self.app.has_pending_plan_approval();
+        let suppress_planning_chatter = suppress_ordered_planning_chatter
+            || (matches!(
+                self.app.agent_execution_mode,
+                crate::agent::AgentExecutionMode::Plan
+            ) && has_exploration_summary
+                && latest_agent
+                    .is_some_and(|message| !contains_structured_planning_output(message))
+                && self.app.snapshot.plan_steps.is_empty()
+                && self.app.pending_request_input().is_none()
+                && !self.app.has_pending_plan_approval());
         let suppress_structured_plan_response = (self.app.snapshot.plan_steps.is_empty()
             && inline_plan_summary.is_some())
             || (!self.app.snapshot.plan_steps.is_empty()
@@ -477,9 +458,6 @@ impl ActiveCell for ActiveTurnCell<'_> {
             && !has_exploration_summary
             && !has_planning_summary
             && !has_running_summary
-            && !has_event_exploration_summary
-            && !has_event_planning_summary
-            && !has_event_running_summary
             && self.app.snapshot.plan_steps.is_empty()
             && !suppress_planning_chatter
             && !suppress_structured_plan_response
@@ -563,7 +541,6 @@ impl ActiveCell for ActiveTurnCell<'_> {
             )));
         } else if !has_active_pending_interaction
             && !has_live_thinking
-            && !has_live_events
             && let Some((role, tool_result)) = latest_tool_result
         {
             cells.push(Box::new(RespondingCell::from_tool_result(
@@ -575,9 +552,6 @@ impl ActiveCell for ActiveTurnCell<'_> {
             && !has_exploration_summary
             && !has_planning_summary
             && !has_running_summary
-            && !has_event_exploration_summary
-            && !has_event_planning_summary
-            && !has_event_running_summary
             && self.app.pending_request_input().is_none()
             && !self.app.has_pending_plan_approval()
             && self.app.pending_command_approval().is_none()

--- a/src/tui/render/cells/cells_tests/active_general.rs
+++ b/src/tui/render/cells/cells_tests/active_general.rs
@@ -154,6 +154,30 @@ fn active_turn_cell_renders_progress_sections_as_compact_stack() {
 }
 
 #[test]
+fn active_turn_cell_keeps_open_thinking_after_prior_agent_segment() {
+    let temp = tempdir().unwrap();
+    let mut app = TuiApp::new(ConfigManager {
+        path: temp.path().join("config.json"),
+    })
+    .expect("build tui app");
+    app.runtime_phase = RuntimePhase::ProcessingResponse;
+    app.push_entry("You", "Explain the ordering");
+    app.append_agent_delta("First response segment.");
+    app.append_agent_thinking_delta("Later reasoning segment.");
+
+    let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
+        .display_lines(100)
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let agent_idx = rendered.find("First response segment.").unwrap();
+    let thinking_idx = rendered.find("┊ Thinking").unwrap();
+    assert!(agent_idx < thinking_idx);
+}
+
+#[test]
 fn active_turn_cell_hides_background_stdout_label_and_pins_stderr() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
@@ -474,7 +498,7 @@ fn active_turn_cell_uses_stateful_live_exploration_sections() {
 }
 
 #[test]
-fn active_turn_cell_compacts_live_response_when_process_sections_exist() {
+fn active_turn_cell_preserves_agent_before_later_live_progress() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
@@ -499,12 +523,16 @@ fn active_turn_cell_compacts_live_response_when_process_sections_exist() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("# Exploring"));
+    let agent_idx = rendered
+        .find("• I have inspected the repository structure.")
+        .unwrap();
+    let exploring_idx = rendered.find("# Exploring").unwrap();
+
+    assert!(agent_idx < exploring_idx);
     assert!(rendered.contains("Read src/runtime_context.rs"));
-    assert!(rendered.contains("• I have inspected the repository structure."));
-    assert!(rendered.contains("• Next I will inspect the persistence layer."));
+    assert!(rendered.contains("Next I will inspect the persistence layer."));
     assert!(!rendered.contains("# Responding"));
-    assert!(!rendered.contains("Then I will verify the restore contract."));
+    assert!(rendered.contains("Then I will verify the restore contract."));
 }
 
 #[test]
@@ -1182,10 +1210,10 @@ fn active_turn_cell_flattens_thinking_and_running_events_in_order() {
     };
 
     app.append_agent_thinking_delta("first reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.record_running_action("Run cargo check");
     app.append_agent_thinking_delta("second reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.record_running_action("Run cargo test");
 
     let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
@@ -1226,7 +1254,7 @@ fn active_turn_cell_places_streaming_thinking_after_latest_progress_event() {
     };
 
     app.append_agent_thinking_delta("first reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.record_running_action("Run cargo check");
     app.append_agent_thinking_delta("second reasoning block\n");
 
@@ -1266,7 +1294,7 @@ fn active_turn_cell_places_streaming_thinking_after_latest_exploration_event() {
     };
 
     app.append_agent_thinking_delta("first reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.record_exploration_action("Read src/tui/render/cells.rs");
     app.append_agent_thinking_delta("second reasoning block\n");
 
@@ -1306,7 +1334,7 @@ fn active_turn_cell_groups_consecutive_thinking_events_with_stream() {
     };
 
     app.append_agent_thinking_delta("first reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.append_agent_thinking_delta("second reasoning block\n");
 
     let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
@@ -1341,7 +1369,7 @@ fn active_turn_cell_preserves_flushed_thinking_leading_indentation() {
     };
 
     app.append_agent_thinking_delta("    let value = 1;\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
 
     let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
         .display_lines(100)

--- a/src/tui/render/cells/mod.rs
+++ b/src/tui/render/cells/mod.rs
@@ -81,6 +81,7 @@ pub(super) mod terminal;
 
 fn ordered_exploration_agent_segments<'a>(
     current_turn: &[&'a TranscriptEntry],
+    force_ordered_agent: bool,
 ) -> Option<Vec<OrderedActiveSegment<'a>>> {
     let mut segments = Vec::new();
     let mut exploration_items = Vec::new();
@@ -123,7 +124,14 @@ fn ordered_exploration_agent_segments<'a>(
                 if messages.is_empty() {
                     continue;
                 }
-                if !exploration_items.is_empty() || !segments.is_empty() {
+                let continues_progress_group = matches!(
+                    segments.last(),
+                    Some(OrderedActiveSegment::Progress(last_role, _))
+                        if *last_role == progress_role
+                );
+                if !exploration_items.is_empty()
+                    || (!continues_progress_group && !segments.is_empty())
+                {
                     saw_interleaving = true;
                 }
                 flush_exploration(&mut segments, &mut exploration_items);
@@ -159,7 +167,10 @@ fn ordered_exploration_agent_segments<'a>(
         && matches!(segments.first(), Some(OrderedActiveSegment::Exploration(_)))
         && matches!(segments.last(), Some(OrderedActiveSegment::Agent(_)));
 
-    if saw_interleaving || (segments.len() > 1 && !simple_exploration_then_agent) {
+    if saw_interleaving
+        || (segments.len() > 1 && !simple_exploration_then_agent)
+        || (force_ordered_agent && !segments.is_empty())
+    {
         Some(segments)
     } else {
         None

--- a/src/tui/render/cells/progress.rs
+++ b/src/tui/render/cells/progress.rs
@@ -1,12 +1,10 @@
 use ratatui::text::Line;
 
-use super::super::{
-    compact_progress_summary_lines, compact_recent_first_summary_lines, compact_summary_lines,
-};
+use super::super::compact_summary_lines;
 use super::HistoryCell;
 use super::summary_cells::{ExploringCell, PlanningCell, RunningCell};
 use super::thinking_cells::ThinkingBlockCell;
-use crate::tui::state::{ActiveLiveEvent, TranscriptEntry};
+use crate::tui::state::TranscriptEntry;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ProgressRole {
@@ -24,17 +22,6 @@ impl ProgressRole {
             "Planning" => Some(Self::Planning),
             "Running" => Some(Self::Running),
             _ => None,
-        }
-    }
-
-    pub(super) fn from_live_event(event: &ActiveLiveEvent) -> Self {
-        match event {
-            ActiveLiveEvent::Thinking(_) => Self::Thinking,
-            ActiveLiveEvent::ExplorationAction(_) | ActiveLiveEvent::ExplorationNote(_) => {
-                Self::Exploring
-            }
-            ActiveLiveEvent::PlanningAction(_) | ActiveLiveEvent::PlanningNote(_) => Self::Planning,
-            ActiveLiveEvent::RunningAction(_) => Self::Running,
         }
     }
 }
@@ -114,182 +101,20 @@ pub(super) fn push_progress_group<'a>(
     }
 }
 
-pub(super) fn push_live_events<'a>(
+pub(super) fn push_streaming_thinking<'a>(
     cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-    events: &[crate::tui::state::ActiveLiveEvent],
     streaming_thinking_lines: Option<&'a [Line<'static>]>,
-    active: bool,
     collapsed: bool,
     thinking_duration: Option<std::time::Duration>,
 ) {
-    let mut thinking_messages = Vec::new();
-    let mut exploration_actions = Vec::new();
-    let mut exploration_notes = Vec::new();
-    let mut planning_actions = Vec::new();
-    let mut planning_notes = Vec::new();
-    let mut running_actions = Vec::new();
-
-    for event in events {
-        match ProgressRole::from_live_event(event) {
-            ProgressRole::Thinking => {
-                push_live_exploration_group(
-                    cells,
-                    &mut exploration_actions,
-                    &mut exploration_notes,
-                    active,
-                );
-                push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
-                push_live_running_group(cells, &mut running_actions, active);
-                thinking_messages.push(event.message().to_string());
-            }
-            ProgressRole::Exploring => {
-                push_live_thinking_group(
-                    cells,
-                    &mut thinking_messages,
-                    None,
-                    collapsed,
-                    thinking_duration,
-                );
-                push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
-                push_live_running_group(cells, &mut running_actions, active);
-                if event.is_note() {
-                    exploration_notes.push(event.message().to_string());
-                } else {
-                    exploration_actions.push(event.message().to_string());
-                }
-            }
-            ProgressRole::Planning => {
-                push_live_thinking_group(
-                    cells,
-                    &mut thinking_messages,
-                    None,
-                    collapsed,
-                    thinking_duration,
-                );
-                push_live_exploration_group(
-                    cells,
-                    &mut exploration_actions,
-                    &mut exploration_notes,
-                    active,
-                );
-                push_live_running_group(cells, &mut running_actions, active);
-                if event.is_note() {
-                    planning_notes.push(event.message().to_string());
-                } else {
-                    planning_actions.push(event.message().to_string());
-                }
-            }
-            ProgressRole::Running => {
-                push_live_thinking_group(
-                    cells,
-                    &mut thinking_messages,
-                    None,
-                    collapsed,
-                    thinking_duration,
-                );
-                push_live_exploration_group(
-                    cells,
-                    &mut exploration_actions,
-                    &mut exploration_notes,
-                    active,
-                );
-                push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
-                running_actions.push(event.message().to_string());
-            }
-        }
-    }
-
-    push_live_exploration_group(
-        cells,
-        &mut exploration_actions,
-        &mut exploration_notes,
-        active,
-    );
-    push_live_planning_group(cells, &mut planning_actions, &mut planning_notes, active);
-    push_live_running_group(cells, &mut running_actions, active);
-    push_live_thinking_group(
-        cells,
-        &mut thinking_messages,
-        streaming_thinking_lines,
-        collapsed,
-        thinking_duration,
-    );
-}
-
-pub(super) fn push_live_thinking_group<'a>(
-    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-    messages: &mut Vec<String>,
-    stream_lines: Option<&'a [Line<'static>]>,
-    collapsed: bool,
-    duration: Option<std::time::Duration>,
-) {
-    if messages.is_empty() && stream_lines.is_none_or(|lines| lines.is_empty()) {
+    let Some(stream_lines) = streaming_thinking_lines.filter(|lines| !lines.is_empty()) else {
         return;
-    }
+    };
     cells.push(Box::new(ThinkingBlockCell::with_stream_lines(
-        std::mem::take(messages).join("\n"),
-        stream_lines,
+        String::new(),
+        Some(stream_lines),
         4,
         collapsed,
-        duration,
+        thinking_duration,
     )));
-}
-
-pub(super) fn push_live_exploration_group<'a>(
-    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-    actions: &mut Vec<String>,
-    notes: &mut Vec<String>,
-    active: bool,
-) {
-    if actions.is_empty() && notes.is_empty() {
-        return;
-    }
-    cells.push(Box::new(ExploringCell::new(
-        compact_progress_summary_lines(
-            actions.as_slice(),
-            notes.as_slice(),
-            4,
-            "more exploration step(s)",
-        ),
-        active,
-    )));
-    actions.clear();
-    notes.clear();
-}
-
-pub(super) fn push_live_planning_group<'a>(
-    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-    actions: &mut Vec<String>,
-    notes: &mut Vec<String>,
-    active: bool,
-) {
-    if actions.is_empty() && notes.is_empty() {
-        return;
-    }
-    cells.push(Box::new(PlanningCell::new(
-        compact_progress_summary_lines(
-            actions.as_slice(),
-            notes.as_slice(),
-            4,
-            "more planning step(s)",
-        ),
-        active,
-    )));
-    actions.clear();
-    notes.clear();
-}
-
-pub(super) fn push_live_running_group<'a>(
-    cells: &mut Vec<Box<dyn HistoryCell + 'a>>,
-    actions: &mut Vec<String>,
-    active: bool,
-) {
-    if actions.is_empty() {
-        return;
-    }
-    cells.push(Box::new(RunningCell::new(
-        compact_recent_first_summary_lines(actions.as_slice(), 4, "more running step(s)"),
-        active,
-    )));
-    actions.clear();
 }

--- a/src/tui/render/cells_tests/active_general.rs
+++ b/src/tui/render/cells_tests/active_general.rs
@@ -937,10 +937,10 @@ fn active_turn_cell_flattens_thinking_and_running_events_in_order() {
     };
 
     app.append_agent_thinking_delta("first reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.record_running_action("Run cargo check");
     app.append_agent_thinking_delta("second reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.record_running_action("Run cargo test");
 
     let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
@@ -980,7 +980,7 @@ fn active_turn_cell_places_streaming_thinking_after_latest_progress_event() {
     };
 
     app.append_agent_thinking_delta("first reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.record_running_action("Run cargo check");
     app.append_agent_thinking_delta("second reasoning block\n");
 
@@ -1019,7 +1019,7 @@ fn active_turn_cell_places_streaming_thinking_after_latest_exploration_event() {
     };
 
     app.append_agent_thinking_delta("first reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.record_exploration_action("Read src/tui/render/cells.rs");
     app.append_agent_thinking_delta("second reasoning block\n");
 
@@ -1058,7 +1058,7 @@ fn active_turn_cell_groups_consecutive_thinking_events_with_stream() {
     };
 
     app.append_agent_thinking_delta("first reasoning block\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
     app.append_agent_thinking_delta("second reasoning block\n");
 
     let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
@@ -1093,7 +1093,7 @@ fn active_turn_cell_preserves_flushed_thinking_leading_indentation() {
     };
 
     app.append_agent_thinking_delta("    let value = 1;\n");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
 
     let rendered = ActiveTurnCell::new(&app, Some(Path::new(".")))
         .display_lines(100)

--- a/src/tui/runtime/events.rs
+++ b/src/tui/runtime/events.rs
@@ -54,11 +54,11 @@ pub(crate) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
                 app.finalize_agent_stream(None);
                 if role == "Tool" {
                     if let Some(action) = exploration_action_label(&message) {
-                        app.record_exploration_action(action);
+                        app.cache_exploration_action(action);
                     } else if let Some(action) = planning_action_label(&message) {
-                        app.record_planning_action(action);
+                        app.cache_planning_action(action);
                     } else if let Some(action) = tool_action_label(&message) {
-                        app.record_running_action(action);
+                        app.cache_running_action(action);
                     }
                 } else if let Some(request) = subagent_request_input(&message) {
                     app.advance_running_tool_boundary();
@@ -193,7 +193,7 @@ pub(crate) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
             if role == "Tool"
                 && let Some(action) = tool_action_label(&message)
             {
-                app.record_running_action(action);
+                app.cache_running_action(action);
             }
             if matches!(role, "Tool Result" | "Tool Error") {
                 app.advance_running_tool_boundary();
@@ -209,7 +209,7 @@ pub(crate) fn apply_tui_event(app: &mut TuiApp, event: TuiEvent) {
             stream,
             chunk,
         } => {
-            app.flush_agent_thinking_stream_to_live_event();
+            app.finalize_agent_thinking_stream();
             if !append_tool_progress(app, &name, stream, &chunk) {
                 return;
             }
@@ -292,11 +292,11 @@ fn apply_runtime_control_event(app: &mut TuiApp, event: RuntimeControlEvent) {
             }
             app.finalize_agent_stream(None);
             if let Some(action) = exploration_action_label_for(&name, &input) {
-                app.record_exploration_action(action);
+                app.cache_exploration_action(action);
             } else if let Some(action) = planning_action_label_for(&name, &input) {
-                app.record_planning_action(action);
+                app.cache_planning_action(action);
             } else if let Some(action) = tool_action_label_for(&name, &input) {
-                app.record_running_action(action);
+                app.cache_running_action(action);
             }
             app.set_runtime_phase(RuntimePhase::RunningTool, Some(name.clone()));
             app.push_tool_entry(

--- a/src/tui/runtime/tasks.rs
+++ b/src/tui/runtime/tasks.rs
@@ -71,7 +71,11 @@ fn forward_task_result_lifecycle<T>(
     provenance: &RuntimeProvenance,
     result: &anyhow::Result<T>,
 ) {
-    let event = match result {
+    forward_lifecycle_event_to_bus(bus, task_result_lifecycle_event(result), provenance);
+}
+
+fn task_result_lifecycle_event<T>(result: &anyhow::Result<T>) -> AgentEvent {
+    match result {
         Ok(_) => AgentEvent::AgentStop {
             reason: "turn complete".to_string(),
         },
@@ -88,8 +92,7 @@ fn forward_task_result_lifecycle<T>(
                 }
             }
         }
-    };
-    forward_lifecycle_event_to_bus(bus, event, provenance);
+    }
 }
 
 fn forward_optional_task_result_lifecycle<T>(
@@ -215,8 +218,6 @@ pub(crate) fn start_input_control_task_with_services(
     let (sender, receiver) = mpsc::unbounded_channel();
     let cancellation_token = Arc::new(AtomicBool::new(false));
     let bus = app.event_bus.clone().expect("event bus must exist");
-    let event_provenance = local_tui_event_provenance(&agent.session_id);
-
     app.clear_pending_planning_suggestion();
     app.clear_active_live_sections();
     app.begin_running_turn();
@@ -238,7 +239,7 @@ pub(crate) fn start_input_control_task_with_services(
     agent.set_full_access_mode(app.permission_mode == PermissionMode::FullAccess);
     sync_bash_prefixes_from_config(app, &mut agent);
     agent.set_cancellation_token(Some(cancellation_token.clone()));
-    forward_lifecycle_event_to_bus(&bus, AgentEvent::AgentStart, &event_provenance);
+    bus.publish_raw(AgentEvent::AgentStart);
     let handle = tokio::spawn(async move {
         let tx = sender.clone();
         let provenance =
@@ -251,7 +252,6 @@ pub(crate) fn start_input_control_task_with_services(
 
         let bus_arg = Some(bus.clone());
         let lifecycle_bus = bus.clone();
-        let lifecycle_provenance = event_provenance.clone();
         let result = crate::control_plane::dispatch(
             envelope,
             &mcp_manager,
@@ -264,14 +264,14 @@ pub(crate) fn start_input_control_task_with_services(
                 bus_arg
                     .as_ref()
                     .expect("runtime event bus must exist")
-                    .publish_control_event(control_event.clone());
+                    .publish_resequenced_control_event(control_event.clone());
                 let _ = tx.send(TuiEvent::Runtime(Box::new(control_event)));
             },
         )
         .await;
 
         let result = result.map_err(|e| anyhow::anyhow!("{e}"));
-        forward_task_result_lifecycle(&lifecycle_bus, &lifecycle_provenance, &result);
+        lifecycle_bus.publish_raw(task_result_lifecycle_event(&result));
         TaskCompletion::Query { agent, result }
     });
 

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -28,7 +28,7 @@ use self::types::CommittedTranscriptRenderCache;
 #[cfg(test)]
 pub use self::types::current_unix_timestamp_secs;
 pub use self::types::{
-    ActiveLiveEvent, ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
+    ActiveLiveSections, ActivePendingInteraction, ActivePendingInteractionKind,
     AgentMarkdownStreamState, ApiKeyTarget, CommandSpec, CompactionTranscriptPayload,
     CompletedInteractionSnapshot, GoalHandle, GoalStatus, HelpTab, InteractionKind, ListPickerKind,
     LocalCommand, LocalCommandKind, ModelCatalogSnapshot, ModelRoutingView, OAuthLoginMode,

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1371,6 +1371,72 @@ fn finalized_agent_stream_does_not_replace_agent_text_before_tool_boundary() {
 }
 
 #[test]
+fn committed_turn_keeps_thinking_before_final_agent_message() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.push_entry("You", "Explain the ordering bug");
+
+    app.append_agent_thinking_delta("Trace the event stream.");
+    app.append_agent_delta("The transcript has two ordering sources.");
+    app.finalize_active_turn();
+
+    let entries = &app.committed_turns[0].entries;
+    let roles = entries
+        .iter()
+        .map(|entry| entry.role.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(roles, vec!["You", "Thinking", "Agent"]);
+    assert_eq!(entries[1].message, "Trace the event stream.");
+    assert_eq!(
+        entries[2].message,
+        "The transcript has two ordering sources."
+    );
+}
+
+#[test]
+fn committed_turn_preserves_interleaved_assistant_segments() {
+    let dir = tempdir().expect("tempdir");
+    let cm = ConfigManager {
+        path: dir.path().join("config.json"),
+    };
+    let mut app = TuiApp::new(cm).expect("app");
+    app.push_entry("You", "Inspect, run a tool, and finish");
+
+    app.append_agent_thinking_delta("Inspect the implementation.");
+    app.append_agent_delta("I found the relevant state transition.");
+    app.finalize_agent_stream(None);
+    app.push_tool_entry(
+        Some("call-1"),
+        "cargo_check",
+        super::ToolTranscriptStatus::Completed,
+        "cargo check passed",
+    );
+    app.append_agent_thinking_delta("Interpret the tool result.");
+    app.append_agent_delta("The fix is ready.");
+    app.finalize_active_turn();
+
+    let entries = &app.committed_turns[0].entries;
+    let ordered = entries
+        .iter()
+        .map(|entry| (entry.role.as_str(), entry.message.as_str()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ordered,
+        vec![
+            ("You", "Inspect, run a tool, and finish"),
+            ("Thinking", "Inspect the implementation."),
+            ("Agent", "I found the relevant state transition."),
+            ("Tool Result", "cargo check passed"),
+            ("Thinking", "Interpret the tool result."),
+            ("Agent", "The fix is ready."),
+        ]
+    );
+}
+
+#[test]
 fn flushed_agent_thinking_stream_scrubs_internal_runtime_blocks() {
     let dir = tempdir().expect("tempdir");
     let cm = ConfigManager {
@@ -1381,14 +1447,14 @@ fn flushed_agent_thinking_stream_scrubs_internal_runtime_blocks() {
     app.append_agent_thinking_delta("Visible thought.\n");
     app.append_agent_thinking_delta("<agent_runtime>\n{\"phase\":\"tool_results_available\"}");
     app.append_agent_thinking_delta("\n</agent_runtime>\nNext thought.");
-    app.flush_agent_thinking_stream_to_live_event();
+    app.finalize_agent_thinking_stream();
 
-    assert_eq!(app.active_live.events.len(), 1);
-    let event = app.active_live.events.first().expect("thinking event");
-    assert_eq!(event.role(), "Thinking");
-    assert_eq!(event.message(), "Visible thought.\n\nNext thought.");
-    assert!(!event.message().contains("agent_runtime"));
-    assert!(!event.message().contains("tool_results_available"));
+    assert_eq!(app.active_turn.entries.len(), 1);
+    let entry = app.active_turn.entries.first().expect("thinking entry");
+    assert_eq!(entry.role, "Thinking");
+    assert_eq!(entry.message, "Visible thought.\n\nNext thought.");
+    assert!(!entry.message.contains("agent_runtime"));
+    assert!(!entry.message.contains("tool_results_available"));
 }
 
 #[test]
@@ -1402,12 +1468,12 @@ fn live_progress_events_sanitize_terminal_controls() {
     app.record_running_action("Run\r\u{1b}[31mcargo check\u{1b}[0m\u{8}");
     app.record_exploration_note("Read\tfile\u{7}");
 
-    assert_eq!(app.active_live.events.len(), 2);
-    assert_eq!(app.active_live.events[0].message(), "Run\ncargo check");
-    assert_eq!(app.active_live.events[1].message(), "Read    file");
-    assert!(!app.active_live.events[0].message().contains('\r'));
-    assert!(!app.active_live.events[0].message().contains('\u{1b}'));
-    assert!(!app.active_live.events[1].message().contains('\u{7}'));
+    assert_eq!(app.active_turn.entries.len(), 2);
+    assert_eq!(app.active_turn.entries[0].message, "Run\ncargo check");
+    assert_eq!(app.active_turn.entries[1].message, "Read    file");
+    assert!(!app.active_turn.entries[0].message.contains('\r'));
+    assert!(!app.active_turn.entries[0].message.contains('\u{1b}'));
+    assert!(!app.active_turn.entries[1].message.contains('\u{7}'));
 }
 
 #[test]

--- a/src/tui/state/transcript.rs
+++ b/src/tui/state/transcript.rs
@@ -5,32 +5,10 @@ use rara_state::state_db::PersistedTurnEntry;
 use ratatui::text::Line;
 
 use super::{
-    ActiveLiveEvent, ActiveLiveSections, PendingFollowUpMessage, RuntimePhase, SystemMessageKind,
-    TranscriptEntry, TranscriptTurn, TuiApp,
+    PendingFollowUpMessage, RuntimePhase, SystemMessageKind, TranscriptEntry, TranscriptTurn,
+    TuiApp,
 };
 use crate::tui::terminal_event::TerminalEvent;
-
-fn legacy_active_live_sections(live: &ActiveLiveSections) -> Vec<(&'static str, Vec<String>)> {
-    vec![
-        (
-            "Exploring",
-            live.exploration_actions
-                .iter()
-                .chain(live.exploration_notes.iter())
-                .cloned()
-                .collect::<Vec<_>>(),
-        ),
-        (
-            "Planning",
-            live.planning_actions
-                .iter()
-                .chain(live.planning_notes.iter())
-                .cloned()
-                .collect::<Vec<_>>(),
-        ),
-        ("Running", live.running_actions.to_vec()),
-    ]
-}
 
 fn is_agent_segment_boundary(entry: &TranscriptEntry) -> bool {
     if matches!(
@@ -167,6 +145,7 @@ impl TuiApp {
     }
 
     pub fn append_agent_delta(&mut self, delta: &str) {
+        self.finalize_agent_thinking_stream();
         let cwd = if !self.snapshot.cwd.is_empty() {
             PathBuf::from(self.snapshot.cwd.as_str())
         } else {
@@ -180,6 +159,9 @@ impl TuiApp {
     }
 
     pub fn append_agent_thinking_delta(&mut self, delta: &str) {
+        if self.agent_markdown_stream.is_some() {
+            self.finalize_agent_stream(None);
+        }
         let cwd = if !self.snapshot.cwd.is_empty() {
             PathBuf::from(self.snapshot.cwd.as_str())
         } else {
@@ -196,7 +178,7 @@ impl TuiApp {
         self.reset_transcript_scroll_if_following_tail();
     }
 
-    pub fn flush_agent_thinking_stream_to_live_event(&mut self) {
+    pub fn finalize_agent_thinking_stream(&mut self) {
         let Some(stream) = self.agent_thinking_stream.take() else {
             return;
         };
@@ -207,7 +189,7 @@ impl TuiApp {
         if message.trim().is_empty() {
             return;
         }
-        self.push_active_live_event(ActiveLiveEvent::Thinking(message));
+        self.push_active_progress_entry("Thinking", message);
         self.reset_transcript_scroll_if_following_tail();
     }
 
@@ -232,7 +214,7 @@ impl TuiApp {
     }
 
     pub fn finalize_agent_stream(&mut self, final_message: Option<String>) {
-        self.flush_agent_thinking_stream_to_live_event();
+        self.finalize_agent_thinking_stream();
         let fallback = self
             .agent_markdown_stream
             .take()
@@ -355,32 +337,8 @@ impl TuiApp {
             + self.active_turn.entries.len()
     }
 
-    fn materialize_active_live_entries(&mut self) {
-        if !self.active_live.events.is_empty() {
-            for event in &self.active_live.events {
-                self.active_turn.entries.push(TranscriptEntry::new(
-                    event.role(),
-                    event.message().to_string(),
-                ));
-            }
-            return;
-        }
-
-        let sections = legacy_active_live_sections(&self.active_live);
-
-        for (role, lines) in sections {
-            if lines.is_empty() {
-                continue;
-            }
-            self.active_turn
-                .entries
-                .push(TranscriptEntry::new(role, lines.join("\n")));
-        }
-    }
-
     fn commit_active_turn(&mut self) {
         self.finalize_agent_stream(None);
-        self.materialize_active_live_entries();
         if self.active_turn.entries.is_empty() {
             self.clear_active_live_sections();
             return;
@@ -426,13 +384,19 @@ impl TuiApp {
         self.active_live = super::ActiveLiveSections::default();
     }
 
-    fn push_active_live_event(&mut self, event: ActiveLiveEvent) {
-        self.active_live
-            .events
-            .push(sanitize_active_live_event(event));
+    fn push_active_progress_entry(&mut self, role: &'static str, message: String) {
+        let message = crate::tui::display_sanitize::sanitize_display_text(&message);
+        self.push_entry(role, message);
     }
 
+    #[cfg(test)]
     pub fn record_exploration_action(&mut self, action: impl Into<String>) {
+        let action = crate::tui::display_sanitize::sanitize_display_text(&action.into());
+        self.cache_exploration_action(action.clone());
+        self.push_active_progress_entry("Exploring", action);
+    }
+
+    pub(crate) fn cache_exploration_action(&mut self, action: impl Into<String>) {
         let action = crate::tui::display_sanitize::sanitize_display_text(&action.into());
         if !self
             .active_live
@@ -440,9 +404,8 @@ impl TuiApp {
             .iter()
             .any(|item| item == &action)
         {
-            self.active_live.exploration_actions.push(action.clone());
+            self.active_live.exploration_actions.push(action);
         }
-        self.push_active_live_event(ActiveLiveEvent::ExplorationAction(action));
     }
 
     pub fn record_exploration_note(&mut self, note: impl Into<String>) {
@@ -455,10 +418,17 @@ impl TuiApp {
         {
             self.active_live.exploration_notes.push(note.clone());
         }
-        self.push_active_live_event(ActiveLiveEvent::ExplorationNote(note));
+        self.push_active_progress_entry("Exploring", note);
     }
 
+    #[cfg(test)]
     pub fn record_running_action(&mut self, action: impl Into<String>) {
+        let action = crate::tui::display_sanitize::sanitize_display_text(&action.into());
+        self.cache_running_action(action.clone());
+        self.push_active_progress_entry("Running", action);
+    }
+
+    pub(crate) fn cache_running_action(&mut self, action: impl Into<String>) {
         let action = crate::tui::display_sanitize::sanitize_display_text(&action.into());
         if !self
             .active_live
@@ -466,12 +436,18 @@ impl TuiApp {
             .iter()
             .any(|item| item == &action)
         {
-            self.active_live.running_actions.push(action.clone());
+            self.active_live.running_actions.push(action);
         }
-        self.push_active_live_event(ActiveLiveEvent::RunningAction(action));
     }
 
+    #[cfg(test)]
     pub fn record_planning_action(&mut self, action: impl Into<String>) {
+        let action = crate::tui::display_sanitize::sanitize_display_text(&action.into());
+        self.cache_planning_action(action.clone());
+        self.push_active_progress_entry("Planning", action);
+    }
+
+    pub(crate) fn cache_planning_action(&mut self, action: impl Into<String>) {
         let action = crate::tui::display_sanitize::sanitize_display_text(&action.into());
         if !self
             .active_live
@@ -479,9 +455,8 @@ impl TuiApp {
             .iter()
             .any(|item| item == &action)
         {
-            self.active_live.planning_actions.push(action.clone());
+            self.active_live.planning_actions.push(action);
         }
-        self.push_active_live_event(ActiveLiveEvent::PlanningAction(action));
     }
 
     pub fn record_planning_note(&mut self, note: impl Into<String>) {
@@ -494,7 +469,7 @@ impl TuiApp {
         {
             self.active_live.planning_notes.push(note.clone());
         }
-        self.push_active_live_event(ActiveLiveEvent::PlanningNote(note));
+        self.push_active_progress_entry("Planning", note);
     }
 
     pub fn has_pending_planning_suggestion(&self) -> bool {
@@ -632,28 +607,5 @@ impl TuiApp {
 
     pub fn clear_pending_planning_suggestion(&mut self) {
         self.bottom_pane.pending_planning_suggestion = None;
-    }
-}
-
-fn sanitize_active_live_event(event: ActiveLiveEvent) -> ActiveLiveEvent {
-    match event {
-        ActiveLiveEvent::Thinking(message) => ActiveLiveEvent::Thinking(
-            crate::tui::display_sanitize::sanitize_display_text(&message),
-        ),
-        ActiveLiveEvent::ExplorationAction(message) => ActiveLiveEvent::ExplorationAction(
-            crate::tui::display_sanitize::sanitize_display_text(&message),
-        ),
-        ActiveLiveEvent::ExplorationNote(message) => ActiveLiveEvent::ExplorationNote(
-            crate::tui::display_sanitize::sanitize_display_text(&message),
-        ),
-        ActiveLiveEvent::PlanningAction(message) => ActiveLiveEvent::PlanningAction(
-            crate::tui::display_sanitize::sanitize_display_text(&message),
-        ),
-        ActiveLiveEvent::PlanningNote(message) => ActiveLiveEvent::PlanningNote(
-            crate::tui::display_sanitize::sanitize_display_text(&message),
-        ),
-        ActiveLiveEvent::RunningAction(message) => ActiveLiveEvent::RunningAction(
-            crate::tui::display_sanitize::sanitize_display_text(&message),
-        ),
     }
 }

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -722,45 +722,8 @@ impl AgentMarkdownStreamState {
     }
 }
 
-#[derive(Clone)]
-pub enum ActiveLiveEvent {
-    Thinking(String),
-    ExplorationAction(String),
-    ExplorationNote(String),
-    PlanningAction(String),
-    PlanningNote(String),
-    RunningAction(String),
-}
-
-impl ActiveLiveEvent {
-    pub fn role(&self) -> &'static str {
-        match self {
-            Self::Thinking(_) => "Thinking",
-            Self::ExplorationAction(_) | Self::ExplorationNote(_) => "Exploring",
-            Self::PlanningAction(_) | Self::PlanningNote(_) => "Planning",
-            Self::RunningAction(_) => "Running",
-        }
-    }
-
-    pub fn message(&self) -> &str {
-        match self {
-            Self::Thinking(message)
-            | Self::ExplorationAction(message)
-            | Self::ExplorationNote(message)
-            | Self::PlanningAction(message)
-            | Self::PlanningNote(message)
-            | Self::RunningAction(message) => message,
-        }
-    }
-
-    pub fn is_note(&self) -> bool {
-        matches!(self, Self::ExplorationNote(_) | Self::PlanningNote(_))
-    }
-}
-
 #[derive(Default)]
 pub struct ActiveLiveSections {
-    pub events: Vec<ActiveLiveEvent>,
     /// Timestamp of the first Thinking event in the current agent turn,
     /// used to display how long the model spent thinking.
     pub thinking_started_at: Option<std::time::Instant>,


### PR DESCRIPTION
## Summary

- make closed thinking, progress, and assistant segments share the active turn's ordered transcript projection
- gate query commit on both the task result and the terminal structured runtime event
- re-sequence in-process dispatch events across requests while preserving external adapter provenance

## Motivation

The TUI previously stored assistant text in `active_turn.entries` but kept closed thinking and progress in a separate `active_live.events` sidecar. Turn commit appended that sidecar at the end, so an actual `Thinking -> Agent` event sequence could be rendered as `Agent -> Thinking`.

The event loop also selected independently between the query task and the structured runtime stream. A ready `JoinHandle` could therefore commit the turn while already-published tail events were still queued. In addition, request-local dispatch sequence numbers restarted for each request, allowing a later turn's events to be rejected as stale by the session-level TUI projection.

## Implementation

- close an open thinking stream before assistant text and close an open assistant stream before later thinking
- write closed semantic segments directly to ordered `TranscriptEntry` values and keep live caches display-only
- require both task completion and a terminal runtime projection before committing a query turn
- use the runtime bus's monotonic sequence domain for in-process dispatch events
- keep external `publish_control_event` identity and provenance semantics unchanged
- send the outer local task lifecycle only to legacy raw subscribers so the ordered control stream has one terminal boundary

## Related issue

No GitHub issue currently tracks this follow-up; it was reported directly during review.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- `cargo test --all-targets --quiet` (`1321` library tests and `1` embedded integration test passed)
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

An exploratory all-features Clippy run is not available on this machine because Candle's CUDA dependency requires `nvcc`; the default feature set is warning-clean.

## Compatibility

This change does not alter public APIs, persisted schemas, or external runtime protocols.
