### PR TITLE
feat(tui): show live subagent activity

### DIFF
--- a/docs/features/subagent-and-aux-compression.md
+++ b/docs/features/subagent-and-aux-compression.md
@@ -11,14 +11,13 @@ Codex, and OpenCode subagent implementations:
    retrieval candidates before injecting them into the main model context.
 
 Neither Claude Code, Codex, nor OpenCode implements aux-model retrieval
-compression — this is a RARA-specific design.  Claude Code uses subagents
-for task decomposition (the reference implementation), OpenCode has its own
-TaskTool subagent system, and Codex has no subagent support (only a config
-migration tool).
+compression — this is a RARA-specific design. Claude Code, Codex, and OpenCode
+all expose structured subagent lifecycle state rather than deriving it from
+ordinary interaction prompts or tool-result text.
 
 ## Reference Systems
 
-### Claude Code (`LocalAgentTask.tsx`)
+### Claude Code (`LocalAgentTask.tsx`, `CoordinatorAgentStatus.tsx`)
 
 - `ProgressTracker`: `{ toolUseCount, latestInputTokens, cumulativeOutputTokens, recentActivities }`
 - `updateProgressFromMessage()`: called per turn to accumulate progress.
@@ -26,12 +25,12 @@ migration tool).
 - Activity descriptions pre-computed from tool `getActivityDescription()`.
 - Tasks can be backgrounded, mid-turn messages queued via `pendingMessages`.
 
-### Codex (`external-agent-migration/`)
+### Codex (`tui/src/app/agent_status_feed.rs`, `tui/src/multi_agents.rs`)
 
-* Not a subagent system.  `external-agent-migration` is a **configuration
-  migration tool** that reads Claude Code config files (`.mcp.json`, hooks,
-  agents) and converts them to Codex's native format.  It does not spawn,
-  track, or manage subagents.
+- Agent status is projected from typed child-thread lifecycle events.
+- `/agent` reports active and recently completed agents by structured status.
+- Activity previews are bounded by item count, line count, and grapheme count.
+- Raw reasoning deltas are excluded from agent activity previews.
 
 ### OpenCode (`tool/task.ts`)
 
@@ -49,17 +48,20 @@ TaskTool supports full subagent delegation:
 
 ### Current State (RARA)
 
-`src/tools/agent.rs` `BackgroundSubAgentRecord` has:
-- `AgentStatus`: `Spawning`, `Running`, `Completed`
-- `created_at`: `Instant`
-- `last_output`: `Vec<ContentBlock>`
+`AgentTreeControl` already owns session-scoped child records, concurrency,
+cancellation, mailboxes, background execution, resolved provider/model data,
+and final token totals. `SubagentProgress` already defines bounded recent
+activity and live token/tool counters.
 
-Missing:
-- Token usage per subagent
-- Per-tool activity tracking (bash, file read, search)
-- Background execution
-- Mid-turn message queuing
-- Shareable output data (`SharedData` in Claude Code)
+The missing integration is projection and display:
+
+- subagent execution does not feed its typed `AgentEvent` stream into
+  `SubagentProgress` while it is running;
+- `RuntimeSnapshot` does not contain child-agent lifecycle state;
+- the sidebar incorrectly labels pending approval/input interactions as
+  subagents, so the displayed identities do not represent the agent tree;
+- `/status` reports configured agent definitions but not live or recently
+  completed child agents.
 
 ### Design
 
@@ -67,58 +69,53 @@ Missing:
 
 ```rust
 pub struct SubagentProgress {
-    pub tool_use_count: u32,
-    pub total_input_tokens: u32,
-    pub total_output_tokens: u32,
-    pub recent_activities: Vec<SubagentActivity>,
-}
-
-pub struct SubagentActivity {
-    pub tool_name: String,
-    pub activity_description: String,
+    pub tool_use_count: usize,
+    pub tool_use_total: Option<usize>,
+    pub total_input_tokens: usize,
+    pub total_output_tokens: usize,
+    pub activity: Vec<String>,
 }
 ```
 
-Update `SpawnAgent`:
+The subagent query reporter updates this state from typed events:
 
-```rust
-pub struct SpawnAgent {
-    pub status: AgentStatus,
-    pub started_at: u64,                      // Unix timestamp
-    pub last_output: Vec<ContentBlock>,
-    pub progress: SubagentProgress,           // NEW
-    pub pending_messages: Vec<String>,         // NEW
-    pub abort_token: Option<CancellationToken>, // NEW
-}
-```
+- `ToolUse` increments the tool count and records a bounded tool label;
+- `Status` records a sanitized, bounded activity label;
+- `ModelRequest` and `ModelResponse` accumulate reported token counts;
+- assistant text and reasoning deltas are not copied into the progress view;
+- final completion metrics replace provisional live counters.
 
-#### Integration with RARA's existing AgentTool
+#### Runtime Projection
 
-RARA already has `src/tools/agent.rs` with `AgentTool::call()`. The
-enhancements wire into the existing `spawn_agent` path:
+The TUI reads a bounded snapshot of the root's full descendant tree from the
+session-owned `AgentTreeControl`.
+The runtime client retains both the tree handle and root session identity even
+while the root `Agent` is moved into an asynchronous task. The existing TUI
+tick refreshes this projection and requests a redraw only when it changes.
 
-1. `spawn_agent(subagent_id, instruction)` creates `SpawnAgent` with
-   `SubagentProgress::default()` and registers it in `self.spawning_agents`.
-2. Each subagent turn calls `update_progress_from_turn()` accumulating
-   tool_use_count and tokens.
-3. Activity descriptions use existing tool output (e.g. "bash: cargo check").
-4. `pending_messages` drained via `send_message_to_subagent()` (future).
+Presentation state contains values only. It must not own `AgentTreeControl`,
+task handles, cancellation tokens, mailboxes, or other mutable runtime
+behavior.
 
 #### Display
 
-In the TUI, subagent progress shows as:
+The wide sidebar and `/status` overview show the same structured projection:
 
 ```
-  explore_agent: analyzing crates/               [4 tools · 12.3K tokens]
-    Reading crates/rara-tools/src/tool.rs
-    Running bash: cargo check
+  [>] explore_agent (explore)
+      4 tools · 12.3k tokens · Using read_file
 ```
+
+Running agents sort before terminal agents. The sidebar displays at most five
+records and reports how many additional records are hidden. Status markers and
+semantic colors distinguish running, completed, failed, and cancelled agents.
 
 ### Non-Goals for Part 1
 
 - Full Claude Code-compatible `SharedData` output format.
-- Subagent streaming to TUI (uses existing `AgentEvent` subscribers).
-- Subagent tool restrictions or permission scoping.
+- Raw subagent assistant or reasoning streaming in the parent transcript.
+- New subagent control actions in the TUI.
+- Changes to subagent tool restrictions or permission scoping.
 
 ---
 
@@ -213,11 +210,12 @@ aux-model compression was applied.
 
 ### Subagent Enhancement
 
-1. Add `SubagentProgress` and `SubagentActivity` structs.
-2. Extend `SpawnAgent` with progress, pending_messages, abort_token.
-3. Add `update_progress_from_turn()` to accumulate per-turn metrics.
-4. Wire progress into existing `sub_agent_display.rs` rendering.
-5. Add snapshot tests for progress display.
+1. Feed typed child events into the existing `SubagentProgress` record.
+2. Add a bounded child-agent activity projection to `AgentTreeControl`.
+3. Retain the session tree handle in `RuntimeClient` while the root agent runs.
+4. Refresh projection state on the existing TUI tick.
+5. Render the projection in the sidebar and `/status` overview.
+6. Add focused progress, state projection, and rendering tests.
 
 ### Aux-Model Compression
 
@@ -233,9 +231,13 @@ aux-model compression was applied.
 
 ### Subagent Enhancement
 
-- Unit test: `SubagentProgress` accumulation.
-- TUI snapshot: subagent with progress bar and activity list.
-- Manual: `spawn_agent` a task, verify progress updates in sidebar.
+- Unit test: typed events update bounded `SubagentProgress` state.
+- Unit test: only children of the current root session are projected.
+- Render test: pending approvals are not rendered as subagents.
+- Render test: running and completed agent identities, status, tool count,
+  tokens, and recent activity appear in the sidebar and `/status`.
+- Manual: spawn parallel agents and verify progress changes without waiting for
+  the root turn to finish.
 
 ### Aux-Model Compression
 

--- a/docs/journal/2026-09-03-tui-subagent-status.md
+++ b/docs/journal/2026-09-03-tui-subagent-status.md
@@ -1,0 +1,60 @@
+# TUI Subagent Status Projection
+
+## Summary
+
+RARA now projects session-scoped child-agent lifecycle and progress into the
+TUI while the root turn is still running. The wide sidebar and `/status`
+overview show the real agents registered in `AgentTreeControl`, including
+their kind, lifecycle status, provider/model route, tool count, token count,
+and latest bounded activity.
+
+## Background
+
+The runtime already tracked child agents, but the presentation snapshot did
+not expose that state. The sidebar's former `Sub-agents` section read pending
+approval and request-input interactions instead, so it could display unrelated
+prompts as running agents and could not display actual children.
+
+The implementation follows two upstream patterns reviewed before coding:
+
+- Codex projects typed child-thread status into a bounded agent status feed and
+  excludes raw reasoning from activity previews.
+- Claude Code derives coordinator status from structured agent task state and
+  accumulated progress rather than parsing tool-result text.
+
+## Implementation
+
+- Child `AgentEvent` values update the existing `SubagentProgress` record.
+  Tool uses and sanitized status messages become bounded activity; assistant
+  and reasoning deltas remain excluded.
+- `AgentTreeControl` exposes an immutable, presentation-safe activity
+  projection containing the root session's full descendant tree.
+- `RuntimeClient` retains the session tree handle and root identity even while
+  the root `Agent` is owned by an asynchronous query task.
+- The existing TUI tick refreshes the activity projection and redraws only
+  when the value changes.
+- Sidebar and `/status` rendering use semantic lifecycle markers and colors.
+
+## Trade-offs
+
+- The TUI polls the in-memory projection on its existing 166 ms tick instead
+  of adding a second event protocol. This keeps lifecycle ownership in the
+  runtime and bounds display latency without coupling child events to TUI
+  rendering types.
+- Live input-token usage remains provider-dependent. The final completion
+  snapshot replaces provisional counters with the runtime's authoritative
+  totals.
+- Completed records remain visible according to the existing agent-tree
+  retention policy; the sidebar limits its rendering to five records.
+
+## Validation
+
+- Verify typed child events update tool, token, and bounded activity state.
+- Verify projections contain only children of the active root session.
+- Verify pending approvals are not rendered as subagents.
+- Verify the sidebar and `/status` render running agent identity and progress.
+- Run Rust formatting and warning checks for the touched workspace.
+
+## Follow-ups
+
+None for this checkpoint.

--- a/src/agent/runtime.rs
+++ b/src/agent/runtime.rs
@@ -205,6 +205,7 @@ impl Agent {
         self.agent_definitions.records()
     }
 
+    #[cfg(test)]
     pub async fn query_with_mode(
         &mut self,
         prompt: String,

--- a/src/runtime_client.rs
+++ b/src/runtime_client.rs
@@ -24,6 +24,7 @@ use crate::protocol_sources::{PromptSourceRegistry, SkillSourceRegistry};
 use crate::runtime_context::RuntimeBootstrap;
 use crate::runtime_event_bus::RuntimeEventBus;
 use crate::runtime_goal::{GoalEvaluation, evaluate_goal_completion};
+use crate::tools::agent::{AgentActivitySnapshot, AgentTreeControl};
 use crate::tui::state::{GoalHandle, GoalStatus, RalphGoal, RuntimeExtensionSnapshot};
 
 /// Fully initialized replacement runtime returned by a backend rebuild.
@@ -76,6 +77,8 @@ pub(crate) enum GoalContinuation {
 /// Runtime objects owned by one interactive session.
 pub(crate) struct RuntimeClient {
     agent: Option<Agent>,
+    agent_tree_control: Arc<AgentTreeControl>,
+    root_session_id: String,
     pub(crate) goal_handle: GoalHandle,
     pub(crate) mcp_tool_cache: McpToolCache,
     pub(crate) mcp_manager: Arc<McpConnectionManager>,
@@ -136,8 +139,15 @@ impl RuntimeClient {
         let event_bus = components.event_bus;
         let memory_config = components.memory_config;
         let memory_lifecycle_enabled = memory_config.enabled;
+        let root_session_id = components.agent.session_id.clone();
+        let agent_tree_control = components
+            .agent
+            .agent_tree_control()
+            .expect("runtime bootstrap must attach an agent tree control");
         Self {
             agent: Some(components.agent),
+            agent_tree_control,
+            root_session_id,
             goal_handle: components.goal_handle,
             mcp_tool_cache: components.mcp_tool_cache,
             mcp_manager: components.mcp_manager,
@@ -164,6 +174,23 @@ impl RuntimeClient {
 
     pub(crate) fn agent_mut(&mut self) -> &mut Option<Agent> {
         &mut self.agent
+    }
+
+    pub(crate) fn refresh_agent_tree_identity(&mut self) {
+        let Some(agent) = self.agent.as_ref() else {
+            return;
+        };
+        self.root_session_id.clone_from(&agent.session_id);
+        if let Some(control) = agent.agent_tree_control() {
+            self.agent_tree_control = control;
+        }
+    }
+
+    pub(crate) fn agent_activity_snapshots(
+        &self,
+    ) -> Result<Vec<AgentActivitySnapshot>, rara_tools::tool::ToolError> {
+        self.agent_tree_control
+            .activity_snapshots_for_root(&self.root_session_id)
     }
 
     pub(crate) fn task_services(&self) -> RuntimeTaskServices {

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -37,6 +37,8 @@ use crate::tools::tasklist::{TaskCreateTool, TaskGetTool, TaskListTool, TaskUpda
 use crate::tools::web::{WebFetchTool, WebSearchTool};
 use crate::workspace::WorkspaceMemory;
 
+#[path = "agent_activity.rs"]
+mod agent_activity;
 #[path = "agent_budget.rs"]
 mod agent_budget;
 #[path = "agent_permission.rs"]
@@ -50,6 +52,7 @@ use agent_budget::{agent_token_budget, parse_agent_token_budget};
 mod agent_control;
 #[path = "agent_control_tools.rs"]
 mod agent_control_tools;
+pub(crate) use agent_activity::AgentActivitySnapshot;
 pub use agent_control::{
     AgentMailboxMessage, AgentSnapshot, AgentTreeConfig, AgentTreeControl, AgentWaitResult,
     BackgroundSubAgentStore,
@@ -182,10 +185,6 @@ impl SubagentProgress {
         }
     }
 
-    /// Reserved for per-tool subagent activity summaries.
-    /// Will be activated with subagent progress tracking
-    /// (docs/features/subagent-and-aux-compression.md).
-    #[allow(dead_code)]
     pub fn record_activity(&mut self, desc: impl Into<String>) {
         let s = desc.into();
         self.activity.push(s);

--- a/src/tools/agent_activity.rs
+++ b/src/tools/agent_activity.rs
@@ -1,0 +1,161 @@
+use std::collections::HashSet;
+
+use rara_persistence::redaction::redact_secrets;
+use rara_tools::tool::ToolError;
+
+use super::{AgentTreeControl, BackgroundSubAgentRecord};
+use crate::agent::AgentEvent;
+
+/// Immutable child-agent activity projected into presentation surfaces.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct AgentActivitySnapshot {
+    pub(crate) agent_id: String,
+    pub(crate) path: String,
+    pub(crate) name: Option<String>,
+    pub(crate) provider: Option<String>,
+    pub(crate) model: Option<String>,
+    pub(crate) kind: String,
+    pub(crate) status: String,
+    pub(crate) summary: Option<String>,
+    pub(crate) error: Option<String>,
+    pub(crate) tool_use_count: usize,
+    pub(crate) total_tokens: usize,
+    pub(crate) latest_activity: Option<String>,
+    pub(crate) started_at: u64,
+}
+
+impl From<&BackgroundSubAgentRecord> for AgentActivitySnapshot {
+    fn from(record: &BackgroundSubAgentRecord) -> Self {
+        Self {
+            agent_id: record.agent_id.clone(),
+            path: record.path.clone(),
+            name: record.name.clone(),
+            provider: record.provider.clone(),
+            model: record.model.clone(),
+            kind: record.kind.to_string(),
+            status: record.status.clone(),
+            summary: record.summary.clone(),
+            error: record.error.clone(),
+            tool_use_count: record.progress.tool_use_count,
+            total_tokens: record.progress.total_tokens(),
+            latest_activity: record.progress.latest_activity().map(str::to_string),
+            started_at: record.started_at,
+        }
+    }
+}
+
+impl AgentTreeControl {
+    pub(super) fn record_progress_event(
+        &self,
+        agent_id: &str,
+        event: &AgentEvent,
+    ) -> Result<(), ToolError> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| ToolError::ExecutionFailed("sub-agent store poisoned".into()))?;
+        let Some(record) = inner.tasks.get_mut(agent_id) else {
+            return Ok(());
+        };
+        if record.status != "running" {
+            return Ok(());
+        }
+
+        match event {
+            AgentEvent::Status(message) => record_progress_activity(record, message),
+            AgentEvent::ToolUse { name, .. } => {
+                record.progress.tool_use_count = record.progress.tool_use_count.saturating_add(1);
+                record_progress_activity(record, &format!("Using {name}"));
+            }
+            AgentEvent::ToolResult { name, is_error, .. } => {
+                let outcome = if *is_error { "failed" } else { "completed" };
+                record_progress_activity(record, &format!("{name} {outcome}"));
+            }
+            AgentEvent::MemoryAction { message } => record_progress_activity(record, message),
+            AgentEvent::AgentStart => record_progress_activity(record, "Starting"),
+            AgentEvent::AgentStop { reason } => record_progress_activity(record, reason),
+            AgentEvent::AgentError { message, .. } => record_progress_activity(record, message),
+            AgentEvent::ModelRequest { input_tokens, .. } => {
+                record.progress.total_input_tokens = record
+                    .progress
+                    .total_input_tokens
+                    .saturating_add(*input_tokens as usize);
+            }
+            AgentEvent::ModelResponse { output_tokens, .. } => {
+                record.progress.total_output_tokens = record
+                    .progress
+                    .total_output_tokens
+                    .saturating_add(*output_tokens as usize);
+            }
+            AgentEvent::AssistantText(_)
+            | AgentEvent::AssistantDelta(_)
+            | AgentEvent::AssistantThinkingDelta(_)
+            | AgentEvent::ToolProgress { .. }
+            | AgentEvent::McpStatusUpdated(_)
+            | AgentEvent::McpStatusLoadFailed { .. }
+            | AgentEvent::TodoUpdated(_)
+            | AgentEvent::PlanUpdated { .. }
+            | AgentEvent::ApprovalRequested { .. }
+            | AgentEvent::ApprovalAnswered { .. }
+            | AgentEvent::Compaction { .. } => {}
+        }
+        Ok(())
+    }
+
+    pub(crate) fn activity_snapshots_for_root(
+        &self,
+        root_session_id: &str,
+    ) -> Result<Vec<AgentActivitySnapshot>, ToolError> {
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| ToolError::ExecutionFailed("sub-agent store poisoned".into()))?;
+        let mut visible_sessions = HashSet::from([root_session_id.to_string()]);
+        let mut visible_agent_ids = HashSet::new();
+        loop {
+            let mut discovered = false;
+            for record in inner.tasks.values() {
+                if record
+                    .parent_session_id
+                    .as_ref()
+                    .is_some_and(|parent| visible_sessions.contains(parent))
+                    && visible_agent_ids.insert(record.agent_id.clone())
+                {
+                    visible_sessions.insert(record.session_id.clone());
+                    discovered = true;
+                }
+            }
+            if !discovered {
+                break;
+            }
+        }
+        let mut snapshots = inner
+            .tasks
+            .values()
+            .filter(|record| visible_agent_ids.contains(&record.agent_id))
+            .map(AgentActivitySnapshot::from)
+            .collect::<Vec<_>>();
+        snapshots.sort_by(|left, right| {
+            let left_rank = usize::from(left.status != "running");
+            let right_rank = usize::from(right.status != "running");
+            left_rank
+                .cmp(&right_rank)
+                .then(right.started_at.cmp(&left.started_at))
+                .then(left.path.cmp(&right.path))
+        });
+        Ok(snapshots)
+    }
+}
+
+fn record_progress_activity(record: &mut BackgroundSubAgentRecord, activity: &str) {
+    let sanitized = redact_secrets(activity.to_string());
+    let normalized = sanitized.split_whitespace().collect::<Vec<_>>().join(" ");
+    if normalized.is_empty() {
+        return;
+    }
+    let mut bounded = normalized.chars().take(120).collect::<String>();
+    if normalized.chars().count() > 120 {
+        bounded.push('…');
+    }
+    record.progress.record_activity(bounded);
+}

--- a/src/tools/agent_control_test.rs
+++ b/src/tools/agent_control_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::agent::AgentEvent;
 
 fn record(agent_id: &str, parent_session_id: &str) -> BackgroundSubAgentRecord {
     BackgroundSubAgentRecord {
@@ -103,6 +104,96 @@ fn resolved_model_replaces_requested_route_metadata() {
         .expect("record");
     assert_eq!(record.provider.as_deref(), Some("gemini"));
     assert_eq!(record.model.as_deref(), Some("gemini-2.5-pro"));
+}
+
+#[test]
+fn typed_events_update_bounded_agent_activity_snapshot() {
+    let control = AgentTreeControl::default();
+    control
+        .inner
+        .lock()
+        .expect("control")
+        .tasks
+        .insert("agent-a".to_string(), record("agent-a", "parent-a"));
+
+    control
+        .record_progress_event("agent-a", &AgentEvent::Status("Searching workspace".into()))
+        .expect("status progress");
+    control
+        .record_progress_event(
+            "agent-a",
+            &AgentEvent::ToolUse {
+                call_id: "call-1".into(),
+                name: "grep".into(),
+                input: json!({"pattern": "AgentTreeControl"}),
+            },
+        )
+        .expect("tool progress");
+    control
+        .record_progress_event(
+            "agent-a",
+            &AgentEvent::ModelRequest {
+                model: "mock-model".into(),
+                input_tokens: 12,
+            },
+        )
+        .expect("input tokens");
+    control
+        .record_progress_event(
+            "agent-a",
+            &AgentEvent::ModelResponse {
+                model: "mock-model".into(),
+                output_tokens: 7,
+                finish_reason: Some("tool_use".into()),
+            },
+        )
+        .expect("output tokens");
+
+    let snapshots = control
+        .activity_snapshots_for_root("parent-a")
+        .expect("snapshots");
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].tool_use_count, 1);
+    assert_eq!(snapshots[0].total_tokens, 19);
+    assert_eq!(snapshots[0].latest_activity.as_deref(), Some("Using grep"));
+
+    control
+        .record_progress_event("agent-a", &AgentEvent::Status("x".repeat(200)))
+        .expect("bounded status");
+    let bounded = control
+        .activity_snapshots_for_root("parent-a")
+        .expect("bounded snapshot")[0]
+        .latest_activity
+        .clone()
+        .expect("activity");
+    assert_eq!(bounded.chars().count(), 121);
+    assert!(bounded.ends_with('…'));
+}
+
+#[test]
+fn activity_projection_includes_descendants_but_not_other_roots() {
+    let control = AgentTreeControl::default();
+    let mut inner = control.inner.lock().expect("control");
+    inner
+        .tasks
+        .insert("agent-a".to_string(), record("agent-a", "root-a"));
+    inner.tasks.insert(
+        "agent-a-child".to_string(),
+        record("agent-a-child", "session-agent-a"),
+    );
+    inner
+        .tasks
+        .insert("agent-b".to_string(), record("agent-b", "root-b"));
+    drop(inner);
+
+    let snapshots = control
+        .activity_snapshots_for_root("root-a")
+        .expect("snapshots");
+    let ids = snapshots
+        .iter()
+        .map(|snapshot| snapshot.agent_id.as_str())
+        .collect::<HashSet<_>>();
+    assert_eq!(ids, HashSet::from(["agent-a", "agent-a-child"]));
 }
 
 #[test]

--- a/src/tools/agent_runtime.rs
+++ b/src/tools/agent_runtime.rs
@@ -92,7 +92,7 @@ pub(crate) async fn run_sub_agent(
     if let Some(session_id) = session_id {
         sub.session_id = session_id;
     }
-    sub.set_agent_tree_control(agent_tree_control);
+    sub.set_agent_tree_control(agent_tree_control.clone());
     sub.set_cancellation_token(cancellation_token);
     let plan_required =
         definition.is_some_and(|d| d.plan_mode_required) || permission_mode.requires_plan_mode();
@@ -128,9 +128,18 @@ pub(crate) async fn run_sub_agent(
         .unwrap_or_else(|| kind.default_max_turns());
     sub.set_max_turns(def_max_turns);
 
-    let query_fut = sub.query_with_mode(
+    let progress_agent_id = agent_id.to_string();
+    let progress_control = agent_tree_control;
+    let query_fut = sub.query_with_mode_and_events(
         instruction.to_string(),
         crate::agent::AgentOutputMode::Silent,
+        move |event| {
+            if let Some(control) = progress_control.as_ref()
+                && let Err(error) = control.record_progress_event(&progress_agent_id, &event)
+            {
+                log::warn!("failed to record progress for sub-agent {progress_agent_id}: {error}");
+            }
+        },
     );
 
     tokio::time::timeout(Duration::from_secs(SUBAGENT_TIMEOUT_SECS), query_fut)

--- a/src/tui/controller.rs
+++ b/src/tui/controller.rs
@@ -246,7 +246,7 @@ impl TuiController {
     /// Sync snapshot from the active agent (must be called at the top of the event loop).
     pub(super) async fn sync_snapshot(
         &mut self,
-        processor: &RuntimeCommandProcessor,
+        processor: &mut RuntimeCommandProcessor,
     ) -> anyhow::Result<()> {
         processor.sync_snapshot(&mut self.app);
         self.app.snapshot = self.runtime_port.snapshot().await?;

--- a/src/tui/event_loop.rs
+++ b/src/tui/event_loop.rs
@@ -98,7 +98,7 @@ pub async fn run_tui(
     let mut tick = interval(Duration::from_millis(166));
     tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-    maintainer.sync_snapshot(&processor).await?;
+    maintainer.sync_snapshot(&mut processor).await?;
     maintainer.start_repo_context_detection();
     if should_start_initial_rebuild(&maintainer.app().explicit_plugin_dirs) {
         maintainer
@@ -145,6 +145,7 @@ pub async fn run_tui(
                     changed = true;
                 }
                 changed |= app.poll_shared_task_files();
+                changed |= processor.sync_agent_activity(app);
                 changed |= super::runtime::emit_query_heartbeat(app);
                 needs_redraw |= changed;
             }
@@ -202,7 +203,7 @@ pub async fn run_tui(
                             needs_redraw = true;
                         }
                         Some(UiEvent::FocusChanged(_focused)) => {
-                            maintainer.sync_snapshot(&processor).await?;
+                            maintainer.sync_snapshot(&mut processor).await?;
                             maintainer.publish_snapshot_projection();
                             needs_redraw = true;
                         }

--- a/src/tui/format.rs
+++ b/src/tui/format.rs
@@ -2,3 +2,13 @@ pub(crate) fn cache_hit_rate_label(hit_tokens: u32, miss_tokens: u32) -> Option<
     let total = hit_tokens.saturating_add(miss_tokens);
     (total > 0).then(|| format!("{:.1}%", hit_tokens as f64 * 100.0 / total as f64))
 }
+
+pub(crate) fn format_token_count(tokens: usize) -> String {
+    if tokens >= 1_000_000 {
+        format!("{:.1}M", tokens as f64 / 1_000_000.0)
+    } else if tokens >= 1_000 {
+        format!("{:.1}k", tokens as f64 / 1_000.0)
+    } else {
+        tokens.to_string()
+    }
+}

--- a/src/tui/render/sidebar.rs
+++ b/src/tui/render/sidebar.rs
@@ -13,6 +13,7 @@ use crate::lsp_manager::LspServerPhase;
 use crate::tui::custom_terminal::Frame;
 use crate::tui::state::{GoalStatus, TuiApp};
 use crate::tui::status_display::context_sidebar_summary;
+use crate::tui::sub_agent_display::SubAgentActivityDisplay;
 use crate::tui::theme::*;
 
 /// Width allocated to the sidebar when the terminal is wide enough.
@@ -420,7 +421,7 @@ fn push_shared_tasks_section(lines: &mut Vec<Line<'static>>, app: &TuiApp) -> bo
 }
 
 fn push_child_sessions(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
-    let child_count = app.snapshot.pending_interactions.len();
+    let child_count = app.snapshot.subagents.len();
     if child_count == 0 {
         return;
     }
@@ -430,12 +431,16 @@ fn push_child_sessions(lines: &mut Vec<Line<'static>>, app: &TuiApp) {
         TEXT_SECONDARY,
     )));
 
-    // Show running sub-agents up to 5.
-    for pi in app.snapshot.pending_interactions.iter().take(5) {
-        let label = format!("  {} (running)", pi.title);
+    for agent in app.snapshot.subagents.iter().take(5) {
+        let display = SubAgentActivityDisplay::new(agent);
+        let (_, color) = display.marker_and_color();
         lines.push(Line::from(Span::styled(
-            label,
-            Style::default().fg(INTERACTION_SUB_AGENT),
+            display.sidebar_header(),
+            Style::default().fg(color),
+        )));
+        lines.push(Line::from(Span::styled(
+            display.progress_line("    "),
+            Style::default().fg(TEXT_MUTED),
         )));
     }
 

--- a/src/tui/render/sidebar_tests.rs
+++ b/src/tui/render/sidebar_tests.rs
@@ -8,6 +8,7 @@ use super::{
 use crate::config::ConfigManager;
 use crate::context::{SharedTaskContextItem, SharedTaskContextView, TodoContextView};
 use crate::todo::TodoSummary;
+use crate::tools::agent::AgentActivitySnapshot;
 use crate::tui::state::{
     InteractionKind, PendingInteractionSnapshot, RuntimeSnapshot, TranscriptEntry, TranscriptTurn,
     TuiApp,
@@ -495,28 +496,28 @@ fn push_plan_section_shows_progress_and_items() {
     assert!(text.contains("[ ] Check nearby side effects"));
     assert!(text.contains("[-] Broader cleanup"));
 }
-// Now shows "# Sub-agents" section header + each title (running).
-
 #[test]
-fn push_child_sessions_shows_titles_running() {
+fn push_child_sessions_shows_runtime_agent_activity() {
     let temp = tempdir().unwrap();
     let mut app = TuiApp::new(ConfigManager {
         path: temp.path().join("config.json"),
     })
     .expect("build tui app");
     app.snapshot = RuntimeSnapshot {
-        pending_interactions: vec![
-            PendingInteractionSnapshot {
-                kind: InteractionKind::Approval,
-                title: "explore-sidebar".into(),
-                ..Default::default()
-            },
-            PendingInteractionSnapshot {
-                kind: InteractionKind::PlanApproval,
-                title: "plan-refactor".into(),
-                ..Default::default()
-            },
-        ],
+        subagents: vec![AgentActivitySnapshot {
+            name: Some("explore-sidebar".into()),
+            kind: "explore".into(),
+            status: "running".into(),
+            tool_use_count: 4,
+            total_tokens: 12_300,
+            latest_activity: Some("Using grep".into()),
+            ..AgentActivitySnapshot::default()
+        }],
+        pending_interactions: vec![PendingInteractionSnapshot {
+            kind: InteractionKind::Approval,
+            title: "approve-command".into(),
+            ..Default::default()
+        }],
         ..RuntimeSnapshot::default()
     };
 
@@ -532,9 +533,11 @@ fn push_child_sessions_shows_titles_running() {
         "should show # Sub-agents section label"
     );
     assert!(
-        text.contains("explore-sidebar (running)"),
-        "should show sub-agent title + (running)"
+        text.contains("[>] explore-sidebar (explore)"),
+        "should show the runtime agent identity and kind"
     );
+    assert!(text.contains("4 tools · 12.3k tokens · Using grep"));
+    assert!(!text.contains("approve-command"));
 }
 
 #[test]
@@ -546,7 +549,7 @@ fn push_child_sessions_skip_when_empty() {
     .expect("build tui app");
     let mut lines = Vec::new();
     push_child_sessions(&mut lines, &app);
-    assert!(lines.is_empty(), "empty when no pending interactions");
+    assert!(lines.is_empty(), "empty when no subagents exist");
 }
 
 // ── PendingInteractionSnapshot default helper ───────────────────────

--- a/src/tui/runtime/processor.rs
+++ b/src/tui/runtime/processor.rs
@@ -160,6 +160,7 @@ impl RuntimeCommandProcessor {
         )
         .await?;
         self.runtime.update_task_services(&services);
+        self.runtime.refresh_agent_tree_identity();
         if let Some(agent) = self.runtime.agent() {
             crate::auto_memory::maybe_auto_memory(app, agent);
             self.runtime
@@ -174,9 +175,26 @@ impl RuntimeCommandProcessor {
         let _ = crate::auto_memory::drain_auto_memory_for_shutdown().await;
     }
 
-    pub(crate) fn sync_snapshot(&self, app: &mut TuiApp) {
+    pub(crate) fn sync_snapshot(&mut self, app: &mut TuiApp) {
+        self.runtime.refresh_agent_tree_identity();
         if let Some(agent) = self.agent() {
             app.apply_runtime_snapshot(agent, self.runtime.extension_snapshot());
         }
+        self.sync_agent_activity(app);
+    }
+
+    pub(crate) fn sync_agent_activity(&self, app: &mut TuiApp) -> bool {
+        let snapshots = match self.runtime.agent_activity_snapshots() {
+            Ok(snapshots) => snapshots,
+            Err(error) => {
+                log::warn!("failed to project sub-agent activity into the TUI: {error}");
+                return false;
+            }
+        };
+        if app.snapshot.subagents == snapshots {
+            return false;
+        }
+        app.snapshot.subagents = snapshots;
+        true
     }
 }

--- a/src/tui/state/runtime_snapshot.rs
+++ b/src/tui/state/runtime_snapshot.rs
@@ -122,6 +122,7 @@ impl TuiApp {
             &pending_interactions,
             &completed_interactions,
         );
+        let subagents = self.snapshot.subagents.clone();
         self.snapshot = RuntimeSnapshot {
             cwd: runtime_context.cwd,
             branch: runtime_context.branch,
@@ -173,6 +174,7 @@ impl TuiApp {
             },
             todo: runtime_context.todo,
             shared_tasks: runtime_context.shared_tasks,
+            subagents,
             prompt_base_kind: runtime_context.prompt.base_prompt_kind,
             prompt_section_keys: runtime_context.prompt.section_keys,
             prompt_source_entries: runtime_context.prompt.source_entries,

--- a/src/tui/state/types.rs
+++ b/src/tui/state/types.rs
@@ -291,6 +291,7 @@ pub struct RuntimeSnapshot {
     pub todo: crate::context::TodoContextView,
     pub todo_artifact_path: Option<String>,
     pub shared_tasks: crate::context::SharedTaskContextView,
+    pub(crate) subagents: Vec<crate::tools::agent::AgentActivitySnapshot>,
     pub prompt_base_kind: String,
     pub prompt_section_keys: Vec<String>,
     pub prompt_source_entries: Vec<PromptSourceContextEntry>,

--- a/src/tui/status_display.rs
+++ b/src/tui/status_display.rs
@@ -9,7 +9,10 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use crate::config::McpServerTransport;
+pub(crate) use crate::tui::format::format_token_count;
 use crate::tui::state::{PlanningApprovalStatus, StatusTab, TuiApp};
+use crate::tui::sub_agent_display::SubAgentActivityDisplay;
+use crate::tui::theme::TEXT_MUTED;
 
 pub(crate) fn render_status_lines(app: &TuiApp, tab: StatusTab) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> = Vec::new();
@@ -71,6 +74,23 @@ fn render_overview_status(app: &TuiApp, lines: &mut Vec<Line<'static>>) {
         app.bash_approval_mode_label(),
         Color::DarkGray,
     );
+
+    if !app.snapshot.subagents.is_empty() {
+        section_spacer(lines);
+        section_header(lines, "Sub-agents");
+        for agent in &app.snapshot.subagents {
+            let display = SubAgentActivityDisplay::new(agent);
+            let (_, color) = display.marker_and_color();
+            lines.push(Line::from(Span::styled(
+                display.status_header(),
+                Style::default().fg(color),
+            )));
+            lines.push(Line::from(Span::styled(
+                display.progress_line("      "),
+                Style::default().fg(TEXT_MUTED),
+            )));
+        }
+    }
 
     section_spacer(lines);
     section_header(lines, "Planning");
@@ -453,16 +473,6 @@ fn format_metric(n: u64) -> String {
 
 /// Shared token count formatter: "1.0k", "2.5M", or plain number.
 /// Keep format stable — sidebar, footer, and context display all use this.
-pub(crate) fn format_token_count(tokens: usize) -> String {
-    if tokens >= 1_000_000 {
-        format!("{:.1}M", tokens as f64 / 1_000_000.0)
-    } else if tokens >= 1_000 {
-        format!("{:.1}k", tokens as f64 / 1_000.0)
-    } else {
-        tokens.to_string()
-    }
-}
-
 /// One-line context summary used by sidebar.
 pub(crate) fn context_sidebar_summary(snap: &crate::tui::state::RuntimeSnapshot) -> String {
     let used = snap
@@ -527,6 +537,7 @@ mod tests {
 
     use super::render_status_lines;
     use crate::config::ConfigManager;
+    use crate::tools::agent::AgentActivitySnapshot;
     use crate::tui::state::{
         PlanningApprovalStatus, PlanningLifecycleSnapshot, RuntimeSnapshot, StatusTab, TuiApp,
     };
@@ -558,6 +569,41 @@ mod tests {
         assert!(rendered.contains("2"));
         assert!(rendered.contains("code-reviewer"));
         assert!(rendered.contains(".rara/agents/code-reviewer.md"));
+    }
+
+    #[test]
+    fn overview_status_reports_live_subagents() {
+        let temp = tempdir().expect("tempdir");
+        let mut app = TuiApp::new(ConfigManager {
+            path: temp.path().join("config.json"),
+        })
+        .expect("app");
+        app.snapshot = RuntimeSnapshot {
+            subagents: vec![AgentActivitySnapshot {
+                name: Some("review-runtime".into()),
+                kind: "general".into(),
+                status: "running".into(),
+                provider: Some("openai".into()),
+                model: Some("gpt-5".into()),
+                tool_use_count: 2,
+                total_tokens: 1_500,
+                latest_activity: Some("Using read_file".into()),
+                ..AgentActivitySnapshot::default()
+            }],
+            ..RuntimeSnapshot::default()
+        };
+
+        let rendered = render_status_lines(&app, StatusTab::Overview)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("Sub-agents"));
+        assert!(rendered.contains("review-runtime"));
+        assert!(rendered.contains("running"));
+        assert!(rendered.contains("2 tools · 1.5k tokens · Using read_file"));
+        assert!(rendered.contains("openai/gpt-5"));
     }
 
     #[test]

--- a/src/tui/sub_agent_display.rs
+++ b/src/tui/sub_agent_display.rs
@@ -5,6 +5,8 @@
 // instead of generic "Tool Result" / "Delegate" text.
 use ratatui::style::Color;
 
+use crate::tools::agent::AgentActivitySnapshot;
+use crate::tui::format::format_token_count;
 use crate::tui::theme::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -50,3 +52,86 @@ impl SubAgentKind {
 /// Color for the "Sub-agent Question" interaction card.
 /// Distinct from the generic green RequestInput.
 pub(crate) const SUB_AGENT_QUESTION_COLOR: Color = INTERACTION_SUB_AGENT;
+
+/// Shared text and semantic style projection for one child-agent status row.
+pub(crate) struct SubAgentActivityDisplay<'a> {
+    activity: &'a AgentActivitySnapshot,
+}
+
+impl<'a> SubAgentActivityDisplay<'a> {
+    pub(crate) fn new(activity: &'a AgentActivitySnapshot) -> Self {
+        Self { activity }
+    }
+
+    pub(crate) fn marker_and_color(&self) -> (&'static str, Color) {
+        match self.activity.status.as_str() {
+            "running" => ("[>]", STATUS_WARNING),
+            "failed" | "budget_limited" => ("[!]", STATUS_WARNING),
+            "cancelled" | "stopped" => ("[-]", TEXT_MUTED),
+            _ => ("[x]", STATUS_SUCCESS),
+        }
+    }
+
+    pub(crate) fn sidebar_header(&self) -> String {
+        let (marker, _) = self.marker_and_color();
+        format!("  {marker} {} ({})", self.name(), self.activity.kind)
+    }
+
+    pub(crate) fn status_header(&self) -> String {
+        let (marker, _) = self.marker_and_color();
+        format!(
+            "  {marker} {} ({}) · {}{}",
+            self.name(),
+            self.activity.kind,
+            self.activity.status,
+            self.route()
+        )
+    }
+
+    pub(crate) fn progress_line(&self, indent: &str) -> String {
+        let mut progress = format!(
+            "{indent}{} tools · {} tokens",
+            self.activity.tool_use_count,
+            format_token_count(self.activity.total_tokens)
+        );
+        if let Some(activity) = self.latest_activity() {
+            progress.push_str(" · ");
+            progress.push_str(activity);
+        }
+        progress
+    }
+
+    fn name(&self) -> &str {
+        self.activity
+            .name
+            .as_deref()
+            .or_else(|| {
+                self.activity
+                    .path
+                    .rsplit('/')
+                    .next()
+                    .filter(|value| !value.is_empty())
+            })
+            .unwrap_or(&self.activity.agent_id)
+    }
+
+    fn latest_activity(&self) -> Option<&str> {
+        self.activity
+            .latest_activity
+            .as_deref()
+            .or(self.activity.error.as_deref())
+            .or(self.activity.summary.as_deref())
+    }
+
+    fn route(&self) -> String {
+        match (
+            self.activity.provider.as_deref(),
+            self.activity.model.as_deref(),
+        ) {
+            (Some(provider), Some(model)) => format!(" · {provider}/{model}"),
+            (Some(provider), None) => format!(" · {provider}"),
+            (None, Some(model)) => format!(" · {model}"),
+            (None, None) => String::new(),
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- feed typed child `AgentEvent` values into bounded subagent progress records
- retain the session-owned agent tree in `RuntimeClient` while the root agent is running
- project the full descendant tree into immutable TUI snapshot state on the existing UI tick
- render real subagent lifecycle, route, tool/token counts, and recent activity in the wide sidebar and `/status`
- stop treating pending approval and request-input interactions as subagents
- update the canonical subagent spec and add an implementation journal

## Why

RARA already tracked spawned agents in `AgentTreeControl`, but that runtime state
never reached the TUI. The sidebar instead used `pending_interactions`, which
could label permission or input prompts as running agents while hiding actual
subagent work.

The projection remains session-scoped and presentation-only: the TUI receives
values, not mutable agent-tree handles. Assistant text and reasoning deltas are
excluded from activity previews.

## Related issue

No linked issue.

## Validation

- `cargo test --lib tools::agent::agent_control::tests -- --nocapture`
- `cargo test --lib push_child_sessions -- --nocapture`
- `cargo test --lib overview_status_reports_live_subagents -- --nocapture`
- `cargo check --locked`
- commit hooks: `cargo fmt`, `cargo clippy`
