### PR TITLE
fix(tui): keep approval event stream connected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8965,6 +8965,7 @@ dependencies = [
  "time",
  "tokenizers 0.23.1",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "two-face",
  "unicode-width 0.2.2",
@@ -11430,6 +11431,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ rara-state = { path = "crates/rara-state" }
 rara-core = { path = "crates/rara-core" }
 rara-background-tasks = { path = "crates/rara-background-tasks" }
 tokio = { version = "1.0", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 clap = { version = "4.0", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/docs/features/tool-transcript.md
+++ b/docs/features/tool-transcript.md
@@ -145,6 +145,10 @@ source of live tool identity.
   keeps final transcript rows human-readable while preserving a stable path for
   full output inspection.
 - When shell execution pauses on a human approval request, the approval card should take visual priority over older live stdout/stderr progress from the same turn.
+- Terminal input must not detach or invalidate the runtime event subscription
+  while an approval is pending. After navigation or selection input, the TUI
+  must continue receiving the approval response, resumed tool progress, and
+  terminal turn event from the same session stream.
 - Approval choices should describe both the action and its scope, such as:
   - allow only the current command;
   - allow commands with the matching prefix for the current session;

--- a/docs/journal/2026-09-03-tui-approval-event-stream.md
+++ b/docs/journal/2026-09-03-tui-approval-event-stream.md
@@ -1,0 +1,40 @@
+# TUI Approval Event Stream Cancellation
+
+## Summary
+
+The in-process TUI runtime subscription now retains its broadcast receiver when
+an outer event-loop selection cancels a pending receive. Permission navigation
+and selection can no longer detach the runtime stream that delivers approval
+responses and resumed turn progress.
+
+## Background
+
+The runtime port adapted `broadcast::Receiver` with a state-consuming
+`stream::unfold`. Terminal input wins the outer `tokio::select!` while a runtime
+receive is pending, which cancels that receive. Cancellation also dropped the
+receiver stored inside the unfold future, so the next poll observed a closed
+stream and the approval UI appeared unresponsive.
+
+Codex keeps its event receiver outside the selected receive future, and Claude
+Code keeps permission requests in an application queue whose callbacks resolve
+the pending tool without replacing the UI input loop. RARA follows the same
+cancellation-safe ownership rule with `BroadcastStream`.
+
+## Scope
+
+- Use a cancellation-safe broadcast stream adapter for production TUI runtime
+  events.
+- Keep the scripted TUI runtime adapter on the same contract.
+- Cover cancellation followed by a later runtime event.
+
+## Validation
+
+- `cargo test --lib tui::runtime_port::tests::in_process_event_stream_survives_cancelled_receive -- --nocapture`
+- `cargo test --lib tui::runtime_port::tests -- --nocapture`
+- `cargo check --all-targets`
+- `cargo fmt --all -- --check`
+- `git diff --check`
+
+## Follow-Ups
+
+None.

--- a/src/tui/runtime_port.rs
+++ b/src/tui/runtime_port.rs
@@ -9,8 +9,10 @@ use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use futures::Stream;
+use futures::StreamExt;
 use rara_provider_catalog::ModelCatalogProvider;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use tokio_stream::wrappers::BroadcastStream;
 
 use crate::runtime_control::{
     ApprovalControlRequest, InputControlRequest, RuntimeControlEvent, SessionControlRequest,
@@ -145,29 +147,24 @@ impl RuntimeClientPort for InProcessRuntimeClientPort {
 
     fn subscribe(&self) -> RuntimeEventStream {
         let receiver = self.event_bus.subscribe_control();
-        Box::pin(futures::stream::unfold(
-            receiver,
-            |mut receiver| async move {
-                loop {
-                    match receiver.recv().await {
-                        Ok(event) => {
-                            return Some((
-                                RuntimeProjectionEvent::Runtime(Box::new(event)),
-                                receiver,
-                            ));
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+        Box::pin(
+            BroadcastStream::new(receiver).filter_map(|event| async move {
+                match event {
+                    Ok(event) => Some(RuntimeProjectionEvent::Runtime(Box::new(event))),
+                    Err(error) => {
+                        log::warn!("TUI runtime event stream lagged: {error}");
+                        None
                     }
                 }
-            },
-        ))
+            }),
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     use async_trait::async_trait;
     use futures::{StreamExt, stream};
@@ -245,6 +242,33 @@ mod tests {
         assert!(matches!(
             events.next().await,
             Some(RuntimeProjectionEvent::Runtime(event))
+                if event.sequence == 1
+        ));
+    }
+
+    #[tokio::test]
+    async fn in_process_event_stream_survives_cancelled_receive() {
+        let bus = std::sync::Arc::new(RuntimeEventBus::new(8));
+        let (port, _commands) = InProcessRuntimeClientPort::new(
+            bus.clone(),
+            std::sync::Arc::new(std::sync::RwLock::new(RuntimeSnapshot::default())),
+        );
+        let mut events = port.subscribe();
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(1), events.next())
+                .await
+                .is_err()
+        );
+
+        bus.send_with_provenance(
+            AgentEvent::Status("ready after input".into()),
+            RuntimeProvenance::local_tui("test-session"),
+        );
+
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), events.next()).await,
+            Ok(Some(RuntimeProjectionEvent::Runtime(event)))
                 if event.sequence == 1
         ));
     }

--- a/src/tui/testing/fake_runtime.rs
+++ b/src/tui/testing/fake_runtime.rs
@@ -1,7 +1,9 @@
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
 
 use crate::tui::runtime_port::{
     RuntimeClientPort, RuntimeCommand, RuntimeEventStream, RuntimeProjectionEvent,
@@ -79,17 +81,16 @@ impl RuntimeClientPort for FakeRuntimeClient {
 
     fn subscribe(&self) -> RuntimeEventStream {
         let receiver = self.events.subscribe();
-        Box::pin(futures::stream::unfold(
-            receiver,
-            |mut receiver| async move {
-                loop {
-                    match receiver.recv().await {
-                        Ok(event) => return Some((event, receiver)),
-                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
-                        Err(broadcast::error::RecvError::Closed) => return None,
+        Box::pin(
+            BroadcastStream::new(receiver).filter_map(|event| async move {
+                match event {
+                    Ok(event) => Some(event),
+                    Err(error) => {
+                        log::warn!("fake runtime event stream lagged: {error}");
+                        None
                     }
                 }
-            },
-        ))
+            }),
+        )
     }
 }


### PR DESCRIPTION
## What changed

- replace the cancellation-unsafe broadcast `unfold` adapter with `BroadcastStream`
- keep the runtime subscription alive when terminal input wins the outer `select!`
- add a regression test that cancels one pending receive and verifies the next runtime event is delivered
- document the approval event-stream contract and implementation checkpoint

## Why

The TUI event loop selects between terminal input and runtime activity. The old
`unfold` stream moved its broadcast receiver into each pending `next()` future.
When a permission selection arrived, cancellation of that future also dropped
the receiver, so approval continuation events could no longer reach the UI.

## Related issue

No linked issue.

## Validation

- `cargo test --lib tui::runtime_port::tests::in_process_event_stream_survives_cancelled_receive -- --nocapture`
- `cargo check --locked`
- commit hooks: `cargo fmt`, `cargo clippy`
