### PR TITLE
feat(tools): add Harbor verification pass

### DIFF
--- a/.github/workflows/harbor-adapter.yml
+++ b/.github/workflows/harbor-adapter.yml
@@ -29,7 +29,11 @@ jobs:
           python -m pip install "harbor==${{ matrix.harbor-version }}"
 
       - name: Run Harbor adapter tests
-        run: PYTHONPATH=$PWD/tools/harbor python -m unittest tools.harbor.test_rara_agent
+        run: |
+          PYTHONPATH=$PWD/tools/harbor python -m unittest \
+            tools.harbor.test_rara_agent \
+            tools.harbor.test_rara_agent_prompts \
+            tools.harbor.test_rara_agent_trajectory
 
   exec-cli:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ ethnum = "1.5.3"
 tempfile = "3.17"
 insta = "1.43"
 
-[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+[target.'cfg(all(target_os = "linux", any(target_arch = "aarch64", target_env = "musl")))'.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }
 
 [patch.crates-io]

--- a/docs/features/terminal-bench-evaluation.md
+++ b/docs/features/terminal-bench-evaluation.md
@@ -18,7 +18,8 @@ RARA should support a Terminal-Bench-compatible evaluation path that can:
 - run under Harbor's Terminal-Bench 2.1 flow:
   `harbor run -d terminal-bench/terminal-bench-2-1 --agent <rara-agent>`;
 - run RARA inside the benchmark task container;
-- map benchmark task instructions into a single RARA session;
+- map benchmark task instructions into one implementation session followed by
+  at most one bounded verification-and-repair session;
 - expose the working directory and terminal environment without requiring TUI
   interaction;
 - allow file edits, shell commands, and validation commands through the same
@@ -64,6 +65,18 @@ Recommended components:
   `/logs/agent/rara-exec.jsonl`. The adapter wraps task text with generic
   non-interactive benchmark guidance so RARA treats named output files as
   required artifacts rather than optional final-answer prose.
+- After a successful implementation pass, the adapter runs one independent
+  verification-and-repair pass by default in the same workspace with the same
+  runtime profile and provider configuration. The pass receives the original
+  task plus the implementation pass's reported validation evidence. It treats
+  that summary as an untrusted coverage map, starts with applicable artifact
+  risks missing from the report, and may repair the artifact.
+  `verification_pass=false` disables this bounded extra pass when cost or
+  latency is the controlling constraint.
+- Linux benchmark uploads use an `x86_64-unknown-linux-musl` release binary so
+  the installed agent does not depend on the task image's glibc or OpenSSL
+  runtime. The adapter's install-time `--version` check remains the final
+  compatibility guard inside each task container.
 - `rara eval terminal-bench` may be added later as a convenience wrapper, but
   the first integration target is Harbor compatibility.
 - Stable workspace setup contract:
@@ -112,11 +125,53 @@ The adapter must not require interactive TUI-only features. Any configuration
 that is currently only exposed through `/model`, `/auth`, or overlays must also
 have a headless path.
 
+Provider reasoning controls are part of that headless path. `rara exec` accepts
+process-local `--reasoning-effort <value>` and `--thinking <true|false>` global
+overrides. The Harbor adapter forwards matching agent kwargs. For DeepSeek, an
+explicit `reasoning_effort` with no explicit `thinking` value enables thinking
+so the requested effort is not silently ignored; an explicit `thinking=false`
+always wins.
+
 The adapter may add generic harness guidance around the raw task instruction.
 That guidance can require non-interactive operation, exact creation of
 task-named output files, focused validation, and blocker reporting. It must not
 embed task-specific solutions, hidden verifier knowledge, or benchmark oracle
-content.
+content. Because long tasks can dilute guidance placed before the raw task, the
+adapter repeats a concise completion gate after the task text. The gate requires
+the agent to reconcile direct public-interface evidence with applicable
+interaction and lifecycle modes before claiming completion; failed or unrun
+checks remain explicit instead of being silently treated as passed.
+
+Prompt placement is not the final correctness boundary. After the implementation
+pass exits successfully, the adapter starts one fresh verification-and-repair
+session by default. The reviewer works in the same task workspace but uses a
+separate instruction, task ID, status file, and JSONL stream. It must derive the
+contract from the original task and public artifact rather than inspecting
+benchmark verifier code. The implementation summary is injected as an
+evidence index so the reviewer does not spend its budget repeating already
+reported checks. Missing artifact-class lifecycle risks take priority over
+optional performance, scale, or robustness exploration. The reviewer's final
+answer becomes
+`/logs/agent/last-message.txt`; both sessions are represented in the combined
+ATIF trajectory and token totals. The implementation summary remains available
+as `/logs/agent/implementation-last-message.txt`, and the review stream remains
+available as `/logs/agent/rara-verification.jsonl`.
+
+The combined ATIF artifact keeps the implementation session as its canonical
+top-level `session_id`, `run_id`, and `task_id`. Ordered per-pass metadata lives
+in `final_metrics.extra.rara_sessions`, with an explicit `implementation` or
+`verification` phase for each independent RARA session. Turn-local state and
+final-message deduplication reset at each pass boundary so equal text or reused
+item IDs cannot collapse evidence from separate sessions. Tool-call IDs are
+namespaced by pass in a combined trajectory so observation references remain
+unambiguous to downstream consumers.
+
+Harbor context metadata distinguishes configuration from execution.
+`verification_pass` records whether the optional pass was enabled, while
+`verification_status` is one of `disabled`, `not_started`, `failed`, or
+`completed`. `verification_jsonl_path` is non-null only after the verification
+invocation was attempted; an implementation failure therefore cannot advertise
+an artifact that was never created.
 
 `RARA_HOME` is the supported process-level state-root override. It must be an
 absolute path. When absent, RARA retains the normal `$HOME/.rara` (or
@@ -213,13 +268,21 @@ The default prompt may describe general terminal-agent discipline:
 - prefer `rg` for search only after checking it is available, then fall back to an equivalent
   available or POSIX tool;
 - use patch/file tools instead of shell redirection for edits;
+- derive a short checklist from every requested behavior and constraint before
+  editing, then validate each applicable interaction and lifecycle mode through
+  the artifact's public interface;
 - run focused verification;
 - verify PATH requirements from a fresh non-interactive process rather than a
   shell with a command-local PATH override;
 - for a background process, daemon, or network service, verify the required
-  behavior through a separate client with readiness polling, a real request or
-  connection, an expected-response assertion, and cleanup of temporary
-  services unless the task requires them to remain running;
+  behavior through the surface under test and a separate client or process,
+  with readiness polling, a real request or connection, an expected-response
+  assertion, and cleanup of temporary services unless the task requires them
+  to remain running;
+- prefer the smallest implementation that satisfies the requested interface,
+  stop investigating dependency internals after a direct behavior check answers
+  the question, and reconcile validation evidence with the original task before
+  claiming completion;
 - summarize unresolved failures.
 
 The default prompt must not contain benchmark task answers, benchmark-specific
@@ -251,7 +314,8 @@ Each trial should end with one of:
   tasks require a Linux RARA binary, not a macOS host build.
 - For single-task smoke runs, filter the dataset with `--task
   terminal-bench/<task-name>` and inspect `/logs/agent/rara-exec.jsonl`,
-  `/logs/agent/rara-exec.status`, and verifier output when reward is `0.0`.
+  `/logs/agent/rara-exec.status`, `/logs/agent/rara-verification.jsonl`, and
+  verifier output when reward is `0.0`.
 - Confirm the Harbor run receives an ATIF-compatible `agent/trajectory.json`
   artifact. The adapter writes this file by converting `rara exec --json`
   events into Harbor's ATIF model and keeps `/logs/agent/rara-exec.jsonl` as
@@ -262,6 +326,22 @@ Each trial should end with one of:
   the next completed or failed turn.
 - Confirm failures include enough trajectory data to reproduce the final
   decision.
+- Confirm a successful implementation pass starts exactly one independent
+  verification pass by default, while an implementation failure does not.
+- Confirm the verification pass uses separate instruction, task ID, status,
+  last-message, and JSONL artifacts; its events and usage must be included in
+  the final ATIF trajectory and aggregate metrics.
+- Confirm the combined ATIF artifact preserves the implementation session as
+  its top-level identity, lists both sessions in ordered `rara_sessions`
+  metadata, keeps equal final messages from both passes, and namespaces reused
+  tool-call IDs by pass.
+- Confirm Harbor metadata distinguishes disabled, not-started, failed, and
+  completed verification states and only publishes the verification JSONL path
+  after invocation is attempted.
+- Confirm the verification instruction includes the implementation summary as
+  an untrusted evidence map, prioritizes applicable risks absent from that map,
+  and defers optional robustness work until the behavior matrix is covered.
+- Confirm `verification_pass=false` retains the single-pass adapter path.
 - Confirm headless configuration can select provider/model/API key without TUI
   overlays.
 - Confirm JSONL and ATIF metadata both record `headless-coding-v1`.
@@ -297,3 +377,4 @@ Each trial should end with one of:
 - `docs/journal/2026-07-11-harbor-atif-trajectory.md`
 - `docs/journal/2026-07-14-terminal-bench-results.md`
 - `docs/journal/2026-08-22-terminal-bench-headless-profile.md`
+- `docs/journal/2026-08-23-terminal-bench-headless-lifecycle.md`

--- a/docs/journal/2026-07-14-terminal-bench-results.md
+++ b/docs/journal/2026-07-14-terminal-bench-results.md
@@ -13,7 +13,7 @@ not sufficient.
 | --- | --- | --- | --- |
 | `terminal-bench/regex-log` | Passed | Harbor verifier reward `1.0` | The original run and the 2026-08-23 Terminal-Bench 2.1 rerun both recorded RARA exit status `0` and an authoritative verifier success. |
 | `terminal-bench/sqlite-with-gcov` | Passed (artifact pending) | User-reported successful benchmark run | This confirms the full-access PATH handling validated in the accompanying Harbor checkpoint. Record the Harbor verifier artifact when its job path is available. |
-| `terminal-bench/headless-terminal` | Failed | Harbor verifier reward `0.0` | Six checks passed, but a background HTTP service was not reachable from the verifier. RARA's default prompt now requires independent-client service validation before the planned rerun. |
+| `terminal-bench/headless-terminal` | Failed | Harbor verifier reward `0.0` | Five completed reruns passed six of seven checks but missed background-process behavior through the generated terminal interface. Job `2026-08-24__12-30-48` confirmed that a fresh reviewer without the first pass's evidence repeats familiar checks and can drift into unrelated robustness work. The reviewer now receives an evidence delta and awaits rerun. |
 | `terminal-bench/overfull-hbox` | Failed | Final task artifact violated an edit constraint | The agent removed the LaTeX warnings, but also changed `an` to `a` when only synonym substitutions were allowed. The task therefore did not pass validation. |
 | `terminal-bench/sparql-university` | Passed (artifact pending) | User-reported successful benchmark run | Earlier attempts were inconclusive because of CA and provider setup failures. Record the Harbor verifier artifact for this successful rerun when its job path is available. |
 
@@ -46,14 +46,17 @@ not sufficient.
   `overfull-hbox` constraint violation.
 - `docs/journal/2026-07-15-terminal-bench-service-validation.md` records the
   `headless-terminal` service-validation failure and adapter correction.
+- `docs/journal/2026-08-23-terminal-bench-headless-lifecycle.md` records the
+  completed rerun, the remaining lifecycle gap, and the follow-up correction.
 
 ## Follow-Ups
 
 - Re-run `overfull-hbox` with the current full-access and constraint-validation
   guidance, then append the authoritative verifier result. This is the next
   scheduled single-task test.
-- Re-run `headless-terminal` with the service-validation guidance, then append
-  the authoritative verifier result.
+- Re-run `headless-terminal` with the evidence-delta verification-and-repair
+  pass and active reasoning controls, then append the authoritative verifier
+  result.
 - Add a more constraint-heavy task to the Terminal-Bench 2.1 smoke subset and
   repeat selected tasks before reporting a suite-level score.
 - Add the successful `sparql-university` Harbor job path and verifier artifact

--- a/docs/journal/2026-08-23-terminal-bench-headless-lifecycle.md
+++ b/docs/journal/2026-08-23-terminal-bench-headless-lifecycle.md
@@ -1,0 +1,244 @@
+# Terminal-Bench Headless Lifecycle Validation
+
+## Summary
+
+The `terminal-bench/headless-terminal` rerun completed normally with no Harbor
+errors but received verifier reward `0.0`. Six of seven checks passed. The
+remaining failure was background-process behavior exercised through the
+generated terminal interface.
+
+## Evidence
+
+- Harbor job: `jobs/2026-08-23__21-38-11`
+- Trial: `headless-terminal__RepPUg9`
+- Dataset task: `terminal-bench/headless-terminal`
+- Harbor version: `0.17.1`
+- RARA binary version: `0.0.22`
+- RARA binary SHA-256:
+  `01f963981b97aae31eedcde355aaed6f65d9a60bc08611a45f083940cda5e1ba`
+- Repository revision:
+  `806839690f4b0a38d76d5da074e94932dc4cbd7f`
+- Provider/model: DeepSeek / `deepseek-v4-pro`
+- RARA exit status: `0`
+- Harbor trial errors: `0`
+- Official verifier reward: `0.0`
+- Usage: `1,331,138` input tokens and `27,239` output tokens
+
+The trajectory shows focused validation of several foreground, interactive,
+signal, and stateful behaviors, but no direct background-process validation
+through the completed artifact. The final response therefore claimed broader
+completion than its recorded evidence supported.
+
+The run configuration also supplied `reasoning_effort=high`, but the Harbor
+adapter did not recognize or forward that kwarg. The underlying RARA config
+supports reasoning effort, so silently accepting the kwarg made the benchmark
+configuration misleading.
+
+## Reference Patterns And Adaptation Plan
+
+- Codex app-server revision
+  [`6ca61345ceb09d76edc3db8c4eb55df18a10888a`](https://github.com/openai/codex/blob/6ca61345ceb09d76edc3db8c4eb55df18a10888a/codex-rs/app-server/tests/suite/v2/review.rs)
+  keeps inline review on the parent thread but gives detached review a distinct
+  `review_thread_id`. The response exposes that child identity instead of
+  replacing the parent identity.
+- Claude Code documents non-fork
+  [subagents](https://code.claude.com/docs/en/sub-agents) as fresh isolated
+  contexts whose result returns as a summary while the subagent transcript and
+  lifecycle remain separate.
+
+RARA adapts those boundaries rather than copying either review surface. The
+verification pass starts a fresh RARA session in the same benchmark workspace,
+receives only the original task and an untrusted implementation summary, and
+keeps its own task ID and artifacts. The combined Harbor trajectory retains the
+implementation session as its envelope identity and records ordered per-pass
+session metadata so downstream consumers can inspect both runs without
+collapsing them.
+
+## Implementation
+
+- Add process-local `--reasoning-effort` and `--thinking` CLI overrides.
+- Forward both controls from the Harbor adapter. For DeepSeek, an explicit
+  reasoning effort enables thinking unless the caller explicitly disables it.
+- Build the Linux benchmark upload for `x86_64-unknown-linux-musl`. Vendored
+  OpenSSL is enabled for Linux musl targets so the binary does not depend on
+  target-container OpenSSL or glibc availability.
+- Require a short validation checklist derived from requested behaviors and
+  constraints before editing.
+- Require wrappers, emulators, protocol clients, and process controllers to
+  exercise applicable lifecycle modes through their public interface.
+- Generalize background-service validation so it applies during artifact
+  validation, not only when an external verifier connects after agent exit.
+- Add a final evidence-to-requirements reconciliation and bounded guidance to
+  stop dependency investigation after a direct behavior check resolves it.
+
+These rules remain task-agnostic. They do not include benchmark answers,
+private verifier logic, or fixed task-specific values.
+
+## Validation
+
+- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tools/harbor
+  /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -m unittest
+  tools.harbor.test_rara_agent tools.harbor.test_rara_agent_prompts
+  tools.harbor.test_rara_agent_trajectory`: 38 passed.
+- `cargo test app_cli::tests -- --nocapture`: 29 passed.
+- `cargo clippy --all-targets -- -D warnings`: passed.
+- `cargo fmt --check`: passed.
+- `git diff --check`: passed.
+- `cargo build --locked --release --target x86_64-unknown-linux-musl --bin rara`:
+  passed.
+- `file target/x86_64-unknown-linux-musl/release/rara`: reports an x86-64
+  static PIE executable.
+- `ldd target/x86_64-unknown-linux-musl/release/rara`: reports statically
+  linked.
+- `readelf -lW` contains no `INTERP` program header and `readelf -dW` contains
+  no `NEEDED` dynamic dependency.
+- The musl binary reports `rara 0.0.22`, is `92,452,808` bytes, and has
+  SHA-256
+  `9ec04a596f57bfc0bab3865213b7d0f7a157fa7b6075a044b54c9b7e5883bc20`.
+
+## 2026-08-24 Musl Smoke Rerun
+
+Harbor job `jobs/2026-08-24__00-28-08` confirmed that the musl binary installs
+and executes inside the task container. The trial completed with RARA exit
+status `0`, no harness errors, and official verifier reward `0.0`: six checks
+passed and the background-command lifecycle check failed again.
+
+This run did not exercise the intended provider configuration. Its recorded
+agent kwargs contain only the musl `binary_path`; the generated RARA command
+selected the inferred DeepSeek provider with the default `deepseek-chat` model
+and did not include model, reasoning-effort, or thinking overrides. The
+trajectory contains no background-process launch or separate-client validation,
+although the agent's final message claimed complete validation.
+
+Compared with the prior run, usage dropped from `1,331,138` input and `27,239`
+output tokens to `222,792` input and `7,528` output tokens, and total runtime
+dropped to 2 minutes 45 seconds. This is useful efficiency evidence but does
+not close the behavior regression.
+
+The next rerun must preserve the same musl binary while explicitly passing the
+planned provider, model, reasoning-effort, and thinking kwargs. No additional
+task-specific prompt guidance is added from the verifier failure.
+
+## 2026-08-24 High-Thinking Rerun
+
+Harbor job `jobs/2026-08-24__09-43-31` was the first valid rerun of the complete
+configuration. Its job artifact records the musl binary, DeepSeek provider,
+`deepseek-v4-pro`, high reasoning effort, and thinking enabled; JSONL model
+events confirm `deepseek-v4-pro` handled the turn.
+
+The trial completed with RARA exit status `0`, no harness errors, and official
+verifier reward `0.0`. Six checks passed and the background-command lifecycle
+check failed again. Usage was `211,466` input tokens and `10,419` output tokens.
+
+The trajectory shows that the agent implemented and checked foreground command
+execution, interactive input, signal handling, startup files, and compilation,
+but never launched or externally observed long-running or detached work through
+the completed interface. Its final message nevertheless claimed the interface
+was complete. This falsifies the assumption that a completion rule placed only
+before a long raw task remains sufficiently visible at the final-answer
+boundary.
+
+The adapter now repeats a concise, task-agnostic completion gate after the raw
+task text. It requires direct public-interface evidence for applicable
+interaction and lifecycle modes and requires failed or unrun checks to remain
+explicit. The gate does not include task-specific commands, ports, expected
+responses, or private verifier details.
+
+## 2026-08-24 Post-Task Gate Rerun
+
+Harbor job `jobs/2026-08-24__11-50-44` loaded the post-task completion gate and
+the full musl, `deepseek-v4-pro`, high-reasoning, thinking-enabled configuration.
+The trial completed with RARA exit status `0`, no harness errors, and official
+verifier reward `0.0`. Six checks passed and the background-command lifecycle
+check failed again. Usage was `322,746` input tokens and `17,445` output tokens.
+
+The recorded instruction confirms that the completion gate appeared after the
+raw task. The trajectory nevertheless contains no background service launch,
+readiness polling, or separate-client request. The agent built two foreground
+validation scripts, checked import, interactive input, startup files, Ctrl-C,
+session state, and cleanup, then claimed completion. This falsifies prompt
+placement as a sufficient completion boundary.
+
+The adapter now uses a bounded independent verification-and-repair pass after a
+successful implementation pass. The second RARA session re-reads the original
+task, inspects the existing artifact without trusting the first summary, maps
+the public interface to lifecycle risks, runs missing behavior checks, and may
+repair failures. It uses separate instruction, task ID, status, last-message,
+and JSONL artifacts. The combined ATIF trajectory and token metrics include both
+passes. `verification_pass=false` remains the explicit cost/latency opt-out.
+
+This remains task-agnostic: the review pass is forbidden from depending on
+benchmark verifier code and contains no fixed commands, ports, expected task
+outputs, or private oracle content.
+
+## 2026-08-24 Independent Verification Rerun
+
+Harbor job `jobs/2026-08-24__12-30-48` confirmed that the independent pass ran
+with separate instruction, JSONL, status, and final-message artifacts. Both RARA
+sessions exited `0` with no Harbor exception, but the official verifier reward
+remained `0.0`: six checks passed and background-command behavior again returned
+HTTP `503`. Combined usage was `988,819` input tokens and `37,161` output tokens.
+
+The verification session used `517,932` input tokens, `17,982` output tokens,
+25 model requests, and 38 shell calls. It repeated foreground execution,
+interactive input, Ctrl-C, startup-file, cwd, and cleanup checks already covered
+by the implementation pass. It then investigated and changed large-output drain
+behavior, which was outside the required lifecycle matrix. Its final behavior
+matrix still omitted background or detached child execution. The only late
+reference to background work was a cleanup thought about leaving no background
+tasks, not a public-interface behavior check.
+
+The fresh reviewer lacked the implementation pass's evidence summary, so it had
+no concrete delta and reconstructed the same familiar checks from scratch. The
+adapter now injects that summary as an untrusted coverage map. The reviewer must
+start with applicable artifact-class risks missing from the report, avoid
+repeating evidenced checks unless a repair can affect them, and defer optional
+performance, scale, or robustness exploration until the matrix is complete.
+This changes reviewer input and work ordering without adding a third pass or
+embedding verifier commands, ports, task answers, or private oracle content.
+
+## 2026-08-31 PR Hardening
+
+Review of the combined trajectory path found that treating two independent
+`thread.started` events as one stream allowed the verification session to
+replace the implementation session's top-level ATIF identity. Global
+final-message deduplication could also suppress a valid verification response
+when both passes returned the same text.
+
+The adapter now:
+
+- preserves the implementation session as the combined trajectory identity;
+- records ordered `implementation` and `verification` metadata under
+  `final_metrics.extra.rara_sessions`;
+- resets turn-local model, reasoning, tool-call, and message-deduplication state
+  at pass boundaries;
+- namespaces tool-call IDs by pass and infers the verification boundary when
+  reconstructing ATIF directly from the combined raw JSONL stream;
+- records verification lifecycle as `disabled`, `not_started`, `failed`, or
+  `completed` and publishes the verification JSONL path only after invocation.
+- keeps the adapter below the source-size limit by extracting pure prompt and
+  option helpers into `rara_agent_prompts.py` with focused tests.
+
+Focused regression coverage exercises the complete two-session event shape,
+equal final messages, aggregate token usage, explicit opt-out, implementation
+failure before verification, and verification artifact visibility after start.
+The validation commands for this checkpoint are:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=tools/harbor \
+  /home/hawkingrei/.local/share/uv/tools/harbor/bin/python -m unittest \
+  tools.harbor.test_rara_agent tools.harbor.test_rara_agent_prompts \
+  tools.harbor.test_rara_agent_trajectory
+cargo test app_cli::tests -- --nocapture
+cargo fmt --all --check
+git diff --check
+```
+
+## Follow-Ups
+
+- Rerun `terminal-bench/headless-terminal` with the evidence-delta verification
+  pass, fresh musl release binary, and active DeepSeek controls.
+- Inspect both `rara-exec.jsonl` and `rara-verification.jsonl` to confirm the
+  second pass directly exercises the missed lifecycle behavior.
+- Treat only an official verifier reward of `1.0` as closure, then expand to a
+  multi-task cohort.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -110,6 +110,11 @@ Active backlog only. Keep this file small and current.
       `headless-coding-v1` profile and record the RARA revision, Harbor version,
       provider/model, run command, JSONL/ATIF artifacts, and official verifier
       reward. Process exit status alone is not a pass result.
+- [ ] Re-run `terminal-bench/headless-terminal` with the evidence-delta
+      verification-and-repair pass, musl binary, and active DeepSeek reasoning
+      controls; confirm the reviewer starts with risks absent from the first
+      summary, inspect both trajectories, and record the official verifier
+      reward before treating the regression as closed.
 - [ ] Expand the Terminal-Bench 2.1 smoke into a multi-task cohort and repeat
       selected tasks before reporting a suite-level score or comparing harness
       quality.

--- a/src/app_cli.rs
+++ b/src/app_cli.rs
@@ -41,6 +41,14 @@ pub(crate) struct Cli {
     #[arg(short, long, global = true)]
     model: Option<String>,
 
+    /// Provider reasoning effort override for this process.
+    #[arg(long, global = true)]
+    reasoning_effort: Option<String>,
+
+    /// Explicitly enable or disable provider thinking mode for this process.
+    #[arg(long, global = true)]
+    thinking: Option<bool>,
+
     #[arg(long, global = true)]
     revision: Option<String>,
 
@@ -301,6 +309,12 @@ fn apply_cli_overrides(config: &mut RaraConfig, cli: Cli) -> Option<Commands> {
     }
     if let Some(model) = cli.model {
         config.set_model(Some(model));
+    }
+    if let Some(reasoning_effort) = cli.reasoning_effort {
+        config.set_reasoning_effort(Some(reasoning_effort));
+    }
+    if let Some(thinking) = cli.thinking {
+        config.set_thinking(Some(thinking));
     }
     if let Some(revision) = cli.revision {
         config.set_revision(Some(revision));

--- a/src/app_cli/tests.rs
+++ b/src/app_cli/tests.rs
@@ -63,6 +63,28 @@ mod tests {
     }
 
     #[test]
+    fn cli_reasoning_overrides_apply_to_headless_config() {
+        let cli = Cli::try_parse_from([
+            "rara",
+            "exec",
+            "--reasoning-effort",
+            "high",
+            "--thinking",
+            "true",
+            "-",
+        ])
+        .expect("parse reasoning overrides");
+        let mut config = RaraConfig::default();
+
+        assert!(matches!(
+            apply_cli_overrides(&mut config, cli),
+            Some(Commands::Exec(_))
+        ));
+        assert_eq!(config.reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(config.thinking, Some(true));
+    }
+
+    #[test]
     fn normalize_plugin_dirs_returns_absolute_paths() {
         let cwd = std::env::current_dir().expect("cwd");
         let normalized = normalize_plugin_dirs(&[

--- a/tools/harbor/rara_agent.py
+++ b/tools/harbor/rara_agent.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+from enum import Enum
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -30,6 +31,12 @@ from harbor.models.trajectories import (
 )
 from harbor.models.trial.paths import EnvironmentPaths
 from harbor.utils.trajectory_utils import format_trajectory_json
+from rara_agent_prompts import (
+    build_benchmark_instruction,
+    build_verification_instruction,
+    last_completed_message,
+    parse_optional_bool,
+)
 
 
 DEFAULT_REMOTE_BINARY = PurePosixPath("/installed-agent/rara")
@@ -37,6 +44,16 @@ DEFAULT_RARA_HOME = PurePosixPath("/logs/agent/rara-home")
 DEFAULT_JSONL_PATH = EnvironmentPaths.agent_dir / "rara-exec.jsonl"
 DEFAULT_EXIT_STATUS_PATH = EnvironmentPaths.agent_dir / "rara-exec.status"
 DEFAULT_INSTRUCTION_PATH = EnvironmentPaths.agent_dir / "instruction.txt"
+DEFAULT_IMPLEMENTATION_LAST_MESSAGE_PATH = (
+    EnvironmentPaths.agent_dir / "implementation-last-message.txt"
+)
+DEFAULT_VERIFICATION_JSONL_PATH = EnvironmentPaths.agent_dir / "rara-verification.jsonl"
+DEFAULT_VERIFICATION_EXIT_STATUS_PATH = (
+    EnvironmentPaths.agent_dir / "rara-verification.status"
+)
+DEFAULT_VERIFICATION_INSTRUCTION_PATH = (
+    EnvironmentPaths.agent_dir / "verification-instruction.txt"
+)
 DEFAULT_LAST_MESSAGE_PATH = EnvironmentPaths.agent_dir / "last-message.txt"
 DEFAULT_TRAJECTORY_PATH = EnvironmentPaths.agent_dir / "trajectory.json"
 DEFAULT_BENCHMARK_CWD = "/app"
@@ -51,6 +68,15 @@ PROVIDER_API_KEY_ENVS = {
     "openai-compatible": ("RARA_API_KEY", "OPENAI_API_KEY"),
 }
 PROVIDER_INFERENCE_ORDER = ("deepseek", "kimi", "gemini", "openrouter", "codex")
+
+
+class VerificationStatus(str, Enum):
+    """Track whether the optional verification process actually ran."""
+
+    DISABLED = "disabled"
+    NOT_STARTED = "not_started"
+    FAILED = "failed"
+    COMPLETED = "completed"
 
 
 class RaraAgent(BaseInstalledAgent):
@@ -68,9 +94,12 @@ class RaraAgent(BaseInstalledAgent):
         rara_home: str | None = None,
         provider: str | None = None,
         model: str | None = None,
+        reasoning_effort: str | None = None,
+        thinking: bool | str | None = None,
         base_url: str | None = None,
         api_key_env: str | None = None,
         runtime_profile: str = DEFAULT_RUNTIME_PROFILE,
+        verification_pass: bool | str = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -82,9 +111,17 @@ class RaraAgent(BaseInstalledAgent):
         self.rara_home = PurePosixPath(rara_home or DEFAULT_RARA_HOME)
         self.provider = provider
         self.model = model
+        self.reasoning_effort = reasoning_effort
+        self.thinking = parse_optional_bool(thinking, name="thinking")
         self.base_url = base_url
         self.api_key_env = api_key_env
         self.runtime_profile = runtime_profile or DEFAULT_RUNTIME_PROFILE
+        parsed_verification_pass = parse_optional_bool(
+            verification_pass, name="verification_pass"
+        )
+        self.verification_pass = (
+            True if parsed_verification_pass is None else parsed_verification_pass
+        )
 
     @staticmethod
     def name() -> str:
@@ -153,14 +190,29 @@ class RaraAgent(BaseInstalledAgent):
             **self.extra_env,
             "RARA_HOME": self.rara_home.as_posix(),
         }
-        command = self._build_exec_command()
+        verification_status = (
+            VerificationStatus.NOT_STARTED
+            if self.verification_pass
+            else VerificationStatus.DISABLED
+        )
+        implementation_last_message_path = (
+            DEFAULT_IMPLEMENTATION_LAST_MESSAGE_PATH
+            if self.verification_pass
+            else DEFAULT_LAST_MESSAGE_PATH
+        )
+        command = self._build_exec_command(
+            last_message_path=implementation_last_message_path
+        )
         result = await environment.exec(command=command, cwd=cwd, env=env)
 
-        stdout = result.stdout or ""
-        events = parse_rara_jsonl(stdout)
-        self._populate_context(context, events)
-        self._write_trajectory(context, instruction=benchmark_instruction, events=events)
+        events = parse_rara_jsonl(result.stdout or "")
         if self._completed_with_mock_backend(events):
+            self._record_run(
+                context,
+                instruction=benchmark_instruction,
+                events=events,
+                verification_status=verification_status,
+            )
             raise RuntimeError(
                 "RARA completed with the mock backend. Pass provider/model credentials "
                 "to the Harbor adapter, for example "
@@ -168,19 +220,112 @@ class RaraAgent(BaseInstalledAgent):
                 "or expose a supported provider API key in the Harbor process environment."
             )
         if result.return_code != 0:
+            self._record_run(
+                context,
+                instruction=benchmark_instruction,
+                events=events,
+                verification_status=verification_status,
+            )
             raise self._classify_exec_error(command, result)
 
-    def _build_exec_command(self) -> str:
+        if self.verification_pass:
+            implementation_summary = last_completed_message(events)
+            verification_instruction = build_verification_instruction(
+                instruction,
+                cwd,
+                implementation_summary=implementation_summary,
+            )
+            verification_instruction_path = self.logs_dir / "verification-instruction.txt"
+            verification_instruction_path.write_text(
+                verification_instruction, encoding="utf-8"
+            )
+            await environment.upload_file(
+                verification_instruction_path,
+                DEFAULT_VERIFICATION_INSTRUCTION_PATH.as_posix(),
+            )
+            verification_command = self._build_exec_command(
+                instruction_path=DEFAULT_VERIFICATION_INSTRUCTION_PATH,
+                jsonl_path=DEFAULT_VERIFICATION_JSONL_PATH,
+                status_path=DEFAULT_VERIFICATION_EXIT_STATUS_PATH,
+                last_message_path=DEFAULT_LAST_MESSAGE_PATH,
+                combined_jsonl_path=DEFAULT_JSONL_PATH,
+                task_id_suffix="-verification",
+            )
+            verification_status = VerificationStatus.FAILED
+            try:
+                verification_result = await environment.exec(
+                    command=verification_command, cwd=cwd, env=env
+                )
+            except Exception:
+                self._record_run(
+                    context,
+                    instruction=benchmark_instruction,
+                    events=events,
+                    verification_status=verification_status,
+                )
+                raise
+            verification_events = parse_rara_jsonl(verification_result.stdout or "")
+            events.append(
+                {
+                    "type": "adapter.user_message",
+                    "phase": "verification",
+                    "message": verification_instruction,
+                }
+            )
+            events.extend(verification_events)
+            if self._completed_with_mock_backend(verification_events):
+                self._record_run(
+                    context,
+                    instruction=benchmark_instruction,
+                    events=events,
+                    verification_status=verification_status,
+                )
+                raise RuntimeError(
+                    "RARA verification completed with the mock backend. Pass "
+                    "provider/model credentials to the Harbor adapter."
+                )
+            if verification_result.return_code != 0:
+                self._record_run(
+                    context,
+                    instruction=benchmark_instruction,
+                    events=events,
+                    verification_status=verification_status,
+                )
+                raise self._classify_exec_error(
+                    verification_command, verification_result
+                )
+            verification_status = VerificationStatus.COMPLETED
+
+        self._record_run(
+            context,
+            instruction=benchmark_instruction,
+            events=events,
+            verification_status=verification_status,
+        )
+
+    def _build_exec_command(
+        self,
+        *,
+        instruction_path: PurePosixPath = DEFAULT_INSTRUCTION_PATH,
+        jsonl_path: PurePosixPath = DEFAULT_JSONL_PATH,
+        status_path: PurePosixPath = DEFAULT_EXIT_STATUS_PATH,
+        last_message_path: PurePosixPath = DEFAULT_LAST_MESSAGE_PATH,
+        combined_jsonl_path: PurePosixPath | None = None,
+        task_id_suffix: str = "",
+    ) -> str:
         binary = shlex.quote(self.remote_binary.as_posix())
         cwd = shlex.quote(self.effective_cwd())
-        jsonl_path = shlex.quote(DEFAULT_JSONL_PATH.as_posix())
-        status_path = shlex.quote(DEFAULT_EXIT_STATUS_PATH.as_posix())
-        instruction_path = shlex.quote(DEFAULT_INSTRUCTION_PATH.as_posix())
-        last_message_path = shlex.quote(DEFAULT_LAST_MESSAGE_PATH.as_posix())
+        quoted_jsonl_path = shlex.quote(jsonl_path.as_posix())
+        quoted_status_path = shlex.quote(status_path.as_posix())
+        quoted_instruction_path = shlex.quote(instruction_path.as_posix())
+        quoted_last_message_path = shlex.quote(last_message_path.as_posix())
         run_id = shlex.quote(self.context_id.hex if self.context_id else "harbor")
-        task_id = shlex.quote(self.session_id or "harbor-task")
+        task_id = shlex.quote(f"{self.session_id or 'harbor-task'}{task_id_suffix}")
         global_flags = self._build_rara_global_flags()
         binary_invocation = f"{binary} {global_flags}".rstrip()
+        jsonl_sink = f"tee {quoted_jsonl_path}"
+        if combined_jsonl_path is not None:
+            jsonl_sink += f" | tee -a {shlex.quote(combined_jsonl_path.as_posix())}"
         return (
             f"mkdir -p {shlex.quote(EnvironmentPaths.agent_dir.as_posix())} "
             f"{shlex.quote(self.rara_home.as_posix())} || exit $?; "
@@ -188,13 +333,32 @@ class RaraAgent(BaseInstalledAgent):
             f"{binary_invocation} exec --json --full-access "
             f"--runtime-profile {shlex.quote(self.runtime_profile)} --cwd {cwd} "
             f"--run-id {run_id} --task-id {task_id} "
-            f"--output-last-message {last_message_path} - "
-            f"< {instruction_path}; "
-            f"printf '%s\\n' \"$?\" > {status_path}; "
-            f"}} | tee {jsonl_path}; "
-            f"status=$(cat {status_path} 2>/dev/null || printf '1'); "
+            f"--output-last-message {quoted_last_message_path} - "
+            f"< {quoted_instruction_path}; "
+            f"printf '%s\\n' \"$?\" > {quoted_status_path}; "
+            f"}} | {jsonl_sink}; "
+            f"status=$(cat {quoted_status_path} 2>/dev/null || printf '1'); "
             'exit "$status"'
         )
+
+    def _record_run(
+        self,
+        context: AgentContext,
+        *,
+        instruction: str,
+        events: list[dict[str, Any]],
+        verification_status: VerificationStatus,
+    ) -> None:
+        self._populate_context(context, events)
+        context.metadata["verification_pass"] = self.verification_pass
+        context.metadata["verification_status"] = verification_status.value
+        context.metadata["verification_jsonl_path"] = (
+            DEFAULT_VERIFICATION_JSONL_PATH.as_posix()
+            if verification_status
+            in {VerificationStatus.FAILED, VerificationStatus.COMPLETED}
+            else None
+        )
+        self._write_trajectory(context, instruction=instruction, events=events)
 
     @staticmethod
     def _ca_certificate_install_command() -> str:
@@ -230,6 +394,17 @@ class RaraAgent(BaseInstalledAgent):
             flags.extend(["--base-url", shlex.quote(self.base_url)])
         if self.model:
             flags.extend(["--model", shlex.quote(self.model)])
+        if self.reasoning_effort:
+            flags.extend(["--reasoning-effort", shlex.quote(self.reasoning_effort)])
+        thinking = self.thinking
+        if (
+            thinking is None
+            and self.reasoning_effort
+            and self.effective_provider() == "deepseek"
+        ):
+            thinking = True
+        if thinking is not None:
+            flags.extend(["--thinking", str(thinking).lower()])
         return " ".join(flags)
 
     def _provider_env(self) -> dict[str, str]:
@@ -280,10 +455,10 @@ class RaraAgent(BaseInstalledAgent):
                 usage = event.get("usage") or {}
                 u_input = usage.get("input_tokens")
                 if u_input is not None:
-                    input_tokens = int(u_input)
+                    input_tokens += int(u_input)
                 u_output = usage.get("output_tokens")
                 if u_output is not None:
-                    output_tokens = int(u_output)
+                    output_tokens += int(u_output)
                 if isinstance(event.get("final_message"), str):
                     final_message = event["final_message"]
             elif event_type == "turn.failed":
@@ -354,31 +529,6 @@ class RaraAgent(BaseInstalledAgent):
         return self.cwd or DEFAULT_BENCHMARK_CWD
 
 
-def build_benchmark_instruction(instruction: str, cwd: str) -> str:
-    """Wrap Harbor task text with generic non-interactive benchmark guidance."""
-    return f"""You are running inside a non-interactive Terminal-Bench task container.
-
-Work only in the benchmark workspace: {cwd}.
-Read the task carefully and create every file path that the task asks for exactly as specified.
-If the task names an absolute output path under the workspace, write that artifact before you finish.
-Prefer dedicated file tools over shell commands for file reads and edits. \
-Use read_file to inspect files, and use apply_patch or write_file for file \
-modifications. Do not use shell redirection, \
-heredocs, sed, awk, perl, or ad-hoc scripts to edit files when a direct edit \
-tool can do the job.
-Use shell commands for process execution and focused validation commands.
-Use bash with run_in_background for long-running non-interactive processes, then poll the background task status. Use PTY tools only for commands that require terminal input or terminal control.
-If the verifier must reach a service after the agent exits, leave that service running in the background and verify it from a separate client before finishing.
-Treat task constraints as validation requirements. If the task says only certain edits are allowed, files must not be edited, output must match an exact format, or substitutions must come from an allowed list, verify those constraints directly before finishing.
-When a task requires a command to be available in PATH, verify it in a fresh non-interactive process without a command-local PATH export. Updating shell startup files alone does not prove that the verifier can resolve the command.
-When running shell commands, request escalated sandbox permissions; Harbor already isolates this task inside its container.
-Do not finish with only an explanation. Finish only after the requested artifacts exist, or report the exact blocker if you cannot create them.
-
-Task instructions:
-{instruction.strip()}
-"""
-
-
 def parse_rara_jsonl(output: str) -> list[dict[str, Any]]:
     """Extract RARA JSONL events from mixed stdout/stderr output."""
     events: list[dict[str, Any]] = []
@@ -418,6 +568,13 @@ def convert_rara_events_to_trajectory(
     pending_reasoning: list[str] = []
     pending_tool_calls: list[tuple[str, str]] = []
     tool_call_steps: dict[str, Step] = {}
+    rara_sessions: list[dict[str, Any]] = []
+    has_multiple_sessions = (
+        sum(1 for event in events if event.get("type") == "thread.started") > 1
+        or any(event.get("type") == "adapter.user_message" for event in events)
+    )
+    current_phase = "implementation"
+    turn_step_start = 0
     total_input_tokens: int | None = None
     total_output_tokens: int | None = None
     final_message: str | None = None
@@ -443,10 +600,51 @@ def convert_rara_events_to_trajectory(
         if event_type == "thread.started":
             metadata = event.get("metadata") or {}
             if isinstance(metadata, dict):
-                session_id = _string_value(metadata.get("session_id")) or session_id
-                run_id = _string_value(metadata.get("run_id"))
-                task_id = _string_value(metadata.get("task_id"))
-                runtime_profile = _string_value(metadata.get("runtime_profile"))
+                is_primary_session = not rara_sessions
+                if not is_primary_session and current_phase == "implementation":
+                    current_phase = "verification"
+                pass_metadata = {
+                    "phase": current_phase,
+                    "session_id": _string_value(metadata.get("session_id")),
+                    "run_id": _string_value(metadata.get("run_id")),
+                    "task_id": _string_value(metadata.get("task_id")),
+                    "runtime_profile": _string_value(
+                        metadata.get("runtime_profile")
+                    ),
+                }
+                rara_sessions.append(
+                    {key: value for key, value in pass_metadata.items() if value is not None}
+                )
+                if is_primary_session:
+                    session_id = pass_metadata["session_id"] or session_id
+                    run_id = pass_metadata["run_id"]
+                    task_id = pass_metadata["task_id"]
+                    runtime_profile = pass_metadata["runtime_profile"]
+            turn_step_start = len(steps)
+            pending_model_input = None
+            pending_reasoning.clear()
+            pending_tool_calls.clear()
+            tool_call_steps.clear()
+            continue
+
+        if event_type == "adapter.user_message":
+            message = _string_value(event.get("message"))
+            if message:
+                append_step(source="user", timestamp=timestamp, message=message)
+            current_phase = _string_value(event.get("phase")) or "verification"
+            turn_step_start = len(steps)
+            pending_model_input = None
+            pending_reasoning.clear()
+            pending_tool_calls.clear()
+            tool_call_steps.clear()
+            continue
+
+        if event_type == "turn.started":
+            turn_step_start = len(steps)
+            pending_model_input = None
+            pending_reasoning.clear()
+            pending_tool_calls.clear()
+            tool_call_steps.clear()
             continue
 
         if event_type == "turn.completed":
@@ -459,14 +657,20 @@ def convert_rara_events_to_trajectory(
                     total_output_tokens, _int_value(usage.get("output_tokens"))
                 )
             final_message = _string_value(event.get("final_message"))
-            if final_message and not _has_agent_message_step(steps, final_message):
+            if final_message and not _has_agent_message_step(
+                steps[turn_step_start:], final_message
+            ):
                 append_step(
                     source="agent",
                     timestamp=timestamp,
                     model_name=last_model_name,
                     message=final_message,
                 )
+            turn_step_start = len(steps)
+            pending_model_input = None
+            pending_reasoning.clear()
             pending_tool_calls.clear()
+            tool_call_steps.clear()
             continue
 
         if event_type == "turn.failed":
@@ -479,7 +683,11 @@ def convert_rara_events_to_trajectory(
                     timestamp=timestamp,
                     message=f"RARA exec failed: {failure_message}",
                 )
+            turn_step_start = len(steps)
+            pending_model_input = None
+            pending_reasoning.clear()
             pending_tool_calls.clear()
+            tool_call_steps.clear()
             continue
 
         if event_type != "item.completed":
@@ -488,7 +696,12 @@ def convert_rara_events_to_trajectory(
         item = event.get("item") or {}
         if not isinstance(item, dict):
             continue
-        item_id = _string_value(item.get("id")) or f"item_{next_step_id}"
+        raw_item_id = _string_value(item.get("id")) or f"item_{next_step_id}"
+        item_id = (
+            f"{current_phase}:{raw_item_id}"
+            if has_multiple_sessions
+            else raw_item_id
+        )
         item_type = item.get("type")
 
         if item_type == "reasoning":
@@ -603,6 +816,7 @@ def convert_rara_events_to_trajectory(
         "run_id": run_id,
         "task_id": task_id,
         "runtime_profile": runtime_profile,
+        "rara_sessions": rara_sessions or None,
         "final_message": final_message,
         "failure": failure_message,
     }

--- a/tools/harbor/rara_agent_prompts.py
+++ b/tools/harbor/rara_agent_prompts.py
@@ -1,0 +1,91 @@
+"""Task-agnostic prompt builders and argument parsing for the Harbor adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_benchmark_instruction(instruction: str, cwd: str) -> str:
+    """Wrap Harbor task text with generic non-interactive benchmark guidance."""
+    return f"""You are running inside a non-interactive Terminal-Bench task container.
+
+Work only in the benchmark workspace: {cwd}.
+Read the task carefully and create every file path that the task asks for exactly as specified.
+If the task names an absolute output path under the workspace, write that artifact before you finish.
+Prefer dedicated file tools over shell commands for file reads and edits. \
+Use read_file to inspect files, and use apply_patch or write_file for file \
+modifications. Do not use shell redirection, \
+heredocs, sed, awk, perl, or ad-hoc scripts to edit files when a direct edit \
+tool can do the job.
+Use shell commands for process execution and focused validation commands.
+Use bash with run_in_background for long-running non-interactive processes, then poll the background task status. Use PTY tools only for commands that require terminal input or terminal control.
+Before editing, turn every requested behavior and explicit constraint into a short validation checklist. For wrappers, emulators, protocol clients, or process controllers, exercise every requested interaction and lifecycle mode through the artifact's public interface, including background-process behavior when applicable.
+For every background process, daemon, or network service involved in the requested behavior, exercise its launch through the surface under test, poll readiness, and verify it from a separate client or process before finishing. Do not infer success from launch output, a PID, or a process listing alone. Clean up temporary processes unless the task requires them to remain running.
+Treat task constraints as validation requirements. If the task says only certain edits are allowed, files must not be edited, output must match an exact format, or substitutions must come from an allowed list, verify those constraints directly before finishing.
+When a task requires a command to be available in PATH, verify it in a fresh non-interactive process without a command-local PATH export. Updating shell startup files alone does not prove that the verifier can resolve the command.
+Prefer the smallest implementation that satisfies the stated interface. Once a direct behavior check answers a question, stop investigating dependency internals and move to uncovered checklist items. Before finishing, compare the implementation and validation evidence against the original task and report any unverified requirement instead of claiming completion.
+When running shell commands, request escalated sandbox permissions; Harbor already isolates this task inside its container.
+Do not finish with only an explanation. Finish only after the requested artifacts exist, or report the exact blocker if you cannot create them.
+
+Task instructions:
+{instruction.strip()}
+
+Completion gate:
+Before your final answer, re-read the task and the generic guidance above. Do not claim an interface is complete unless every applicable interaction and lifecycle mode has a direct behavior check through the artifact's public interface. Long-running or detached work must be observed from a separate client or process rather than inferred from launch output, a PID, or a process listing. If a required check fails or was not run, keep working or report it as unverified.
+"""
+
+
+def build_verification_instruction(
+    instruction: str,
+    cwd: str,
+    *,
+    implementation_summary: str | None,
+) -> str:
+    """Build an evidence-delta review-and-repair pass for benchmark work."""
+    reported_evidence = implementation_summary or "No implementation summary was recorded."
+    return f"""You are the independent final verification and repair pass for a completed coding-agent task.
+
+Work only in the benchmark workspace: {cwd}.
+Treat the existing implementation and its prior summary as untrusted evidence. Do not search for or depend on benchmark verifier code. Derive the contract from the original task, the public interface, and the artifact itself.
+
+Original task:
+{instruction.strip()}
+
+Reported implementation and validation evidence:
+{reported_evidence.strip()}
+
+Evidence-delta review protocol:
+1. Build a compact behavior matrix from the original task and artifact class.
+2. Use the reported evidence only to identify checks already attempted; do not trust a pass claim without direct artifact evidence when inspecting or repairing it.
+3. Do not repeat already evidenced checks unless a repair can affect them. Start with applicable matrix items missing from the reported evidence.
+4. Process controllers and terminal-like interfaces require foreground commands, interactive input, control or signal handling, startup environment, state across calls, and background or detached child behavior. Services and long-running processes require readiness polling and an observation from a separate client or process.
+5. Do not explore optional performance, scale, or robustness improvements until every applicable matrix item has direct evidence.
+
+Reproduce uncovered failures through the public interface, make the smallest robust repair, and rerun only affected checks. Preserve correct existing work and task constraints. Remove temporary validation artifacts and processes before finishing.
+
+Completion condition:
+Every applicable matrix item must have direct evidence. An item absent from the reported evidence remains unverified until you check it. If a required behavior cannot be verified, report the exact blocker instead of claiming completion.
+"""
+
+
+def last_completed_message(events: list[dict[str, Any]]) -> str | None:
+    """Return the most recent completed-turn message from an event stream."""
+    for event in reversed(events):
+        if event.get("type") != "turn.completed":
+            continue
+        message = event.get("final_message")
+        if isinstance(message, str) and message.strip():
+            return message
+    return None
+
+
+def parse_optional_bool(value: bool | str | None, *, name: str) -> bool | None:
+    """Parse Harbor string kwargs without collapsing an omitted value to false."""
+    if value is None or isinstance(value, bool):
+        return value
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean value, got {value!r}")

--- a/tools/harbor/test_rara_agent.py
+++ b/tools/harbor/test_rara_agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,8 +12,7 @@ from harbor.models.agent.context import AgentContext
 
 from rara_agent import (
     RaraAgent,
-    build_benchmark_instruction,
-    convert_rara_events_to_trajectory,
+    VerificationStatus,
     parse_rara_jsonl,
 )
 
@@ -49,6 +49,7 @@ class FakeRunEnvironment:
         self.uploads: list[tuple[Path, str]] = []
         self.exec_env: dict[str, str] | None = None
         self.exec_cwd: str | None = None
+        self.commands: list[str] = []
 
     async def upload_file(self, source: Path, destination: str) -> None:
         self.uploads.append((source, destination))
@@ -61,6 +62,7 @@ class FakeRunEnvironment:
     ) -> FakeExecResult:
         self.exec_cwd = cwd
         self.exec_env = dict(env or {})
+        self.commands.append(command)
         return FakeExecResult(
             0,
             stdout='{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1},"final_message":"done"}\n',
@@ -76,6 +78,7 @@ class FakeTrajectoryEnvironment(FakeRunEnvironment):
     ) -> FakeExecResult:
         self.exec_cwd = cwd
         self.exec_env = dict(env or {})
+        self.commands.append(command)
         events = [
             {
                 "type": "thread.started",
@@ -163,8 +166,6 @@ class FakeTrajectoryEnvironment(FakeRunEnvironment):
 
 
 def json_line(value: dict[str, object]) -> str:
-    import json
-
     return json.dumps(value)
 
 
@@ -223,6 +224,27 @@ class RaraAgentTests(unittest.TestCase):
         self.assertEqual(context.n_input_tokens, 0)
         self.assertEqual(context.n_output_tokens, 0)
 
+    def test_populate_context_accumulates_multiple_passes(self) -> None:
+        context = AgentContext()
+        events = [
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 5, "output_tokens": 2},
+                "final_message": "implemented",
+            },
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 7, "output_tokens": 3},
+                "final_message": "verified",
+            },
+        ]
+
+        RaraAgent._populate_context(context, events)
+
+        self.assertEqual(context.n_input_tokens, 12)
+        self.assertEqual(context.n_output_tokens, 5)
+        self.assertEqual(context.metadata["final_message"], "verified")
+
     def test_build_exec_command_uses_context_and_session_ids(self) -> None:
         agent = RaraAgent(
             logs_dir=Path("/tmp/logs"),
@@ -267,6 +289,46 @@ class RaraAgentTests(unittest.TestCase):
         )
         self.assertNotIn("--api-key", command)
 
+    def test_build_exec_command_enables_deepseek_thinking_for_reasoning_effort(self) -> None:
+        agent = RaraAgent(
+            logs_dir=Path("/tmp/logs"),
+            binary_path="/tmp/rara",
+            remote_binary="/opt/rara",
+            provider="deepseek",
+            model="deepseek-v4-pro",
+            reasoning_effort="high",
+        )
+
+        command = agent._build_exec_command()
+
+        self.assertIn("--reasoning-effort high", command)
+        self.assertIn("--thinking true", command)
+
+    def test_explicit_thinking_override_wins_over_deepseek_inference(self) -> None:
+        agent = RaraAgent(
+            logs_dir=Path("/tmp/logs"),
+            binary_path="/tmp/rara",
+            provider="deepseek",
+            reasoning_effort="high",
+            thinking="false",
+        )
+
+        flags = agent._build_rara_global_flags()
+
+        self.assertIn("--reasoning-effort high", flags)
+        self.assertIn("--thinking false", flags)
+
+    def test_verification_pass_defaults_on_and_accepts_explicit_false(self) -> None:
+        default_agent = RaraAgent(logs_dir=Path("/tmp/logs"), binary_path="/tmp/rara")
+        disabled_agent = RaraAgent(
+            logs_dir=Path("/tmp/logs"),
+            binary_path="/tmp/rara",
+            verification_pass="false",
+        )
+
+        self.assertTrue(default_agent.verification_pass)
+        self.assertFalse(disabled_agent.verification_pass)
+
     def test_default_cwd_matches_terminal_bench_workdir(self) -> None:
         agent = RaraAgent(logs_dir=Path("/tmp/logs"), binary_path="/tmp/rara")
 
@@ -300,7 +362,11 @@ class RaraAgentTests(unittest.TestCase):
 
     def test_run_writes_atif_trajectory(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
-            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            agent = RaraAgent(
+                logs_dir=Path(temp),
+                binary_path="/tmp/rara",
+                verification_pass=False,
+            )
             context = AgentContext()
             environment = FakeTrajectoryEnvironment()
 
@@ -318,112 +384,217 @@ class RaraAgentTests(unittest.TestCase):
         self.assertEqual(context.n_input_tokens, 13)
         self.assertEqual(context.n_output_tokens, 9)
 
-    def test_convert_rara_events_to_trajectory_links_tool_observations(self) -> None:
-        events = parse_rara_jsonl(
-            "\n".join(
-                [
-                    '{"type":"thread.started","metadata":{"session_id":"s"},"timestamp":"2026-07-11T00:00:00Z"}',
-                    '{"type":"item.completed","item":{"id":"call_1","type":"tool_call","name":"bash","input":{"command":"true"}}}',
-                    '{"type":"item.completed","item":{"id":"result_1","type":"tool_result","name":"bash","content":"ok","is_error":false}}',
-                    '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2},"final_message":"done","timestamp":"2026-07-11T00:00:01Z"}',
-                ]
+    def test_run_executes_independent_verification_and_aggregates_usage(self) -> None:
+        class FakeTwoPassEnvironment(FakeRunEnvironment):
+            async def exec(
+                self,
+                command: str,
+                cwd: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> FakeExecResult:
+                self.exec_cwd = cwd
+                self.exec_env = dict(env or {})
+                self.commands.append(command)
+                is_implementation = len(self.commands) == 1
+                session_id = (
+                    "implementation-session"
+                    if is_implementation
+                    else "verification-session"
+                )
+                task_id = (
+                    "harbor-task"
+                    if is_implementation
+                    else "harbor-task-verification"
+                )
+                usage = (
+                    {"input_tokens": 5, "output_tokens": 2}
+                    if is_implementation
+                    else {"input_tokens": 7, "output_tokens": 3}
+                )
+                return FakeExecResult(
+                    0,
+                    stdout="\n".join(
+                        json_line(event)
+                        for event in [
+                            {
+                                "type": "thread.started",
+                                "metadata": {
+                                    "session_id": session_id,
+                                    "run_id": "harbor-run",
+                                    "task_id": task_id,
+                                    "runtime_profile": "headless-coding-v1",
+                                },
+                            },
+                            {"type": "turn.started"},
+                            {
+                                "type": "item.completed",
+                                "item": {
+                                    "id": "call_0",
+                                    "type": "tool_call",
+                                    "name": "bash",
+                                    "input": {"command": task_id},
+                                },
+                            },
+                            {
+                                "type": "item.completed",
+                                "item": {
+                                    "id": "result_0",
+                                    "type": "tool_result",
+                                    "name": "bash",
+                                    "content": task_id,
+                                    "is_error": False,
+                                },
+                            },
+                            {
+                                "type": "turn.completed",
+                                "usage": usage,
+                                "final_message": "completed",
+                            },
+                        ]
+                    ),
+                )
+
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            context = AgentContext()
+            environment = FakeTwoPassEnvironment()
+
+            asyncio.run(agent.run("Implement /app/tool.py.", environment, context))  # type: ignore[arg-type]
+
+            verification_instruction = Path(
+                temp, "verification-instruction.txt"
+            ).read_text(encoding="utf-8")
+            trajectory = json.loads(
+                Path(temp, "trajectory.json").read_text(encoding="utf-8")
             )
+
+        self.assertEqual(len(environment.commands), 2)
+        self.assertIn(
+            "--output-last-message /logs/agent/implementation-last-message.txt",
+            environment.commands[0],
         )
-
-        trajectory = convert_rara_events_to_trajectory(
-            events,
-            instruction="Run a command.",
-            agent_version="test",
-            default_model_name="mock",
+        self.assertIn("< /logs/agent/verification-instruction.txt", environment.commands[1])
+        self.assertIn("| tee /logs/agent/rara-verification.jsonl", environment.commands[1])
+        self.assertIn("| tee -a /logs/agent/rara-exec.jsonl", environment.commands[1])
+        self.assertIn("--task-id harbor-task-verification", environment.commands[1])
+        self.assertIn("independent final verification and repair pass", verification_instruction)
+        self.assertIn("Original task:\nImplement /app/tool.py.", verification_instruction)
+        self.assertIn(
+            "Reported implementation and validation evidence:\ncompleted",
+            verification_instruction,
         )
-
-        self.assertIsNotNone(trajectory)
-        assert trajectory is not None
-        tool_step = next(step for step in trajectory.steps if step.tool_calls)
-        self.assertEqual(tool_step.tool_calls[0].tool_call_id, "call_1")
-        self.assertIsNotNone(tool_step.observation)
-        assert tool_step.observation is not None
-        self.assertEqual(tool_step.observation.results[0].source_call_id, "call_1")
-        self.assertEqual(tool_step.observation.results[0].content, "ok")
-        self.assertEqual(trajectory.final_metrics.total_prompt_tokens, 5)
-        self.assertEqual(trajectory.final_metrics.total_completion_tokens, 2)
-
-    def test_convert_rara_events_to_trajectory_keeps_same_name_results_with_calls(self) -> None:
-        events = parse_rara_jsonl(
-            "\n".join(
-                [
-                    '{"type":"item.completed","item":{"id":"call_1","type":"tool_call","name":"read_file","input":{"path":"/app/main.tex"}}}',
-                    '{"type":"item.completed","item":{"id":"call_2","type":"tool_call","name":"read_file","input":{"path":"/app/input.tex"}}}',
-                    '{"type":"item.completed","item":{"id":"call_3","type":"tool_call","name":"read_file","input":{"path":"/app/synonyms.txt"}}}',
-                    '{"type":"item.completed","item":{"id":"progress_1","type":"tool_progress","name":"read_file","stream":"stdout","chunk":"main progress"}}',
-                    '{"type":"item.completed","item":{"id":"result_1","type":"tool_result","name":"read_file","content":"main result","is_error":false}}',
-                    '{"type":"item.completed","item":{"id":"result_2","type":"tool_result","name":"read_file","content":"input result","is_error":false}}',
-                    '{"type":"item.completed","item":{"id":"result_3","type":"tool_result","name":"read_file","content":"synonyms result","is_error":false}}',
-                ]
-            )
-        )
-
-        trajectory = convert_rara_events_to_trajectory(
-            events,
-            instruction="Read the input files.",
-        )
-
-        self.assertIsNotNone(trajectory)
-        assert trajectory is not None
-        tool_steps = [step for step in trajectory.steps if step.tool_calls]
+        self.assertIn("Do not repeat already evidenced checks", verification_instruction)
+        self.assertIn("missing from the reported evidence", verification_instruction)
+        self.assertIn("background or detached child behavior", verification_instruction)
+        self.assertEqual(trajectory["session_id"], "implementation-session")
+        sessions = trajectory["final_metrics"]["extra"]["rara_sessions"]
         self.assertEqual(
-            [step.tool_calls[0].tool_call_id for step in tool_steps],
-            ["call_1", "call_2", "call_3"],
+            [session["phase"] for session in sessions],
+            ["implementation", "verification"],
+        )
+        self.assertEqual(
+            [session["session_id"] for session in sessions],
+            ["implementation-session", "verification-session"],
+        )
+        self.assertEqual(
+            [session["task_id"] for session in sessions],
+            ["harbor-task", "harbor-task-verification"],
+        )
+        agent_messages = [
+            step.get("message")
+            for step in trajectory["steps"]
+            if step["source"] == "agent"
+        ]
+        self.assertEqual(agent_messages.count("completed"), 2)
+        tool_steps = [step for step in trajectory["steps"] if step.get("tool_calls")]
+        self.assertEqual(
+            [step["tool_calls"][0]["tool_call_id"] for step in tool_steps],
+            ["implementation:call_0", "verification:call_0"],
+        )
+        self.assertEqual(
+            [step["observation"]["results"][0]["content"] for step in tool_steps],
+            ["harbor-task", "harbor-task-verification"],
         )
         self.assertEqual(
             [
-                [(result.source_call_id, result.content) for result in step.observation.results]
+                step["observation"]["results"][0]["source_call_id"]
                 for step in tool_steps
             ],
-            [
-                [("call_1", "main progress"), ("call_1", "main result")],
-                [("call_2", "input result")],
-                [("call_3", "synonyms result")],
-            ],
+            ["implementation:call_0", "verification:call_0"],
         )
+        self.assertEqual(context.n_input_tokens, 12)
+        self.assertEqual(context.n_output_tokens, 5)
+        self.assertEqual(context.metadata["final_message"], "completed")
+        self.assertEqual(context.metadata["verification_status"], "completed")
 
-    def test_convert_rara_events_to_trajectory_drops_orphaned_calls_at_turn_boundaries(self) -> None:
-        events = parse_rara_jsonl(
-            "\n".join(
-                [
-                    '{"type":"item.completed","item":{"id":"completed_orphan","type":"tool_call","name":"read_file","input":{"path":"/app/orphan-after-completion"}}}',
-                    '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1},"final_message":"first"}',
-                    '{"type":"item.completed","item":{"id":"after_completion","type":"tool_call","name":"read_file","input":{"path":"/app/after-completion"}}}',
-                    '{"type":"item.completed","item":{"id":"result_after_completion","type":"tool_result","name":"read_file","content":"after completion","is_error":false}}',
-                    '{"type":"item.completed","item":{"id":"failed_orphan","type":"tool_call","name":"read_file","input":{"path":"/app/orphan-after-failure"}}}',
-                    '{"type":"turn.failed","error":{"message":"interrupted"}}',
-                    '{"type":"item.completed","item":{"id":"after_failure","type":"tool_call","name":"read_file","input":{"path":"/app/after-failure"}}}',
-                    '{"type":"item.completed","item":{"id":"result_after_failure","type":"tool_result","name":"read_file","content":"after failure","is_error":false}}',
-                ]
+    def test_run_skips_verification_when_explicitly_disabled(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(
+                logs_dir=Path(temp),
+                binary_path="/tmp/rara",
+                verification_pass=False,
             )
-        )
+            context = AgentContext()
+            environment = FakeRunEnvironment()
 
-        trajectory = convert_rara_events_to_trajectory(
-            events,
-            instruction="Read the files.",
-        )
+            asyncio.run(agent.run("Implement /app/tool.py.", environment, context))  # type: ignore[arg-type]
 
-        self.assertIsNotNone(trajectory)
-        assert trajectory is not None
-        tool_steps = {
-            step.tool_calls[0].tool_call_id: step
-            for step in trajectory.steps
-            if step.tool_calls
-        }
-        self.assertIsNone(tool_steps["completed_orphan"].observation)
+        self.assertEqual(len(environment.commands), 1)
+        self.assertNotIn("verification-instruction.txt", environment.commands[0])
+        self.assertFalse(context.metadata["verification_pass"])
+        self.assertEqual(context.metadata["verification_status"], "disabled")
+        self.assertIsNone(context.metadata["verification_jsonl_path"])
+
+    def test_run_does_not_verify_after_implementation_failure(self) -> None:
+        class FakeFailedEnvironment(FakeRunEnvironment):
+            async def exec(
+                self,
+                command: str,
+                cwd: str | None = None,
+                env: dict[str, str] | None = None,
+            ) -> FakeExecResult:
+                self.exec_cwd = cwd
+                self.exec_env = dict(env or {})
+                self.commands.append(command)
+                return FakeExecResult(
+                    2,
+                    stdout=json_line(
+                        {
+                            "type": "turn.failed",
+                            "error": {"message": "implementation failed"},
+                        }
+                    ),
+                    stderr="implementation failed",
+                )
+
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            context = AgentContext()
+            environment = FakeFailedEnvironment()
+
+            with self.assertRaises(RuntimeError):
+                asyncio.run(agent.run("Implement /app/tool.py.", environment, context))  # type: ignore[arg-type]
+
+        self.assertEqual(len(environment.commands), 1)
+        self.assertEqual(context.metadata["failure"], "implementation failed")
+        self.assertEqual(context.metadata["verification_status"], "not_started")
+        self.assertIsNone(context.metadata["verification_jsonl_path"])
+
+    def test_record_run_exposes_verification_artifact_after_failure(self) -> None:
+        with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
+            agent = RaraAgent(logs_dir=Path(temp), binary_path="/tmp/rara")
+            context = AgentContext()
+            agent._record_run(
+                context,
+                instruction="Verify /app/tool.py.",
+                events=[],
+                verification_status=VerificationStatus.FAILED,
+            )
+
+        self.assertEqual(context.metadata["verification_status"], "failed")
         self.assertEqual(
-            tool_steps["after_completion"].observation.results[0].source_call_id,
-            "after_completion",
-        )
-        self.assertIsNone(tool_steps["failed_orphan"].observation)
-        self.assertEqual(
-            tool_steps["after_failure"].observation.results[0].source_call_id,
-            "after_failure",
+            context.metadata["verification_jsonl_path"],
+            "/logs/agent/rara-verification.jsonl",
         )
 
     def test_write_trajectory_preserves_zero_token_context_metrics(self) -> None:
@@ -440,73 +611,6 @@ class RaraAgentTests(unittest.TestCase):
 
         self.assertEqual(context.n_input_tokens, 0)
         self.assertEqual(context.n_output_tokens, 0)
-
-    def test_convert_rara_events_to_trajectory_accumulates_turn_usage(self) -> None:
-        events = parse_rara_jsonl(
-            "\n".join(
-                [
-                    '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2},"final_message":"first"}',
-                    '{"type":"turn.completed","usage":{"input_tokens":7,"output_tokens":3},"final_message":"second"}',
-                ]
-            )
-        )
-
-        trajectory = convert_rara_events_to_trajectory(
-            events,
-            instruction="Run multiple turns.",
-        )
-
-        self.assertIsNotNone(trajectory)
-        assert trajectory is not None
-        self.assertEqual(trajectory.final_metrics.total_prompt_tokens, 12)
-        self.assertEqual(trajectory.final_metrics.total_completion_tokens, 5)
-
-    def test_unmatched_tool_result_does_not_borrow_other_tool_call_id(self) -> None:
-        events = parse_rara_jsonl(
-            "\n".join(
-                [
-                    '{"type":"item.completed","item":{"id":"call_1","type":"tool_call","name":"read_file","input":{"path":"/app/a"}}}',
-                    '{"type":"item.completed","item":{"id":"result_1","type":"tool_result","name":"bash","content":"ok","is_error":false}}',
-                    '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1},"final_message":"done"}',
-                ]
-            )
-        )
-
-        trajectory = convert_rara_events_to_trajectory(
-            events,
-            instruction="Run one tool.",
-        )
-
-        self.assertIsNotNone(trajectory)
-        assert trajectory is not None
-        tool_step = next(step for step in trajectory.steps if step.tool_calls)
-        self.assertIsNotNone(tool_step.observation)
-        assert tool_step.observation is not None
-        self.assertIsNone(tool_step.observation.results[0].source_call_id)
-
-    def test_model_response_does_not_attach_metrics_to_older_agent_step(self) -> None:
-        events = parse_rara_jsonl(
-            "\n".join(
-                [
-                    '{"type":"item.completed","item":{"id":"msg_1","type":"agent_message","text":"first"}}',
-                    '{"type":"item.completed","item":{"id":"resp_1","type":"model_response","model":"mock","output_tokens":1,"finish_reason":"stop"}}',
-                    '{"type":"item.completed","item":{"id":"msg_2","type":"agent_message","text":"second"}}',
-                    '{"type":"item.completed","item":{"id":"resp_2","type":"model_response","model":"mock","output_tokens":2,"finish_reason":"stop"}}',
-                    '{"type":"item.completed","item":{"id":"resp_3","type":"model_response","model":"mock","output_tokens":3,"finish_reason":"stop"}}',
-                ]
-            )
-        )
-
-        trajectory = convert_rara_events_to_trajectory(
-            events,
-            instruction="Check metrics.",
-        )
-
-        self.assertIsNotNone(trajectory)
-        assert trajectory is not None
-        agent_steps = [step for step in trajectory.steps if step.source == "agent"]
-        self.assertEqual(agent_steps[0].metrics.completion_tokens, 1)
-        self.assertEqual(agent_steps[1].metrics.completion_tokens, 2)
 
     def test_run_maps_inferred_provider_api_key_to_rara_api_key(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:
@@ -587,21 +691,26 @@ class RaraAgentTests(unittest.TestCase):
         self.assertIn("Use shell commands for process execution", uploaded_instruction)
         self.assertIn("run_in_background for long-running", uploaded_instruction)
         self.assertIn("Use PTY tools only", uploaded_instruction)
-        self.assertIn("leave that service running in the background", uploaded_instruction)
+        self.assertIn("short validation checklist", uploaded_instruction)
+        self.assertIn("through the artifact's public interface", uploaded_instruction)
+        self.assertIn("poll readiness", uploaded_instruction)
+        self.assertIn("separate client or process", uploaded_instruction)
+        self.assertIn("Do not infer success from launch output", uploaded_instruction)
         self.assertIn("Treat task constraints as validation requirements", uploaded_instruction)
         self.assertIn("substitutions must come from an allowed list", uploaded_instruction)
         self.assertIn("fresh non-interactive process", uploaded_instruction)
         self.assertIn("shell startup files alone does not prove", uploaded_instruction)
+        self.assertIn("smallest implementation that satisfies", uploaded_instruction)
+        self.assertIn("move to uncovered checklist items", uploaded_instruction)
+        self.assertIn("compare the implementation and validation evidence", uploaded_instruction)
         self.assertIn("request escalated sandbox permissions", uploaded_instruction)
         self.assertIn("/app/solution.sparql", uploaded_instruction)
         self.assertIn("Do not finish with only an explanation", uploaded_instruction)
-
-    def test_build_benchmark_instruction_preserves_task_text(self) -> None:
-        instruction = "\nCreate /app/solution.sparql.\n"
-
-        wrapped = build_benchmark_instruction(instruction, "/app")
-
-        self.assertTrue(wrapped.endswith("Create /app/solution.sparql.\n"))
+        self.assertIn("Completion gate:", uploaded_instruction)
+        self.assertIn("Before your final answer, re-read the task", uploaded_instruction)
+        self.assertIn("every applicable interaction and lifecycle mode", uploaded_instruction)
+        self.assertIn("Long-running or detached work", uploaded_instruction)
+        self.assertIn("keep working or report it as unverified", uploaded_instruction)
 
     def test_binary_path_is_resolved(self) -> None:
         with tempfile.TemporaryDirectory(dir=Path.cwd()) as temp:

--- a/tools/harbor/test_rara_agent_prompts.py
+++ b/tools/harbor/test_rara_agent_prompts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import unittest
+
+from rara_agent_prompts import (
+    build_benchmark_instruction,
+    build_verification_instruction,
+    last_completed_message,
+    parse_optional_bool,
+)
+
+
+class RaraAgentPromptTests(unittest.TestCase):
+    def test_parse_optional_bool_rejects_invalid_agent_kwarg(self) -> None:
+        self.assertTrue(parse_optional_bool("yes", name="thinking"))
+        self.assertFalse(parse_optional_bool("off", name="thinking"))
+        self.assertIsNone(parse_optional_bool(None, name="thinking"))
+        with self.assertRaisesRegex(ValueError, "thinking must be a boolean"):
+            parse_optional_bool("sometimes", name="thinking")
+
+    def test_build_benchmark_instruction_preserves_task_text(self) -> None:
+        instruction = "\nCreate /app/solution.sparql.\n"
+
+        wrapped = build_benchmark_instruction(instruction, "/app")
+
+        task_text = "Create /app/solution.sparql."
+        self.assertIn(task_text, wrapped)
+        self.assertLess(wrapped.index(task_text), wrapped.index("Completion gate:"))
+        self.assertTrue(wrapped.endswith("report it as unverified.\n"))
+
+    def test_build_verification_instruction_is_task_derived_and_repair_oriented(self) -> None:
+        instruction = build_verification_instruction(
+            "Create /app/output.txt.",
+            "/app",
+            implementation_summary="Created the requested file and checked its format.",
+        )
+
+        self.assertIn("Work only in the benchmark workspace: /app", instruction)
+        self.assertIn("Do not search for or depend on benchmark verifier code", instruction)
+        self.assertIn("make the smallest robust repair", instruction)
+        self.assertIn("Original task:\nCreate /app/output.txt.", instruction)
+        self.assertIn(
+            "Reported implementation and validation evidence:\nCreated the requested file",
+            instruction,
+        )
+        self.assertLess(
+            instruction.index("Reported implementation and validation evidence:"),
+            instruction.index("Evidence-delta review protocol:"),
+        )
+        self.assertTrue(instruction.endswith("instead of claiming completion.\n"))
+
+    def test_last_completed_message_returns_latest_non_empty_summary(self) -> None:
+        events = [
+            {"type": "turn.completed", "final_message": "implemented"},
+            {"type": "turn.failed", "error": {"message": "retry"}},
+            {"type": "turn.completed", "final_message": "verified"},
+        ]
+
+        self.assertEqual(last_completed_message(events), "verified")
+        self.assertIsNone(last_completed_message([{"type": "turn.started"}]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/harbor/test_rara_agent_trajectory.py
+++ b/tools/harbor/test_rara_agent_trajectory.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import unittest
+
+from rara_agent import convert_rara_events_to_trajectory, parse_rara_jsonl
+
+
+class RaraAgentTrajectoryTests(unittest.TestCase):
+    def test_convert_rara_events_to_trajectory_links_tool_observations(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"thread.started","metadata":{"session_id":"s"},"timestamp":"2026-07-11T00:00:00Z"}',
+                    '{"type":"item.completed","item":{"id":"call_1","type":"tool_call","name":"bash","input":{"command":"true"}}}',
+                    '{"type":"item.completed","item":{"id":"result_1","type":"tool_result","name":"bash","content":"ok","is_error":false}}',
+                    '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2},"final_message":"done","timestamp":"2026-07-11T00:00:01Z"}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Run a command.",
+            agent_version="test",
+            default_model_name="mock",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        tool_step = next(step for step in trajectory.steps if step.tool_calls)
+        self.assertEqual(tool_step.tool_calls[0].tool_call_id, "call_1")
+        self.assertIsNotNone(tool_step.observation)
+        assert tool_step.observation is not None
+        self.assertEqual(tool_step.observation.results[0].source_call_id, "call_1")
+        self.assertEqual(tool_step.observation.results[0].content, "ok")
+        self.assertEqual(trajectory.final_metrics.total_prompt_tokens, 5)
+        self.assertEqual(trajectory.final_metrics.total_completion_tokens, 2)
+
+    def test_convert_raw_combined_jsonl_infers_verification_phase(self) -> None:
+        trajectory = convert_rara_events_to_trajectory(
+            [
+                {
+                    "type": "thread.started",
+                    "metadata": {"session_id": "implementation-session"},
+                },
+                {
+                    "type": "thread.started",
+                    "metadata": {"session_id": "verification-session"},
+                },
+            ],
+            instruction="Implement /app/tool.py.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        self.assertEqual(
+            trajectory.final_metrics.extra["rara_sessions"],
+            [
+                {"phase": "implementation", "session_id": "implementation-session"},
+                {"phase": "verification", "session_id": "verification-session"},
+            ],
+        )
+
+    def test_convert_rara_events_to_trajectory_keeps_same_name_results_with_calls(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"item.completed","item":{"id":"call_1","type":"tool_call","name":"read_file","input":{"path":"/app/main.tex"}}}',
+                    '{"type":"item.completed","item":{"id":"call_2","type":"tool_call","name":"read_file","input":{"path":"/app/input.tex"}}}',
+                    '{"type":"item.completed","item":{"id":"call_3","type":"tool_call","name":"read_file","input":{"path":"/app/synonyms.txt"}}}',
+                    '{"type":"item.completed","item":{"id":"progress_1","type":"tool_progress","name":"read_file","stream":"stdout","chunk":"main progress"}}',
+                    '{"type":"item.completed","item":{"id":"result_1","type":"tool_result","name":"read_file","content":"main result","is_error":false}}',
+                    '{"type":"item.completed","item":{"id":"result_2","type":"tool_result","name":"read_file","content":"input result","is_error":false}}',
+                    '{"type":"item.completed","item":{"id":"result_3","type":"tool_result","name":"read_file","content":"synonyms result","is_error":false}}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Read the input files.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        tool_steps = [step for step in trajectory.steps if step.tool_calls]
+        self.assertEqual(
+            [step.tool_calls[0].tool_call_id for step in tool_steps],
+            ["call_1", "call_2", "call_3"],
+        )
+        self.assertEqual(
+            [
+                [(result.source_call_id, result.content) for result in step.observation.results]
+                for step in tool_steps
+            ],
+            [
+                [("call_1", "main progress"), ("call_1", "main result")],
+                [("call_2", "input result")],
+                [("call_3", "synonyms result")],
+            ],
+        )
+
+    def test_convert_rara_events_to_trajectory_drops_orphaned_calls_at_turn_boundaries(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"item.completed","item":{"id":"completed_orphan","type":"tool_call","name":"read_file","input":{"path":"/app/orphan-after-completion"}}}',
+                    '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1},"final_message":"first"}',
+                    '{"type":"item.completed","item":{"id":"after_completion","type":"tool_call","name":"read_file","input":{"path":"/app/after-completion"}}}',
+                    '{"type":"item.completed","item":{"id":"result_after_completion","type":"tool_result","name":"read_file","content":"after completion","is_error":false}}',
+                    '{"type":"item.completed","item":{"id":"failed_orphan","type":"tool_call","name":"read_file","input":{"path":"/app/orphan-after-failure"}}}',
+                    '{"type":"turn.failed","error":{"message":"interrupted"}}',
+                    '{"type":"item.completed","item":{"id":"after_failure","type":"tool_call","name":"read_file","input":{"path":"/app/after-failure"}}}',
+                    '{"type":"item.completed","item":{"id":"result_after_failure","type":"tool_result","name":"read_file","content":"after failure","is_error":false}}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Read the files.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        tool_steps = {
+            step.tool_calls[0].tool_call_id: step
+            for step in trajectory.steps
+            if step.tool_calls
+        }
+        self.assertIsNone(tool_steps["completed_orphan"].observation)
+        self.assertEqual(
+            tool_steps["after_completion"].observation.results[0].source_call_id,
+            "after_completion",
+        )
+        self.assertIsNone(tool_steps["failed_orphan"].observation)
+        self.assertEqual(
+            tool_steps["after_failure"].observation.results[0].source_call_id,
+            "after_failure",
+        )
+
+    def test_convert_rara_events_to_trajectory_accumulates_turn_usage(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2},"final_message":"first"}',
+                    '{"type":"turn.completed","usage":{"input_tokens":7,"output_tokens":3},"final_message":"second"}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Run multiple turns.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        self.assertEqual(trajectory.final_metrics.total_prompt_tokens, 12)
+        self.assertEqual(trajectory.final_metrics.total_completion_tokens, 5)
+
+    def test_unmatched_tool_result_does_not_borrow_other_tool_call_id(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"item.completed","item":{"id":"call_1","type":"tool_call","name":"read_file","input":{"path":"/app/a"}}}',
+                    '{"type":"item.completed","item":{"id":"result_1","type":"tool_result","name":"bash","content":"ok","is_error":false}}',
+                    '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1},"final_message":"done"}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Run one tool.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        tool_step = next(step for step in trajectory.steps if step.tool_calls)
+        self.assertIsNotNone(tool_step.observation)
+        assert tool_step.observation is not None
+        self.assertIsNone(tool_step.observation.results[0].source_call_id)
+
+    def test_model_response_does_not_attach_metrics_to_older_agent_step(self) -> None:
+        events = parse_rara_jsonl(
+            "\n".join(
+                [
+                    '{"type":"item.completed","item":{"id":"msg_1","type":"agent_message","text":"first"}}',
+                    '{"type":"item.completed","item":{"id":"resp_1","type":"model_response","model":"mock","output_tokens":1,"finish_reason":"stop"}}',
+                    '{"type":"item.completed","item":{"id":"msg_2","type":"agent_message","text":"second"}}',
+                    '{"type":"item.completed","item":{"id":"resp_2","type":"model_response","model":"mock","output_tokens":2,"finish_reason":"stop"}}',
+                    '{"type":"item.completed","item":{"id":"resp_3","type":"model_response","model":"mock","output_tokens":3,"finish_reason":"stop"}}',
+                ]
+            )
+        )
+
+        trajectory = convert_rara_events_to_trajectory(
+            events,
+            instruction="Check metrics.",
+        )
+
+        self.assertIsNotNone(trajectory)
+        assert trajectory is not None
+        agent_steps = [step for step in trajectory.steps if step.source == "agent"]
+        self.assertEqual(agent_steps[0].metrics.completion_tokens, 1)
+        self.assertEqual(agent_steps[1].metrics.completion_tokens, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add process-local `--reasoning-effort` and `--thinking` overrides for headless runs and forward them through the Harbor adapter;
- run one independent verification-and-repair pass by default after a successful implementation pass, with separate instructions, status, final-message, and JSONL artifacts;
- aggregate both passes into one ATIF trajectory while preserving the implementation session as the canonical identity, recording ordered per-pass metadata, and namespacing reused tool-call IDs;
- expose explicit verification lifecycle metadata (`disabled`, `not_started`, `failed`, or `completed`), with `verification_pass=false` as the cost/latency opt-out;
- enable vendored OpenSSL for Linux musl builds and document the benchmark evidence, design contract, and remaining rerun.

## Motivation

Repeated `terminal-bench/headless-terminal` runs passed six of seven checks but missed background-process behavior through the generated terminal interface. Prompt placement and a fresh reviewer without implementation evidence were not sufficient: the reviewer repeated familiar checks and drifted into unrelated robustness work.

This change gives the bounded reviewer the original task plus the implementation summary as an untrusted evidence map, so it starts with applicable behavior missing from the first pass. The pass remains independent and may repair the artifact in the same workspace.

## Design notes

- The implementation and verification runs remain separate RARA sessions, following the detached-review boundary used by Codex and the isolated-context pattern documented for Claude Code subagents.
- The combined ATIF envelope keeps the implementation session identity. `final_metrics.extra.rara_sessions` records both sessions in order.
- Turn-local reasoning, tool-call, and final-message deduplication state resets at each pass boundary.
- The adapter source and tests were split into narrow prompt and trajectory modules to stay below the repository file-size limit.

## Related issue

None. The rollout history and open benchmark rerun are tracked in `docs/journal/2026-08-23-terminal-bench-headless-lifecycle.md` and `docs/todo.md`.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo test --locked app_cli::tests -- --nocapture` (29 passed)
- [x] `cargo clippy --locked --workspace --all-targets -- -D warnings`
- [x] Harbor adapter, prompt, and trajectory unit tests (38 passed)
- [x] `cargo build --locked --release --target x86_64-unknown-linux-musl --bin rara`
- [x] Confirmed the musl binary is a statically linked x86-64 PIE
- [ ] GitHub Actions Harbor compatibility matrix for 0.20.0 and 0.22.0
- [ ] Authoritative evidence-delta `terminal-bench/headless-terminal` rerun

## Benchmark status

The latest authoritative verifier reward remains `0.0`. This PR is intentionally a draft until the evidence-delta rerun is recorded; it does not claim that the benchmark regression is closed.
