### PR TITLE
fix(context): preserve DeepSeek prompt prefixes

### DIFF
--- a/crates/instructions/src/prompt.rs
+++ b/crates/instructions/src/prompt.rs
@@ -6,6 +6,10 @@ use rara_config::RaraConfig;
 
 use crate::workspace::WorkspaceMemory;
 
+mod turn_context;
+
+pub use self::turn_context::{TurnPromptContext, build_turn_prompt_context};
+
 /// Agent lifecycle phase.  File-based hooks are tagged with this phase
 /// and only injected into the prompt when the assembler requests the
 /// matching phase.
@@ -158,7 +162,7 @@ impl PromptSource {
                 "included as durable workspace memory from the local RARA memory file"
             }
             PromptSourceKind::ProtocolPromptSource => {
-                "included as a structured protocol-registered prompt source with runtime-control provenance"
+                "included as append-only model context with runtime-control provenance"
             }
             PromptSourceKind::CustomSystemPrompt => "included as the configured base system prompt",
             PromptSourceKind::AppendSystemPrompt => {
@@ -186,15 +190,12 @@ impl BasePromptKind {
     }
 }
 
-pub const DYNAMIC_BOUNDARY: &str = "__DYNAMIC_BOUNDARY__";
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EffectivePrompt {
     pub text: String,
     pub base_prompt_kind: BasePromptKind,
     pub section_keys: Vec<&'static str>,
     pub sources: Vec<PromptSource>,
-    pub dynamic_boundary_index: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -352,11 +353,11 @@ pub fn build_compact_instruction(runtime: &PromptRuntimeConfig) -> String {
 pub fn build_effective_prompt(
     workspace: &WorkspaceMemory,
     runtime: &PromptRuntimeConfig,
-    mode: PromptMode,
+    _mode: PromptMode,
 ) -> EffectivePrompt {
     let sources = discover_prompt_sources(workspace, runtime);
-    let dynamic_sections =
-        dynamic_system_prompt_sections(workspace, &sources, &runtime.available_skills, mode);
+    let system_sections =
+        session_system_prompt_sections(workspace, &sources, &runtime.available_skills);
     let (base_prompt_kind, base_prompt_text, mut section_keys) =
         if let Some(custom_prompt) = &runtime.system_prompt {
             (
@@ -375,20 +376,14 @@ pub fn build_effective_prompt(
         };
 
     let mut final_sections = vec![base_prompt_text];
-
-    // Boundary separates static rules from session-specific context.
-    final_sections.push(DYNAMIC_BOUNDARY.to_string());
-    let dynamic_boundary_index = Some(final_sections.len() - 1);
-    section_keys.push("dynamic_boundary");
-
     section_keys.extend(
-        dynamic_sections
+        system_sections
             .iter()
             .filter(|section| section.content.is_some())
             .map(|section| section.key),
     );
 
-    final_sections.extend(resolve_sections(dynamic_sections));
+    final_sections.extend(resolve_sections(system_sections));
     if let Some(append) = &runtime.append_system_prompt {
         final_sections.push(append.clone());
         section_keys.push("append_system_prompt");
@@ -403,7 +398,6 @@ pub fn build_effective_prompt(
         base_prompt_kind,
         section_keys,
         sources,
-        dynamic_boundary_index,
     }
 }
 
@@ -715,13 +709,12 @@ fn default_system_prompt_sections() -> Vec<PromptSection> {
     ]
 }
 
-fn dynamic_system_prompt_sections(
+fn session_system_prompt_sections(
     workspace: &WorkspaceMemory,
     sources: &[PromptSource],
     available_skills: &[PromptSkillSummary],
-    mode: PromptMode,
 ) -> Vec<PromptSection> {
-    let (cwd, branch) = workspace.get_env_info();
+    let (cwd, _) = workspace.get_env_info();
     let instruction_sections = sources
         .iter()
         .filter(|source| {
@@ -755,89 +748,14 @@ fn dynamic_system_prompt_sections(
         )),
     };
 
-    let protocol_prompt_sources_block = render_protocol_prompt_sources_section(sources);
     let skills_block = render_available_skills_section(available_skills);
     let language_prompt = crate::languages::get_language_prompt(&cwd);
 
     vec![
         PromptSection::optional("project_context", project_context_block),
-        PromptSection::optional("protocol_prompt_sources", protocol_prompt_sources_block),
         PromptSection::optional("skills", skills_block),
         PromptSection::optional("language_best_practices", language_prompt),
-        PromptSection::new("runtime_context", render_environment_context(&cwd, &branch)),
-        PromptSection::optional(
-            "execute_mode",
-            matches!(mode, PromptMode::Execute).then(execute_mode_prompt),
-        ),
-        PromptSection::optional(
-            "plan_mode",
-            matches!(mode, PromptMode::Plan).then(plan_mode_prompt),
-        ),
-        PromptSection::optional(
-            "review_mode",
-            matches!(mode, PromptMode::Review).then(review_mode_prompt),
-        ),
     ]
-}
-
-fn render_protocol_prompt_sources_section(sources: &[PromptSource]) -> Option<String> {
-    let sections = sources
-        .iter()
-        .filter(|source| matches!(source.kind, PromptSourceKind::ProtocolPromptSource))
-        .map(|source| {
-            format!(
-                "### {}\nSource: {}\n\n{}",
-                source.label, source.display_path, source.content
-            )
-        })
-        .collect::<Vec<_>>();
-    if sections.is_empty() {
-        None
-    } else {
-        Some(format!(
-            "## Protocol Prompt Sources\n\n{}",
-            sections.join("\n\n")
-        ))
-    }
-}
-
-fn render_environment_context(cwd: &str, branch: &str) -> String {
-    let shell = std::env::var("SHELL")
-        .ok()
-        .and_then(|value| {
-            Path::new(&value)
-                .file_name()
-                .map(|name| name.to_string_lossy().to_string())
-        })
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| "unknown".to_string());
-
-    format!(
-        "<environment_context>\n  \
-         <cwd>{}</cwd>\n  \
-         <shell>{}</shell>\n  \
-         <git_branch>{}</git_branch>\n  \
-         Note: This is a snapshot at conversation start and will not update.\n\
-         </environment_context>",
-        escape_xml_text(cwd),
-        escape_xml_text(&shell),
-        escape_xml_text(branch),
-    )
-}
-
-fn escape_xml_text(value: &str) -> String {
-    let mut escaped = String::with_capacity(value.len());
-    for ch in value.chars() {
-        match ch {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            '"' => escaped.push_str("&quot;"),
-            '\'' => escaped.push_str("&apos;"),
-            ch => escaped.push(ch),
-        }
-    }
-    escaped
 }
 
 fn render_available_skills_section(skills: &[PromptSkillSummary]) -> Option<String> {

--- a/crates/instructions/src/prompt/tests.rs
+++ b/crates/instructions/src/prompt/tests.rs
@@ -3,7 +3,7 @@ use std::fs;
 use super::{
     PromptMode, PromptRuntimeConfig, PromptSkillSummary, PromptSource, PromptSourceKind,
     build_compact_instruction, build_effective_prompt, build_system_prompt,
-    discover_prompt_sources, render_skill_listing,
+    build_turn_prompt_context, discover_prompt_sources, render_skill_listing,
 };
 use crate::workspace::WorkspaceMemory;
 
@@ -54,7 +54,7 @@ fn discover_prompt_sources_includes_workspace_and_runtime_sources() {
 }
 
 #[test]
-fn build_effective_prompt_includes_protocol_prompt_sources() {
+fn protocol_prompt_sources_are_rendered_in_turn_context() {
     let temp = tempfile::tempdir().expect("tempdir");
     let root = temp.path().join("workspace");
     let rara_dir = root.join(".rara");
@@ -71,83 +71,93 @@ fn build_effective_prompt_includes_protocol_prompt_sources() {
     };
 
     let effective = build_effective_prompt(&workspace, &runtime, PromptMode::Execute);
+    let turn = build_turn_prompt_context(&workspace, &runtime, PromptMode::Execute);
 
-    assert!(effective.section_keys.contains(&"protocol_prompt_sources"));
-    assert!(effective.text.contains("## Protocol Prompt Sources"));
-    assert!(effective.text.contains("Protocol Prompt Source acp-note"));
-    assert!(
-        effective
-            .text
-            .contains("Use the active editor selection as extra context.")
-    );
+    assert!(!effective.section_keys.contains(&"protocol_prompt_sources"));
+    assert!(!effective.text.contains("Protocol Prompt Source acp-note"));
     assert!(
         effective
             .sources
             .iter()
             .any(|source| matches!(source.kind, PromptSourceKind::ProtocolPromptSource))
     );
+    let protocol = turn
+        .protocol_prompt_sources
+        .expect("protocol prompt context");
+    assert!(protocol.contains("## Protocol Prompt Sources"));
+    assert!(protocol.contains("Protocol Prompt Source acp-note"));
+    assert!(protocol.contains("Use the active editor selection as extra context."));
 }
 
 #[test]
-fn build_system_prompt_includes_plan_mode_and_runtime_context() {
+fn environment_and_mode_are_rendered_outside_the_system_prompt() {
     let temp = tempfile::tempdir().expect("tempdir");
     let root = temp.path().join("workspace");
     let rara_dir = root.join(".rara");
     fs::create_dir_all(&rara_dir).expect("mkdir .rara");
     let workspace = WorkspaceMemory::from_paths(root, rara_dir);
-    let prompt = build_system_prompt(
+    let system = build_system_prompt(
         &workspace,
         &PromptRuntimeConfig::default(),
         PromptMode::Plan,
     );
-    assert!(prompt.contains("Current Execution Mode"));
-    assert!(prompt.contains("<environment_context>"));
-    assert!(prompt.contains("<cwd>"));
-    assert!(prompt.contains("<shell>"));
-    assert!(prompt.contains("<git_branch>"));
+    let turn = build_turn_prompt_context(
+        &workspace,
+        &PromptRuntimeConfig::default(),
+        PromptMode::Plan,
+    );
+    assert!(!system.contains("Current Execution Mode"));
+    assert!(!system.contains("<environment_context>"));
+    assert!(turn.execution_mode.contains("Current Execution Mode"));
+    assert!(turn.environment.contains("<environment_context>"));
+    assert!(turn.environment.contains("<cwd>"));
+    assert!(turn.environment.contains("<shell>"));
+    assert!(turn.environment.contains("<git_branch>"));
 }
 
 #[test]
-fn build_system_prompt_includes_execute_mode_guidance_only_in_execute_mode() {
+fn execute_mode_guidance_is_rendered_only_in_execute_turn_context() {
     let temp = tempfile::tempdir().expect("tempdir");
     let root = temp.path().join("workspace");
     let rara_dir = root.join(".rara");
     fs::create_dir_all(&rara_dir).expect("mkdir .rara");
     let workspace = WorkspaceMemory::from_paths(root, rara_dir);
 
-    let execute = build_effective_prompt(
+    let execute = build_turn_prompt_context(
         &workspace,
         &PromptRuntimeConfig::default(),
         PromptMode::Execute,
     );
-    assert!(execute.section_keys.contains(&"execute_mode"));
-    assert!(execute.text.contains("# Execute Mode"));
-    assert!(execute.text.contains("todo_write"));
-    assert!(execute.text.contains("refresh the full list"));
+    assert!(execute.execution_mode.contains("# Execute Mode"));
+    assert!(execute.execution_mode.contains("todo_write"));
+    assert!(execute.execution_mode.contains("refresh the full list"));
     assert!(
         execute
-            .text
+            .execution_mode
             .contains("do not batch status changes until the end")
     );
     assert!(
         execute
-            .text
+            .execution_mode
             .contains("relevant validation item is still pending or failing")
     );
-    assert!(execute.text.contains("stopping at 'sandbox blocked'"));
     assert!(
         execute
-            .text
+            .execution_mode
+            .contains("stopping at 'sandbox blocked'")
+    );
+    assert!(
+        execute
+            .execution_mode
             .contains("keep the relevant verification todo item pending")
     );
 
-    let plan = build_effective_prompt(
+    let plan = build_turn_prompt_context(
         &workspace,
         &PromptRuntimeConfig::default(),
         PromptMode::Plan,
     );
-    assert!(!plan.section_keys.contains(&"execute_mode"));
-    assert!(!plan.text.contains("# Execute Mode"));
+    assert!(!plan.execution_mode.contains("# Execute Mode"));
 }
 
 #[test]
@@ -391,7 +401,7 @@ fn default_system_prompt_mentions_tool_safety_and_compaction() {
     assert!(prompt.contains("available GitHub tools or the 'gh' CLI"));
     assert!(prompt.contains("never rewrite history"));
     assert!(prompt.contains("Use memory and delegation tools only when available"));
-    assert!(prompt.contains("todo_write"));
+    assert!(!prompt.contains("todo_write"));
     assert!(!prompt.contains("starts with '*** Begin Patch'"));
     assert!(!prompt.contains("Claude-style Write/Edit split"));
     assert!(!prompt.contains("Use 'spawn_agent' or 'team_create'"));
@@ -628,7 +638,7 @@ fn compact_prompt_uses_override_when_present() {
 
 #[test]
 fn environment_context_escapes_xml_values() {
-    let rendered = super::render_environment_context("/tmp/a&b", "feat/<tag>");
+    let rendered = super::turn_context::render_environment_context("/tmp/a&b", "feat/<tag>");
 
     assert!(rendered.contains("<cwd>/tmp/a&amp;b</cwd>"));
     assert!(rendered.contains("<git_branch>feat/&lt;tag&gt;</git_branch>"));
@@ -680,8 +690,7 @@ fn effective_prompt_reports_base_kind_and_active_sections() {
 
     let effective = super::build_effective_prompt(&workspace, &runtime, PromptMode::Execute);
     assert_eq!(effective.base_prompt_kind, super::BasePromptKind::Default);
-    assert!(effective.section_keys.contains(&"dynamic_boundary"));
-    assert!(effective.section_keys.contains(&"runtime_context"));
+    assert!(!effective.section_keys.contains(&"runtime_context"));
     assert!(effective.section_keys.contains(&"append_system_prompt"));
     assert!(
         effective
@@ -689,6 +698,5 @@ fn effective_prompt_reports_base_kind_and_active_sections() {
             .contains(&"subagent_capability_policy")
     );
     assert!(effective.text.ends_with("policy"));
-    assert!(effective.text.contains(super::DYNAMIC_BOUNDARY));
-    assert!(effective.dynamic_boundary_index.is_some());
+    assert!(!effective.text.contains("__DYNAMIC_BOUNDARY__"));
 }

--- a/crates/instructions/src/prompt/turn_context.rs
+++ b/crates/instructions/src/prompt/turn_context.rs
@@ -1,0 +1,94 @@
+use std::path::Path;
+
+use super::{PromptMode, PromptRuntimeConfig, PromptSource, PromptSourceKind};
+use crate::workspace::WorkspaceMemory;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnPromptContext {
+    pub environment: String,
+    pub execution_mode: String,
+    pub protocol_prompt_sources: Option<String>,
+}
+
+pub fn build_turn_prompt_context(
+    workspace: &WorkspaceMemory,
+    runtime: &PromptRuntimeConfig,
+    mode: PromptMode,
+) -> TurnPromptContext {
+    let (cwd, branch) = workspace.get_env_info();
+    TurnPromptContext {
+        environment: render_environment_context(&cwd, &branch),
+        execution_mode: render_mode_context(mode),
+        protocol_prompt_sources: render_protocol_prompt_sources_section(
+            runtime.protocol_prompt_sources.as_slice(),
+        ),
+    }
+}
+
+fn render_protocol_prompt_sources_section(sources: &[PromptSource]) -> Option<String> {
+    let sections = sources
+        .iter()
+        .filter(|source| matches!(source.kind, PromptSourceKind::ProtocolPromptSource))
+        .map(|source| {
+            format!(
+                "### {}\nSource: {}\n\n{}",
+                source.label, source.display_path, source.content
+            )
+        })
+        .collect::<Vec<_>>();
+    if sections.is_empty() {
+        None
+    } else {
+        Some(format!(
+            "## Protocol Prompt Sources\n\n{}",
+            sections.join("\n\n")
+        ))
+    }
+}
+
+pub(super) fn render_environment_context(cwd: &str, branch: &str) -> String {
+    let shell = std::env::var("SHELL")
+        .ok()
+        .and_then(|value| {
+            Path::new(&value)
+                .file_name()
+                .map(|name| name.to_string_lossy().to_string())
+        })
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    format!(
+        "<environment_context>\n  \
+         <cwd>{}</cwd>\n  \
+         <shell>{}</shell>\n  \
+         <git_branch>{}</git_branch>\n  \
+         Note: This snapshot was observed before the current user turn.\n\
+         </environment_context>",
+        escape_xml_text(cwd),
+        escape_xml_text(&shell),
+        escape_xml_text(branch),
+    )
+}
+
+fn escape_xml_text(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            ch => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn render_mode_context(mode: PromptMode) -> String {
+    match mode {
+        PromptMode::Execute => super::execute_mode_prompt(),
+        PromptMode::Plan => super::plan_mode_prompt(),
+        PromptMode::Review => super::review_mode_prompt(),
+    }
+}

--- a/docs/features/context-compression.md
+++ b/docs/features/context-compression.md
@@ -28,7 +28,7 @@ For long coding sessions, this increases the risk of losing:
 ## Non-Goals
 
 - Full recent-file snippet reattachment after compaction.
-- Token-cache aware prompt reuse.
+- Provider-specific cache retention or cache-edit execution.
 - Provider-specific remote compaction APIs.
 - Claude-style cache-edit microcompaction for providers that do not expose a
   cache-edit API.
@@ -149,12 +149,18 @@ deterministic descriptor namespace.
   excerpts.
 - The retained recent API-round suffix always comes after compact metadata, summary, and carry-over
   sources. This keeps deterministic system/context material before volatile conversation history.
+- Environment, mode, protocol/LSP, and retrieved-memory attachments use typed
+  `rara_model_context` blocks on user messages. Once a block has been sent, it
+  remains in model-visible history until durable compaction replaces that
+  history range.
 
 ### 7) Tool Result Projection
 
-Tool-result projection is a read-time microcompact pass that runs before the
-model request and before summary autocompaction pressure becomes the only
-option.
+Tool-result projection is a read-time microcompact pass for backends that do
+not declare automatic prefix caching. Backends that declare automatic prefix
+caching without cache edit preserve raw tool-result history until ordinary
+durable compaction, because changing an old request copy destroys the reusable
+provider prefix after the edited point.
 
 The projection pass:
 
@@ -175,10 +181,10 @@ The projection pass:
 - never changes `tool_use` / `tool_result` pairing or removes the block itself;
 - never rewrites stable system, tool schema, skill, or memory prompt prefixes.
 
-This is the safe baseline for DeepSeek and OpenAI-compatible providers that
-have automatic prefix caching but no cache-edit API. It reduces volatile
-history size while preserving the full local transcript for restore,
-distillation, and debugging.
+This remains useful for uncached/custom OpenAI-compatible providers because it
+reduces volatile request size while preserving the full local transcript for
+restore, distillation, and debugging. It is disabled for DeepSeek's warm-prefix
+path; normal compaction is the bounded-history mechanism there.
 
 The runtime exposes projection as a transient status event when old tool
 results are projected out of a model request and as a structured context
@@ -233,7 +239,10 @@ to no declared cache capability unless RARA has a provider-specific contract.
 
 Compression logic must choose behavior from the cache profile:
 
-- no `cache_edit`: use projection and ordinary compaction only;
+- `automatic_prefix_cache` without `cache_edit`: preserve request history and
+  use ordinary durable compaction;
+- no automatic prefix cache and no `cache_edit`: request projection remains
+  available in addition to ordinary compaction;
 - `cache_edit`: mark the request eligible for a provider cache-edit pass while
   continuing to preserve local messages; until a backend implements the actual
   executor, `cache_edit_applied` remains false;
@@ -253,15 +262,18 @@ RARA has two memory classes with different cache behavior:
 
 Retrieved memory must not be prepended to the stable system prompt or inserted
 before tool schemas. Doing so would make automatic prefix caches less useful for
-providers such as DeepSeek. The current runtime injects selected retrieved memory
-into the latest user message and does not persist that injected block to
-`Agent.history`; this is the correct baseline until RARA has a first-class
-attachment carrier for volatile context.
+providers such as DeepSeek. The runtime stores selected retrieved memory as a
+typed `rara_model_context` block on the current user message. This is the
+first-class attachment carrier: provider serializers render it, while transcript
+display, retrieval queries, and memory-lifecycle capture ignore it. Persisting
+the exact block ensures that a later request does not silently remove content
+that an earlier model request saw.
 
 When future models are added, memory placement must follow the provider cache
 profile:
 
-- providers without cache edit: keep retrieved memory in the volatile suffix;
+- providers without cache edit: attach retrieved memory to the current user
+  suffix and retain that exact attachment in later model-visible history;
 - providers with cache edit: cache-edit may optimize old tool results, but
   retrieved memory still remains per-turn volatile context unless explicitly
   promoted to workspace memory;
@@ -359,9 +371,14 @@ This is similar in spirit to sub-agent isolation, but its storage model is diffe
 
 ## Validation Matrix
 
-- `cargo check`
-- focused prompt tests for the default compact schema
-- focused agent tests ensuring manual compaction stores the structured marker
+| Contract | Validation |
+|---|---|
+| Compact schema | Focused prompt tests for the default compact instruction |
+| Durable compact marker | Focused agent compaction tests |
+| Uncached request projection | `model_request_projects_old_tool_results_without_mutating_history` |
+| Automatic-prefix preservation | `automatic_prefix_cache_preserves_tool_results_until_durable_compaction` |
+| Retrieved-memory persistence | `query_persists_selected_memory_as_typed_model_context` |
+| Compile and lint | `cargo check`; `cargo clippy --workspace --all-targets -- -D warnings` |
 
 ## Open Risks
 
@@ -372,8 +389,12 @@ This is similar in spirit to sub-agent isolation, but its storage model is diffe
   excerpt payload separately from history.
 - Partial compaction currently exists as a runtime entrypoint. TUI, ACP, and Wire command surfaces
   still need to expose the range-selection workflow.
+- Live DeepSeek cache improvement still requires an official-API A/B run using
+  `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens` from comparable
+  repeated turns.
 
 ## Source Journals
 
 - [2026-04-19-context-compression](../journal/2026-04-19-context-compression.md)
 - [2026-05-06-prefix-stable-microcompact](../journal/2026-05-06-prefix-stable-microcompact.md)
+- [2026-08-21-deepseek-prefix-cache-locality](../journal/2026-08-21-deepseek-prefix-cache-locality.md)

--- a/docs/features/project-context-merge.md
+++ b/docs/features/project-context-merge.md
@@ -2,167 +2,134 @@
 
 ## Problem
 
-RARA currently injects project-level instructions and session memory as two
-separate dynamic prompt sections (`instructions` and `memory`).  Claude Code
-takes the opposite approach: all file-based context (CLAUDE.md, auto-memory,
-rules) is merged into a single `claudeMd` string with labeled sub-sections,
-injected into the system prompt as one `## Memory section` block.
-
-This split model has downsides:
-
-- The model sees instructions and memory as disconnected regions, leading to
-  weaker cross-referencing between project rules and remembered facts.
-- Adding a new injection path (e.g. charter sync) requires deciding which
-  section it belongs to, introducing fragmentation.
-- Two sections with small dynamic content each creates section bloat.
+RARA needs one deterministic system-prompt prefix for durable repository
+instructions while keeping per-turn state close to the user request. Mixing
+environment, execution mode, live protocol sources, or retrieved memory into
+the system message invalidates automatic prefix caches before reusable history
+can be reached.
 
 ## Scope
 
-- Merge the current `instructions` and `memory` dynamic sections into a single
-  `project_context` section.
-- Sub-sections within `project_context` mirror Claude Code's labeling:
-  `### Project Instructions` and `### Session Memory`.
-- Accept a one-time provider-cache invalidation.
-- Do not change content sources, discovery, or `WorkspaceCache` behavior.
+- Merge file-based project instructions and stable workspace memory into one
+  `project_context` system section.
+- Keep stable skill metadata and language guidance in the system prompt.
+- Route environment, execution mode, protocol/LSP sources, and retrieved memory
+  through typed model context on the current user message.
+- Preserve typed model context in model-visible history so later requests keep
+  the exact bytes that earlier requests sent.
 
 ## Non-Goals
 
 - Changing how `ProjectInstruction`, `UserInstruction`, or `LocalMemory`
-  sources are discovered or cached.
-- Adding the memdir-style semantic retrieval path (that is a separate feature).
-- Changing `PromptSourceKind` variants or their semantics.
-- Changing the `DYNAMIC_BOUNDARY` or static prefix sections.
+  sources are discovered.
+- Treating query-dependent retrieval as stable workspace memory.
+- Adding provider-specific cache keys or Anthropic `cache_control` fields.
+- Guaranteeing a provider cache hit; providers may evict or decline an
+  otherwise reusable prefix.
 
 ## Architecture
 
-### Section before
+The request is assembled in this order:
 
-```
-static prefix
-...
-__DYNAMIC_BOUNDARY__
-## instructions
-  ## <UserInstruction.label>
-  ## <ProjectInstruction.label>
-## memory
-  ## <LocalMemory.label>
-## protocol_prompt_sources
-## skills
-## language_best_practices
-## runtime_context
-## execute_mode / plan_mode / review_mode
-```
-
-### Section after
-
-```
-static prefix
-...
-__DYNAMIC_BOUNDARY__
-## project_context
-  ### Project Instructions
-  <UserInstruction content>
-  <ProjectInstruction content>
-  ### Session Memory
-  <LocalMemory content>
-## protocol_prompt_sources
-## skills
-## language_best_practices
-## runtime_context
-## execute_mode / plan_mode / review_mode
+```text
+deterministically ordered tool schemas and stable system prompt
+  base prompt
+  project_context
+    project instructions
+    stable workspace memory
+  skills
+  language best practices
+  append prompt and session capability policy
+append-only conversation history
+current user message
+  changed environment context, if any
+  changed execution-mode context, if any
+  changed protocol/LSP context, if any
+  selected retrieved memory, if any
+  human-authored request text
 ```
 
-### Implementation
+`rara_model_context` is the typed carrier for the current-user attachments:
 
-In `crates/instructions/src/prompt.rs`, the function that builds dynamic
-sections currently does:
-
-```rust
-let instruction_block = /* concat UserInstruction + ProjectInstruction sources */;
-let memory_block = /* find LocalMemory source */;
-
-vec![
-    PromptSection::optional("instructions", instruction_block),
-    PromptSection::optional("memory", memory_block),
-    PromptSection::optional("protocol_prompt_sources", protocol_prompt_sources_block),
-    PromptSection::optional("skills", skills_block),
-    PromptSection::optional("language_best_practices", language_prompt),
-    PromptSection::new("runtime_context", render_environment_context(&cwd, &branch)),
-    PromptSection::optional("execute_mode", ...),
-    PromptSection::optional("plan_mode", ...),
-    PromptSection::optional("review_mode", ...),
-]
+```json
+{
+  "type": "rara_model_context",
+  "kind": "environment",
+  "text": "<environment_context>...</environment_context>"
+}
 ```
 
-After the change, the two blocks are merged into one:
+The carrier is persisted with the user message. Transcript rendering, memory
+retrieval queries, and memory-lifecycle capture ignore the carrier, while model
+provider serializers render its `text` field. This makes the model-visible
+history append-only without presenting runtime attachments as user-authored
+text.
 
-```rust
-let project_context_block = build_project_context_block(sources);
+### Project context rendering
 
-vec![
-    PromptSection::optional("project_context", project_context_block),
-    PromptSection::optional("protocol_prompt_sources", protocol_prompt_sources_block),
-    PromptSection::optional("skills", skills_block),
-    PromptSection::optional("language_best_practices", language_prompt),
-    PromptSection::new("runtime_context", render_environment_context(&cwd, &branch)),
-    PromptSection::optional("execute_mode", ...),
-    PromptSection::optional("plan_mode", ...),
-    PromptSection::optional("review_mode", ...),
-]
-```
+`project_context` contains up to two labeled subsections:
 
-Where `build_project_context_block`:
+- `### Project Instructions` contains ordered user and project instruction
+  sources.
+- `### Session Memory` contains stable local workspace memory.
 
-1. Collects `UserInstruction` and `ProjectInstruction` sources — if any exist,
-   renders them under `### Project Instructions`.
-2. Finds the `LocalMemory` source — if it exists, renders it under
-   `### Session Memory`.
-3. Wraps both sub-sections under `## Project Context`.
-4. Returns `None` when both sub-sections are empty (preserving the existing
-   behavior where absent sources produce no section).
+The complete section is omitted when both source classes are absent.
+
+### Turn-context deltas
+
+Environment, execution mode, and protocol prompt sources are appended only
+when their rendered value differs from the latest value of the same kind in
+history. Retrieved memory is query-dependent and is attached to every turn
+where selection returns content. When protocol sources disappear, the runtime
+appends an explicit cleared-state context so stale instructions do not remain
+authoritative.
 
 ### Prefix stability
 
-The change reduces the dynamic section count from 9 to 8.  Section keys change
-from `[instructions, memory, ...]` to `[project_context, ...]`.  This is a
-**one-time cache invalidation** for every provider.  After the merge, the
-`project_context` section becomes the new stable prefix boundary, and future
-changes within it (new source content) do not invalidate again (the section
-key stays the same).
+The literal `__DYNAMIC_BOUNDARY__` marker is not a provider cache primitive and
+must not appear in requests. RARA sends a plain system string. Stable-source
+changes may intentionally produce a new system prefix, but ordinary changes to
+cwd, branch, mode, diagnostics, protocol sources, or retrieval do not rewrite
+the earlier prefix.
 
 ## Contracts
 
 | Contract | Detail |
-|----------|--------|
-| **Merged section** | `project_context` is the only section for file-based context. |
-| **Sub-section labeling** | `### Project Instructions` for instruction sources, `### Session Memory` for memory sources. |
-| **Empty handling** | If no instruction sources AND no memory sources, `project_context` is absent (no empty section rendered). |
-| **Source kinds unchanged** | `UserInstruction`, `ProjectInstruction`, `LocalMemory` remain as is; only the renderer changes. |
-| **Section count** | Dynamic sections reduce by 1 (two sections → one). |
-| **DYNAMIC_BOUNDARY** | Unchanged. `project_context` is below the boundary, as instructions and memory were. |
+|---|---|
+| Stable system | Environment, mode, protocol/LSP data, and retrieved memory are absent from the system message. |
+| Merged project context | File instructions and stable workspace memory share the `project_context` section. |
+| Append-only model view | A later request preserves all earlier model-visible messages byte-for-byte until durable compaction. |
+| Hidden runtime attachments | `rara_model_context` is rendered to providers but omitted from human transcript and memory-query text. |
+| Cleared protocol state | Removal of previously active protocol sources is represented by a new turn-context delta. |
+| Provider neutrality | OpenAI-compatible, Codex Responses, Ollama, Gemini, Bedrock, and local prompt serializers preserve model-context text. |
 
 ## Validation Matrix
 
 | Check | Method | Expected |
-|-------|--------|----------|
-| Project instructions appear under `### Project Instructions` | Unit test with instruction sources | Content wrapped with sub-section header |
-| Session memory appears under `### Session Memory` | Unit test with LocalMemory source | Content wrapped with sub-section header |
-| No LocalMemory source | Unit test | `### Session Memory` sub-section absent |
-| No instruction sources | Unit test | `### Project Instructions` sub-section absent |
-| Both absent | Unit test | `project_context` section absent |
-| Section count | Assert on vec len | 8 instead of 9 |
-| `cargo build` | `cargo build` | No new warnings |
-| `cargo test` | `cargo test` | All existing tests pass, snapshot tests may need update |
-| Prefix cache key change | Manual: inspect `section_keys` | `project_context` replaces `instructions` + `memory` |
+|---|---|---|
+| Stable project merge | `rara-instructions` prompt tests | Project instructions and memory remain in `project_context`. |
+| Dynamic placement | `rara-instructions` turn-context tests | Environment, mode, and protocol sources are absent from system and present in turn context. |
+| Prefix invariant | Agent two-query regression | Request two starts with every message from request one. |
+| Memory placement | Agent retrieval regression | Selected memory is a persisted `rara_model_context` block before user text. |
+| Provider serialization | DeepSeek, Codex Responses, Gemini, Bedrock, and local-renderer regressions | Context text is model-visible; DeepSeek sends no fake boundary or `cache_control`. |
+| Quality gates | `cargo fmt`, focused tests, `cargo check`, Clippy | No new formatting, compile, or lint failures. |
 
 ## Operational Notes
 
-- This is a one-time break in provider prefix caches.  The new section key
-  `project_context` becomes the stable boundary going forward.
-- Snapshot tests that assert on the full prompt output will need regeneration.
-- Existing journal entries referencing `instructions` or `memory` section keys
-  are historical records and do not need updating.
+- Shipping this layout causes a one-time cold prefix for existing sessions.
+- DeepSeek cache effectiveness must be measured from official
+  `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens`; request shape alone
+  is not proof of a hit.
+- Mode-specific tool availability remains a separate request field and can
+  intentionally create a new provider prefix when the mode changes.
+
+## Open Risks
+
+- Live edits to stable project instructions still change the system prompt and
+  intentionally invalidate the provider prefix.
+- A future protocol source with stronger authority requirements may need a
+  dedicated signed context class rather than generic user-role placement.
 
 ## Source Journals
 
-- _(this spec, written before implementation)_
+- [2026-08-21 DeepSeek prefix cache locality](../journal/2026-08-21-deepseek-prefix-cache-locality.md)

--- a/docs/features/prompt-runtime.md
+++ b/docs/features/prompt-runtime.md
@@ -13,11 +13,13 @@ to align with the prompt-management patterns used by mature coding agents.
 - Prompt override and append behavior from config.
 - Dedicated prompt handling for context compaction.
 - Shared runtime bootstrap wiring for prompt runtime inputs.
+- Stable-prefix request assembly for providers with automatic prompt caching.
+- Typed, append-only model context for volatile per-turn inputs.
 
 ## Non-Goals
 
 - Codex-style state DB driven instruction layering.
-- Prompt caching or token-level prompt reuse.
+- Provider-controlled cache retention or cache-edit APIs.
 - Full coordinator / worker prompt families.
 
 ## Architecture
@@ -32,28 +34,35 @@ The effective prompt may draw from:
 - an optional final subagent capability policy section;
 - workspace instruction files;
 - local memory files;
-- protocol-registered prompt sources routed through the runtime control plane;
-- runtime context;
-- plan-mode specific guidance.
+- stable protocol-independent project context;
+- append-only runtime context attached to the current user message;
+- mode-specific guidance attached to the current user message.
 
 ### 2) Base Prompt Selection
 
 - If `system_prompt` or `system_prompt_file` is configured, that content replaces the default base
   prompt family.
 - Otherwise the default built-in prompt family is used.
-- Dynamic runtime sections still apply even when a custom base prompt is configured.
+- Stable project, skill, language, append, and capability sections still apply
+  when a custom base prompt is configured.
 
 ### 3) Effective Prompt Composition
 
-The effective prompt is assembled in this order:
+The model request is assembled in this order:
 
-1. base prompt;
-2. dynamic instruction sources;
-3. memory sources;
-4. runtime context;
-5. mode-specific addenda such as execute mode, plan mode, and review mode;
-6. append prompt.
-7. subagent capability policy section, when a child session is active.
+1. tool schemas in deterministic registry order;
+2. one plain system message containing the base prompt, project context,
+   stable skills, language guidance, append prompt, and child capability policy;
+3. persisted append-only conversation history;
+4. typed environment, mode, protocol/LSP, and retrieved-memory context on the
+   latest user message;
+5. the human-authored user request.
+
+The system prompt does not contain a synthetic dynamic-boundary marker or
+Anthropic-style `cache_control`. Provider cache reuse is based on repeated
+request prefixes. Volatile context is persisted as `rara_model_context` blocks
+so the bytes sent in one turn remain present in subsequent turns until durable
+history compaction replaces an older prefix.
 
 ### 3.1) Built-In Engineering Workflow Guidance
 
@@ -200,7 +209,21 @@ Examples:
 
 ## Contracts
 
-### 1) Prompt Observability
+### 1) Stable Prefix And Model Context
+
+- Environment, cwd, branch, execution mode, protocol/LSP sources, and selected
+  retrieved memory must not be rendered into the system message.
+- Environment, execution mode, and protocol sources are appended only when the
+  value differs from the latest persisted context of the same kind.
+- Retrieved memory remains query-dependent but is persisted with the current
+  user message as typed model context after selection.
+- A later model request must preserve the previous model-visible message prefix
+  byte-for-byte unless stable sources intentionally changed or durable
+  compaction replaced history.
+- Human transcript rendering, memory retrieval queries, and memory lifecycle
+  capture must ignore typed model-context blocks.
+
+### 2) Prompt Observability
 
 - The TUI status view must be able to report:
   - whether the base prompt is default or custom;
@@ -235,13 +258,13 @@ Examples:
 - Session restore must rebuild the same prompt/runtime surface that a direct run would produce for
   persisted session-scoped state such as execution mode, append prompt text, and prompt warnings.
 
-### 2) Workspace Prompt Sources
+### 3) Workspace Prompt Sources
 
 - Workspace instructions and local memory are treated as explicit prompt sources instead of opaque
   text blobs.
 - Prompt source discovery must remain reusable across agent runtime and TUI status reporting.
 
-### 3) Protocol Prompt Sources
+### 4) Protocol Prompt Sources
 
 - ACP, Wire, and future appserver integrations may register prompt-affecting
   material only through structured prompt source objects.
@@ -255,29 +278,30 @@ Examples:
   into a `PromptSourceKind::ProtocolPromptSource` entry before prompt assembly,
   preserving the source id in the label, protocol provenance in the display
   path, and adapter-provided content as the source body.
-- Protocol prompt sources are rendered in a dedicated dynamic
-  `protocol_prompt_sources` section. This keeps workspace instructions,
-  workspace memory, skills, runtime environment, and append prompts in their
-  existing relative order while still making protocol input visible in the
-  effective prompt and prompt-source context view.
+- Protocol prompt sources are rendered as a typed
+  `protocol_prompt_sources` model-context block on the current user message.
+  They never edit the stable system message. If the active source set changes
+  or clears, the next user turn carries a new delta while prior model-visible
+  history remains unchanged.
 - Runtime bootstrap owns the live `PromptSourceRegistry` and attaches it to the
   agent. At the start of each user query, the agent atomically snapshots
   turn-active registry entries into `PromptRuntimeConfig::protocol_prompt_sources`
   and advances turn-limited lifetimes under the same registry lock. The
-  snapshotted sources remain active for every model request inside that query's
-  agent loop. This keeps live protocol input on the normal prompt-runtime path
-  instead of letting adapters edit final prompt text.
+  snapshotted sources are persisted on that query's user message and remain
+  active for every model request inside the query's agent loop. This keeps live
+  protocol input on the normal prompt-runtime path instead of letting adapters
+  edit final prompt text.
 - The registry emits lifecycle events for protocol prompt sources:
   `Registered` when accepted, `Injected` when snapshotted into a user query, and
   `Dropped` when a turn-limited source expires or is removed from the registry.
 
-### 4) Agent Loop Integration
+### 5) Agent Loop Integration
 
 - `Agent::build_system_prompt()` must delegate to the prompt runtime instead of hand-building the
   prompt inline.
 - Compaction must pass the dedicated compact instruction down to every backend summarization path.
 
-### 5) Runtime Bootstrap Contract
+### 6) Runtime Bootstrap Contract
 
 - Runtime/bootstrap callers must initialize workspace, prompt runtime config, skills, and tools
   through one shared entrypoint instead of wiring those pieces independently in `main.rs` and TUI
@@ -290,9 +314,14 @@ Examples:
 
 ## Validation Matrix
 
-- `cargo check`
-- focused prompt runtime tests for source discovery and prompt precedence
-- focused agent tests for compaction instruction wiring
+| Contract | Validation |
+|---|---|
+| Stable system placement | `cargo test -p rara-instructions` |
+| Append-only request prefix | `cargo test -p rara agent::tests::prompt_cache::later_request_preserves_the_previous_model_visible_prefix` |
+| Protocol and memory attachment | Focused `agent::tests::context_view` regressions |
+| Official DeepSeek request shape | `llm::tests::deepseek_request_uses_plain_prefix_without_anthropic_cache_controls` |
+| Provider-neutral typed context | Provider conversion unit tests plus `cargo check` |
+| Warning cleanliness | `cargo clippy --workspace --all-targets -- -D warnings` |
 
 ## Open Risks
 
@@ -303,6 +332,10 @@ Examples:
   vector/thread selection instead of only prompt-injected or compacted carry-over.
 - Protocol-registered prompt sources need strict provenance and lifetime rules
   before ACP/Wire can safely control prompt material.
+- Mode-dependent tool sets remain outside `messages` and can intentionally
+  break provider prefix reuse on a mode transition.
+- Cache request locality does not prove a provider hit; production validation
+  must use official provider usage accounting.
 
 ## Source Journals
 
@@ -313,4 +346,5 @@ Examples:
 - [2026-05-07-engineering-guidance-placement](../journal/2026-05-07-engineering-guidance-placement.md)
 - [2026-05-13-claude-prompt-locality](../journal/2026-05-13-claude-prompt-locality.md)
 - [2026-05-14-sandbox-denial-escalation-guidance](../journal/2026-05-14-sandbox-denial-escalation-guidance.md)
+- [2026-08-21-deepseek-prefix-cache-locality](../journal/2026-08-21-deepseek-prefix-cache-locality.md)
 - [Runtime Control Plane](runtime-control-plane.md)

--- a/docs/features/retrieval-orchestration.md
+++ b/docs/features/retrieval-orchestration.md
@@ -374,8 +374,11 @@ The display should keep details compact and path/URI-like fields visible.
 - Tight budget drops candidates with explicit `budget_exceeded` reason.
 - `/context` shows provider status, selected, available, dropped, and budget.
 - ACP/Wire view uses the same structured data as `/context`.
-- Retrieved candidates are not persisted as ordinary chat history.
-- Stable prompt-prefix bytes are unchanged when only volatile retrieval changes.
+- Retrieved candidate records are not persisted as ordinary chat history;
+  selected rendered context is persisted as a typed model-only attachment on
+  the current user message.
+- Stable system and prior-message prefix bytes are unchanged when only volatile
+  retrieval changes.
 
 ## Open Risks
 
@@ -391,3 +394,4 @@ The display should keep details compact and path/URI-like fields visible.
 ## Source Journals
 
 - `docs/journal/2026-05-07-retrieval-orchestration-spec.md`
+- `docs/journal/2026-08-21-deepseek-prefix-cache-locality.md`

--- a/docs/journal/2026-08-21-deepseek-prefix-cache-locality.md
+++ b/docs/journal/2026-08-21-deepseek-prefix-cache-locality.md
@@ -1,0 +1,89 @@
+# DeepSeek Prefix Cache Locality
+
+## Summary
+
+RARA now keeps its model-visible prompt history append-only for ordinary turns.
+Environment, execution mode, protocol/LSP sources, and selected retrieved memory
+move out of the system message into persisted typed context on the current user
+message. DeepSeek continues to use its official OpenAI-compatible endpoint and
+automatic prefix-cache accounting.
+
+## Background
+
+The previous `__DYNAMIC_BOUNDARY__` marker was internal text, not a provider
+cache boundary. OpenAI-compatible serialization flattened the system content,
+dropped the attached Anthropic-style cache hint, and still sent volatile
+environment and mode text inside the first message.
+
+There was a second prefix-locality failure: retrieved memory and projected tool
+results were applied only to a request copy. A later request reconstructed old
+history without the exact content seen by the previous model call, so the
+provider could not reuse the earlier prefix beyond the system message.
+
+The design was compared with two upstream patterns before implementation:
+
+- Claude Code can move per-machine dynamic system sections into the first user
+  message to improve shared prompt-cache locality.
+- Codex persists typed world-state context and appends changes instead of
+  rebuilding earlier message content on every turn.
+
+## Scope
+
+- Removed the synthetic dynamic-boundary marker and generic `cache_control`.
+- Kept project instructions, stable workspace memory, skills, language
+  guidance, append text, and child capability policy in the system prompt.
+- Added `rara_model_context` blocks for environment, execution mode,
+  protocol/LSP sources, and retrieved memory.
+- Persisted those blocks with the current user message while excluding them
+  from human transcript and memory-query text.
+- Added provider rendering for OpenAI-compatible chat, Codex Responses,
+  Ollama, Gemini, Bedrock, and local prompts.
+- Disabled request-only tool-result projection when a backend declares
+  automatic prefix caching without cache edit. Durable compaction remains the
+  bounded-history mechanism.
+
+## Key Decisions
+
+1. Prefix stability is a request-history invariant, not a marker in prompt
+   text.
+2. Query-dependent memory remains in the current-user suffix, but the exact
+   model-visible attachment is retained in later history.
+3. Mode and protocol changes append deltas. Clearing protocol sources appends
+   an explicit cleared state so old instructions do not remain current.
+4. Stable project source changes may intentionally produce a new cold system
+   prefix; RARA does not freeze changed repository instructions for cache hits.
+5. DeepSeek uses the official `chat/completions` interface. RARA relies on the
+   provider's automatic cache and parses `prompt_cache_hit_tokens` and
+   `prompt_cache_miss_tokens`; it does not emulate Anthropic cache controls.
+
+## Validation
+
+Executed locally:
+
+```bash
+cargo fmt --all
+cargo test -p rara-instructions
+cargo test -p rara model_context::tests::model_context_is_upserted_before_user_text -- --nocapture
+cargo test -p rara agent::tests::prompt_cache::later_request_preserves_the_previous_model_visible_prefix -- --nocapture
+cargo test -p rara agent::tests::microcompact::automatic_prefix_cache_preserves_tool_results_until_durable_compaction -- --nocapture
+cargo test -p rara agent::tests::context_view::query_persists_selected_memory_as_typed_model_context -- --nocapture
+cargo test -p rara agent::tests::context_view::protocol_prompt_registry_feeds_prompt_runtime_for_query -- --nocapture
+cargo test -p rara llm::model_context_tests -- --nocapture
+cargo test --workspace --quiet
+cargo check --workspace --all-targets
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+The focused tests, the complete workspace test suite, workspace check, and
+warning-denying Clippy run passed. The root library suite completed 1,325 tests.
+On macOS, the root test binary emitted the existing linker notice about the
+compact-unwind `__eh_frame` size; all tests still completed successfully.
+
+## Follow-Ups
+
+- Run an opt-in A/B test against the official DeepSeek API and compare cache
+  hit/miss usage across repeated turns. No live provider call was made in this
+  implementation checkpoint.
+- Evaluate whether mode-specific tool-set changes should use a stable
+  capability envelope. Runtime enforcement must remain authoritative before
+  changing that request shape.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -90,6 +90,12 @@ Active backlog only. Keep this file small and current.
 - [x] Compaction lifecycle — /compact command + PreCompact/PostCompact hooks (PR #598)
 - [x] Tool result compression — ToolResultProjectionPolicy + model_preview_bash_output
 - [x] Context file routing — FileSearchCandidateProvider → retrieval pipeline (spec-only PR #606)
+- [x] Keep volatile environment, mode, protocol/LSP, and retrieved-memory
+      context out of the system prompt and preserve earlier model-visible
+      request prefixes with typed append-only context.
+- [ ] Run an opt-in official DeepSeek API A/B measurement and record
+      `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` for comparable
+      repeated turns; request-shape regressions alone do not prove a cache hit.
 
 ## Benchmark / Evaluation
 

--- a/src/agent/compact/main.rs
+++ b/src/agent/compact/main.rs
@@ -342,7 +342,7 @@ impl Agent {
         }
     }
 
-    fn recompute_history_token_estimate(&mut self) {
+    pub(in crate::agent) fn recompute_history_token_estimate(&mut self) {
         self.compact_state.estimated_history_tokens =
             estimate_history_tokens(&self.history).unwrap_or_default();
     }

--- a/src/agent/memory_retrieval.rs
+++ b/src/agent/memory_retrieval.rs
@@ -1,10 +1,18 @@
-use serde_json::{Value, json};
+use serde_json::Value;
 
 use super::{Agent, Message};
 use crate::context::{
     MemoryRetrievalOrchestrator, MemorySelectionItemContextEntry, RetrievedMemoryRenderItem,
     SharedRuntimeContext, is_retrieved_memory_kind, render_retrieved_memory_context,
 };
+use crate::model_context::{
+    ModelContextFragment, ModelContextKind, latest_model_context_text,
+    upsert_latest_user_model_context,
+};
+use crate::prompt;
+
+const CLEARED_PROTOCOL_PROMPT_SOURCES: &str =
+    "## Protocol Prompt Sources\n\nNo protocol prompt sources are active for this turn.";
 
 impl Agent {
     pub(super) async fn refresh_memory_retrieval_candidates(&mut self) {
@@ -43,59 +51,72 @@ impl Agent {
         render_selected_memory_context(selected.as_slice())
     }
 
-    pub(super) fn prepend_memory_context_to_latest_user_message(
-        messages: &mut [Message],
-        memory_context: String,
-    ) {
-        let Some(message) = messages
-            .iter_mut()
-            .rfind(|message| message.role == "user" && is_user_text_request(message))
-        else {
-            return;
-        };
+    pub(super) fn persist_model_context_for_latest_user_message(&mut self) -> bool {
+        let turn_context = prompt::build_turn_prompt_context(
+            &self.workspace,
+            &self.prompt_config,
+            self.prompt_mode(),
+        );
+        let mut fragments = Vec::new();
 
-        prepend_text_to_message(message, memory_context);
-    }
-}
-
-fn prepend_text_to_message(message: &mut Message, text: String) {
-    match &mut message.content {
-        Value::Array(items) => items.insert(0, memory_text_block(text)),
-        Value::String(existing) => {
-            let original = std::mem::take(existing);
-            *existing = format!("{text}\n\n{original}");
+        push_changed_context(
+            &self.history,
+            &mut fragments,
+            ModelContextKind::Environment,
+            turn_context.environment,
+        );
+        push_changed_context(
+            &self.history,
+            &mut fragments,
+            ModelContextKind::ExecutionMode,
+            turn_context.execution_mode,
+        );
+        match turn_context.protocol_prompt_sources {
+            Some(protocol_sources) => push_changed_context(
+                &self.history,
+                &mut fragments,
+                ModelContextKind::ProtocolPromptSources,
+                protocol_sources,
+            ),
+            None if latest_model_context_text(
+                &self.history,
+                ModelContextKind::ProtocolPromptSources,
+            )
+            .is_some_and(|text| text != CLEARED_PROTOCOL_PROMPT_SOURCES) =>
+            {
+                fragments.push(ModelContextFragment::new(
+                    ModelContextKind::ProtocolPromptSources,
+                    CLEARED_PROTOCOL_PROMPT_SOURCES,
+                ));
+            }
+            None => {}
         }
-        other => {
-            let original = other.take();
-            *other = json!([
-                memory_text_block(text),
-                {"type": "text", "text": original.to_string()}
-            ]);
+        let mut changed = upsert_latest_user_model_context(&mut self.history, fragments.as_slice());
+
+        let assembled = self.assemble_turn_context();
+        if let Some(memory_context) = Agent::selected_memory_context_text(&assembled.runtime) {
+            changed |= upsert_latest_user_model_context(
+                &mut self.history,
+                &[ModelContextFragment::new(
+                    ModelContextKind::RetrievedMemory,
+                    memory_context,
+                )],
+            );
         }
+
+        changed
     }
 }
 
-fn is_user_text_request(message: &Message) -> bool {
-    if message
-        .content
-        .as_str()
-        .is_some_and(|text| !text.trim().is_empty())
-    {
-        return true;
+fn push_changed_context(
+    history: &[Message],
+    fragments: &mut Vec<ModelContextFragment>,
+    kind: ModelContextKind,
+    text: String,
+) {
+    if latest_model_context_text(history, kind) != Some(text.as_str()) {
+        fragments.push(ModelContextFragment::new(kind, text));
     }
-    message.content.as_array().is_some_and(|items| {
-        items.iter().any(|item| {
-            item.get("type").and_then(Value::as_str) == Some("text")
-                && item
-                    .get("text")
-                    .and_then(Value::as_str)
-                    .is_some_and(|text| !text.trim().is_empty())
-        })
-    })
-}
-
-fn memory_text_block(text: String) -> Value {
-    json!({"type": "text", "text": text})
 }
 
 fn render_selected_memory_context(items: &[&MemorySelectionItemContextEntry]) -> Option<String> {

--- a/src/agent/prompting.rs
+++ b/src/agent/prompting.rs
@@ -15,13 +15,7 @@ impl Agent {
     /// docs/features/prompt-runtime.md.
     #[allow(dead_code)]
     pub fn assemble_context(&self) -> AssembledContext {
-        self.context_assembler().assemble({
-            match self.execution_mode {
-                AgentExecutionMode::Execute => PromptMode::Execute,
-                AgentExecutionMode::Plan => PromptMode::Plan,
-                AgentExecutionMode::Review => PromptMode::Review,
-            }
-        })
+        self.context_assembler().assemble(self.prompt_mode())
     }
 
     pub(super) fn context_assembler(&self) -> ContextAssembler<'_> {
@@ -29,23 +23,21 @@ impl Agent {
     }
 
     pub fn assemble_turn_context(&self) -> AssembledTurnContext {
-        let mode = match self.execution_mode {
-            AgentExecutionMode::Execute => PromptMode::Execute,
-            AgentExecutionMode::Plan => PromptMode::Plan,
-            AgentExecutionMode::Review => PromptMode::Review,
-        };
         self.context_assembler()
-            .assemble_turn(mode, self.runtime_context_inputs())
+            .assemble_turn(self.prompt_mode(), self.runtime_context_inputs())
     }
 
     pub fn assemble_runtime_context(&self) -> crate::context::SharedRuntimeContext {
-        let mode = match self.execution_mode {
+        self.context_assembler()
+            .assemble_runtime(self.prompt_mode(), self.runtime_context_inputs())
+    }
+
+    pub(super) fn prompt_mode(&self) -> PromptMode {
+        match self.execution_mode {
             AgentExecutionMode::Execute => PromptMode::Execute,
             AgentExecutionMode::Plan => PromptMode::Plan,
             AgentExecutionMode::Review => PromptMode::Review,
-        };
-        self.context_assembler()
-            .assemble_runtime(mode, self.runtime_context_inputs())
+        }
     }
 
     fn runtime_context_inputs(&self) -> RuntimeContextInputs<'_> {
@@ -99,8 +91,13 @@ impl Agent {
     }
 
     pub(super) fn tool_result_projection_policy(&self) -> ToolResultProjectionPolicy {
-        let mut policy = ToolResultProjectionPolicy::default()
-            .for_provider_cache_edit(self.llm_backend.cache_profile().cache_edit);
+        let cache_profile = self.llm_backend.cache_profile();
+        let mut policy =
+            ToolResultProjectionPolicy::default().for_provider_cache_edit(cache_profile.cache_edit);
+
+        if cache_profile.automatic_prefix_cache && !cache_profile.cache_edit {
+            policy.enabled = false;
+        }
 
         // Time-based trigger (Claude Code microcompact style):
         // When the gap since the last interaction exceeds 60 minutes, the

--- a/src/agent/runtime.rs
+++ b/src/agent/runtime.rs
@@ -239,6 +239,10 @@ impl Agent {
         self.refresh_file_search_candidates();
         self.refresh_protocol_prompt_sources_for_query().await;
         self.refresh_protocol_skill_sources_for_query().await;
+        if self.persist_model_context_for_latest_user_message() {
+            self.recompute_history_token_estimate();
+            self.checkpoint_session()?;
+        }
 
         match self
             .run_agent_loop_with_limit(output_mode, &mut report, &mut agentic_turns)
@@ -438,61 +442,13 @@ impl Agent {
                 "Projected {projected_result_count} tool result(s) into evidence-preserving summaries for this model request."
             )));
         }
-        let mut system_content = Vec::new();
-        if let Some(_index) = assembled.prompt.effective_prompt.dynamic_boundary_index {
-            let full_text = &assembled.prompt.effective_prompt.text;
-            // The text is joined by "\n\n". We want to split it back or just use the sections.
-            // But EffectivePrompt only gives us the full text and boundary index.
-            // Actually, build_effective_prompt joins them.
-
-            let parts: Vec<&str> = full_text
-                .split(rara_instructions::DYNAMIC_BOUNDARY)
-                .collect();
-            if parts.len() >= 2 {
-                let static_part = parts[0].trim();
-                let dynamic_part = parts[1..].join(rara_instructions::DYNAMIC_BOUNDARY);
-                let dynamic_part = dynamic_part.trim();
-
-                if !static_part.is_empty() {
-                    system_content.push(json!({
-                        "type": "text",
-                        "text": static_part,
-                        "cache_control": {"type": "ephemeral"} // Add hint for Anthropic-style caching
-                    }));
-                }
-                // Add the boundary itself if needed or just skip it.
-                // Claude Code keeps it to mark the boundary for future edits.
-                system_content.push(json!({
-                    "type": "text",
-                    "text": rara_instructions::DYNAMIC_BOUNDARY,
-                }));
-                if !dynamic_part.is_empty() {
-                    system_content.push(json!({
-                        "type": "text",
-                        "text": dynamic_part,
-                    }));
-                }
-            } else {
-                system_content.push(json!(assembled.prompt.effective_prompt.text));
-            }
-        } else {
-            system_content.push(json!(assembled.prompt.effective_prompt.text));
-        }
-
         messages.insert(
             0,
             Message {
                 role: "system".to_string(),
-                content: if system_content.len() == 1 {
-                    system_content.remove(0)
-                } else {
-                    Value::Array(system_content)
-                },
+                content: Value::String(assembled.prompt.effective_prompt.text),
             },
         );
-        if let Some(memory_context) = Agent::selected_memory_context_text(&assembled.runtime) {
-            Agent::prepend_memory_context_to_latest_user_message(&mut messages, memory_context);
-        }
 
         let model_label = self.model_event_label();
         report(AgentEvent::ModelRequest {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -5,5 +5,6 @@ mod mailbox;
 mod microcompact;
 mod planning;
 mod plugin_hooks;
+mod prompt_cache;
 mod stop_hooks;
 mod support;

--- a/src/agent/tests/context_view.rs
+++ b/src/agent/tests/context_view.rs
@@ -5,7 +5,7 @@ use rara_tools::tool::ToolManager;
 use serde_json::json;
 
 use super::support::{SequencedBackend, test_runtime_storage};
-use crate::agent::{Agent, AgentExecutionMode, Message, PlanStep, PlanStepStatus};
+use crate::agent::{Agent, AgentExecutionMode, AgentOutputMode, Message, PlanStep, PlanStepStatus};
 use crate::llm::{ContentBlock, LlmResponse};
 use crate::memory_store::{MemoryLabel, MemoryScope, MemorySource, MemoryStore, NewMemoryRecord};
 use crate::prompt::PromptRuntimeConfig;
@@ -251,11 +251,8 @@ fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
     assert_eq!(runtime.retrieval.entries[4].status, "missing");
     assert_eq!(runtime.retrieval.entries[5].kind, "graph_context");
     assert_eq!(runtime.retrieval.entries[5].status, "missing");
-    assert_eq!(runtime.retrieval.memory_selection.selected_items.len(), 9);
-    assert_eq!(
-        runtime.retrieval.memory_selection.selected_items[0].kind,
-        "workspace_memory"
-    );
+    let selected = &runtime.retrieval.memory_selection.selected_items;
+    assert_eq!(selected[0].kind, "workspace_memory");
     assert!(
         runtime.retrieval.memory_selection.selected_items[0]
             .detail
@@ -266,48 +263,26 @@ fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
             .detail
             .contains("2 non-empty lines")
     );
+    let selected_kinds = selected
+        .iter()
+        .map(|item| item.kind.as_str())
+        .collect::<Vec<_>>();
+    for expected in [
+        "compacted_summary",
+        "recent_files",
+        "recent_file_excerpts",
+        "plan_explanation",
+        "plan_steps",
+        "latest_user_request",
+    ] {
+        assert!(selected_kinds.contains(&expected), "missing {expected}");
+    }
     assert_eq!(
-        runtime.retrieval.memory_selection.selected_items[1].kind,
-        "compacted_summary"
-    );
-    assert_eq!(
-        runtime.retrieval.memory_selection.selected_items[2].kind,
-        "recent_files"
-    );
-    assert_eq!(
-        runtime.retrieval.memory_selection.selected_items[3].kind,
-        "recent_file_excerpts"
-    );
-    assert_eq!(
-        runtime.retrieval.memory_selection.selected_items[4].kind,
-        "plan_explanation"
-    );
-    assert_eq!(
-        runtime.retrieval.memory_selection.selected_items[5].kind,
-        "plan_steps"
-    );
-    assert_eq!(
-        runtime.retrieval.memory_selection.selected_items[6].kind,
-        "latest_user_request"
-    );
-    assert_eq!(
-        runtime.retrieval.memory_selection.selected_items[7].kind,
-        "tool_result"
-    );
-    assert_eq!(
-        runtime.retrieval.memory_selection.selected_items[8].kind,
-        "tool_result"
-    );
-    assert!(
-        runtime
-            .retrieval
-            .memory_selection
-            .selected_items
+        selected_kinds
             .iter()
-            .all(|item| !matches!(
-                item.kind.as_str(),
-                "retrieved_workspace_memory" | "retrieved_thread_context"
-            ))
+            .filter(|kind| **kind == "tool_result")
+            .count(),
+        2
     );
     assert_eq!(runtime.retrieval.memory_selection.available_items.len(), 2);
     assert_eq!(
@@ -318,22 +293,18 @@ fn shared_runtime_context_collects_prompt_plan_and_compaction_state() {
         runtime.retrieval.memory_selection.available_items[1].kind,
         "local_memory"
     );
-    assert_eq!(runtime.retrieval.memory_selection.dropped_items.len(), 2);
-    assert_eq!(
-        runtime.retrieval.memory_selection.dropped_items[0].kind,
-        "retrieved_thread_context"
-    );
+    let retrieved_items = runtime
+        .retrieval
+        .memory_selection
+        .selected_items
+        .iter()
+        .chain(runtime.retrieval.memory_selection.dropped_items.iter())
+        .filter(|item| item.kind == "retrieved_thread_context")
+        .collect::<Vec<_>>();
+    assert_eq!(retrieved_items.len(), 2);
+    assert!(retrieved_items[0].detail.contains("bootstrap contract"));
     assert!(
-        runtime.retrieval.memory_selection.dropped_items[0]
-            .detail
-            .contains("bootstrap contract")
-    );
-    assert_eq!(
-        runtime.retrieval.memory_selection.dropped_items[1].kind,
-        "retrieved_thread_context"
-    );
-    assert!(
-        runtime.retrieval.memory_selection.dropped_items[1]
+        retrieved_items[1]
             .detail
             .contains("Auth picker already moved behind the shared runtime bootstrap.")
     );
@@ -429,16 +400,25 @@ fn assemble_turn_context_matches_prompt_and_runtime_views() {
 #[tokio::test]
 async fn protocol_prompt_registry_feeds_prompt_runtime_for_query() {
     let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
-    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
-        content: vec![ContentBlock::Text {
-            text: "ok".to_string(),
-        }],
-        stop_reason: Some("end_turn".to_string()),
-        usage: None,
-    }]));
+    let backend = Arc::new(SequencedBackend::new(vec![
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "ok".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: None,
+        },
+        LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "cleared".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: None,
+        },
+    ]));
     let mut agent = Agent::new(
         ToolManager::new(),
-        backend,
+        backend.clone(),
         Arc::new(MemoryHandle::new(
             &rara_dir.join("memory").display().to_string(),
         )),
@@ -461,19 +441,28 @@ async fn protocol_prompt_registry_feeds_prompt_runtime_for_query() {
         .await;
     agent.set_prompt_source_registry(registry.clone());
 
-    agent.refresh_protocol_prompt_sources_for_query().await;
+    agent
+        .query_with_mode("inspect the selection".to_string(), AgentOutputMode::Silent)
+        .await
+        .expect("query");
 
-    let effective = agent.effective_prompt();
-    assert!(effective.section_keys.contains(&"protocol_prompt_sources"));
-    assert!(effective.text.contains("## Protocol Prompt Sources"));
+    let observed = backend.observed_messages();
+    let first_request = observed.first().expect("model request").clone();
     assert!(
-        effective
-            .text
-            .contains("### Protocol Prompt Source editor-selection")
+        !first_request[0]
+            .content
+            .to_string()
+            .contains("editor-selection")
     );
+    let user = first_request
+        .iter()
+        .find(|message| message.role == "user")
+        .expect("user request");
+    assert!(user.content.to_string().contains("rara_model_context"));
+    assert!(user.content.to_string().contains("editor-selection"));
     assert!(
-        effective
-            .text
+        user.content
+            .to_string()
             .contains("The active editor selection is src/main.rs.")
     );
     assert!(
@@ -492,25 +481,36 @@ async fn protocol_prompt_registry_feeds_prompt_runtime_for_query() {
         "turn-limited source should be consumed after one user query"
     );
     assert!(
-        agent
-            .effective_prompt()
-            .section_keys
-            .contains(&"protocol_prompt_sources"),
-        "the current query keeps the snapshotted source for every model request"
-    );
-
-    agent.refresh_protocol_prompt_sources_for_query().await;
-
-    assert!(
         !agent
             .effective_prompt()
             .section_keys
             .contains(&"protocol_prompt_sources")
     );
+
+    agent
+        .query_with_mode(
+            "continue without selection".to_string(),
+            AgentOutputMode::Silent,
+        )
+        .await
+        .expect("second query");
+    let observed = backend.observed_messages();
+    let second_request = observed.get(1).expect("second model request");
+    assert_eq!(
+        &second_request[..first_request.len()],
+        first_request.as_slice()
+    );
+    let latest_user = second_request.last().expect("latest user request");
+    assert!(
+        latest_user
+            .content
+            .to_string()
+            .contains("No protocol prompt sources are active for this turn.")
+    );
 }
 
 #[tokio::test]
-async fn query_injects_selected_memory_context_without_persisting_it_to_history() {
+async fn query_persists_selected_memory_as_typed_model_context() {
     let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
     let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
         content: vec![ContentBlock::Text {
@@ -591,11 +591,21 @@ async fn query_injects_selected_memory_context_without_persisting_it_to_history(
                 .to_string()
                 .contains("<rara_internal_history_context>")
     }));
-    assert!(!agent.history.iter().any(|message| {
+    assert!(agent.history.iter().any(|message| {
         message
             .content
             .to_string()
-            .contains("<rara_internal_history_context>")
+            .contains("\"type\":\"rara_model_context\"")
+    }));
+    let restored_history = agent
+        .session_manager
+        .load_thread_history(&agent.session_id)
+        .expect("restore persisted history");
+    assert!(restored_history.iter().any(|message| {
+        message
+            .content
+            .to_string()
+            .contains("\"type\":\"rara_model_context\"")
     }));
     assert!(
         agent
@@ -606,94 +616,4 @@ async fn query_injects_selected_memory_context_without_persisting_it_to_history(
             .iter()
             .any(|item| item.kind == crate::context::RETRIEVED_WORKSPACE_MEMORY_KIND)
     );
-}
-
-#[test]
-fn memory_context_prepends_to_existing_user_message_without_adding_user_turn() {
-    let mut messages = vec![
-        Message {
-            role: "system".to_string(),
-            content: json!("system"),
-        },
-        Message {
-            role: "user".to_string(),
-            content: json!([{"type":"text","text":"current request"}]),
-        },
-    ];
-
-    Agent::prepend_memory_context_to_latest_user_message(
-        &mut messages,
-        "<rara_internal_history_context>\nrecall\n</rara_internal_history_context>".to_string(),
-    );
-
-    assert_eq!(messages.len(), 2);
-    assert_eq!(messages[1].role, "user");
-    let text = messages[1].content.to_string();
-    assert!(text.contains("<rara_internal_history_context>"));
-    assert!(text.find("recall").expect("recall") < text.find("current request").expect("request"));
-    assert!(
-        !messages
-            .windows(2)
-            .any(|pair| pair[0].role == "user" && pair[1].role == "user")
-    );
-}
-
-#[test]
-fn memory_context_noops_without_user_text_request() {
-    let mut messages = vec![
-        Message {
-            role: "system".to_string(),
-            content: json!("system"),
-        },
-        Message {
-            role: "assistant".to_string(),
-            content: json!([{"type":"tool_use","id":"tool-1","name":"list_files","input":{}}]),
-        },
-        Message {
-            role: "user".to_string(),
-            content: json!([{"type":"tool_result","tool_use_id":"tool-1","content":"ok"}]),
-        },
-    ];
-
-    Agent::prepend_memory_context_to_latest_user_message(
-        &mut messages,
-        "<rara_internal_history_context>\nrecall\n</rara_internal_history_context>".to_string(),
-    );
-
-    assert_eq!(messages.len(), 3);
-    assert!(
-        !messages
-            .iter()
-            .any(|message| message.content.to_string().contains("recall"))
-    );
-}
-
-#[test]
-fn memory_context_skips_tool_result_user_messages() {
-    let mut messages = vec![
-        Message {
-            role: "system".to_string(),
-            content: json!("system"),
-        },
-        Message {
-            role: "user".to_string(),
-            content: json!([{"type":"text","text":"current request"}]),
-        },
-        Message {
-            role: "assistant".to_string(),
-            content: json!([{"type":"tool_use","id":"tool-1","name":"list_files","input":{}}]),
-        },
-        Message {
-            role: "user".to_string(),
-            content: json!([{"type":"tool_result","tool_use_id":"tool-1","content":"ok"}]),
-        },
-    ];
-
-    Agent::prepend_memory_context_to_latest_user_message(
-        &mut messages,
-        "<rara_internal_history_context>\nrecall\n</rara_internal_history_context>".to_string(),
-    );
-
-    assert!(messages[1].content.to_string().contains("recall"));
-    assert!(!messages[3].content.to_string().contains("recall"));
 }

--- a/src/agent/tests/microcompact.rs
+++ b/src/agent/tests/microcompact.rs
@@ -6,29 +6,10 @@ use serde_json::json;
 
 use super::support::{SequencedBackend, test_runtime_storage};
 use crate::agent::{Agent, AgentOutputMode, Message};
-use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
+use crate::llm::{ContentBlock, LlmResponse, ProviderCacheProfile, TokenUsage};
 
-#[tokio::test]
-async fn model_request_projects_old_tool_results_without_mutating_history() {
-    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
-        content: vec![ContentBlock::Text {
-            text: "done".to_string(),
-        }],
-        stop_reason: Some("end_turn".to_string()),
-        usage: Some(TokenUsage::default()),
-    }]));
-    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
-    let mut agent = Agent::new(
-        ToolManager::new(),
-        backend.clone(),
-        Arc::new(MemoryHandle::new(
-            &rara_dir.join("memory").to_string_lossy(),
-        )),
-        session_manager,
-        workspace,
-    );
-
-    agent.history = (0..8)
+fn large_tool_history() -> Vec<Message> {
+    (0..8)
         .flat_map(|idx| {
             [
                 Message {
@@ -50,7 +31,30 @@ async fn model_request_projects_old_tool_results_without_mutating_history() {
                 },
             ]
         })
-        .collect();
+        .collect()
+}
+
+#[tokio::test]
+async fn model_request_projects_old_tool_results_without_mutating_history() {
+    let backend = Arc::new(SequencedBackend::new(vec![LlmResponse {
+        content: vec![ContentBlock::Text {
+            text: "done".to_string(),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: Some(TokenUsage::default()),
+    }]));
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        Arc::new(MemoryHandle::new(
+            &rara_dir.join("memory").to_string_lossy(),
+        )),
+        session_manager,
+        workspace,
+    );
+
+    agent.history = large_tool_history();
     agent.compact_state.estimated_history_tokens = 1;
 
     agent
@@ -96,4 +100,48 @@ async fn model_request_projects_old_tool_results_without_mutating_history() {
     let persisted_history = serde_json::to_string(&agent.history).expect("history json");
     assert!(persisted_history.contains("old-result-0"));
     assert!(persisted_history.contains("old-result-7"));
+}
+
+#[tokio::test]
+async fn automatic_prefix_cache_preserves_tool_results_until_durable_compaction() {
+    let backend = Arc::new(
+        SequencedBackend::new(vec![LlmResponse {
+            content: vec![ContentBlock::Text {
+                text: "done".to_string(),
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Some(TokenUsage::default()),
+        }])
+        .with_cache_profile(ProviderCacheProfile::automatic_prefix_cache_with_usage()),
+    );
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        Arc::new(MemoryHandle::new(
+            &rara_dir.join("memory").to_string_lossy(),
+        )),
+        session_manager,
+        workspace,
+    );
+    agent.history = large_tool_history();
+    agent.compact_state.estimated_history_tokens = 1;
+
+    agent
+        .query_with_mode("continue".to_string(), AgentOutputMode::Silent)
+        .await
+        .expect("query");
+
+    let request = backend
+        .observed_messages()
+        .into_iter()
+        .next()
+        .expect("model request");
+    let request_text = serde_json::to_string(&request).expect("request json");
+    assert!(request_text.contains("old-result-0"));
+    assert!(request_text.contains("old-result-7"));
+    assert!(!request_text.contains("Tool result reference"));
+    let projection = agent.shared_runtime_context().observability.microcompact;
+    assert!(!projection.enabled);
+    assert_eq!(projection.saved_chars, 0);
 }

--- a/src/agent/tests/prompt_cache.rs
+++ b/src/agent/tests/prompt_cache.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use rara_memory::memory_handle::MemoryHandle;
+use rara_tools::tool::ToolManager;
+
+use super::support::{SequencedBackend, test_runtime_storage};
+use crate::agent::{Agent, AgentExecutionMode, AgentOutputMode};
+use crate::llm::{ContentBlock, LlmResponse, ProviderCacheProfile, TokenUsage};
+
+fn text_response(text: &str) -> LlmResponse {
+    LlmResponse {
+        content: vec![ContentBlock::Text {
+            text: text.to_string(),
+        }],
+        stop_reason: Some("end_turn".to_string()),
+        usage: Some(TokenUsage::default()),
+    }
+}
+
+#[tokio::test]
+async fn later_request_preserves_the_previous_model_visible_prefix() {
+    let backend = Arc::new(
+        SequencedBackend::new(vec![
+            text_response("first answer"),
+            text_response("second answer"),
+        ])
+        .with_cache_profile(ProviderCacheProfile::automatic_prefix_cache_with_usage()),
+    );
+    let (_temp, session_manager, workspace, rara_dir) = test_runtime_storage();
+    let mut agent = Agent::new(
+        ToolManager::new(),
+        backend.clone(),
+        Arc::new(MemoryHandle::new(
+            &rara_dir.join("memory").to_string_lossy(),
+        )),
+        session_manager,
+        workspace,
+    );
+
+    agent
+        .query_with_mode("first request".to_string(), AgentOutputMode::Silent)
+        .await
+        .expect("first query");
+    agent.execution_mode = AgentExecutionMode::Plan;
+    agent
+        .query_with_mode("second request".to_string(), AgentOutputMode::Silent)
+        .await
+        .expect("second query");
+
+    let observed = backend.observed_messages();
+    let first = observed.first().expect("first model request");
+    let second = observed.get(1).expect("second model request");
+    assert_eq!(&second[..first.len()], first.as_slice());
+    assert_eq!(first[0].role, "system");
+    let system = first[0].content.as_str().expect("plain system prompt");
+    assert!(!system.contains("__DYNAMIC_BOUNDARY__"));
+    assert!(!system.contains("<environment_context>"));
+    assert!(!system.contains("Current Execution Mode"));
+    assert!(first[1].content.to_string().contains("environment"));
+    assert!(first[1].content.to_string().contains("execution_mode"));
+    assert!(
+        second
+            .last()
+            .expect("latest user request")
+            .content
+            .to_string()
+            .contains("Planning mode is active.")
+    );
+}

--- a/src/agent/tests/support.rs
+++ b/src/agent/tests/support.rs
@@ -11,8 +11,7 @@ use serde_json::{Value, json};
 use tempfile::tempdir;
 
 use crate::agent::Message;
-use crate::llm::LlmBackend;
-use crate::llm::LlmResponse;
+use crate::llm::{LlmBackend, LlmResponse, ProviderCacheProfile};
 use crate::session::SessionManager;
 use crate::workspace::WorkspaceMemory;
 
@@ -50,6 +49,7 @@ pub(super) struct SequencedBackend {
     model_label: Mutex<Option<String>>,
     classifier_responses: Mutex<Vec<String>>,
     classifier_calls: AtomicUsize,
+    cache_profile: ProviderCacheProfile,
 }
 
 impl SequencedBackend {
@@ -61,6 +61,7 @@ impl SequencedBackend {
             model_label: Mutex::new(None),
             classifier_responses: Mutex::new(Vec::new()),
             classifier_calls: AtomicUsize::new(0),
+            cache_profile: ProviderCacheProfile::none(),
         }
     }
 
@@ -74,6 +75,11 @@ impl SequencedBackend {
             .lock()
             .expect("lock")
             .push(response.into());
+        self
+    }
+
+    pub(super) fn with_cache_profile(mut self, cache_profile: ProviderCacheProfile) -> Self {
+        self.cache_profile = cache_profile;
         self
     }
 
@@ -148,5 +154,9 @@ impl LlmBackend for SequencedBackend {
             Some(response) => Ok(response),
             None => self.summarize(messages, instructions).await,
         }
+    }
+
+    fn cache_profile(&self) -> ProviderCacheProfile {
+        self.cache_profile
     }
 }

--- a/src/context/assembly_view.rs
+++ b/src/context/assembly_view.rs
@@ -6,6 +6,7 @@ use crate::context::{
     CompactionSourceContextEntry, ContextAssemblyEntry, ContextAssemblyView,
     MemorySelectionItemContextEntry, is_retrieved_memory_kind,
 };
+use crate::model_context::{ModelContextKind, model_context_kind, model_context_text};
 use crate::prompt::EffectivePrompt;
 
 #[allow(clippy::too_many_arguments)]
@@ -50,6 +51,7 @@ pub(crate) fn assemble_context_view(
             "user_instruction" => "stable_instructions",
             "project_instruction" => "stable_instructions",
             "local_memory" => "workspace_prompt_sources",
+            "protocol_prompt_source" => "active_turn_state",
             _ => "workspace_prompt_sources",
         };
         push(ContextAssemblyEntry {
@@ -139,6 +141,55 @@ pub(crate) fn assemble_context_view(
             budget_impact_tokens: Some(estimate_text_tokens(user_request.as_str())),
             dropped_reason: None,
         });
+    }
+
+    if let Some(message) = history.iter().rev().find(|message| {
+        message.role == "user"
+            && message.content.as_array().is_some_and(|blocks| {
+                blocks.iter().any(|block| {
+                    block.get("type").and_then(serde_json::Value::as_str) == Some("text")
+                })
+            })
+    }) && let Some(blocks) = message.content.as_array()
+    {
+        for block in blocks {
+            let Some(kind) = model_context_kind(block) else {
+                continue;
+            };
+            if kind == ModelContextKind::RetrievedMemory
+                && selected_memory_items
+                    .iter()
+                    .any(|item| is_retrieved_memory_kind(item.kind.as_str()))
+            {
+                continue;
+            }
+            let Some(text) = model_context_text(block) else {
+                continue;
+            };
+            let (kind, label) = match kind {
+                ModelContextKind::Environment => ("environment", "Environment Context"),
+                ModelContextKind::ExecutionMode => ("execution_mode", "Execution Mode"),
+                ModelContextKind::ProtocolPromptSources => {
+                    ("protocol_prompt_sources", "Protocol Prompt Sources")
+                }
+                ModelContextKind::RetrievedMemory => {
+                    ("retrieved_memory", "Persisted Retrieved Memory")
+                }
+            };
+            push(ContextAssemblyEntry {
+                order: 0,
+                cache_status: None,
+                layer: "active_turn_state".to_string(),
+                kind: kind.to_string(),
+                label: label.to_string(),
+                source_path: None,
+                injected: true,
+                inclusion_reason:
+                    "persisted as append-only model context on the latest user request".to_string(),
+                budget_impact_tokens: Some(estimate_text_tokens(text)),
+                dropped_reason: None,
+            });
+        }
     }
 
     for (label, detail) in latest_tool_results(history) {

--- a/src/context/budget_assembly.rs
+++ b/src/context/budget_assembly.rs
@@ -38,8 +38,42 @@ fn active_turn_budget(
         .into_iter()
         .map(|(_, detail)| estimate_text_tokens(detail.as_str()))
         .sum::<usize>();
+    let model_context_budget = latest_user_model_context(history)
+        .into_iter()
+        .map(estimate_text_tokens)
+        .sum::<usize>();
 
-    plan_budget + interaction_budget + latest_request_budget + tool_budget
+    plan_budget
+        + interaction_budget
+        + latest_request_budget
+        + tool_budget
+        + model_context_budget
+}
+
+fn latest_user_model_context(history: &[Message]) -> Vec<&str> {
+    history
+        .iter()
+        .rev()
+        .find(|message| {
+            message.role == "user"
+                && message.content.as_array().is_some_and(|blocks| {
+                    blocks.iter().any(|block| {
+                        block.get("type").and_then(Value::as_str) == Some("text")
+                    })
+                })
+        })
+        .and_then(|message| message.content.as_array())
+        .map(|blocks| {
+            blocks
+                .iter()
+                .filter(|block| {
+                    crate::model_context::model_context_kind(block)
+                        != Some(crate::model_context::ModelContextKind::RetrievedMemory)
+                })
+                .filter_map(crate::model_context::model_context_text)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 pub(crate) fn latest_user_request(history: &[Message]) -> Option<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod memory_files;
 mod memory_lifecycle;
 mod memory_notice;
 mod memory_store;
+mod model_context;
 mod oauth;
 mod plugin_cli;
 mod plugin_middleware;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -3,6 +3,8 @@ mod codex_tools_compat;
 pub(crate) mod deepseek_dsml;
 mod gemini;
 mod gemini_schema;
+#[cfg(test)]
+mod model_context_tests;
 mod ollama;
 mod openai_compatible;
 mod shared;

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -9,6 +9,7 @@ use serde_json::{Value, json};
 use super::shared::{ContextBudget, LlmBackend};
 use crate::agent::Message;
 use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
+use crate::model_context::{MODEL_CONTEXT_BLOCK_TYPE, model_context_text};
 
 pub struct BedrockBackend {
     client: BedrockConverseClient,
@@ -55,6 +56,9 @@ fn convert_content_to_bedrock(content: &Value) -> Vec<BedrockChatContent> {
                 .get("text")
                 .and_then(Value::as_str)
                 .map(|text| BedrockChatContent::Text(text.to_string())),
+            Some(MODEL_CONTEXT_BLOCK_TYPE) => {
+                model_context_text(item).map(|text| BedrockChatContent::Text(text.to_string()))
+            }
             Some("tool_use") => Some(BedrockChatContent::ToolUse {
                 id: item["id"].as_str().unwrap_or_default().to_string(),
                 name: item["name"].as_str().unwrap_or_default().to_string(),
@@ -184,6 +188,7 @@ mod tests {
             Message {
                 role: "user".to_string(),
                 content: json!([
+                    {"type": "rara_model_context", "kind": "environment", "text": "workspace context"},
                     {"type": "text", "text": "hello"},
                     {"type": "tool_result", "tool_use_id": "call-1", "content": "ok", "is_error": false}
                 ]),
@@ -197,6 +202,7 @@ mod tests {
         assert_eq!(
             converted[0].content,
             vec![
+                BedrockChatContent::Text("workspace context".to_string()),
                 BedrockChatContent::Text("hello".to_string()),
                 BedrockChatContent::ToolResult {
                     tool_use_id: "call-1".to_string(),

--- a/src/llm/gemini.rs
+++ b/src/llm/gemini.rs
@@ -527,7 +527,10 @@ mod tests {
             },
             Message {
                 role: "user".to_string(),
-                content: json!("Hello"),
+                content: json!([
+                    {"type": "rara_model_context", "kind": "environment", "text": "Workspace context."},
+                    {"type": "text", "text": "Hello"}
+                ]),
             },
         ];
         let req = build_gemini_request(&messages, &[]).unwrap();
@@ -536,7 +539,10 @@ mod tests {
             "You are helpful."
         );
         assert_eq!(req["contents"][0]["role"], "user");
-        assert_eq!(req["contents"][0]["parts"][0]["text"], "Hello");
+        assert_eq!(
+            req["contents"][0]["parts"][0]["text"],
+            "Workspace context.\nHello"
+        );
     }
 
     #[test]

--- a/src/llm/model_context_tests.rs
+++ b/src/llm/model_context_tests.rs
@@ -1,0 +1,62 @@
+use serde_json::json;
+
+use super::LlmTurnMetadata;
+use super::openai_compatible::{build_chat_completion_request_body, to_codex_input_items};
+use crate::agent::Message;
+use crate::config::OpenAiEndpointKind;
+
+#[test]
+fn deepseek_request_uses_plain_prefix_without_anthropic_cache_controls() {
+    let messages = model_context_messages();
+
+    let body = build_chat_completion_request_body(
+        "deepseek-chat",
+        &messages,
+        &[],
+        OpenAiEndpointKind::Deepseek,
+        None,
+        None,
+        LlmTurnMetadata::execute(),
+    );
+    let serialized = body.to_string();
+
+    assert_eq!(body["messages"][0]["content"], "stable system prompt");
+    assert_eq!(
+        body["messages"][1]["content"],
+        "<environment_context><cwd>/workspace</cwd></environment_context>\n\ninspect the cache"
+    );
+    assert!(!serialized.contains("cache_control"));
+    assert!(!serialized.contains("__DYNAMIC_BOUNDARY__"));
+}
+
+#[test]
+fn codex_responses_renders_model_context_before_human_text() {
+    let input = to_codex_input_items(&model_context_messages());
+
+    assert_eq!(input.len(), 1);
+    assert_eq!(input[0]["role"], "user");
+    assert_eq!(
+        input[0]["content"][0]["text"],
+        "<environment_context><cwd>/workspace</cwd></environment_context>\n\ninspect the cache"
+    );
+}
+
+fn model_context_messages() -> Vec<Message> {
+    vec![
+        Message {
+            role: "system".to_string(),
+            content: json!("stable system prompt"),
+        },
+        Message {
+            role: "user".to_string(),
+            content: json!([
+                {
+                    "type": "rara_model_context",
+                    "kind": "environment",
+                    "text": "<environment_context><cwd>/workspace</cwd></environment_context>"
+                },
+                {"type": "text", "text": "inspect the cache"}
+            ]),
+        },
+    ]
+}

--- a/src/llm/openai_compatible/codex.rs
+++ b/src/llm/openai_compatible/codex.rs
@@ -543,7 +543,7 @@ fn render_codex_user_items(content: &Value) -> Vec<Value> {
                     rendered.push(tool_result);
                 }
             }
-            Some("text") => {
+            Some("text") | Some(crate::model_context::MODEL_CONTEXT_BLOCK_TYPE) => {
                 if let Some(text) = item.get("text").and_then(Value::as_str)
                     && !text.trim().is_empty()
                 {

--- a/src/llm/shared.rs
+++ b/src/llm/shared.rs
@@ -13,6 +13,7 @@ use url::Url;
 
 use crate::agent::Message;
 use crate::llm::{ContentBlock, LlmResponse, TokenUsage};
+use crate::model_context::{MODEL_CONTEXT_BLOCK_TYPE, model_context_text};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(super) struct AssistantToolUse {
@@ -186,7 +187,13 @@ impl LlmBackend for MockLlm {
         let last_msg_json = &messages.last().unwrap().content;
         let last_msg_text = if last_msg_json.is_array() {
             last_msg_json
-                .get(0)
+                .as_array()
+                .and_then(|blocks| {
+                    blocks
+                        .iter()
+                        .rev()
+                        .find(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+                })
                 .and_then(|b| b.get("text"))
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
@@ -220,6 +227,7 @@ pub(super) fn render_openai_message_content(content: &Value) -> String {
             .iter()
             .filter_map(|item| match item.get("type").and_then(Value::as_str) {
                 Some("text") => item.get("text").and_then(Value::as_str).map(str::to_string),
+                Some(MODEL_CONTEXT_BLOCK_TYPE) => model_context_text(item).map(str::to_string),
                 Some("tool_result") => item
                     .get("content")
                     .and_then(Value::as_str)

--- a/src/local_backend/prompt.rs
+++ b/src/local_backend/prompt.rs
@@ -1,6 +1,7 @@
 use serde_json::{Value, json};
 
 use crate::agent::Message;
+use crate::model_context::{MODEL_CONTEXT_BLOCK_TYPE, model_context_text};
 
 pub(super) fn scenario_token_cap(messages: &[Message], tools: &[Value]) -> usize {
     if !tools.is_empty() {
@@ -11,7 +12,7 @@ pub(super) fn scenario_token_cap(messages: &[Message], tools: &[Value]) -> usize
         .iter()
         .rev()
         .find(|message| message.role == "user")
-        .map(|message| render_content(&message.content))
+        .map(|message| render_human_text(&message.content))
         .unwrap_or_default();
     let normalized = last_user_text.to_ascii_lowercase();
     let trimmed = last_user_text.trim();
@@ -33,6 +34,23 @@ pub(super) fn scenario_token_cap(messages: &[Message], tools: &[Value]) -> usize
     } else {
         192
     }
+}
+
+fn render_human_text(content: &Value) -> String {
+    if let Some(text) = content.as_str() {
+        return text.to_string();
+    }
+    content
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|item| item.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default()
 }
 
 pub(super) fn build_agent_prompt(messages: &[Message], tools: &[Value]) -> String {
@@ -87,6 +105,9 @@ pub(super) fn render_content(content: &Value) -> String {
                         .unwrap_or("")
                         .to_string(),
                 ),
+                Some(MODEL_CONTEXT_BLOCK_TYPE) => {
+                    rendered.push(model_context_text(item).unwrap_or_default().to_string())
+                }
                 Some("tool_result") => rendered.push(format!(
                     "tool_result(id={}): {}",
                     item.get("tool_use_id")

--- a/src/local_backend/tests.rs
+++ b/src/local_backend/tests.rs
@@ -54,9 +54,11 @@ fn parses_tool_reply() {
 #[test]
 fn renders_tool_results_for_prompting() {
     let rendered = render_content(&json!([
+        {"type": "rara_model_context", "kind": "environment", "text": "workspace context"},
         {"type": "text", "text": "hello"},
         {"type": "tool_result", "tool_use_id": "1", "content": "world"}
     ]));
+    assert!(rendered.contains("workspace context"));
     assert!(rendered.contains("hello"));
     assert!(rendered.contains("tool_result(id=1): world"));
 }
@@ -75,7 +77,14 @@ fn extracts_context_window_from_text_config() {
 fn uses_smaller_budget_for_short_and_tool_prompts() {
     let short_messages = vec![Message {
         role: "user".to_string(),
-        content: json!([{"type": "text", "text": "你好"}]),
+        content: json!([
+            {
+                "type": "rara_model_context",
+                "kind": "environment",
+                "text": "a deliberately long model-only environment context"
+            },
+            {"type": "text", "text": "你好"}
+        ]),
     }];
     assert_eq!(scenario_token_cap(&short_messages, &[]), 96);
 

--- a/src/model_context.rs
+++ b/src/model_context.rs
@@ -1,0 +1,191 @@
+use rara_core::llm::types::Message;
+use serde_json::{Value, json};
+
+pub(crate) const MODEL_CONTEXT_BLOCK_TYPE: &str = "rara_model_context";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModelContextKind {
+    Environment,
+    ExecutionMode,
+    ProtocolPromptSources,
+    RetrievedMemory,
+}
+
+impl ModelContextKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Environment => "environment",
+            Self::ExecutionMode => "execution_mode",
+            Self::ProtocolPromptSources => "protocol_prompt_sources",
+            Self::RetrievedMemory => "retrieved_memory",
+        }
+    }
+
+    const fn sort_key(self) -> u8 {
+        match self {
+            Self::Environment => 0,
+            Self::ExecutionMode => 1,
+            Self::ProtocolPromptSources => 2,
+            Self::RetrievedMemory => 3,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelContextFragment {
+    pub(crate) kind: ModelContextKind,
+    pub(crate) text: String,
+}
+
+impl ModelContextFragment {
+    pub(crate) fn new(kind: ModelContextKind, text: impl Into<String>) -> Self {
+        Self {
+            kind,
+            text: text.into(),
+        }
+    }
+}
+
+pub(crate) fn model_context_text(block: &Value) -> Option<&str> {
+    (block.get("type").and_then(Value::as_str) == Some(MODEL_CONTEXT_BLOCK_TYPE))
+        .then(|| block.get("text").and_then(Value::as_str))
+        .flatten()
+}
+
+pub(crate) fn latest_model_context_text(
+    messages: &[Message],
+    kind: ModelContextKind,
+) -> Option<&str> {
+    messages.iter().rev().find_map(|message| {
+        message.content.as_array()?.iter().rev().find_map(|block| {
+            (model_context_kind(block) == Some(kind))
+                .then(|| model_context_text(block))
+                .flatten()
+        })
+    })
+}
+
+pub(crate) fn upsert_latest_user_model_context(
+    messages: &mut [Message],
+    fragments: &[ModelContextFragment],
+) -> bool {
+    if fragments.is_empty() {
+        return false;
+    }
+    let Some(message) = messages
+        .iter_mut()
+        .rfind(|message| message.role == "user" && is_user_text_request(message))
+    else {
+        return false;
+    };
+
+    let previous = message.content.clone();
+    let mut content = match std::mem::take(&mut message.content) {
+        Value::Array(items) => items,
+        Value::String(text) => vec![json!({"type": "text", "text": text})],
+        other => vec![json!({"type": "text", "text": other.to_string()})],
+    };
+    content.retain(|block| {
+        model_context_kind(block)
+            .is_none_or(|kind| !fragments.iter().any(|fragment| fragment.kind == kind))
+    });
+    content.splice(
+        0..0,
+        fragments
+            .iter()
+            .map(|fragment| model_context_block(fragment.kind, fragment.text.as_str())),
+    );
+    content
+        .sort_by_key(|block| model_context_kind(block).map_or(u8::MAX, ModelContextKind::sort_key));
+    message.content = Value::Array(content);
+    message.content != previous
+}
+
+fn model_context_block(kind: ModelContextKind, text: &str) -> Value {
+    json!({
+        "type": MODEL_CONTEXT_BLOCK_TYPE,
+        "kind": kind.as_str(),
+        "text": text,
+    })
+}
+
+pub(crate) fn model_context_kind(block: &Value) -> Option<ModelContextKind> {
+    if block.get("type").and_then(Value::as_str) != Some(MODEL_CONTEXT_BLOCK_TYPE) {
+        return None;
+    }
+    match block.get("kind").and_then(Value::as_str)? {
+        "environment" => Some(ModelContextKind::Environment),
+        "execution_mode" => Some(ModelContextKind::ExecutionMode),
+        "protocol_prompt_sources" => Some(ModelContextKind::ProtocolPromptSources),
+        "retrieved_memory" => Some(ModelContextKind::RetrievedMemory),
+        _ => None,
+    }
+}
+
+fn is_user_text_request(message: &Message) -> bool {
+    if message
+        .content
+        .as_str()
+        .is_some_and(|text| !text.trim().is_empty())
+    {
+        return true;
+    }
+    message.content.as_array().is_some_and(|items| {
+        items.iter().any(|item| {
+            item.get("type").and_then(Value::as_str) == Some("text")
+                && item
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .is_some_and(|text| !text.trim().is_empty())
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_context_is_upserted_before_user_text() {
+        let mut messages = vec![Message {
+            role: "user".to_string(),
+            content: json!([{"type": "text", "text": "inspect the cache"}]),
+        }];
+        let fragments = vec![
+            ModelContextFragment::new(ModelContextKind::Environment, "workspace A"),
+            ModelContextFragment::new(ModelContextKind::ExecutionMode, "execute"),
+        ];
+
+        assert!(upsert_latest_user_model_context(&mut messages, &fragments));
+        let blocks = messages[0].content.as_array().expect("content blocks");
+        assert_eq!(blocks[0]["kind"], "environment");
+        assert_eq!(blocks[1]["kind"], "execution_mode");
+        assert_eq!(blocks[2]["text"], "inspect the cache");
+        assert_eq!(
+            latest_model_context_text(&messages, ModelContextKind::Environment),
+            Some("workspace A")
+        );
+
+        assert!(!upsert_latest_user_model_context(&mut messages, &fragments));
+        assert!(upsert_latest_user_model_context(
+            &mut messages,
+            &[ModelContextFragment::new(
+                ModelContextKind::RetrievedMemory,
+                "memory"
+            )]
+        ));
+        let blocks = messages[0].content.as_array().expect("content blocks");
+        assert_eq!(blocks[0]["kind"], "environment");
+        assert_eq!(blocks[1]["kind"], "execution_mode");
+        assert_eq!(blocks[2]["kind"], "retrieved_memory");
+        assert_eq!(blocks[3]["text"], "inspect the cache");
+        assert_eq!(
+            messages[0]
+                .content
+                .as_array()
+                .expect("content blocks")
+                .len(),
+            4
+        );
+    }
+}

--- a/src/runtime_client.rs
+++ b/src/runtime_client.rs
@@ -98,6 +98,7 @@ fn memory_message_content(content: &Value) -> String {
     if let Some(parts) = content.as_array() {
         let text = parts
             .iter()
+            .filter(|part| part.get("type").and_then(Value::as_str) == Some("text"))
             .filter_map(|part| part.get("text").and_then(Value::as_str))
             .collect::<Vec<_>>();
         if !text.is_empty() {
@@ -460,4 +461,25 @@ Summarize the completed work, remaining blockers, and the next safest step for t
         goal_budget_label(goal),
         goal_remaining_label(goal)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::memory_message_content;
+
+    #[test]
+    fn memory_capture_excludes_model_only_context() {
+        let content = json!([
+            {
+                "type": "rara_model_context",
+                "kind": "retrieved_memory",
+                "text": "internal retrieved context"
+            },
+            {"type": "text", "text": "human request"}
+        ]);
+
+        assert_eq!(memory_message_content(&content), "human request");
+    }
 }

--- a/src/thread_store/format.rs
+++ b/src/thread_store/format.rs
@@ -131,6 +131,12 @@ fn render_message_content(content: &serde_json::Value) -> String {
         if !rendered.is_empty() {
             return rendered.join("\n\n");
         }
+        if items.iter().any(|item| {
+            item.get("type").and_then(serde_json::Value::as_str)
+                == Some(crate::model_context::MODEL_CONTEXT_BLOCK_TYPE)
+        }) {
+            return String::new();
+        }
     }
     serde_json::to_string_pretty(content).unwrap_or_else(|_| content.to_string())
 }
@@ -158,6 +164,7 @@ fn render_content_item(item: &serde_json::Value) -> Option<String> {
             .get("content")
             .and_then(serde_json::Value::as_str)
             .map(str::to_string),
+        Some(crate::model_context::MODEL_CONTEXT_BLOCK_TYPE) => None,
         _ => Some(serde_json::to_string_pretty(item).unwrap_or_else(|_| item.to_string())),
     }
 }
@@ -177,5 +184,34 @@ fn truncate_chars(value: &str, max_chars: usize) -> String {
         format!("{truncated}...")
     } else {
         truncated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::render_message_content;
+
+    #[test]
+    fn human_thread_rendering_excludes_model_context() {
+        let content = json!([
+            {
+                "type": "rara_model_context",
+                "kind": "retrieved_memory",
+                "text": "model-only context must stay out of exports"
+            },
+            {"type": "text", "text": "human request"}
+        ]);
+
+        assert_eq!(render_message_content(&content), "human request");
+        assert_eq!(
+            render_message_content(&json!([{
+                "type": "rara_model_context",
+                "kind": "environment",
+                "text": "model-only context"
+            }])),
+            ""
+        );
     }
 }

--- a/src/tools/agent_test.rs
+++ b/src/tools/agent_test.rs
@@ -12,7 +12,8 @@ use rara_state::state_db::StateDb;
 use rara_tools::tool::{Tool, ToolCallContext, ToolError};
 use serde_json::json;
 use tempfile::tempdir;
-use tokio::time::{Duration, sleep};
+use tokio::sync::Barrier;
+use tokio::time::{Duration, sleep, timeout};
 
 use super::{
     AgentDefinition, AgentDefinitionCache, AgentResultDelivery,
@@ -46,6 +47,9 @@ struct CountingBackend {
 struct PeakBackend {
     in_flight: Arc<AtomicUsize>,
     peak: Arc<AtomicUsize>,
+    first_wave_arrivals: Arc<AtomicUsize>,
+    first_wave_size: usize,
+    first_wave: Arc<Barrier>,
 }
 
 struct PlanStateBackend;
@@ -156,6 +160,11 @@ impl LlmBackend for PeakBackend {
     ) -> anyhow::Result<LlmResponse> {
         let current = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
         record_peak(current, &self.peak);
+        if self.first_wave_arrivals.fetch_add(1, Ordering::SeqCst) < self.first_wave_size {
+            timeout(Duration::from_secs(5), self.first_wave.wait())
+                .await
+                .expect("team_create should fill the configured first wave");
+        }
         sleep(Duration::from_millis(50)).await;
         self.in_flight.fetch_sub(1, Ordering::SeqCst);
         let last = messages

--- a/src/tools/agent_tests/execution.rs
+++ b/src/tools/agent_tests/execution.rs
@@ -233,10 +233,15 @@ async fn team_create_limits_concurrent_subagents() {
     let root = temp.path().join("workspace");
     let rara_dir = temp.path().join(".rara");
     std::fs::create_dir_all(&root).expect("workspace");
+    let background_subagents = Arc::new(BackgroundSubAgentStore::default());
+    let active_capacity = background_subagents.max_active_subagents();
     let tool = TeamCreateTool {
         backend: Arc::new(PeakBackend {
             in_flight,
             peak: peak.clone(),
+            first_wave_arrivals: Arc::new(AtomicUsize::new(0)),
+            first_wave_size: active_capacity,
+            first_wave: Arc::new(Barrier::new(active_capacity)),
         }),
         backend_resolver: inherited_backend_resolver(),
         memory_handle: Arc::new(MemoryHandle::new(
@@ -249,14 +254,12 @@ async fn team_create_limits_concurrent_subagents() {
         skill_manager: Arc::new(std::sync::RwLock::new(SkillManager::new())),
         workspace: Arc::new(WorkspaceMemory::from_paths(root, rara_dir)),
         prompt_config: PromptRuntimeConfig::default(),
-        background_subagents: Arc::new(BackgroundSubAgentStore::default()),
+        background_subagents,
         task_list_id: test_task_list_id(),
     };
     let tasks = (0..8)
         .map(|idx| json!({ "kind": "general", "instruction": format!("task {idx}") }))
         .collect::<Vec<_>>();
-    let active_capacity = tool.background_subagents.max_active_subagents();
-
     let result = tool
         .call(json!({ "tasks": tasks }))
         .await
@@ -517,7 +520,19 @@ Custom reviewer prompt from workspace definition.
         .find(|message| message.role == "system")
         .map(message_text)
         .expect("system prompt");
-    assert!(system_prompt.contains("Planning mode is active."));
+    assert!(!system_prompt.contains("Planning mode is active."));
+    assert!(request.messages.iter().any(|message| {
+        message.role == "user"
+            && message.content.as_array().is_some_and(|blocks| {
+                blocks.iter().any(|block| {
+                    block.get("kind").and_then(serde_json::Value::as_str) == Some("execution_mode")
+                        && block
+                            .get("text")
+                            .and_then(serde_json::Value::as_str)
+                            .is_some_and(|text| text.contains("Planning mode is active."))
+                })
+            })
+    }));
     assert!(system_prompt.contains("You are a custom workspace sub-agent."));
     assert!(system_prompt.contains(
         "Inspect repository or web evidence only through the read-only tools exposed to you."


### PR DESCRIPTION
## Summary

- keep the system prompt limited to stable project, skill, language, append, and capability guidance
- persist environment, execution mode, protocol/LSP sources, and selected retrieval as typed append-only user context
- preserve raw tool-result history for providers with automatic prefix caching until durable compaction
- render typed model context consistently across DeepSeek/OpenAI-compatible, Codex Responses, Ollama, Gemini, Bedrock, and local backends
- exclude model-only context from human thread exports, memory queries, and memory lifecycle capture

## Motivation

DeepSeek's official OpenAI-compatible API caches repeated prompt prefixes automatically. RARA previously rebuilt volatile system sections and request-only retrieval/tool projections, so later turns could remove or rewrite bytes that an earlier model request had seen. The synthetic dynamic-boundary marker and Anthropic-style cache hint did not create a cache boundary for DeepSeek.

This change makes prefix reuse an append-only history invariant while keeping the official DeepSeek `chat/completions` integration and its `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` accounting.

## Implementation details

- add persisted `rara_model_context` blocks with deterministic ordering
- append explicit cleared state when turn-scoped protocol sources disappear
- keep selected retrieval attached to the exact user turn seen by the model and restore it from session history
- disable request-only tool-result projection for automatic-prefix-cache providers without cache-edit support
- retain ordinary durable compaction as the bounded-history mechanism
- split turn-context rendering out of the system-prompt module to keep source files below the project size limit
- update prompt, context-compression, retrieval, and project-context specifications plus the implementation journal

## Related issue

None. No matching DeepSeek or prompt-cache issue exists in the repository.

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace --quiet` (root library: 1,325 passed)
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`

The macOS test linker emitted the existing compact-unwind `__eh_frame` size notice; all tests completed successfully.

## Follow-up

- run an opt-in A/B measurement against the official DeepSeek API and record comparable `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`; no live provider credentials were used in this change
- evaluate a stable capability envelope separately if mode-specific tool-set changes remain a material cache-key source
