### PR TITLE
chore: remove deprecated local_embeddings config field

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -24,10 +24,9 @@ pub use self::mcp::{
 pub use self::migration::migrate_reasoning_summary;
 pub use self::model::{
     BuiltinPluginConfig, ConfigManager, ContextFileSearchPolicy, DEFAULT_NOWLEDGE_MEM_CLOUD_URL,
-    LocalEmbeddingPolicy, NowledgeMemMode, NowledgeMemPluginConfig, OpenAiEndpointKind,
-    OpenAiEndpointProfile, ProviderConfigState, RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig,
-    TuiThemeConfig, ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for,
-    workspace_data_dir_for_home,
+    NowledgeMemMode, NowledgeMemPluginConfig, OpenAiEndpointKind, OpenAiEndpointProfile,
+    ProviderConfigState, RaraConfig, SandboxWorkspaceWriteConfig, TuiConfig, TuiThemeConfig,
+    ensure_rara_home_dir, rara_home_dir, workspace_data_dir_for, workspace_data_dir_for_home,
 };
 pub use self::multi_agent::MultiAgentPolicy;
 pub use self::provider_surface::{

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -89,25 +89,6 @@ impl ContextFileSearchPolicy {
     }
 }
 
-/// Deprecated compatibility setting. Local semantic memory is delegated to
-/// official Mem, so this value is parsed but no longer starts a bundled
-/// embedding runtime.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum LocalEmbeddingPolicy {
-    #[default]
-    Off,
-    Auto,
-    Provider,
-    Local,
-}
-
-impl LocalEmbeddingPolicy {
-    pub fn is_default(&self) -> bool {
-        *self == Self::default()
-    }
-}
-
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProviderConfigState {
     #[serde(

--- a/crates/config/src/model/rara_config.rs
+++ b/crates/config/src/model/rara_config.rs
@@ -44,8 +44,6 @@ pub struct RaraConfig {
     pub memory_consolidation: MemoryConsolidationConfig,
     #[serde(default, skip_serializing_if = "ContextFileSearchPolicy::is_default")]
     pub context_file_search: ContextFileSearchPolicy,
-    #[serde(default, skip_serializing_if = "LocalEmbeddingPolicy::is_default")]
-    pub local_embeddings: LocalEmbeddingPolicy,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub plugin_dirs: Vec<PathBuf>,
     #[serde(default, skip_serializing_if = "BuiltinPluginConfig::is_default")]
@@ -96,16 +94,6 @@ impl RaraConfig {
     where
         F: FnMut(&str) -> Option<String>,
     {
-        if let Some(value) = read_env("RARA_LOCAL_EMBEDDINGS") {
-            self.local_embeddings = match value.trim().to_ascii_lowercase().as_str() {
-                "off" | "false" | "0" | "no" => LocalEmbeddingPolicy::Off,
-                "auto" | "on" | "true" | "1" | "yes" => LocalEmbeddingPolicy::Auto,
-                "provider" | "native" | "llm" => LocalEmbeddingPolicy::Provider,
-                "local" | "sidecar" => LocalEmbeddingPolicy::Local,
-                _ => self.local_embeddings,
-            };
-        }
-
         if self.has_api_key() {
             return;
         }

--- a/crates/config/src/model_test.rs
+++ b/crates/config/src/model_test.rs
@@ -6,9 +6,9 @@ use secrecy::ExposeSecret;
 use tempfile::tempdir;
 
 use super::{
-    ConfigManager, ContextFileSearchPolicy, LocalEmbeddingPolicy, NowledgeMemMode,
-    NowledgeMemPluginConfig, OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState,
-    RaraConfig, workspace_data_dir_for_home,
+    ConfigManager, ContextFileSearchPolicy, NowledgeMemMode, NowledgeMemPluginConfig,
+    OpenAiEndpointKind, OpenAiEndpointProfile, ProviderConfigState, RaraConfig,
+    workspace_data_dir_for_home,
 };
 use crate::defaults::{
     DEFAULT_CODEX_BASE_URL, DEFAULT_CODEX_CHATGPT_BASE_URL, DEFAULT_CODEX_MODEL,
@@ -161,83 +161,6 @@ fn context_file_search_can_disable_automatic_retrieval_candidates() {
     .expect("deserialize config");
 
     assert_eq!(config.context_file_search, ContextFileSearchPolicy::Off);
-}
-
-#[test]
-fn local_embeddings_default_off_and_omitted() {
-    let config = RaraConfig::default();
-
-    assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
-
-    let json = serde_json::to_string(&config).expect("serialize config");
-    assert!(!json.contains("local_embeddings"));
-}
-
-#[test]
-fn local_embeddings_can_enable_sidecar_policy() {
-    let config: RaraConfig = serde_json::from_str(
-        r#"{
-            "provider": "deepseek",
-            "local_embeddings": "auto"
-        }"#,
-    )
-    .expect("deserialize config");
-
-    assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
-}
-
-#[test]
-fn local_embeddings_accepts_explicit_provider_and_local_overrides() {
-    let provider: RaraConfig = serde_json::from_str(
-        r#"{
-            "provider": "deepseek",
-            "local_embeddings": "provider"
-        }"#,
-    )
-    .expect("deserialize provider override");
-    assert_eq!(provider.local_embeddings, LocalEmbeddingPolicy::Provider);
-
-    let local: RaraConfig = serde_json::from_str(
-        r#"{
-            "provider": "codex",
-            "local_embeddings": "local"
-        }"#,
-    )
-    .expect("deserialize local override");
-    assert_eq!(local.local_embeddings, LocalEmbeddingPolicy::Local);
-}
-
-#[test]
-fn local_embeddings_can_be_enabled_and_disabled_by_environment() {
-    let mut config = RaraConfig::default();
-
-    config.apply_provider_environment_defaults_from(|key| match key {
-        "RARA_LOCAL_EMBEDDINGS" => Some("on".to_string()),
-        _ => None,
-    });
-
-    assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Auto);
-
-    config.apply_provider_environment_defaults_from(|key| match key {
-        "RARA_LOCAL_EMBEDDINGS" => Some("provider".to_string()),
-        _ => None,
-    });
-
-    assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Provider);
-
-    config.apply_provider_environment_defaults_from(|key| match key {
-        "RARA_LOCAL_EMBEDDINGS" => Some("local".to_string()),
-        _ => None,
-    });
-
-    assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Local);
-
-    config.apply_provider_environment_defaults_from(|key| match key {
-        "RARA_LOCAL_EMBEDDINGS" => Some("off".to_string()),
-        _ => None,
-    });
-
-    assert_eq!(config.local_embeddings, LocalEmbeddingPolicy::Off);
 }
 
 #[test]

--- a/docs/features/embedding-provider-decoupling.md
+++ b/docs/features/embedding-provider-decoupling.md
@@ -131,16 +131,8 @@ vector indexing/search is a separate dependency.
   `EmbeddingInputKind::Document`.
 - Runtime bootstrap must build one embedding backend per process runtime and
   pass it through to the main agent and sub-agents.
-- `local_embeddings` defaults to `off`, so ordinary startup must not prepare,
-  download, or start the bundled local embedding sidecar.
-- `local_embeddings = "auto"` and `RARA_LOCAL_EMBEDDINGS=auto|on|true|1|yes`
-  explicitly opt in to the provider-aware local sidecar routing matrix.
-- `local_embeddings = "provider"` and
-  `RARA_LOCAL_EMBEDDINGS=provider|native|llm` force embedding calls through the
-  current chat provider embedding route and must not start the local sidecar.
-- `local_embeddings = "local"` and `RARA_LOCAL_EMBEDDINGS=local|sidecar`
-  force embedding calls through the bundled local sidecar, even for providers
-  that would otherwise use provider-native embeddings.
+- The `local_embeddings` config field and `RARA_LOCAL_EMBEDDINGS` environment
+  override were removed; local semantic memory is delegated to Nowledge Mem.
 - Provider-native embeddings must be enabled only through an explicit capability
   entry or equivalent allowlist, not by assuming that all providers in one chat
   family expose usable embedding models.

--- a/docs/features/local-embedding-runtimes.md
+++ b/docs/features/local-embedding-runtimes.md
@@ -144,19 +144,9 @@ warning for hard failures.
 
 ### Configuration Policy
 
-Local embeddings default to `auto` so ordinary CLI, TUI, ACP, and memory
-workflows keep the provider-aware sidecar behavior. This preserves the normal
-local-first memory path.
-
-Benchmark adapters can disable sidecar routing for faster startup by setting:
-
-```text
-RARA_LOCAL_EMBEDDINGS=off
-```
-
-`auto` preserves the provider-aware routing policy: providers with a usable
-embedding surface can keep using the current backend, while local or
-embedding-limited chat providers may use the bundled local model server.
+The bundled local embedding sidecar and its `local_embeddings` /
+`RARA_LOCAL_EMBEDDINGS` configuration surface have been removed. Local
+semantic memory is delegated to Nowledge Mem.
 
 `off` always routes embedding calls through the current `LlmBackend`
 implementation. The Harbor Terminal-Bench adapter uses this mode so benchmark
@@ -525,8 +515,7 @@ Valid preparation states:
   versioned by profile.
 - LanceDB table versioning still needs a separate migration plan before mixed
   embedding dimensions or model profiles are enabled.
-- Explicit provider/local embedding route overrides are available through
-  `local_embeddings = "provider"` and `local_embeddings = "local"`.
+- The `local_embeddings` provider/local route override field has been removed.
 
 ## Source Journals
 

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -58,9 +58,7 @@ Recommended components:
   binary_path=$PWD/target/release/rara`. The adapter defaults to `/app` as the
   benchmark cwd, passes that cwd explicitly to `rara exec`, and preserves the
   `rara exec` exit code while teeing JSONL output into
-  `/logs/agent/rara-exec.jsonl`. It also sets
-  `RARA_LOCAL_EMBEDDINGS=off` so benchmark startup does not prepare the bundled
-  local embedding sidecar. The adapter wraps task text with generic
+  `/logs/agent/rara-exec.jsonl`. The adapter wraps task text with generic
   non-interactive benchmark guidance so RARA treats named output files as
   required artifacts rather than optional final-answer prose.
 - `rara eval terminal-bench` may be added later as a convenience wrapper, but

--- a/docs/journal/2026-08-21-remove-deprecated-local-embeddings-config.md
+++ b/docs/journal/2026-08-21-remove-deprecated-local-embeddings-config.md
@@ -1,0 +1,38 @@
+# Remove Deprecated `local_embeddings` Config Field
+
+## What
+
+Removed the last remaining local-embedding config surface, which had been kept
+as deprecated compatibility-only since
+`docs/journal/2026-08-08-remove-embedded-vector-memory.md`:
+
+- `crates/config/src/model.rs` — deleted the `LocalEmbeddingPolicy` enum
+  (`Off` / `Auto` / `Provider` / `Local`) and its `is_default` helper.
+- `crates/config/src/model/rara_config.rs` — deleted the `local_embeddings`
+  field, its serde skip rule, and the `RARA_LOCAL_EMBEDDINGS` environment
+  parsing in `apply_provider_environment_defaults_from`.
+- `crates/config/src/lib.rs` — dropped the `LocalEmbeddingPolicy` re-export.
+- `crates/config/src/model_test.rs` — deleted the four `local_embeddings`
+  config tests.
+- `tools/harbor/rara_agent.py` — stopped injecting `RARA_LOCAL_EMBEDDINGS=off`
+  for benchmark runs; `tools/harbor/test_rara_agent.py` test renamed and the
+  assertion removed.
+
+## Why
+
+The bundled local embedding sidecar was already removed and local semantic
+memory delegated to Nowledge Mem, so the field had zero runtime consumers and
+only existed to let stale configs deserialize. Keeping dead config invites
+maintenance drift and false signals in provider/status surfaces.
+
+## Trade-offs
+
+- Old config files that still set `local_embeddings` will now be silently
+  ignored by serde rather than parsed. This is acceptable because the field no
+  longer had any behavior attached and its prior value was never acted on.
+
+## Remains
+
+- Nothing for this field. The unrelated Nowledge Mem read-side runtime
+  pre-fetch is still tracked separately in `docs/todo.md` under Memory
+  Lifecycle.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -195,13 +195,8 @@ Active backlog only. Keep this file small and current.
 
 ## Configuration
 
-- [x] Default bundled local embedding sidecar startup to off while preserving
-      explicit `local_embeddings = "auto"` opt-in.
-- [x] Explicit embedding provider override beyond `off` / `auto`.
-- [x] Remove bundled local embedding runtime from memory retrieval; keep
-      `local_embeddings` as deprecated config compatibility only.
-- [ ] Decide whether to keep or migrate away the deprecated
-      `local_embeddings` config field.
+- [x] Remove the bundled local embedding sidecar, the provider/local embedding
+      overrides, and the deprecated `local_embeddings` config field entirely.
 
 ## WASM Core
 

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -149,7 +149,6 @@ class RaraAgent(BaseInstalledAgent):
             **self._provider_env(),
             **self.extra_env,
             "RARA_HOME": self.rara_home.as_posix(),
-            "RARA_LOCAL_EMBEDDINGS": "off",
         }
         command = self._build_exec_command()
         result = await environment.exec(command=command, cwd=cwd, env=env)

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -285,7 +285,7 @@ class RaraAgentTests(unittest.TestCase):
         self.assertIn("--cwd /app", agent._build_exec_command())
         self.assertIn("Work only in the benchmark workspace: /app", uploaded_instruction)
 
-    def test_run_disables_local_embeddings_for_benchmark(self) -> None:
+    def test_run_sets_home_and_cwd_for_benchmark(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
             agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
             context = AgentContext()
@@ -293,7 +293,6 @@ class RaraAgentTests(unittest.TestCase):
 
             asyncio.run(agent.run("solve task", environment, context))  # type: ignore[arg-type]
 
-        self.assertEqual(environment.exec_env["RARA_LOCAL_EMBEDDINGS"], "off")
         self.assertEqual(environment.exec_env["RARA_HOME"], "/logs/agent/rara-home")
         self.assertEqual(environment.exec_cwd, "/app")
 


### PR DESCRIPTION
## What

Fully removes the deprecated `local_embeddings` config surface, which was kept only for stale-config compatibility after the bundled local embedding sidecar was already removed.

- `crates/config/src/model.rs`: delete the `LocalEmbeddingPolicy` enum (`Off`/`Auto`/`Provider`/`Local`) and its `is_default` helper.
- `crates/config/src/model/rara_config.rs`: delete the `local_embeddings` field, its serde skip rule, and the `RARA_LOCAL_EMBEDDINGS` environment parsing.
- `crates/config/src/lib.rs`: drop the `LocalEmbeddingPolicy` re-export.
- `crates/config/src/model_test.rs`: delete the four `local_embeddings` config tests and the import.
- `tools/harbor/rara_agent.py`: stop injecting `RARA_LOCAL_EMBEDDINGS=off` for benchmark runs; rename the test and drop the assertion in `tools/harbor/test_rara_agent.py`.
- Docs: update `docs/todo.md`, `embedding-provider-decoupling.md`, `local-embedding-runtimes.md`, `terminal-bench-evaluation.md`, and add a dated journal note.

## Why

The field had zero runtime consumers after local semantic memory moved to Nowledge Mem. Keeping dead config invites maintenance drift and false signals in provider/status surfaces. Old configs that still set `local_embeddings` are now silently ignored by serde, which is acceptable since the value was never acted on.

## Validation

- `cargo fmt`
- `cargo test -p rara-config` → 50 passed, 0 failed